### PR TITLE
print JSON logs onto single line

### DIFF
--- a/packages/hoprd/src/logs.ts
+++ b/packages/hoprd/src/logs.ts
@@ -10,7 +10,9 @@ import { TileDocument } from '@ceramicnetwork/stream-tile'
 
 export type Socket = ws
 
-let debugLog = debug('hoprd')
+// ensure log including JSON objects is always printed on a single line
+const debugBase = debug('hoprd')
+const debugLog = (msg) => debugBase('%o', msg)
 
 const MAX_MESSAGES_CACHED = 100
 


### PR DESCRIPTION
This is needed for log forwarding from outside of the daemon.