### PR TITLE
Add already announced nodes to libp2p

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -236,6 +236,8 @@ class Hopr extends EventEmitter {
 
     recentlyAnnouncedNodes.forEach(this.onPeerAnnouncement.bind(this))
 
+    initialNodes.forEach(this.onPeerAnnouncement.bind(this))
+
     this.libp2p.connectionManager.on('peer:connect', (conn: Connection) => {
       this.emit('hopr:peer:connection', conn.remotePeer)
       this.networkPeers.register(conn.remotePeer)


### PR DESCRIPTION
Cherry picks DEADR fix from #2387 


Changes:
- feed libp2p instance with previously announced nodes such that libp2p can use them