### PR TITLE
Enable e2e testing on gcloud networks

### DIFF
--- a/.github/workflows/e2e-gcloud.yaml
+++ b/.github/workflows/e2e-gcloud.yaml
@@ -8,7 +8,9 @@ env:
 
 on:
   push:
-    branches: ['master', 'release/**', 'debug-e2e-gcloud/**']
+    # FIXME: make funding work reliably
+    # branches: ['master', 'release/**', 'debug-e2e-gcloud/**']
+    branches: ['debug-e2e-gcloud/**']
     paths-ignore:
       - '**/docs/**/*'
 

--- a/.github/workflows/e2e-gcloud.yaml
+++ b/.github/workflows/e2e-gcloud.yaml
@@ -20,7 +20,8 @@ jobs:
     strategy:
       matrix:
         node-version: [14]
-        os: ['ubuntu-latest', 'macos-latest']
+        # only need to run on one OS since all testing is done on cloud VMs
+        os: ['ubuntu-latest']
 
     steps:
       - uses: actions/checkout@v2
@@ -59,14 +60,35 @@ jobs:
       - name: Install jq
         run: ./scripts/install-jq.sh
 
+      - name: Setup Google Cloud Credentials
+        uses: google-github-actions/setup-gcloud@v0.2.1
+        with:
+          project_id: ${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}
+          service_account_key: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
+          export_default_credentials: true
+
       - name: Test
-        run: ./scripts/run-integration-tests-gcloud.sh
+        id: test
+        run: |
+          # generating and storing test id for cleanup later
+          declare test_id="ci-test-${RANDOM}-${RANDOM}"
+          echo "::set-output name=test_id::${test_id}"
+          ./scripts/run-integration-tests-gcloud.sh ${test_id}
         env:
           FUNDING_PRIV_KEY: ${{ secrets.FUNDING_WALLET_PRIVATE_KEY }}
           HOPRD_INFURA_KEY: ${{ secrets.INFURA_KEY }}
 
+      - name: Cleanup resources in case the job was cancelled or failed
+        if: ${{ always() }}
+        run: |
+          ./scripts/run-integration-tests-gcloud.sh ${HOPRD_TEST_ID}
+        env:
+          HOPRD_TEST_ID: ${{ steps.test.outputs.test_id }}
+          HOPRD_RUN_CLEANUP_ONLY: true
+          HOPRD_INFURA_KEY: placeholder
+
       - name: Send notification if anything failed on master or release branches
-        if: ${{ failure() && !env.ACT }}
+        if: ${{ failure() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && !env.ACT }}
         run: |
           ./scripts/notify-matrix-github-workflow-failure.sh "${MATRIX_ROOM}" "${{ github.repository }}" \
             "${{ github.workflow }}" "${{ github.run_id }}"

--- a/.github/workflows/e2e-gcloud.yaml
+++ b/.github/workflows/e2e-gcloud.yaml
@@ -1,4 +1,4 @@
-name: HOPR End-to-end tests (NPM)
+name: HOPR End-to-end tests (gcloud)
 
 env:
   HOPR_GITHUB_REF: ${{ github.ref }}
@@ -8,12 +8,12 @@ env:
 
 on:
   push:
-    branches: ['master', 'release/**', 'debug-npm-e2e/**']
+    branches: ['master', 'release/**', 'debug-e2e-gcloud/**']
     paths-ignore:
       - '**/docs/**/*'
 
 jobs:
-  npm-e2e:
+  e2e-gcloud:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
 
@@ -56,27 +56,17 @@ jobs:
       - name: Install websocat
         run: ./scripts/install-websocat.sh
 
+      - name: Install jq
+        run: ./scripts/install-jq.sh
+
       - name: Test
-        run: ./scripts/run-integration-tests-npm.sh
-
-      - name: Upload node logs (Linux)
-        uses: actions/upload-artifact@v2
-        if: ${{ always() && runner.os == 'Linux' }}
-        with:
-          name: hopr-e2e-source-node-logs
-          path: |
-            /tmp/hopr-*-node*.log
-
-      - name: Upload node logs (macOS)
-        uses: actions/upload-artifact@v2
-        if: ${{ always() && runner.os == 'macOS' }}
-        with:
-          name: hopr-e2e-source-node-logs
-          path: |
-            /var/tmp/hopr-*-node*.log
+        run: ./scripts/run-integration-tests-gcloud.sh
+        env:
+          FUNDING_PRIV_KEY: ${{ secrets.FUNDING_WALLET_PRIVATE_KEY }}
+          INFURA_KEY: ${{ secrets.INFURA_KEY }}
 
       - name: Send notification if anything failed on master or release branches
-        if: ${{ failure() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && !env.ACT }}
+        if: ${{ failure() && !env.ACT }}
         run: |
           ./scripts/notify-matrix-github-workflow-failure.sh "${MATRIX_ROOM}" "${{ github.repository }}" \
             "${{ github.workflow }}" "${{ github.run_id }}"

--- a/.github/workflows/e2e-gcloud.yaml
+++ b/.github/workflows/e2e-gcloud.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   e2e-gcloud:
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 15
+    timeout-minutes: 30
 
     strategy:
       matrix:

--- a/.github/workflows/e2e-gcloud.yaml
+++ b/.github/workflows/e2e-gcloud.yaml
@@ -63,7 +63,7 @@ jobs:
         run: ./scripts/run-integration-tests-gcloud.sh
         env:
           FUNDING_PRIV_KEY: ${{ secrets.FUNDING_WALLET_PRIVATE_KEY }}
-          INFURA_KEY: ${{ secrets.INFURA_KEY }}
+          HOPRD_INFURA_KEY: ${{ secrets.INFURA_KEY }}
 
       - name: Send notification if anything failed on master or release branches
         if: ${{ failure() && !env.ACT }}

