### PR TITLE
Add basic topology script

### DIFF
--- a/scripts/run-integration-tests-gcloud.sh
+++ b/scripts/run-integration-tests-gcloud.sh
@@ -51,7 +51,7 @@ usage() {
 declare test_id="e2e-gcloud-test-${1:-$RANDOM-$RANDOM}"
 declare docker_image=${2:-gcr.io/hoprassociation/hoprd:latest}
 
-declare api_token="${HOPRD_API_TOKEN:-token${RANDOM}${RANDOM}${RANDOM}token}"
+declare api_token="${HOPRD_API_TOKEN:-Token${RANDOM}%${RANDOM}%${RANDOM}Token}"
 declare password="${HOPRD_PASSWORD:-pw${RANDOM}${RANDOM}${RANDOM}pw}"
 declare provider="${HOPRD_PROVIDER:-https://goerli.infura.io/v3/${HOPRD_INFURA_KEY}}"
 declare hopr_token_contract="${HOPRD_TOKEN_CONTRACT:-0x566a5c774bb8ABE1A88B4f187e24d4cD55C207A5}"

--- a/scripts/setup-gcloud-cluster.sh
+++ b/scripts/setup-gcloud-cluster.sh
@@ -20,6 +20,10 @@ source "${mydir}/testnet.sh"
 
 usage() {
   msg
+  msg "This script can be used to setup a cluster of nodes on gcloud and run"
+  msg "an initial setup script against these nodes. Once testing has"
+  msg "completed the script can be used to cleanup the cluster as well."
+  msg
   msg "Usage: $0 [<cluster_id> [<docker_image> [<init_script>]]]"
   msg
   msg "where <cluster_id>:\t\tuses a random value as default"

--- a/scripts/setup-gcloud-cluster.sh
+++ b/scripts/setup-gcloud-cluster.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+# TODO: this script currently uses goerli as the RPC provider. However, it
+# should be extended to use its own instance of hardhat too.
+
+# prevent souring of this script, only allow execution
+$(return >/dev/null 2>&1)
+test "$?" -eq "0" && { echo "This script should only be executed." >&2; exit 1; }
+
+# exit on errors, undefined variables, ensure errors in pipes are not hidden
+set -Eeuo pipefail
+
+# set log id and use shared log function for readable logs
+declare mydir
+mydir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+declare -x HOPR_LOG_ID="setup-gcloud-cluster"
+source "${mydir}/utils.sh"
+source "${mydir}/gcloud.sh"
+source "${mydir}/testnet.sh"
+
+usage() {
+  msg
+  msg "Usage: $0 [<cluster_id> [<docker_image> [<init_script>]]]"
+  msg
+  msg "where <cluster_id>:\t\tuses a random value as default"
+  msg "      <docker_image>:\t\tuses 'gcr.io/hoprassociation/hoprd:latest' as default"
+  msg "      <init_script>:\t\tpath to a script which is called with all node API endpoints as parameters"
+  msg
+  msg "Required environment variables"
+  msg "------------------------------"
+  msg
+  msg "FUNDING_PRIV_KEY\t\tsets the account which is used to fund nodes"
+  msg
+  msg "Optional environment variables"
+  msg "------------------------------"
+  msg
+  msg "HOPRD_API_TOKEN\t\t\tused as api token for all nodes, defaults to a random value"
+  msg "HOPRD_PASSWORD\t\t\tused as password for all nodes, defaults to a random value"
+  msg "HOPRD_PROVIDER\t\t\tused as provider for all nodes, defaults to infura/goerli"
+  msg "              \t\t\twhich requires the additional env var HOPRD_INFURA_KEY to be set"
+  msg "HOPRD_SHOW_PRESTART_INFO\tset to 'true' to print used parameter values before starting"
+  msg "HOPRD_PERFORM_CLEANUP\t\tset to 'true' to perform the cleanup process for the given cluster id"
+  msg "HOPRD_TOKEN_CONTRACT\t\tused to fund HOPR token, defaults to 0x566a5c774bb8ABE1A88B4f187e24d4cD55C207A5"
+  msg
+}
+
+# return early with help info when requested
+{ [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; } && { usage; exit 0; }
+
+# verify and set parameters
+declare cluster_id="${1:-custom-cluster-${RANDOM}-${RANDOM}}"
+declare docker_image=${2:-gcr.io/hoprassociation/hoprd:latest}
+declare init_script=${3:-}
+
+declare api_token="${HOPRD_API_TOKEN:-token${RANDOM}${RANDOM}${RANDOM}token}"
+declare password="${HOPRD_PASSWORD:-pw${RANDOM}${RANDOM}${RANDOM}pw}"
+declare provider="${HOPRD_PROVIDER:-https://goerli.infura.io/v3/${HOPRD_INFURA_KEY}}"
+declare hopr_token_contract="${HOPRD_TOKEN_CONTRACT:-0x566a5c774bb8ABE1A88B4f187e24d4cD55C207A5}"
+declare perform_cleanup="${HOPRD_PERFORM_CLEANUP:-false}"
+declare show_prestartinfo="${HOPRD_SHOW_PRESTART_INFO:-false}"
+
+test -z "${FUNDING_PRIV_KEY:-}" && { msg "Missing FUNDING_PRIV_KEY"; usage; exit 1; }
+
+function cleanup {
+  local EXIT_CODE=$?
+
+  trap - SIGINT SIGTERM ERR EXIT
+  set +Eeuo pipefail
+
+  if [ ${EXIT_CODE} -ne 0 ] || [ "${perform_cleanup}" = "true" ] || [ "${perform_cleanup}" = "1" ]; then
+    # Cleaning up everything upon failure
+    gcloud_delete_managed_instance_group "${cluster_id}"
+    gcloud_delete_instance_template "${cluster_id}"
+  fi
+
+  exit $EXIT_CODE
+}
+
+function fund_ip() {
+  local ip="${1}"
+  local eth_address
+
+  wait_until_node_is_ready "${ip}"
+  eth_address=$(get_eth_address "${ip}")
+  fund_if_empty "${eth_address}" "${provider}" "${hopr_token_contract}"
+  wait_for_port "9091" "${ip}"
+}
+
+if [ "${perform_cleanup}" = "1" ] || [ "${perform_cleanup}" = "true" ]; then
+  cleanup
+
+  # exit right away
+  exit
+fi
+
+if [ "${skip_cleanup}" != "1" ] && [ "${skip_cleanup}" != "true" ]; then
+  trap cleanup SIGINT SIGTERM ERR EXIT
+fi
+
+# --- Log test info {{{
+if [ "${show_prestartinfo}" = "1" ] || [ "${show_prestartinfo}" = "true" ]; then
+  log "Pre-Start Info"
+  log "\tdocker_image: ${docker_image}"
+  log "\tcluster_id: ${cluster_id}"
+  log "\tinit_script: ${init_script}"
+  log "\tapi_token: ${api_token}"
+  log "\tpassword: ${password}"
+  log "\tprovider: ${provider}"
+  log "\thopr_token_contract: ${hopr_token_contract}"
+  log "\tperform_cleanup: ${perform_cleanup}"
+  log "\tshow_prestartinfo: ${show_prestartinfo}"
+fi
+# }}}
+
+# create test specific instance template
+gcloud_create_or_update_instance_template "${cluster_id}" \
+  "${docker_image}" \
+  "${provider}" \
+  "${api_token}" \
+  "${password}"
+#
+# start nodes
+gcloud_create_or_update_managed_instance_group "${cluster_id}" \
+  6 \
+  "${cluster_id}"
+
+# get IPs of newly started VMs which run hoprd
+declare node_ips
+node_ips=$(gcloud_get_managed_instance_group_instances_ips "${cluster_id}")
+declare node_ips_arr=( ${node_ips} )
+
+#  --- Fund nodes --- {{{
+declare eth_address
+for ip in ${node_ips}; do
+  wait_until_node_is_ready "${ip}"
+  eth_address=$(get_eth_address "${ip}")
+  fund_if_empty "${eth_address}" "${provider}" "${hopr_token_contract}"
+done
+
+for ip in ${node_ips}; do
+  wait_for_port "9091" "${ip}"
+done
+# }}}
+
+# --- Call init script--- {{{
+if [ -n "${init_script}" ] && [ -x "${init_script}" ]; then
+"${init_script}" \
+  ${node_ips_arr[@]/%/:3001}
+# }}}

--- a/scripts/setup-gcloud-cluster.sh
+++ b/scripts/setup-gcloud-cluster.sh
@@ -52,7 +52,7 @@ declare cluster_id="${1:-custom-cluster-${RANDOM}-${RANDOM}}"
 declare docker_image=${2:-gcr.io/hoprassociation/hoprd:latest}
 declare init_script=${3:-}
 
-declare api_token="${HOPRD_API_TOKEN:-token${RANDOM}${RANDOM}${RANDOM}token}"
+declare api_token="${HOPRD_API_TOKEN:-Token${RANDOM}%${RANDOM}%${RANDOM}Token}"
 declare password="${HOPRD_PASSWORD:-pw${RANDOM}${RANDOM}${RANDOM}pw}"
 declare provider="${HOPRD_PROVIDER:-https://goerli.infura.io/v3/${HOPRD_INFURA_KEY}}"
 declare hopr_token_contract="${HOPRD_TOKEN_CONTRACT:-0x566a5c774bb8ABE1A88B4f187e24d4cD55C207A5}"
@@ -91,10 +91,6 @@ if [ "${perform_cleanup}" = "1" ] || [ "${perform_cleanup}" = "true" ]; then
 
   # exit right away
   exit
-fi
-
-if [ "${skip_cleanup}" != "1" ] && [ "${skip_cleanup}" != "true" ]; then
-  trap cleanup SIGINT SIGTERM ERR EXIT
 fi
 
 # --- Log test info {{{
@@ -144,6 +140,10 @@ done
 
 # --- Call init script--- {{{
 if [ -n "${init_script}" ] && [ -x "${init_script}" ]; then
-"${init_script}" \
-  ${node_ips_arr[@]/%/:3001}
+  HOPRD_API_TOKEN="${api_token}" \
+    "${init_script}" \
+    ${node_ips_arr[@]/%/:3001}
+fi
 # }}}
+
+log "finished"

--- a/scripts/topologies/full_interconnected_cluster.sh
+++ b/scripts/topologies/full_interconnected_cluster.sh
@@ -17,6 +17,11 @@ usage() {
   msg
   msg "Usage: $0 <node_api_1> <node_api_2> <node_api_3> <node_api_4> <node_api_5>"
   msg
+  msg "Required environment variables"
+  msg "------------------------------"
+  msg
+  msg "HOPRD_API_TOKEN\t\t\tused as api token for all nodes"
+  msg
 }
 
 # return early with help info when requested
@@ -28,12 +33,14 @@ test -z "${2:-}" && { msg "Missing <node_api_2>"; usage; exit 1; }
 test -z "${3:-}" && { msg "Missing <node_api_3>"; usage; exit 1; }
 test -z "${4:-}" && { msg "Missing <node_api_4>"; usage; exit 1; }
 test -z "${5:-}" && { msg "Missing <node_api_5>"; usage; exit 1; }
+test -z "${HOPRD_API_TOKEN:-}" && { msg "Missing HOPRD_API_TOKEN"; usage; exit 1; }
 
 declare api1="${1}"
 declare api2="${2}"
 declare api3="${3}"
 declare api4="${4}"
 declare api5="${5}"
+declare api_token=${HOPRD_API_TOKEN}
 
 # $1 = endpoint
 # $2 = Hopr command
@@ -52,7 +59,7 @@ run_command(){
   local step_time=${5:-5}
   local end_time_ns=${6:-0}
   # no timeout set since the test execution environment should cancel the test if it takes too long
-  local cmd="curl --silent -X POST --header X-Auth-Token:e2e-API-token^^ --url ${endpoint}/api/v1/command --data "
+  local cmd="curl --silent -X POST --header X-Auth-Token:${api_token} --url ${endpoint}/api/v1/command --data "
 
   # if no end time was given we need to calculate it once
   if [ ${end_time_ns} -eq 0 ]; then
@@ -189,3 +196,5 @@ done
 
 log "Wait for all operations to finish"
 wait
+
+log "finished"

--- a/scripts/topologies/full_interconnected_cluster.sh
+++ b/scripts/topologies/full_interconnected_cluster.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+
+# prevent souring of this script, only allow execution
+$(return >/dev/null 2>&1)
+test "$?" -eq "0" && { echo "This script should only be executed." >&2; exit 1; }
+
+# exit on errors, undefined variables, ensure errors in pipes are not hidden
+set -Eeuo pipefail
+
+# set log id and use shared log function for readable logs
+declare mydir
+mydir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+declare HOPR_LOG_ID="full-interconnected_cluster"
+source "${mydir}/../utils.sh"
+
+usage() {
+  msg
+  msg "Usage: $0 <node_api_1> <node_api_2> <node_api_3> <node_api_4> <node_api_5>"
+  msg
+}
+
+# return early with help info when requested
+([ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]) && { usage; exit 0; }
+
+# verify and set parameters
+test -z "${1:-}" && { msg "Missing <node_api_1>"; usage; exit 1; }
+test -z "${2:-}" && { msg "Missing <node_api_2>"; usage; exit 1; }
+test -z "${3:-}" && { msg "Missing <node_api_3>"; usage; exit 1; }
+test -z "${4:-}" && { msg "Missing <node_api_4>"; usage; exit 1; }
+test -z "${5:-}" && { msg "Missing <node_api_5>"; usage; exit 1; }
+
+declare api1="${1}"
+declare api2="${2}"
+declare api3="${3}"
+declare api4="${4}"
+declare api5="${5}"
+
+# $1 = endpoint
+# $2 = Hopr command
+# $3 = OPTIONAL: positive assertion message
+# $4 = OPTIONAL: maximum wait time in seconds during which we busy try
+# afterwards we fail, defaults to 0
+# $4 = OPTIONAL: step time between retries in seconds, defaults to 5 seconds
+# $5 = OPTIONAL: end time for busy wait in nanoseconds since epoch, has higher
+# priority than wait time, defaults to 0
+run_command(){
+  local result now
+  local endpoint="${1}"
+  local hopr_cmd="${2}"
+  local assertion="${3:-}"
+  local wait_time=${4:-0}
+  local step_time=${5:-5}
+  local end_time_ns=${6:-0}
+  # no timeout set since the test execution environment should cancel the test if it takes too long
+  local cmd="curl --silent -X POST --header X-Auth-Token:e2e-API-token^^ --url ${endpoint}/api/v1/command --data "
+
+  # if no end time was given we need to calculate it once
+  if [ ${end_time_ns} -eq 0 ]; then
+    now=$(node -e "console.log(process.hrtime.bigint().toString());")
+    # need to calculate in nanoseconds
+    ((end_time_ns=now+wait_time*1000000000))
+  fi
+
+  result=$(${cmd} "${hopr_cmd}")
+
+  # if an assertion was given and has not been fulfilled, we fail
+  if [ -z "${assertion}" ] || [[ -n "${assertion}" && "${result}" == *"${assertion}"* ]]; then
+    echo "${result}"
+  else
+    now=$(node -e "console.log(process.hrtime.bigint().toString());")
+    if [ ${end_time_ns} -lt ${now} ]; then
+      log "${RED}run_command (${cmd} \"${hopr_cmd}\") FAILED, received: ${result}${NOFORMAT}"
+      exit 1
+    else
+      log "${YELLOW}run_command (${cmd} \"${hopr_cmd}\") FAILED, retrying in ${step_time} seconds${NOFORMAT}"
+      sleep ${step_time}
+      run_command "${endpoint}" "${hopr_cmd}" "${assertion}" "${wait_time}" \
+        "${step_time}" "${end_time_ns}"
+    fi
+  fi
+}
+
+get_eth_address(){
+  curl --silent "$1/api/v1/address/eth"
+}
+
+get_hopr_address(){
+  curl --silent "$1/api/v1/address/hopr"
+}
+
+validate_node_eth_address() {
+  local ETH_ADDRESS IS_VALID_ETH_ADDRESS
+
+  ETH_ADDRESS="$(get_eth_address $1)"
+  if [ -z "$ETH_ADDRESS" ]; then
+    log "could not derive ETH_ADDRESS from first parameter $1"
+    exit 1
+  fi
+
+  IS_VALID_ETH_ADDRESS="$(node -e "const ethers = require('ethers'); console.log(ethers.utils.isAddress('$ETH_ADDRESS'))")"
+  if [ "$IS_VALID_ETH_ADDRESS" == "false" ]; then
+    log "⛔️ Node returns an invalid address ETH_ADDRESS: $ETH_ADDRESS derived from $1"
+    exit 1
+  fi
+  echo "$ETH_ADDRESS"
+}
+
+# TODO better validation
+validate_node_balance_gt0() {
+  local balance eth_balance hopr_balance
+
+  balance="$(run_command ${1} "balance")"
+  eth_balance="$(echo -e "$balance" | grep -c " xDAI" || true)"
+  hopr_balance="$(echo -e "$balance" | grep -c " HOPR" || true)"
+
+  if [[ "$eth_balance" != "0" && "$hopr_balance" != "Hopr Balance: 0 HOPR" ]]; then
+    log "$1 is funded"
+  else
+    log "⛔️ $1 Node has an invalid balance: $eth_balance, $hopr_balance"
+    log "$balance"
+    exit 1
+  fi
+}
+
+log "Running full E2E test with ${api1}, ${api2}, ${api3}, ${api4}, ${api5}"
+
+validate_node_eth_address "${api1}"
+validate_node_eth_address "${api2}"
+validate_node_eth_address "${api3}"
+validate_node_eth_address "${api4}"
+validate_node_eth_address "${api5}"
+log "ETH addresses exist"
+
+validate_node_balance_gt0 "${api1}"
+validate_node_balance_gt0 "${api2}"
+validate_node_balance_gt0 "${api3}"
+validate_node_balance_gt0 "${api4}"
+validate_node_balance_gt0 "${api5}"
+log "Nodes are funded"
+
+declare addr1 addr2 addr3 addr4 addr5 result
+addr1="$(get_hopr_address "${api1}")"
+addr2="$(get_hopr_address "${api2}")"
+addr3="$(get_hopr_address "${api3}")"
+addr4="$(get_hopr_address "${api4}")"
+addr5="$(get_hopr_address "${api5}")"
+log "hopr addr1: ${addr1}"
+log "hopr addr2: ${addr2}"
+log "hopr addr3: ${addr3}"
+log "hopr addr4: ${addr4}"
+log "hopr addr5: ${addr5}"
+
+log "Check peers"
+result=$(run_command ${api1} "peers" 'peers have announced themselves' 600)
+log "-- ${result}"
+
+for node in ${addr2} ${addr3} ${addr4} ${addr5}; do
+  log "Node 1 ping other node ${node}"
+  result=$(run_command ${api1} "ping ${node}" "Pong received in:" 600)
+  log "-- ${result}"
+done
+
+log "Opening channels in background to parallelize operations"
+
+for addr in ${addr2} ${addr3} ${addr4} ${addr5}; do
+  log "Node ${addr1} open channel to node ${addr}"
+  run_command "${api1}" "open ${addr} 0.1" "Successfully opened channel" 600 &
+done
+
+for addr in ${addr1} ${addr3} ${addr4} ${addr5}; do
+  log "Node ${addr2} open channel to node ${addr}"
+  run_command "${api2}" "open ${addr} 0.1" "Successfully opened channel" 600 &
+done
+
+for addr in ${addr1} ${addr2} ${addr4} ${addr5}; do
+  log "Node ${addr3} open channel to node ${addr}"
+  run_command "${api3}" "open ${addr} 0.1" "Successfully opened channel" 600 &
+done
+
+for addr in ${addr1} ${addr2} ${addr3} ${addr5}; do
+  log "Node ${addr4} open channel to node ${addr}"
+  run_command "${api4}" "open ${addr} 0.1" "Successfully opened channel" 600 &
+done
+
+for addr in ${addr1} ${addr2} ${addr3} ${addr4}; do
+  log "Node ${addr5} open channel to node ${addr}"
+  run_command "${api5}" "open ${addr} 0.1" "Successfully opened channel" 600 &
+done
+
+log "Wait for all operations to finish"
+wait


### PR DESCRIPTION
This PR adds a script to spin up a cluster of nodes on gcloud against which a setup script can be executed to create channels and send messages. This is useful top create certain channel topologies for further testing.

Check out the help info of the script:

```
./scripts/setup-gcloud-cluster.sh -h
```

Create a cluster and setup channels between all nodes:

```
HOPRD_PERFORM_CLEANUP=false HOPRD_SHOW_PRESTART_INFO=true ./scripts/setup-gcloud-cluster.sh mysupertestcluster gcr.io/hoprassociation/hoprd:latest `pwd`/scripts/topologies/full_interconnected_cluster.sh
```

Once manual testing has finished cleanup the cluster:

```
HOPRD_PERFORM_CLEANUP=true ./scripts/setup-gcloud-cluster.sh mysupertestcluster
```