### PR TITLE
Adding initial report from Snyk

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,340 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.19.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-ADMZIP-1065796:
+    - adm-zip:
+        reason: None given
+        expires: '2021-05-29T15:25:25.674Z'
+    - hardhat > adm-zip:
+        reason: None given
+        expires: '2021-05-29T15:25:25.674Z'
+  SNYK-JS-BROWSERSLIST-1090194:
+    - '@hoprnet/hoprd > next > browserslist':
+        reason: None given
+        expires: '2021-05-29T15:25:25.674Z'
+  SNYK-JS-COLORSTRING-1082939:
+    - '@hoprnet/hoprd > jazzicon > color > color-string':
+        reason: None given
+        expires: '2021-05-29T15:25:25.674Z'
+  SNYK-JS-ELLIPTIC-1064899:
+    - '@truffle/interface-adapter > ethers > elliptic':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - eth-gas-reporter > ethers > elliptic:
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - ganache-cli > ethereumjs-util > elliptic:
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - '@truffle/provider > @truffle/interface-adapter > ethers > elliptic':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - hardhat-gas-reporter > eth-gas-reporter > ethers > elliptic:
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - solidity-coverage > ganache-cli > ethereumjs-util > elliptic:
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - solidity-coverage > @truffle/provider > @truffle/interface-adapter > ethers > elliptic:
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - ganache-cli > ethereumjs-util > ethereum-cryptography > secp256k1 > elliptic:
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - solidity-coverage > ganache-cli > ethereumjs-util > ethereum-cryptography > secp256k1 > elliptic:
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+  SNYK-JS-LODASH-1018905:
+    - '@ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > lodash':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - ethereum-waffle > @ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > lodash:
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+  SNYK-JS-LODASH-1040724:
+    - '@ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > lodash':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - ethereum-waffle > @ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > lodash:
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+  SNYK-JS-LODASHTEMPLATE-1088054:
+    - rewiremock > lodash.template:
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - lerna > @lerna/publish > @lerna/version > @lerna/conventional-commits > lodash.template:
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+  SNYK-JS-NODEFETCH-674311:
+    - '@ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3-provider-engine > cross-fetch > node-fetch':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - ethereum-waffle > @ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3-provider-engine > cross-fetch > node-fetch:
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - '@ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3-provider-engine > eth-json-rpc-infura > eth-json-rpc-middleware > fetch-ponyfill > node-fetch':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - ethereum-waffle > @ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3-provider-engine > eth-json-rpc-infura > eth-json-rpc-middleware > fetch-ponyfill > node-fetch:
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+  SNYK-JS-NODEFORGE-598677:
+    - '@hoprnet/hopr-connect > @hoprnet/hopr-utils > libp2p-crypto > node-forge':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - '@hoprnet/hopr-core > @hoprnet/hopr-connect > @hoprnet/hopr-utils > libp2p-crypto > node-forge':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - '@hoprnet/hoprd > @hoprnet/hopr-core > @hoprnet/hopr-connect > @hoprnet/hopr-utils > libp2p-crypto > node-forge':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+  SNYK-JS-OPENZEPPELINCONTRACTS-1065254:
+    - '@openzeppelin/contracts':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+  SNYK-JS-UNDERSCORE-1080984:
+    - '@ensdomains/ens > web3-utils > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - '@truffle/interface-adapter > web3 > web3-bzz > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - '@truffle/interface-adapter > web3 > web3-eth > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - '@truffle/provider > @truffle/interface-adapter > web3 > web3-bzz > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - '@truffle/interface-adapter > web3 > web3-core > web3-core-helpers > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - '@truffle/interface-adapter > web3 > web3-core > web3-core-method > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - '@truffle/interface-adapter > web3 > web3-core > web3-core-requestmanager > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - '@truffle/interface-adapter > web3 > web3-eth > web3-eth-abi > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - '@truffle/interface-adapter > web3 > web3-eth > web3-eth-accounts > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - '@truffle/interface-adapter > web3 > web3-eth > web3-eth-contract > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - '@truffle/interface-adapter > web3 > web3-eth > web3-eth-ens > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - '@truffle/provider > @truffle/interface-adapter > web3 > web3-eth > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - '@ethereum-waffle/chai > @ethereum-waffle/provider > @ethereum-waffle/ens > @ensdomains/ens > web3-utils > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - '@ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-bzz > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - '@ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-eth > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - solidity-coverage > @truffle/provider > @truffle/interface-adapter > web3 > web3-bzz > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - '@truffle/provider > @truffle/interface-adapter > web3 > web3-core > web3-core-helpers > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - '@truffle/interface-adapter > web3 > web3-core > web3-core-method > web3-core-subscriptions > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - '@truffle/provider > @truffle/interface-adapter > web3 > web3-core > web3-core-method > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.675Z'
+    - '@truffle/interface-adapter > web3 > web3-core > web3-core-requestmanager > web3-providers-ipc > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.676Z'
+    - '@truffle/interface-adapter > web3 > web3-core > web3-core-requestmanager > web3-providers-ws > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.676Z'
+    - '@truffle/provider > @truffle/interface-adapter > web3 > web3-core > web3-core-requestmanager > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.676Z'
+    - '@truffle/provider > @truffle/interface-adapter > web3 > web3-eth > web3-eth-abi > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.676Z'
+    - '@truffle/provider > @truffle/interface-adapter > web3 > web3-eth > web3-eth-accounts > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.676Z'
+    - '@truffle/provider > @truffle/interface-adapter > web3 > web3-eth > web3-eth-contract > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.676Z'
+    - '@truffle/provider > @truffle/interface-adapter > web3 > web3-eth > web3-eth-ens > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.676Z'
+    - solidity-coverage > @truffle/provider > @truffle/interface-adapter > web3 > web3-eth > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.676Z'
+    - ethereum-waffle > @ethereum-waffle/chai > @ethereum-waffle/provider > @ethereum-waffle/ens > @ensdomains/ens > web3-utils > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.676Z'
+    - '@truffle/interface-adapter > web3 > web3-core > web3-core-helpers > web3-eth-iban > web3-utils > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.676Z'
+    - ethereum-waffle > @ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-bzz > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.676Z'
+    - '@ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-core > web3-core-helpers > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.677Z'
+    - '@ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-core > web3-core-method > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.677Z'
+    - '@ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-core > web3-core-requestmanager > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.677Z'
+    - '@ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-eth > web3-eth-abi > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.677Z'
+    - '@ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-eth > web3-eth-accounts > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.677Z'
+    - '@ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-eth > web3-eth-contract > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.677Z'
+    - '@ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-eth > web3-eth-ens > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.677Z'
+    - ethereum-waffle > @ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-eth > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.677Z'
+    - solidity-coverage > @truffle/provider > @truffle/interface-adapter > web3 > web3-core > web3-core-helpers > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.677Z'
+    - '@truffle/provider > @truffle/interface-adapter > web3 > web3-core > web3-core-method > web3-core-subscriptions > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.677Z'
+    - solidity-coverage > @truffle/provider > @truffle/interface-adapter > web3 > web3-core > web3-core-method > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.677Z'
+    - '@truffle/provider > @truffle/interface-adapter > web3 > web3-core > web3-core-requestmanager > web3-providers-ipc > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.677Z'
+    - '@truffle/provider > @truffle/interface-adapter > web3 > web3-core > web3-core-requestmanager > web3-providers-ws > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.677Z'
+    - solidity-coverage > @truffle/provider > @truffle/interface-adapter > web3 > web3-core > web3-core-requestmanager > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.677Z'
+    - solidity-coverage > @truffle/provider > @truffle/interface-adapter > web3 > web3-eth > web3-eth-abi > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.677Z'
+    - solidity-coverage > @truffle/provider > @truffle/interface-adapter > web3 > web3-eth > web3-eth-accounts > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.677Z'
+    - solidity-coverage > @truffle/provider > @truffle/interface-adapter > web3 > web3-eth > web3-eth-contract > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.677Z'
+    - solidity-coverage > @truffle/provider > @truffle/interface-adapter > web3 > web3-eth > web3-eth-ens > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.677Z'
+    - '@truffle/provider > @truffle/interface-adapter > web3 > web3-core > web3-core-helpers > web3-eth-iban > web3-utils > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.677Z'
+    - ethereum-waffle > @ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-core > web3-core-helpers > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.677Z'
+    - '@ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-core > web3-core-method > web3-core-subscriptions > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.677Z'
+    - ethereum-waffle > @ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-core > web3-core-method > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.677Z'
+    - '@ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-core > web3-core-requestmanager > web3-providers-ipc > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - '@ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-core > web3-core-requestmanager > web3-providers-ws > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - ethereum-waffle > @ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-core > web3-core-requestmanager > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - ethereum-waffle > @ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-eth > web3-eth-abi > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - ethereum-waffle > @ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-eth > web3-eth-accounts > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - ethereum-waffle > @ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-eth > web3-eth-contract > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - ethereum-waffle > @ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-eth > web3-eth-ens > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - solidity-coverage > @truffle/provider > @truffle/interface-adapter > web3 > web3-core > web3-core-method > web3-core-subscriptions > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - solidity-coverage > @truffle/provider > @truffle/interface-adapter > web3 > web3-core > web3-core-requestmanager > web3-providers-ipc > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - solidity-coverage > @truffle/provider > @truffle/interface-adapter > web3 > web3-core > web3-core-requestmanager > web3-providers-ws > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - solidity-coverage > @truffle/provider > @truffle/interface-adapter > web3 > web3-core > web3-core-helpers > web3-eth-iban > web3-utils > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - '@ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-core > web3-core-helpers > web3-eth-iban > web3-utils > underscore':
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - ethereum-waffle > @ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-core > web3-core-method > web3-core-subscriptions > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - ethereum-waffle > @ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-core > web3-core-requestmanager > web3-providers-ipc > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - ethereum-waffle > @ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-core > web3-core-requestmanager > web3-providers-ws > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - ethereum-waffle > @ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3 > web3-core > web3-core-helpers > web3-eth-iban > web3-utils > underscore:
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+  SNYK-JS-WEB3-174533:
+    - '@ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3':
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - ethereum-waffle > @ethereum-waffle/chai > @ethereum-waffle/provider > ganache-core > web3:
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - '@truffle/interface-adapter > web3':
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - '@truffle/provider > web3':
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - '@truffle/provider > @truffle/interface-adapter > web3':
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - solidity-coverage > @truffle/provider > web3:
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - solidity-coverage > @truffle/provider > @truffle/interface-adapter > web3:
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+  SNYK-JS-Y18N-1021887:
+    - ganache-cli > yargs > y18n:
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - solidity-coverage > ganache-cli > yargs > y18n:
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+  SNYK-JS-YARGSPARSER-560381:
+    - '@ensdomains/ens > solc > yargs > yargs-parser':
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - '@ethereum-waffle/chai > @ethereum-waffle/provider > @ethereum-waffle/ens > @ensdomains/ens > solc > yargs > yargs-parser':
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+    - ethereum-waffle > @ethereum-waffle/chai > @ethereum-waffle/provider > @ethereum-waffle/ens > @ensdomains/ens > solc > yargs > yargs-parser:
+        reason: None given
+        expires: '2021-05-29T15:25:25.678Z'
+patch: {}

