### PR TITLE
Add basic Docker build support to cover traffic daemon

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -250,6 +250,115 @@ jobs:
           ./scripts/notify-matrix-github-workflow-failure.sh "${MATRIX_ROOM}" "${{ github.repository }}" \
             "${{ github.workflow }}" "${{ github.run_id }}"
 
+  build_hopr_cover_traffic_daemon_docker:
+    name: Build HOPR cover traffic daemon docker
+    runs-on: ubuntu-latest
+    needs: [build_deploy_sc_npm]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git info
+        run: ./scripts/configure-git-info.sh
+
+      - name: Setup Google Cloud Credentials
+        uses: google-github-actions/setup-gcloud@v0.2.1
+        with:
+          project_id: ${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}
+          service_account_key: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
+          export_default_credentials: true
+
+      - name: Pull recent Git changes
+        if: ${{ !env.ACT }}
+        run: |
+          # need to pull changes because we've updated the package versions in
+          # the job publish_npm beforehand
+          branch=$(git rev-parse --abbrev-ref HEAD)
+          git pull origin "${branch}" --rebase
+
+      - name: Set image version
+        id: set-image-version
+        run: echo "::set-output name=vsn::$(date +%s)"
+
+      - name: Set package version
+        id: set-package-version
+        run: echo "::set-output name=vsn::$(./scripts/get-package-version.sh)"
+        env:
+          HOPR_PACKAGE: hopr-cover-traffic-daemon
+
+      - name: Set latest release tag
+        id: set-latest-release-tag
+        run: |
+          # we must set the tag specific to the release to prevent overrides
+          # from other release branches
+          declare release_name=${HOPR_GITHUB_REF##refs/heads/release/}
+          declare tag="latest-${release_name}"
+          echo "::set-output name=tag::${tag}"
+
+      - name: Building Docker image using Google Cloud Build
+        working-directory: packages/cover-traffic
+        run: |
+          gcloud builds submit --config cloudbuild.yaml \
+            --substitutions=_PACKAGE_VERSION=${PACKAGE_VERSION},_IMAGE_VERSION=${IMAGE_VERSION}
+        env:
+          DOCKER_IMAGE: gcr.io/hoprassociation/hopr-cover-traffic-daemon
+          IMAGE_VERSION: ${{ steps.set-image-version.outputs.vsn }}
+          PACKAGE_VERSION: ${{ steps.set-package-version.outputs.vsn }}
+
+      - name: Verify the correct package version has been bundled
+        run: |
+          declare v=$(docker run --pull always ${DOCKER_IMAGE}:${IMAGE_VERSION} --version 2> /dev/null | sed -n '3p')
+          [ "${v}" = "${PACKAGE_VERSION}" ]
+        env:
+          DOCKER_IMAGE: gcr.io/hoprassociation/hopr-cover-traffic-daemon
+          IMAGE_VERSION: ${{ steps.set-image-version.outputs.vsn }}
+          PACKAGE_VERSION: ${{ steps.set-package-version.outputs.vsn }}
+
+      - name: Add additional tags to new Docker image (on master and release branches)
+        if: ${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && !env.ACT }}
+        run: |
+          gcloud container images add-tag ${DOCKER_IMAGE}:${IMAGE_VERSION} ${DOCKER_IMAGE}:${PACKAGE_VERSION}
+        env:
+          DOCKER_IMAGE: gcr.io/hoprassociation/hopr-cover-traffic-daemon
+          IMAGE_VERSION: ${{ steps.set-image-version.outputs.vsn }}
+          PACKAGE_VERSION: ${{ steps.set-package-version.outputs.vsn }}
+
+      - name: Add tag latest to new Docker image on master
+        if: ${{ !env.ACT }} && ${{ github.ref == 'refs/heads/master' }}
+        run: |
+          gcloud container images add-tag ${DOCKER_IMAGE}:${IMAGE_VERSION} ${DOCKER_IMAGE}:latest
+        env:
+          DOCKER_IMAGE: gcr.io/hoprassociation/hopr-cover-traffic-daemon
+          IMAGE_VERSION: ${{ steps.set-image-version.outputs.vsn }}
+
+      - name: Add tag for latest release to new Docker image on release branches
+        if: ${{ !env.ACT &&  startsWith(github.ref, 'refs/heads/release/') }}
+        run: |
+          gcloud container images add-tag ${DOCKER_IMAGE}:${IMAGE_VERSION} ${DOCKER_IMAGE}:${TAG}
+        env:
+          DOCKER_IMAGE: gcr.io/hoprassociation/hopr-cover-traffic-daemon
+          IMAGE_VERSION: ${{ steps.set-image-version.outputs.vsn }}
+          TAG: ${{ steps.set-latest-release-tag.outputs.tag }}
+
+      - name: Add debug tags to new Docker image (on debug-deploy branches)
+        if: ${{ startsWith(github.ref, 'refs/heads/debug-deploy/') && !env.ACT }}
+        run: |
+          declare last_git_tag="$(git describe --tags --abbrev=0)"
+          declare commits_since_tag="$(git rev-list ${last_git_tag}..HEAD --count)"
+          declare tag="debug-${HOPR_GITHUB_REF##refs/heads/debug-deploy/}-${last_git_tag}-${commits_since_tag}"
+          gcloud container images add-tag ${DOCKER_IMAGE}:${IMAGE_VERSION} ${DOCKER_IMAGE}:${tag}
+        env:
+          DOCKER_IMAGE: gcr.io/hoprassociation/hopr-cover-traffic-daemon
+          IMAGE_VERSION: ${{ steps.set-image-version.outputs.vsn }}
+          PACKAGE_VERSION: ${{ steps.set-package-version.outputs.vsn }}
+
+      - name: Send notification if anything failed on master or release branches
+        if: ${{ failure() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && !env.ACT }}
+        run: |
+          ./scripts/notify-matrix-github-workflow-failure.sh "${MATRIX_ROOM}" "${{ github.repository }}" \
+            "${{ github.workflow }}" "${{ github.run_id }}"
+
   avado:
     name: Build Avado (master or release pushes)
     runs-on: ubuntu-latest

