### PR TITLE
Port hopr-connect fixes to release/kiautschou

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -285,11 +285,20 @@ jobs:
 
       - name: Building Docker image using Google Cloud Build
         working-directory: packages/hoprd
-        run: | # TODO - actually parse semver to tag v1
+        run: |
           gcloud builds submit --config cloudbuild.yaml \
             --substitutions=_HOPR_PACKAGE_VERSION=${HOPR_PACKAGE_VERSION},_HOPR_IMAGE_VERSION=${HOPR_IMAGE_VERSION}
         env:
           HOPR_PACKAGE: hoprd
+          HOPR_DOCKER_IMAGE: gcr.io/hoprassociation/hoprd
+          HOPR_IMAGE_VERSION: ${{ steps.set-image-version.outputs.vsn }}
+          HOPR_PACKAGE_VERSION: ${{ steps.set-package-version.outputs.vsn }}
+
+      - name: Verify the correct hoprd package version has been bundled
+        run: |
+          declare v=$(docker run --pull always ${HOPR_DOCKER_IMAGE}:${HOPR_IMAGE_VERSION} --version 2> /dev/null | sed -n '3p')
+          [ "${v}" = "${HOPR_PACKAGE_VERSION}" ]
+        env:
           HOPR_DOCKER_IMAGE: gcr.io/hoprassociation/hoprd
           HOPR_IMAGE_VERSION: ${{ steps.set-image-version.outputs.vsn }}
           HOPR_PACKAGE_VERSION: ${{ steps.set-package-version.outputs.vsn }}
@@ -318,14 +327,6 @@ jobs:
         env:
           HOPR_DOCKER_IMAGE: gcr.io/hoprassociation/hoprd
           HOPR_IMAGE_VERSION: ${{ steps.set-image-version.outputs.vsn }}
-          TAG: ${{ steps.set-latest-release-tag.outputs.tag }}
-
-      - name: Verify the correct hoprd package version has been bundled
-        run: |
-          declare v=$(docker run --pull always gcr.io/hoprassociation/hoprd:${TAG} --version 2> /dev/null | sed -n '3p')
-          [ "${v}" = "${HOPR_PACKAGE_VERSION}" ]
-        env:
-          HOPR_PACKAGE_VERSION: ${{ steps.set-package-version.outputs.vsn }}
           TAG: ${{ steps.set-latest-release-tag.outputs.tag }}
 
   avado:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -274,6 +274,15 @@ jobs:
         env:
           HOPR_PACKAGE: hoprd
 