--- a/yarn.lock
+++ b/yarn.lock
@@ -167,9 +167,9 @@
     miller-rabin "^4.0.0"
 
 "@ethereumjs/tx@^3.1.3":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-3.1.3.tgz#0e4b0ccec2f12b1f0bbbb0e7542dd79d9ec25d87"
-  integrity sha512-DJBu6cbwYtiPTFeCUR8DF5p+PF0jxs+0rALJZiEcTz2tiRPIEkM72GEbrkGuqzENLCzBrJHT43O0DxSYTqeo+g==
+  version "3.1.4"
+  resolved "https://registry.yarnpkg.com/@ethereumjs/tx/-/tx-3.1.4.tgz#04cf9e9406da5f04a1a26c458744641f4b4b8dd0"
+  integrity sha512-6cJpmmjCpG5ZVN9NJYtWvmrEQcevw9DIR8hj2ca2PszD2fxbIFXky3Z37gpf8S6u0Npv09kG8It+G4xjydZVLg==
   dependencies:
     "@ethereumjs/common" "^2.2.0"
     ethereumjs-util "^7.0.10"
@@ -577,9 +577,9 @@
     "@hapi/hoek" "9.x.x"
 
 "@hapi/hoek@9.x.x":
-  version "9.1.1"
-  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.1.1.tgz#9daf5745156fd84b8e9889a2dc721f0c58e894aa"
-  integrity sha512-CAEbWH7OIur6jEOzaai83jq3FmKmv4PmX1JYfs9IrYcGEVI/lyL1EXJGCj7eFVJ0bg5QR8LMxBlEtA+xKiLpFw==
+  version "9.2.0"
+  resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.0.tgz#f3933a44e365864f4dad5db94158106d511e8131"
+  integrity sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==
 
 "@hoprnet/hopr-connect@0.2.23":
   version "0.2.23"
@@ -1393,18 +1393,17 @@
   integrity sha512-oN3y7FAROHhrAt7Rr7PnTSwrHrZVRTS2ZbyxeQwSSYD0ifwM3YNgQqbaRmjcWoPyq77MjchusjJDspbzMmip1Q==
 
 "@npmcli/git@^2.0.1":
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/@npmcli/git/-/git-2.0.6.tgz#47b97e96b2eede3f38379262fa3bdfa6eae57bf2"
-  integrity sha512-a1MnTfeRPBaKbFY07fd+6HugY1WAkKJzdiJvlRub/9o5xz2F/JtPacZZapx5zRJUQFIzSL677vmTSxEcDMrDbg==
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/@npmcli/git/-/git-2.0.8.tgz#c38b54cdeec556ab641cf6161cc7825711a88d65"
+  integrity sha512-LPnzyBZ+1p7+JzHVwwKycMF8M3lr1ze3wxGRnxn/QxJtk++Y3prSJQrdBDGCxJyRpFsup6J3lrRBVYBhJVrM8Q==
   dependencies:
-    "@npmcli/promise-spawn" "^1.1.0"
+    "@npmcli/promise-spawn" "^1.3.2"
     lru-cache "^6.0.0"
-    mkdirp "^1.0.3"
-    npm-pick-manifest "^6.0.0"
+    mkdirp "^1.0.4"
+    npm-pick-manifest "^6.1.1"
     promise-inflight "^1.0.1"
     promise-retry "^2.0.1"
-    semver "^7.3.2"
-    unique-filename "^1.1.1"
+    semver "^7.3.5"
     which "^2.0.2"
 
 "@npmcli/installed-package-contents@^1.0.6":
@@ -1428,7 +1427,7 @@
   resolved "https://registry.yarnpkg.com/@npmcli/node-gyp/-/node-gyp-1.0.2.tgz#3cdc1f30e9736dbc417373ed803b42b1a0a29ede"
   integrity sha512-yrJUe6reVMpktcvagumoqD9r08fH1iRo01gn1u0zoCApa9lnZGEigVKUd2hzsCId4gdtkZZIVscLhNxMECKgRg==
 
-"@npmcli/promise-spawn@^1.1.0", "@npmcli/promise-spawn@^1.2.0", "@npmcli/promise-spawn@^1.3.2":
+"@npmcli/promise-spawn@^1.2.0", "@npmcli/promise-spawn@^1.3.2":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@npmcli/promise-spawn/-/promise-spawn-1.3.2.tgz#42d4e56a8e9274fba180dabc0aea6e38f29274f5"
   integrity sha512-QyAGYo/Fbj4MXeGdJcFzZ+FkDkomfRBrPM+9QYJSg+PxgAUL+LU3FneQk37rKR2/zjqkCV1BLHccX98wRXG3Sg==
@@ -1436,9 +1435,9 @@
     infer-owner "^1.0.4"
 
 "@npmcli/run-script@^1.8.2":
-  version "1.8.4"
-  resolved "https://registry.yarnpkg.com/@npmcli/run-script/-/run-script-1.8.4.tgz#03ced92503a6fe948cbc0975ce39210bc5e824d6"
-  integrity sha512-Yd9HXTtF1JGDXZw0+SOn+mWLYS0e7bHBHVC/2C8yqs4wUrs/k8rwBSinD7rfk+3WG/MFGRZKxjyoD34Pch2E/A==
+  version "1.8.5"
+  resolved "https://registry.yarnpkg.com/@npmcli/run-script/-/run-script-1.8.5.tgz#f250a0c5e1a08a792d775a315d0ff42fc3a51e1d"
+  integrity sha512-NQspusBCpTjNwNRFMtz2C5MxoxyzlbuJ4YEhxAKrIonTiirKDtatsZictx9RgamQIx6+QuHMNmPl0wQdoESs9A==
   dependencies:
     "@npmcli/node-gyp" "^1.0.2"
     "@npmcli/promise-spawn" "^1.3.2"
@@ -1484,10 +1483,10 @@
     "@octokit/types" "^6.0.3"
     universal-user-agent "^6.0.0"
 
-"@octokit/openapi-types@^6.0.0":
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-6.0.0.tgz#7da8d7d5a72d3282c1a3ff9f951c8133a707480d"
-  integrity sha512-CnDdK7ivHkBtJYzWzZm7gEkanA7gKH6a09Eguz7flHw//GacPJLmkHA3f3N++MJmlxD1Fl+mB7B32EEpSCwztQ==
+"@octokit/openapi-types@^6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@octokit/openapi-types/-/openapi-types-6.2.1.tgz#5830395622ca0d8e945532c7ace722aec3670508"
+  integrity sha512-rSyuVb2zVwEbWpl1FJzVziyDfvEhNcvIsp6QxmEJkpiFuPfcZ4LwXz2/fhVdVC8Xy7BCugUQr7/ISdhYwgs3zQ==
 
 "@octokit/plugin-enterprise-rest@^6.0.1":
   version "6.0.1"
@@ -1506,12 +1505,12 @@
   resolved "https://registry.yarnpkg.com/@octokit/plugin-request-log/-/plugin-request-log-1.0.3.tgz#70a62be213e1edc04bb8897ee48c311482f9700d"
   integrity sha512-4RFU4li238jMJAzLgAwkBAw+4Loile5haQMQr+uhFq27BmyJXcXSKvoQKqh0agsZEiUlW6iSv3FAgvmGkur7OQ==
 
