### PR TITLE
Updated randomInteger function to be cryptographically safe

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `node hopr <id>` spawns a HOPR node at port _9091 + <id>_
 - crawling: crawling is not block anymore, leads to faster crawling
 - heartbeat: every connection uses its own timer now
+- `randomInteger` function is now cryptographically safe
 
 ### Fixed
 

--- a/packages/utils/src/crypto/randomInteger.spec.ts
+++ b/packages/utils/src/crypto/randomInteger.spec.ts
@@ -1,5 +1,5 @@
 import assert from 'assert'
-import { randomInteger } from './randomInteger'
+import { randomInteger, randomBigInteger } from './randomInteger'
 
 describe('testing random-number generator', function () {
   let ATTEMPTS = 10000
@@ -10,6 +10,17 @@ describe('testing random-number generator', function () {
       result = randomInteger(end)
 
       assert(0 <= result, result + ' gte 0')
+      assert(result < end, result + ' lt ' + end)
+    }
+  })
+
+  it(`should output generate bigint values between [0, end)`, function () {
+    let result: bigint
+    let end = BigInt(Number.MAX_SAFE_INTEGER) + 10024n
+    for (let i = 0; i < ATTEMPTS; i++) {
+      result = randomBigInteger(end)
+
+      assert(0n <= result, result + ' gte 0')
       assert(result < end, result + ' lt ' + end)
     }
   })
@@ -25,59 +36,37 @@ describe('testing random-number generator', function () {
     }
   })
 
-  /*
-  it('should throw error for falsy interval input', function () {
-    assert.throws(() => randomInteger(2, 1))
+  it(`should output bigint values between [start, end) with start > 0`, function () {
+    let result: bigint
+    let start = BigInt(Number.MAX_SAFE_INTEGER) + 253n
+    let end = BigInt(Number.MAX_SAFE_INTEGER) + 73111n
+    for (let i = 0; i < ATTEMPTS; i++) {
+      result = randomBigInteger(start, end)
 
-    assert.throws(() => randomInteger(2 ** 32))
-
-    assert.throws(() => randomInteger(-1))
-
-    assert.throws(() => randomInteger(-1, -2))
+      assert(start <= result && result < end)
+    }
   })
-  */
 
   it('should yield correct values for edge cases', function () {
-    /*
-    const MAX_INTEGER = 2 ** 31
-
-    assert(randomInteger(0, MAX_INTEGER, new Uint8Array(4).fill(0xff)) == MAX_INTEGER - 1)
-
-    assert.throws(() => randomInteger(0, MAX_INTEGER + 1, new Uint8Array(4).fill(0xff)))
-
-    assert(randomInteger(0, 2 ** 24, new Uint8Array(4).fill(0xff)) == 2 ** 24 - 1)
-
-    assert(randomInteger(0, 1) == 0)
-
-    assert.throws(() => randomInteger(0))
-*/
     assert(randomInteger(23, 24) == 23)
 
     assert(randomInteger(1) == 0)
+
+    assert.throws(() => randomInteger(-1), Error(`invalid range`))
+
+    // Number.MAX_SAFE_INTEGER * 2 is strictly greater than Number.MAX_SAFE_INTEGER
+    // due to increased exponent in IEEE754 representation
+    assert.throws(() => randomInteger(0, Number.MAX_SAFE_INTEGER * 2), Error(`invalid range`))
   })
 
-  /*
+  it('should yield correct values for bigint edge cases', function () {
+    assert(
+      randomBigInteger(BigInt(Number.MAX_SAFE_INTEGER) + 23n, BigInt(Number.MAX_SAFE_INTEGER) + 24n) ==
+        BigInt(Number.MAX_SAFE_INTEGER) + 23n
+    )
 
-NOTE: This test has been removed, because once we started using CSPRNG in randomInteger,
- we can no longer inject custom fixed seed.
+    assert(randomBigInteger(1n) == 0n)
 
-it('should verify the randomInteger by using deterministic seeds', function () {
-    const LENGTH = 2
-
-    const LOWERBOUND = 27
-    const UPPERBOUND = 480
-    const bytes = new Uint8Array(LENGTH).fill(0)
-
-    const ONE = new Uint8Array(LENGTH).fill(0)
-    ONE[ONE.length - 1] = 1
-
-    for (let i = 0; i < ATTEMPTS; i++) {
-      u8aAdd(true, bytes, ONE)
-
-      let result = randomInteger(LOWERBOUND, UPPERBOUND, bytes)
-      assert(result < UPPERBOUND && result >= LOWERBOUND)
-    }
+    assert.throws(() => randomBigInteger(-1n), Error(`invalid range`))
   })
-})
-*/
 })