+      - name: Set latest release tag
+        id: set-latest-release-tag
+        run: |
+          # we must set the tag specific to the release to prevent overrides
+          # from other release branches
+          declare release_name=${HOPR_GITHUB_REF##refs/heads/release/}
+          declare tag="latest-${release_name}"
+          echo "::set-output name=tag::${tag}"
+
       - name: Building Docker image using Google Cloud Build
         working-directory: packages/hoprd
         run: | # TODO - actually parse semver to tag v1
@@ -302,13 +311,22 @@ jobs:
           HOPR_DOCKER_IMAGE: gcr.io/hoprassociation/hoprd
           HOPR_IMAGE_VERSION: ${{ steps.set-image-version.outputs.vsn }}
 
-      - name: Add tag latest-release to new Docker image on release branches
+      - name: Add tag for latest release to new Docker image on release branches
         if: ${{ !env.ACT &&  startsWith(github.ref, 'refs/heads/release/') }}
         run: |
-          gcloud container images add-tag ${HOPR_DOCKER_IMAGE}:${HOPR_IMAGE_VERSION} ${HOPR_DOCKER_IMAGE}:latest-release
+          gcloud container images add-tag ${HOPR_DOCKER_IMAGE}:${HOPR_IMAGE_VERSION} ${HOPR_DOCKER_IMAGE}:${TAG}
         env:
           HOPR_DOCKER_IMAGE: gcr.io/hoprassociation/hoprd
           HOPR_IMAGE_VERSION: ${{ steps.set-image-version.outputs.vsn }}
+          TAG: ${{ steps.set-latest-release-tag.outputs.tag }}
+
+      - name: Verify the correct hoprd package version has been bundled
+        run: |
+          declare v=$(docker run --pull always gcr.io/hoprassociation/hoprd:${TAG} --version 2> /dev/null | sed -n '3p')
+          [ "${v}" = "${HOPR_PACKAGE_VERSION}" ]
+        env:
+          HOPR_PACKAGE_VERSION: ${{ steps.set-package-version.outputs.vsn }}
+          TAG: ${{ steps.set-latest-release-tag.outputs.tag }}
 
   avado:
     name: Build Avado (master or release pushes)

--- a/README.md
+++ b/README.md
@@ -62,19 +62,19 @@ npm install @hoprnet/hoprd@1.72
 
 All our docker images can be found in [our Google Cloud Container Registry][4].
 Each image is prefixed with `gcr.io/hoprassociation/$PROJECT:$RELEASE`.
-The `latest` tag represents the `master` branch, while the `latest-release` tag
+The `latest` tag represents the `master` branch, while the `latest-paphos` tag
 represents the most recent `release/*` branch.
 
 You can pull the Docker image like so:
 
 ```sh
-docker pull gcr.io/hoprassociation/hoprd:latest-release
+docker pull gcr.io/hoprassociation/hoprd:latest-paphos
 ```
 
 For ease of use you can set up a shell alias to run the latest release as a docker container:
 
 ```sh
-alias hoprd='docker run --pull always -ti -v ${HOPRD_DATA_DIR:-$HOME/.hoprd-db}:/app/db -p 9091:9091 -p 3000:3000 -p 3001:3001 gcr.io/hoprassociation/hoprd:latest-release'
+alias hoprd='docker run --pull always -ti -v ${HOPRD_DATA_DIR:-$HOME/.hoprd-db}:/app/db -p 9091:9091 -p 3000:3000 -p 3001:3001 gcr.io/hoprassociation/hoprd:latest-paphos'
 ```
 
 **IMPORTANT:** Using the above command will map the database folder used by hoprd to a local folder called `.hoprd-db` in your home directory. You can customize the location of that folder further by executing the following command:

--- a/README.md
+++ b/README.md
@@ -62,19 +62,19 @@ npm install @hoprnet/hoprd@1.72
 
 All our docker images can be found in [our Google Cloud Container Registry][4].
 Each image is prefixed with `gcr.io/hoprassociation/$PROJECT:$RELEASE`.
-The `latest` tag represents the `master` branch, while the `latest-paphos` tag
+The `latest` tag represents the `master` branch, while the `latest-kiautschou` tag
 represents the most recent `release/*` branch.
 
 You can pull the Docker image like so:
 
 ```sh
-docker pull gcr.io/hoprassociation/hoprd:latest-paphos
+docker pull gcr.io/hoprassociation/hoprd:latest-kiautschou
 ```
 
 For ease of use you can set up a shell alias to run the latest release as a docker container:
 
 ```sh
-alias hoprd='docker run --pull always -ti -v ${HOPRD_DATA_DIR:-$HOME/.hoprd-db}:/app/db -p 9091:9091 -p 3000:3000 -p 3001:3001 gcr.io/hoprassociation/hoprd:latest-paphos'
+alias hoprd='docker run --pull always -ti -v ${HOPRD_DATA_DIR:-$HOME/.hoprd-db}:/app/db -p 9091:9091 -p 3000:3000 -p 3001:3001 gcr.io/hoprassociation/hoprd:latest-kiautschou'
 ```
 
 **IMPORTANT:** Using the above command will map the database folder used by hoprd to a local folder called `.hoprd-db` in your home directory. You can customize the location of that folder further by executing the following command:

--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -34,7 +34,7 @@ particular branch to deploy on every change.
 ```
 
 
-   release/paphos          master          jjpa/solves-channels-1556
+   release/kiautschou          master          jjpa/solves-channels-1556
 
          x                   │                       x
          x                   │                       x
@@ -75,7 +75,7 @@ particular branch to deploy on every change.
 
 ```
 
-   hotfix/patch-paphos    release/paphos          master
+   hotfix/patch-kiautschou    release/kiautschou          master
 
          x                   x                       x 1.71.0-next.44
          x                   │ ◄─────────────────────x

--- a/docs/hopr-documentation/src/install-hoprd/using-docker.md
+++ b/docs/hopr-documentation/src/install-hoprd/using-docker.md
@@ -41,10 +41,28 @@ Before doing anything else, you need to install [Docker Desktop](https://hub.doc
 
 ## Downloading HOPRd image using Docker
 
-To use **HOPRd,** run `docker pull gcr.io/hoprassociation/hoprd` from your terminal. This process may take some time depending on your internet connection.
+All our docker images can be found in [our Google Cloud Container Registry][4].
+Each image is prefixed with `gcr.io/hoprassociation/$PROJECT:$RELEASE`.
+The `latest` tag represents the `master` branch, while the `latest-*` tags
+represent the most recent builds for `release/*` branches.
 
 ![Currently HOPRd is about ~1.25 GB, please be patient.](../../images/docker_install_macos.gif)
 
-To ensure your machine has successfully downloaded **HOPRd,** run `docker images`.You will be shown the **HOPRd** image being installed locally, ready to be run.
+```sh
+docker pull gcr.io/hoprassociation/hoprd:latest-kiautschou
+```
+
+For ease of use you can set up a shell alias to run the latest release as a docker container:
+
+```sh
+alias hoprd='docker run --pull always -ti -v ${HOPRD_DATA_DIR:-$HOME/.hoprd-db}:/app/db -p 9091:9091 -p 3000:3000 -p 3001:3001 gcr.io/hoprassociation/hoprd:latest-paphos'
+```
+
+**IMPORTANT:** Using the above command will map the database folder used by hoprd to a local folder called `.hoprd-db` in your home directory. You can customize the location of that folder further by executing the following command:
+
+```sh
+HOPRD_DATA_DIR=${HOME}/.hoprd-better-db-folder eval hoprd
+```
+>>>>>>> d62c3e8da (Change Docker tag latest-release to latest-SOMERELEASENAME)
 
 ![HOPR Chat distributed as a Docker image](../../images/docker_images.gif)

--- a/docs/hopr-documentation/src/install-hoprd/using-docker.md
+++ b/docs/hopr-documentation/src/install-hoprd/using-docker.md
@@ -55,7 +55,7 @@ docker pull gcr.io/hoprassociation/hoprd:latest-kiautschou
 For ease of use you can set up a shell alias to run the latest release as a docker container:
 
 ```sh
-alias hoprd='docker run --pull always -ti -v ${HOPRD_DATA_DIR:-$HOME/.hoprd-db}:/app/db -p 9091:9091 -p 3000:3000 -p 3001:3001 gcr.io/hoprassociation/hoprd:latest-paphos'
+alias hoprd='docker run --pull always -ti -v ${HOPRD_DATA_DIR:-$HOME/.hoprd-db}:/app/db -p 9091:9091 -p 3000:3000 -p 3001:3001 gcr.io/hoprassociation/hoprd:latest-kiautschou'
 ```
 
 **IMPORTANT:** Using the above command will map the database folder used by hoprd to a local folder called `.hoprd-db` in your home directory. You can customize the location of that folder further by executing the following command:
@@ -63,6 +63,5 @@ alias hoprd='docker run --pull always -ti -v ${HOPRD_DATA_DIR:-$HOME/.hoprd-db}:
 ```sh
 HOPRD_DATA_DIR=${HOME}/.hoprd-better-db-folder eval hoprd
 ```
->>>>>>> d62c3e8da (Change Docker tag latest-release to latest-SOMERELEASENAME)
 
 ![HOPR Chat distributed as a Docker image](../../images/docker_images.gif)

--- a/packages/avado/Dockerfile
+++ b/packages/avado/Dockerfile
@@ -1,3 +1,3 @@
-FROM gcr.io/hoprassociation/hoprd:latest-paphos
+FROM gcr.io/hoprassociation/hoprd:latest-kiautschou
 
 ENTRYPOINT ["/usr/bin/tini", "--", "yarn", "hoprd", "--password='open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0'", "--init", "--admin", "--adminHost", "0.0.0.0", "--identity", "/app/db/.hopr-identity"]

--- a/packages/avado/Dockerfile
+++ b/packages/avado/Dockerfile
@@ -1,3 +1,3 @@
-FROM gcr.io/hoprassociation/hoprd:latest-release
+FROM gcr.io/hoprassociation/hoprd:latest-paphos
 
 ENTRYPOINT ["/usr/bin/tini", "--", "yarn", "hoprd", "--password='open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0'", "--init", "--admin", "--adminHost", "0.0.0.0", "--identity", "/app/db/.hopr-identity"]

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
     "!**/*.spec.js.map"
   ],
   "dependencies": {
-    "@hoprnet/hopr-connect": "0.2.29",
+    "@hoprnet/hopr-connect": "0.2.30",
     "@hoprnet/hopr-core-ethereum": "1.72.17",
     "@hoprnet/hopr-utils": "1.72.17",
     "abort-controller": "^3.0.0",

--- a/packages/hoprd/Dockerfile
+++ b/packages/hoprd/Dockerfile
@@ -15,7 +15,9 @@ WORKDIR /app
 # environment variable
 # if its not given, yarn will install the latest version of the package
 ARG HOPRD_VERSION
+RUN echo "ARG HOPRD_VERSION=${HOPRD_VERSION}"
 ENV HOPRD_VERSION=${HOPRD_VERSION:-}
+RUN echo "ENV HOPRD_VERSION=${HOPRD_VERSION}"
 
 # making sure some standard environment variables are set for production use
 ENV NODE_ENV production

--- a/packages/hoprd/cloudbuild.yaml
+++ b/packages/hoprd/cloudbuild.yaml
@@ -4,8 +4,8 @@ steps:
       - 'build'
       - '.'
       - '--tag=gcr.io/$PROJECT_ID/hoprd:$_HOPR_IMAGE_VERSION'
+      - '--build-arg=HOPRD_VERSION=$_HOPR_PACKAGE_VERSION'
 options:
-  env:
-    - 'HOPRD_VERSION=$_HOPR_PACKAGE_VERSION'
+  logStreamingOption: STREAM_ON
 images:
   - 'gcr.io/$PROJECT_ID/hoprd'

--- a/yarn.lock
+++ b/yarn.lock
@@ -607,17 +607,18 @@
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.0.tgz#f3933a44e365864f4dad5db94158106d511e8131"
   integrity sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==
 
-"@hoprnet/hopr-connect@0.2.29":
-  version "0.2.29"
-  resolved "https://registry.yarnpkg.com/@hoprnet/hopr-connect/-/hopr-connect-0.2.29.tgz#2e12d5e1398f393d7dc2a9b802947d402d8c7ddb"
-  integrity sha512-BKGD7HGMGk7DiFOR8Ofj20m7j1WBr/N9IQ5boaaEgBUfccnIRUbjwZ7GZDIlOqy3+IqHr9DIi5f4SyLU4JT92Q==
+"@hoprnet/hopr-connect@0.2.30":
+  version "0.2.30"
+  resolved "https://registry.yarnpkg.com/@hoprnet/hopr-connect/-/hopr-connect-0.2.30.tgz#2db795fa843580b880ab09b7edc8fb99a9cfbcfe"
+  integrity sha512-ZpLjGP66xEL8/seahUrAijRMqYg3xHryta3FtouagGDOMZFeuYipWROkV+iCHx8pq1q0jR7iEF3rDnhQxsEQzg==
   dependencies:
-    "@hoprnet/hopr-utils" "1.71.0-next.145"
+    "@hoprnet/hopr-utils" "1.74.0-next.16"
     abortable-iterator "^3.0.0"
     bl "^5.0"
     debug "^4.3.1"
+    heap-js "^2.1.5"
     it-handshake "^2.0.0"
-    multiaddr "~9.0.1"
+    multiaddr "~9.0.2"
     multihashes "^4.0.2"
     p-defer "3"
     peer-id "~0.14.8"
@@ -626,28 +627,29 @@
     webrtc-stun "3.0.0"
     wrtc "0.4.7"
 
-"@hoprnet/hopr-utils@1.71.0-next.145":
-  version "1.71.0-next.145"
-  resolved "https://registry.yarnpkg.com/@hoprnet/hopr-utils/-/hopr-utils-1.71.0-next.145.tgz#8836b5a1dfcef8d58b6fabc4c7154c6f35b67c22"
-  integrity sha512-141mqrBLJpMXvvdy2VFXAbBXiDsMqwNlFHqZgLYmvZBN1y0fnxrSRLUfTJJpn54k8eDKY9EeeaIWVhV2whjZqQ==
+"@hoprnet/hopr-utils@1.74.0-next.16":
+  version "1.74.0-next.16"
+  resolved "https://registry.yarnpkg.com/@hoprnet/hopr-utils/-/hopr-utils-1.74.0-next.16.tgz#a5d2fbd67e297b28ad0f751d8daa334cd1277ade"
+  integrity sha512-KC+WhLRlgn/Y7ulXo4DSXrALb2M9NBoMgkjwHk/wfHrnlujHFwaJEtCQKZzvLfEq0UZc5quvCvtbGpVmBan9lw==
   dependencies:
     abort-controller "~3.0.0"
     bignumber.js "^9.0.0"
     bn.js "^5.2.0"
+    bs58 "^4.0.1"
     chalk "^4.1.1"
     ethers "^5.1.3"
     futoin-hkdf "~1.3.2"
     it-pipe "^1.1.0"
     leveldown "^6.0.0"
     levelup "^5.0.0"
-    libp2p "0.31.3"
+    libp2p "0.31.7"
     libp2p-crypto "0.19.4"
     memdown "^6.0.0"
-    multiaddr "9.0.1"
+    multiaddr "^9.0.1"
     multihashes "~4.0.1"
     peer-id "0.14.8"
+    private-ip "^2.2.1"
     secp256k1 "^4.0.2"
-    strip-ansi "^7.0.0"
 
 "@lerna/add@4.0.0":
   version "4.0.0"
@@ -2371,11 +2373,6 @@ ansi-regex@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
-
-ansi-regex@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-6.0.0.tgz#ecc7f5933cbe5ac7b33e209a5ff409ab1669c6b2"
-  integrity sha512-tAaOSrWCHF+1Ear1Z4wnJCXA9GGox4K6Ic85a5qalES2aeEwQGr7UC93mwef49536PkCYjzkp0zIxfFvexJ6zQ==
 
 ansi-styles@^2.2.1:
   version "2.2.1"
@@ -6969,7 +6966,7 @@ he@1.2.0:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-heap-js@^2.1.2:
+heap-js@^2.1.2, heap-js@^2.1.5:
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/heap-js/-/heap-js-2.1.5.tgz#43251ecdd23c632653fe783bc8bdc2b7da4baf4c"
   integrity sha512-zJeFH1ZxUHuYG6x9+a8Dy+5kjqbKk1K8yPI1KZEdsi18VCd0UjTyJ2u9PfuIoj7t3+saMmI132rJGV33tP52VQ==
@@ -8684,63 +8681,6 @@ libp2p-utils@^0.3.0, libp2p-utils@^0.3.1:
     multiaddr "^9.0.1"
     private-ip "^2.1.1"
 
-libp2p@0.31.3:
-  version "0.31.3"
-  resolved "https://registry.yarnpkg.com/libp2p/-/libp2p-0.31.3.tgz#fbd69f13d5fe6a3256f9ccb986035836f18d69f1"
-  integrity sha512-EwdTkmbp4kcaVDoSoXzTqI1TzhnX0LrEDMODsOiuglFvvbK0dSgoOBQS1qpFUDJ6DNBqCsPFxR0cFkSTgRCgUA==
-  dependencies:
-    "@motrix/nat-api" "^0.3.1"
-    "@vascosantos/moving-average" "^1.1.0"
-    abort-controller "^3.0.0"
-    aggregate-error "^3.1.0"
-    any-signal "^2.1.1"
-    bignumber.js "^9.0.1"
-    cids "^1.1.5"
-    class-is "^1.1.0"
-    debug "^4.3.1"
-    err-code "^3.0.0"
-    es6-promisify "^6.1.1"
-    events "^3.3.0"
-    hashlru "^2.3.0"
-    interface-datastore "^4.0.0"
-    ipfs-utils "^7.0.0"
-    it-all "^1.0.4"
-    it-buffer "^0.1.2"
-    it-drain "^1.0.3"
-    it-filter "^1.0.1"
-    it-first "^1.0.4"
-    it-handshake "^2.0.0"
-    it-length-prefixed "^5.0.2"
-    it-map "^1.0.4"
-    it-merge "1.0.0"
-    it-pipe "^1.1.0"
-    it-take "1.0.0"
-    libp2p-crypto "^0.19.4"
-    libp2p-interfaces "^0.10.4"
-    libp2p-utils "^0.3.1"
-    mafmt "^9.0.0"
-    merge-options "^3.0.4"
-    multiaddr "^9.0.1"
-    multicodec "^3.0.1"
-    multihashing-async "^2.1.2"
-    multistream-select "^2.0.0"
-    mutable-proxy "^1.0.0"
-    node-forge "^0.10.0"
-    p-any "^3.0.0"
-    p-fifo "^1.0.0"
-    p-retry "^4.4.0"
-    p-settle "^4.1.1"
-    peer-id "^0.14.2"
-    private-ip "^2.1.0"
-    protobufjs "^6.10.2"
-    retimer "^3.0.0"
-    sanitize-filename "^1.6.3"
-    set-delayed-interval "^1.0.0"
-    streaming-iterables "^5.0.2"
-    timeout-abort-controller "^1.1.1"
-    varint "^6.0.0"
-    xsalsa20 "^1.1.0"
-
 libp2p@0.31.6:
   version "0.31.6"
   resolved "https://registry.yarnpkg.com/libp2p/-/libp2p-0.31.6.tgz#4f2c30ceba8f37302ef31d2e4b0619e16efdf8e7"
@@ -8796,6 +8736,63 @@ libp2p@0.31.6:
     streaming-iterables "^5.0.2"
     timeout-abort-controller "^1.1.1"
     varint "^6.0.0"
+    xsalsa20 "^1.1.0"
+
+libp2p@0.31.7:
+  version "0.31.7"
+  resolved "https://registry.yarnpkg.com/libp2p/-/libp2p-0.31.7.tgz#49ff8b74cd5a3ed252b8584aaa6071f73cf62e6c"
+  integrity sha512-0FUHYlwoDQ8+x3qQM9iTrZP0Ui1LWYxAbLZ9H8Hs57hqevEv08eX5EDFlkpqu/W9dkl4gsQ3kv3sa7ye8+lokA==
+  dependencies:
+    "@motrix/nat-api" "^0.3.1"
+    "@vascosantos/moving-average" "^1.1.0"
+    abort-controller "^3.0.0"
+    aggregate-error "^3.1.0"
+    any-signal "^2.1.1"
+    bignumber.js "^9.0.1"
+    cids "^1.1.5"
+    class-is "^1.1.0"
+    debug "^4.3.1"
+    err-code "^3.0.0"
+    es6-promisify "^6.1.1"
+    events "^3.3.0"
+    hashlru "^2.3.0"
+    interface-datastore "^4.0.0"
+    it-all "^1.0.4"
+    it-buffer "^0.1.2"
+    it-drain "^1.0.3"
+    it-filter "^1.0.1"
+    it-first "^1.0.4"
+    it-handshake "^2.0.0"
+    it-length-prefixed "^5.0.2"
+    it-map "^1.0.4"
+    it-merge "1.0.0"
+    it-pipe "^1.1.0"
+    it-take "1.0.0"
+    libp2p-crypto "^0.19.4"
+    libp2p-interfaces "^0.10.4"
+    libp2p-utils "^0.3.1"
+    mafmt "^9.0.0"
+    merge-options "^3.0.4"
+    multiaddr "^9.0.1"
+    multicodec "^3.0.1"
+    multihashing-async "^2.1.2"
+    multistream-select "^2.0.0"
+    mutable-proxy "^1.0.0"
+    node-forge "^0.10.0"
+    p-any "^3.0.0"
+    p-fifo "^1.0.0"
+    p-retry "^4.4.0"
+    p-settle "^4.1.1"
+    peer-id "^0.14.2"
+    private-ip "^2.1.0"
+    protobufjs "^6.10.2"
+    retimer "^3.0.0"
+    sanitize-filename "^1.6.3"
+    set-delayed-interval "^1.0.0"
+    streaming-iterables "^5.0.2"
+    timeout-abort-controller "^1.1.1"
+    varint "^6.0.0"
+    wherearewe "^1.0.0"
     xsalsa20 "^1.1.0"
 
 lines-and-columns@^1.1.6:
@@ -9646,10 +9643,23 @@ multiaddr@8.1.2:
     uint8arrays "^1.1.0"
     varint "^5.0.0"
 
-multiaddr@9.0.1, multiaddr@^9.0.0, multiaddr@^9.0.1, multiaddr@~9.0.1:
+multiaddr@9.0.1, multiaddr@^9.0.0, multiaddr@^9.0.1:
   version "9.0.1"
   resolved "https://registry.yarnpkg.com/multiaddr/-/multiaddr-9.0.1.tgz#4a3b5a21b37e4df5b443f2ca957304ea5bfd4604"
   integrity sha512-fubxMjVoRPcz3GYBb63Z6ADCY6BoqezbnL2o8owDcfYqhwW61oFtIlsZGiNKIVC2Fk1Od5rf/3z34QSGJFT/uA==
+  dependencies:
+    cids "^1.0.0"
+    dns-over-http-resolver "^1.0.0"
+    err-code "^3.0.1"
+    is-ip "^3.1.0"
+    multibase "^4.0.2"
+    uint8arrays "^2.1.3"
+    varint "^6.0.0"
+
+multiaddr@~9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/multiaddr/-/multiaddr-9.0.2.tgz#ab322bb768e77270650ebce71a452fdc760bda0d"
+  integrity sha512-YFaEb9t4yXSbaGksSEdg+Kn2U02s7w4wXUgyEMQmPxFJj7CfVHY10WOsScAX/rK6Soa15S1zXYadqH9TtlVreQ==
   dependencies:
     cids "^1.0.0"
     dns-over-http-resolver "^1.0.0"
@@ -12953,13 +12963,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   dependencies:
     ansi-regex "^4.1.0"
 
-strip-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-7.0.0.tgz#1dc49b980c3a4100366617adac59327eefdefcb0"
-  integrity sha512-UhDTSnGF1dc0DRbUqr1aXwNoY3RgVkSWG8BrpnuFIxhP57IqbS7IRta2Gfiavds4yCxc5+fEAVVOgBZWnYkvzg==
-  dependencies:
-    ansi-regex "^6.0.0"
-
 strip-bom@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-2.0.0.tgz#6219a85616520491f35788bdbf1447a99c7e6b0e"
@@ -14587,6 +14590,13 @@ whatwg-url@^8.4.0:
     lodash "^4.7.0"
     tr46 "^2.0.2"
     webidl-conversions "^6.1.0"
+
+wherearewe@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/wherearewe/-/wherearewe-1.0.0.tgz#e6c2440bb757e57eb2ad76b4abf9961b532ee358"
+  integrity sha512-oQnRsAfMCqNAC7U4JrBdmFXAhBRLOkPGOfU5+nw9fs2D3g8O6EV7hn7BhpXtt0yno4pxFiRD55rMyt0fsLMqlw==
+  dependencies:
+    is-electron "^2.2.0"
 
 which-boxed-primitive@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
This includes some fixes for the CI docker pipeline to properly tag the images.

These changes fix the behavior seen in #2020 and #1995

I've verified this by manually running 2 public relay nodes and one node behind NAT.