-"@octokit/plugin-rest-endpoint-methods@5.0.0":
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.0.tgz#cf2cdeb24ea829c31688216a5b165010b61f9a98"
-  integrity sha512-Jc7CLNUueIshXT+HWt6T+M0sySPjF32mSFQAK7UfAg8qGeRI6OM1GSBxDLwbXjkqy2NVdnqCedJcP1nC785JYg==
+"@octokit/plugin-rest-endpoint-methods@5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.0.1.tgz#631b8d4edc6798b03489911252a25f2a4e58c594"
+  integrity sha512-vvWbPtPqLyIzJ7A4IPdTl+8IeuKAwMJ4LjvmqWOOdfSuqWQYZXq2CEd0hsnkidff2YfKlguzujHs/reBdAx8Sg==
   dependencies:
-    "@octokit/types" "^6.13.0"
+    "@octokit/types" "^6.13.1"
     deprecation "^2.3.1"
 
 "@octokit/request-error@^2.0.0", "@octokit/request-error@^2.0.5":
@@ -1524,35 +1523,33 @@
     once "^1.4.0"
 
 "@octokit/request@^5.3.0", "@octokit/request@^5.4.12":
-  version "5.4.14"
-  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.14.tgz#ec5f96f78333bb2af390afa5ff66f114b063bc96"
-  integrity sha512-VkmtacOIQp9daSnBmDI92xNIeLuSRDOIuplp/CJomkvzt7M18NXgG044Cx/LFKLgjKt9T2tZR6AtJayba9GTSA==
+  version "5.4.15"
+  resolved "https://registry.yarnpkg.com/@octokit/request/-/request-5.4.15.tgz#829da413dc7dd3aa5e2cdbb1c7d0ebe1f146a128"
+  integrity sha512-6UnZfZzLwNhdLRreOtTkT9n57ZwulCve8q3IT/Z477vThu6snfdkBuhxnChpOKNGxcQ71ow561Qoa6uqLdPtag==
   dependencies:
     "@octokit/endpoint" "^6.0.1"
     "@octokit/request-error" "^2.0.0"
     "@octokit/types" "^6.7.1"
-    deprecation "^2.0.0"
     is-plain-object "^5.0.0"
     node-fetch "^2.6.1"
-    once "^1.4.0"
     universal-user-agent "^6.0.0"
 
 "@octokit/rest@^18.1.0":
-  version "18.5.2"
-  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.5.2.tgz#0369e554b7076e3749005147be94c661c7a5a74b"
-  integrity sha512-Kz03XYfKS0yYdi61BkL9/aJ0pP2A/WK5vF/syhu9/kY30J8He3P68hv9GRpn8bULFx2K0A9MEErn4v3QEdbZcw==
+  version "18.5.3"
+  resolved "https://registry.yarnpkg.com/@octokit/rest/-/rest-18.5.3.tgz#6a2e6006a87ebbc34079c419258dd29ec9ff659d"
+  integrity sha512-KPAsUCr1DOdLVbZJgGNuE/QVLWEaVBpFQwDAz/2Cnya6uW2wJ/P5RVGk0itx7yyN1aGa8uXm2pri4umEqG1JBA==
   dependencies:
     "@octokit/core" "^3.2.3"
     "@octokit/plugin-paginate-rest" "^2.6.2"
     "@octokit/plugin-request-log" "^1.0.2"
-    "@octokit/plugin-rest-endpoint-methods" "5.0.0"
+    "@octokit/plugin-rest-endpoint-methods" "5.0.1"
 
-"@octokit/types@^6.0.3", "@octokit/types@^6.11.0", "@octokit/types@^6.13.0", "@octokit/types@^6.7.1":
-  version "6.13.0"
-  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.13.0.tgz#779e5b7566c8dde68f2f6273861dd2f0409480d0"
-  integrity sha512-W2J9qlVIU11jMwKHUp5/rbVUeErqelCsO5vW5PKNb7wAXQVUz87Rc+imjlEvpvbH8yUb+KHmv8NEjVZdsdpyxA==
+"@octokit/types@^6.0.3", "@octokit/types@^6.11.0", "@octokit/types@^6.13.1", "@octokit/types@^6.7.1":
+  version "6.14.1"
+  resolved "https://registry.yarnpkg.com/@octokit/types/-/types-6.14.1.tgz#4579bbdabee9a8349ce302f29ebc6f81775f0f5c"
+  integrity sha512-RDzkeFPaT2TgZcNtB2s1HtaMmtOrvXsc5VsAdpzApNkTwNN7Jk76RRCzGYhjm+hQ/HHuQXZkxUDWhJlt2QAyKQ==
   dependencies:
-    "@octokit/openapi-types" "^6.0.0"
+    "@octokit/openapi-types" "^6.2.1"
 
 "@opentelemetry/api@0.14.0":
   version "0.14.0"
@@ -1754,9 +1751,9 @@
     "@sinonjs/commons" "^1.7.0"
 
 "@sinonjs/fake-timers@^7.0.4":
-  version "7.0.4"
-  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-7.0.4.tgz#4c95dd62c506824a9c969d231e6174f4d545b07c"
-  integrity sha512-fW3SzjLF0sjI0x1Opc7cUG4J/Nr4U0TXPNnKNAgrxA4xXsQNk6nypZK0yJg5FNw5cCo2yC/ZMdaVhDTKeeF6zg==
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-7.0.5.tgz#558a7f8145a01366c44b3dcbdd7172c05c461564"
+  integrity sha512-fUt6b15bjV/VW93UP5opNXJxdwZSbK1EdiwnhN7XrQrcpaOhMJpZ/CjwFpM3THpxwA+YviBUJKSuEqKlCK5alw==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
@@ -1764,15 +1761,6 @@
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-5.3.1.tgz#375a45fe6ed4e92fca2fb920e007c48232a6507f"
   integrity sha512-1Hc0b1TtyfBu8ixF/tpfSHTVWKwCBLY4QJbkgnE7HcwyvT2xArDxb4K7dMgqRm3szI+LJbzmW/s4xxEhv6hwDg==
-  dependencies:
-    "@sinonjs/commons" "^1.6.0"
-    lodash.get "^4.4.2"
-    type-detect "^4.0.8"
-
-"@sinonjs/samsam@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-6.0.1.tgz#4cbe02e9bd5c17612a2f0d5f42a5c082523023ed"
-  integrity sha512-zJ+xzDBMETj/kFkagaZBG4G8e80Et182r6xpCzpubS7cavdTLwBKtCU3sgmPvZDC0u41gd87atcoUxcmiamBgw==
   dependencies:
     "@sinonjs/commons" "^1.6.0"
     lodash.get "^4.4.2"
@@ -1789,9 +1777,9 @@
   integrity sha512-H8BSBoKE8EubJa0ONqecA2TviT3TnHeC4NpgnAHSUiuhZoQBfPB4L2P9bs8R6AoTW10Endvh3vc+fomVMIDIYQ==
 
 "@solidity-parser/parser@^0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.12.0.tgz#18a0fb2a9d2484b23176f63b16093c64794fc323"
-  integrity sha512-DT3f/Aa4tQysZwUsuqBwvr8YRJzKkvPUKV/9o2/o5EVw3xqlbzmtx4O60lTUcZdCawL+N8bBLNUyOGpHjGlJVQ==
+  version "0.12.2"
+  resolved "https://registry.yarnpkg.com/@solidity-parser/parser/-/parser-0.12.2.tgz#1afad367cb29a2ed8cdd4a3a62701c2821fb578f"
+  integrity sha512-d7VS7PxgMosm5NyaiyDJRNID5pK4AWj1l64Dbz0147hJgy5k2C0/ZiKK/9u5c5K+HRUVHmp+RMvGEjGh84oA5Q==
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
@@ -1805,27 +1793,27 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
 
-"@truffle/error@^0.0.12":
-  version "0.0.12"
-  resolved "https://registry.yarnpkg.com/@truffle/error/-/error-0.0.12.tgz#83e02e6ffe1d154fe274141d90038a91fd1e186d"
-  integrity sha512-kZqqnPR9YDJG7KCDOcN1qH16Qs0oz1PzF0Y93AWdhXuL9S9HYo/RUUeqGKbPpRBEZldQUS8aa4EzfK08u5pu6g==
+"@truffle/error@^0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@truffle/error/-/error-0.0.13.tgz#d2d8b9be8ed8c876e1a63f64d1ebe74f9827a08c"
+  integrity sha512-tzB2Kt9QSMK0He86ZFYhNyew9V6vZ7FboqmCFL5YyQd/P2mY14PJIw92NdkcTGxn1GNe+oYoHBS0Eu1c7DhC5Q==
 
