### PR TITLE
Fix path to identity in Avado Docker container

### DIFF
--- a/packages/avado/Dockerfile
+++ b/packages/avado/Dockerfile
@@ -9,4 +9,4 @@ EXPOSE 3001
 # Healthcheck server
 EXPOSE 8080
 
-ENTRYPOINT ["node", "/app/index.js", "--password='open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0'", "--init", "--admin", "--adminHost", "0.0.0.0"]
+ENTRYPOINT ["node", "/app/index.js", "--password='open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0'", "--init", "--admin", "--adminHost", "0.0.0.0", "--identity", "/app/db/.hopr-identity"]


### PR DESCRIPTION
That path has been set to its default before which would lead to the
identity being wiped if the container was removed. Now that identity is
stored within the database folder on a separate volume.

Fixes #1788