--- a/packages/cover-traffic/Dockerfile
+++ b/packages/cover-traffic/Dockerfile
@@ -1,0 +1,61 @@
+# Run hopr-cover-traffic-daemon within a single container using npm
+
+# use slim version of node on Debian buster for smaller image sizes
+FROM node:16-buster-slim@sha256:ddb4d0ea63591c5a4ef6a9778e3913c3bfcc70328240bb4f97d31d4843587f9b as build
+
+# python is used by some nodejs dependencies as an installation requirement
+RUN apt-get update && \
+    apt-get install -y \
+    python3 \
+    build-essential
+
+WORKDIR /app
+
+# enable to pass the version to Docker using either --build-arg or an
+# environment variable
+# if its not given, yarn will install the latest version of the package
+ARG TARGET_VERSION
+RUN echo "ARG TARGET_VERSION=${TARGET_VERSION}"
+ENV TARGET_VERSION=${TARGET_VERSION:-}
+RUN echo "ENV TARGET_VERSION=${TARGET_VERSION}"
+
+# making sure some standard environment variables are set for production use
+ENV NODE_ENV production
+ENV NODE_OPTIONS=--max_old_space_size=4096
+ENV npm_config_build_from_source false
+
+# install hoprd as a local module
+RUN yarn add @hoprnet/hopr-cover-traffic-daemon@${TARGET_VERSION}
+
+# use slim version of node on Debian buster for smaller image sizes
+FROM node:16-buster-slim@sha256:ddb4d0ea63591c5a4ef6a9778e3913c3bfcc70328240bb4f97d31d4843587f9b as runtime
+
+# we use tini as process 1 to catch signals properly, which is also built into
+# D<Plug>_ocker by default
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+     tini \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
+
+WORKDIR /app
+
+# copy over the contents of node_modules etc
+COPY --from=build /app .
+
+# create directory which is later used for the database, so that it inherits
+# permissions when mapped to a volume
+RUN mkdir db
+
+# set volume which can be mapped by users on the host system
+VOLUME ["/app/db"]
+
+# making sure some standard environment variables are set for production use
+ENV NODE_ENV production
+ENV DEBUG 'hopr*'
+ENV NODE_OPTIONS=--max_old_space_size=4096
+
+# p2p
+EXPOSE 9091
+
+ENTRYPOINT ["/usr/bin/tini", "--", "yarn", "hopr-cover-traffic-daemon"]