-"@truffle/interface-adapter@^0.4.21":
-  version "0.4.21"
-  resolved "https://registry.yarnpkg.com/@truffle/interface-adapter/-/interface-adapter-0.4.21.tgz#5b42c6f8f59155f36e54a25ce4609694a84d6a7f"
-  integrity sha512-uGU9T0a1S1f1xiTrNksd9ba+55SyU9jaCLNauFGOtppWDmjHD7dorxncEyj7lM9dcKl+w8Y+wHy79bb/LG4XFQ==
+"@truffle/interface-adapter@^0.4.22":
+  version "0.4.22"
+  resolved "https://registry.yarnpkg.com/@truffle/interface-adapter/-/interface-adapter-0.4.22.tgz#cd77c3acf2d5b1bf3ca8caab5784d61d3ba18dcf"
+  integrity sha512-G5uLkXUv/1Cp4090hEGX9Y96FwUuLvsZloZu/cF3ltK/oj0ltNPMxt009v5ptFu3jH1c2IwLvxtvvL0Y+pI8GQ==
   dependencies:
     bn.js "^5.1.3"
     ethers "^4.0.32"
     web3 "1.3.5"
 
 "@truffle/provider@^0.2.24":
-  version "0.2.28"
-  resolved "https://registry.yarnpkg.com/@truffle/provider/-/provider-0.2.28.tgz#a6e5ce81fdfb8151ca53c76d93f438309cfa692f"
-  integrity sha512-lowQkQPVSnn1jG3JIrp5iTDxkHZErjjjbLsvpI1kd8sYQ5LcGorgPQVsGlhM5BfYUQCeHLeFwwFb0ghx3hisKw==
+  version "0.2.29"
+  resolved "https://registry.yarnpkg.com/@truffle/provider/-/provider-0.2.29.tgz#c10becacb2a970ed73c19296d166667b5079945e"
+  integrity sha512-hZs9pWjPHsQ1HPROYf5N9pnLMPsDeLYUaDCO/D8sO4mjE+u3ZfUf2scIfNh7/BP76WQDXO7GzzV8CDLS8Zln3Q==
   dependencies:
-    "@truffle/error" "^0.0.12"
-    "@truffle/interface-adapter" "^0.4.21"
+    "@truffle/error" "^0.0.13"
+    "@truffle/interface-adapter" "^0.4.22"
     web3 "1.3.5"
 
 "@typechain/ethers-v5@^2.0.0":
@@ -1999,30 +1987,35 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@14", "@types/node@14.14.37":
-  version "14.14.37"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.37.tgz#a3dd8da4eb84a996c36e331df98d82abd76b516e"
-  integrity sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==
+"@types/node@*", "@types/node@>=13.7.0":
+  version "15.0.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-15.0.1.tgz#ef34dea0881028d11398be5bf4e856743e3dc35a"
+  integrity sha512-TMkXt0Ck1y0KKsGr9gJtWGjttxlZnnvDtphxUOSd0bfaR6Q1jle+sPvrzNR1urqYTWMinoKvjKfXUGsumaO1PA==
+
+"@types/node@14":
+  version "14.14.43"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.43.tgz#26bcbb0595b305400e8ceaf9a127a7f905ae49c8"
+  integrity sha512-3pwDJjp1PWacPTpH0LcfhgjvurQvrZFBrC6xxjaUEZ7ifUtT32jtjPxEMMblpqd2Mvx+k8haqQJLQxolyGN/cQ==
 
 "@types/node@14.14.35":
   version "14.14.35"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.35.tgz#42c953a4e2b18ab931f72477e7012172f4ffa313"
   integrity sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag==
 
+"@types/node@14.14.37":
+  version "14.14.37"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.37.tgz#a3dd8da4eb84a996c36e331df98d82abd76b516e"
+  integrity sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==
+
 "@types/node@^10.0.3":
-  version "10.17.56"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.56.tgz#010c9e047c3ff09ddcd11cbb6cf5912725cdc2b3"
-  integrity sha512-LuAa6t1t0Bfw4CuSR0UITsm1hP17YL+u82kfHGrHUWdhlBtH7sa7jGY5z7glGaIj/WDYDkRtgGd+KCjCzxBW1w==
+  version "10.17.59"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.59.tgz#03f440ccf746a27f7da6e141e6cbae64681dbd2f"
+  integrity sha512-7Uc8IRrL8yZz5ti45RaFxpbU8TxlzdC3HvxV+hOWo1EyLsuKv/w7y0n+TwZzwL3vdx3oZ2k3ubxPq131hNtXyg==
 
 "@types/node@^12.12.6":
-  version "12.20.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.7.tgz#1cb61fd0c85cb87e728c43107b5fd82b69bc9ef8"
-  integrity sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA==
-
-"@types/node@^13.7.0":
-  version "13.13.48"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-13.13.48.tgz#46a3df718aed5217277f2395a682e055a487e341"
-  integrity sha512-z8wvSsgWQzkr4sVuMEEOvwMdOQjiRY2Y/ZW4fDfjfe3+TfQrZqFKOthBgk2RnVEmtOKrkwdZ7uTvsxTBLjKGDQ==
+  version "12.20.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.11.tgz#980832cd56efafff8c18aa148c4085eb02a483f4"
+  integrity sha512-gema+apZ6qLQK7k7F0dGkGCWQYsL0qqKORWOQO6tq46q+x+1C0vbOiOqOwRVlh4RAdbQwV/j/ryr3u5NOG1fPQ==
 
 "@types/node@^8.0.0":
   version "8.10.66"
@@ -2088,7 +2081,14 @@
     "@types/chai" "*"
     "@types/sinon" "*"
 
-"@types/sinon@*", "@types/sinon@^9.0.10", "@types/sinon@^9.0.8":
+"@types/sinon@*":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-10.0.0.tgz#eecc3847af03d45ffe53d55aaaaf6ecb28b5e584"
+  integrity sha512-jDZ55oCKxqlDmoTBBbBBEx+N8ZraUVhggMZ9T5t+6/Dh8/4NiOjSUfpLrPiEwxQDlAe3wpAkoXhWvE6LibtsMQ==
+  dependencies:
+    "@sinonjs/fake-timers" "^7.0.4"
+
+"@types/sinon@^9.0.10", "@types/sinon@^9.0.8":
   version "9.0.11"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-9.0.11.tgz#7af202dda5253a847b511c929d8b6dda170562eb"
   integrity sha512-PwP4UY33SeeVKodNE37ZlOsR9cReypbMJOhZ7BVE0lB+Hix3efCOxiJWiE5Ia+yL9Cn2Ch72EjFTRze8RZsNtg==
@@ -2101,9 +2101,9 @@
   integrity sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==
 
 "@types/underscore@*":
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.11.1.tgz#5b773d04c44897137485615dbef56a2919b9fa5a"
-  integrity sha512-mW23Xkp9HYgdMV7gnwuzqnPx6aG0J7xg/b7erQszOcyOizWylwCr9cgYM/BVVJHezUDxwyigG6+wCFQwCvyMBw==
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/@types/underscore/-/underscore-1.11.2.tgz#9441e0f6402bbcb72dbee771582fa57c5a1dedd3"
+  integrity sha512-Ls2ylbo7++ITrWk2Yc3G/jijwSq5V3GT0tlgVXEl2kKYXY3ImrtmTCoE2uyTWFRI5owMBriloZFWbE1SXOsE7w==
 
 "@types/web3@1.0.19":
   version "1.0.19"
@@ -4330,9 +4330,9 @@ copy-descriptor@^0.1.0:
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
 core-js-pure@^3.0.1:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.10.1.tgz#28642697dfcf02e0fd9f4d9891bd03a22df28ecf"
-  integrity sha512-PeyJH2SE0KuxY5eCGNWA+W+CeDpB6M1PN3S7Am7jSv/Ttuxz2SnWbIiVQOn/TDaGaGtxo8CRWHkXwJscbUHtVw==
+  version "3.11.1"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.11.1.tgz#fd52fa8c8b7b797b3606524b3d97278a8d8e7f09"
+  integrity sha512-2JukQi8HgAOCD5CSimxWWXVrUBoA9Br796uIA5Z06bIjt7PBBI19ircFaAxplgE1mJf3x2BY6MkT/HWA/UryPg==
 
 core-js@^2.4.0, core-js@^2.5.0:
   version "2.6.12"
@@ -4935,9 +4935,9 @@ electron-fetch@^1.7.2:
     encoding "^0.1.13"
 
 electron-to-chromium@^1.3.47, electron-to-chromium@^1.3.634:
-  version "1.3.711"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.711.tgz#92c3caf7ffed5e18bf63f66b4b57b4db2409c450"
-  integrity sha512-XbklBVCDiUeho0PZQCjC25Ha6uBwqqJeyDhPLwLwfWRAo4x+FZFsmu1pPPkXT+B4MQMQoQULfyaMltDopfeiHQ==
+  version "1.3.723"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.723.tgz#52769a75635342a4db29af5f1e40bd3dad02c877"
+  integrity sha512-L+WXyXI7c7+G1V8ANzRsPI5giiimLAUDC6Zs1ojHHPhYXb3k/iTABFmWjivEtsWrRQymjnO66/rO2ZTABGdmWg==
 
 elliptic@6.5.3:
   version "6.5.3"
@@ -6187,9 +6187,9 @@ fmix@^0.1.0:
     imul "^1.0.0"
 
 follow-redirects@^1.10.0, follow-redirects@^1.12.1:
