### PR TITLE
Add notification on CI failures

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,6 +2,9 @@ name: HOPR Deploy
 
 env:
   HOPR_GITHUB_REF: ${{ github.ref }}
+  MATRIX_ROOM: ${{ secrets.MATRIX_ROOM }}
+  MATRIX_SERVER: ${{ secrets.MATRIX_SERVER }}
+  MATRIX_ACCESS_TOKEN: ${{ secrets.MATRIX_ACCESS_TOKEN }}
 
 on:
   push:
@@ -56,6 +59,12 @@ jobs:
           yarn setup
           yarn util:link
           yarn build
+
+      - name: Send notification if anything failed on master or release branches
+        if: ${{ failure() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && !env.ACT }}
+        run: |
+          ./scripts/notify-matrix-github-workflow-failure.sh "${MATRIX_ROOM}" "${{ github.repository }}" \
+            "${{ github.workflow }}" "${{ github.run_id }}"
 
   publish_npm:
     name: Publish to NPM
@@ -135,6 +144,12 @@ jobs:
         env:
           HOPR_PACKAGE: hoprd
 
+      - name: Send notification if anything failed on master or release branches
+        if: ${{ failure() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && !env.ACT }}
+        run: |
+          ./scripts/notify-matrix-github-workflow-failure.sh "${MATRIX_ROOM}" "${{ github.repository }}" \
+            "${{ github.workflow }}" "${{ github.run_id }}"
+
   deploy_smart_contracts:
     name: Deploy Smart Contracts
     runs-on: ubuntu-latest
@@ -212,6 +227,12 @@ jobs:
           HOPR_GIT_MSG: "Update smart contract deployments"
         run: ./scripts/commit-and-push-all-changes.sh
 
+      - name: Send notification if anything failed on master or release branches
+        if: ${{ failure() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && !env.ACT }}
+        run: |
+          ./scripts/notify-matrix-github-workflow-failure.sh "${MATRIX_ROOM}" "${{ github.repository }}" \
+            "${{ github.workflow }}" "${{ github.run_id }}"
+
   github_release:
     name: Create Github Release
     runs-on: ubuntu-latest
@@ -238,6 +259,12 @@ jobs:
           name: HOPR - ${{ steps.get-package-version.outputs.tag }}
           draft: false
           prerelease: false
+
+      - name: Send notification if anything failed on master or release branches
+        if: ${{ failure() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && !env.ACT }}
+        run: |
+          ./scripts/notify-matrix-github-workflow-failure.sh "${MATRIX_ROOM}" "${{ github.repository }}" \
+            "${{ github.workflow }}" "${{ github.run_id }}"
 
   build_hoprd_docker:
     name: Build HOPRD Docker
@@ -310,6 +337,12 @@ jobs:
           HOPR_DOCKER_IMAGE: gcr.io/hoprassociation/hoprd
           HOPR_IMAGE_VERSION: ${{ steps.set-image-version.outputs.vsn }}
 
+      - name: Send notification if anything failed on master or release branches
+        if: ${{ failure() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && !env.ACT }}
+        run: |
+          ./scripts/notify-matrix-github-workflow-failure.sh "${MATRIX_ROOM}" "${{ github.repository }}" \
+            "${{ github.workflow }}" "${{ github.run_id }}"
+
   avado:
     name: Build Avado (master or release pushes)
     runs-on: ubuntu-latest
@@ -360,6 +393,12 @@ jobs:
           HOPR_GITHUB_REF: ${{ github.ref }}
         run: ./scripts/commit-and-push-all-changes.sh
 
+      - name: Send notification if anything failed on master or release branches
+        if: ${{ failure() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && !env.ACT }}
+        run: |
+          ./scripts/notify-matrix-github-workflow-failure.sh "${MATRIX_ROOM}" "${{ github.repository }}" \
+            "${{ github.workflow }}" "${{ github.run_id }}"
+
   deploy_instances:
     name: 'Continuous Deployment: Deploy instances'
     runs-on: ubuntu-latest
@@ -406,3 +445,9 @@ jobs:
           GITHUB_REF: ${{ github.ref }}
           BS_PASSWORD: ${{ secrets.BS_PASSWORD }}
           RPC_NETWORK: ${{ steps.set-rpc-network.outputs.network }}
+
+      - name: Send notification if anything failed on master or release branches
+        if: ${{ failure() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && !env.ACT }}
+        run: |
+          ./scripts/notify-matrix-github-workflow-failure.sh "${MATRIX_ROOM}" "${{ github.repository }}" \
+            "${{ github.workflow }}" "${{ github.run_id }}"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,6 +2,9 @@ name: HOPR End-to-end tests
 
 env:
   HOPR_GITHUB_REF: ${{ github.ref }}
+  MATRIX_ROOM: ${{ secrets.MATRIX_ROOM }}
+  MATRIX_SERVER: ${{ secrets.MATRIX_SERVER }}
+  MATRIX_ACCESS_TOKEN: ${{ secrets.MATRIX_ACCESS_TOKEN }}
 
 on:
   push:
@@ -51,7 +54,7 @@ jobs:
           yarn build
 
       - name: Install websocat
-        run: ./scripts/install-websocat.sh 
+        run: ./scripts/install-websocat.sh
 
       - name: Test
         run: ./scripts/run-integration-tests-source.sh
@@ -71,3 +74,9 @@ jobs:
           name: hopr-e2e-source-node-logs
           path: |
             /var/tmp/hopr-*-node*.log
