### PR TITLE
caching chain ID

### DIFF
--- a/packages/core-ethereum/src/ethereum.ts
+++ b/packages/core-ethereum/src/ethereum.ts
@@ -39,7 +39,7 @@ export type ChainWrapper = PromiseValue<ReturnType<typeof createChainWrapper>>
 
 export async function createChainWrapper(providerURI: string, privateKey: Uint8Array) {
   const provider = providerURI.startsWith('http')
-    ? new providers.JsonRpcProvider(providerURI)
+    ? new providers.StaticJsonRpcProvider(providerURI)
     : new providers.WebSocketProvider(providerURI)
   const wallet = new Wallet(privateKey).connect(provider)
   const address = Address.fromString(wallet.address)

--- a/packages/ethereum/test/utils.ts
+++ b/packages/ethereum/test/utils.ts
@@ -31,12 +31,12 @@ export const toSolPercent = (multiplier: number, percent: number): string => {
   return String(Math.floor(percent * multiplier))
 }
 
-export const advanceBlock = async (provider: providers.JsonRpcProvider) => {
+export const advanceBlock = async (provider: providers.StaticJsonRpcProvider) => {
   return provider.send('evm_mine', [])
 }
 
 // increases ganache time by the passed duration in seconds
-export const increaseTime = async (provider: providers.JsonRpcProvider, _duration: ethers.BigNumberish) => {
+export const increaseTime = async (provider: providers.StaticJsonRpcProvider, _duration: ethers.BigNumberish) => {
   const duration = ethers.BigNumber.from(_duration)
 
   if (duration.isNegative()) throw Error(`Cannot increase time by a negative amount (${duration})`)


### PR DESCRIPTION
Fixes #2337

In `wildhorn` we have used an [http endpoint](https://github.com/hoprnet/hoprnet/blob/310463dd1489f51cc9c2de13dfd83540a00c2735/packages/hoprd/src/index.ts#L21) for our provider, see https://github.com/ethers-io/ethers.js/issues/901 for why that causes many chain ID calls.

We now use `StaticJsonRpcProvider` which assumes the network wont change, caching chain ID.
At the same time, this is not an issue when a `websocket` provider is used. https://github.com/ethers-io/ethers.js/issues/1054