### PR TITLE
Bump hopr-connect to 0.2.41 & minor fixes

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -33,7 +33,7 @@
     "!**/*.spec.js.map"
   ],
   "dependencies": {
-    "@hoprnet/hopr-connect": "0.2.40",
+    "@hoprnet/hopr-connect": "0.2.41",
     "@hoprnet/hopr-core-ethereum": "1.76.0-next.4",
     "@hoprnet/hopr-utils": "1.76.0-next.4",
     "abort-controller": "^3.0.0",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -459,7 +459,7 @@ class Hopr extends EventEmitter {
    * @param peer peer to query for
    */
   public getObservedAddresses(peer: PeerId): Multiaddr[] {
-    return this.libp2p.peerStore.get(peer).addresses ?? []
+    return (this.libp2p.peerStore.get(peer).addresses ?? []).map((addr) => addr.multiaddr)
   }
 
   /**

--- a/packages/ethereum/deployments/default/goerli/HoprChannels.json
+++ b/packages/ethereum/deployments/default/goerli/HoprChannels.json
@@ -1,6 +1,7 @@
 {
   "address": "0xa3722f4758C6F41e3c1Dfd3a7dbA6FD9BAec9190",
   "transactionHash": "0x531ba0e70fba86b0c67a53e43c6d082d2000cba7eb6cc77858bac820acf7b469",
+  "blockNumber": "5225357",
   "abi": [
     {
       "inputs": [

--- a/packages/ethereum/deployments/default/goerli/HoprChannels.json
+++ b/packages/ethereum/deployments/default/goerli/HoprChannels.json
@@ -1,7 +1,7 @@
 {
   "address": "0xa3722f4758C6F41e3c1Dfd3a7dbA6FD9BAec9190",
   "transactionHash": "0x531ba0e70fba86b0c67a53e43c6d082d2000cba7eb6cc77858bac820acf7b469",
-  "blockNumber": "5225357",
+  "blockNumber": 5225357,
   "abi": [
     {
       "inputs": [

--- a/packages/ethereum/deployments/default/goerli/HoprToken.json
+++ b/packages/ethereum/deployments/default/goerli/HoprToken.json
@@ -1,6 +1,7 @@
 {
   "address": "0x566a5c774bb8ABE1A88B4f187e24d4cD55C207A5",
   "transactionHash": "0x604a9e4f6e5ca38a03f3371f7ea60014746d0c47c8e6c04c328831241fb3c89a",
+  "blockNumber": 4260230,
   "abi": [
     {
       "inputs": [],

--- a/packages/ethereum/deployments/default/mumbai/HoprChannels.json
+++ b/packages/ethereum/deployments/default/mumbai/HoprChannels.json
@@ -1,6 +1,7 @@
 {
   "address": "0xf4Ff7E5bf2cC7eF89196c8086982F6f5Ec502685",
   "transactionHash": "0xc9fac0d7d8a5b8d8a19f7892980707c2d68d6014a0f5af63f8d3144af4ac4051",
+  "blockNumber": 16662634,
   "abi": [
     {
       "inputs": [

--- a/packages/ethereum/deployments/default/mumbai/HoprToken.json
+++ b/packages/ethereum/deployments/default/mumbai/HoprToken.json
@@ -1,6 +1,7 @@
 {
   "address": "0x566a5c774bb8ABE1A88B4f187e24d4cD55C207A5",
   "transactionHash": "0xbaac5478c3b53228fa3dbc3d9186c3b1d9ad2b9ae2bb94e346abb0814b856a58",
+  "blockNumber": 16662532,
   "abi": [
     {
       "inputs": [],

--- a/packages/ethereum/deployments/default/polygon/HoprChannels.json
+++ b/packages/ethereum/deployments/default/polygon/HoprChannels.json
@@ -1,6 +1,7 @@
 {
   "address": "0xd8F4E1867BBff6647B80bC624D22bD552EB81eEF",
   "transactionHash": "0x447d45c8f22bf02682e977cccfc0ed32dde72e332da230537757e3a05c5b9734",
+  "blockNumber": 17612296,
   "abi": [
     {
       "inputs": [

--- a/packages/ethereum/deployments/default/polygon/HoprDistributor.json
+++ b/packages/ethereum/deployments/default/polygon/HoprDistributor.json
@@ -1,6 +1,7 @@
 {
   "address": "0xfb7A68692b27839ee82c711cf79Bd19BE698B011",
   "transactionHash": "0x04fd8c06aaeadf2358e9ec71b6000a999a47232ed5f6cfb8eab49c69f8f8fe4f",
+  "blockNumber": 17612292,
   "abi": [
     {
       "inputs": [

--- a/packages/ethereum/deployments/default/polygon/HoprToken.json
+++ b/packages/ethereum/deployments/default/polygon/HoprToken.json
@@ -1,6 +1,7 @@
 {
   "address": "0x6F80d1a3AB9006548c2fBb180879b87364D63Bf7",
   "transactionHash": "0x5ddbdc5fa138d14874078c967995c9a70a0993b42b967d395d40fce76060119d",
+  "blockNumber": 17612109,
   "abi": [
     {
       "inputs": [],

--- a/packages/ethereum/deployments/default/xdai/HoprChannels.json
+++ b/packages/ethereum/deployments/default/xdai/HoprChannels.json
@@ -1,6 +1,7 @@
 {
   "address": "0x71B1BA4C741Dc9B1FFFB3EA22a831707eCc826B6",
   "transactionHash": "0x0c3a96cd96b7d59ea2e9fce8489bea491262dcd4eb1e836f9299c771f963699e",
+  "blockNumber": 17313128,
   "abi": [
     {
       "inputs": [

--- a/packages/ethereum/deployments/default/xdai/HoprDistributor.json
+++ b/packages/ethereum/deployments/default/xdai/HoprDistributor.json
@@ -1,6 +1,7 @@
 {
   "address": "0x987cb736fBfBc4a397Acd06045bf0cD9B9deFe66",
   "transactionHash": "0xe11e1a3aed81826a6ad8b64bad8d46dddc1a5c57a0957661de9f68f0b0739d02",
+  "blockNumber": 14829414,
   "abi": [
     {
       "type": "constructor",

--- a/packages/ethereum/deployments/default/xdai/HoprToken.json
+++ b/packages/ethereum/deployments/default/xdai/HoprToken.json
@@ -1,6 +1,7 @@
 {
   "address": "0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1",
   "transactionHash": "0x9667d7ac97f133d7b78cc7698a209455f7030aa1743968ba0a6dab2ba4ed8cb0",
+  "blockNumber": 14744161,
   "abi": [
     {
       "type": "constructor",

--- a/packages/ethereum/deployments/default/xdai/HoprWrapper.json
+++ b/packages/ethereum/deployments/default/xdai/HoprWrapper.json
@@ -1,6 +1,7 @@
 {
   "address": "0x097707143e01318734535676cfe2e5cF8b656ae8",
   "transactionHash": "0x4063a5afba53e7ee827120eac732b70aea61a67b584611d29a82dd2f623cc7db",
+  "blockNumber": 14744265,
   "abi": [
     {
       "type": "constructor",

--- a/packages/ethereum/tasks/slimDeployments.ts
+++ b/packages/ethereum/tasks/slimDeployments.ts
@@ -22,11 +22,11 @@ const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     const data = require(filePath)
     const contractName = contract.replace('.json', '')
     const compilerData =
-      data.compilerData ?? (await hre.artifacts.getBuildInfo(`contracts/${contractName}.sol:${contractName}`))
+      (await hre.artifacts.getBuildInfo(`contracts/${contractName}.sol:${contractName}`)) ?? data.compilerData
     const slimmed = {
       address: data.address,
       transactionHash: data.transactionHash,
-      blockNumber: data.blockNumber ?? data.receipt.blockNumber,
+      blockNumber: data.receipt.blockNumber ?? data.blockNumber,
       metadata: {
         solcVersion: compilerData.solcVersion,
         input: compilerData.input

--- a/packages/ethereum/tasks/slimDeployments.ts
+++ b/packages/ethereum/tasks/slimDeployments.ts
@@ -26,7 +26,7 @@ const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     const slimmed = {
       address: data.address,
       transactionHash: data.transactionHash,
-      blockNumber: data.receipt.blockNumber ?? data.blockNumber,
+      blockNumber: data.receipt ? data.receipt.blockNumber : data.blockNumber,
       metadata: {
         solcVersion: compilerData.solcVersion,
         input: compilerData.input

--- a/yarn.lock
+++ b/yarn.lock
@@ -703,10 +703,10 @@
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.0.tgz#f3933a44e365864f4dad5db94158106d511e8131"
   integrity sha512-sqKVVVOe5ivCaXDWivIJYVSaEgdQK9ul7a4Kity5Iw7u9+wBAPbX1RMSnLLmp7O4Vzj0WOWwMAJsTL00xwaNug==
 
-"@hoprnet/hopr-connect@0.2.40":
-  version "0.2.40"
-  resolved "https://registry.yarnpkg.com/@hoprnet/hopr-connect/-/hopr-connect-0.2.40.tgz#a17aed985e0a43cd06bc40c3120b4b6c180ec17a"
-  integrity sha512-v/vfLLn6k2+Fliv5z2btV2/alkQdw+YCG3quuWPzCGGuigFbaaNMIeTD+8/JuhHsTaZp87HZ+N3KlipMHYkr0Q==
+"@hoprnet/hopr-connect@0.2.41":
+  version "0.2.41"
+  resolved "https://registry.yarnpkg.com/@hoprnet/hopr-connect/-/hopr-connect-0.2.41.tgz#b7dca8cae378df57dd9abbd42e9961373eea6aa4"
+  integrity sha512-W6vwEU+GCDxOn2okalS+wdFwUYzyC45ANETw/1Od1ucwB1Y7WToKjPYalVtenk+sOfGNZnHYFCFlG9y4J+5ZvA==
   dependencies:
     "@hoprnet/hopr-utils" "1.75.0-next.19"
     abort-controller "3.0.0"


### PR DESCRIPTION
Fixes:
- fix type issue on `core/index.ts#getObservedAddrs()`
- fix `missing blockNumber`, see https://github.com/hoprnet/hoprnet/actions/runs/1127815375
- fix deployment slimmer

Changes:
- `hopr-connect@0.2.41`, see [changes](https://github.com/hoprnet/hopr-connect/compare/v0.2.40...v0.2.41)