### PR TITLE
Use single-quotes in Github workflow yaml conditions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,7 +27,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
 
       - name: Install Yarn (only when using ACT)
-        if: env.ACT != ""
+        if: env.ACT != ''
         run: |
           curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
           echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
@@ -82,7 +82,7 @@ jobs:
           HOPR_PACKAGE: hoprd
 
       - name: Wait for NPM
-        if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && env.ACT == ""
+        if: (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && env.ACT == ''
         run: |
           export HOPR_PACKAGE_VERSION=$(./scripts/get-package-version.sh)
           bash -x scripts/wait-for-npm-package.sh

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,7 +25,7 @@ jobs:
           registry-url: https://registry.npmjs.org/
 
       - name: Install Yarn (only when using ACT)
-        if: env.ACT != ""
+        if: env.ACT != ''
         run: |
           curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
           echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
@@ -48,7 +48,7 @@ jobs:
         run: bash -x scripts/regenerate-typedocs.sh
 
       - name: Commit docs changes
-        if: env.ACT == ""
+        if: env.ACT == ''
         run: bash -x scripts/commit-and-push-all-changes.sh
         env:
           HOPR_GIT_MSG: "Re-generate API docs for packages"


### PR DESCRIPTION
Using double-quotes in such conditions breaks when there are multiple conditions.