--- a/packages/cover-traffic/README.md
+++ b/packages/cover-traffic/README.md
@@ -1,23 +1,33 @@
 ## CT node
 
 ```sh
-DEBUG=hopr* node ./lib/index.js <Private key as hex>
+$ node ./lib/index.js --help
+Options:
+  --help        Show help  [boolean]
+  --version     Show version number  [boolean]
+  --provider    A provider url for the network this node shall operate on  [default: "https://still-patient-forest.xdai.quiknode.pro/f0cdbd6455c0b3aea8512fc9e7d161c1c0abf66a/"]
+  --privateKey  A private key to be used for the node  [string]
 ```
 
 Example
 
 ```sh
-DEBUG=hopr* node ./lib/index.js 0xcb1e5d91d46eb54a477a7eefec9c87a1575e3e5384d38f990f19c09aa8ddd332
+DEBUG="hopr*" node ./lib/index.js --privateKey 0xcb1e5d91d46eb54a477a7eefec9c87a1575e3e5384d38f990f19c09aa8ddd332
 ```
 
 ## CT Dashboard
 
-```
-node ./lib/dashboard.js <Private key as hex>
+```sh
+$ node ./lib/dashboard.js --help
+Options:
+  --help        Show help  [boolean]
+  --version     Show version number  [boolean]
+  --provider    A provider url for the network this node shall operate on  [default: "https://still-patient-forest.xdai.quiknode.pro/f0cdbd6455c0b3aea8512fc9e7d161c1c0abf66a/"]
+  --privateKey  A private key to be used for the node  [string]
 ```
 
 Example:
 
 ```sh
