### PR TITLE
Fix prefix of docker image names for cover traffic daemon

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -196,7 +196,7 @@ jobs:
           git pull origin "${branch}" --rebase
 
       - name: Build Docker image
-        run: ./scripts/build-docker.sh -p cover-traffic-daemon
+        run: ./scripts/build-docker.sh -p hopr-cover-traffic-daemon
 
       - name: Send notification if anything failed on master or release branches
         if: ${{ failure() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && !env.ACT }}

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -15,7 +15,7 @@ source "${mydir}/utils.sh"
 
 usage() {
   msg
-  msg "Usage: $0 [-h|--help] [-p|--package hoprd|cover-traffic-daemon] [-f|--force] [-n|--no-tags]"
+  msg "Usage: $0 [-h|--help] [-p|--package hoprd|hopr-cover-traffic-daemon] [-f|--force] [-n|--no-tags]"
   msg
   msg "Use -f to force a Docker build even though no environment can be found. This is useful for local testing. No additional docker tags will be applied though if no environment has been found which is in contrast to the normal execution of the script."
   msg
@@ -52,7 +52,7 @@ while (( "$#" )); do
   esac
 done
 
-if [ "${package:-}" != "hoprd" ] && [ "${package:-}" != "cover-traffic-daemon" ]; then
+if [ "${package:-}" != "hoprd" ] && [ "${package:-}" != "hopr-cover-traffic-daemon" ]; then
   msg "Error: unsupported package"
   usage
   exit 1


### PR DESCRIPTION
The image names were missing the prefix `hopr-` which resulted in some
other helper scripts not working.