+
+      - name: Send notification if anything failed on master or release branches
+        if: ${{ failure() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && !env.ACT }}
+        run: |
+          ./scripts/notify-matrix-github-workflow-failure.sh "${MATRIX_ROOM}" "${{ github.repository }}" \
+            "${{ github.workflow }}" "${{ github.run_id }}"

--- a/.github/workflows/npm-e2e.yaml
+++ b/.github/workflows/npm-e2e.yaml
@@ -2,6 +2,9 @@ name: HOPR End-to-end tests (NPM)
 
 env:
   HOPR_GITHUB_REF: ${{ github.ref }}
+  MATRIX_ROOM: ${{ secrets.MATRIX_ROOM }}
+  MATRIX_SERVER: ${{ secrets.MATRIX_SERVER }}
+  MATRIX_ACCESS_TOKEN: ${{ secrets.MATRIX_ACCESS_TOKEN }}
 
 on:
   push:
@@ -51,7 +54,7 @@ jobs:
           yarn build
 
       - name: Install websocat
-        run: ./scripts/install-websocat.sh 
+        run: ./scripts/install-websocat.sh
 
       - name: Test
         run: ./scripts/run-integration-tests-npm.sh
@@ -71,3 +74,9 @@ jobs:
           name: hopr-e2e-source-node-logs
           path: |
             /var/tmp/hopr-*-node*.log
+
+      - name: Send notification if anything failed on master or release branches
+        if: ${{ failure() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && !env.ACT }}
+        run: |
+          ./scripts/notify-matrix-github-workflow-failure.sh "${MATRIX_ROOM}" "${{ github.repository }}" \
+            "${{ github.workflow }}" "${{ github.run_id }}"

--- a/scripts/notify-matrix-github-workflow-failure.sh
+++ b/scripts/notify-matrix-github-workflow-failure.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# prevent souring of this script, only allow execution
+$(return >/dev/null 2>&1)
+test "$?" -eq "0" && { echo "This script should only be executed." >&2; exit 1; }
+
+# exit on errors, undefined variables, ensure errors in pipes are not hidden
+set -Eeuo pipefail
+
+# set log id and use shared log function for readable logs
+declare mydir
+mydir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+declare HOPR_LOG_ID="notify-matrix-github-workflow-failure"
+source "${mydir}/utils.sh"
+
+usage() {
+  msg
+  msg "Usage: $0 <room> <repo> <workflow> <run_id>"
+  msg
+  msg "The following environment variables are used to perform the request:"
+  msg
+  msg "MATRIX_SERVER, default 'https://matrix.org'"
+  msg "MATRIX_ACCESS_TOKEN, default ''"
+}
+
+# return early with help info when requested
+([ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]) && { usage; exit 0; }
+
+# do work
+[ -z "${1:-}" ] && { msg "Parameter <room> required"; usage; exit 1; }
+[ -z "${2:-}" ] && { msg "Parameter <repo> required"; usage; exit 1; }
+[ -z "${3:-}" ] && { msg "Parameter <workflow> required"; usage; exit 1; }
+[ -z "${4:-}" ] && { msg "Parameter <run_id> required"; usage; exit 1; }
+
+declare room="${1}"
+declare repo="${2}"
+declare workflow="${3}"
+declare run_id="${4}"
+
+declare url="https://github.com/${repo}/actions/runs/${run_id}"
+declare branch
+branch=$(git rev-parse --abbrev-ref HEAD)
+declare msg="Github workflow ${workflow} failed on branch ${branch}, see ${url}"
+
+${mydir}/notify-matrix.sh "${room}" "${msg}"

--- a/scripts/notify-matrix.sh
+++ b/scripts/notify-matrix.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# prevent souring of this script, only allow execution
+$(return >/dev/null 2>&1)
+test "$?" -eq "0" && { echo "This script should only be executed." >&2; exit 1; }
+
+# exit on errors, undefined variables, ensure errors in pipes are not hidden
+set -Eeuo pipefail
+
+# set log id and use shared log function for readable logs
+declare mydir
+mydir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+declare HOPR_LOG_ID="notify-matrix"
+source "${mydir}/utils.sh"
+
+usage() {
+  msg
+  msg "Usage: $0 <room> <message>"
+  msg
+  msg "The following environment variables are used to perform the request:"
+  msg
+  msg "MATRIX_SERVER, default 'https://matrix.org'"
+  msg "MATRIX_ACCESS_TOKEN, default ''"
+}
+
+# return early with help info when requested
+([ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]) && { usage; exit 0; }
+
+# do work
+
+[ -z "${1:-}" ] && { msg "Parameter <room> required"; usage; exit 1; }
+[ -z "${2:-}" ] && { msg "Parameter <message> required"; usage; exit 1; }
+which curl > /dev/null || { msg "Required binary 'curl' not found in PATH"; exit 1; }
+
+declare room="${1}"
+declare msg="${2}"
+declare server="${MATRIX_SERVER:-https://matrix.org}"
+declare token="${MATRIX_ACCESS_TOKEN:-}"
+declare event_id="$(date -u +%y%m%d%H%M%S)${RANDOM}"
+declare url="${server}/_matrix/client/r0/rooms/%21${room}/send/m.room.message/${event_id}"
+
+curl -s -X PUT \
+  -H "Authorization: Bearer ${token}" \
+  -H "Accept: application/json" \
+  -H "Content-Type: application/json" \
+  -d "{\"msgtype\": \"m.text\", \"body\": \"${msg}\"}" \
+  "${url}"


### PR DESCRIPTION
Fixes #1735 

NOTE: This only enables such notifications for failures on `master` and `release/*` branches and specifically for the `deploy` and `e2e` workflows. We can add more workflows later if needed.