### PR TITLE
Check that values are on the curve

### DIFF
--- a/DISCUSSIONS.md
+++ b/DISCUSSIONS.md
@@ -106,12 +106,3 @@ is out of scope.
 
 - Shrinking packet size by removing derivable values (initially in #1523)
 - Bulk redeem tickets (originally #793)
-
-## Smart Contract changes
-
-### Prevent secp256k1 twist attacks by verifying points are on the curve.
-
-See
-https://github.com/christianlundkvist/blog/blob/master/2020_05_26_secp256k1_twist_attacks/secp256k1_twist_attacks.md
-
-(Formerly https://github.com/hoprnet/hoprnet/issues/1791)

--- a/packages/core-ethereum/src/indexer/index.ts
+++ b/packages/core-ethereum/src/indexer/index.ts
@@ -286,7 +286,7 @@ class Indexer extends EventEmitter {
       })
       await this.db.updateAccount(account)
     } catch (e) {
-      // Issue with the multiaddress, no worries, we ignore this announcement.
+      // Issue with the multiaddress or invalid public key, no worries, we ignore this announcement.
       log('Error with announced peer', e, event)
     }
   }

--- a/packages/core/src/interactions/packet/index.spec.ts
+++ b/packages/core/src/interactions/packet/index.spec.ts
@@ -45,7 +45,7 @@ function createFakeChain(privKey: PeerId) {
   const acknowledge = (unacknowledgedTicket: UnacknowledgedTicket, _ackKeyShare: HalfKey) => {
     return new AcknowledgedTicket(
       unacknowledgedTicket.ticket,
-      new Response(new Uint8Array({ length: Response.SIZE })),
+      Response.createMock(),
       new Hash(new Uint8Array({ length: Hash.SIZE })),
       unacknowledgedTicket.signer
     )

--- a/packages/ethereum/contracts/HoprChannels.sol
+++ b/packages/ethereum/contracts/HoprChannels.sol
@@ -427,9 +427,8 @@ contract HoprChannels is IERC777Recipient, ERC1820Implementer {
         // Field order of the base field
         uint256 FIELD_ORDER = 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141;
 
-        // TODO: We need to check whether the point lies on our curve to prevent
-        // secp256k1 twist attacks. This is currently out of scope, but will be
-        // addressed at some point.
+        require(0 < uint256(response), "Invalid response. Value must be within the field");
+        require(uint256(response) < FIELD_ORDER, "Invalid response. Value must be within the field");
 
         // x-coordinate of the base point
         uint256 gx = 0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F81798;

--- a/packages/ethereum/test/HoprChannels.spec.ts
+++ b/packages/ethereum/test/HoprChannels.spec.ts
@@ -2,7 +2,7 @@ import { deployments, ethers } from 'hardhat'
 import Multiaddr from 'multiaddr'
 import { expect } from 'chai'
 import BN from 'bn.js'
-import { HoprToken__factory, ChannelsMock__factory, HoprChannels__factory } from '../types'
+import { HoprToken__factory, ChannelsMock__factory, HoprChannels__factory, HoprChannels, HoprToken } from '../types'
 import { increaseTime } from './utils'
 import { ACCOUNT_A, ACCOUNT_B } from './constants'
 import {
@@ -17,9 +17,11 @@ import {
   AcknowledgedTicket,
   PublicKey,
   generateChannelId,
-  ChannelStatus
+  ChannelStatus,
+  PromiseValue
 } from '@hoprnet/hopr-utils'
 import { randomBytes } from 'crypto'
+import type { Wallet } from '@ethersproject/wallet'
 
 type TicketValues = {
   recipient: string
@@ -33,7 +35,7 @@ type TicketValues = {
 
 const percentToUint256 = (percent: any) => ethers.constants.MaxUint256.mul(percent).div(100)
 
-export const redeemArgs = (ticket: AcknowledgedTicket) => [
+export const redeemArgs = (ticket: AcknowledgedTicket): Parameters<HoprChannels['redeemTicket']> => [
   ticket.signer.toAddress().toHex(),
   ticket.preImage.toHex(),
   ticket.ticket.epoch.toHex(),
@@ -188,7 +190,7 @@ describe('announce user', function () {
 })
 
 describe('funding HoprChannel catches failures', function () {
-  let fixtures, channels, accountA
+  let fixtures: PromiseValue<ReturnType<typeof useFixtures>>, channels: HoprChannels, accountA: Wallet
   before(async function () {
     // All of these tests revert, so we can rely on stateless single fixture.
     fixtures = await useFixtures()
@@ -326,8 +328,8 @@ describe('funding a HoprChannel success', function () {
 })
 
 describe('with single funded HoprChannels: AB: 70', function () {
-  let channels
-  let fixtures
+  let channels: HoprChannels
+  let fixtures: PromiseValue<ReturnType<typeof useFixtures>>
 
   beforeEach(async function () {
     fixtures = await useFixtures()
@@ -352,8 +354,8 @@ describe('with single funded HoprChannels: AB: 70', function () {
 })
 
 describe('with funded HoprChannels: AB: 70, BA: 30, secrets initialized', function () {
-  let channels
-  let fixtures
+  let channels: HoprChannels
+  let fixtures: PromiseValue<ReturnType<typeof useFixtures>>
 
   beforeEach(async function () {
     fixtures = await useFixtures()
@@ -516,7 +518,10 @@ describe('with funded HoprChannels: AB: 70, BA: 30, secrets initialized', functi
 })
 
 describe('with a pending_to_close HoprChannel (A:70, B:30)', function () {
-  let channels, token, fixtures
+  let channels: HoprChannels
+  let fixtures: PromiseValue<ReturnType<typeof useFixtures>>
+  let token: HoprToken
+
   beforeEach(async function () {
     fixtures = await useFixtures()
     channels = fixtures.channels
@@ -564,7 +569,9 @@ describe('with a pending_to_close HoprChannel (A:70, B:30)', function () {
 })
 
 describe('with a closed channel', function () {
-  let channels, fixtures
+  let channels: HoprChannels
+  let fixtures: PromiseValue<ReturnType<typeof useFixtures>>
+
   beforeEach(async function () {
     fixtures = await useFixtures()
     channels = fixtures.channels
@@ -594,7 +601,10 @@ describe('with a closed channel', function () {
 })
 
 describe('with a reopened channel', function () {
-  let channels, fixtures, TICKET_AB_WIN_RECYCLED
+  let channels: HoprChannels
+  let fixtures: PromiseValue<ReturnType<typeof useFixtures>>
+  let TICKET_AB_WIN_RECYCLED: PromiseValue<ReturnType<typeof createTicket>>
+
   beforeEach(async function () {
     fixtures = await useFixtures()
     channels = fixtures.channels
@@ -650,8 +660,8 @@ describe('with a reopened channel', function () {
   })
 })
 
-describe('test internals with mock', function () {
-  let channels
+describe.only('test internals with mock', function () {
+  let channels: HoprChannels
   beforeEach(async function () {
     channels = (await useFixtures()).mockChannels
   })

--- a/packages/utils/src/types/accountEntry.spec.ts
+++ b/packages/utils/src/types/accountEntry.spec.ts
@@ -33,7 +33,7 @@ describe('AccountEntry', function () {
   it('should fail on invalid public keys', function () {
     const INVALID_PUBLIC_KEY = Uint8Array.from([0x03, ...new Uint8Array(32).fill(0xff)])
 
-    assert(!publicKeyVerify(INVALID_PUBLIC_KEY), 'Public key must be invalid')
+    assert(!publicKeyVerify(INVALID_PUBLIC_KEY), 'Public key must not be invalid')
 
     const MULTIHASH_PREFIX = Uint8Array.from([0x00, 0x25, 0x08, 0x02, 0x12, 0x21])
     const INVALID_ENCODED_KEY = encode(Uint8Array.from([...MULTIHASH_PREFIX, ...INVALID_PUBLIC_KEY]))
@@ -41,7 +41,7 @@ describe('AccountEntry', function () {
     assert.throws(
       () =>
         new AccountEntry(PARTY_A_ADDRESS, new Multiaddr(`/ip4/1.2.3.4/tcp/0/p2p/${INVALID_ENCODED_KEY}`), new BN('1')),
-      Error('Invalid public key')
+      Error('Multiaddr does not contain a valid public key.')
     )
   })
 })

--- a/packages/utils/src/types/accountEntry.ts
+++ b/packages/utils/src/types/accountEntry.ts
@@ -3,7 +3,7 @@ import PeerId from 'peer-id'
 import { ethers } from 'ethers'
 import { u8aSplit, serializeToU8a, MULTI_ADDR_MAX_LENGTH, u8aEquals } from '..'
 import BN from 'bn.js'
-import { Address, PublicKey } from '.' // TODO: cyclic dep
+import { Address, PublicKey } from './primitives'
 import { decode } from 'bs58'
 import { publicKeyVerify } from 'secp256k1'
 
@@ -26,7 +26,7 @@ export class AccountEntry {
         const pubKey = decode(encodedPublicKey).slice(-33)
 
         if (!publicKeyVerify(pubKey)) {
-          throw Error(`Invalid public key`)
+          throw Error(`Multiaddr does not contain a valid public key.`)
         }
       }
     }

--- a/packages/utils/src/types/response.spec.ts
+++ b/packages/utils/src/types/response.spec.ts
@@ -1,0 +1,19 @@
+import { Response } from './response'
+import { stringToU8a, u8aAdd, toU8a } from '../u8a'
+import assert from 'assert'
+
+describe(`test response`, function () {
+  const FIELD_ORDER = stringToU8a('0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141')
+  const INVALID_FIELD_ELEMENT = u8aAdd(false, FIELD_ORDER, toU8a(1, 32))
+
+  it('check response generation and edge cases', function () {
+      // Zero is not allowed
+    assert.throws(() => new Response(toU8a(0, 32)))
+
+    // FIELD_ORDER is in same equality class as zero, hence not allowed
+    assert.throws(() => new Response(FIELD_ORDER))
+
+    // INVALID_FIELD_ELEMENT is outside field, hence not allowed
+    assert.throws(() => new Response(INVALID_FIELD_ELEMENT))
+  })
+})

--- a/packages/utils/src/types/response.spec.ts
+++ b/packages/utils/src/types/response.spec.ts
@@ -19,7 +19,7 @@ describe(`test response`, function () {
       Error(`Invalid input argument. Given value is not a valid field element.`)
     )
 
-    // INVALID_FIELD_ELEMENT is outside field, hence not allowed
+    // INVALID_FIELD_ELEMENT is outside of the field, hence not allowed
     assert.throws(
       () => new Response(INVALID_FIELD_ELEMENT),
       Error(`Invalid input argument. Given value is not a valid field element.`)

--- a/packages/utils/src/types/response.spec.ts
+++ b/packages/utils/src/types/response.spec.ts
@@ -7,13 +7,22 @@ describe(`test response`, function () {
   const INVALID_FIELD_ELEMENT = u8aAdd(false, FIELD_ORDER, toU8a(1, 32))
 
   it('check response generation and edge cases', function () {
-      // Zero is not allowed
-    assert.throws(() => new Response(toU8a(0, 32)))
+    // Zero is not allowed
+    assert.throws(
+      () => new Response(toU8a(0, 32)),
+      Error(`Invalid input argument. Given value is not a valid field element.`)
+    )
 
     // FIELD_ORDER is in same equality class as zero, hence not allowed
-    assert.throws(() => new Response(FIELD_ORDER))
+    assert.throws(
+      () => new Response(FIELD_ORDER),
+      Error(`Invalid input argument. Given value is not a valid field element.`)
+    )
 
     // INVALID_FIELD_ELEMENT is outside field, hence not allowed
-    assert.throws(() => new Response(INVALID_FIELD_ELEMENT))
+    assert.throws(
+      () => new Response(INVALID_FIELD_ELEMENT),
+      Error(`Invalid input argument. Given value is not a valid field element.`)
+    )
   })
 })

--- a/packages/utils/src/types/response.ts
+++ b/packages/utils/src/types/response.ts
@@ -1,9 +1,11 @@
 import { Challenge } from '.'
-import { u8aToHex } from '../u8a'
+import { u8aToHex, stringToU8a } from '../u8a'
 import { SECP256K1_CONSTANTS } from '../crypto'
 import type { HalfKey } from '.'
 
-import { publicKeyCreate, privateKeyTweakAdd } from 'secp256k1'
+import { publicKeyCreate, privateKeyTweakAdd, privateKeyVerify } from 'secp256k1'
+
+const MOCK_RESPONSE = '0x0364e9fee43e1625e38aaf4b1efa44b265e2403377e8fed0963ed8b698f14b66'
 
 export class Response {
   constructor(private readonly arr: Uint8Array) {
@@ -14,13 +16,17 @@ export class Response {
     if (arr.length != Response.SIZE) {
       throw new Error('Incorrect size Uint8Array for hash')
     }
+
+    if (!privateKeyVerify(arr)) {
+      throw new Error(`Invalid input argument. Given value is not a valid field element.`)
+    }
   }
 
   static fromHalfKeys(firstHalfKey: HalfKey, secondHalfKey: HalfKey): Response {
     return new Response(privateKeyTweakAdd(firstHalfKey.clone().serialize(), secondHalfKey.serialize()))
   }
 
-  static deserialize(arr: Uint8Array) {
+  static deserialize(arr: Uint8Array): Response {
     return new Response(arr)
   }
 
@@ -37,4 +43,8 @@ export class Response {
   }
 
   static SIZE = SECP256K1_CONSTANTS.PRIVATE_KEY_LENGTH
+
+  static createMock(): Response {
+    return new Response(stringToU8a(MOCK_RESPONSE))
+  }
 }


### PR DESCRIPTION
Fixes #1791 

Changes:
- check that response is within the field. Previously it was possible to use e.g. `1` and `1 + FIELD_ORDER` as a response.
- fail on invalid public keys that are announced on-chain. Make sure that nodes cannot trick other nodes with wrong public keys, see https://github.com/christianlundkvist/blog/blob/master/2020_05_26_secp256k1_twist_attacks/secp256k1_twist_attacks.md
- add test that checks SC for invalid response to challenge