### PR TITLE
add missing dependency

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -30,6 +30,7 @@
     "abort-controller": "~3.0.0",
     "bignumber.js": "^9.0.0",
     "bn.js": "^5.2.0",
+    "bs58": "^4.0.1",
     "chalk": "^4.1.1",
     "ethers": "^5.1.3",
     "futoin-hkdf": "~1.3.2",


### PR DESCRIPTION
`bs58` is required by `hopr-utils` in `AccountEntry` but not part of dependencies in package.json