### PR TITLE
gitpod: add possibility to install additional tools like tmux and vim

### DIFF
--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -1,0 +1,15 @@
+FROM gitpod/workspace-full
+
+# Switch to the root user to install system wide tools
+USER root
+
+# Install packages is a script provided by the base gitpod image
+# Ref: https://github.com/gitpod-io/workspace-images/tree/master/base
+RUN sudo install-packages \
+      tmux \
+      neovim
+
+# Switch to the gitpod user to install user specific tools
+USER gitpod
+RUN curl -so "$HOME/.tmux.conf" https://raw.githubusercontent.com/gpakosz/.tmux/master/.tmux.conf && \
+    curl -so "$HOME/.tmux.conf.local" https://raw.githubusercontent.com/gpakosz/.tmux/master/.tmux.conf.local

--- a/.gitpod.dockerfile
+++ b/.gitpod.dockerfile
@@ -5,7 +5,7 @@ USER root
 
 # Install packages is a script provided by the base gitpod image
 # Ref: https://github.com/gitpod-io/workspace-images/tree/master/base
-RUN sudo install-packages \
+RUN install-packages \
       tmux \
       neovim
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,8 @@
+image:
+  file: .gitpod.dockerfile
+
 tasks:
-  - init: yarn && yarn setup
+  - init: yarn && yarn build
 
 ports:
   - port: 3000-9095


### PR DESCRIPTION
Solves https://github.com/hoprnet/hoprnet/issues/1500

- Added the `gitpod.dockerfile` so that we can extend the gitpod workspace image with custom tooling.
- Added `tmux` and `nvim` to the tool chain
- Ran `yarn build` instead of `yarn setup`


Small note regarding the Dockerfile:

I did choose to use the USER switching on the Dockerfile instead of calling "sudo", so that it's more readable and we know exactly which user is executing given commands. This comes with the downside that we're adding more layers to the docker image but this isn't a problem on development images IMO. Gitpod themselves do the same thing on their base images:  https://github.com/gitpod-io/workspace-images/tree/master/base & https://github.com/gitpod-io/workspace-images/tree/master/full