### PR TITLE
weak api token not allowed

### DIFF
--- a/packages/hoprd/package.json
+++ b/packages/hoprd/package.json
@@ -34,6 +34,7 @@
     "@hoprnet/hopr-utils": "1.74.0-next.27",
     "body-parser": "^1.19.0",
     "bs58": "^4.0.1",
+    "check-password-strength": "^2.0.3",
     "cookie": "^0.4.1",
     "dids": "^2.1.0",
     "ethereumjs-wallet": "^1.0.1",

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -217,7 +217,7 @@ async function main() {
     if (argv.apiToken == null) {
       throw Error(`Must provide --apiToken when --admin or --rest is specified`)
     }
-    const { contains: hasSymbolTypes, length }: { contains: string[], length: number } = passwordStrength(argv.apiToken)
+    const { contains: hasSymbolTypes, length }: { contains: string[]; length: number } = passwordStrength(argv.apiToken)
     for (const requiredSymbolType of ['uppercase', 'lowercase', 'symbol', 'number']) {
       if (!hasSymbolTypes.includes(requiredSymbolType)) {
         throw new Error(`API token must include a ${requiredSymbolType}`)

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -178,8 +178,7 @@ async function generateNodeOptions(): Promise<HoprOptions> {
 function addUnhandledPromiseRejectionHandler() {
   process.on('unhandledRejection', (reason: any, promise: Promise<any>) => {
     console.error('Unhandled Rejection at:', promise, 'reason:', reason)
-    // @TODO uncomment next line
-    // process.exit(1)
+    process.exit(1)
   })
 }
 
@@ -223,9 +222,9 @@ async function main() {
       if (!hasSymbolTypes.includes(requiredSymbolType)) {
         throw new Error(`API token must include a ${requiredSymbolType}`)
       }
-      if (length < 8) {
-        throw new Error(`API token be at least 8 characters long`)
-      }
+    }
+    if (length < 8) {
+      throw new Error(`API token be at least 8 characters long`)
     }
   }
 

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -224,7 +224,7 @@ async function main() {
       }
     }
     if (length < 8) {
-      throw new Error(`API token be at least 8 characters long`)
+      throw new Error(`API token must be at least 8 characters long`)
     }
   }
 

--- a/scripts/run-integration-tests-npm.sh
+++ b/scripts/run-integration-tests-npm.sh
@@ -122,7 +122,7 @@ function setup_node() {
     --testAnnounceLocalAddresses --identity="${id}" \
     --host="127.0.0.1:${node_port}" --testPreferLocalAddresses \
     --data="${dir}" --rest --restPort "${rest_port}" --announce \
-    --api-token "e2e-api-token" \
+    --api-token "e2e-API-token^^" \
     --admin --adminHost "127.0.0.1" --adminPort ${admin_port} \
     --password="e2e-test" --testUseWeakCrypto \
     ${additional_args} \

--- a/scripts/run-integration-tests-source.sh
+++ b/scripts/run-integration-tests-source.sh
@@ -107,7 +107,7 @@ function setup_node() {
     --testAnnounceLocalAddresses --identity="${id}" \
     --host="127.0.0.1:${node_port}" --testPreferLocalAddresses \
     --data="${dir}" --rest --restPort "${rest_port}" --announce \
-    --api-token "e2e-api-token" \
+    --api-token "e2e-API-token^^" \
     --admin --adminHost "127.0.0.1" --adminPort ${admin_port} \
     --password="e2e-test" --testUseWeakCrypto \
     ${additional_args} \

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -52,7 +52,7 @@ run_command(){
   local step_time=${5:-5}
   local end_time_ns=${6:-0}
   # no timeout set since the test execution environment should cancel the test if it takes too long
-  local cmd="curl --silent -X POST --header X-Auth-Token:e2e-api-token --url ${endpoint}/api/v1/command --data "
+  local cmd="curl --silent -X POST --header X-Auth-Token:e2e-API-token^^ --url ${endpoint}/api/v1/command --data "
 
   # if no end time was given we need to calculate it once
   if [ ${end_time_ns} -eq 0 ]; then

--- a/test/security-test.sh
+++ b/test/security-test.sh
@@ -86,7 +86,7 @@ if [ "${msg_type}" != "auth-failed" ]; then
 fi
 
 log "Admin websocket should execute info command with correct token"
-ws_response=$(echo "info" | websocat ws://${host}:${admin_port}/ -0 --header "Cookie:X-Auth-Token=e2e-api-token")
+ws_response=$(echo "info" | websocat ws://${host}:${admin_port}/ -0 --header "Cookie:X-Auth-Token=e2e-API-token^^")
 if [[ "${ws_response}" != *"ws client connected [ authentication ENABLED ]"* ]]; then
   log "⛔️ Didn't succeed ws authentication"
   log "Expected response should contain: 'ws client connected [ authentication ENABLED ]' "

--- a/yarn.lock
+++ b/yarn.lock
@@ -4028,6 +4028,11 @@ check-error@^1.0.2:
   resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.2.tgz#574d312edd88bb5dd8912e9286dd6c0aed4aac82"
   integrity sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=
 
+check-password-strength@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/check-password-strength/-/check-password-strength-2.0.3.tgz#fed038b1c457ac11a2999bd96f3185af34e88895"
+  integrity sha512-UW3YgMUne9QuejgnNWjWwYi4QhWArVj+1OXqDR1NkEQcmMKKO74O3P5ZvXr9JZNbTBfcwlK3yurYCMuJsck83A==
+
 checkpoint-store@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/checkpoint-store/-/checkpoint-store-1.1.0.tgz#04e4cb516b91433893581e6d4601a78e9552ea06"


### PR DESCRIPTION
Closes #1984 
Doesn't allow you to start hoprd with missing security. 

How to test:

`hoprd --admin` or `hoprd --rest` should fail.
`hoprd --admin --apiToken <weak_token>` should fail
`hoprd --admin --apiToken <strong_token>` should succeed.

A strong token requires a lowercase letter, an uppercase letter, a number and a special symbol and be at least 8 symbols long.