### PR TITLE
added hack not to crash

### DIFF
--- a/packages/cover-traffic-daemon/src/index.ts
+++ b/packages/cover-traffic-daemon/src/index.ts
@@ -112,7 +112,17 @@ if (require.main === module) {
   process.on('SIGINT', stopGracefully)
   process.on('SIGTERM', stopGracefully)
 
+  process.on('unhandledRejection', (err: Error) => {
+    if(err.message === 'Peer lookup failed') {
+      // @TODO: this is a hack to prevent from crashing with unresolved rejection
+      // due to libp2p bug, see: https://github.com/libp2p/js-libp2p/pull/1025/files
+      return
+    }
+    throw err
+  })
+
   process.on('uncaughtExceptionMonitor', (err, origin) => {
+    
     // Make sure we get a log.
     log(`FATAL ERROR, exiting with uncaught exception: ${origin} ${err}`)
   })

--- a/packages/cover-traffic-daemon/src/index.ts
+++ b/packages/cover-traffic-daemon/src/index.ts
@@ -113,7 +113,7 @@ if (require.main === module) {
   process.on('SIGTERM', stopGracefully)
 
   process.on('unhandledRejection', (err: Error) => {
-    if(err.message === 'Peer lookup failed') {
+    if (err.message === 'Peer lookup failed') {
       // @TODO: this is a hack to prevent from crashing with unresolved rejection
       // due to libp2p bug, see: https://github.com/libp2p/js-libp2p/pull/1025/files
       return
@@ -122,7 +122,6 @@ if (require.main === module) {
   })
 
   process.on('uncaughtExceptionMonitor', (err, origin) => {
-    
     // Make sure we get a log.
     log(`FATAL ERROR, exiting with uncaught exception: ${origin} ${err}`)
   })


### PR DESCRIPTION
This PR implements a simple hack to prevent CT daemon from crashing on startup until libp2p is updated.
See: https://github.com/libp2p/js-libp2p/pull/1025