### PR TITLE
Updated AVADO to listen to 0.0.0.0

### DIFF
--- a/packages/avado/Dockerfile
+++ b/packages/avado/Dockerfile
@@ -7,4 +7,4 @@ EXPOSE 3000
 # REST API
 EXPOSE 3001
 
-ENTRYPOINT ["node", "/app/index.js", "--password='open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0'", "--init", "--admin"]
+ENTRYPOINT ["node", "/app/index.js", "--password='open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0'", "--init", "--admin", "--adminHost", "0.0.0.0"]


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1128312/105278656-41b4d180-5ba6-11eb-8d9b-96a19da32f6f.png)

As `localhost` isn't a valid configuration for an AVADO.