### PR TITLE
Reinstated docker-entrypoint values

### DIFF
--- a/packages/avado/docker-compose.yml
+++ b/packages/avado/docker-compose.yml
@@ -4,8 +4,7 @@ services:
     build:
       context: ../hoprd
       dockerfile: ./Dockerfile
-      args:
-        network: bnb-testnet
+    command: "--password=\"open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0\" --init --admin"
     image: 'hopr.avado.dnp.dappnode.eth:0.100.0'
     restart: always
     volumes:

--- a/packages/avado/docker-compose.yml
+++ b/packages/avado/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: ../hoprd
       dockerfile: ./Dockerfile
-    command: "--password=\"open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0\" --init --admin"
+    command: '--password="open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0" --init --admin'
     image: 'hopr.avado.dnp.dappnode.eth:0.100.0'
     restart: always
     volumes:


### PR DESCRIPTION
Since we [removed](https://github.com/hoprnet/hoprnet/blob/095fdb8e51077b2febcba222d19d21668d43b437/packages/hoprd/docker-entrypoint.sh) the default one now our AVADO users can’t automatically start their nodes.