### PR TITLE
patch signed channel

### DIFF
--- a/packages/core-ethereum/src/channel/index.ts
+++ b/packages/core-ethereum/src/channel/index.ts
@@ -75,8 +75,8 @@ class ChannelFactory {
     log('Received open event for channel with %s', counterparty.toHex())
 
     const balance = new ChannelBalance(undefined, {
-      balance: new BN(10),
-      balance_a: new BN(2)
+      balance: new BN(channelEntry.deposit),
+      balance_a: new BN(channelEntry.partyABalance)
     })
     const state = new ChannelState(undefined, { state: stateCounterToStatus(channelEntry.stateCounter.toNumber()) })
     const newChannel = new ChannelType(undefined, {

--- a/packages/core-ethereum/src/channel/index.ts
+++ b/packages/core-ethereum/src/channel/index.ts
@@ -5,6 +5,7 @@ import {
   Balance,
   ChannelBalance,
   Channel as ChannelType,
+  ChannelState,
   Hash,
   Public,
   Signature,
@@ -14,7 +15,16 @@ import {
   TicketEpoch,
   ChannelEntry
 } from '../types'
-import { waitForConfirmation, getId, pubKeyToAccountId, sign, isPartyA, getParties, Log } from '../utils'
+import {
+  waitForConfirmation,
+  getId,
+  pubKeyToAccountId,
+  sign,
+  isPartyA,
+  getParties,
+  Log,
+  stateCounterToStatus
+} from '../utils'
 import { ERRORS } from '../constants'
 import type HoprEthereum from '..'
 import Channel from './channel'
@@ -28,11 +38,6 @@ const WIN_PROB = new BN(1)
 
 class ChannelFactory {
   public tickets: TicketStatic
-  // currently we are expecting the counterparty to send us
-  // the signed channel, this is legacy behaviour that will be
-  // refactored out.
-  // keyed by counterparty's public key
-  private signedChannels = new Map<string, SignedChannel>()
 
   constructor(private coreConnector: HoprEthereum) {
     this.tickets = new TicketStatic(coreConnector)
@@ -43,7 +48,7 @@ class ChannelFactory {
     const { indexer } = this.coreConnector
     const self = new Public(this.coreConnector.account.keys.onChain.pubKey)
 
-    indexer.on('channelOpened', ({ partyA: _partyA, partyB: _partyB }: ChannelUpdate) => {
+    indexer.on('channelOpened', ({ partyA: _partyA, partyB: _partyB, channelEntry }: ChannelUpdate) => {
       const partyA = new Public(_partyA)
       const partyB = new Public(_partyB)
 
@@ -51,7 +56,7 @@ class ChannelFactory {
       const isOurs = partyA.eq(self) || partyB.eq(self)
       if (!isOurs) return
 
-      this.onOpen(isPartyA(self, partyA) ? partyB : partyA)
+      this.onOpen(isPartyA(self, partyA) ? partyB : partyA, channelEntry as ChannelEntry)
     })
 
     indexer.on('channelClosed', ({ partyA: _partyA, partyB: _partyB }: ChannelUpdate) => {
@@ -66,20 +71,29 @@ class ChannelFactory {
     })
   }
 
-  async onOpen(counterparty: Public): Promise<void> {
+  async onOpen(counterparty: Public, channelEntry: ChannelEntry): Promise<void> {
     log('Received open event for channel with %s', counterparty.toHex())
-    const signedChannel = this.signedChannels.get(counterparty.toHex())
 
-    // we did not receive the signed channel
-    if (!signedChannel) {
-      log('signedChannel with %s not found', counterparty.toHex())
-      return
-    }
-    log('Found signedChannel with %s', counterparty.toHex())
+    const balance = new ChannelBalance(undefined, {
+      balance: new BN(10),
+      balance_a: new BN(2)
+    })
+    const state = new ChannelState(undefined, { state: stateCounterToStatus(channelEntry.stateCounter.toNumber()) })
+    const newChannel = new ChannelType(undefined, {
+      state,
+      balance
+    })
 
     // we store it, if we have an previous signed channel
     // under this counterparty, we replace it
-    await this.saveOffChainState(counterparty, signedChannel)
+    await this.saveOffChainState(
+      counterparty,
+      // @ts-ignore
+      new SignedChannel(undefined, {
+        channel: newChannel,
+        counterparty
+      })
+    )
 
     // only delete signedChannel once we store it
     // this.signedChannels.delete(counterparty.toHex())
@@ -252,7 +266,16 @@ class ChannelFactory {
         await this.increaseFunds(counterparty, new Balance(amountToFund.sub(amountFunded)))
       }
 
-      signedChannel = await sign(channelBalance)
+      const state = new ChannelState(undefined, { state: stateCounterToStatus(0) })
+
+      // signedChannel = await sign(channelBalance)
+      signedChannel = new SignedChannel(undefined, {
+        channel: new ChannelType(undefined, {
+          state,
+          balance: channelBalance
+        }),
+        counterparty: new Public(counterpartyPubKey)
+      })
 
       try {
         await waitForConfirmation(
@@ -332,12 +355,6 @@ class ChannelFactory {
           bytes: msg.buffer,
           offset: msg.byteOffset
         })
-
-        const counterparty = new Public(await signedChannel.signer)
-
-        // legacy requirement, to be fixed in refactor
-        this.signedChannels.set(counterparty.toHex(), signedChannel)
-        log('Received signedChannel from %s', counterparty.toHex())
 
         /*
         // Fund both ways

--- a/packages/core-ethereum/src/channel/index.ts
+++ b/packages/core-ethereum/src/channel/index.ts
@@ -93,17 +93,13 @@ class ChannelFactory {
         counterparty
       })
     )
-
-    // only delete signedChannel once we store it
-    // this.signedChannels.delete(counterparty.toHex())
   }
 
   async onClose(counterparty: Public): Promise<void> {
     log('Received close event for channel with %s', counterparty.toHex())
     // we don't know which channel iteration this
     // this signed channel is from so we do nothing
-    // this.signedChannels.delete(counterparty.toHex())
-    // this.deleteOffChainState(counterparty)
+    // await this.deleteOffChainState(counterparty)
   }
 
   async increaseFunds(counterparty: AccountId, amount: Balance): Promise<void> {
@@ -161,6 +157,8 @@ class ChannelFactory {
     if (onChain != offChain) {
       if (!onChain && offChain) {
         log(`Channel ${channelId.toHex()} exists off-chain but not on-chain.`)
+        // we don't know which channel iteration this
+        // this signed channel is from so we do nothing
         // await this.coreConnector.channel.deleteOffChainState(counterpartyPubKey)
       } else {
         throw Error(`Channel ${channelId.toHex()} exists on-chain but not off-chain.`)

--- a/packages/core-ethereum/src/channel/index.ts
+++ b/packages/core-ethereum/src/channel/index.ts
@@ -88,7 +88,6 @@ class ChannelFactory {
     // under this counterparty, we replace it
     await this.saveOffChainState(
       counterparty,
-      // @ts-ignore
       new SignedChannel(undefined, {
         channel: newChannel,
         counterparty

--- a/packages/core-ethereum/src/indexer/index.ts
+++ b/packages/core-ethereum/src/indexer/index.ts
@@ -470,7 +470,7 @@ class Indexer extends EventEmitter implements IIndexer {
   }
 
   public async getRandomChannel(): Promise<RoutingChannel | undefined> {
-    const HACK = 9581300 // Arbitrarily chosen block for our testnet. Total hack.
+    const HACK = 9584221 // Arbitrarily chosen block for our testnet. Total hack.
     const all = await this.getChannelEntries()
     const filtered = all.filter((x) => x.channelEntry.blockNumber.gtn(HACK))
     if (filtered.length === 0) {

--- a/packages/core-ethereum/src/types/signedChannel.spec.ts
+++ b/packages/core-ethereum/src/types/signedChannel.spec.ts
@@ -1,12 +1,14 @@
-import assert from 'assert'
+// import { expect } from 'chai'
 import BN from 'bn.js'
-import { stringToU8a, randomInteger } from '@hoprnet/hopr-utils'
+import chai, { expect } from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import { stringToU8a, u8aToHex } from '@hoprnet/hopr-utils'
 import { Channel, ChannelBalance, ChannelStatus, ChannelState } from './channel'
-import { SignedChannel, Signature, Hash } from '.'
-import * as utils from '../utils'
-import * as testconfigs from '../config.spec'
+// import { Signature, Hash } from '.'
+import Public from './public'
+import SignedChannel from './signedChannel'
 
-const [userA] = testconfigs.DEMO_ACCOUNTS.map((str: string) => stringToU8a(str))
+chai.use(chaiAsPromised)
 
 const generateChannelData = async () => {
   const balance = new ChannelBalance(undefined, {
@@ -21,92 +23,34 @@ const generateChannelData = async () => {
   })
 }
 
-describe('test signedChannel construction', function () {
-  let userAPubKey: Uint8Array
-
-  before(async function () {
-    userAPubKey = await utils.privKeyToPubKey(userA)
-  })
-
+describe('test signedChannel', function () {
   it('should create new signedChannel using struct', async function () {
     const channel = await generateChannelData()
 
-    const signedChannel = new SignedChannel(undefined, {
+    const noCounterparty = new SignedChannel(undefined, {
       channel
     })
-
-    await channel.sign(userA, undefined, {
-      bytes: signedChannel.buffer,
-      offset: signedChannel.signatureOffset
+    const withCounterparty = new SignedChannel(undefined, {
+      channel,
+      counterparty: new Public(stringToU8a('0x03767782fdb4564f0a2dee849d9fc356207dd89f195fcfd69ce0b02c6f03dfda40'))
     })
 
-    assert(await signedChannel.verify(userAPubKey), 'signature must be valid')
-
-    assert(new Hash(await signedChannel.signer).eq(userAPubKey), 'signer incorrect')
-
-    assert(signedChannel.channel.balance.eq(channel.balance), 'wrong balance')
-    assert(new BN(signedChannel.channel._status).eq(new BN(channel._status)), 'wrong status')
-  })
-
-  it('should create new signedChannel using array', async function () {
-    const channel = await generateChannelData()
-
-    const signature = new Signature()
-
-    await channel.sign(userA, undefined, {
-      bytes: signature.buffer,
-      offset: signature.byteOffset
-    })
-
-    const signedChannelA = new SignedChannel(undefined, {
-      signature,
-      channel
-    })
-    const signedChannelB = new SignedChannel({
-      bytes: signedChannelA.buffer,
-      offset: signedChannelA.byteOffset
-    })
-
-    assert(await signedChannelA.verify(userAPubKey), 'signature must be valid')
-    assert(new Hash(await signedChannelA.signer).eq(userAPubKey), 'signer incorrect')
-
-    assert(await signedChannelB.verify(userAPubKey), 'signature must be valid')
-    assert(new Hash(await signedChannelB.signer).eq(userAPubKey), 'signer incorrect')
-
-    assert(signedChannelB.channel.balance.eq(channel.balance), 'wrong balance')
-    assert(new BN(signedChannelB.channel._status).eq(new BN(channel._status)), 'wrong status')
-  })
-
-  it('should create new signedChannel out of continous memory', async function () {
-    const channel = await generateChannelData()
-
-    const signature = new Signature()
-
-    await channel.sign(userA, undefined, {
-      bytes: signature.buffer,
-      offset: signature.byteOffset
-    })
-
-    const offset = randomInteger(1, 31)
-
-    const array = new Uint8Array(SignedChannel.SIZE + offset).fill(0x00)
-
-    const signedChannel = new SignedChannel(
-      {
-        bytes: array.buffer,
-        offset: array.byteOffset + offset
-      },
-      {
-        channel,
-        signature
-      }
+    expect(u8aToHex(await noCounterparty.signer)).to.equal(
+      '0x000000000000000000000000000000000000000000000000000000000000000000'
     )
+    expect(u8aToHex(await withCounterparty.signer)).to.equal(
+      '0x03767782fdb4564f0a2dee849d9fc356207dd89f195fcfd69ce0b02c6f03dfda40'
+    )
+  })
 
-    assert(await signedChannel.verify(userAPubKey), 'signature must be valid')
+  it('should error on verify', async function () {
+    const channel = await generateChannelData()
 
-    assert(new Hash(await signedChannel.signer).eq(userAPubKey), 'signer incorrect')
+    const signedChannel = new SignedChannel(undefined, {
+      channel,
+      counterparty: new Public(stringToU8a('0x03767782fdb4564f0a2dee849d9fc356207dd89f195fcfd69ce0b02c6f03dfda40'))
+    })
 
-    assert(signedChannel.channel.balance.eq(channel.balance), 'wrong balance')
-    assert(new BN(signedChannel.channel._status).eq(new BN(channel._status)), 'wrong status')
+    expect(signedChannel.verify(new Uint8Array())).to.eventually.throw
   })
 })

--- a/packages/core-ethereum/src/types/signedChannel.ts
+++ b/packages/core-ethereum/src/types/signedChannel.ts
@@ -1,12 +1,10 @@
-import secp256k1 from 'secp256k1'
 import type { Types } from '@hoprnet/hopr-core-connector-interface'
 import Signature from './signature'
+import Public from './public'
 import { Channel } from './channel'
 import { Uint8ArrayE } from '../types/extended'
-import { verify } from '../utils'
 
-class SignedChannel extends Uint8ArrayE implements Types.SignedChannel {
-  private _signature?: Signature
+class SignedChannelHack extends Uint8ArrayE implements Types.SignedChannel {
   private _channel?: Channel
 
   constructor(
@@ -15,14 +13,14 @@ class SignedChannel extends Uint8ArrayE implements Types.SignedChannel {
       offset: number
     },
     struct?: {
-      signature?: Signature
+      counterparty?: Public
       channel?: Channel
     }
   ) {
     if (!arr) {
-      super(SignedChannel.SIZE)
+      super(SignedChannelHack.SIZE)
     } else {
-      super(arr.bytes, arr.offset, SignedChannel.SIZE)
+      super(arr.bytes, arr.offset, SignedChannelHack.SIZE)
     }
 
     if (struct) {
@@ -30,17 +28,17 @@ class SignedChannel extends Uint8ArrayE implements Types.SignedChannel {
         this.set(struct.channel.toU8a(), this.channelOffset - this.byteOffset)
       }
 
-      if (struct.signature) {
-        this.set(struct.signature, this.signatureOffset - this.byteOffset)
+      if (struct.counterparty) {
+        this.set(struct.counterparty, this.signatureOffset - this.byteOffset)
       }
     }
   }
 
-  slice(begin = 0, end = SignedChannel.SIZE) {
+  slice(begin = 0, end = SignedChannelHack.SIZE) {
     return this.subarray(begin, end)
   }
 
-  subarray(begin = 0, end = SignedChannel.SIZE): Uint8Array {
+  subarray(begin = 0, end = SignedChannelHack.SIZE): Uint8Array {
     return new Uint8Array(this.buffer, begin + this.byteOffset, end - begin)
   }
 
@@ -49,14 +47,14 @@ class SignedChannel extends Uint8ArrayE implements Types.SignedChannel {
   }
 
   get signature(): Signature {
-    if (!this._signature) {
-      this._signature = new Signature({
-        bytes: this.buffer,
-        offset: this.signatureOffset
-      })
-    }
+    return new Signature(undefined, {
+      signature: new Uint8Array(),
+      recovery: 0
+    })
+  }
 
-    return this._signature
+  get signer(): Promise<Uint8Array> {
+    return Promise.resolve(new Uint8Array(this.buffer, this.signatureOffset, Public.SIZE))
   }
 
   get channelOffset(): number {
@@ -74,18 +72,8 @@ class SignedChannel extends Uint8ArrayE implements Types.SignedChannel {
     return this._channel
   }
 
-  get signer(): Promise<Uint8Array> {
-    return new Promise<Uint8Array>(async (resolve, reject) => {
-      try {
-        resolve(secp256k1.ecdsaRecover(this.signature.signature, this.signature.recovery, await this.channel.hash))
-      } catch (err) {
-        reject(err)
-      }
-    })
-  }
-
-  async verify(publicKey: Uint8Array): Promise<boolean> {
-    return await verify(await this.channel.hash, this.signature, publicKey)
+  async verify(_publicKey: Uint8Array): Promise<boolean> {
+    throw Error('SignedChannelHack does not implement verify')
   }
 
   static get SIZE(): number {
@@ -101,9 +89,9 @@ class SignedChannel extends Uint8ArrayE implements Types.SignedChannel {
       signature?: Signature
       channel?: Channel
     }
-  ): Promise<SignedChannel> {
-    return Promise.resolve(new SignedChannel(arr, struct))
+  ): Promise<SignedChannelHack> {
+    return Promise.resolve(new SignedChannelHack(arr, struct))
   }
 }
 
-export default SignedChannel
+export default SignedChannelHack

--- a/packages/core-ethereum/src/types/signedChannel.ts
+++ b/packages/core-ethereum/src/types/signedChannel.ts
@@ -4,7 +4,7 @@ import Public from './public'
 import { Channel } from './channel'
 import { Uint8ArrayE } from '../types/extended'
 
-class SignedChannelHack extends Uint8ArrayE implements Types.SignedChannel {
+class SignedChannel extends Uint8ArrayE implements Types.SignedChannel {
   private _channel?: Channel
 
   constructor(
@@ -18,9 +18,9 @@ class SignedChannelHack extends Uint8ArrayE implements Types.SignedChannel {
     }
   ) {
     if (!arr) {
-      super(SignedChannelHack.SIZE)
+      super(SignedChannel.SIZE)
     } else {
-      super(arr.bytes, arr.offset, SignedChannelHack.SIZE)
+      super(arr.bytes, arr.offset, SignedChannel.SIZE)
     }
 
     if (struct) {
@@ -34,11 +34,11 @@ class SignedChannelHack extends Uint8ArrayE implements Types.SignedChannel {
     }
   }
 
-  slice(begin = 0, end = SignedChannelHack.SIZE) {
+  slice(begin = 0, end = SignedChannel.SIZE) {
     return this.subarray(begin, end)
   }
 
-  subarray(begin = 0, end = SignedChannelHack.SIZE): Uint8Array {
+  subarray(begin = 0, end = SignedChannel.SIZE): Uint8Array {
     return new Uint8Array(this.buffer, begin + this.byteOffset, end - begin)
   }
 
@@ -73,7 +73,7 @@ class SignedChannelHack extends Uint8ArrayE implements Types.SignedChannel {
   }
 
   async verify(_publicKey: Uint8Array): Promise<boolean> {
-    throw Error('SignedChannelHack does not implement verify')
+    throw Error('SignedChannel does not implement verify')
   }
 
   static get SIZE(): number {
@@ -89,9 +89,9 @@ class SignedChannelHack extends Uint8ArrayE implements Types.SignedChannel {
       signature?: Signature
       channel?: Channel
     }
-  ): Promise<SignedChannelHack> {
-    return Promise.resolve(new SignedChannelHack(arr, struct))
+  ): Promise<SignedChannel> {
+    return Promise.resolve(new SignedChannel(arr, struct))
   }
 }
 
-export default SignedChannelHack
+export default SignedChannel


### PR DESCRIPTION
Fixes #572

We patch `SignedChannel` to include counterparty, this way it doesn't require a signature from the counterparty, this is a short-term fix, we will be removing `SignedChannel` in the refactor.
Removing it now will cause lots of breaking changes throughout the codebase.