### PR TITLE
fixed nextjs version

### DIFF
--- a/packages/hoprd/package.json
+++ b/packages/hoprd/package.json
@@ -43,7 +43,7 @@
     "js-cookie": "^3.0.0",
     "key-did-provider-ed25519": "^1.1.0",
     "key-did-resolver": "^1.2.1",
-    "next": "^11.0.0",
+    "next": "11.1.2",
     "peer-id": "0",
     "prop-types": "^15.7.2",
     "react": "17.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1136,7 +1136,7 @@ __metadata:
     key-did-provider-ed25519: ^1.1.0
     key-did-resolver: ^1.2.1
     mocha: ^9.0.0
-    next: ^11.1.2
+    next: 11.1.2
     peer-id: 0
     prop-types: ^15.7.2
     react: 17.0.2
@@ -11976,7 +11976,7 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"next@npm:^11.1.2":
+"next@npm:11.1.2":
   version: 11.1.2
   resolution: "next@npm:11.1.2"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1136,7 +1136,7 @@ __metadata:
     key-did-provider-ed25519: ^1.1.0
     key-did-resolver: ^1.2.1
     mocha: ^9.0.0
-    next: ^11.0.0
+    next: ^11.1.2
     peer-id: 0
     prop-types: ^15.7.2
     react: 17.0.2
@@ -11976,7 +11976,7 @@ fsevents@~2.1.1:
   languageName: node
   linkType: hard
 
-"next@npm:^11.0.0":
+"next@npm:^11.1.2":
   version: 11.1.2
   resolution: "next@npm:11.1.2"
   dependencies:


### PR DESCRIPTION
## Context

When building `hoprd`, `hopr-admin` is built using `next-js`'built system which assumes certain files being present in `next-js` installation directory. If built `hopr-admin` is used with a different version of `next-js`, some files might have been renamed, or deleted.

## Changes

Hardcode version of Next JS to prevent from version updates that change internals