### PR TITLE
Simplify signing

### DIFF
--- a/packages/core-connector-interface/src/types/ticket.d.ts
+++ b/packages/core-connector-interface/src/types/ticket.d.ts
@@ -37,14 +37,7 @@ declare interface Ticket {
 
   toU8a(): Uint8Array
 
-  sign(
-    privKey: Uint8Array,
-    pubKey: Uint8Array | undefined,
-    arr?: {
-      bytes: ArrayBuffer
-      offset: number
-    }
-  ): Promise<Signature>
+  sign(privKey: Uint8Array): Promise<Signature>
 }
 
 declare var Ticket: TicketStatic

--- a/packages/core-connector-interface/src/utils.d.ts
+++ b/packages/core-connector-interface/src/utils.d.ts
@@ -34,10 +34,7 @@ export declare function hash(msg: Uint8Array): Promise<Hash>
  * @param privKey private key of the signer
  * @param pubKey public key of the signer
  */
-export declare function sign(
-  msg: Uint8Array,
-  privKey: Uint8Array
-): Promise<Signature>
+export declare function sign(msg: Uint8Array, privKey: Uint8Array): Promise<Signature>
 
 /**
  * Uses the native on-chain signature scheme to check a signature for its validity.

--- a/packages/core-connector-interface/src/utils.d.ts
+++ b/packages/core-connector-interface/src/utils.d.ts
@@ -33,16 +33,10 @@ export declare function hash(msg: Uint8Array): Promise<Hash>
  * @param msg message to sign
  * @param privKey private key of the signer
  * @param pubKey public key of the signer
- * @param arr optional memory for the signature
  */
 export declare function sign(
   msg: Uint8Array,
-  privKey: Uint8Array,
-  pubKey: Uint8Array | undefined,
-  arr?: {
-    bytes: ArrayBuffer
-    offset: number
-  }
+  privKey: Uint8Array
 ): Promise<Signature>
 
 /**

--- a/packages/core-connector-interface/src/utils.d.ts
+++ b/packages/core-connector-interface/src/utils.d.ts
@@ -32,7 +32,6 @@ export declare function hash(msg: Uint8Array): Promise<Hash>
  * Uses the native on-chain signature scheme to create an on-chain verifiable signature.
  * @param msg message to sign
  * @param privKey private key of the signer
- * @param pubKey public key of the signer
  */
 export declare function sign(msg: Uint8Array, privKey: Uint8Array): Promise<Signature>
 

--- a/packages/core-ethereum/src/channel/index.ts
+++ b/packages/core-ethereum/src/channel/index.ts
@@ -203,11 +203,8 @@ class ChannelFactory {
       }
     )
 
-    await sign(await ticket.hash, this.coreConnector.account.keys.onChain.privKey, undefined, {
-      bytes: signedTicket.buffer,
-      offset: signedTicket.signatureOffset
-    })
-
+    const signature = await sign(await ticket.hash, this.coreConnector.account.keys.onChain.privKey)
+    signedTicket.set(signature, signedTicket.signatureOffset - signedTicket.byteOffset)
     return signedTicket
   }
 
@@ -224,10 +221,8 @@ class ChannelFactory {
     const signedChannel = new SignedChannel(arr, struct)
 
     if (signedChannel.signature.eq(EMPTY_SIGNATURE)) {
-      await signedChannel.channel.sign(this.coreConnector.account.keys.onChain.privKey, undefined, {
-        bytes: signedChannel.buffer,
-        offset: signedChannel.signatureOffset
-      })
+      const signature = await signedChannel.channel.sign(this.coreConnector.account.keys.onChain.privKey)
+      signedChannel.set(signature, signedChannel.signatureOffset - signedChannel.byteOffset)
     }
 
     return signedChannel

--- a/packages/core-ethereum/src/channel/ticket.ts
+++ b/packages/core-ethereum/src/channel/ticket.ts
@@ -157,10 +157,8 @@ class TicketFactory {
       }
     )
 
-    await ticket.sign(this.channel.coreConnector.account.keys.onChain.privKey, undefined, {
-      bytes: signedTicket.buffer,
-      offset: signedTicket.signatureOffset
-    })
+    const signature = await ticket.sign(this.channel.coreConnector.account.keys.onChain.privKey)
+    signedTicket.set(signature, signedTicket.signatureOffset - signedTicket.byteOffset)
 
     return signedTicket
   }

--- a/packages/core-ethereum/src/types/channel/index.ts
+++ b/packages/core-ethereum/src/types/channel/index.ts
@@ -86,9 +86,7 @@ class Channel extends Uint8ArrayE implements Types.Channel {
     return hash(this)
   }
 
