### PR TITLE
add closure time to info

### DIFF
--- a/packages/core-ethereum/src/ethereum.ts
+++ b/packages/core-ethereum/src/ethereum.ts
@@ -54,6 +54,7 @@ export async function createChainWrapper(providerURI: string, privateKey: Uint8A
   const token = HoprToken__factory.connect(hoprTokenDeployment.address, wallet)
   const channels = HoprChannels__factory.connect(hoprChannelsDeployment.address, wallet)
   const genesisBlock = (await provider.getTransaction(hoprChannelsDeployment.transactionHash)).blockNumber
+  const closureTime = await channels.secsClosure()
 
   const transactions = new TransactionManager()
   const nonceTracker = new NonceTracker(
@@ -292,12 +293,12 @@ export async function createChainWrapper(providerURI: string, privateKey: Uint8A
     getChannels: () => channels,
     getPrivateKey: () => utils.arrayify(wallet.privateKey),
     getPublicKey: () => PublicKey.fromString(utils.computePublicKey(wallet.publicKey, true)),
-    getInfo: () =>
-      [
-        `Running on: ${network}`,
-        `HOPR Token: ${hoprTokenDeployment.address}`,
-        `HOPR Channels: ${hoprChannelsDeployment.address}`
-      ].join('\n')
+    getInfo: () => ({
+      network,
+      hoprTokenAddress: hoprTokenDeployment.address,
+      hoprChannelsAddress: hoprChannelsDeployment.address,
+      channelClosureTime: closureTime
+    })
   }
 
   return api

--- a/packages/core-ethereum/src/ethereum.ts
+++ b/packages/core-ethereum/src/ethereum.ts
@@ -54,7 +54,7 @@ export async function createChainWrapper(providerURI: string, privateKey: Uint8A
   const token = HoprToken__factory.connect(hoprTokenDeployment.address, wallet)
   const channels = HoprChannels__factory.connect(hoprChannelsDeployment.address, wallet)
   const genesisBlock = (await provider.getTransaction(hoprChannelsDeployment.transactionHash)).blockNumber
-  const closureTime = await channels.secsClosure()
+  const channelClosureSecs = await channels.secsClosure()
 
   const transactions = new TransactionManager()
   const nonceTracker = new NonceTracker(
@@ -297,7 +297,7 @@ export async function createChainWrapper(providerURI: string, privateKey: Uint8A
       network,
       hoprTokenAddress: hoprTokenDeployment.address,
       hoprChannelsAddress: hoprChannelsDeployment.address,
-      channelClosureTime: closureTime
+      channelClosureSecs
     })
   }
 

--- a/packages/core-ethereum/src/index.ts
+++ b/packages/core-ethereum/src/index.ts
@@ -125,7 +125,7 @@ export default class HoprEthereum {
     network: string
     hoprTokenAddress: string
     hoprChannelsAddress: string
-    channelClosureTime: number
+    channelClosureSecs: number
   } {
     return this.chain.getInfo()
   }

--- a/packages/core-ethereum/src/index.ts
+++ b/packages/core-ethereum/src/index.ts
@@ -121,7 +121,12 @@ export default class HoprEthereum {
     return useCache ? this.cachedGetNativeBalance() : this.uncachedGetNativeBalance()
   }
 
-  public smartContractInfo() {
+  public smartContractInfo(): {
+    network: string
+    hoprTokenAddress: string
+    hoprChannelsAddress: string
+    channelClosureTime: number
+  } {
     return this.chain.getInfo()
   }
 

--- a/packages/core-ethereum/src/index.ts
+++ b/packages/core-ethereum/src/index.ts
@@ -121,7 +121,7 @@ export default class HoprEthereum {
     return useCache ? this.cachedGetNativeBalance() : this.uncachedGetNativeBalance()
   }
 
-  public smartContractInfo(): string {
+  public smartContractInfo() {
     return this.chain.getInfo()
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -594,7 +594,7 @@ class Hopr extends EventEmitter {
     network: string
     hoprTokenAddress: string
     hoprChannelsAddress: string
-    channelClosureTime: number
+    channelClosureSecs: number
   }> {
     const chain = await this.paymentChannels
     return chain.smartContractInfo()

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -590,7 +590,12 @@ class Hopr extends EventEmitter {
     return await chain.getNativeBalance(true)
   }
 
-  public async smartContractInfo() {
+  public async smartContractInfo(): Promise<{
+    network: string
+    hoprTokenAddress: string
+    hoprChannelsAddress: string
+    channelClosureTime: number
+  }> {
     const chain = await this.paymentChannels
     return chain.smartContractInfo()
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -590,7 +590,7 @@ class Hopr extends EventEmitter {
     return await chain.getNativeBalance(true)
   }
 
-  public async smartContractInfo(): Promise<string> {
+  public async smartContractInfo() {
     const chain = await this.paymentChannels
     return chain.smartContractInfo()
   }

--- a/packages/hoprd/src/commands/closeChannel.ts
+++ b/packages/hoprd/src/commands/closeChannel.ts
@@ -32,14 +32,14 @@ export default class CloseChannel extends AbstractCommand {
     try {
       const { status, receipt } = await this.node.closeChannel(peerId)
       const smartContractInfo = await this.node.smartContractInfo()
-      const channelClosureSecs = Math.ceil(smartContractInfo.channelClosureSecs / 60) // convert to minutes
+      const channelClosureMins = Math.ceil(smartContractInfo.channelClosureSecs / 60) // convert to minutes
 
       if (status === 'PENDING_TO_CLOSE') {
         return log(`${chalk.green(`Closing channel. Receipt: ${styleValue(receipt, 'hash')}`)}.`)
       } else {
         return log(
           `${chalk.green(
-            `Initiated channel closure, the channel must remain open for at least ${channelClosureSecs} minutes. Please send the close command again once the cool-off has passed. Receipt: ${styleValue(
+            `Initiated channel closure, the channel must remain open for at least ${channelClosureMins} minutes. Please send the close command again once the cool-off has passed. Receipt: ${styleValue(
               receipt,
               'hash'
             )}`

--- a/packages/hoprd/src/commands/closeChannel.ts
+++ b/packages/hoprd/src/commands/closeChannel.ts
@@ -31,13 +31,15 @@ export default class CloseChannel extends AbstractCommand {
 
     try {
       const { status, receipt } = await this.node.closeChannel(peerId)
+      const smartContractInfo = await this.node.smartContractInfo()
+      const channelClosureTime = Math.ceil(smartContractInfo.channelClosureTime / 60)
 
       if (status === 'PENDING_TO_CLOSE') {
         return log(`${chalk.green(`Closing channel. Receipt: ${styleValue(receipt, 'hash')}`)}.`)
       } else {
         return log(
           `${chalk.green(
-            `Initiated channel closure, the channel must remain open for at least 2 minutes. Please send the close command again once the cool-off has passed. Receipt: ${styleValue(
+            `Initiated channel closure, the channel must remain open for at least ${channelClosureTime} minutes. Please send the close command again once the cool-off has passed. Receipt: ${styleValue(
               receipt,
               'hash'
             )}`

--- a/packages/hoprd/src/commands/closeChannel.ts
+++ b/packages/hoprd/src/commands/closeChannel.ts
@@ -32,14 +32,14 @@ export default class CloseChannel extends AbstractCommand {
     try {
       const { status, receipt } = await this.node.closeChannel(peerId)
       const smartContractInfo = await this.node.smartContractInfo()
-      const channelClosureTime = Math.ceil(smartContractInfo.channelClosureTime / 60)
+      const channelClosureSecs = Math.ceil(smartContractInfo.channelClosureSecs / 60) // convert to minutes
 
       if (status === 'PENDING_TO_CLOSE') {
         return log(`${chalk.green(`Closing channel. Receipt: ${styleValue(receipt, 'hash')}`)}.`)
       } else {
         return log(
           `${chalk.green(
-            `Initiated channel closure, the channel must remain open for at least ${channelClosureTime} minutes. Please send the close command again once the cool-off has passed. Receipt: ${styleValue(
+            `Initiated channel closure, the channel must remain open for at least ${channelClosureSecs} minutes. Please send the close command again once the cool-off has passed. Receipt: ${styleValue(
               receipt,
               'hash'
             )}`

--- a/packages/hoprd/src/commands/commands.spec.ts
+++ b/packages/hoprd/src/commands/commands.spec.ts
@@ -112,7 +112,7 @@ describe('Commands', () => {
   it('close channel', async () => {
     let mockNode: any = sinon.fake()
     mockNode.smartContractInfo = async () => ({
-      channelClosureTime: 300
+      channelClosureSecs: 300
     })
     mockNode.closeChannel = sinon.fake(async () => ({
       status: undefined

--- a/packages/hoprd/src/commands/commands.spec.ts
+++ b/packages/hoprd/src/commands/commands.spec.ts
@@ -111,11 +111,15 @@ describe('Commands', () => {
 
   it('close channel', async () => {
     let mockNode: any = sinon.fake()
+    mockNode.smartContractInfo = async () => ({
+      channelClosureTime: 300
+    })
     mockNode.closeChannel = sinon.fake(async () => ({
       status: undefined
     }))
     let cmds = new mod.Commands(mockNode)
     await assertMatch(cmds, 'close 16Uiu2HAmAJStiomwq27Kkvtat8KiEHLBSnAkkKCqZmLYKVLtkiB7', /Initiated channel closure/)
+    await assertMatch(cmds, 'close 16Uiu2HAmAJStiomwq27Kkvtat8KiEHLBSnAkkKCqZmLYKVLtkiB7', /5 minutes/)
   })
 
   it('cover traffic', async () => {

--- a/packages/hoprd/src/commands/commands.spec.ts
+++ b/packages/hoprd/src/commands/commands.spec.ts
@@ -146,4 +146,15 @@ describe('Commands', () => {
 
     clock.restore()
   })
+
+  it('info', async () => {
+    let mockNode: any = sinon.fake()
+    mockNode.getAnnouncedAddresses = async () => []
+    mockNode.getListeningAddresses = () => []
+    mockNode.smartContractInfo = async () => ({
+      channelClosureSecs: 300
+    })
+    let cmds = new mod.Commands(mockNode)
+    await assertMatch(cmds, 'info', /Channel closure period: 5 minutes/)
+  })
 })

--- a/packages/hoprd/src/commands/info.ts
+++ b/packages/hoprd/src/commands/info.ts
@@ -15,12 +15,16 @@ export class Info extends AbstractCommand {
   }
 
   public async execute(log): Promise<void> {
+    const smartContractInfo = await this.node.smartContractInfo()
+
     // @TODO Add connector info etc.
     return log(
       [
         `Announcing to other nodes as: ${(await this.node.getAnnouncedAddresses()).map((ma) => ma.toString())}`,
         `Listening on: ${this.node.getListeningAddresses().map((ma) => ma.toString())}`,
-        `${await this.node.smartContractInfo()}`
+        `Running on: ${smartContractInfo.network}`,
+        `HOPR Token: ${smartContractInfo.hoprTokenAddress}`,
+        `HOPR Channels: ${smartContractInfo.hoprChannelsAddress}`
       ].join('\n')
     )
   }

--- a/packages/hoprd/src/commands/info.ts
+++ b/packages/hoprd/src/commands/info.ts
@@ -16,6 +16,7 @@ export class Info extends AbstractCommand {
 
   public async execute(log): Promise<void> {
     const smartContractInfo = await this.node.smartContractInfo()
+    const channelClosureSecs = Math.ceil(smartContractInfo.channelClosureSecs / 60) // convert to minutes
 
     // @TODO Add connector info etc.
     return log(
@@ -24,7 +25,8 @@ export class Info extends AbstractCommand {
         `Listening on: ${this.node.getListeningAddresses().map((ma) => ma.toString())}`,
         `Running on: ${smartContractInfo.network}`,
         `HOPR Token: ${smartContractInfo.hoprTokenAddress}`,
-        `HOPR Channels: ${smartContractInfo.hoprChannelsAddress}`
+        `HOPR Channels: ${smartContractInfo.hoprChannelsAddress}`,
+        `Channel closure period: ${channelClosureSecs} minutes`
       ].join('\n')
     )
   }

--- a/packages/hoprd/src/commands/info.ts
+++ b/packages/hoprd/src/commands/info.ts
@@ -16,7 +16,7 @@ export class Info extends AbstractCommand {
 
   public async execute(log): Promise<void> {
     const smartContractInfo = await this.node.smartContractInfo()
-    const channelClosureSecs = Math.ceil(smartContractInfo.channelClosureSecs / 60) // convert to minutes
+    const channelClosureMins = Math.ceil(smartContractInfo.channelClosureSecs / 60) // convert to minutes
 
     // @TODO Add connector info etc.
     return log(
@@ -26,7 +26,7 @@ export class Info extends AbstractCommand {
         `Running on: ${smartContractInfo.network}`,
         `HOPR Token: ${smartContractInfo.hoprTokenAddress}`,
         `HOPR Channels: ${smartContractInfo.hoprChannelsAddress}`,
-        `Channel closure period: ${channelClosureSecs} minutes`
+        `Channel closure period: ${channelClosureMins} minutes`
       ].join('\n')
     )
   }


### PR DESCRIPTION
- fixes #1770
- return an object with smart contract info from `core-ethereum`