### PR TITLE
Fix sourcing check of shell scripts

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -141,29 +141,30 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@v2
+
       - name: Update repo from latest pushes.
         run: |
           git config --global user.email "noreply@hoprnet.org"
           git config --global user.name "HOPR Versioning robot"
           git config pull.rebase false
           git pull origin ${{ github.ref }} # This should pull new packages with versions etc.
+
       - name: Setup Google Cloud Credentials
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud
         with:
-          version: '290.0.1'
+          project_id: ${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}
           service_account_key: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
           export_default_credentials: true
+
       - name: Get version from package.json
-        run: echo "RELEASE=$(node -p -e "require('./packages/hoprd/package.json').version")" >> $GITHUB_ENV 
-      - name: Set Project for Google Cloud HOPR Association
-        working-directory: packages/hoprd
-        run: gcloud config set project ${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}
+        run : echo "RELEASE=$(node -p -e "require('./packages/hoprd/package.json').version")" >> $GITHUB_ENV
+
       - name: Building Docker image using Google Cloud Build
         working-directory: packages/hoprd
         run: | # TODO - actually parse semver to tag v1
           gcloud builds submit --tag gcr.io/hoprassociation/hoprd:${{ env.RELEASE }}
           gcloud container images add-tag gcr.io/hoprassociation/hoprd:${{ env.RELEASE }} gcr.io/hoprassociation/hoprd:1
-          gcloud container images add-tag gcr.io/hoprassociation/hoprd:${{ env.RELEASE }} gcr.io/hoprassociation/hoprd:latest 
+          gcloud container images add-tag gcr.io/hoprassociation/hoprd:${{ env.RELEASE }} gcr.io/hoprassociation/hoprd:latest
 
   avado:
     name: Build Avado (master or release pushes)
@@ -171,6 +172,7 @@ jobs:
     needs: [build_hoprd_docker]
     steps:
       - uses: actions/checkout@v2
+
       - name: Update repo from latest pushes.
         run: |
           git config --global user.email "noreply@hoprnet.org"
@@ -180,12 +182,12 @@ jobs:
 
       - name: Get version from package.json
         run: |
-          echo "RELEASE=$(node -p -e "require('./packages/hoprd/package.json').version")" >> $GITHUB_ENV 
+          echo "RELEASE=$(node -p -e "require('./packages/hoprd/package.json').version")" >> $GITHUB_ENV
 
       - name: Avado hack version if we are in master (they don't support prerelease versions)
         if: github.ref == 'refs/heads/master'
         run: |
-          echo "RELEASE=0.100.0" >> $GITHUB_ENV # Set this to an arbitrary number less than 1 
+          echo "RELEASE=0.100.0" >> $GITHUB_ENV # Set this to an arbitrary number less than 1
 
       - name: Build Avado
         working-directory: packages/avado
@@ -209,25 +211,27 @@ jobs:
     needs: [build_hoprd_docker]
     steps:
       - uses: actions/checkout@v2
+
       - name: Use Node.js 14
         uses: actions/setup-node@v2
         with:
           node-version: 14
           registry-url: https://registry.npmjs.org/
+
       - name: Update repo from latest pushes.
         run: |
           git config --global user.email "noreply@hoprnet.org"
           git config --global user.name "HOPR Versioning robot"
           git config pull.rebase false
           git pull origin ${{ github.ref }} # This should pull new packages with versions etc.
+
       - name: Setup Google Cloud Credentials
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud
         with:
-          version: '290.0.1'
+          project_id: ${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}
           service_account_key: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
           export_default_credentials: true
-      - name: Set Project for Google Cloud HOPR Association
-        run: gcloud config set project ${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}
+
       - name: Run start script
         run: |
           bash scripts/deploy.sh
@@ -235,4 +239,3 @@ jobs:
           FUNDING_PRIV_KEY: ${{ secrets.FUNDING_WALLET_PRIVATE_KEY }}
           GITHUB_REF: ${{ github.ref }}
           BS_PASSWORD: ${{ secrets.BS_PASSWORD }}
-

--- a/scripts/cleanup.sh
+++ b/scripts/cleanup.sh
@@ -5,13 +5,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ -z "$GCLOUD_INCLUDED" ]; then
-  source scripts/gcloud.sh
-fi
+# Don't source this file twice
+test -z "${CLEANUP_SOURCED:-}" && CLEANUP_SOURCED=1 || exit 0
 
