### PR TITLE
Fix DHT address population and dial error

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -202,6 +202,12 @@ class Hopr extends EventEmitter {
       this.emit('hopr:peer:connection', conn.remotePeer)
       this.networkPeers.register(conn.remotePeer)
     })
+
+    // Feed previously announced addresses to DHT
+    for (const ma of publicNodes) {
+      this.libp2p.peerStore.addressBook.add(PeerId.createFromB58String(ma.getPeerId()), [ma])
+    }
+
     this.networkPeers = new NetworkPeers(Array.from(this.libp2p.peerStore.peers.values()).map((x) => x.id))
 
     const subscribe = (protocol: string, handler: LibP2PHandlerFunction, includeReply = false) =>

--- a/packages/utils/src/libp2p/index.ts
+++ b/packages/utils/src/libp2p/index.ts
@@ -156,7 +156,7 @@ export async function dial(
   }
 
   // Try to get some fresh addresses from the DHT
-  let dhtResponse: { id: PeerId, multiaddrs: Multiaddr[] } | undefined
+  let dhtResponse: { id: PeerId; multiaddrs: Multiaddr[] } | undefined
   try {
     // Let libp2p populate its internal peerStore with fresh addresses
     dhtResponse = await libp2p._dht.findPeer(destination, { timeout: DEFAULT_DHT_QUERY_TIMEOUT })


### PR DESCRIPTION
Fixes:
- repopulates DHT on restart
- various bug fixes in `dial` logic

Also fixes #1356 