-  version "1.13.3"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.3.tgz#e5598ad50174c1bc4e872301e82ac2cd97f90267"
-  integrity sha512-DUgl6+HDzB0iEptNQEXLx/KhTmDb8tZUHSeLqpnjpknR70H0nC2t9N73BK6fN4hOvJ84pKlIQVQ4k5FFlBedKA==
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.0.tgz#f5d260f95c5f8c105894491feee5dc8993b402fe"
+  integrity sha512-0vRwd7RKQBTt+mgu87mtYeofLFZpTas2S9zY+jIeuLJMNvudIgF52nr19q40HOwH5RrhWIPuj9puybzSJiRrVg==
 
 for-each@^0.3.3, for-each@~0.3.3:
   version "0.3.3"
@@ -6511,9 +6511,9 @@ get-stream@^5.1.0:
     pump "^3.0.0"
 
 get-stream@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.0.tgz#3e0012cb6827319da2706e601a1583e8629a6718"
-  integrity sha512-A1B3Bh1UmL0bidM/YX2NsCOTnGJePL9rO/M+Mw3m9f2gUpfokS0hi5Eah0WSUEWZdZhIZtMjkIYS7mDfOqNHbg==
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
+  integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
 get-value@^2.0.3, get-value@^2.0.6:
   version "2.0.6"
@@ -7244,16 +7244,16 @@ ini@^1.3.2, ini@^1.3.4, ini@^1.3.5, ini@~1.3.0:
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
 init-package-json@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/init-package-json/-/init-package-json-2.0.2.tgz#d81a7e6775af9b618f20bba288e440b8d1ce05f3"
-  integrity sha512-PO64kVeArePvhX7Ff0jVWkpnE1DfGRvaWcStYrPugcJz9twQGYibagKJuIMHCX7ENcp0M6LJlcjLBuLD5KeJMg==
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/init-package-json/-/init-package-json-2.0.3.tgz#c8ae4f2a4ad353bcbc089e5ffe98a8f1a314e8fd"
+  integrity sha512-tk/gAgbMMxR6fn1MgMaM1HpU1ryAmBWWitnxG5OhuNXeX0cbpbgV5jA4AIpQJVNoyOfOevTtO6WX+rPs+EFqaQ==
   dependencies:
     glob "^7.1.1"
-    npm-package-arg "^8.1.0"
+    npm-package-arg "^8.1.2"
     promzard "^0.3.0"
     read "~1.0.1"
-    read-package-json "^3.0.0"
-    semver "^7.3.2"
+    read-package-json "^3.0.1"
+    semver "^7.3.5"
     validate-npm-package-license "^3.0.4"
     validate-npm-package-name "^3.0.0"
 
@@ -7296,13 +7296,13 @@ inquirer@^7.3.3:
     through "^2.3.6"
 
 interface-datastore@^3.0.3:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/interface-datastore/-/interface-datastore-3.0.5.tgz#045d30f26f318f03fe9bff49a3f5b25173496138"
-  integrity sha512-vekEGOvvGdmMESHSjpKbPLPYH8ouC2bSINj5ZN6oGvJl5E6PGutecvu9rIq6f+bvLaEjBFRQgv3tb9t3saDXPw==
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/interface-datastore/-/interface-datastore-3.0.6.tgz#b3aa353aff7b41c77b20d7a927e0b45406a8b36e"
+  integrity sha512-ruF9CVmtKCNfzCZYW6YeEKDRDbgFaiKGrSWof19BVCv6Qx/WrL1jRV4sCQUHCaXwJI7FCFknhw++PGafWCXvfw==
   dependencies:
     err-code "^3.0.1"
     ipfs-utils "^6.0.0"
-    iso-random-stream "^1.1.1"
+    iso-random-stream "^2.0.0"
     it-all "^1.0.2"
     it-drain "^1.0.1"
     nanoid "^3.0.2"
@@ -7388,9 +7388,9 @@ ipaddr.js@1.9.1:
   integrity sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==
 
 ipfs-utils@^6.0.0:
-  version "6.0.6"
-  resolved "https://registry.yarnpkg.com/ipfs-utils/-/ipfs-utils-6.0.6.tgz#c2d09263a340eb8fb32a91eea71fa7baba3fa082"
-  integrity sha512-MqLrdaikkFd1VF1/XlzMD6w7euJ5+iigKt2jpIIPHDgdnNsV/9v5BrMOB6oMO/GK/k1krqyLoOiwd0HBYArpbw==
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/ipfs-utils/-/ipfs-utils-6.0.7.tgz#876acf88ca012e33a8be29f16e6826eafaa4b16b"
+  integrity sha512-VlFDyRuCSOKXPOXb68nXSUVEPA+eXbdS7LT22k4aZvFNIoB2OtysDEt8lal93UOB/QS0Gy+6DUoxj1wJ37SIxQ==
   dependencies:
     abort-controller "^3.0.0"
     any-signal "^2.1.0"
@@ -7401,7 +7401,7 @@ ipfs-utils@^6.0.0:
     is-electron "^2.2.0"
     iso-url "^1.0.0"
     it-glob "~0.0.11"
-    it-to-stream "^0.1.2"
+    it-to-stream "^1.0.0"
     merge-options "^3.0.4"
     nanoid "^3.1.20"
     native-abort-controller "^1.0.3"
@@ -7459,7 +7459,7 @@ is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-buffer@^2.0.4, is-buffer@^2.0.5, is-buffer@~2.0.3:
+is-buffer@^2.0.5, is-buffer@~2.0.3:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.5.tgz#ebc252e400d22ff8d77fa09888821a24a658c191"
   integrity sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==
@@ -7477,9 +7477,9 @@ is-ci@^2.0.0:
     ci-info "^2.0.0"
 
 is-core-module@^2.2.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.2.0.tgz#97037ef3d52224d85163f5597b2b63d9afed981a"
-  integrity sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.3.0.tgz#d341652e3408bca69c4671b79a0954a3d349f887"
+  integrity sha512-xSphU2KG9867tsYdLD4RWQ1VqdFl4HTO9Thf3I/3dLEfr0dbPTWKsuCKrgqMljg4nPE+Gq0VCnzT3gr0CyBmsw==
   dependencies:
     has "^1.0.3"
 
@@ -7789,7 +7789,7 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
 
-iso-random-stream@^1.1.0, iso-random-stream@^1.1.1:
+iso-random-stream@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/iso-random-stream/-/iso-random-stream-1.1.2.tgz#c703da2c518db573277c5678cc43c5298283d64c"
   integrity sha512-7y0tsBBgQs544iTYjyrMp5xvgrbYR8b+plQq1Bryp+03p0LssrxC9C1M0oHv4QESDt7d95c74XvMk/yawKqX+A==
@@ -7841,12 +7841,12 @@ it-all@^1.0.2, it-all@^1.0.4:
   integrity sha512-ygD4kA4vp8fi+Y+NBgEKt6W06xSbv6Ub/0V8d1r3uCyJ9Izwa1UspkIOlqY9fOee0Z1w3WRo1+VWyAU4DgtufA==
 
 it-buffer@^0.1.1, it-buffer@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/it-buffer/-/it-buffer-0.1.2.tgz#2b37e2c66bbbb94479c2e47c1904bd729f04fc39"
-  integrity sha512-NOJ3ogSNq3Y2c75ZDcPs9qlgitWyCkUQdmgqqMw+/LMmHZqwWQw7OBDodonz250nJ4EEBXkRQ+pIwz1sL9Zuyg==
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/it-buffer/-/it-buffer-0.1.3.tgz#efebef1cc35a6133cb9558e759345d4f17b3e1d0"
+  integrity sha512-9a2/9SYVwG7bcn3tpRDR4bXbtuMLXnDK48KVC+GXiQg97ZOOdWz2nIITBsOQ19b+gj01Rw8RNwtiLDLI8P8oiQ==
   dependencies:
-    bl "^4.0.2"
-    buffer "^5.5.0"
+    bl "^5.0.0"
+    buffer "^6.0.3"
 
 it-drain@^1.0.1, it-drain@^1.0.3:
   version "1.0.4"
@@ -7894,6 +7894,15 @@ it-handshake@^1.0.2, it-handshake@~1.0.2:
     it-reader "^2.0.0"
     p-defer "^3.0.0"
 
+it-handshake@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/it-handshake/-/it-handshake-2.0.0.tgz#97671f33c13c47218a3df8a8d92de565a075b28c"
+  integrity sha512-K4q+mz8aLlCK3vTjtgNdHC9c/JbuOATsfogarjMsLcBZC5vYfKbX3Gq3AWcCdjIsIrPqzTlhPKSxl64LJkrt2w==
+  dependencies:
+    it-pushable "^1.4.0"
+    it-reader "^3.0.0"
+    p-defer "^3.0.0"
+
 it-length-prefixed@^3.0.0, it-length-prefixed@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/it-length-prefixed/-/it-length-prefixed-3.1.0.tgz#f9226967e0d4e3823bb25e6b7867764509ae70e8"
@@ -7933,13 +7942,13 @@ it-pair@^1.0.0:
     get-iterator "^1.0.2"
 
 it-pb-rpc@^0.1.9:
