### PR TITLE
Merge tangling pre-release tag to unblock master

### DIFF
--- a/packages/core-ethereum/package.json
+++ b/packages/core-ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hopr-core-ethereum",
-  "version": "1.77.0-next.11",
+  "version": "1.77.0-next.12",
   "description": "",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hopr-core",
-  "version": "1.77.0-next.11",
+  "version": "1.77.0-next.12",
   "description": "Privacy-preserving messaging protocol with incentivations for relay operators",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",

--- a/packages/cover-traffic/package.json
+++ b/packages/cover-traffic/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hoprnet/hopr-cover-traffic-daemon",
   "description": "Generate chaffing traffic",
-  "version": "1.77.0-next.11",
+  "version": "1.77.0-next.12",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",
   "license": "GPL-3.0",

--- a/packages/ethereum/package.json
+++ b/packages/ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hopr-ethereum",
-  "version": "1.77.0-next.11",
+  "version": "1.77.0-next.12",
   "description": "On-chain logic for hoprnet.org",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "license": "GPL-3.0",

--- a/packages/hoprd/package.json
+++ b/packages/hoprd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hoprd",
-  "version": "1.77.0-next.11",
+  "version": "1.77.0-next.12",
   "description": "",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hoprnet/hopr-utils",
   "description": "HOPR-based utilities to process multiple data structures",
-  "version": "1.77.0-next.11",
+  "version": "1.77.0-next.12",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",
   "license": "GPL-3.0",


### PR DESCRIPTION
For some reason the branch, in which this tag was created is gone. I suspect it was on a debug branch.

Thus merging it into master will trigger the generation of the next pre-release which can be published to NPM.