--- a/packages/utils/src/crypto/randomInteger.spec.ts
+++ b/packages/utils/src/crypto/randomInteger.spec.ts
@@ -52,6 +52,9 @@ describe('testing random-number generator', function () {
     assert.throws(() => randomInteger(0))
 */
     assert(randomInteger(23, 24) == 23)
+
+    assert(randomInteger(1) == 0)
+
   })
 
   /*

--- a/packages/utils/src/crypto/randomInteger.spec.ts
+++ b/packages/utils/src/crypto/randomInteger.spec.ts
@@ -53,8 +53,13 @@ describe('testing random-number generator', function () {
 */
     assert(randomInteger(23, 24) == 23)
   })
-})
-/*it('should verify the randomInteger by using deterministic seeds', function () {
+
+/*
+
+NOTE: This test has been removed, because once we started using CSPRNG in randomInteger,
+ we can no longer inject custom fixed seed.
+
+it('should verify the randomInteger by using deterministic seeds', function () {
     const LENGTH = 2
 
     const LOWERBOUND = 27
@@ -71,4 +76,7 @@ describe('testing random-number generator', function () {
       assert(result < UPPERBOUND && result >= LOWERBOUND)
     }
   })
-})*/
+})
+*/
+
+})

--- a/packages/utils/src/crypto/randomInteger.spec.ts
+++ b/packages/utils/src/crypto/randomInteger.spec.ts
@@ -54,7 +54,6 @@ describe('testing random-number generator', function () {
     assert(randomInteger(23, 24) == 23)
 
     assert(randomInteger(1) == 0)
-
   })
 
   /*

--- a/packages/utils/src/crypto/randomInteger.spec.ts
+++ b/packages/utils/src/crypto/randomInteger.spec.ts
@@ -1,10 +1,9 @@
 import assert from 'assert'
 import { randomInteger } from './randomInteger'
 
-
 describe('testing random-number generator', function () {
   let ATTEMPTS = 10000
-  it(`should output generate values between [0, end)`, function() {
+  it(`should output generate values between [0, end)`, function () {
     let result: number
     let end = 10024
     for (let i = 0; i < ATTEMPTS; i++) {
@@ -15,7 +14,7 @@ describe('testing random-number generator', function () {
     }
   })
 
-  it(`should output values between [start, end) with start > 0`, function() {
+  it(`should output values between [start, end) with start > 0`, function () {
     let result: number
     let start = 253
     let end = 73111
@@ -38,7 +37,7 @@ describe('testing random-number generator', function () {
   })
   */
 
