### PR TITLE
Upgrading to avadosdk

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -150,7 +150,7 @@ jobs:
         working-directory: packages/avado
         run: |
           docker-compose build
-          sudo npm install -g git+https://github.com/AvadoDServer/AVADOSDK.git
+          sudo npm install -g git+https://github.com/AvadoDServer/AVADOSDK.git#c11c4bd
           avadosdk increase minor
           sed -i 's/version"[ ]*:[ ]*"[0-9]*\.[0-9]*\.[0-9]*"/version": "${{ env.RELEASE }}"/' ./dappnode_package.json
           cat ./dappnode_package.json | grep 'version'

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -151,11 +151,10 @@ jobs:
         run: |
           docker-compose build
           sudo npm install -g git+https://github.com/AvadoDServer/AVADOSDK.git
-          #sudo npm install -g @dappnode/dappnodesdk@0.2.9-beta.0
-          dappnodesdk increase minor
+          avadosdk increase minor
           sed -i 's/version"[ ]*:[ ]*"[0-9]*\.[0-9]*\.[0-9]*"/version": "${{ env.RELEASE }}"/' ./dappnode_package.json
           cat ./dappnode_package.json | grep 'version'
-          sudo dappnodesdk build --provider http://80.208.229.228:5001
+          sudo avadosdk build --provider http://80.208.229.228:5001
           git add dappnode_package.json docker-compose.yml releases.json
           git commit -m "Avado CI: new release"
           git pull origin ${{ github.ref }}


### PR DESCRIPTION
NB: Ideally we keep `dappnodesdk` to avoid forking to much from the original project if the contributions to the original `sdk` are not too many.