### PR TITLE
Remove uses of GITHUB_ENV in Github release workflow

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,2 @@
+# use image with standard tools installed
+-P ubuntu-latest=catthehacker/ubuntu:act-latest

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Install dependencies / link / build
         run: |
           yarn
-          yarn lerna bootstrap
+          yarn setup
           yarn util:link
           yarn build
 

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -26,6 +26,14 @@ jobs:
           node-version: 14
           registry-url: https://registry.npmjs.org/
 
+      - name: Install Yarn (only when using ACT)
+        if: env.ACT != ""
+        run: |
+          curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+          echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+          apt update
+          apt install --no-install-recommends yarn
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
@@ -42,13 +50,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nodejs-
 
-      - name: Install dependencies
+      - name: Install dependencies / link / build
         run: |
           yarn
           yarn lerna bootstrap
-
-      - name: Link & Build
-        run: |
           yarn util:link
           yarn build
 
@@ -57,8 +62,8 @@ jobs:
         run: |
           # skip releasing for changes from our bots to prevent circular change propagation
           [ "noreply@hoprnet.org" = "$(git show -s --format='%ae' ${HOPR_GITHUB_REF})" ] && exit 0
-          HOPR_PACKAGE_VERSION=$(./scripts/get-package-version.sh) \
-            bash -x scripts/publish-pre-release.sh
+          export HOPR_PACKAGE_VERSION=$(./scripts/get-package-version.sh)
+          bash -x scripts/publish-pre-release.sh
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           HOPR_PACKAGE: hoprd
@@ -76,20 +81,13 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           HOPR_PACKAGE: hoprd
 
-      - name: Get version from package.json
-        run: echo "RELEASE=$(./scripts/get-package-version.sh)" >> $GITHUB_ENV
-        env:
-          HOPR_PACKAGE: hoprd
-
-      - name: Debug release number
-        run: echo ${{ env.RELEASE }}
-
       - name: Wait for NPM
-        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')
-        run: bash -x scripts/wait-for-npm-package.sh
+        if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && !env.ACT
+        run: |
+          export HOPR_PACKAGE_VERSION=$(./scripts/get-package-version.sh)
+          bash -x scripts/wait-for-npm-package.sh
         env:
           HOPR_PACKAGE: hoprd
-          HOPR_PACKAGE_VERSION: ${{ env.RELEASE }}
 
   release:
     name: Create Github Release
@@ -107,14 +105,17 @@ jobs:
           git pull origin ${{ github.ref }} # This should pull new packages with versions etc.
 
       - name: Get version from package.json
-        run: echo "RELEASE_NAME=v$(node -p -e "require('./packages/hoprd/package.json').version")" >> $GITHUB_ENV
+        id: get-package-version
+        run: echo "::set-output name=tag::v$(./scripts/get-package-version.sh)"
+        env:
+          HOPR_PACKAGE: hoprd
 
       - uses: softprops/action-gh-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ env.RELEASE_NAME }}
-          name: HOPR - ${{ env.RELEASE_NAME }}
+          tag_name: ${{ steps.get-package-version.outputs.tag }}
+          name: HOPR - ${{ steps.get-package-version.outputs.tag }}
           draft: false
           prerelease: false
 
@@ -139,15 +140,16 @@ jobs:
           service_account_key: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
           export_default_credentials: true
 
-      - name: Get version from package.json
-        run : echo "RELEASE=$(node -p -e "require('./packages/hoprd/package.json').version")" >> $GITHUB_ENV
-
       - name: Building Docker image using Google Cloud Build
         working-directory: packages/hoprd
         run: | # TODO - actually parse semver to tag v1
