### PR TITLE
Using xDAI default RPC endpoint

### DIFF
--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -18,7 +18,7 @@ const argv = yargs
   })
   .option('provider', {
     describe: 'A provider url for the Network you specified',
-    default: 'wss://still-patient-forest.xdai.quiknode.pro/f0cdbd6455c0b3aea8512fc9e7d161c1c0abf66a/'
+    default: 'wss://rpc.xdaichain.com/wss'
   })
   .option('host', {
     describe: 'The network host to run the HOPR node on.',


### PR DESCRIPTION
* Since Quiknode does not support archive node yet, nodes are useless at this point
* Will be used to showcase the release workflow for documentation purposes