-if [ -z "$OLD_RELEASES" ]; then
-  source scripts/environments.sh
-fi
+source scripts/gcloud.sh
+source scripts/environments.sh
 
 cleanup_ips() {
   local IPS

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -7,6 +7,9 @@ set -o pipefail
 shopt -s expand_aliases
 #set -o xtrace
 
+# Don't source this file twice
+test -z "${DEPLOY_SOURCED:-}" && DEPLOY_SOURCED=1 || exit 0
+
 source scripts/environments.sh
 source scripts/testnet.sh
 source scripts/cleanup.sh

--- a/scripts/dns.sh
+++ b/scripts/dns.sh
@@ -4,6 +4,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Don't source this file twice
+test -z "${DNS_SOURCED:-}" && DNS_SOURCED=1 || exit 0
+
 # Get dns entry for a release and node
 # e.g. gcloud_dns_entry master
 # $1 = release name

--- a/scripts/environments.sh
+++ b/scripts/environments.sh
@@ -4,6 +4,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Don't source this file twice
+test -z "${ENVIRONMENTS_SOURCED:-}" && ENVIRONMENTS_SOURCED=1 || exit 0
+
 source scripts/utils.sh
 
 # These will be cleaned up and machines stopped

--- a/scripts/gcloud.sh
+++ b/scripts/gcloud.sh
@@ -4,13 +4,13 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+test -z "${GCLOUD_SOURCED:-}" && GCLOUD_SOURCED=1 || exit 0
+
 # ------ GCloud utilities ------
 #
 # NB. functions here should not rely on any external env. variables, or functions
 # not in this file, as this is intended for reuse in various scenarios.
 
-# shellcheck disable=SC2034
-GCLOUD_INCLUDED=1 # So we can test for inclusion
 ZONE="--zone=europe-west6-a"
 REGION="--region=europe-west6"
 

--- a/scripts/internal.sh
+++ b/scripts/internal.sh
@@ -4,6 +4,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Don't source this file twice
+test -z "${INTERNAL_SOURCED:-}" && INTERNAL_SOURCED=1 || exit 0
+
 source scripts/testnet.sh
 source scripts/cleanup.sh
 

--- a/scripts/nightly.sh
+++ b/scripts/nightly.sh
@@ -4,6 +4,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Don't source this file twice
+test -z "${NIGHTLY_SOURCED:-}" && NIGHTLY_SOURCED=1 || exit 0
+
 source scripts/testnet.sh
 source scripts/cleanup.sh
 

--- a/scripts/qa.sh
+++ b/scripts/qa.sh
@@ -4,6 +4,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Don't source this file twice
+test -z "${QA_SOURCED:-}" && QA_SOURCED=1 || exit 0
+
 # Smoke test a running node
 
 #$1 command

--- a/scripts/testnet.sh
+++ b/scripts/testnet.sh
@@ -4,11 +4,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-if [ -z "$GCLOUD_INCLUDED" ]; then
-  source scripts/gcloud.sh
-  source scripts/dns.sh
-fi
+# Don't source this file twice
+test -z "${TESTNET_SOURCED:-}" && TESTNET_SOURCED=1 || exit 0
 
+source scripts/gcloud.sh
+source scripts/dns.sh
 source scripts/utils.sh
 
 MIN_FUNDS=0.01291

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -4,6 +4,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Don't source this file twice
+test -z "${UTILS_SOURCED:-}" && UTILS_SOURCED=1 || exit 0
+
 # $1=version string, semver
 function get_version_maj_min() {
   get_version_maj_min_pat "$1" | cut -d. -f1,2


### PR DESCRIPTION
After my changes to make the shell scripts more strict, the deploy workflow, specifically `deploy.sh` didn't work anymore due to an undefined variable. This PR fixes such occasions by moving the check into the files themselves. 