### PR TITLE
catch event processing errors

### DIFF
--- a/packages/core-ethereum/src/indexer/index.ts
+++ b/packages/core-ethereum/src/indexer/index.ts
@@ -252,13 +252,15 @@ class Indexer extends EventEmitter {
 
     for (const event of confirmedEvents) {
       const eventName = event.event as EventNames
-      if (eventName === ANNOUNCEMENT) {
-        await this.onAnnouncement(event as Event<'Announcement'>, new BN(blockNumber.toPrecision()))
-      } else if (eventName === 'ChannelUpdated') {
-        await this.onChannelUpdated(event as Event<'ChannelUpdated'>)
-      } else {
-        log('skipping event: ', eventName, ' as it isnt recognized')
-        //throw new Error('bad event name: ' + eventName)
+
+      try {
+        if (eventName === ANNOUNCEMENT) {
+          await this.onAnnouncement(event as Event<'Announcement'>, new BN(blockNumber.toPrecision()))
+        } else if (eventName === 'ChannelUpdated') {
+          await this.onChannelUpdated(event as Event<'ChannelUpdated'>)
+        }
+      } catch (err) {
+        log('error processing event:', event, err)
       }
 
       lastSnapshot = new Snapshot(new BN(event.blockNumber), new BN(event.transactionIndex), new BN(event.logIndex))

--- a/packages/core-ethereum/src/indexer/index.ts
+++ b/packages/core-ethereum/src/indexer/index.ts
@@ -258,6 +258,8 @@ class Indexer extends EventEmitter {
           await this.onAnnouncement(event as Event<'Announcement'>, new BN(blockNumber.toPrecision()))
         } else if (eventName === 'ChannelUpdated') {
           await this.onChannelUpdated(event as Event<'ChannelUpdated'>)
+        } else {
+          log(`ignoring event '${eventName}'`)
         }
       } catch (err) {
         log('error processing event:', event, err)


### PR DESCRIPTION
related to #2359

Catch errors caused by missing `Announcements`, channels in which one of the parties have not announced will not be indexed.
Once they announce they will remain unindexed.

Follow up on https://github.com/hoprnet/hoprnet/pull/2448