### PR TITLE
Increasing confirmation blocks

### DIFF
--- a/packages/core-ethereum/src/constants.ts
+++ b/packages/core-ethereum/src/constants.ts
@@ -4,5 +4,5 @@
  */
 export const PROVIDER_CACHE_TTL = 30e3 // 30 seconds
 export const PROVIDER_DEFAULT_URI = 'http://127.0.0.1:8545/'
-export const CONFIRMATIONS = 8
+export const CONFIRMATIONS = 40
 export const INDEXER_BLOCK_RANGE = 2000


### PR DESCRIPTION
Increasing confirmation blocks to `40` as @SCBuergel noticed that Polygon goes through heavy reorgs even at 10-12 blocks. #2305 will increase this to `100` if we see this behaviour prevail on `40` block confirmations.