### PR TITLE
Let renovate use pinned versions less often

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,8 +2,7 @@
   "enabled": true,
   "prCreation": "not-pending",
   "extends": [
-    "config:base",
-    ":pinAllExceptPeerDependencies"
+    "config:base"
   ],
   "docker": {
     "enabled": true,
@@ -12,5 +11,6 @@
   "vulnerabilityAlerts": {
     "enabled": true
   },
-  "semanticCommits": "enabled"
+  "semanticCommits": "enabled",
+  "rangeStrategy": "auto"
 }


### PR DESCRIPTION
This will reduce the amount of auto-pinning done in https://github.com/hoprnet/hoprnet/pull/2480