-  version "0.1.9"
-  resolved "https://registry.yarnpkg.com/it-pb-rpc/-/it-pb-rpc-0.1.9.tgz#28cc99e55a9cdbe980c1d8b89729135479a883bc"
-  integrity sha512-IMPXz+a+lUEclV5qIlT/1WAjCMIZyqQtMRaKaL8cwgvH2P5LtMJlrbNZr3b4VEONK1H6mqAV1upfMTSSBSrOqA==
+  version "0.1.11"
+  resolved "https://registry.yarnpkg.com/it-pb-rpc/-/it-pb-rpc-0.1.11.tgz#22c3d3e4d635ffdd24453a225ff16cc1bde463c5"
+  integrity sha512-1Yvae7LNHNM/WzxWT7OyHqwpA7DZoGos22JioMZ5H6i9iExQf71NHE0phHKEfkJdWLo7SRqPLLbqs2zaeKCwPA==
   dependencies:
-    is-buffer "^2.0.4"
-    it-handshake "^1.0.2"
-    it-length-prefixed "^3.1.0"
+    is-buffer "^2.0.5"
+    it-handshake "^2.0.0"
+    it-length-prefixed "^5.0.2"
 
 it-pipe@^1.0.1, it-pipe@^1.1.0:
   version "1.1.0"
@@ -7968,6 +7977,13 @@ it-reader@^2.0.0:
   dependencies:
     bl "^4.0.0"
 
+it-reader@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/it-reader/-/it-reader-3.0.0.tgz#56596c7742ec7c63b7f7998f6bfa3f712e333d0e"
+  integrity sha512-NxR40odATeaBmSefn6Xn43DplYvn2KtEKQzn4jrTRuPYXMky5M4e+KQ7aTJh0k0vkytLyeenGO1I1GXlGm4laQ==
+  dependencies:
+    bl "^5.0.0"
+
 it-take@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/it-take/-/it-take-1.0.0.tgz#2319a39d91463b4bf6151289126aa44889eda903"
@@ -7978,12 +7994,12 @@ it-take@^1.0.1:
   resolved "https://registry.yarnpkg.com/it-take/-/it-take-1.0.1.tgz#155b0f8ed4b6ff5eb4e9e7a2f4395f16b137b68a"
   integrity sha512-6H6JAWYcyumKSpcIPLs6tHN4xnibphmyU79WQaYVCBtaBOzf4fn75wzvSH8fH8fcMlPBTWY1RlmOWleQxBt2Ug==
 
-it-to-stream@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/it-to-stream/-/it-to-stream-0.1.2.tgz#7163151f75b60445e86b8ab1a968666acaacfe7b"
-  integrity sha512-DTB5TJRZG3untmZehcaFN0kGWl2bNv7tnJRgQHAO9QEt8jfvVRrebZtnD5NZd4SCj4WVPjl0LSrugNWE/UaZRQ==
+it-to-stream@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/it-to-stream/-/it-to-stream-1.0.0.tgz#6c47f91d5b5df28bda9334c52782ef8e97fe3a4a"
+  integrity sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==
   dependencies:
-    buffer "^5.6.0"
+    buffer "^6.0.3"
     fast-fifo "^1.0.0"
     get-iterator "^1.0.2"
     p-defer "^3.0.0"
@@ -8228,9 +8244,9 @@ keccak@^2.0.0:
     safe-buffer "^5.2.0"
 
 keypair@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/keypair/-/keypair-1.0.2.tgz#9aab2dea3355d22364e0156ef6a4282487c8fdee"
-  integrity sha512-7zRr8fKOWp/N8xfZyZV6WG1CUvKNiNahSDI4vjJnPJD60lHtIg62dpv60yCgcM2PP8QKv4S2UkZl+8MsYmQRpw==
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/keypair/-/keypair-1.0.3.tgz#4314109d94052a0acfd6b885695026ad29529c80"
+  integrity sha512-0wjZ2z/SfZZq01+3/8jYLd8aEShSa+aat1zyPGQY3IuKoEAp6DJGvu2zt6snELrQU9jbCkIlCyNOD7RdQbHhkQ==
 
 keyv@^3.0.0:
   version "3.1.0"
@@ -8567,25 +8583,25 @@ levn@^0.3.0, levn@~0.3.0:
     type-check "~0.3.2"
 
 libnpmaccess@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/libnpmaccess/-/libnpmaccess-4.0.1.tgz#17e842e03bef759854adf6eb6c2ede32e782639f"
-  integrity sha512-ZiAgvfUbvmkHoMTzdwmNWCrQRsDkOC+aM5BDfO0C9aOSwF3R1LdFDBD+Rer1KWtsoQYO35nXgmMR7OUHpDRxyA==
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/libnpmaccess/-/libnpmaccess-4.0.2.tgz#781832fb7ccb867b26343a75a85ad9c43e50406e"
+  integrity sha512-avXtJibZuGap0/qADDYqb9zdpgzVu/yG5+tl2sTRa7MCkDNv2ZlGwCYI0r6/+tmqXPj0iB9fKexHz426vB326w==
   dependencies:
     aproba "^2.0.0"
     minipass "^3.1.1"
-    npm-package-arg "^8.0.0"
-    npm-registry-fetch "^9.0.0"
+    npm-package-arg "^8.1.2"
+    npm-registry-fetch "^10.0.0"
 
 libnpmpublish@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/libnpmpublish/-/libnpmpublish-4.0.0.tgz#ad6413914e0dfd78df868ce14ba3d3a4cc8b385b"
-  integrity sha512-2RwYXRfZAB1x/9udKpZmqEzSqNd7ouBRU52jyG14/xG8EF+O9A62d7/XVR3iABEQHf1iYhkm0Oq9iXjrL3tsXA==
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/libnpmpublish/-/libnpmpublish-4.0.1.tgz#08ca2cbb5d7f6be1ce4f3f9c49b3822682bcf166"
+  integrity sha512-hZCrZ8v4G9YH3DxpIyBdob25ijD5v5LNzRbwsej4pPDopjdcLLj1Widl+BUeFa7D0ble1JYL4F3owjLJqiA8yA==
   dependencies:
-    normalize-package-data "^3.0.0"
-    npm-package-arg "^8.1.0"
-    npm-registry-fetch "^9.0.0"
+    normalize-package-data "^3.0.2"
+    npm-package-arg "^8.1.2"
+    npm-registry-fetch "^10.0.0"
     semver "^7.1.3"
-    ssri "^8.0.0"
+    ssri "^8.0.1"
 
 libp2p-crypto@0.18.0:
   version "0.18.0"
@@ -8760,9 +8776,9 @@ libp2p-noise@^2.0.4:
     uint8arrays "^2.0.5"
 
 libp2p-record@^0.10.0:
-  version "0.10.1"
-  resolved "https://registry.yarnpkg.com/libp2p-record/-/libp2p-record-0.10.1.tgz#b991d1a04102c13e8e85f6ccc225134c400c4304"
-  integrity sha512-mPrO/yM8F7Syeucw6zvr+gIy/RWe4k8mTh4ErPT0kxAvHndPj39FVe32LbUrdgXh1B/NL4MfiniVlaAoUNBb9g==
+  version "0.10.3"
+  resolved "https://registry.yarnpkg.com/libp2p-record/-/libp2p-record-0.10.3.tgz#a5d2ca245981f1d1163c0b1fdfef479f845b518c"
+  integrity sha512-0sg2HtCuFSHZ0jxAAND1CxTeEsiWHNs1oBNWcRKK0l2/MjYg+etQ7LxUC+7o2mT0FLzFPnxe6zPODem5y5Gtkw==
   dependencies:
     err-code "^3.0.0"
     multihashes "^4.0.2"
@@ -9422,12 +9438,12 @@ micromatch@^3.1.4:
     to-regex "^3.0.2"
 
 micromatch@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.2.tgz#4fcb0999bf9fbc2fcbdd212f6d629b9a56c39259"
-  integrity sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
+  integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
   dependencies:
     braces "^3.0.1"
-    picomatch "^2.0.5"
+    picomatch "^2.2.3"
 
 miller-rabin@^4.0.0:
   version "4.0.1"
@@ -9694,9 +9710,9 @@ mocha@^8.2.0, mocha@^8.3.2:
     yargs-unparser "2.0.0"
 
 mock-fs@^4.1.0:
-  version "4.13.0"
-  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.13.0.tgz#31c02263673ec3789f90eb7b6963676aa407a598"
-  integrity sha512-DD0vOdofJdoaRNtnWcrXe6RQbpHkPPmtqGq14uRX0F8ZKJ5nv89CVTYl/BZdppDxBDaV0hl75htg3abpEWlPZA==
+  version "4.14.0"
+  resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.14.0.tgz#ce5124d2c601421255985e6e94da80a7357b1b18"
+  integrity sha512-qYvlv/exQ4+svI3UOvPUpLDF0OMX5euvUH0Ny4N5QyRyhNdgAgUrVH3iUINSzEPLvx0kbo/Bp28GJKIqvE7URw==
 
 modify-values@^1.0.0:
   version "1.0.1"
@@ -10065,21 +10081,10 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
-nise@^4.0.4:
+nise@^4.0.4, nise@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/nise/-/nise-4.1.0.tgz#8fb75a26e90b99202fa1e63f448f58efbcdedaf6"
   integrity sha512-eQMEmGN/8arp0xsvGoQ+B1qvSkR73B1nWSCh7nOt5neMCtwcQVYQGdzQMhcNscktTsWB54xnlSQFzOAPJD8nXA==
