### PR TITLE
Ensure Avado builds are only done on version changes

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -223,29 +223,29 @@ jobs:
       - name: Configure Git info
         run: ./scripts/configure-git-info.sh
 
-      - name: Set Avado release version
-        id: set-avado-release-version
-        run: |
-          if [ "${{ github.ref }}" = "refs/heads/master" ]; then
-            # Hack version if we are in master (they don't support prerelease versions)
-            # Set this to an arbitrary number less than 1
-            echo "::set-output name=version::0.100.0"
-          else
-            echo "::set-output name=version::$(./scripts/get-package-version.sh)"
-          fi
-        env:
-          HOPR_PACKAGE: hoprd
-
       - name: Build Avado
         working-directory: packages/avado
         env:
           HOPR_GIT_MSG: "placeholder"
           HOPR_GITHUB_REF: ${{ github.ref }}
+          HOPR_PACKAGE: hoprd
         run: |
+          # only release on version updates from our versioning bot to prevent
+          # duplicate releases
+          [ "noreply@hoprnet.org" != "$(git show -s --format='%ae' ${HOPR_GITHUB_REF})" ] && exit 0
+          # only release on commits with messages starting with the prefix 'v'
+          # which determines version commits
+          [[ "v"* != "$(git show -s --format='%B' ${HOPR_GITHUB_REF})" ]] && exit 0
+          # Hack version if we are in master (they don't support prerelease versions)
+          # Set this to an arbitrary number less than 1
+          local version="0.100.0"
+          if [ "${HOPR_GITHUB_REF}" != "refs/heads/master" ]; then
+            version="$(scripts/get-package-version.sh)"
+          fi
           docker-compose build
           sudo npm install -g git+https://github.com/AvadoDServer/AVADOSDK.git#c11c4bd
           avadosdk increase minor
-          sed -i 's/version"[ ]*:[ ]*"[0-9]*\.[0-9]*\.[0-9]*"/version": "${{ steps.set-avado-release-version.outputs.version }}"/' \
+          sed -i 's/version"[ ]*:[ ]*"[0-9]*\.[0-9]*\.[0-9]*"/version": "${version}"/' \
             ./dappnode_package.json
           cat ./dappnode_package.json | grep 'version'
           sudo avadosdk build --provider http://80.208.229.228:5001

--- a/scripts/testnet.sh
+++ b/scripts/testnet.sh
@@ -120,9 +120,17 @@ start_chain_provider(){
 # $3 node number
 # $4 = OPTIONAL chain provider
 start_testnode() {
-  local vm=$(vm_name "node-$3" $1)
+  local vm ip eth_address
+
+  # start or update vm
+  vm=$(vm_name "node-$3" $1)
   echo "- Starting test node $vm with $2 ${4:-}"
   start_testnode_vm $vm $2 ${4:-}
+
+  # ensure node has funds, even after just updating a release
+  ip=$(gcloud_get_ip "${vm}")
+  eth_address=$(get_eth_address "${ip}")
+  fund_if_empty "${eth_address}"
 }
 
 # $1 authorized keys file


### PR DESCRIPTION
Also re-add funding of nodes upon deployment

This process step got lost after deprecating bootstrap nodes. This
change runs the funding check whenever a node is started or updated.

Fixes #1842 