-  async sign(
-    privKey: Uint8Array
-  ): Promise<Types.Signature> {
+  async sign(privKey: Uint8Array): Promise<Types.Signature> {
     return await sign(await this.hash, privKey)
   }
 

--- a/packages/core-ethereum/src/types/channel/index.ts
+++ b/packages/core-ethereum/src/types/channel/index.ts
@@ -87,14 +87,9 @@ class Channel extends Uint8ArrayE implements Types.Channel {
   }
 
   async sign(
-    privKey: Uint8Array,
-    _pubKey: Uint8Array | undefined,
-    arr?: {
-      bytes: ArrayBuffer
-      offset: number
-    }
+    privKey: Uint8Array
   ): Promise<Types.Signature> {
-    return await sign(await this.hash, privKey, undefined, arr)
+    return await sign(await this.hash, privKey)
   }
 
   get isFunded(): boolean {

--- a/packages/core-ethereum/src/types/signedTicket.spec.ts
+++ b/packages/core-ethereum/src/types/signedTicket.spec.ts
@@ -45,10 +45,7 @@ describe('test signedTicket construction', async function () {
 
     const signature = new Signature()
 
-    await ticket.sign(userAPrivKey, undefined, {
-      bytes: signature.buffer,
-      offset: signature.byteOffset
-    })
+    await ticket.sign(userAPrivKey)
 
     const signedTicket = new SignedTicket(undefined, {
       signature,
@@ -85,10 +82,7 @@ describe('test signedTicket construction', async function () {
       ticket
     })
 
-    ticket.sign(userAPrivKey, undefined, {
-      bytes: signedTicketA.buffer,
-      offset: signedTicketA.signatureOffset
-    })
+    ticket.sign(userAPrivKey)
 
     assert(await signedTicketA.verify(userAPubKey))
 
@@ -136,10 +130,7 @@ describe('test signedTicket construction', async function () {
 
     const signature = new Signature()
 
-    await ticket.sign(userAPrivKey, undefined, {
-      bytes: signature.buffer,
-      offset: signature.byteOffset
-    })
+    await ticket.sign(userAPrivKey)
 
     const offset = randomInteger(1, 31)
 

--- a/packages/core-ethereum/src/types/signedTicket.spec.ts
+++ b/packages/core-ethereum/src/types/signedTicket.spec.ts
@@ -2,7 +2,7 @@ import assert from 'assert'
 import { randomBytes } from 'crypto'
 import { stringToU8a, randomInteger, u8aToHex } from '@hoprnet/hopr-utils'
 import BN from 'bn.js'
-import { AccountId, Ticket, Hash, TicketEpoch, Balance, Signature, SignedTicket } from '.'
+import { AccountId, Ticket, Hash, TicketEpoch, Balance, SignedTicket } from '.'
 import { pubKeyToAccountId, privKeyToPubKey } from '../utils'
 import * as testconfigs from '../config.spec'
 
@@ -43,9 +43,7 @@ describe('test signedTicket construction', async function () {
 
     const ticket = new Ticket(undefined, ticketData)
 
-    const signature = new Signature()
-
-    await ticket.sign(userAPrivKey)
+    const signature = await ticket.sign(userAPrivKey)
 
     const signedTicket = new SignedTicket(undefined, {
       signature,
@@ -82,7 +80,8 @@ describe('test signedTicket construction', async function () {
       ticket
     })
 
-    ticket.sign(userAPrivKey)
+    const signature = await ticket.sign(userAPrivKey)
+    signedTicketA.set(signature, signedTicketA.signatureOffset - signedTicketA.byteOffset)
 
     assert(await signedTicketA.verify(userAPubKey))
 
@@ -128,9 +127,7 @@ describe('test signedTicket construction', async function () {
 
     const ticket = new Ticket(undefined, ticketData)
 
-    const signature = new Signature()
-
-    await ticket.sign(userAPrivKey)
+    const signature = await ticket.sign(userAPrivKey)
 
     const offset = randomInteger(1, 31)
 

--- a/packages/core-ethereum/src/types/ticket.ts
+++ b/packages/core-ethereum/src/types/ticket.ts
@@ -128,9 +128,7 @@ class Ticket extends Uint8ArrayE implements Types.Ticket {
     return new Balance(this.amount.mul(new BN(this.winProb)).div(new BN(new Uint8Array(Hash.SIZE).fill(0xff))))
   }
 
-  async sign(
-    privKey: Uint8Array
-  ): Promise<Signature> {
+  async sign(privKey: Uint8Array): Promise<Signature> {
     return sign(await this.hash, privKey)
   }
 

--- a/packages/core-ethereum/src/types/ticket.ts
+++ b/packages/core-ethereum/src/types/ticket.ts
@@ -129,14 +129,9 @@ class Ticket extends Uint8ArrayE implements Types.Ticket {
   }
 
   async sign(
-    privKey: Uint8Array,
-    _pubKey: Uint8Array | undefined,
-    arr?: {
-      bytes: ArrayBuffer
-      offset: number
-    }
+    privKey: Uint8Array
   ): Promise<Signature> {
-    return sign(await this.hash, privKey, undefined, arr)
+    return sign(await this.hash, privKey)
   }
 
   static create(

--- a/packages/core-ethereum/src/utils/index.ts
+++ b/packages/core-ethereum/src/utils/index.ts
@@ -108,11 +108,6 @@ export async function hash(msg: Uint8Array): Promise<Hash> {
 export async function sign(
   msg: Uint8Array,
   privKey: Uint8Array,
-  _pubKey?: Uint8Array,
-  arr?: {
-    bytes: ArrayBuffer
-    offset: number
-  }
 ): Promise<Signature> {
   if (privKey.length != constants.PRIVATE_KEY_LENGTH) {
     throw Error(
@@ -120,13 +115,10 @@ export async function sign(
     )
   }
   const result = ecdsaSign(msg, privKey)
-
-  const response = new Signature(arr, {
+  return new Signature(null, {
     signature: result.signature,
     recovery: result.recid
   })
-
-  return response
 }
 
 /**

--- a/packages/core-ethereum/src/utils/index.ts
+++ b/packages/core-ethereum/src/utils/index.ts
@@ -105,10 +105,7 @@ export async function hash(msg: Uint8Array): Promise<Hash> {
  * @param arr
  * @returns a promise resolved to Hash
  */
-export async function sign(
-  msg: Uint8Array,
-  privKey: Uint8Array,
-): Promise<Signature> {
+export async function sign(msg: Uint8Array, privKey: Uint8Array): Promise<Signature> {
   if (privKey.length != constants.PRIVATE_KEY_LENGTH) {
     throw Error(
       `Invalid privKey argument. Expected a Uint8Array with ${constants.PRIVATE_KEY_LENGTH} elements but got one with ${privKey.length}.`

--- a/packages/core/src/messages/acknowledgement/index.ts
+++ b/packages/core/src/messages/acknowledgement/index.ts
@@ -146,11 +146,8 @@ class Acknowledgement<Chain extends HoprCoreConnector> extends Uint8Array {
   }
 
   async sign(peerId: PeerId): Promise<Acknowledgement<Chain>> {
-    await this.paymentChannels.utils.sign(await this.hash, peerId.privKey.marshal(), peerId.pubKey.marshal(), {
-      bytes: this.buffer,
-      offset: this.responseSignatureOffset
-    })
-
+    const signature = await this.paymentChannels.utils.sign(await this.hash, peerId.privKey.marshal())
+    this.set(signature, this.responseSignatureOffset - this.byteOffset)
     return this
   }
 

--- a/packages/core/src/messages/packet/challenge.ts
+++ b/packages/core/src/messages/packet/challenge.ts
@@ -131,12 +131,8 @@ class Challenge<Chain extends HoprCoreConnector> extends Uint8Array {
    * @param peerId that contains private key and public key of the node
    */
   async sign(peerId: PeerId): Promise<Challenge<Chain>> {
-    // const hashedChallenge = hash(Buffer.concat([this._hashedKey, this._fee.toBuffer('be', VALUE_LENGTH)], HASH_LENGTH + VALUE_LENGTH))
-    await this.paymentChannels.utils.sign(this.hash, peerId.privKey.marshal(), peerId.pubKey.marshal(), {
-      bytes: this.buffer,
-      offset: this.challengeSignatureOffset
-    })
-
+    const signature = await this.paymentChannels.utils.sign(this.hash, peerId.privKey.marshal())
+    this.set(signature, this.challengeSignatureOffset - this.byteOffset)
     return this
   }
 

--- a/packages/core/src/messages/ticket/index.spec.ts
+++ b/packages/core/src/messages/ticket/index.spec.ts
@@ -67,10 +67,8 @@ describe(`check serialization and deserialization of ticket objects`, function (
       }
     )
 
-    await ticket.sign(peerA.privKey.marshal(), undefined, {
-      bytes: signedTicket.buffer,
-      offset: signedTicket.signatureOffset
-    })
+    const signature = await ticket.sign(peerA.privKey.marshal())
+    signedTicket.set(signature, signedTicket.signatureOffset - signedTicket.byteOffset )
 
     assert(await unAcknowledgedTicket.verifySignature(peerA), 'signature must be valid')
 

--- a/packages/core/src/messages/ticket/index.spec.ts
+++ b/packages/core/src/messages/ticket/index.spec.ts
@@ -68,7 +68,7 @@ describe(`check serialization and deserialization of ticket objects`, function (
     )
 
     const signature = await ticket.sign(peerA.privKey.marshal())
-    signedTicket.set(signature, signedTicket.signatureOffset - signedTicket.byteOffset )
+    signedTicket.set(signature, signedTicket.signatureOffset - signedTicket.byteOffset)
 
     assert(await unAcknowledgedTicket.verifySignature(peerA), 'signature must be valid')
 


### PR DESCRIPTION
Part of overall refactoring.

- Remove side effects of signature function
- Make explicit where we are mutating array buffers.