### PR TITLE
specify E2E networks

### DIFF
--- a/packages/ethereum/chain/contracts.json
+++ b/packages/ethereum/chain/contracts.json
@@ -2,15 +2,15 @@
   "localhost": {
     "HoprToken": {
       "address": "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512",
-      "deployedAt": 4
+      "deployedAt": 5
     },
     "HoprChannels": {
       "address": "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",
-      "deployedAt": 8
+      "deployedAt": 9
     },
     "HoprDistributor": {
       "address": "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9",
-      "deployedAt": 7
+      "deployedAt": 8
     }
   },
   "goerli": {

--- a/packages/ethereum/tasks/utils/contracts.ts
+++ b/packages/ethereum/tasks/utils/contracts.ts
@@ -39,6 +39,9 @@ export const storeContract = async (
 }
 
 export const getContract = async (network: string, name: string): Promise<ContractData> => {
+  // HACK: hardhat keeps using localhost internally - fix coming in https://github.com/hoprnet/hoprnet/pull/1676
+  if (network === 'hardhat') network = 'localhost'
+
   try {
     return require(OUTPUT_FILE)?.[network]?.[name]
   } catch {

--- a/packages/ethereum/tasks/utils/contracts.ts
+++ b/packages/ethereum/tasks/utils/contracts.ts
@@ -39,9 +39,6 @@ export const storeContract = async (
 }
 
 export const getContract = async (network: string, name: string): Promise<ContractData> => {
-  // HACK: hardhat keeps using localhost internally - fix coming in https://github.com/hoprnet/hoprnet/pull/1676
-  if (network === 'hardhat') network = 'localhost'
-
   try {
     return require(OUTPUT_FILE)?.[network]?.[name]
   } catch {

--- a/scripts/run-integration-tests-locally.sh
+++ b/scripts/run-integration-tests-locally.sh
@@ -67,7 +67,7 @@ function fund_node {
   fi
 
   echo "- Funding 1 ETH and 1 HOPR to $ETH"
-  $hardhat faucet --config packages/ethereum/hardhat.config.ts --address "$ETH" --network hardhat --ishopraddress true
+  $hardhat faucet --config packages/ethereum/hardhat.config.ts --address "$ETH" --ishopraddress true
 }
 
 function cleanup {
@@ -125,7 +125,7 @@ check_port 9093
 
 # --- Running Mock Blockchain --- {{{
 echo "- Running hardhat local node"
-DEVELOPMENT=true $hardhat node --config packages/ethereum/hardhat.config.ts --network hardhat --show-stack-traces > "${hardhat_rpc_log}" 2>&1 &
+DEVELOPMENT=true $hardhat node --config packages/ethereum/hardhat.config.ts --show-stack-traces > "${hardhat_rpc_log}" 2>&1 &
 #HARDHAT_PID="$(lsof -i :8545 | grep 'LISTEN' | awk '{ print $2 }')"  || true # FML
 HARDHAT_PID="$!"
 echo "- Hardhat node started (127.0.0.1:8545) with PID $HARDHAT_PID"

--- a/scripts/run-integration-tests-locally.sh
+++ b/scripts/run-integration-tests-locally.sh
@@ -67,7 +67,7 @@ function fund_node {
   fi
 
   echo "- Funding 1 ETH and 1 HOPR to $ETH"
-  $hardhat faucet --config packages/ethereum/hardhat.config.ts --address "$ETH" --ishopraddress true
+  $hardhat faucet --config packages/ethereum/hardhat.config.ts --address "$ETH" --network hardhat --ishopraddress true
 }
 
 function cleanup {
@@ -125,7 +125,7 @@ check_port 9093
 
 # --- Running Mock Blockchain --- {{{
 echo "- Running hardhat local node"
-DEVELOPMENT=true $hardhat node --config packages/ethereum/hardhat.config.ts --as-network localhost --show-stack-traces > "${hardhat_rpc_log}" 2>&1 &
+DEVELOPMENT=true $hardhat node --config packages/ethereum/hardhat.config.ts --network hardhat --as-network localhost --show-stack-traces > "${hardhat_rpc_log}" 2>&1 &
 #HARDHAT_PID="$(lsof -i :8545 | grep 'LISTEN' | awk '{ print $2 }')"  || true # FML
 HARDHAT_PID="$!"
 echo "- Hardhat node started (127.0.0.1:8545) with PID $HARDHAT_PID"

--- a/scripts/run-integration-tests-locally.sh
+++ b/scripts/run-integration-tests-locally.sh
@@ -67,7 +67,7 @@ function fund_node {
   fi
 
   echo "- Funding 1 ETH and 1 HOPR to $ETH"
-  $hardhat faucet --config packages/ethereum/hardhat.config.ts --address "$ETH" --network hardhat --ishopraddress true
+  $hardhat faucet --config packages/ethereum/hardhat.config.ts --address "$ETH" --network localhost --ishopraddress true
 }
 
 function cleanup {

--- a/scripts/run-integration-tests-locally.sh
+++ b/scripts/run-integration-tests-locally.sh
@@ -125,7 +125,7 @@ check_port 9093
 
 # --- Running Mock Blockchain --- {{{
 echo "- Running hardhat local node"
-DEVELOPMENT=true $hardhat node --config packages/ethereum/hardhat.config.ts --show-stack-traces > "${hardhat_rpc_log}" 2>&1 &
+DEVELOPMENT=true $hardhat node --config packages/ethereum/hardhat.config.ts --as-network hardhat --show-stack-traces > "${hardhat_rpc_log}" 2>&1 &
 #HARDHAT_PID="$(lsof -i :8545 | grep 'LISTEN' | awk '{ print $2 }')"  || true # FML
 HARDHAT_PID="$!"
 echo "- Hardhat node started (127.0.0.1:8545) with PID $HARDHAT_PID"

--- a/scripts/run-integration-tests-locally.sh
+++ b/scripts/run-integration-tests-locally.sh
@@ -125,7 +125,7 @@ check_port 9093
 
 # --- Running Mock Blockchain --- {{{
 echo "- Running hardhat local node"
-DEVELOPMENT=true $hardhat node --config packages/ethereum/hardhat.config.ts --as-network hardhat --show-stack-traces > "${hardhat_rpc_log}" 2>&1 &
+DEVELOPMENT=true $hardhat node --config packages/ethereum/hardhat.config.ts --as-network localhost --show-stack-traces > "${hardhat_rpc_log}" 2>&1 &
 #HARDHAT_PID="$(lsof -i :8545 | grep 'LISTEN' | awk '{ print $2 }')"  || true # FML
 HARDHAT_PID="$!"
 echo "- Hardhat node started (127.0.0.1:8545) with PID $HARDHAT_PID"


### PR DESCRIPTION
due to a hardhat + hardhat-deploy quirk we are forced to use the `hardhat` network when we want to run a hardhat node
this update runs the node in hardhat network but pretends to be a localhost network, all other scripts should do `--network localhost`, addressing this issue better in #1676 