### PR TITLE
fix reported channel source in admin channels list

### DIFF
--- a/packages/hoprd/src/commands/listOpenChannels.ts
+++ b/packages/hoprd/src/commands/listOpenChannels.ts
@@ -59,7 +59,7 @@ Balance:                ${styleValue(channel.balance.toFormattedString(), 'numbe
       for (const channel of channelsTo) {
         log(`
 Incoming Channel:       ${styleValue(channel.getId().toHex(), 'hash')}
-From:                   ${styleValue(channel.destination.toPeerId().toB58String(), 'peerId')}
+From:                   ${styleValue(channel.source.toPeerId().toB58String(), 'peerId')}
 Status:                 ${styleValue(channelStatusToString(channel.status), 'highlight')}
 Balance:                ${styleValue(channel.balance.toFormattedString(), 'number')}
 `)


### PR DESCRIPTION
Previously an incoming channel would be shown as coming from the destination.