### PR TITLE
disabled indexer db recreation

### DIFF
--- a/packages/cover-traffic-daemon/src/index.ts
+++ b/packages/cover-traffic-daemon/src/index.ts
@@ -55,7 +55,7 @@ async function generateNodeOptions(environment: ResolvedEnvironment): Promise<Ho
     announce: false,
     createDbIfNotExist: true,
     environment,
-    forceCreateDB: true,
+    forceCreateDB: false,
     password: ''
   }
 


### PR DESCRIPTION
This PR disables forceful indexer DB recreation on CT daemon startup, speeding up the spinup time.