-  dependencies:
-    "@sinonjs/commons" "^1.7.0"
-    "@sinonjs/fake-timers" "^6.0.0"
-    "@sinonjs/text-encoding" "^0.7.1"
-    just-extend "^4.0.2"
-    path-to-regexp "^1.7.0"
-
-nise@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/nise/-/nise-5.0.1.tgz#786be6c1da8b88e5fae0f8e726c18f252efe8d54"
-  integrity sha512-U6qdfulSDpEgx3WSoeMlKZ6hGaTMKtyW7CY3bjj0MK3uzHvmugyteB2zyHQRRvi5I91oErSUR595s7htS6IYRQ==
   dependencies:
     "@sinonjs/commons" "^1.7.0"
     "@sinonjs/fake-timers" "^6.0.0"
@@ -10267,7 +10272,7 @@ normalize-package-data@^2.0.0, normalize-package-data@^2.3.0, normalize-package-
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-normalize-package-data@^3.0.0:
+normalize-package-data@^3.0.0, normalize-package-data@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-3.0.2.tgz#cae5c410ae2434f9a6c1baa65d5bc3b9366c8699"
   integrity sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==
@@ -10293,9 +10298,9 @@ normalize-url@^4.1.0:
   integrity sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
 
 npm-bundled@^1.0.1, npm-bundled@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.1.tgz#1edd570865a94cdb1bc8220775e29466c9fb234b"
-  integrity sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/npm-bundled/-/npm-bundled-1.1.2.tgz#944c78789bd739035b70baa2ca5cc32b8d860bc1"
+  integrity sha512-x5DHup0SuyQcmL3s7Rx/YQ8sbw/Hzg0rj48eN0dV7hf5cmQq5PXIeioroH3raV1QC1yh3uTYuMThvEQF3iKgGQ==
   dependencies:
     npm-normalize-package-bin "^1.0.1"
 
@@ -10353,7 +10358,7 @@ npm-packlist@^2.1.4:
     npm-bundled "^1.1.1"
     npm-normalize-package-bin "^1.0.1"
 
-npm-pick-manifest@^6.0.0:
+npm-pick-manifest@^6.0.0, npm-pick-manifest@^6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/npm-pick-manifest/-/npm-pick-manifest-6.1.1.tgz#7b5484ca2c908565f43b7f27644f36bb816f5148"
   integrity sha512-dBsdBtORT84S8V8UTad1WlUyKIY9iMsAmqxHbLdeEeBNMLQDlDWWra3wYUx9EBEIiG/YwAy0XyNHDd2goAsfuA==
@@ -10362,6 +10367,19 @@ npm-pick-manifest@^6.0.0:
     npm-normalize-package-bin "^1.0.1"
     npm-package-arg "^8.1.2"
     semver "^7.3.4"
+
+npm-registry-fetch@^10.0.0:
+  version "10.1.1"
+  resolved "https://registry.yarnpkg.com/npm-registry-fetch/-/npm-registry-fetch-10.1.1.tgz#97bc7a0fca5e8f76cc5162185b8de8caa8bea639"
+  integrity sha512-F6a3l+ffCQ7hvvN16YG5bpm1rPZntCg66PLHDQ1apWJPOCUVHoKnL2w5fqEaTVhp42dmossTyXeR7hTGirfXrg==
+  dependencies:
+    lru-cache "^6.0.0"
+    make-fetch-happen "^8.0.9"
+    minipass "^3.1.3"
+    minipass-fetch "^1.3.0"
+    minipass-json-stream "^1.0.1"
+    minizlib "^2.0.0"
+    npm-package-arg "^8.0.0"
 
 npm-registry-fetch@^9.0.0:
   version "9.0.0"
@@ -10434,9 +10452,9 @@ object-copy@^0.1.0:
     kind-of "^3.0.3"
 
 object-inspect@^1.9.0:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.9.0.tgz#c90521d74e1127b67266ded3394ad6116986533a"
-  integrity sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.10.2.tgz#b6385a3e2b7cae0b5eafcf90cddf85d128767f30"
+  integrity sha512-gz58rdPpadwztRrPjZE9DZLOABUpTGdcANUgOwBFO1C+HZZhePoP83M65WGDmbpwFYJSWqavbl4SgDn4k8RYTA==
 
 object-inspect@~1.7.0:
   version "1.7.0"
@@ -10832,9 +10850,9 @@ p-waterfall@^2.1.1:
     p-reduce "^2.0.0"
 
 pacote@^11.2.6:
-  version "11.3.1"
-  resolved "https://registry.yarnpkg.com/pacote/-/pacote-11.3.1.tgz#6ce95dd230db475cbd8789fd1f986bec51b4bf7c"
-  integrity sha512-TymtwoAG12cczsJIrwI/euOQKtjrQHlD0k0oyt9QSmZGpqa+KdlxKdWR/YUjYizkixaVyztxt/Wsfo8bL3A6Fg==
+  version "11.3.3"
+  resolved "https://registry.yarnpkg.com/pacote/-/pacote-11.3.3.tgz#d7d6091464f77c09691699df2ded13ab906b3e68"
+  integrity sha512-GQxBX+UcVZrrJRYMK2HoG+gPeSUX/rQhnbPkkGrCYa4n2F/bgClFPaMm0nsdnYrxnmUy85uMHoFXZ0jTD0drew==
   dependencies:
     "@npmcli/git" "^2.0.1"
     "@npmcli/installed-package-contents" "^1.0.6"
@@ -10849,7 +10867,7 @@ pacote@^11.2.6:
     npm-package-arg "^8.0.1"
     npm-packlist "^2.1.4"
     npm-pick-manifest "^6.0.0"
-    npm-registry-fetch "^9.0.0"
+    npm-registry-fetch "^10.0.0"
     promise-retry "^2.0.1"
     read-package-json-fast "^2.0.1"
     rimraf "^3.0.2"
@@ -11077,9 +11095,9 @@ pathval@^1.1.1:
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
 pbkdf2@^3.0.17, pbkdf2@^3.0.3, pbkdf2@^3.0.9:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.1.tgz#cb8724b0fada984596856d1a6ebafd3584654b94"
-  integrity sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.1.2.tgz#dd822aa0887580e52f1a039dc3eda108efae3075"
+  integrity sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==
   dependencies:
     create-hash "^1.1.2"
     create-hmac "^1.1.4"
@@ -11125,10 +11143,10 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
-  integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.3.tgz#465547f359ccc206d3c48e46a1bcb89bf7ee619d"
+  integrity sha512-KpELjfwcCDUb9PeigTs2mBJzXUPzAuP2oPcA989He8Rte0+YUAjw1JVedDhuTKPkHjSYzMN3npC9luThGYEKdg==
 
 pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
@@ -11236,9 +11254,9 @@ printj@~1.1.0:
   integrity sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==
 
 private-ip@^2.0.0, private-ip@^2.1.1:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/private-ip/-/private-ip-2.2.0.tgz#1b2baa6306994912b61e9e4321f7ac2282918162"
-  integrity sha512-2bPfzZfESxwPE+b8RezesOdnSwcLlnem3U0dV/5ayqbWZHI/bq63WlQR3dOSnLYNp13+h2ZJ894WPSUcqQqaAg==
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/private-ip/-/private-ip-2.2.1.tgz#4fe167d04e12eca5c67cdcbd3224e86b38c79253"
+  integrity sha512-jN1WT/br/VNW9xEcwHr6DjtOKxQ5qOIqmh7o+co2TWgq56pZJw99iO3UT1tWdfgsQiyK9FqG4ji3ykwpjFqITA==
   dependencies:
     ip-regex "^4.3.0"
     netmask "^2.0.2"
@@ -11313,9 +11331,9 @@ proto-list@~1.2.1:
   integrity sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk=
 
 protobufjs@^6.10.1, protobufjs@^6.10.2:
-  version "6.10.2"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.10.2.tgz#b9cb6bd8ec8f87514592ba3fdfd28e93f33a469b"
-  integrity sha512-27yj+04uF6ya9l+qfpH187aqEzfCF4+Uit0I9ZBQVqK09hk/SQzKa2MUqUpXaVa7LOFRg1TSSr3lVxGOk6c0SQ==
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.0.tgz#b890a2d3f64c62f0395e1e000d39ff91634bafb7"
+  integrity sha512-i4usrGD86mtOLnoTwUsVXphDY7yHM2rDiV3JU4Ix43BOtHi0DHy5rSCciX8MRHSYHaxnoc0TcpwEBlrNUAxvQQ==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
@@ -11328,7 +11346,7 @@ protobufjs@^6.10.1, protobufjs@^6.10.2:
     "@protobufjs/pool" "^1.1.0"
     "@protobufjs/utf8" "^1.1.0"
     "@types/long" "^4.0.1"
-    "@types/node" "^13.7.0"
+    "@types/node" ">=13.7.0"
     long "^4.0.0"
 
 protocol-buffers-schema@^3.3.1:
@@ -11342,13 +11360,13 @@ protocols@^1.1.0, protocols@^1.4.0:
   integrity sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg==
 
 protons@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/protons/-/protons-2.0.0.tgz#a6910161f0ed0f3a9007c1503acda7a402023cd8"
