### PR TITLE
Fix entrypoint in Avado docker image

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -289,7 +289,6 @@ jobs:
         if: ${{ !env.ACT }}
         run: |
           gcloud container images add-tag ${HOPR_DOCKER_IMAGE}:${HOPR_IMAGE_VERSION} ${HOPR_DOCKER_IMAGE}:${HOPR_PACKAGE_VERSION}
-          gcloud container images add-tag ${HOPR_DOCKER_IMAGE}:${HOPR_IMAGE_VERSION} ${HOPR_DOCKER_IMAGE}:latest
         env:
           HOPR_DOCKER_IMAGE: gcr.io/hoprassociation/hoprd
           HOPR_IMAGE_VERSION: ${{ steps.set-image-version.outputs.vsn }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -289,12 +289,27 @@ jobs:
         if: ${{ !env.ACT }}
         run: |
           gcloud container images add-tag ${HOPR_DOCKER_IMAGE}:${HOPR_IMAGE_VERSION} ${HOPR_DOCKER_IMAGE}:${HOPR_PACKAGE_VERSION}
-          gcloud container images add-tag ${HOPR_DOCKER_IMAGE}:${HOPR_IMAGE_VERSION} ${HOPR_DOCKER_IMAGE}:1
           gcloud container images add-tag ${HOPR_DOCKER_IMAGE}:${HOPR_IMAGE_VERSION} ${HOPR_DOCKER_IMAGE}:latest
         env:
           HOPR_DOCKER_IMAGE: gcr.io/hoprassociation/hoprd
           HOPR_IMAGE_VERSION: ${{ steps.set-image-version.outputs.vsn }}
           HOPR_PACKAGE_VERSION: ${{ steps.set-package-version.outputs.vsn }}
+
+      - name: Add tag latest to new Docker image on master
+        if: ${{ !env.ACT }} && ${{ github.ref == 'refs/heads/master' }}
+        run: |
+          gcloud container images add-tag ${HOPR_DOCKER_IMAGE}:${HOPR_IMAGE_VERSION} ${HOPR_DOCKER_IMAGE}:latest
+        env:
+          HOPR_DOCKER_IMAGE: gcr.io/hoprassociation/hoprd
+          HOPR_IMAGE_VERSION: ${{ steps.set-image-version.outputs.vsn }}
+
+      - name: Add tag latest-release to new Docker image on release branches
+        if: ${{ !env.ACT &&  startsWith(github.ref, 'refs/heads/release/') }}
+        run: |
+          gcloud container images add-tag ${HOPR_DOCKER_IMAGE}:${HOPR_IMAGE_VERSION} ${HOPR_DOCKER_IMAGE}:latest-release
+        env:
+          HOPR_DOCKER_IMAGE: gcr.io/hoprassociation/hoprd
+          HOPR_IMAGE_VERSION: ${{ steps.set-image-version.outputs.vsn }}
 
   avado:
     name: Build Avado (master or release pushes)

--- a/packages/avado/Dockerfile
+++ b/packages/avado/Dockerfile
@@ -1,12 +1,3 @@
-FROM gcr.io/hoprassociation/hoprd:1
+FROM gcr.io/hoprassociation/hoprd:latest-release
 
-VOLUME ["/app/db"]
-
-# Admin web server
-EXPOSE 3000
-# REST API
-EXPOSE 3001
-# Healthcheck server
-EXPOSE 8080
-
-ENTRYPOINT ["node", "/app/index.js", "--password='open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0'", "--init", "--admin", "--adminHost", "0.0.0.0", "--identity", "/app/db/.hopr-identity"]
+ENTRYPOINT ["/usr/bin/tini", "--", "yarn", "hoprd", "--password='open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0'", "--init", "--admin", "--adminHost", "0.0.0.0", "--identity", "/app/db/.hopr-identity"]


### PR DESCRIPTION
This fixes a crash where the entrypoint module could not be found.
Also changed the tag of the docker image so that Avado only uses images
from release branches and not pre-releases.