--- a/.github/workflows/e2e-npm.yaml
+++ b/.github/workflows/e2e-npm.yaml
@@ -1,0 +1,85 @@
+name: HOPR End-to-end tests (NPM)
+
+env:
+  HOPR_GITHUB_REF: ${{ github.ref }}
+  MATRIX_ROOM: ${{ secrets.MATRIX_ROOM }}
+  MATRIX_SERVER: ${{ secrets.MATRIX_SERVER }}
+  MATRIX_ACCESS_TOKEN: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+
+on:
+  push:
+    branches: ['master', 'release/**', 'debug-e2e-npm/**']
+    paths-ignore:
+      - '**/docs/**/*'
+
+jobs:
+  e2e-npm:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+
+    strategy:
+      matrix:
+        node-version: [14]
+        os: ['ubuntu-latest', 'macos-latest']
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: https://registry.npmjs.org/
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn config get cacheFolder)"
+
+      - name: Restore cache of node modules and yarn cache
+        uses: actions/cache@v2
+        if: ${{ !env.ACT }}
+        id: nodejs-cache
+        with:
+          path: |
+            node_modules
+            */*/node_modules
+            ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-nodejs-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-nodejs-
+
+      - name: Build
+        run: |
+          yarn
+          yarn build
+
+      - name: Install websocat
+        run: ./scripts/install-websocat.sh
+
+      - name: Install jq
+        run: ./scripts/install-jq.sh
+
+      - name: Test
+        run: ./scripts/run-integration-tests-npm.sh
+
+      - name: Upload node logs (Linux)
+        uses: actions/upload-artifact@v2
+        if: ${{ always() && runner.os == 'Linux' }}
+        with:
+          name: hopr-e2e-npm-node-logs
+          path: |
+            /tmp/hopr-*-node*.log
+
+      - name: Upload node logs (macOS)
+        uses: actions/upload-artifact@v2
+        if: ${{ always() && runner.os == 'macOS' }}
+        with:
+          name: hopr-e2e-npm-node-logs
+          path: |
+            /var/tmp/hopr-*-node*.log
+
+      - name: Send notification if anything failed on master or release branches
+        if: ${{ failure() && !env.ACT }}
+        run: |
+          ./scripts/notify-matrix-github-workflow-failure.sh "${MATRIX_ROOM}" "${{ github.repository }}" \
+            "${{ github.workflow }}" "${{ github.run_id }}"

--- a/.github/workflows/e2e-npm.yaml
+++ b/.github/workflows/e2e-npm.yaml
@@ -79,7 +79,7 @@ jobs:
             /var/tmp/hopr-*-node*.log
 
       - name: Send notification if anything failed on master or release branches
-        if: ${{ failure() && !env.ACT }}
+        if: ${{ failure() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && !env.ACT }}
         run: |
           ./scripts/notify-matrix-github-workflow-failure.sh "${MATRIX_ROOM}" "${{ github.repository }}" \
             "${{ github.workflow }}" "${{ github.run_id }}"

--- a/scripts/gcloud.sh
+++ b/scripts/gcloud.sh
@@ -1,8 +1,17 @@
 #!/usr/bin/env bash
 
-set -o errexit
-set -o nounset
-set -o pipefail
+# prevent execution of this script, only allow sourcing
+$(return >/dev/null 2>&1)
+test "$?" -eq "0" || { echo "This script should only be sourced." >&2; exit 1; }
+
+# exit on errors, undefined variables, ensure errors in pipes are not hidden
+set -Eeuo pipefail
+
+# set log id and use shared log function for readable logs
+declare mydir
+mydir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+declare HOPR_LOG_ID="gcloud"
+source "${mydir}/utils.sh"
 
 # ------ GCloud utilities ------
 #
@@ -11,7 +20,8 @@ set -o pipefail
 
 GCLOUD_INCLUDED=1 # So we can test for inclusion
 ZONE="--zone=europe-west6-a"
-REGION="--region=europe-west6"
+declare gcloud_region="--region=europe-west6"
+declare gcloud_disk_name="hoprd-data-disk"
 
 GCLOUD_MACHINE="--machine-type=e2-medium"
 GCLOUD_META="--metadata=google-logging-enabled=true,google-monitoring-enabled=true,enable-oslogin=true --maintenance-policy=MIGRATE"
@@ -28,12 +38,12 @@ alias gssh="gcloud compute ssh --force-key-file-overwrite --ssh-key-expire-after
 # Get or create an IP address
 # $1 = name
 gcloud_get_address() {
-  local ip=$(gcloud compute addresses describe $1 $REGION 2>&1)
+  local ip=$(gcloud compute addresses describe $1 $gcloud_region 2>&1)
   # Google does not return an appropriate exit code :(
   if [ "$(echo "$ip" | grep 'ERROR')" ]; then
     echo "No address, creating" 1>&2
-    gcloud compute addresses create $1 $REGION
-    local ip=$(gcloud compute addresses describe $1 $REGION 2>&1)
+    gcloud compute addresses create $1 $gcloud_region
+    local ip=$(gcloud compute addresses describe $1 $gcloud_region 2>&1)
   fi
   echo $ip | awk '{ print $2 }'
 }
@@ -121,5 +131,125 @@ gcloud_get_logs() {
 
 # $1 - vm name
 gcloud_cleanup_docker_images() {
+  log "pruning docker images on host $1"
   gssh "$1" --command "sudo docker system prune -a -f"
+}
+
+# $1 - template name
+# $2 - container image
+# $3 - rpc endpoint
+# $4 - api token
+# $5 - password
+gcloud_create_or_update_instance_template() {
+  local name mount_path image rpc api_token password host_path
+
+  name="${1}"
+  image="${2}"
+  rpc="${3}"
+  api_token="${4}"
+  password="${5}"
+  mount_path="/app/db"
+  host_path="/root"
+
+  log "checking for instance template ${name}"
+  if gcloud compute instance-templates describe "${name}" --quiet >/dev/null; then
+    log "instance template ${name} already present"
+    gcloud_delete_instance_template "${name}"
+  fi
+
+  log "creating instance template ${name}"
+  gcloud compute instance-templates create-with-container "${name}" \
+    --machine-type=e2-medium \
+    --metadata=google-logging-enabled=true,google-monitoring-enabled=true,enable-oslogin=true \
+    --maintenance-policy=MIGRATE \
+    --tags=hopr-node,web-client,rest-client,portainer,healthcheck \
+    --boot-disk-size=20GB \
+    --boot-disk-type=pd-balanced \
+    --image-family=cos-stable \
+    --image-project=cos-cloud \
+    --container-image="${image}" \
+    --container-env=^,@^DEBUG=hopr\*,@NODE_OPTIONS=--max-old-space-size=4096,@GCLOUD=1 \
+    --container-mount-host-path=mount-path="${mount_path}",host-path="${host_path}" \
+    --container-arg="--admin" \
+    --container-arg="--adminHost" --container-arg="0.0.0.0" \
+    --container-arg="--announce" \
+    --container-arg="--apiToken" --container-arg="${api_token}" \
+    --container-arg="--healthCheck" \
+    --container-arg="--healthCheckHost" --container-arg="0.0.0.0" \
+    --container-arg="--identity" --container-arg="${mount_path}/.hopr-identity" \
+    --container-arg="--init" \
+    --container-arg="--password" --container-arg="${password}" \
+    --container-arg="--provider" --container-arg="${rpc}" \
+    --container-arg="--rest" \
+    --container-arg="--restHost" --container-arg="0.0.0.0" \
+    --container-arg="--run" --container-arg="\"cover-traffic start;daemonize\"" \
+    --container-restart-policy=always
+}
+
+# $1 - template name
+gcloud_delete_instance_template() {
+  local name
+
+  name="${1}"
+
+  log "deleting instance template ${name}"
+  gcloud compute instance-templates delete "${name}" --quiet
+}
+
+# $1 = group name
+# $2 = group size
+# $3 = template name
+gcloud_create_or_update_managed_instance_group() {
+  local name size template
+
+  name="${1}"
+  size="${2}"
+  template="${3}"
+
+  log "checking for managed instance group ${name}"
+  if gcloud compute instance-groups managed describe "${name}" ${gcloud_region} --quiet; then
+    log "managed instance group ${name} already present, updating..."
+    gcloud compute instance-groups managed rolling-action start-update \
+      "${name}"\
+      --version=template=${template} \
+      ${gcloud_region}
+  else
+    log "creating managed instance group ${name}"
+    gcloud compute instance-groups managed create "${name}" \
+      --base-instance-name "${name}-vm" \
+      --size ${size} \
+      --template "${template}" \
+      --instance-redistribution-type=NONE \
+      ${gcloud_region}
+  fi
+
+  log "waiting for managed instance group ${name}"
+  gcloud compute instance-groups managed wait-until "${name}" \
+    --stable \
+    ${gcloud_region}
+}
+
+# $1 = group name
+gcloud_delete_managed_instance_group() {
+  local name
+
+  name="${1}"
+
+  log "deleting managed instance group ${name}"
+  gcloud compute instance-groups managed delete "${name}" \
+    --quiet \
+    ${gcloud_region}
+}
+
+# $1 = group name
+gcloud_get_managed_instance_group_instances_ips() {
+  local name
+
+  name="${1}"
+
+  gcloud compute instance-groups list-instances "${name}" \
+    ${gcloud_region} --uri | \
+    xargs -P `nproc` -I '{}' gcloud compute instances describe '{}' \
+    --flatten 'networkInterfaces[].accessConfigs[]' \
+    --format 'csv[no-heading](networkInterfaces.accessConfigs.natIP)'
 }

--- a/scripts/run-integration-tests-gcloud.sh
+++ b/scripts/run-integration-tests-gcloud.sh
@@ -59,6 +59,8 @@ declare skip_cleanup="${HOPRD_SKIP_CLEANUP:-false}"
 declare show_prestartinfo="${HOPRD_SHOW_PRESTART_INFO:-false}"
 declare run_cleanup_only="${HOPRD_RUN_CLEANUP_ONLY:-false}"
 
+test -z "${FUNDING_PRIV_KEY:-}" && { msg "Missing FUNDING_PRIV_KEY"; usage; exit 1; }
+
 function cleanup {
   local EXIT_CODE=$?
 

--- a/scripts/run-integration-tests-gcloud.sh
+++ b/scripts/run-integration-tests-gcloud.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+
+# prevent souring of this script, only allow execution
+$(return >/dev/null 2>&1)
+test "$?" -eq "0" && { echo "This script should only be executed." >&2; exit 1; }
+
+# exit on errors, undefined variables, ensure errors in pipes are not hidden
+set -Eeuo pipefail
+
+# set log id and use shared log function for readable logs
+declare mydir
+mydir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+declare HOPR_LOG_ID="e2e-gcloud-test"
+source "${mydir}/utils.sh"
+source "${mydir}/gcloud.sh"
+
+usage() {
+  msg
+  msg "Usage: $0 [<docker_image>]"
+  msg
+  msg "\twhere <docker_image> uses latest as default"
+  msg
+}
+
+# return early with help info when requested
+([ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]) && { usage; exit 0; }
+
+# verify and set parameters
+declare docker_image rpc_endpoint rpc_endpoint_ip
+docker_image=${1:-latest}
+
+declare test_id="e2e-gcloud-test-${RANDOM}"
+declare api_token="e2e-API-token^^"
+declare password="${RANDOM}${RANDOM}${RANDOM}"
+declare wait_delay=2
+declare wait_max_wait=1000
+
+if [ "${CI:-}" = "true" ] && [ -z "${ACT:-}" ]; then
+  wait_delay=10
+  wait_max_wait=10
+fi
+
+function cleanup {
+  local EXIT_CODE=$?
+
+  trap - SIGINT SIGTERM ERR EXIT
+
+  # Cleaning up everything
+  gcloud_delete_managed_instance_group "${test_id}"
+  gcloud_delete_instance_template "${test_id}"
+
+  # TODO: delete hardhat instance
+
+  exit $EXIT_CODE
+}
+
+trap cleanup SIGINT SIGTERM ERR EXIT
+
+# $1 = endpoint
+function fund_node() {
+  local endpoint=${1}
+
+  local eth_address
+  eth_address="$(curl --silent "${endpoint}/api/v1/address/hopr")"
+
+  if [ -z "${eth_address}" ]; then
+    log "Can't fund node - couldn't load ETH address"
+    exit 1
+  fi
+
+  log "Funding 1 ETH and 1 HOPR to ${eth_address}"
+  yarn hardhat faucet --config packages/ethereum/hardhat.config.ts \
+    --address "${eth_address}" --network "${rpc_endpoint_ip}" --ishopraddress true
+}
+
+# --- Running Mock Blockchain --- {{{
+log "Running hardhat local node"
+DEVELOPMENT=true yarn hardhat node --config packages/ethereum/hardhat.config.ts \
+  --network hardhat --show-stack-traces > \
+  "${hardhat_rpc_log}" 2>&1 &
+# TODO: start hardhat instance
+
+rpc_endpoint="1.1.1.1:8545"
+
+log "Hardhat node started (${rpc_endpoint})"
+wait_for_http_port 8545 "" "${wait_delay}" "${wait_max_wait}"
+# }}}
+
+gcloud_create_or_update_instance_template "${test_id}" \
+  "${docker_image}" \
+  "${rpc_endpoint}}" \
+  "${api_token}" \
+  "${password}"
+
+gcloud_create_or_update_managed_instance_group "${test_id}" \
+  6 \
+  "${test_id}"
+
+# get IPs of newly started VMs which run hoprd
+local node_ips
+node_ips=$(gcloud_get_managed_instance_group_instances_ips "${test_id}")
+
+#  --- Fund nodes --- {{{
+for ip in ${node_ips}; do
+  fund_node "${ip}:3001"
+done
+# }}}
+
+#  --- Wait for nodes to register funding and complete startup--- {{{
+for ip in ${node_ips}; do
+  wait_for_port "${ip}" "9091"
+done
+# }}}
+
+# --- Run security tests --- {{{
+${mydir}/../test/security-test.sh \
+  "${node_ips%% *}" 3001 9091
+#}}}
+
+# --- Run test --- {{{
+${mydir}/../test/integration-test.sh \
+  ${node_ips// /:3001 }:3001
+# }}}

--- a/scripts/run-integration-tests-gcloud.sh
+++ b/scripts/run-integration-tests-gcloud.sh
@@ -40,6 +40,7 @@ declare password="pw${RANDOM}${RANDOM}${RANDOM}pw"
 declare wait_delay=2
 declare wait_max_wait=1000
 declare rpc_endpoint="https://goerli.infura.io/v3/${HOPRD_INFURA_KEY}"
+declare hopr_token_contract="0x566a5c774bb8ABE1A88B4f187e24d4cD55C207A5"
 
 if [ "${CI:-}" = "true" ] && [ -z "${ACT:-}" ]; then
   wait_delay=10
@@ -82,7 +83,7 @@ node_ips_arr=( ${node_ips} )
 for ip in ${node_ips}; do
   wait_until_node_is_ready "${ip}"
   declare eth_address=$(get_eth_address "${ip}")
-  fund_if_empty "${eth_address}" "${rpc_endpoint}"
+  fund_if_empty "${eth_address}" "${rpc_endpoint}" "${hopr_token_contract}"
 done
 # }}}
 

--- a/scripts/run-integration-tests-gcloud.sh
+++ b/scripts/run-integration-tests-gcloud.sh
@@ -118,8 +118,7 @@ declare eth_address
 for ip in ${node_ips}; do
   wait_until_node_is_ready "${ip}"
   eth_address=$(get_eth_address "${ip}")
-  # let the funding be done async, the following wait will sync this step again
-  fund_if_empty "${eth_address}" "${rpc_endpoint}" "${hopr_token_contract}" &
+  fund_if_empty "${eth_address}" "${rpc_endpoint}" "${hopr_token_contract}"
 done
 
 for ip in ${node_ips}; do

--- a/scripts/run-integration-tests-gcloud.sh
+++ b/scripts/run-integration-tests-gcloud.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# TODO: this script currently uses goerli as the RPC provider. However, it
+# should be extended to use its own instance of hardhat too.
+
 # prevent souring of this script, only allow execution
 $(return >/dev/null 2>&1)
 test "$?" -eq "0" && { echo "This script should only be executed." >&2; exit 1; }
@@ -13,12 +16,14 @@ mydir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 declare HOPR_LOG_ID="e2e-gcloud-test"
 source "${mydir}/utils.sh"
 source "${mydir}/gcloud.sh"
+source "${mydir}/testnet.sh"
 
 usage() {
   msg
-  msg "Usage: $0 [<docker_image>]"
+  msg "Usage: $0 [<docker_image>] [<test_id>]"
   msg
-  msg "\twhere <docker_image> uses latest as default"
+  msg "\twhere <docker_image>: uses 'gcr.io/hoprassociation/hoprd:latest' as default"
+  msg "\t      <test_id>: uses a random value as default"
   msg
 }
 
@@ -26,14 +31,15 @@ usage() {
 ([ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]) && { usage; exit 0; }
 
 # verify and set parameters
-declare docker_image rpc_endpoint rpc_endpoint_ip
-docker_image=${1:-latest}
+declare docker_image test_id
+docker_image=${1:-gcr.io/hoprassociation/hoprd:latest}
+test_id="e2e-gcloud-test-${2:-$RANDOM-$RANDOM}"
 
-declare test_id="e2e-gcloud-test-${RANDOM}"
 declare api_token="e2e-API-token^^"
-declare password="${RANDOM}${RANDOM}${RANDOM}"
+declare password="pw${RANDOM}${RANDOM}${RANDOM}pw"
 declare wait_delay=2
 declare wait_max_wait=1000
+declare rpc_endpoint="https://goerli.infura.io/v3/${HOPRD_INFURA_KEY}"
 
 if [ "${CI:-}" = "true" ] && [ -z "${ACT:-}" ]; then
   wait_delay=10
@@ -44,80 +50,54 @@ function cleanup {
   local EXIT_CODE=$?
 
   trap - SIGINT SIGTERM ERR EXIT
+  set +Eeuo pipefail
 
   # Cleaning up everything
   gcloud_delete_managed_instance_group "${test_id}"
   gcloud_delete_instance_template "${test_id}"
-
-  # TODO: delete hardhat instance
 
   exit $EXIT_CODE
 }
 
 trap cleanup SIGINT SIGTERM ERR EXIT
 
-# $1 = endpoint
-function fund_node() {
-  local endpoint=${1}
-
-  local eth_address
-  eth_address="$(curl --silent "${endpoint}/api/v1/address/hopr")"
-
-  if [ -z "${eth_address}" ]; then
-    log "Can't fund node - couldn't load ETH address"
-    exit 1
-  fi
-
-  log "Funding 1 ETH and 1 HOPR to ${eth_address}"
-  yarn hardhat faucet --config packages/ethereum/hardhat.config.ts \
-    --address "${eth_address}" --network "${rpc_endpoint_ip}" --ishopraddress true
-}
-
-# --- Running Mock Blockchain --- {{{
-log "Running hardhat local node"
-DEVELOPMENT=true yarn hardhat node --config packages/ethereum/hardhat.config.ts \
-  --network hardhat --show-stack-traces > \
-  "${hardhat_rpc_log}" 2>&1 &
-# TODO: start hardhat instance
-
-rpc_endpoint="1.1.1.1:8545"
-
-log "Hardhat node started (${rpc_endpoint})"
-wait_for_http_port 8545 "" "${wait_delay}" "${wait_max_wait}"
-# }}}
-
+# create test specific instance template
 gcloud_create_or_update_instance_template "${test_id}" \
   "${docker_image}" \
-  "${rpc_endpoint}}" \
+  "${rpc_endpoint}" \
   "${api_token}" \
   "${password}"
-
+#
+# start nodes
 gcloud_create_or_update_managed_instance_group "${test_id}" \
   6 \
   "${test_id}"
 
 # get IPs of newly started VMs which run hoprd
-local node_ips
+declare node_ips node_ips_arr
 node_ips=$(gcloud_get_managed_instance_group_instances_ips "${test_id}")
+node_ips_arr=( ${node_ips} )
 
 #  --- Fund nodes --- {{{
 for ip in ${node_ips}; do
-  fund_node "${ip}:3001"
+  wait_until_node_is_ready "${ip}"
+  declare eth_address=$(get_eth_address "${ip}")
+  fund_if_empty "${eth_address}" "${rpc_endpoint}"
 done
 # }}}
 
 #  --- Wait for nodes to register funding and complete startup--- {{{
 for ip in ${node_ips}; do
-  wait_for_port "${ip}" "9091"
+  wait_for_port "9091" "${ip}"
 done
 # }}}
 
 # --- Run security tests --- {{{
 ${mydir}/../test/security-test.sh \
-  "${node_ips%% *}" 3001 9091
+  "${node_ips_arr[0]}" 3001 3000
 #}}}
 
 # --- Run test --- {{{
 ${mydir}/../test/integration-test.sh \
-  ${node_ips// /:3001 }:3001
+  ${node_ips_arr[@]/%/:3001}
 # }}}

--- a/scripts/run-integration-tests-gcloud.sh
+++ b/scripts/run-integration-tests-gcloud.sh
@@ -13,39 +13,41 @@ set -Eeuo pipefail
 # set log id and use shared log function for readable logs
 declare mydir
 mydir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
-declare HOPR_LOG_ID="e2e-gcloud-test"
+declare -x HOPR_LOG_ID="e2e-gcloud-test"
 source "${mydir}/utils.sh"
 source "${mydir}/gcloud.sh"
 source "${mydir}/testnet.sh"
 
 usage() {
   msg
-  msg "Usage: $0 [<docker_image>] [<test_id>]"
+  msg "Usage: $0 [<test_id> [<docker_image>]]"
   msg
-  msg "\twhere <docker_image>: uses 'gcr.io/hoprassociation/hoprd:latest' as default"
-  msg "\t      <test_id>: uses a random value as default"
+  msg "where <test_id>:\tuses a random value as default"
+  msg "      <docker_image>:\tuses 'gcr.io/hoprassociation/hoprd:latest' as default"
+  msg
+  msg "Supported environment variables"
+  msg "-------------------------------"
+  msg
+  msg "HOPRD_SKIP_CLEANUP\t\tSet to 'true' to skip the cleanup process and keep resources running."
+  msg "HOPRD_SHOW_PRESTART_INFO\tSet to 'true' to print used parameter values before starting."
+  msg "HOPRD_RUN_CLEANUP_ONLY\t\tSet to 'true' to execute the cleanup process only."
   msg
 }
 
 # return early with help info when requested
-([ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]) && { usage; exit 0; }
+{ [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; } && { usage; exit 0; }
 
 # verify and set parameters
-declare docker_image test_id
-docker_image=${1:-gcr.io/hoprassociation/hoprd:latest}
-test_id="e2e-gcloud-test-${2:-$RANDOM-$RANDOM}"
+declare test_id="e2e-gcloud-test-${1:-$RANDOM-$RANDOM}"
+declare docker_image=${2:-gcr.io/hoprassociation/hoprd:latest}
 
 declare api_token="e2e-API-token^^"
 declare password="pw${RANDOM}${RANDOM}${RANDOM}pw"
-declare wait_delay=2
-declare wait_max_wait=1000
 declare rpc_endpoint="https://goerli.infura.io/v3/${HOPRD_INFURA_KEY}"
 declare hopr_token_contract="0x566a5c774bb8ABE1A88B4f187e24d4cD55C207A5"
-
-if [ "${CI:-}" = "true" ] && [ -z "${ACT:-}" ]; then
-  wait_delay=10
-  wait_max_wait=10
-fi
+declare skip_cleanup="${HOPRD_SKIP_CLEANUP:-false}"
+declare show_prestartinfo="${HOPRD_SHOW_PRESTART_INFO:-false}"
+declare run_cleanup_only="${HOPRD_RUN_CLEANUP_ONLY:-false}"
 
 function cleanup {
   local EXIT_CODE=$?
@@ -60,7 +62,39 @@ function cleanup {
   exit $EXIT_CODE
 }
 
-trap cleanup SIGINT SIGTERM ERR EXIT
+function fund_ip() {
+  local ip="${1}"
+  local eth_address
+
+  wait_until_node_is_ready "${ip}"
+  eth_address=$(get_eth_address "${ip}")
+  fund_if_empty "${eth_address}" "${rpc_endpoint}" "${hopr_token_contract}"
+  wait_for_port "9091" "${ip}"
+}
+
+if [ "${run_cleanup_only}" = "1" ] || [ "${run_cleanup_only}" = "true" ]; then
+  cleanup
+
+  # exit right away
+  exit
+fi
+
+if [ "${skip_cleanup}" != "1" ] && [ "${skip_cleanup}" != "true" ]; then
+  trap cleanup SIGINT SIGTERM ERR EXIT
+fi
+
+# --- Log test info {{{
+if [ "${show_prestartinfo}" = "1" ] || [ "${show_prestartinfo}" = "true" ]; then
+  log "Pre-Start Info"
+  log "\tdocker_image: ${docker_image}"
+  log "\ttest_id: ${test_id}"
+  log "\tapi_token: ${api_token}"
+  log "\tpassword: ${password}"
+  log "\trpc_endpoint: ${rpc_endpoint}"
+  log "\thopr_token_contract: ${hopr_token_contract}"
+  log "\tskip_cleanup: ${skip_cleanup}"
+fi
+# }}}
 
 # create test specific instance template
 gcloud_create_or_update_instance_template "${test_id}" \
@@ -75,30 +109,30 @@ gcloud_create_or_update_managed_instance_group "${test_id}" \
   "${test_id}"
 
 # get IPs of newly started VMs which run hoprd
-declare node_ips node_ips_arr
+declare node_ips
 node_ips=$(gcloud_get_managed_instance_group_instances_ips "${test_id}")
-node_ips_arr=( ${node_ips} )
+declare node_ips_arr=( ${node_ips} )
 
 #  --- Fund nodes --- {{{
+declare eth_address
 for ip in ${node_ips}; do
   wait_until_node_is_ready "${ip}"
-  declare eth_address=$(get_eth_address "${ip}")
-  fund_if_empty "${eth_address}" "${rpc_endpoint}" "${hopr_token_contract}"
+  eth_address=$(get_eth_address "${ip}")
+  # let the funding be done async, the following wait will sync this step again
+  fund_if_empty "${eth_address}" "${rpc_endpoint}" "${hopr_token_contract}" &
 done
-# }}}
 
-#  --- Wait for nodes to register funding and complete startup--- {{{
 for ip in ${node_ips}; do
   wait_for_port "9091" "${ip}"
 done
 # }}}
 
 # --- Run security tests --- {{{
-${mydir}/../test/security-test.sh \
+"${mydir}/../test/security-test.sh" \
   "${node_ips_arr[0]}" 3001 3000
 #}}}
 
 # --- Run test --- {{{
-${mydir}/../test/integration-test.sh \
+"${mydir}/../test/integration-test.sh" \
   ${node_ips_arr[@]/%/:3001}
 # }}}

--- a/scripts/run-integration-tests-npm.sh
+++ b/scripts/run-integration-tests-npm.sh
@@ -19,6 +19,8 @@ usage() {
   msg
   msg "\twhere <npm_package_version> uses the most recent Git tag as default"
   msg
+  msg "\tThe cleanup process can be skipped by setting the environment variable HOPRD_SKIP_CLEANUP to 'true'."
+  msg
 }
 
 # return early with help info when requested
@@ -26,6 +28,7 @@ usage() {
 
 # verify and set parameters
 declare npm_package_version
+declare skip_cleanup="${HOPRD_SKIP_CLEANUP:-false}"
 
 # we rely on Git tags so need to fetch the tags in case they are not present
 git fetch --unshallow --tags || :
@@ -87,7 +90,9 @@ function cleanup {
   exit $EXIT_CODE
 }
 
-trap cleanup SIGINT SIGTERM ERR EXIT
+if [ "${skip_cleanup}" != "1" ] && [ "${skip_cleanup}" != "true" ]; then
+  trap cleanup SIGINT SIGTERM ERR EXIT
+fi
 
 # $1 = rest port
 # $2 = node port

--- a/scripts/run-integration-tests-npm.sh
+++ b/scripts/run-integration-tests-npm.sh
@@ -73,6 +73,7 @@ function cleanup {
   local EXIT_CODE=$?
 
   trap - SIGINT SIGTERM ERR EXIT
+  set +Eeuo pipefail
 
   # Cleaning up everything
   log "Wiping databases"
@@ -80,9 +81,7 @@ function cleanup {
 
   log "Cleaning up processes"
   for port in 8545 13301 13302 13303 13304 13305 13306 19091 19092 19093 19094 19095 19096; do
-    if lsof -i ":${port}" -s TCP:LISTEN; then
-      lsof -i ":${port}" -s TCP:LISTEN -t | xargs -I {} -n 1 kill {}
-    fi
+    lsof -i ":${port}" -s TCP:LISTEN -t | xargs -I {} -n 1 kill {}
   done
 
   exit $EXIT_CODE
@@ -137,7 +136,7 @@ function setup_node() {
     ${additional_args} \
     > "${log}" 2>&1 &
 
-  wait_for_http_port "${rest_port}" "${log}" "${wait_delay}" "${wait_max_wait}"
+  wait_for_http_port "${rest_port}" "127.0.0.1" "${log}" "${wait_delay}" "${wait_max_wait}"
 }
 
 # $1 = port
@@ -215,7 +214,7 @@ DEVELOPMENT=true yarn hardhat node --config packages/ethereum/hardhat.config.ts 
   "${hardhat_rpc_log}" 2>&1 &
 
 log "Hardhat node started (127.0.0.1:8545)"
-wait_for_http_port 8545 "${hardhat_rpc_log}" "${wait_delay}" "${wait_max_wait}"
+wait_for_http_port 8545 "127.0.0.1" "${hardhat_rpc_log}" "${wait_delay}" "${wait_max_wait}"
 # }}}
 
 #  --- Run nodes --- {{{
@@ -237,11 +236,11 @@ fund_node 13306 "${node6_log}"
 # }}}
 
 #  --- Wait for ports to be bound --- {{{
-wait_for_port 19091 "${node1_log}"
-wait_for_port 19092 "${node2_log}"
-wait_for_port 19093 "${node3_log}"
-wait_for_port 19094 "${node4_log}"
-wait_for_port 19095 "${node5_log}"
+wait_for_port 19091 "127.0.0.1" "${node1_log}"
+wait_for_port 19092 "127.0.0.1" "${node2_log}"
+wait_for_port 19093 "127.0.0.1" "${node3_log}"
+wait_for_port 19094 "127.0.0.1" "${node4_log}"
+wait_for_port 19095 "127.0.0.1" "${node5_log}"
 # no need to wait for node 6 since that will stop right away
 # }}}
 

--- a/scripts/run-integration-tests-source.sh
+++ b/scripts/run-integration-tests-source.sh
@@ -63,6 +63,7 @@ function cleanup {
   local EXIT_CODE=$?
 
   trap - SIGINT SIGTERM ERR EXIT
+  set +Eeuo pipefail
 
   # Cleaning up everything
   log "Wiping databases"
@@ -70,9 +71,7 @@ function cleanup {
 
   log "Cleaning up processes"
   for port in 8545 13301 13302 13303 13304 13305 13306 19091 19092 19093 19094 19095 19096; do
-    if lsof -i ":${port}" -s TCP:LISTEN; then
-      lsof -i ":${port}" -s TCP:LISTEN -t | xargs -I {} -n 1 kill {}
-    fi
+    lsof -i ":${port}" -s TCP:LISTEN -t | xargs -I {} -n 1 kill {}
   done
 
   exit $EXIT_CODE
@@ -122,7 +121,7 @@ function setup_node() {
     ${additional_args} \
     > "${log}" 2>&1 &
 
-  wait_for_http_port "${rest_port}" "${log}" "${wait_delay}" "${wait_max_wait}"
+  wait_for_http_port "${rest_port}" "127.0.0.1" "${log}" "${wait_delay}" "${wait_max_wait}"
 }
 
 # $1 = rest port
@@ -198,7 +197,7 @@ DEVELOPMENT=true yarn hardhat node --config packages/ethereum/hardhat.config.ts 
   "${hardhat_rpc_log}" 2>&1 &
 
 log "Hardhat node started (127.0.0.1:8545)"
-wait_for_http_port 8545 "${hardhat_rpc_log}" "${wait_delay}" "${wait_max_wait}"
+wait_for_http_port 8545 "127.0.0.1" "${hardhat_rpc_log}" "${wait_delay}" "${wait_max_wait}"
 # }}}
 
 #  --- Run nodes --- {{{
@@ -220,11 +219,11 @@ fund_node 13306 "${node6_log}"
 # }}}
 
 #  --- Wait for ports to be bound --- {{{
-wait_for_port 19091 "${node1_log}"
-wait_for_port 19092 "${node2_log}"
-wait_for_port 19093 "${node3_log}"
-wait_for_port 19094 "${node4_log}"
-wait_for_port 19095 "${node5_log}"
+wait_for_port 19091 "127.0.0.1" "${node1_log}"
+wait_for_port 19092 "127.0.0.1" "${node2_log}"
+wait_for_port 19093 "127.0.0.1" "${node3_log}"
+wait_for_port 19094 "127.0.0.1" "${node4_log}"
+wait_for_port 19095 "127.0.0.1" "${node5_log}"
 # no need to wait for node 6 since that will stop right away
 # }}}
 

--- a/scripts/run-integration-tests-source.sh
+++ b/scripts/run-integration-tests-source.sh
@@ -17,6 +17,8 @@ usage() {
   msg
   msg "Usage: $0"
   msg
+  msg "\tThe cleanup process can be skipped by setting the environment variable HOPRD_SKIP_CLEANUP to 'true'."
+  msg
 }
 
 # return early with help info when requested
@@ -25,6 +27,7 @@ usage() {
 # verify and set parameters
 declare wait_delay=2
 declare wait_max_wait=1000
+declare skip_cleanup="${HOPRD_SKIP_CLEANUP:-false}"
 
 if [ "${CI:-}" = "true" ] && [ -z "${ACT:-}" ]; then
   wait_delay=10
@@ -77,7 +80,9 @@ function cleanup {
   exit $EXIT_CODE
 }
 
-trap cleanup SIGINT SIGTERM ERR EXIT
+if [ "${skip_cleanup}" != "1" ] && [ "${skip_cleanup}" != "true" ]; then
+  trap cleanup SIGINT SIGTERM ERR EXIT
+fi
 
 # $1 = rest port
 # $2 = node port

--- a/scripts/testnet.sh
+++ b/scripts/testnet.sh
@@ -1,18 +1,21 @@
 #!/usr/bin/env bash
 
-set -o errexit
-set -o nounset
-set -o pipefail
+# prevent execution of this script, only allow sourcing
+$(return >/dev/null 2>&1)
+test "$?" -eq "0" || { echo "This script should only be sourced." >&2; exit 1; }
 
-if [ -z "${GCLOUD_INCLUDED:-}" ]; then
-  source scripts/gcloud.sh
-  source scripts/dns.sh
-fi
+# exit on errors, undefined variables, ensure errors in pipes are not hidden
+set -Eeuo pipefail
 
-source scripts/utils.sh
+# set log id and use shared log function for readable logs
+declare mydir
+mydir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+declare HOPR_LOG_ID="testnet"
+source "${mydir}/utils.sh"
+source "${mydir}/gcloud.sh"
+source "${mydir}/dns.sh"
 
-MIN_FUNDS=0.01291
-ZONE="--zone=europe-west6-a"
+declare min_funds=0.01291
 
 # $1 = role (ie. node-4)
 # $2 = network name
@@ -27,7 +30,7 @@ disk_name() {
 
 # $1 = account (hex)
 # $2 = chain provider
-balance() {
+wallet_balance() {
   local address=${1}
   local rpc=${2}
 
@@ -35,75 +38,72 @@ balance() {
 }
 
 # $1 = chain provider
-funding_wallet_balance() {
-  local rpc=${1}
-
-  yarn run --silent ethers --rpc "${rpc}" --account "$FUNDING_PRIV_KEY" eval 'accounts[0].getBalance().then(b => formatEther(b))'
-}
-
-# $1 = chain provider
 funding_wallet_address() {
-  local rpc=${1}
+  local rpc="${1}"
 
-  yarn run --silent ethers --rpc "${rpc}" --account "$FUNDING_PRIV_KEY" eval 'accounts[0].getAddress().then(a => a)'
+  # the value of FUNDING_PRIV_KEY must be prefixed with 0x
+  yarn run --silent ethers --rpc "${rpc}" --account "${FUNDING_PRIV_KEY}" eval 'accounts[0].getAddress().then(a => a)'
 }
 
 # $1 = account (hex)
 # $2 = chain provider
 fund_if_empty() {
-  local address=${1}
-  local rpc=${2}
+  local address="${1}"
+  local rpc="${2}"
 
-  echo "Starting funding wallet process"
-  local FUNDING_WALLET_ADDRESS=$(funding_wallet_address "${rpc}")
+  local funding_address funding_balance balance
 
-  echo "Checking balance of funding wallet $FUNDING_WALLET_ADDRESS using RPC ${rpc}"
-  local FUNDING_WALLET_BALANCE="$(funding_wallet_balance "${rpc}")"
+  funding_address=$(funding_wallet_address "${rpc}")
 
-  if [ "$FUNDING_WALLET_BALANCE" = '0.0' ]; then
-    echo "Wallet $FUNDING_WALLET_ADDRESS has zero balance and cannot fund node ${address}"
+  log "Checking balance of funding wallet ${funding_address} using RPC ${rpc}"
+  funding_balance="$(wallet_balance "${funding_address}" "${rpc}")"
+
+  if [ "${funding_balance}" = '0.0' ]; then
+    log "Wallet ${funding_address} has zero balance and cannot fund node ${address}"
   else
-    echo "Funding wallet $FUNDING_WALLET_ADDRESS has enough: $FUNDING_WALLET_BALANCE"
-    echo "Checking balance of the wallet ${address} to be funded"
-    local BALANCE="$(balance ${address} "${rpc}")"
+    log "Funding wallet ${funding_address} has enough funds: ${funding_balance}"
+    log "Checking balance of the wallet ${address} to be funded"
+    balance="$(wallet_balance "${address}" "${rpc}")"
 
-    echo "Balance of ${address} is $BALANCE"
-    if [ "$BALANCE" = '0.0' ]; then
-      echo "Funding account ... ${rpc} -> ${address} $MIN_FUNDS"
-      yarn ethers send --rpc "${rpc}" --account "$FUNDING_PRIV_KEY" "${address}" $MIN_FUNDS --yes
+    log "Balance of ${address} is ${balance}"
+    if [ "${balance}" = '0.0' ]; then
+      log "Funding account -> ${address} ${min_funds}"
+      yarn ethers send --rpc "${rpc}" --account "${FUNDING_PRIV_KEY}" "${address}" ${min_funds} --yes
     fi
   fi
 }
 
 # $1 = IP
+# $2 = optional: port
 get_eth_address(){
-  curl "$1:3001/api/v1/address/eth"
+  curl "${1}:${2:-3001}/api/v1/address/eth"
 }
 
 # $1 = IP
+# $2 = optional: port
 get_hopr_address() {
-  curl "$1:3001/api/v1/address/hopr"
+  curl "${1}:${2:-3001}/api/v1/address/hopr"
 }
 
 # $1 = IP
 # $2 = Hopr command
+# $3 = optional: port
 run_command(){
-  curl --silent -X POST --data "$2" "$1:3001/api/v1/command"
+  curl --silent -X POST --data "${2}" "${1}:${3:-3001}/api/v1/command"
 }
-
 
 # $1 = vm name
 # $2 = docker image
 # $3 = chain provider
 update_if_existing() {
   if [[ $(gcloud_find_vm_with_name $1) ]]; then
-    echo "Container exists, updating" 1>&2
+    log "Container exists, updating" 1>&2
     PREV=$(gcloud_get_image_running_on_vm $1)
     if [ "$PREV" == "$2" ]; then
-      echo "Same version of image is currently running. Skipping update to $PREV" 1>&2
+      log "Same version of image is currently running. Skipping update to $PREV" 1>&2
       return 0
     fi
-    echo "Previous GCloud VM Image: $PREV"
+    log "Previous GCloud VM Image: $PREV"
     gcloud_update_container_with_image $1 $2 "$(disk_name $1)" "/app/db" "${3}"
 
     # prevent docker images overloading the disk space
@@ -165,7 +165,7 @@ start_testnode() {
 
   # start or update vm
   vm=$(vm_name "node-$3" $1)
-  echo "- Starting test node $vm with $2 ${4}"
+  log "- Starting test node $vm with $2 ${4}"
   start_testnode_vm $vm $2 ${4}
 
   # ensure node has funds, even after just updating a release
@@ -178,7 +178,7 @@ start_testnode() {
 # $1 authorized keys file
 add_keys() {
   if test -f "$1"; then
-    echo "Reading keys from $1"
+    log "Reading keys from $1"
     cat $1 | xargs -I {} gcloud compute os-login ssh-keys add --key="{}"
   else
     echo "Authorized keys file not found"
@@ -198,7 +198,7 @@ add_keys() {
 start_testnet() {
   for i in $(seq 1 $2);
   do
-    echo "Start node $i"
+    log "Start node $i"
     start_testnode $1 $3 $i ${4}
   done
   # @jose can you fix this pls.

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -34,32 +34,36 @@ function ensure_port_is_free() {
   fi
 }
 
-# $1 = port to wait for
-# $2 = optional: file to tail for debug info
-# $3 = optional: delay between checks in seconds, defaults to 2s
-# $4 = optional: max number of checks, defaults to 1000
+# $1 = host to check port on
+# $2 = port to wait for
+# $3 = optional: file to tail for debug info
+# $4 = optional: delay between checks in seconds, defaults to 2s
+# $5 = optional: max number of checks, defaults to 1000
 function wait_for_http_port() {
-  local port=${1}
-  local log_file=${2:-}
-  local delay=${3:-2}
-  local max_wait=${4:-1000}
-  local cmd="curl --silent "localhost:${port}""
+  local host=${1}
+  local port=${2}
+  local log_file=${3:-}
+  local delay=${4:-2}
+  local max_wait=${5:-1000}
+  local cmd="curl --silent "${host}:${port}""
 
-  wait_for_port "${port}" "${log_file}" "${delay}" "${max_wait}" "${cmd}"
+  wait_for_port "${host}" "${port}" "${log_file}" "${delay}" "${max_wait}" "${cmd}"
 }
 
-# $1 = port to wait for
-# $2 = optional: file to tail for debug info
-# $3 = optional: delay between checks in seconds, defaults to 2s
-# $4 = optional: max number of checks, defaults to 1000
-# $5 = optional: command to check
+# $1 = host to check port on
+# $2 = port to wait for
+# $3 = optional: file to tail for debug info
+# $4 = optional: delay between checks in seconds, defaults to 2s
+# $5 = optional: max number of checks, defaults to 1000
+# $6 = optional: command to check
 function wait_for_port() {
-  local port=${1}
-  local log_file=${2:-}
-  local delay=${3:-2}
-  local max_wait=${4:-1000}
+  local host=${1}
+  local port=${2}
+  local log_file=${3:-}
+  local delay=${4:-2}
+  local max_wait=${5:-1000}
   # by default we do a basic listen check
-  local cmd=${5:-lsof -i ":${port}" -s TCP:LISTEN}
+  local cmd=${6:-nc -z -w 0 ${host} ${port}}
 
   i=0
   until ${cmd}; do

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -34,36 +34,36 @@ function ensure_port_is_free() {
   fi
 }
 
-# $1 = host to check port on
-# $2 = port to wait for
+# $1 = port to wait for
+# $2 = host to check port on
 # $3 = optional: file to tail for debug info
 # $4 = optional: delay between checks in seconds, defaults to 2s
 # $5 = optional: max number of checks, defaults to 1000
 function wait_for_http_port() {
-  local host=${1}
-  local port=${2}
+  local port=${1}
+  local host=${2}
   local log_file=${3:-}
   local delay=${4:-2}
   local max_wait=${5:-1000}
   local cmd="curl --silent "${host}:${port}""
 
-  wait_for_port "${host}" "${port}" "${log_file}" "${delay}" "${max_wait}" "${cmd}"
+  wait_for_port "${port}" "${host}" "${log_file}" "${delay}" "${max_wait}" "${cmd}"
 }
 
-# $1 = host to check port on
-# $2 = port to wait for
+# $1 = port to wait for
+# $2 = optional: host to check port on, defaults to 127.0.0.1
 # $3 = optional: file to tail for debug info
 # $4 = optional: delay between checks in seconds, defaults to 2s
 # $5 = optional: max number of checks, defaults to 1000
 # $6 = optional: command to check
 function wait_for_port() {
-  local host=${1}
-  local port=${2}
+  local port=${1}
+  local host=${2:-127.0.0.1}
   local log_file=${3:-}
   local delay=${4:-2}
   local max_wait=${5:-1000}
   # by default we do a basic listen check
-  local cmd=${6:-nc -z -w 0 ${host} ${port}}
+  local cmd=${6:-nc -z -w 1 ${host} ${port}}
 
   i=0
   until ${cmd}; do

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -89,8 +89,7 @@ get_hopr_address(){
 }
 
 validate_node_eth_address() {
-  local ETH_ADDRESS
-  local IS_VALID_ETH_ADDRESS
+  local ETH_ADDRESS IS_VALID_ETH_ADDRESS
 
   ETH_ADDRESS="$(get_eth_address $1)"
   if [ -z "$ETH_ADDRESS" ]; then
@@ -173,11 +172,11 @@ log "Node 1 send 0-hop message to node 2"
 run_command "${api1}" "send ,${addr2} 'hello, world'" "Message sent" 600
 
 log "Node 1 open channel to Node 2"
-result=$(run_command "${api1}" "open ${addr2} 0.1" "Successfully opened channel")
+result=$(run_command "${api1}" "open ${addr2} 0.001" "Successfully opened channel")
 log "-- ${result}"
 
 log "Node 2 open channel to Node 3"
-result=$(run_command "${api2}" "open ${addr3} 0.1" "Successfully opened channel")
+result=$(run_command "${api2}" "open ${addr3} 0.001" "Successfully opened channel")
 log "-- ${result}"
 
 for i in `seq 1 10`; do
@@ -195,7 +194,7 @@ for i in `seq 1 10`; do
 done
 
 log "Node 3 open channel to Node 4"
-result=$(run_command "${api3}" "open ${addr4} 0.1" "Successfully opened channel")
+result=$(run_command "${api3}" "open ${addr4} 0.001" "Successfully opened channel")
 log "-- ${result}"
 
 for i in `seq 1 10`; do

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -172,11 +172,11 @@ log "Node 1 send 0-hop message to node 2"
 run_command "${api1}" "send ,${addr2} 'hello, world'" "Message sent" 600
 
 log "Node 1 open channel to Node 2"
-result=$(run_command "${api1}" "open ${addr2} 0.001" "Successfully opened channel")
+result=$(run_command "${api1}" "open ${addr2} 0.1" "Successfully opened channel")
 log "-- ${result}"
 
 log "Node 2 open channel to Node 3"
-result=$(run_command "${api2}" "open ${addr3} 0.001" "Successfully opened channel")
+result=$(run_command "${api2}" "open ${addr3} 0.1" "Successfully opened channel")
 log "-- ${result}"
 
 for i in `seq 1 10`; do
@@ -194,7 +194,7 @@ for i in `seq 1 10`; do
 done
 
 log "Node 3 open channel to Node 4"
-result=$(run_command "${api3}" "open ${addr4} 0.001" "Successfully opened channel")
+result=$(run_command "${api3}" "open ${addr4} 0.1" "Successfully opened channel")
 log "-- ${result}"
 
 for i in `seq 1 10`; do

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -172,39 +172,66 @@ log "Node 1 send 0-hop message to node 2"
 run_command "${api1}" "send ,${addr2} 'hello, world'" "Message sent" 600
 
 log "Node 1 open channel to Node 2"
-result=$(run_command "${api1}" "open ${addr2} 0.1" "Successfully opened channel")
+result=$(run_command "${api1}" "open ${addr2} 0.1" "Successfully opened channel" 600)
 log "-- ${result}"
 
 log "Node 2 open channel to Node 3"
-result=$(run_command "${api2}" "open ${addr3} 0.1" "Successfully opened channel")
+result=$(run_command "${api2}" "open ${addr3} 0.1" "Successfully opened channel" 600)
+log "-- ${result}"
+
+log "Node 3 open channel to Node 4"
+result=$(run_command "${api3}" "open ${addr4} 0.1" "Successfully opened channel" 600)
+log "-- ${result}"
+
+log "Node 4 open channel to Node 5"
+result=$(run_command "${api4}" "open ${addr5} 0.1" "Successfully opened channel" 600)
 log "-- ${result}"
 
 for i in `seq 1 10`; do
   log "Node 1 send 1 hop message to self via node 2"
   run_command "${api1}" "send ${addr2},${addr1} 'hello, world'" "Message sent" 600
+
+  log "Node 2 send 1 hop message to self via node 3"
+  run_command "${api2}" "send ${addr3},${addr2} 'hello, world'" "Message sent" 600
+
+  log "Node 3 send 1 hop message to self via node 4"
+  run_command "${api3}" "send ${addr4},${addr3} 'hello, world'" "Message sent" 600
+
+  log "Node 4 send 1 hop message to self via node 5"
+  run_command "${api4}" "send ${addr5},${addr4} 'hello, world'" "Message sent" 600
 done
 
 log "Node 2 should now have a ticket"
 result=$(run_command ${api2} "tickets" "Win Proportion:   100%" 600)
 log "-- ${result}"
 
+log "Node 3 should now have a ticket"
+result=$(run_command ${api3} "tickets" "Win Proportion:   100%" 600)
+log "-- ${result}"
+
+log "Node 4 should now have a ticket"
+result=$(run_command ${api4} "tickets" "Win Proportion:   100%" 600)
+log "-- ${result}"
+
+log "Node 5 should now have a ticket"
+result=$(run_command ${api5} "tickets" "Win Proportion:   100%" 600)
+log "-- ${result}"
+
 for i in `seq 1 10`; do
   log "Node 1 send 1 hop message to node 3 via node 2"
   run_command "${api1}" "send ${addr2},${addr3} 'hello, world'" "Message sent" 600
-done
 
-log "Node 3 open channel to Node 4"
-result=$(run_command "${api3}" "open ${addr4} 0.1" "Successfully opened channel")
-log "-- ${result}"
+  log "Node 2 send 1 hop message to node 4 via node 3"
+  run_command "${api2}" "send ${addr3},${addr4} 'hello, world'" "Message sent" 600
+
+  log "Node 3 send 1 hop message to node 5 via node 4"
+  run_command "${api3}" "send ${addr4},${addr5} 'hello, world'" "Message sent" 600
+done
 
 for i in `seq 1 10`; do
   log "Node 1 send 3 hop message to node 5 via node 2, node 3 and node 4"
   run_command "${api1}" "send ${addr2},${addr3},${addr4},${addr5} 'hello, world'" "Message sent" 600
 done
-
-log "Node 4 should now have a ticket"
-result=$(run_command ${api4} "tickets" "Win Proportion:   100%" 600)
-log "-- ${result}"
 
 # this works locally but fails in CI, the quality of the peers is lower than the
 # expected 0.5

--- a/test/security-test.sh
+++ b/test/security-test.sh
@@ -35,8 +35,8 @@ alias websocat=websocat
 [ -x "${mydir}/../.bin/websocat" ] && alias websocat="${mydir}/../.bin/websocat"
 
 # wait for input ports to be ready
-wait_for_port ${rest_port}
-wait_for_port ${admin_port}
+wait_for_port "${rest_port}" "${host}"
+wait_for_port "${admin_port}" "${host}"
 
 declare http_status_code
 


### PR DESCRIPTION
1. Introducing the basic blocks to start/stop a cluster of hoprd nodes on gcloud which can then be used to run tests against. The nodes can be configured to use a given RPC endpoint.
2. A new e2e script uses that to start a cluster of nodes with the latest Docker image and run the existing end-2-end tests against it. The nodes are configured to use Goerli as the network, and are funded upon startup.
3. The new Github Actions workflow executes that script on pushed to specific branches.

The script itself can also be tested locally (must have a working gcloud account set up though):

```
export FUNDING_PRIV_KEY="<add_value>"
export HOPRD_INFURA_KEY="<add_value>"
./scripts/run-integration-tests-gcloud.sh
```

Alternatively check all options:

```
./scripts/run-integration-tests-gcloud.sh -h
```
Refs #1865 