### PR TITLE
Add macos as platform to CI tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         node-version: [14]
-        os: ['ubuntu-latest', 'macos-11']
+        os: ['ubuntu-latest', 'macos-latest']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -11,17 +11,21 @@ on:
 
 jobs:
   source-e2e:
-    name: ${{ matrix.test }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+
+    strategy:
+      matrix:
+        node-version: [14]
+        os: ['ubuntu-latest', 'macos-11']
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Use Node.js
+      - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: ${{ matrix.node-version }}
           registry-url: https://registry.npmjs.org/
 
       - name: Get yarn cache directory path

--- a/.github/workflows/npm-e2e.yaml
+++ b/.github/workflows/npm-e2e.yaml
@@ -11,17 +11,21 @@ on:
 
 jobs:
   npm-e2e:
-    name: ${{ matrix.test }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 15
+
+    strategy:
+      matrix:
+        node-version: [14]
+        os: ['ubuntu-latest', 'macos-latest']
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Use Node.js
+      - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: ${{ matrix.node-version }}
           registry-url: https://registry.npmjs.org/
 
       - name: Get yarn cache directory path

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         node-version: [14]
-        os: ['ubuntu-latest', 'macos-latest']
+        os: ['ubuntu-latest']
         package: ['core', 'ethereum', 'all', 'core-ethereum']
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,11 +9,12 @@ on:
 jobs:
   build_and_test:
     name: Build & Test
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
         node-version: [14]
+        os: ['ubuntu-latest', 'macos-11']
         package: ['core', 'ethereum', 'all', 'core-ethereum']
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         node-version: [14]
-        os: ['ubuntu-latest', 'macos-11']
+        os: ['ubuntu-latest', 'macos-latest']
         package: ['core', 'ethereum', 'all', 'core-ethereum']
 
     steps:


### PR DESCRIPTION
Using macos as a platform for tests in CI ensures that all scripts and tools work on both supported platforms. This addresses issues where PRs introduced incompatible tooling.