-  it('should yield correct values for edge cases', function() {
+  it('should yield correct values for edge cases', function () {
     /*
     const MAX_INTEGER = 2 ** 31
 
@@ -55,7 +54,7 @@ describe('testing random-number generator', function () {
     assert(randomInteger(23, 24) == 23)
   })
 })
-  /*it('should verify the randomInteger by using deterministic seeds', function () {
+/*it('should verify the randomInteger by using deterministic seeds', function () {
     const LENGTH = 2
 
     const LOWERBOUND = 27

--- a/packages/utils/src/crypto/randomInteger.spec.ts
+++ b/packages/utils/src/crypto/randomInteger.spec.ts
@@ -1,10 +1,10 @@
 import assert from 'assert'
 import { randomInteger } from './randomInteger'
-import { u8aAdd } from '../u8a'
+
 
 describe('testing random-number generator', function () {
   let ATTEMPTS = 10000
-  it(`should output generate values between [0, end)`, function () {
+  it(`should output generate values between [0, end)`, function() {
     let result: number
     let end = 10024
     for (let i = 0; i < ATTEMPTS; i++) {
@@ -15,7 +15,7 @@ describe('testing random-number generator', function () {
     }
   })
 
-  it(`should output values between [start, end) with start > 0`, function () {
+  it(`should output values between [start, end) with start > 0`, function() {
     let result: number
     let start = 253
     let end = 73111
@@ -38,7 +38,7 @@ describe('testing random-number generator', function () {
   })
   */
 
-  it('should yield correct values for edge cases', function () {
+  it('should yield correct values for edge cases', function() {
     /*
     const MAX_INTEGER = 2 ** 31
 
@@ -54,8 +54,8 @@ describe('testing random-number generator', function () {
 */
     assert(randomInteger(23, 24) == 23)
   })
-
-  it('should verify the randomInteger by using deterministic seeds', function () {
+})
+  /*it('should verify the randomInteger by using deterministic seeds', function () {
     const LENGTH = 2
 
     const LOWERBOUND = 27
@@ -72,4 +72,4 @@ describe('testing random-number generator', function () {
       assert(result < UPPERBOUND && result >= LOWERBOUND)
     }
   })
-})
+})*/

--- a/packages/utils/src/crypto/randomInteger.ts
+++ b/packages/utils/src/crypto/randomInteger.ts
@@ -41,23 +41,25 @@ function randomBoundedInteger(bound: number): number {
  * Returns a random value between `start` and `end`.
  * @example
  * ```
- * randomInteger(3) // result in { 0, 1, 2, 3 }
- * randomInteger(0, 3) // result in { 0, 1, 2, 3 }
- * randomInteger(7, 9) // result in { 7, 8, 9 }
- * randomInteger(8, 8) == 8
+ * randomInteger(3) // result in { 0, 1, 2}
+ * randomInteger(0, 3) // result in { 0, 1, 2 }
+ * randomInteger(7, 9) // result in { 7, 8 }
  * ```
- * @param start start of the interval
- * @param end end of the interval inclusive
+ * @param start start of the interval (inclusive)
+ * @param end end of the interval (not inclusive)
  * @returns random number between @param start and @param end
  */
 export function randomInteger(start: number, end?: number): number {
 
-  if (!end) end = Number(MAX_RANDOM_INTEGER)
+  if (!end) {
+    end = start;
+    start = 0
+  }
 
   if (end <= start || start < 0)
     throw Error("invalid range")
 
-  return start + randomBoundedInteger(end-start+1)
+  return start + randomBoundedInteger(end-start)
 }
 
 export function randomChoice<T>(collection: T[]): T {

--- a/packages/utils/src/crypto/randomInteger.ts
+++ b/packages/utils/src/crypto/randomInteger.ts
@@ -27,10 +27,103 @@ export const MAX_RANDOM_INTEGER = (1n << BIT_WIDTH) - 1n
  * @param bound Maximum number that can be generated.
  */
 function randomBoundedInteger(bound: number): number {
-  let bnBound = BigInt(bound) > MAX_RANDOM_INTEGER ? MAX_RANDOM_INTEGER : BigInt(bound)
+
+  /* -- Here's the original explanation of the optimized method by Stephen Canon: --
+   *
+   * Everyone knows that generating an unbiased random integer in a range
+   * 0 ..< upperBound, where upperBound is not a power of two, requires
+   * rejection sampling. What if I told you that Big Random Number has
+   * lied to us for decades, and we have been played for absolute fools?
+   *
+   * Previously Swift used Lemire's "nearly divisionless" method
+   * (https://arxiv.org/abs/1805.10941) for this operation. We instead
+   * now use a novel method that:
+   *
+   * - never divides
+   * - avoids rejection sampling entirely
+   * - achieves a theoretically optimal bound on the amount of randomness
+   *   consumed to generate a sample
+   * - delivers actual performance improvements for most real cases
+   *
+   * Lemire interprets each word from the random source as a fixed-point
+   * number in [0, 1), multiplies by upperBound, and takes the floor. Up
+   * to this point, this is the algorithm suggested by Knuth in TAoCP vol 2,
+   * and as observed by Knuth, it is slightly biased. Lemire cleverly
+   * corrects this bias via rejection sampling, which requires one division
+   * in the general case (hence, "nearly divisionless").
+   *
+   * Our new algorithm takes a different approach. Rather than using
+   * rejection sampling, we observe that the bias decreases exponentially
+   * in the number of bits used for the computation. In the limit we are
+   * interpreting the bitstream from the random source as a uniform real
+   * number r in [0, 1) and ⌊r * upperBound⌋ provides an unbiased sample
+   * in 0 ..< upperBound. The only challenge, then, is to know when we
+   * have computed enough bits of the product to know what the result is.
+   *
+   * Observe that we can split the random stream at any bit position i,
+   * yielding r = r₀ + r₁ with r₀ a fixed-point number in [0,1) and
+   * 0 ≤ r₁ < 2⁻ⁱ. Further observe that:
+   *
+   *    result = ⌊r * upperBound⌋
+   *           = ⌊r₀ * upperBound⌋ + ⌊frac(r₀*upperBound) + r₁*upperBound⌋
+   *
+   * The first term of this expression is Knuth's biased sample, which is
+   * computed with just a full-width multiply.
+   *
+   * If i > log₂(upperBound), both summands in the second term are smaller
+   * than 1, so the second term is either 0 or 1. Applying the bound on r₁,
+   * we see that if frac(r₀ * upperBound) <= 1 - upperBound * 2⁻ⁱ, the
+   * second term is necessarily zero, and the first term is the unbiased
+   * result. Happily, this is _also_ a trivial computation on the low-order
+   * part of the full-width multiply.
+   *
+   * If the test fails, we do not reject the sample, throwing away the bits
+   * we have already consumed from the random source; instead we increase i
+   * by a convenient amount, computing more bits of the product. This is the
+   * criticial improvement; while Lemire has a probability of 1/2 to reject
+   * for each word consumed in the worst case, we have a probability of
+   * terminating of 1/2 for each _bit_ consumed. This reduces the worst-case
+   * expected number of random bits required from O(log₂(upperBound)) to
+   * log₂(upperBound) + O(1), which is optimal[1].
+   *
+   * Of more practical interest, this new algorithm opens an intriguing
+   * possibility: we can compute just 64 extra bits, and have a probability
+   * of 1 - 2⁻⁶⁴ of terminating. This is so close to certainty that we can
+   * simply stop without introducing any measurable bias (detecting any
+   * difference would require about 2¹²⁸ samples, which is prohibitive).
+   * This is a significant performance improvement for slow random
+   * generators, since it asymptotically reduces the number of bits
+   * required by a factor of two for bignums, while matching or reducing
+   * the expected number of bits required for smaller numbers. This is the
+   * algorithm implemented below (the formally-uniform method is not
+   * much more complex to implement and is only a little bit slower, but
+   * there's no reason to do so).
+   *
+   * More intriguing still, this algorithm can be made unconditional by
+   * removing the early out, so that every value computed requires word
+   * size + 64 bits from the stream, which breaks the loop-carried
+   * dependency for fast generators, unlocking vectorization and
+   * parallelization where it was previously impossible. This is an
+   * especially powerful advantage when paired with bitstream generators
+   * that allow skip-ahead such as newer counter-based generators used
+   * in simulations and ML.
+   *
+   * Note that it is _possible_ to employ Lemire's tighter early-out
+   * check that involves a division with this algorithm as well; this
+   * is beneficial in some cases when upperBound is a constant and the
+   * generator is slow, but we do not think it necessary with the new
+   * algorithm and other planned improvements.
+   *
+   * [1] We can actually achieve log₂(upperBound) + ε for any ε > 0 by
+   * generating multiple random samples at once, but that is only of
+   * theoretical interest--it is still interesting, however, since I
+   * don't think anyone has described how to attain it previously.
+  */
+
+  const bnBound = BigInt(bound) > MAX_RANDOM_INTEGER ? MAX_RANDOM_INTEGER : BigInt(bound)
 
   // 2's complement
-  let uboundNeg = MAX_RANDOM_INTEGER - bnBound + 1n
+  const uboundNeg = MAX_RANDOM_INTEGER - bnBound + 1n
 
   let res = bnBound * nextRandomFullWidth()
   let resHi = res >> BIT_WIDTH
@@ -52,8 +145,9 @@ function randomBoundedInteger(bound: number): number {
  * randomInteger(0, 3) // result in { 0, 1, 2 }
  * randomInteger(7, 9) // result in { 7, 8 }
  * ```
- * @param start start of the interval (inclusive)
- * @param end end of the interval (not inclusive)
+ * The maximum number generated by this function is MAX_RANDOM_INTEGER.
+ * @param start start of the interval (inclusive). Must be non-negative.
+ * @param end end of the interval (not inclusive). Must not exceed MAX_RANDOM_INTEGER.
  * @returns random number between @param start and @param end
  */
 export function randomInteger(start: number, end?: number): number {
@@ -62,7 +156,7 @@ export function randomInteger(start: number, end?: number): number {
     start = 0
   }
 
-  if (end <= start || start < 0) throw Error('invalid range')
+  if (end <= start || start < 0 || end > MAX_RANDOM_INTEGER) throw Error('invalid range')
 
   return start + randomBoundedInteger(end - start)
 }

--- a/packages/utils/src/crypto/randomInteger.ts
+++ b/packages/utils/src/crypto/randomInteger.ts
@@ -6,7 +6,7 @@ import crypto from 'crypto'
 const BIT_WIDTH = 64n
 
 /**
- * Internal function generating fix length random integer.
+ * Internal function generating fixed length random integer.
  */
 function nextRandomFullWidth(): bigint {
   return crypto.randomBytes(Number(BIT_WIDTH / 8n)).readBigUInt64LE()

--- a/packages/utils/src/crypto/randomInteger.ts
+++ b/packages/utils/src/crypto/randomInteger.ts
@@ -141,16 +141,7 @@ function randomBoundedBigInteger(bound: bigint): bigint {
 /**
  * Maximum random integer that can be generated using randomInteger function.
  */
-export const MAX_RANDOM_INTEGER = Number.MAX_SAFE_INTEGER
-
-/**
- * A convenience function, supporting less precise type Number.
- * @param bound Maximum non-negative number that can be generated. Maximum bound is currently MAX_RANDOM_INTEGER.
- */
-function randomBoundedInteger(bound: number): number {
-  const bnBound = BigInt(Math.min(Math.max(0, bound), MAX_RANDOM_INTEGER))
-  return Number(randomBoundedBigInteger(bnBound))
-}
+export const MAX_RANDOM_INTEGER = BigInt(Number.MAX_SAFE_INTEGER)
 
 /**
  * Returns a random value between `start` and `end`.
@@ -166,14 +157,38 @@ function randomBoundedInteger(bound: number): number {
  * @returns random number between @param start and @param end
  */
 export function randomInteger(start: number, end?: number): number {
+  let _start: bigint
+  let _end: bigint
+
   if (!end) {
-    end = start
-    start = 0
+    _end = BigInt(start)
+    _start = 0n
+  } else {
+    _end = BigInt(end)
+    _start = BigInt(start)
   }
 
-  if (end <= start || start < 0 || end > MAX_RANDOM_INTEGER) throw Error('invalid range')
+  if (_end > MAX_RANDOM_INTEGER) {
+    throw Error('invalid range')
+  }
 
-  return start + randomBoundedInteger(end - start)
+  return Number(randomBigInteger(_start, _end))
+}
+
+/**
+ * same as randomInteger, but for BigInts
+ */
+export function randomBigInteger(start: bigint, end?: bigint): bigint {
+  if (!end) {
+    end = start
+    start = 0n
+  }
+
+  if (end <= start || start < 0n || end > MAX_RANDOM_BIGINTEGER) {
+    throw Error('invalid range')
+  }
+
+  return start + randomBoundedBigInteger(end - start)
 }
 
 export function randomChoice<T>(collection: T[]): T {

--- a/packages/utils/src/crypto/randomInteger.ts
+++ b/packages/utils/src/crypto/randomInteger.ts
@@ -18,7 +18,7 @@ function nextRandomFullWidth(): bigint {
 export const MAX_RANDOM_INTEGER = (1n << BIT_WIDTH) - 1n
 
 /**
- * Internal function generating random integer in half-close interval [0, bound).
+ * Internal function generating random integer in { 0,1,2,... bound-1 }.
  * Uses an optimized Lemire's method (https://arxiv.org/abs/1805.10941)
  * as devised in https://github.com/apple/swift/pull/39143 by Stepen Canon.
  *
@@ -125,14 +125,14 @@ function randomBoundedInteger(bound: number): number {
   // 2's complement
   const uboundNeg = MAX_RANDOM_INTEGER - bnBound + 1n
 
-  let res = bnBound * nextRandomFullWidth()
-  let resHi = res >> BIT_WIDTH
+  const res = bnBound * nextRandomFullWidth()
+  const resHi = res >> BIT_WIDTH
 
-  // Fast-out
+  // Early-out
   if ((res & MAX_RANDOM_INTEGER) <= uboundNeg) return Number(resHi)
 
-  let newRnd = (bnBound * nextRandomFullWidth()) >> BIT_WIDTH
-  let carry = ((resHi + newRnd) >> BIT_WIDTH) & 1n
+  const newRnd = (bnBound * nextRandomFullWidth()) >> BIT_WIDTH
+  const carry = ((resHi + newRnd) >> BIT_WIDTH) & 1n
 
   return Number(resHi + carry)
 }

--- a/packages/utils/src/crypto/randomInteger.ts
+++ b/packages/utils/src/crypto/randomInteger.ts
@@ -48,15 +48,14 @@ function randomBoundedInteger(bound: number): number {
  * @returns random number between @param start and @param end
  */
 export function randomInteger(start: number, end?: number): number {
-
   if (!end) {
-    end = start;
+    end = start
     start = 0
   }
 
   if (end <= start || start < 0) throw Error('invalid range')
 
-  return start + randomBoundedInteger(end-start)
+  return start + randomBoundedInteger(end - start)
 }
 
 export function randomChoice<T>(collection: T[]): T {


### PR DESCRIPTION
Now uses an optimized Lemire's method of generating upper-bounded non-negative random integers.

See https://github.com/apple/swift/pull/39143 for details on this method.

Also had to remove one unit test for `randomInteger` as we cannot force a fixed seed while using a proper CSPRNG.

Resolves #2932 