-  integrity sha512-BTrE9D6/d1NGis+0D8TqAO1THdn4evHQhfjapA0NUaRH4+ecJJcbqaF7TE/DKv5czE9VB/TeOllBOmCyJhHnhg==
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/protons/-/protons-2.0.1.tgz#bfee5123c100001dcf56ab8f71b1b36f2e8289f1"
+  integrity sha512-FlmPorLEeCEDPu+uIn0Qardgiy5XqVA4IyNTz9wb9c0e2U7BEXdRcIbx64r09o4Abtf+4B7mkTtMbsIXMxZzKw==
   dependencies:
     protocol-buffers-schema "^3.3.1"
     signed-varint "^2.0.1"
-    uint8arrays "^1.0.0"
+    uint8arrays "^2.1.3"
     varint "^5.0.0"
 
 proxy-addr@~2.0.5:
@@ -11635,7 +11653,7 @@ read-package-json@^2.0.0:
     normalize-package-data "^2.0.0"
     npm-normalize-package-bin "^1.0.0"
 
-read-package-json@^3.0.0:
+read-package-json@^3.0.0, read-package-json@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/read-package-json/-/read-package-json-3.0.1.tgz#c7108f0b9390257b08c21e3004d2404c806744b9"
   integrity sha512-aLcPqxovhJTVJcsnROuuzQvv6oziQx4zd3JvG0vGCL5MjTONUc4uJ90zCBC6R7W7oUKBNoR/F8pkyfVwlbxqng==
@@ -12298,7 +12316,7 @@ semver@^6.0.0, semver@^6.3.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.1.1, semver@^7.1.3, semver@^7.3.2, semver@^7.3.4:
+semver@^7.1.1, semver@^7.1.3, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5:
   version "7.3.5"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
   integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
@@ -12507,15 +12525,15 @@ simple-peer@9.9.3:
     readable-stream "^3.6.0"
 
 sinon@^10.0.0:
-  version "10.0.1"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-10.0.1.tgz#0d1a13ecb86f658d15984f84273e57745b1f4c57"
-  integrity sha512-1rf86mvW4Mt7JitEIgmNaLXaWnrWd/UrVKZZlL+kbeOujXVf9fmC4kQEQ/YeHoiIA23PLNngYWK+dngIx/AumA==
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-10.0.0.tgz#52279f97e35646ff73d23207d0307977c9b81430"
+  integrity sha512-XAn5DxtGVJBlBWYrcYKEhWCz7FLwZGdyvANRyK06419hyEpdT0dMc5A8Vcxg5SCGHc40CsqoKsc1bt1CbJPfNw==
   dependencies:
     "@sinonjs/commons" "^1.8.1"
-    "@sinonjs/fake-timers" "^7.0.4"
-    "@sinonjs/samsam" "^6.0.1"
+    "@sinonjs/fake-timers" "^6.0.1"
+    "@sinonjs/samsam" "^5.3.1"
     diff "^4.0.2"
-    nise "^5.0.1"
+    nise "^4.1.0"
     supports-color "^7.1.0"
 
 sinon@^9.2.4:
@@ -12604,9 +12622,9 @@ socks-proxy-agent@^5.0.0:
     socks "^2.3.3"
 
 socks@^2.3.3:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/socks/-/socks-2.6.0.tgz#6b984928461d39871b3666754b9000ecf39dfac2"
-  integrity sha512-mNmr9owlinMplev0Wd7UHFlqI4ofnBnNzFuzrm63PPaHgbkqCFe4T5LzwKmtQ/f2tX0NTpcdVLyD/FHxFBstYw==
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.6.1.tgz#989e6534a07cf337deb1b1c94aaa44296520d30e"
+  integrity sha512-kLQ9N5ucj8uIcxrDwjm0Jsqk06xdpBjGNQtpXy4Q8/QY2k+fY7nZH8CARy+hkbG+SGAovmzzuauCpBlb8FrnBA==
   dependencies:
     ip "^1.1.5"
     smart-buffer "^4.1.0"
@@ -12932,9 +12950,9 @@ stream-parser@^0.3.1:
     debug "2"
 
 stream-to-it@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/stream-to-it/-/stream-to-it-0.2.2.tgz#fb3de7917424c354a987c7bc2aab2d0facbd7d94"
-  integrity sha512-waULBmQpVdr6TkDzci6t1P7dIaSZ0bHC1TaPXDUeJC5PpSK7U3T0H0Zeo/LWUnd6mnhXOmGGDKAkjUCHw5IOng==
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/stream-to-it/-/stream-to-it-0.2.3.tgz#b9320ceb26a51b313de81036d4354d9b657f4d2d"
+  integrity sha512-xaK9EjPtLox5rrC7YLSBXSanTtUJN/lzJlMFvy9VaROmnyvy0U/X6m2uMhXPJRn3g3M9uOSIzTszW7BPiWSg9w==
   dependencies:
     get-iterator "^1.0.2"
 
@@ -13746,16 +13764,16 @@ typical@^2.6.0, typical@^2.6.1:
   integrity sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=
 
 uglify-js@^3.1.4:
-  version "3.13.3"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.13.3.tgz#ce72a1ad154348ea2af61f50933c76cc8802276e"
-  integrity sha512-otIc7O9LyxpUcQoXzj2hL4LPWKklO6LJWoJUzNa8A17Xgi4fOeDC8FBDOLHnC/Slo1CQgsZMcM6as0M76BZaig==
+  version "3.13.4"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.13.4.tgz#592588bb9f47ae03b24916e2471218d914955574"
+  integrity sha512-kv7fCkIXyQIilD5/yQy8O+uagsYIOt5cZvs890W40/e/rvjMSzJw81o9Bg0tkURxzZBROtDQhW2LFjOGoK3RZw==
 
 uid-number@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/uid-number/-/uid-number-0.0.6.tgz#0ea10e8035e8eb5b8e4449f06da1c730663baa81"
   integrity sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=
 
-uint8arrays@1.1.0, uint8arrays@^1.0.0, uint8arrays@^1.1.0:
+uint8arrays@1.1.0, uint8arrays@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/uint8arrays/-/uint8arrays-1.1.0.tgz#d034aa65399a9fd213a1579e323f0b29f67d0ed2"
   integrity sha512-cLdlZ6jnFczsKf5IH1gPHTtcHtPGho5r4CvctohmQjw8K7Q3gFdfIGHxSTdTaCKrL4w09SsPRJTqRS0drYeszA==
@@ -14072,9 +14090,9 @@ wcwidth@^1.0.0:
     defaults "^1.0.3"
 
 web-encoding@^1.0.2, web-encoding@^1.0.6:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/web-encoding/-/web-encoding-1.1.4.tgz#fe15f7be090e64c3b640e8e9f3846403fe6fef9e"
-  integrity sha512-EJn3rQ/blHgaOTG8XvxGsZXTCyw9p1RAaDI/L0W3jjJRvW25F8uRshacU4h49wc9Fj0JlKU+oyOKm40HDAj75w==
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/web-encoding/-/web-encoding-1.1.5.tgz#fc810cf7667364a6335c939913f5051d3e0c4864"
+  integrity sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==
   dependencies:
     util "^0.12.3"
   optionalDependencies:
@@ -14616,9 +14634,9 @@ websocket@1.0.32:
     yaeti "^0.0.6"
 
 websocket@^1.0.31, websocket@^1.0.32:
-  version "1.0.33"
-  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.33.tgz#407f763fc58e74a3fa41ca3ae5d78d3f5e3b82a5"
-  integrity sha512-XwNqM2rN5eh3G2CUQE3OHZj+0xfdH42+OFK6LdC2yqiC0YU8e5UK0nYre220T0IyyN031V/XOvtHvXozvJYFWA==
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/websocket/-/websocket-1.0.34.tgz#2bdc2602c08bf2c82253b730655c0ef7dcab3111"
+  integrity sha512-PRDso2sGwF6kM75QykIesBijKSVceR6jL2G8NGYyq2XrItNC2P5/qL5XeR056GhA+Ly7JMFvJb9I312mJfmqnQ==
   dependencies:
     bufferutil "^4.0.1"
     debug "^2.2.0"
@@ -14858,9 +14876,9 @@ ws@^5.1.1:
     async-limiter "~1.0.0"
 
 ws@^7.2.1:
-  version "7.4.4"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.4.tgz#383bc9742cb202292c9077ceab6f6047b17f2d59"
-  integrity sha512-Qm8k8ojNQIMx7S+Zp8u/uHOx7Qazv3Yv4q68MiWWWOJhiwG5W3x7iqmRtJo8xxrciZUY4vRxUTJCKuRnF28ZZw==
+  version "7.4.5"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-7.4.5.tgz#a484dd851e9beb6fdb420027e3885e8ce48986c1"
+  integrity sha512-xzyu3hFvomRfXKH8vOFMU3OguG6oOvhXMo3xsGy3xWExqaM2dxBbVxuD99O7m3ZUFMvvscsZDqxfgMaRr/Nr1g==
 
 xhr-request-promise@^0.1.2:
   version "0.1.3"


### PR DESCRIPTION
Whenever there's a security on our dependencies, we can run `snyk protect` as part of our build process to patch vulnerabilities found by Snyk even if the package does not have an upgrade available. More information in their [docs](https://support.snyk.io/hc/en-us/articles/360003812558-Protect-your-code-with-patches).

Fixes #1306