### PR TITLE
added build:copy step when building ct daemon

### DIFF
--- a/packages/cover-traffic-daemon/package.json
+++ b/packages/cover-traffic-daemon/package.json
@@ -12,7 +12,8 @@
     "clean": "rimraf ./lib ./tsconfig.tsbuildinfo",
     "test": "mocha --parallel",
     "dev": "yarn clean && tsc -w",
-    "build": "yarn clean && tsc -p .",
+    "build": "yarn clean && tsc -p . && yarn build:copy",
+    "build:copy": "cp ./src/unreleasedTokens.json ./lib",
     "prepublishOnly": "tsc -p ./tsconfig.npm.json",
     "docs:generate": "yarn typedoc",
     "docs:watch": "yarn typedoc --watch"


### PR DESCRIPTION
This fixes CT daemon inability to start due to the resource file not being copied during the build step.