### PR TITLE
Remove unused docker images when updating container VM

### DIFF
--- a/scripts/gcloud.sh
+++ b/scripts/gcloud.sh
@@ -84,3 +84,8 @@ gcloud_get_logs() {
   local id=$(gcloud compute ssh $ZONE $1 --command "docker ps -q --filter ancestor='$2' | xargs docker inspect --format='{{.Id}}'" | grep -v 'warning')
   gcloud compute ssh $ZONE $1 --command "docker logs $id"
 }
+
+# $1 - vm name
+gcloud_cleanup_docker_images() {
+  gcloud compute ssh $ZONE "$1" --command "sudo docker system prune -a -f"
+}

--- a/scripts/testnet.sh
+++ b/scripts/testnet.sh
@@ -72,6 +72,9 @@ update_if_existing() {
     echo "Previous GCloud VM Image: $PREV"
     gcloud_update_container_with_image $1 $2 "$(disk_name $1)" "/app/db"
     sleep 60
+
+    # prevent docker images overloading the disk space
+    gcloud_cleanup_docker_images "$1"
   else
     echo "no container"
   fi


### PR DESCRIPTION
These images add up and can fill the available disk space,
making the VM unreachable. Instead we remove old images right away.
If they are used at a later point in time again, they will be fetched
again by Docker.