-          gcloud builds submit --tag gcr.io/hoprassociation/hoprd:${{ env.RELEASE }}
-          gcloud container images add-tag gcr.io/hoprassociation/hoprd:${{ env.RELEASE }} gcr.io/hoprassociation/hoprd:1
-          gcloud container images add-tag gcr.io/hoprassociation/hoprd:${{ env.RELEASE }} gcr.io/hoprassociation/hoprd:latest
+          export HOPR_PACKAGE_VERSION=$(./scripts/get-package-version.sh)
+          gcloud builds submit --tag ${HOPR_DOCKER_IMAGE}:${HOPR_PACKAGE_VERSION}
+          gcloud container images add-tag ${HOPR_DOCKER_IMAGE}:${HOPR_PACKAGE_VERSION} ${HOPR_DOCKER_IMAGE}:1
+          gcloud container images add-tag ${HOPR_DOCKER_IMAGE}:${HOPR_PACKAGE_VERSION} ${HOPR_DOCKER_IMAGE}:latest
+        env:
+          HOPR_PACKAGE: hoprd
+          HOPR_DOCKER_IMAGE: gcr.io/hoprassociation/hoprd
 
   avado:
     name: Build Avado (master or release pushes)
@@ -163,14 +165,18 @@ jobs:
         run: |
           git pull origin ${{ github.ref }} # This should pull new packages with versions etc.
 
-      - name: Get version from package.json
+      - name: Set Avado release version
+        id: set-avado-release-version
         run: |
