### PR TITLE
Initial coverage for `cover-traffic`

### DIFF
--- a/packages/cover-traffic-daemon/src/index.spec.ts
+++ b/packages/cover-traffic-daemon/src/index.spec.ts
@@ -3,7 +3,16 @@ import PeerId from 'peer-id'
 import Hopr from '@hoprnet/hopr-core'
 import { HoprOptions } from '@hoprnet/hopr-core'
 import HoprCoreEthereum, { Indexer } from '@hoprnet/hopr-core-ethereum'
-import { debug, privKeyToPeerId, HoprDB, NativeBalance, AccountEntry, Address, PublicKey, wait } from '@hoprnet/hopr-utils'
+import {
+  debug,
+  privKeyToPeerId,
+  HoprDB,
+  NativeBalance,
+  AccountEntry,
+  Address,
+  PublicKey,
+  wait
+} from '@hoprnet/hopr-utils'
 import sinon from 'sinon'
 import BN from 'bn.js'
 import ConnectionManager from 'libp2p/src/connection-manager'


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1128312/143427129-5b2f6586-8060-4792-ba2d-a2931c07328e.png)

Current tests simply set up the strategy w/o letting a single tick to work, but allowing kickstarting the process.

- Fixes #2902