### PR TITLE
Extend current representative's to February

### DIFF
--- a/.processes/development.md
+++ b/.processes/development.md
@@ -50,7 +50,7 @@ Responsibilities:
 
 _Current:_ [Tino](https://github.com/tolbrino), [Steve](https://github.com/nionis)
 
-_Expiry:_ 5/11/21
+_Expiry:_ 01/02/22
 
 ### Trifecta
 


### PR DESCRIPTION
This is a proposal, vote with 👍👎 or 👀 if u are not voting.

Extend the current representatives (Steve & Tino) "rule" to February 1st of 2022.

Why:
- we are at the early stages of our new processes, it's more difficult right now to onboard new representatives
- considering our strict December / January deadlines, makes more sense to stick with the current representatives as they are more familiar with the processes

Why Feb 1st:
I chose 1st of February because it's after our 2 major deadlines,
20th December: myne-chat 0.2
17th January: stable developer guide
and added 1 more sprint in case of delays