-          echo "RELEASE=$(node -p -e "require('./packages/hoprd/package.json').version")" >> $GITHUB_ENV
-
-      - name: Avado hack version if we are in master (they don't support prerelease versions)
-        if: github.ref == 'refs/heads/master'
-        run: |
-          echo "RELEASE=0.100.0" >> $GITHUB_ENV # Set this to an arbitrary number less than 1
+          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
+            # Hack version if we are in master (they don't support prerelease versions)
+            # Set this to an arbitrary number less than 1
+            echo "::set-output name=version::0.100.0"
+          else
+            echo "::set-output name=version::$(./scripts/get-package-version.sh)
+          fi
+        env:
+          HOPR_PACKAGE: hoprd
 
       - name: Build Avado
         working-directory: packages/avado
@@ -178,7 +184,8 @@ jobs:
           docker-compose build
           sudo npm install -g git+https://github.com/AvadoDServer/AVADOSDK.git#c11c4bd
           avadosdk increase minor
-          sed -i 's/version"[ ]*:[ ]*"[0-9]*\.[0-9]*\.[0-9]*"/version": "${{ env.RELEASE }}"/' ./dappnode_package.json
+          sed -i 's/version"[ ]*:[ ]*"[0-9]*\.[0-9]*\.[0-9]*"/version": "${{ steps.set-avado-release-version.outputs.version }}"/' \
+            ./dappnode_package.json
           cat ./dappnode_package.json | grep 'version'
           sudo avadosdk build --provider http://80.208.229.228:5001
           git add dappnode_package.json docker-compose.yml releases.json

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -82,7 +82,7 @@ jobs:
           HOPR_PACKAGE: hoprd
 
       - name: Wait for NPM
-        if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && !env.ACT
+        if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && env.ACT == ""
         run: |
           export HOPR_PACKAGE_VERSION=$(./scripts/get-package-version.sh)
           bash -x scripts/wait-for-npm-package.sh

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -62,6 +62,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           HOPR_PACKAGE: hoprd
+          HOPR_VERSION_MAJMIN: true
 
       # Pushing a PR to a release branch should increment the patch version in
       # accordance with semver.
@@ -70,8 +71,7 @@ jobs:
         run: |
           # skip releasing for changes from our bots to prevent circular change propagation
           [ "noreply@hoprnet.org" = "$(git show -s --format='%ae' ${HOPR_GITHUB_REF})" ] && exit 0
-          HOPR_PACKAGE_VERSION=$(./scripts/get-package-version.sh) \
-            bash -x scripts/publish-patch-release.sh
+          bash -x scripts/publish-patch-release.sh
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           HOPR_PACKAGE: hoprd

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -48,7 +48,7 @@ jobs:
         run: bash -x scripts/regenerate-typedocs.sh
 
       - name: Commit docs changes
-        if: !env.ACT
+        if: env.ACT == ""
         run: bash -x scripts/commit-and-push-all-changes.sh
         env:
           HOPR_GIT_MSG: "Re-generate API docs for packages"

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Configure Git info
+        run: bash -x scripts/configure-git-info.sh
+
       - name: Use Node.js
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,7 +6,7 @@ env:
 
 on:
   push:
-    branches: ['master', 'release/**', 'avado', 'debug-docs/**', 'tb/*']
+    branches: ['master', 'release/**', 'avado', 'debug-docs/**']
 
 jobs:
   docs:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -6,7 +6,7 @@ env:
 
 on:
   push:
-    branches: ['master', 'release/**', 'avado', 'debug-docs/**']
+    branches: ['master', 'release/**', 'avado', 'debug-docs/**', 'tb/*']
 
 jobs:
   docs:
@@ -24,6 +24,14 @@ jobs:
           node-version: 14
           registry-url: https://registry.npmjs.org/
 
+      - name: Install Yarn (only when using ACT)
+        if: env.ACT != ""
+        run: |
+          curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
+          echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
+          apt update
+          apt install --no-install-recommends yarn
+
       - name: Restore cache of node modules.
         uses: actions/cache@v2
         id: nodejs-cache
@@ -34,13 +42,13 @@ jobs:
           key: ${{ runner.os }}-lerna-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies
-        if: steps.nodejs-cache.outputs.cache-hit != 'true'
         run: yarn
 
       - name: Generate docs
         run: bash -x scripts/regenerate-typedocs.sh
 
       - name: Commit docs changes
+        if: !env.ACT
         run: bash -x scripts/commit-and-push-all-changes.sh
         env:
           HOPR_GIT_MSG: "Re-generate API docs for packages"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -44,24 +44,24 @@ jobs:
         if: steps.nodejs-cache.outputs.cache-hit != 'true'
         run: |
           yarn --prefer-offline
-          yarn lerna bootstrap
+          npx lerna bootstrap
 
       - name: Build (all)
         if: matrix.package == 'all'
         run: |
-          yarn lerna link
-          yarn lerna run build --include-dependencies --ignore @hoprnet/hopr-core --ignore @hoprnet/hopr-ethereum --ignore @hoprnet/hopr-core-ethereum
+          npx lerna link
+          npx lerna run build --include-dependencies --ignore @hoprnet/hopr-core --ignore @hoprnet/hopr-ethereum --ignore @hoprnet/hopr-core-ethereum
 
       - name: Test (all)
         if: matrix.package == 'all'
         run: |
-          yarn lerna run test --ignore @hoprnet/hopr-core --ignore @hoprnet/hopr-ethereum --ignore @hoprnet/hopr-core-ethereum
+          npx lerna run test --ignore @hoprnet/hopr-core --ignore @hoprnet/hopr-ethereum --ignore @hoprnet/hopr-core-ethereum
 
       - name: Build ${{ matrix.package }}
         if: matrix.package != 'all'
         run: |
-          yarn lerna run build --include-dependencies --scope @hoprnet/hopr-${{ matrix.package }}
+          npx lerna run build --include-dependencies --scope @hoprnet/hopr-${{ matrix.package }}
       - name: Test ${{ matrix.package }}
         if: matrix.package != 'all'
         run: |
-          yarn lerna run test --scope @hoprnet/hopr-${{ matrix.package }}
+          npx lerna run test --scope @hoprnet/hopr-${{ matrix.package }}

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@
   - [Starting database](#starting-database)
   - [Starting node with custom port](#starting-node-with-custom-port)
 - [Develop](#develop)
+- [Test](#test)
+  - [Github Actions CI](#github-actions-ci)
 - [Tooling](#tooling)
 - [Contact](#contact)
 - [License](#license)
@@ -118,6 +120,22 @@ DEBUG=hopr* yarn run:hoprd:bob
 yarn run:faucet:all
 ```
 
+## Test
+
+### Github Actions CI
+
+We run a fair amount of automation using Github Actions. To ease development
+of these workflows one can use [act][8] to run workflows locally in a
+Docker environment.
+
+E.g. running the build workflow:
+
+```sh
+act -j build
+```
+
+For more information please refer to [act][8]'s documentation.
+
 ## Tooling
 
 As some tools are only partially supported, please tag the respective team member
@@ -149,3 +167,4 @@ whenever you need an issue about a particular tool.
 [5]: https://hub.docker.com/u/hopr
 [6]: https://www.npmjs.com/package/@hoprnet/hoprd
 [7]: https://www.youtube.com/watch?v=d0Eb6haIUu4
+[8]: https://github.com/nektos/act

--- a/packages/hoprd/.gitignore
+++ b/packages/hoprd/.gitignore
@@ -1,7 +1,8 @@
-node_modules
+node_modules/
 lib
 db
 hopr-admin/.next
 
 # Exclude built npm packages
 *.tgz
+cache/

--- a/scripts/get-package-version.sh
+++ b/scripts/get-package-version.sh
@@ -6,6 +6,14 @@ set -o pipefail
 
 test -z "${HOPR_PACKAGE:-}" && (echo "Missing environment variable HOPR_PACKAGE"; exit 1)
 
-# returns the maj-min version as found in the local package info
-node -p -e "require('./packages/${HOPR_PACKAGE:-}/package.json').version" | \
-  sed 's/\(\.[0-9]*\-alpha\)*\.[0-9]*$//'
+declare full_version
+
+# get full version info from package description
+full_version=$(node -p -e "require('./packages/${HOPR_PACKAGE:-}/package.json').version")
+
+# returns the maj-min version if requested, otherwise the full version
+if [ -n "${HOPR_VERSION_MAJMIN:-}" ]; then
+  echo "${full_version}" | sed 's/\(\.[0-9]*\-alpha\)*\.[0-9]*$//'
+else
+  echo "${full_version}"
+fi

--- a/scripts/publish-patch-release.sh
+++ b/scripts/publish-patch-release.sh
@@ -10,7 +10,7 @@ test -z "${HOPR_GITHUB_REF:-}" && (echo "Missing environment variable HOPR_GITHU
 git pull origin "${HOPR_GITHUB_REF}"
 
 # create new version in each package, and tag in Git
-yarn lerna version patch --yes --exact --no-push --no-changelog
+npx lerna version patch --yes --exact --no-push --no-changelog
 
 # only make remote changes if running in CI
 if [ -n "${HOPR_IN_CI:-}" ]; then
@@ -18,5 +18,5 @@ if [ -n "${HOPR_IN_CI:-}" ]; then
   git push origin "${HOPR_GITHUB_REF}" --tags
 
   # publish version to npm
-  yarn lerna publish from-package --yes
+  npx lerna publish from-package --yes
 fi

--- a/scripts/publish-pre-release.sh
+++ b/scripts/publish-pre-release.sh
@@ -21,7 +21,7 @@ npm_package=$(${mydir}/get-npm-package-info.sh)
 test -n "${npm_package}" && version_type="preminor" || version_type="prerelease"
 
 # create new version in each package, and tag in Git
-yarn lerna version "${version_type}" --yes --exact --no-push --no-changelog --preid next
+npx lerna version "${version_type}" --yes --exact --no-push --no-changelog --preid next
 
 # only make remote changes if running in CI
 if [ -n "${HOPR_IN_CI:-}" ]; then
@@ -29,5 +29,5 @@ if [ -n "${HOPR_IN_CI:-}" ]; then
   git push origin "${branch}" --tags
 
   # publish version to npm
-  yarn lerna publish from-package --yes
+  npx lerna publish from-package --yes
 fi

--- a/shell.nix
+++ b/shell.nix
@@ -29,6 +29,9 @@ mkShell {
     ## python is required by node module bcrypto
     python3
 
+    # test Github automation
+    act
+
     # custom pkg groups
     macosPkgs
     linuxPkgs


### PR DESCRIPTION
This way the workflow can be tested locally via 

```sh
act -j release
```