-node ./lib/dashboard.js 0x5d09dea41b9d7510f1bd40099da3ac524f9f3e674d03c78a9c4bec742587cbd3
+node ./lib/dashboard.js --privateKey 0x5d09dea41b9d7510f1bd40099da3ac524f9f3e674d03c78a9c4bec742587cbd3
 ```

--- a/packages/cover-traffic/cloudbuild.yaml
+++ b/packages/cover-traffic/cloudbuild.yaml
@@ -1,0 +1,11 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '.'
+      - '--tag=gcr.io/$PROJECT_ID/hopr-cover-traffic-daemon:$_IMAGE_VERSION'
+      - '--build-arg=PACKAGE_VERSION=$_PACKAGE_VERSION'
+options:
+  logStreamingOption: STREAM_ON
+images:
+  - 'gcr.io/$PROJECT_ID/hopr-cover-traffic-daemon'

--- a/packages/cover-traffic/package.json
+++ b/packages/cover-traffic/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hoprnet/cover-traffic",
+  "name": "@hoprnet/hopr-cover-traffic-daemon",
   "description": "Generate chaffing traffic",
   "version": "1.77.0-next.11",
   "repository": "https://github.com/hoprnet/hoprnet.git",
@@ -29,11 +29,15 @@
     "blessed": "^0.1.81",
     "blessed-contrib": "^4.10.0",
     "bn.js": "5.2.0",
-    "peer-id": "0.15.3"
+    "peer-id": "0.15.3",
+    "yargs": "^17.1.1"
   },
   "devDependencies": {
     "@types/blessed": "0.1.19",
+    "@types/rimraf": "^3",
+    "@types/yargs": "^17",
     "mocha": "9.1.1",
+    "rimraf": "^3.0.2",
     "typedoc": "0.21.9",
     "typedoc-plugin-markdown": "3.10.4",
     "typescript": "4.4.2"

--- a/packages/cover-traffic/src/dashboard.ts
+++ b/packages/cover-traffic/src/dashboard.ts
@@ -3,6 +3,8 @@ import contrib from 'blessed-contrib'
 import type { State, OpenChannels } from './state'
 import { findChannel, totalChannelBalanceFor, findChannelsFrom, importance } from './utils'
 import { main } from '.'
+import yargs from 'yargs/yargs'
+import { terminalWidth } from 'yargs'
 import { privKeyToPeerId } from '@hoprnet/hopr-utils'
 import { PublicKey } from '@hoprnet/hopr-utils'
 import { BigNumber } from 'bignumber.js'
@@ -127,9 +129,17 @@ function setupDashboard(selfPub: PublicKey) {
   return update
 }
 
+const argv = yargs(process.argv.slice(2))
+  .option('privateKey', {
+    describe: 'A private key to be used for the node',
+    string: true,
+    demandOption: true
+  })
+  .wrap(Math.min(120, terminalWidth()))
+  .parseSync()
+
 if (require.main === module) {
-  const priv = process.argv[2]
-  const peerId = privKeyToPeerId(priv)
+  const peerId = privKeyToPeerId(argv.privateKey)
   const selfPub = PublicKey.fromPeerId(peerId)
   const update = setupDashboard(selfPub)
   main(update, peerId)

--- a/packages/cover-traffic/src/index.ts
+++ b/packages/cover-traffic/src/index.ts
@@ -30,12 +30,12 @@ const argv = yargs(process.argv.slice(2))
 
 async function generateNodeOptions(): Promise<HoprOptions> {
   const options: HoprOptions = {
-  provider: argv.provider,
-  createDbIfNotExist: true,
-  password: '',
-  forceCreateDB: true,
-  announce: false
-}
+    provider: argv.provider,
+    createDbIfNotExist: true,
+    password: '',
+    forceCreateDB: true,
+    announce: false
+  }
 
   return options
 }

--- a/packages/cover-traffic/src/index.ts
+++ b/packages/cover-traffic/src/index.ts
@@ -2,30 +2,49 @@ import { PersistedState } from './state'
 import type { PeerData, State } from './state'
 import type { HoprOptions } from '@hoprnet/hopr-core'
 import Hopr from '@hoprnet/hopr-core'
+import yargs from 'yargs/yargs'
+import { terminalWidth } from 'yargs'
 import { CoverTrafficStrategy } from './strategy'
 import { ChannelEntry, privKeyToPeerId, PublicKey } from '@hoprnet/hopr-utils'
 import type PeerId from 'peer-id'
 import BN from 'bn.js'
-
-const priv = process.argv[2]
-const peerId = privKeyToPeerId(priv)
 
 function stopGracefully(signal: number) {
   console.log(`Process exiting with signal ${signal}`)
   process.exit()
 }
 
-const options: HoprOptions = {
-  //provider: 'wss://still-patient-forest.xdai.quiknode.pro/f0cdbd6455c0b3aea8512fc9e7d161c1c0abf66a/',
-  // provider: 'https://eth-goerli.gateway.pokt.network/v1/6021a2b6928ff9002e6c7f2f',
-  provider: 'wss://goerli.infura.io/ws/v3/51d4d972f30c4d92b61f2b3898fccaf6',
+const argv = yargs(process.argv.slice(2))
+  .option('provider', {
+    describe: 'A provider url for the network this node shall operate on',
+    default: 'https://still-patient-forest.xdai.quiknode.pro/f0cdbd6455c0b3aea8512fc9e7d161c1c0abf66a/',
+    string: true
+  })
+  .option('privateKey', {
+    describe: 'A private key to be used for the node',
+    string: true,
+    demandOption: true
+  })
+  .wrap(Math.min(120, terminalWidth()))
+  .parseSync()
+
+async function generateNodeOptions(): Promise<HoprOptions> {
+  const options: HoprOptions = {
+  provider: argv.provider,
   createDbIfNotExist: true,
   password: '',
   forceCreateDB: true,
   announce: false
 }
 
-export async function main(update: (State: State) => void, peerId: PeerId) {
+  return options
+}
+
+export async function main(update: (State: State) => void, peerId?: PeerId) {
+  const options = await generateNodeOptions()
+  if (!peerId) {
+    peerId = privKeyToPeerId(argv.privateKey)
+  }
   const selfPub = PublicKey.fromPeerId(peerId)
   const selfAddr = selfPub.toAddress()
   const data = new PersistedState(update)
@@ -63,5 +82,5 @@ if (require.main === module) {
 
   main((_state: State) => {
     console.log('CT: State update')
-  }, peerId)
+  })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -927,25 +927,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hoprnet/cover-traffic@workspace:packages/cover-traffic":
-  version: 0.0.0-use.local
-  resolution: "@hoprnet/cover-traffic@workspace:packages/cover-traffic"
-  dependencies:
-    "@hoprnet/hopr-core": "workspace:packages/core"
-    "@hoprnet/hopr-utils": "workspace:packages/utils"
-    "@types/blessed": 0.1.19
-    bignumber.js: 9.0.1
-    blessed: ^0.1.81
-    blessed-contrib: ^4.10.0
-    bn.js: 5.2.0
-    mocha: 9.1.1
-    peer-id: 0.15.3
-    typedoc: 0.21.9
-    typedoc-plugin-markdown: 3.10.4
-    typescript: 4.4.2
-  languageName: unknown
-  linkType: soft
-
 "@hoprnet/hopr-connect@npm:0.2.42":
   version: 0.2.42
   resolution: "@hoprnet/hopr-connect@npm:0.2.42"
@@ -1035,6 +1016,29 @@ __metadata:
     typedoc: 0.21.9
     typedoc-plugin-markdown: 3.10.4
     typescript: 4.4.2
+  languageName: unknown
+  linkType: soft
+
+"@hoprnet/hopr-cover-traffic-daemon@workspace:packages/cover-traffic":
+  version: 0.0.0-use.local
+  resolution: "@hoprnet/hopr-cover-traffic-daemon@workspace:packages/cover-traffic"
+  dependencies:
+    "@hoprnet/hopr-core": "workspace:packages/core"
+    "@hoprnet/hopr-utils": "workspace:packages/utils"
+    "@types/blessed": 0.1.19
+    "@types/rimraf": ^3
+    "@types/yargs": ^17
+    bignumber.js: 9.0.1
+    blessed: ^0.1.81
+    blessed-contrib: ^4.10.0
+    bn.js: 5.2.0
+    mocha: 9.1.1
+    peer-id: 0.15.3
+    rimraf: ^3.0.2
+    typedoc: 0.21.9
+    typedoc-plugin-markdown: 3.10.4
+    typescript: 4.4.2
+    yargs: ^17.1.1
   languageName: unknown
   linkType: soft
 
@@ -2085,7 +2089,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/glob@npm:^7.1.1":
+"@types/glob@npm:*, @types/glob@npm:^7.1.1":
   version: 7.1.4
   resolution: "@types/glob@npm:7.1.4"
   dependencies:
@@ -2245,6 +2249,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/rimraf@npm:^3":
+  version: 3.0.2
+  resolution: "@types/rimraf@npm:3.0.2"
+  dependencies:
+    "@types/glob": "*"
+    "@types/node": "*"
+  checksum: b47fa302f46434cba704d20465861ad250df79467d3d289f9d6490d3aeeb41e8cb32dd80bd1a8fd833d1e185ac719fbf9be12e05ad9ce9be094d8ee8f1405347
+  languageName: node
+  linkType: hard
+
 "@types/secp256k1@npm:^4.0.1":
   version: 4.0.3
   resolution: "@types/secp256k1@npm:4.0.3"
@@ -2304,7 +2318,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/yargs@npm:^17.0.2":
+"@types/yargs@npm:^17, @types/yargs@npm:^17.0.2":
   version: 17.0.2
   resolution: "@types/yargs@npm:17.0.2"
   dependencies:


### PR DESCRIPTION
Refers to #2004 

This adds a Docker image build which is based on the generated NPM package.
The image is built and published in parallel to the `hoprd` Docker image to not delay the deploy pipeline further.
The `provider` option has been made configurable via the command line as a parameter such that resulting Docker image can be tested against different networks.