### PR TITLE
Add renovate configuration

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,16 @@
+{
+  "enabled": true,
+  "prCreation": "not-pending",
+  "extends": [
+    "config:base",
+    ":pinAllExceptPeerDependencies"
+  ],
+  "docker": {
+    "enabled": true,
+    "pinDigests": true
+  },
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
+  "semanticCommits": "enabled"
+}


### PR DESCRIPTION
See https://docs.renovatebot.com/configuration-options/ for options.

This shall replace the broken dependabot integration which doesn't work with yarn v3.