### PR TITLE
Fix build dependencies in YP/README.md

### DIFF
--- a/docs/yellowpaper/README.md
+++ b/docs/yellowpaper/README.md
@@ -15,7 +15,7 @@ Contains the source code for the [yellowpaper](./yellowpaper.pdf) of [hoprnet.or
 
 ```sh
 apt install -y git
-apt install -y texlive texlive-latex-extra texlive-science texlive-bibtex-extra
+apt install -y texlive texlive-latex-extra texlive-science texlive-bibtex-extra latexmk
 ```
 
 - "LaTeX Workshop" in VSCode


### PR DESCRIPTION
The `latexmk` was missing from the build requirements.