### PR TITLE
Make promiscuous strategy open channels to any interesting node.

### DIFF
--- a/packages/core/src/channel-strategy.ts
+++ b/packages/core/src/channel-strategy.ts
@@ -79,19 +79,19 @@ export class PromiscuousStrategy implements ChannelStrategy {
       .map((x) => indexerDest(x))
 
     // First let's open channels to any interesting peers we have
-    peers.all().forEach(peerId => {
+    peers.all().forEach((peerId) => {
       if (
         balance.gtn(0) &&
         currentChannels.length + toOpen.length < MAX_AUTO_CHANNELS &&
         !toOpen.find((x) => dest(x).equals(peerId)) &&
         !currentChannels.find((x) => indexerDest(x).equals(peerId)) &&
         peers.qualityOf(peerId) > NETWORK_QUALITY_THRESHOLD
-         ) {
+      ) {
         toOpen.push([peerId, MINIMUM_REASONABLE_CHANNEL_STAKE])
         balance.isub(MINIMUM_REASONABLE_CHANNEL_STAKE)
       }
     })
-    
+
     // Now let's evaluate new channels
     while (
       balance.gtn(0) &&

--- a/packages/core/src/channel-strategy.ts
+++ b/packages/core/src/channel-strategy.ts
@@ -78,6 +78,21 @@ export class PromiscuousStrategy implements ChannelStrategy {
       .filter((x: IndexerChannel) => peers.qualityOf(indexerDest(x)) < 0.1)
       .map((x) => indexerDest(x))
 
+    // First let's open channels to any interesting peers we have
+    peers.all().forEach(peerId => {
+      if (
+        balance.gtn(0) &&
+        currentChannels.length + toOpen.length < MAX_AUTO_CHANNELS &&
+        !toOpen.find((x) => dest(x).equals(peerId)) &&
+        !currentChannels.find((x) => indexerDest(x).equals(peerId)) &&
+        peers.qualityOf(peerId) > NETWORK_QUALITY_THRESHOLD
+         ) {
+        toOpen.push([peerId, MINIMUM_REASONABLE_CHANNEL_STAKE])
+        balance.isub(MINIMUM_REASONABLE_CHANNEL_STAKE)
+      }
+    })
+    
+    // Now let's evaluate new channels
     while (
       balance.gtn(0) &&
       i++ < MAX_NEW_CHANNELS_PER_TICK &&


### PR DESCRIPTION
Before, the promiscuous channel would simply take a random channel, and
evaluate it for quality. If the threshold was above a level it would
auto open.

The problem is, if it hadn't seen the channel before, the quality is not
good enough. Therefore to open a channel, it must be randomly selected
twice. When there are a lot of channels open, this takes a while.

To avoid this, and as a naive solution, appropriate for our promiscuous
strategy, we now auto open to any interesting node at the beginning of
the tick, before also adding new random channels to evaluate.