### PR TITLE
Add missing dep restana to cover-traffic-daemon

### DIFF
--- a/packages/cover-traffic-daemon/package.json
+++ b/packages/cover-traffic-daemon/package.json
@@ -31,6 +31,7 @@
     "bignumber.js": "9.0.1",
     "bn.js": "5.2.0",
     "peer-id": "0.15.3",
+    "restana": "4.9.2",
     "yargs": "17.2.1"
   },
   "devDependencies": {

--- a/packages/hoprd/package.json
+++ b/packages/hoprd/package.json
@@ -51,7 +51,7 @@
     "prop-types": "^15.7.2",
     "react": "17.0.2",
     "react-dom": "17.0.2",
-    "restana": "^4.8.0",
+    "restana": "4.9.2",
     "rlp": "2.2.7",
     "run-queue": "^2.0.1",
     "strip-ansi": "6.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1253,6 +1253,7 @@ __metadata:
     mocha: 9.1.3
     nyc: 15.1.0
     peer-id: 0.15.3
+    restana: 4.9.2
     rimraf: 3.0.2
     typedoc: 0.22.9
     typedoc-plugin-markdown: 3.11.7
@@ -1398,7 +1399,7 @@ __metadata:
     prop-types: ^15.7.2
     react: 17.0.2
     react-dom: 17.0.2
-    restana: ^4.8.0
+    restana: 4.9.2
     rimraf: 3.0.2
     rlp: 2.2.7
     run-queue: ^2.0.1
@@ -14989,7 +14990,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"restana@npm:^4.8.0":
+"restana@npm:4.9.2":
   version: 4.9.2
   resolution: "restana@npm:4.9.2"
   dependencies:


### PR DESCRIPTION
The PR #2889 introduced using restana, but didn't add it to the
dependencies. Thus, the resulting Docker images cannot start.