### PR TITLE
increase confirmation blocks

### DIFF
--- a/packages/core-ethereum/src/constants.ts
+++ b/packages/core-ethereum/src/constants.ts
@@ -4,5 +4,5 @@
  */
 export const PROVIDER_CACHE_TTL = 30e3 // 30 seconds
 export const PROVIDER_DEFAULT_URI = 'http://127.0.0.1:8545/'
-export const CONFIRMATIONS = 100
+export const CONFIRMATIONS = 8
 export const INDEXER_BLOCK_RANGE = 2000

--- a/packages/core-ethereum/src/constants.ts
+++ b/packages/core-ethereum/src/constants.ts
@@ -4,5 +4,5 @@
  */
 export const PROVIDER_CACHE_TTL = 30e3 // 30 seconds
 export const PROVIDER_DEFAULT_URI = 'http://127.0.0.1:8545/'
-export const CONFIRMATIONS = 8
+export const CONFIRMATIONS = 50
 export const INDEXER_BLOCK_RANGE = 2000

--- a/packages/core-ethereum/src/constants.ts
+++ b/packages/core-ethereum/src/constants.ts
@@ -4,5 +4,5 @@
  */
 export const PROVIDER_CACHE_TTL = 30e3 // 30 seconds
 export const PROVIDER_DEFAULT_URI = 'http://127.0.0.1:8545/'
-export const CONFIRMATIONS = 50
+export const CONFIRMATIONS = 100
 export const INDEXER_BLOCK_RANGE = 2000

--- a/packages/core-ethereum/src/ethereum.ts
+++ b/packages/core-ethereum/src/ethereum.ts
@@ -113,7 +113,7 @@ export async function createChainWrapper(providerURI: string, privateKey: Uint8A
     ...rest: Parameters<T>
   ): Promise<ContractTransaction | { hash: string }> {
     const gasLimit = 400e3
-    const gasPrice = networkInfo?.gas ?? (await provider.getGasPrice())
+    const gasPrice = networkInfo?.gas ?? (await provider.getGasPrice()).mul(10)
     const nonceLock = await nonceTracker.getNonceLock(address)
     const nonce = nonceLock.nextNonce
     let transaction: ContractTransaction

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -133,7 +133,8 @@ class Hopr extends EventEmitter {
       options.forceCreateDB
     )
     this.paymentChannels = new HoprCoreEthereum(this.db, PublicKey.fromPeerId(this.id), this.id.privKey.marshal(), {
-      provider: this.options.provider
+      provider: this.options.provider,
+      maxConfirmations: 100
     })
 
     this.publicNodesEmitter = new EventEmitter()


### PR DESCRIPTION
_Experimental PR_

Sets confirmation block number to `100` which is more suitable for the matic chain.
Using number `100` which seems to be a little bit higher than the maximum reorg depth seen in https://polygonscan.com/blocks_forked