### PR TITLE
Use opening instead of commitment when redeeming tickets

### DIFF
--- a/packages/core-ethereum/src/channel.ts
+++ b/packages/core-ethereum/src/channel.ts
@@ -61,7 +61,6 @@ class Channel {
 
     const ticket = unacknowledgedTicket.ticket
 
-    // @TODO use some caching to optimize execution time
     const opening = await this.commitment.findPreImage(await this.commitment.getCurrentCommitment())
 
     if (ticket.isWinningTicket(opening, response, ticket.winProb)) {

--- a/packages/core-ethereum/src/channel.ts
+++ b/packages/core-ethereum/src/channel.ts
@@ -61,13 +61,11 @@ class Channel {
 
     const ticket = unacknowledgedTicket.ticket
 
-    if (ticket.isWinningTicket(await this.commitment.getCurrentCommitment(), response, ticket.winProb)) {
-      const ack = new AcknowledgedTicket(
-        ticket,
-        response,
-        await this.commitment.getCurrentCommitment(),
-        unacknowledgedTicket.signer
-      )
+    // @TODO use some caching to optimize execution time
+    const opening = await this.commitment.findPreImage(await this.commitment.getCurrentCommitment())
+
+    if (ticket.isWinningTicket(opening, response, ticket.winProb)) {
+      const ack = new AcknowledgedTicket(ticket, response, opening, unacknowledgedTicket.signer)
       await this.commitment.bumpCommitment()
       return ack
     } else {
@@ -84,7 +82,6 @@ class Channel {
   }
 
   async getChainCommitment(): Promise<Hash> {
-    console.log(`getChainCommitment`, this, this.self)
     return (await this.getState()).commitmentFor(this.self.toAddress())
   }
 

--- a/packages/core-ethereum/src/commitment.ts
+++ b/packages/core-ethereum/src/commitment.ts
@@ -40,7 +40,7 @@ export class Commitment {
     )
   }
 
-  private async findPreImage(hash: Hash): Promise<Hash> {
+  async findPreImage(hash: Hash): Promise<Hash> {
     // TODO refactor after we move primitives
     let result = await recoverIteratedHash(
       hash.serialize(),

--- a/packages/ethereum/contracts/mocks/ChannelsMock.sol
+++ b/packages/ethereum/contracts/mocks/ChannelsMock.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8;
 
 import "../HoprChannels.sol";
+import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 contract ChannelsMock is HoprChannels {
     constructor(address _token, uint32 _secsClosure)
@@ -48,7 +49,7 @@ contract ChannelsMock is HoprChannels {
         uint256 amount,
         uint256 ticketIndex,
         uint256 winProb
-    ) external pure returns (bytes memory) {
+    ) external pure returns (bytes32) {
         return _getEncodedTicket(recipient, recipientCounter, proofOfRelaySecret, channelIteration, amount, ticketIndex, winProb);
     }
 

--- a/packages/utils/src/types/primitives.spec.ts
+++ b/packages/utils/src/types/primitives.spec.ts
@@ -199,4 +199,14 @@ describe('test Signature primitive', function () {
 
     assert(s.verify(utils.arrayify(message), PublicKey.fromString(publicKey)))
   })
+
+  it('should serialize to Ethereum', function () {
+    const s = new Signature(utils.arrayify(signature), recovery)
+
+    assert(Signature.deserializeEthereum(s.serializeEthereum()).toHex() === s.toHex())
+
+    assert.throws(() => Signature.deserialize(s.serializeEthereum()))
+
+    assert.throws(() => Signature.deserializeEthereum(s.serialize()))
+  })
 })

--- a/packages/utils/src/types/primitives.ts
+++ b/packages/utils/src/types/primitives.ts
@@ -174,7 +174,7 @@ export class Signature {
 
     const r = u8aToNumber(preRecovery) as number
 
-    if (![0,1].includes(r)) {
+    if (![0, 1].includes(r)) {
       throw Error(`v must be either 0 or 1. Got ${r}`)
     }
 


### PR DESCRIPTION
Fixes:
```
  hopr:core-ethereum:chain-operations Transaction with nonce 3 failed to sent: Error: processing response error (body="{\"jsonrpc\":\"2.0\",\"id\":1468,\"error\":{\"code\":-32603,\"message\":\"Error: VM Exception while processing transaction: revert commitment must be hash of next commitment\",\"data\":{\"txHash\":\"0x33547467b38bee65dd73dfc71f671a9e2b55748ef21eb0417feb247cad128ade\"}}}", error={"code":-32603,"data":{"txHash":"0x33547467b38bee65dd73dfc71f671a9e2b55748ef21eb0417feb247cad128ade"}}, requestBody="{\"method\":\"eth_sendRawTransaction\",\"params\":[\"0xf901ed038501dcd65000830493e094dc64a140aa3e981100a9beca4e685f962f0cf6c980b901842bcead2f000000000000000000000000ed62b48ff09019cd5b25c16d908d42b86b715dd7ed27200d59efbd7b9d066bbf27654d90b41ef779a870ed192e6ab44c2945e89e00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001bf00d6e0ff60a59092b1c51ef9e6ed853d97524612dcc549d76a02b548f2fb0e000000000000000000000000000000000000000000000000002386f26fc10000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000041b4d1010dbae0ac26849c8940be5de431361d947fbdbc9b8d930d2f26b668274f2b4751968751d273750ab5c70b315892575c477e839a4bfec49c60ef8d7b34d0010000000000000000000000000000000000000000000000000000000000000082f4f6a07715ec41efbae021ff4bc18c4737fe0adc1312e0f1f3c16060da77f243780418a0603ab2370c06407561b731112a540b2c36f034e154313ad9cda0746bac57fc69\"],\"id\":1468,\"jsonrpc\":\"2.0\"}", requestMethod="POST", url="http://127.0.0.1:8545/", code=SERVER_ERROR, version=web/5.2.0)
    at Logger.makeError (/home/robert/Documents/HOPR/hoprnet/node_modules/@ethersproject/logger/lib/index.js:187:21)
    at Logger.throwError (/home/robert/Documents/HOPR/hoprnet/node_modules/@ethersproject/logger/lib/index.js:196:20)
    at /home/robert/Documents/HOPR/hoprnet/node_modules/@ethersproject/web/lib/index.js:266:32
    at step (/home/robert/Documents/HOPR/hoprnet/node_modules/@ethersproject/web/lib/index.js:33:23)
    at Object.next (/home/robert/Documents/HOPR/hoprnet/node_modules/@ethersproject/web/lib/index.js:14:53)
    at fulfilled (/home/robert/Documents/HOPR/hoprnet/node_modules/@ethersproject/web/lib/index.js:5:58)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (internal/process/task_queues.js:93:5) {
  reason: 'processing response error',
  code: 'SERVER_ERROR',
  body: '{"jsonrpc":"2.0","id":1468,"error":{"code":-32603,"message":"Error: VM Exception while processing transaction: revert commitment must be hash of next commitment","data":{"txHash":"0x33547467b38bee65dd73dfc71f671a9e2b55748ef21eb0417feb247cad128ade"}}}',
  error: [Error],
  requestBody: '{"method":"eth_sendRawTransaction","params":["0xf901ed038501dcd65000830493e094dc64a140aa3e981100a9beca4e685f962f0cf6c980b901842bcead2f000000000000000000000000ed62b48ff09019cd5b25c16d908d42b86b715dd7ed27200d59efbd7b9d066bbf27654d90b41ef779a870ed192e6ab44c2945e89e00000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001bf00d6e0ff60a59092b1c51ef9e6ed853d97524612dcc549d76a02b548f2fb0e000000000000000000000000000000000000000000000000002386f26fc10000ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000041b4d1010dbae0ac26849c8940be5de431361d947fbdbc9b8d930d2f26b668274f2b4751968751d273750ab5c70b315892575c477e839a4bfec49c60ef8d7b34d0010000000000000000000000000000000000000000000000000000000000000082f4f6a07715ec41efbae021ff4bc18c4737fe0adc1312e0f1f3c16060da77f243780418a0603ab2370c06407561b731112a540b2c36f034e154313ad9cda0746bac57fc69"],"id":1468,"jsonrpc":"2.0"}',
  requestMethod: 'POST',
  url: 'http://127.0.0.1:8545/',
  transaction: [Object],
  transactionHash: '0x33547467b38bee65dd73dfc71f671a9e2b55748ef21eb0417feb247cad128ade'
} +99ms
```