### PR TITLE
Reduce hash calls in hashedSecret

### DIFF
--- a/packages/core-ethereum/src/account.ts
+++ b/packages/core-ethereum/src/account.ts
@@ -3,7 +3,7 @@ import type { TransactionObject } from './tsc/web3/types'
 import type { TransactionConfig } from 'web3-core'
 import Web3 from 'web3'
 import { getRpcOptions, Network } from '@hoprnet/hopr-ethereum'
-import { durations, Intermediate, stringToU8a, u8aEquals, u8aToHex } from '@hoprnet/hopr-utils'
+import { durations, stringToU8a, u8aEquals, u8aToHex } from '@hoprnet/hopr-utils'
 import NonceTracker from './nonce-tracker'
 import TransactionManager from './transaction-manager'
 import { AccountId, AcknowledgedTicket, Balance, Hash, NativeBalance, TicketEpoch } from './types'
@@ -70,11 +70,9 @@ class Account {
     this._preImageIterator = async function* (this: Account) {
       let ticket: AcknowledgedTicket = yield
 
-      let currentPreImage: Promise<Intermediate> = this.coreConnector.hashedSecret.findPreImage(
+      let tmp = await this.coreConnector.hashedSecret.findPreImage(
         await this.onChainSecret
       )
-
-      let tmp: Intermediate = await currentPreImage
 
       while (true) {
         if (
@@ -85,10 +83,7 @@ class Account {
             (await ticket.signedTicket).ticket.winProb
           )
         ) {
-          currentPreImage = this.coreConnector.hashedSecret.findPreImage(tmp.preImage)
-
           ticket.preImage = new Hash(tmp.preImage)
-
           if (tmp.iteration == 0) {
             // @TODO dispatch call of next hashedSecret submit
             return true
@@ -96,7 +91,7 @@ class Account {
             yield true
           }
 
-          tmp = await currentPreImage
+          tmp = await this.coreConnector.hashedSecret.findPreImage(tmp.preImage) 
         } else {
           yield false
         }

--- a/packages/core-ethereum/src/hashedSecret.spec.ts
+++ b/packages/core-ethereum/src/hashedSecret.spec.ts
@@ -16,6 +16,7 @@ import * as testconfigs from './config.spec'
 import * as configs from './config'
 import Account from './account'
 import { randomBytes } from 'crypto'
+import { hash as hashFunction } from './utils'
 
 const HoprChannelsAbi = abis.HoprChannels
 
@@ -119,7 +120,7 @@ describe('test hashedSecret', function () {
 
       assert(
         u8aEquals(
-          (await connector.hashedSecret.hashFunction(preImage.preImage)).slice(0, HASHED_SECRET_WIDTH),
+          (await hashFunction(preImage.preImage)).slice(0, HASHED_SECRET_WIDTH),
           onChainHash
         )
       )
@@ -149,7 +150,7 @@ describe('test hashedSecret', function () {
 
       assert(
         u8aEquals(
-          (await connector.hashedSecret.hashFunction(updatedPreImage.preImage)).slice(0, HASHED_SECRET_WIDTH),
+          (await hashFunction(updatedPreImage.preImage)).slice(0, HASHED_SECRET_WIDTH),
           updatedOnChainHash
         )
       )
@@ -211,7 +212,7 @@ describe('test hashedSecret', function () {
 
       assert(
         u8aEquals(
-          (await connector.hashedSecret.hashFunction(preImage.preImage)).slice(0, HASHED_SECRET_WIDTH),
+          (await hashFunction(preImage.preImage)).slice(0, HASHED_SECRET_WIDTH),
           onChainHash
         )
       )
@@ -242,7 +243,7 @@ describe('test hashedSecret', function () {
 
       assert(
         u8aEquals(
-          (await connector.hashedSecret.hashFunction(updatedPreImage.preImage)).slice(0, HASHED_SECRET_WIDTH),
+          (await hashFunction(updatedPreImage.preImage)).slice(0, HASHED_SECRET_WIDTH),
           updatedOnChainHash
         )
       )
@@ -280,7 +281,7 @@ describe('test hashedSecret', function () {
           secondPreImage != null &&
           !firstPreImage.eq(secondPreImage) &&
           u8aEquals(
-            (await connector.hashedSecret.hashFunction(secondPreImage)).slice(0, HASHED_SECRET_WIDTH),
+            (await hashFunction(secondPreImage)).slice(0, HASHED_SECRET_WIDTH),
             firstPreImage
           )
       )
@@ -309,7 +310,7 @@ describe('test hashedSecret', function () {
         fourthPreImage != null &&
           !fourthPreImage.eq(secondPreImage) &&
           u8aEquals(
-            (await connector.hashedSecret.hashFunction(fourthPreImage)).slice(0, HASHED_SECRET_WIDTH),
+            (await hashFunction(fourthPreImage)).slice(0, HASHED_SECRET_WIDTH),
             secondPreImage
           )
       )
@@ -344,59 +345,6 @@ describe('test hashedSecret', function () {
           )
         }
       }
-    })
-  })
-
-  describe('integration', function () {
-    this.timeout(durations.minutes(2))
-
-    before(async function () {
-      this.timeout(durations.minutes(1))
-      await ganache.start()
-      await migrate()
-      await fund(FUND_ARGS)
-
-      connector = await generateConnector()
-    })
-
-    after(async function () {
-      await connector.stop()
-      await ganache.stop()
-    })
-
-    it('should initialize hashedSecret', async function () {
-      assert(!(await connector.hashedSecret.check()).initialized, "hashedSecret shouldn't be initialized")
-
-      await connector.hashedSecret.initialize()
-      assert((await connector.hashedSecret.check()).initialized, 'hashedSecret should be initialized')
-    })
-
-    it('should already be initialized', async function () {
-      await connector.hashedSecret.initialize()
-      assert((await connector.hashedSecret.check()).initialized, 'hashedSecret should be initialized')
-    })
-
-    it('should reinitialize hashedSecret when off-chain secret is missing', async function () {
-      connector.db = LevelUp(Memdown())
-
-      await connector.hashedSecret.initialize()
-      assert((await connector.hashedSecret.check()).initialized, 'hashedSecret should be initialized')
-    })
-
-    it('should submit hashedSecret when on-chain secret is missing', async function () {
-      this.timeout(durations.minutes(2))
-      const db = connector.db
-
-      await ganache.stop()
-      await ganache.start()
-      await migrate()
-      await fund(FUND_ARGS)
-
-      connector = await generateConnector()
-      connector.db = db
-
-      await connector.hashedSecret.initialize()
-      assert((await connector.hashedSecret.check()).initialized, 'hashedSecret should be initialized')
     })
   })
 })

--- a/packages/core-ethereum/src/hashedSecret.spec.ts
+++ b/packages/core-ethereum/src/hashedSecret.spec.ts
@@ -53,7 +53,7 @@ describe('test hashedSecret', function () {
       chainId
     )
 
-    connector.hashedSecret = new PreImage(connector)
+    connector.hashedSecret = new PreImage(connector.db, connector.account, connector.hoprChannels)
 
     connector.stop = async () => {
       await connector.account.stop()

--- a/packages/core-ethereum/src/hashedSecret.ts
+++ b/packages/core-ethereum/src/hashedSecret.ts
@@ -21,7 +21,6 @@ export async function hashFunction(msg: Uint8Array): Promise<Uint8Array> {
   return (await hashFunctionUtils(msg)).slice(0, HASHED_SECRET_WIDTH)
 }
 
-
 async function getFromDB<T>(db: LevelUp, key): Promise<T | undefined> {
   try {
     return await db.get(Buffer.from(key))
@@ -145,7 +144,7 @@ class HashedSecret {
       hashFunction,
       TOTAL_ITERATIONS,
       DB_ITERATION_BLOCK_SIZE,
-      (index) => getFromDB(this.db, OnChainSecretIntermediary(index)),
+      (index) => getFromDB(this.db, OnChainSecretIntermediary(index))
     )
 
     if (result == undefined) {

--- a/packages/core-ethereum/src/hashedSecret.ts
+++ b/packages/core-ethereum/src/hashedSecret.ts
@@ -161,7 +161,7 @@ class HashedSecret {
     )
 
     if (result == undefined) {
-      return await this.createAndStoreSecretOffChain(debug)
+      return await this.createAndStoreSecretOffChainAndReturnOnChainSecret(debug)
     }
 
     return new Hash(result.hash)

--- a/packages/core-ethereum/src/hashedSecret.ts
+++ b/packages/core-ethereum/src/hashedSecret.ts
@@ -44,7 +44,9 @@ class HashedSecret {
    */
   private async getDebugAccountSecret(): Promise<Hash> {
     const account = await this.channels.methods.accounts((await this.account.address).toHex()).call()
-    return new Hash(await hashFunction(u8aConcat(new Uint8Array([parseInt(account.counter)]), this.account.keys.onChain.pubKey)))
+    return new Hash(
+      await hashFunction(u8aConcat(new Uint8Array([parseInt(account.counter)]), this.account.keys.onChain.pubKey))
+    )
   }
 
   /**

--- a/packages/core-ethereum/src/hashedSecret.ts
+++ b/packages/core-ethereum/src/hashedSecret.ts
@@ -202,12 +202,8 @@ class HashedSecret {
     return result
   }
 
-  /**
-   * Initializes hashedSecret.
-   */
   public async initialize(debug?: boolean): Promise<void> {
     if (this.initialized) return
-
     this.offChainSecret = await this.getOffChainSecret()
     this.onChainSecret = await this.account.onChainSecret
     if (this.onChainSecret != undefined && this.offChainSecret != undefined) {

--- a/packages/core-ethereum/src/index.ts
+++ b/packages/core-ethereum/src/index.ts
@@ -48,12 +48,12 @@ export default class HoprEthereum implements HoprCoreConnector {
     publicKey: Uint8Array,
     maxConfirmations: number
   ) {
-    this.hashedSecret = new HashedSecret(this)
     this.account = new Account(this, privateKey, publicKey, chainId)
     this.indexer = new Indexer(this, maxConfirmations)
     this.types = new types()
     this.channel = new ChannelFactory(this)
     this._debug = debug
+    this.hashedSecret = new HashedSecret(this.db, this.account, this.hoprChannels)
   }
 
   readonly dbKeys = dbkeys


### PR DESCRIPTION
Fixes #1202

Because hashedSecret wasn't actually an instance, and reloaded values
every time it was `check()`ed, `findPreImage` was called whenever we
initialized, which was incorrectly assumed to be a no-op.

In core we use initialize to try and initialize on each tick, so we
initialize as soon as possible, therefore findPreImage was being called
repeatedly.

Instead of simply hacking this init call, this PR refactors hashedSecret
to actually store information in it's instance.