### PR TITLE
Fix incorrect coin type on withdraw

### DIFF
--- a/scripts/fund-address.ts
+++ b/scripts/fund-address.ts
@@ -83,7 +83,7 @@ async function fundNative(chain, sender: string, receiver: string, targetBalance
   console.log(
     `transfer ${diff.toFormattedString()} from ${sender} to ${receiver} to top up ${balance.toFormattedString()}`
   )
-  await chain.withdraw('HOPR', receiver, diff.toString())
+  await chain.withdraw('NATIVE', receiver, diff.toString())
 }
 
 async function main() {


### PR DESCRIPTION
There was an incorrect type (`HOPR` but should be `NATIVE`) in the funding script.