### PR TITLE
Store node logs as CI artifacts after e2e tests

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -52,6 +52,6 @@ jobs:
       - name: Upload node logs
         uses: actions/upload-artifact@v2
         with:
-          name: node-logs
+          name: hopr-e2e-source-node-logs
           path: |
             /tmp/hopr-*-node*.log

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -48,3 +48,10 @@ jobs:
 
       - name: Test
         run: ./scripts/run-integration-tests-source.sh
+
+      - name: Upload node logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: node-logs
+          path: |
+            /tmp/hopr-*-node*.log

--- a/.github/workflows/npm-e2e.yaml
+++ b/.github/workflows/npm-e2e.yaml
@@ -48,3 +48,10 @@ jobs:
 
       - name: Test
         run: ./scripts/run-integration-tests-npm.sh
+
+      - name: Upload node logs
+        uses: actions/upload-artifact@v2
+        with:
+          name: node-logs
+          path: |
+            /tmp/hopr-*-node*.log

--- a/.github/workflows/npm-e2e.yaml
+++ b/.github/workflows/npm-e2e.yaml
@@ -52,6 +52,6 @@ jobs:
       - name: Upload node logs
         uses: actions/upload-artifact@v2
         with:
-          name: node-logs
+          name: hopr-e2e-npm-node-logs
           path: |
             /tmp/hopr-*-node*.log


### PR DESCRIPTION
Being able to download the full node logs is useful when debugging CI test failures.