### PR TITLE
Update required release steps

### DIFF
--- a/.processes/release.md
+++ b/.processes/release.md
@@ -144,37 +144,46 @@ particular branch to deploy on every change.
 
 ```
 
-1. On new release, there will be a code-freeze on `master` by creating a `release/**` branch
-   tracking `master`. Release specific changes will be done in this branch to trigger
-   this particular release, which requires to insert name and release version of the new milestone
-   in the files:
-
-   - create new environment in `scripts/environment.sh`
-   - update image to point to `latest-<release>` in `packages/avado/Dockerfile`
-   - update image to point to new version in `packages/avado/docker-compose.yml`
-   - add an entry to `CHANGELOG.md`
-   - add any chain specific changes
-
-2. The information about the release, how to test and what commands to run, are
-   then shared within our `#release` channel. On the `#testing` channel, members are expected
-   to run their own nodes (either AVADO or via their workstation) to participate in the release.
-
-3. Patches to the release are created via `hotfix/RELEASE_NAME/**` branches.
+1. Create a release tracking issue on Github. Use previous issues as templates: https://github.com/hoprnet/hoprnet/issues/3044
+1. (on `master`) As a preparation for a release there should be a respective entry in `packages/hoprs/releases.json` and if needed in `packages/core/protocol-config.json`. If the entries are missing, create and merge them before starting the actual release process. This step can be done way in advance to plan environments and releases, too.
+2. (on `master`) Now create the release branch locally. E.g. doing `git checkout -b release/${RELEASE_NAME}`.
+3. (on `release/${RELEASE_NAME}`) Before pushing the branch to Github, some release-specific changes should be applied to ensure the resulting CD artifacts actually are proper release artifacts.
+3.1. Change all occurences of the last release name to the new release name within documentation files and Docker files. Don't touch the `protocol-config.json` and `releases.json` files in this step. Changes should be committed locally.
+3.2. Change use of `master-goerli` in `packages/avado/Dockerfile` to the new release name. Changes should be committed locally. 
+3.3. Update `CHANGELOG.md` with the new release's information. Changes should be committed locally.
+3.4. Copy contract deployment files from the old release. This can be done doing
+  ```
+  mkdir -p packages/ethereum/deployments/${RELEASE_NAME}/xdai
+  cp packages/ethereum/deployments/${OLD_RELEASE_NAME}/xdai/* packages/ethereum/deployments/${RELEASE_NAME}/xdai/
+  rm packages/ethereum/deployments/${RELEASE_NAME}/xdai/HoprChannels.json
+  ```
+  
+  NOTE: Don't include the deployment of HoprChannels, because this will be re-deployed anyway by the CD system.
+  
+  Changes should be committed locally.
+4. (on `release/${RELEASE_NAME}`) Now everything is ready and can be pushed to Github: `git push origin`. Wait until the deployment of the basic cluster has completed by the CD.
+5. Create a release tracking PR which can be used to follow CD builds. However, the PR should never be merged! As a reference take a look at https://github.com/hoprnet/hoprnet/pull/3048
+6. (on `release/${RELEASE_NAME}`) Start a topology cluster using the script mentioned at the end of this document.
+7. Create a release testnet page in the wiki at: https://www.notion.so/Testnets-e53255f7003f4c8eae2f1b6644a676e0
+   You may use previous testnet pages as templates. Ensure all started nodes are documented.
+8. Share the links to the release tracking issue, tracking PR and testnet wiki page in the `#release` Element channel.
+   On the `#testing` channel, members are expected to run their own nodes (either AVADO or via their workstation) to participate in the release.
+9. Patches to the release are created via `hotfix/RELEASE_NAME/**` branches.
    Each of these merges will trigger a new release version, and re-build our infrastructure
-   for that version. Upon successfullly testing a release, the release branch may be merged back into
-   `master` by following these steps:
+   for that version. Upon successfullly testing a release
+10. Once the first release version has been built and is running, the release branch should be merged-back into `master` once to trigger version upgrades on `master`. See the next section for details.
 
-- locally create a merge-back branch based on the release branch
-- merge the latest `master` branch into the merge-back branch, in case of conflicts changes
-  from `master` have preference
-- revert changes in `packages/avado/Dockerfile`
-- revert changes in `packages/avado/docker-compose.yml`
-- revert any chain specific changes
-- bump the package versions to the next preminor version:
-  `yarn workspaces foreach -piv --no-private --topological-dev exec -- npm version preminor --preid=next`
-- revert changes made to Avado configuration files as part of the initial release creation
-  a new release version, and re-build our infrastructure for that version. Upon successfullly
-  testing a release, merge it back to trigger a new pre-release version via our actions.
+Once the release testing has concluded, or if any signifant amount of patches were applied to the release branch, the release branch should be merged back into `master` again.
+   
+#### Release merge-back
+
+1. (on `release/${RELEASE_NAME}`) Create a PR branch off of the release branch: `git checkout -b merge-back-release-${RELEASE_NAME}`
+2. (on `merge-back-release-${RELEASE_NAME}`) Merge `master` into the branch: `git merge master`.
+   For an example of a merge-back, take a look at older releases: https://github.com/hoprnet/hoprnet/pull/2956
+   In case of conflicts (which is expected) changes from `master` have preference in the following cases:
+2.1. Revert changes in `packages/avado/docker-compose.yml`
+2.2. Revert any chain specific changes.
+2.3. Revert changes made to Avado configuration files as part of the initial release creation.
 
 ### Actions
 

--- a/.processes/release.md
+++ b/.processes/release.md
@@ -148,20 +148,22 @@ particular branch to deploy on every change.
 1. (on `master`) As a preparation for a release there should be a respective entry in `packages/hoprs/releases.json` and if needed in `packages/core/protocol-config.json`. If the entries are missing, create and merge them before starting the actual release process. This step can be done way in advance to plan environments and releases, too.
 1. (on `master`) Now create the release branch locally. E.g. doing `git checkout -b release/${RELEASE_NAME}`.
 1. (on `release/${RELEASE_NAME}`) Before pushing the branch to Github, some release-specific changes should be applied to ensure the resulting CD artifacts actually are proper release artifacts.
-    1. Change all occurences of the last release name to the new release name within documentation files and Docker files. Don't touch the `protocol-config.json` and `releases.json` files in this step. Changes should be committed locally.
-    1. Change use of `master-goerli` in `packages/avado/Dockerfile` to the new release name. Changes should be committed locally.
-    1. Update `CHANGELOG.md` with the new release's information. Changes should be committed locally.
-    1. Copy contract deployment files from the old release. This can be done doing
 
-    ```
-    mkdir -p packages/ethereum/deployments/${RELEASE_NAME}/xdai
-    cp packages/ethereum/deployments/${OLD_RELEASE_NAME}/xdai/* packages/ethereum/deployments/${RELEASE_NAME}/xdai/
-    rm packages/ethereum/deployments/${RELEASE_NAME}/xdai/HoprChannels.json
-    ```
-  
-    NOTE: Don't include the deployment of HoprChannels, because this will be re-deployed anyway by the CD system.
+   1. Change all occurences of the last release name to the new release name within documentation files and Docker files. Don't touch the `protocol-config.json` and `releases.json` files in this step. Changes should be committed locally.
+   1. Change use of `master-goerli` in `packages/avado/Dockerfile` to the new release name. Changes should be committed locally.
+   1. Update `CHANGELOG.md` with the new release's information. Changes should be committed locally.
+   1. Copy contract deployment files from the old release. This can be done doing
 
-    Changes should be committed locally.
+   ```
+   mkdir -p packages/ethereum/deployments/${RELEASE_NAME}/xdai
+   cp packages/ethereum/deployments/${OLD_RELEASE_NAME}/xdai/* packages/ethereum/deployments/${RELEASE_NAME}/xdai/
+   rm packages/ethereum/deployments/${RELEASE_NAME}/xdai/HoprChannels.json
+   ```
+
+   NOTE: Don't include the deployment of HoprChannels, because this will be re-deployed anyway by the CD system.
+
+   Changes should be committed locally.
+
 1. (on `release/${RELEASE_NAME}`) Now everything is ready and can be pushed to Github: `git push origin`. Wait until the deployment of the basic cluster has completed by the CD.
 1. Create a release tracking PR which can be used to follow CD builds. However, the PR should never be merged! As a reference take a look at https://github.com/hoprnet/hoprnet/pull/3048
 1. (on `release/${RELEASE_NAME}`) Start a topology cluster using the script mentioned at the end of this document.
@@ -182,9 +184,9 @@ Once the release testing has concluded, or if any signifant amount of patches we
 1. (on `merge-back-release-${RELEASE_NAME}`) Merge `master` into the branch: `git merge master`.
    For an example of a merge-back, take a look at older releases: https://github.com/hoprnet/hoprnet/pull/2956
    In case of conflicts (which is expected) changes from `master` have preference in the following cases:
-    1. Revert changes in `packages/avado/docker-compose.yml`
-    1. Revert any chain specific changes.
-    1. Revert changes made to Avado configuration files as part of the initial release creation.
+   1. Revert changes in `packages/avado/docker-compose.yml`
+   1. Revert any chain specific changes.
+   1. Revert changes made to Avado configuration files as part of the initial release creation.
 
 ### Actions
 
@@ -222,8 +224,8 @@ The following are a series of manual tasks that are needed to be executed for th
 
 - [ ] Create a DNS alias for each node (cloud, cover-traffic, topology), to be accessed via our `hoprnet.link` domain (e.g. ct-1-$release.hoprnet.link)
 - [ ] Tag a distribution manually $release on npm and on Docker Hub.
-    - `npm login`, `npm dist-tag add @hoprnet/hoprd@$version $mountain/$city`
-    - `docker login`, `docker tag gcr.io/hoprassociation/hoprd:latest hopr/hoprd:$city/$mountain`
+  - `npm login`, `npm dist-tag add @hoprnet/hoprd@$version $mountain/$city`
+  - `docker login`, `docker tag gcr.io/hoprassociation/hoprd:latest hopr/hoprd:$city/$mountain`
 
 #### Per $chain
 

--- a/.processes/release.md
+++ b/.processes/release.md
@@ -145,7 +145,7 @@ particular branch to deploy on every change.
 ```
 
 1. Create a release tracking issue on Github. Use previous issues as templates: https://github.com/hoprnet/hoprnet/issues/3044
-2. (on `master`) As a preparation for a release there should be a respective entry in `packages/hoprs/releases.json` and if needed in `packages/core/protocol-config.json`. If the entries are missing, create and merge them before starting the actual release process. This step can be done way in advance to plan environments and releases, too.
+2. (on `master`) As a preparation for a release there should be a respective entry in `packages/hoprd/releases.json` and if needed in `packages/core/protocol-config.json`. If the entries are missing, create and merge them before starting the actual release process. This step can be done way in advance to plan environments and releases, too.
 3. (on `master`) Now create the release branch locally. E.g. doing `git checkout -b release/${RELEASE_NAME}`.
 4. (on `release/${RELEASE_NAME}`) Before pushing the branch to Github, some release-specific changes should be applied to ensure the resulting CD artifacts actually are proper release artifacts.
 

--- a/.processes/release.md
+++ b/.processes/release.md
@@ -148,21 +148,20 @@ particular branch to deploy on every change.
 1. (on `master`) As a preparation for a release there should be a respective entry in `packages/hoprs/releases.json` and if needed in `packages/core/protocol-config.json`. If the entries are missing, create and merge them before starting the actual release process. This step can be done way in advance to plan environments and releases, too.
 1. (on `master`) Now create the release branch locally. E.g. doing `git checkout -b release/${RELEASE_NAME}`.
 1. (on `release/${RELEASE_NAME}`) Before pushing the branch to Github, some release-specific changes should be applied to ensure the resulting CD artifacts actually are proper release artifacts.
-   1.1. Change all occurences of the last release name to the new release name within documentation files and Docker files. Don't touch the `protocol-config.json` and `releases.json` files in this step. Changes should be committed locally.
-   1.2. Change use of `master-goerli` in `packages/avado/Dockerfile` to the new release name. Changes should be committed locally.
-   1.3. Update `CHANGELOG.md` with the new release's information. Changes should be committed locally.
-   1.4. Copy contract deployment files from the old release. This can be done doing
+    1. Change all occurences of the last release name to the new release name within documentation files and Docker files. Don't touch the `protocol-config.json` and `releases.json` files in this step. Changes should be committed locally.
+    1. Change use of `master-goerli` in `packages/avado/Dockerfile` to the new release name. Changes should be committed locally.
+    1. Update `CHANGELOG.md` with the new release's information. Changes should be committed locally.
+    1. Copy contract deployment files from the old release. This can be done doing
 
-   ```
-   mkdir -p packages/ethereum/deployments/${RELEASE_NAME}/xdai
-   cp packages/ethereum/deployments/${OLD_RELEASE_NAME}/xdai/* packages/ethereum/deployments/${RELEASE_NAME}/xdai/
-   rm packages/ethereum/deployments/${RELEASE_NAME}/xdai/HoprChannels.json
-   ```
+    ```
+    mkdir -p packages/ethereum/deployments/${RELEASE_NAME}/xdai
+    cp packages/ethereum/deployments/${OLD_RELEASE_NAME}/xdai/* packages/ethereum/deployments/${RELEASE_NAME}/xdai/
+    rm packages/ethereum/deployments/${RELEASE_NAME}/xdai/HoprChannels.json
+    ```
+  
+    NOTE: Don't include the deployment of HoprChannels, because this will be re-deployed anyway by the CD system.
 
-   NOTE: Don't include the deployment of HoprChannels, because this will be re-deployed anyway by the CD system.
-
-   Changes should be committed locally.
-
+    Changes should be committed locally.
 1. (on `release/${RELEASE_NAME}`) Now everything is ready and can be pushed to Github: `git push origin`. Wait until the deployment of the basic cluster has completed by the CD.
 1. Create a release tracking PR which can be used to follow CD builds. However, the PR should never be merged! As a reference take a look at https://github.com/hoprnet/hoprnet/pull/3048
 1. (on `release/${RELEASE_NAME}`) Start a topology cluster using the script mentioned at the end of this document.
@@ -183,9 +182,9 @@ Once the release testing has concluded, or if any signifant amount of patches we
 1. (on `merge-back-release-${RELEASE_NAME}`) Merge `master` into the branch: `git merge master`.
    For an example of a merge-back, take a look at older releases: https://github.com/hoprnet/hoprnet/pull/2956
    In case of conflicts (which is expected) changes from `master` have preference in the following cases:
-   1.1. Revert changes in `packages/avado/docker-compose.yml`
-   1.2. Revert any chain specific changes.
-   1.3. Revert changes made to Avado configuration files as part of the initial release creation.
+    1. Revert changes in `packages/avado/docker-compose.yml`
+    1. Revert any chain specific changes.
+    1. Revert changes made to Avado configuration files as part of the initial release creation.
 
 ### Actions
 
@@ -216,17 +215,15 @@ daily workflow as it was before.
 The following are a series of manual tasks that are needed to be executed for the launch of a release. Ideally, we automate these entirely and delete this document in the future, but in the meantime, we'll have this document to keep track of these.
 
 - [ ] Deploy a set of `$release` CT nodes for our testnet using our **`cover-traffic` deployment script**.
-
 - [ ] Deploy a set of `$release` cloud nodes for our testnet with a full topology connected to feed event data for our leaderboard using our **`topology` deployment script**.
+- [ ] Verify the $release smart contract in the explorer platform, see [verification guide](../VERIFICATION_GUIDE.md).
 
-- [ ] Tag a distribution manually $release on npm and on Docker Hub.
-
-  1. `npm login`, `npm dist-tag add @hoprnet/hoprd@$version $mountain/$city`
-  2. `docker login`, `docker tag gcr.io/hoprassociation/hoprd:latest hopr/hoprd:$city/$mountain`
+##### Optional
 
 - [ ] Create a DNS alias for each node (cloud, cover-traffic, topology), to be accessed via our `hoprnet.link` domain (e.g. ct-1-$release.hoprnet.link)
-
-- [ ] Verify the $release smart contract in the explorer platform, see [verification guide](../VERIFICATION_GUIDE.md).
+- [ ] Tag a distribution manually $release on npm and on Docker Hub.
+    - `npm login`, `npm dist-tag add @hoprnet/hoprd@$version $mountain/$city`
+    - `docker login`, `docker tag gcr.io/hoprassociation/hoprd:latest hopr/hoprd:$city/$mountain`
 
 #### Per $chain
 

--- a/.processes/release.md
+++ b/.processes/release.md
@@ -146,44 +146,46 @@ particular branch to deploy on every change.
 
 1. Create a release tracking issue on Github. Use previous issues as templates: https://github.com/hoprnet/hoprnet/issues/3044
 1. (on `master`) As a preparation for a release there should be a respective entry in `packages/hoprs/releases.json` and if needed in `packages/core/protocol-config.json`. If the entries are missing, create and merge them before starting the actual release process. This step can be done way in advance to plan environments and releases, too.
-2. (on `master`) Now create the release branch locally. E.g. doing `git checkout -b release/${RELEASE_NAME}`.
-3. (on `release/${RELEASE_NAME}`) Before pushing the branch to Github, some release-specific changes should be applied to ensure the resulting CD artifacts actually are proper release artifacts.
-3.1. Change all occurences of the last release name to the new release name within documentation files and Docker files. Don't touch the `protocol-config.json` and `releases.json` files in this step. Changes should be committed locally.
-3.2. Change use of `master-goerli` in `packages/avado/Dockerfile` to the new release name. Changes should be committed locally. 
-3.3. Update `CHANGELOG.md` with the new release's information. Changes should be committed locally.
-3.4. Copy contract deployment files from the old release. This can be done doing
-  ```
-  mkdir -p packages/ethereum/deployments/${RELEASE_NAME}/xdai
-  cp packages/ethereum/deployments/${OLD_RELEASE_NAME}/xdai/* packages/ethereum/deployments/${RELEASE_NAME}/xdai/
-  rm packages/ethereum/deployments/${RELEASE_NAME}/xdai/HoprChannels.json
-  ```
-  
-  NOTE: Don't include the deployment of HoprChannels, because this will be re-deployed anyway by the CD system.
-  
-  Changes should be committed locally.
-4. (on `release/${RELEASE_NAME}`) Now everything is ready and can be pushed to Github: `git push origin`. Wait until the deployment of the basic cluster has completed by the CD.
-5. Create a release tracking PR which can be used to follow CD builds. However, the PR should never be merged! As a reference take a look at https://github.com/hoprnet/hoprnet/pull/3048
-6. (on `release/${RELEASE_NAME}`) Start a topology cluster using the script mentioned at the end of this document.
-7. Create a release testnet page in the wiki at: https://www.notion.so/Testnets-e53255f7003f4c8eae2f1b6644a676e0
+1. (on `master`) Now create the release branch locally. E.g. doing `git checkout -b release/${RELEASE_NAME}`.
+1. (on `release/${RELEASE_NAME}`) Before pushing the branch to Github, some release-specific changes should be applied to ensure the resulting CD artifacts actually are proper release artifacts.
+   1.1. Change all occurences of the last release name to the new release name within documentation files and Docker files. Don't touch the `protocol-config.json` and `releases.json` files in this step. Changes should be committed locally.
+   1.2. Change use of `master-goerli` in `packages/avado/Dockerfile` to the new release name. Changes should be committed locally.
+   1.3. Update `CHANGELOG.md` with the new release's information. Changes should be committed locally.
+   1.4. Copy contract deployment files from the old release. This can be done doing
+
+   ```
+   mkdir -p packages/ethereum/deployments/${RELEASE_NAME}/xdai
+   cp packages/ethereum/deployments/${OLD_RELEASE_NAME}/xdai/* packages/ethereum/deployments/${RELEASE_NAME}/xdai/
+   rm packages/ethereum/deployments/${RELEASE_NAME}/xdai/HoprChannels.json
+   ```
+
+   NOTE: Don't include the deployment of HoprChannels, because this will be re-deployed anyway by the CD system.
+
+   Changes should be committed locally.
+
+1. (on `release/${RELEASE_NAME}`) Now everything is ready and can be pushed to Github: `git push origin`. Wait until the deployment of the basic cluster has completed by the CD.
+1. Create a release tracking PR which can be used to follow CD builds. However, the PR should never be merged! As a reference take a look at https://github.com/hoprnet/hoprnet/pull/3048
+1. (on `release/${RELEASE_NAME}`) Start a topology cluster using the script mentioned at the end of this document.
+1. Create a release testnet page in the wiki at: https://www.notion.so/Testnets-e53255f7003f4c8eae2f1b6644a676e0
    You may use previous testnet pages as templates. Ensure all started nodes are documented.
-8. Share the links to the release tracking issue, tracking PR and testnet wiki page in the `#release` Element channel.
+1. Share the links to the release tracking issue, tracking PR and testnet wiki page in the `#release` Element channel.
    On the `#testing` channel, members are expected to run their own nodes (either AVADO or via their workstation) to participate in the release.
-9. Patches to the release are created via `hotfix/RELEASE_NAME/**` branches.
+1. Patches to the release are created via `hotfix/RELEASE_NAME/**` branches.
    Each of these merges will trigger a new release version, and re-build our infrastructure
    for that version. Upon successfullly testing a release
-10. Once the first release version has been built and is running, the release branch should be merged-back into `master` once to trigger version upgrades on `master`. See the next section for details.
+1. Once the first release version has been built and is running, the release branch should be merged-back into `master` once to trigger version upgrades on `master`. See the next section for details.
 
 Once the release testing has concluded, or if any signifant amount of patches were applied to the release branch, the release branch should be merged back into `master` again.
-   
+
 #### Release merge-back
 
 1. (on `release/${RELEASE_NAME}`) Create a PR branch off of the release branch: `git checkout -b merge-back-release-${RELEASE_NAME}`
-2. (on `merge-back-release-${RELEASE_NAME}`) Merge `master` into the branch: `git merge master`.
+1. (on `merge-back-release-${RELEASE_NAME}`) Merge `master` into the branch: `git merge master`.
    For an example of a merge-back, take a look at older releases: https://github.com/hoprnet/hoprnet/pull/2956
    In case of conflicts (which is expected) changes from `master` have preference in the following cases:
-2.1. Revert changes in `packages/avado/docker-compose.yml`
-2.2. Revert any chain specific changes.
-2.3. Revert changes made to Avado configuration files as part of the initial release creation.
+   1.1. Revert changes in `packages/avado/docker-compose.yml`
+   1.2. Revert any chain specific changes.
+   1.3. Revert changes made to Avado configuration files as part of the initial release creation.
 
 ### Actions
 

--- a/.processes/release.md
+++ b/.processes/release.md
@@ -187,7 +187,7 @@ Once the release testing has concluded, or if any signifant amount of patches we
    1. Revert changes in `packages/avado/docker-compose.yml`
    2. Revert any chain specific changes.
    3. Revert changes made to Avado configuration files as part of the initial release creation.
-3. merge the `merge-back-release-${RELEASE_NAME}` PR back to `master` (ask someone to review first) 
+3. merge the `merge-back-release-${RELEASE_NAME}` PR back to `master` (ask someone to review first)
 
 ### Actions
 

--- a/.processes/release.md
+++ b/.processes/release.md
@@ -145,14 +145,14 @@ particular branch to deploy on every change.
 ```
 
 1. Create a release tracking issue on Github. Use previous issues as templates: https://github.com/hoprnet/hoprnet/issues/3044
-1. (on `master`) As a preparation for a release there should be a respective entry in `packages/hoprs/releases.json` and if needed in `packages/core/protocol-config.json`. If the entries are missing, create and merge them before starting the actual release process. This step can be done way in advance to plan environments and releases, too.
-1. (on `master`) Now create the release branch locally. E.g. doing `git checkout -b release/${RELEASE_NAME}`.
-1. (on `release/${RELEASE_NAME}`) Before pushing the branch to Github, some release-specific changes should be applied to ensure the resulting CD artifacts actually are proper release artifacts.
+2. (on `master`) As a preparation for a release there should be a respective entry in `packages/hoprs/releases.json` and if needed in `packages/core/protocol-config.json`. If the entries are missing, create and merge them before starting the actual release process. This step can be done way in advance to plan environments and releases, too.
+3. (on `master`) Now create the release branch locally. E.g. doing `git checkout -b release/${RELEASE_NAME}`.
+4. (on `release/${RELEASE_NAME}`) Before pushing the branch to Github, some release-specific changes should be applied to ensure the resulting CD artifacts actually are proper release artifacts.
 
    1. Change all occurences of the last release name to the new release name within documentation files and Docker files. Don't touch the `protocol-config.json` and `releases.json` files in this step. Changes should be committed locally.
-   1. Change use of `master-goerli` in `packages/avado/Dockerfile` to the new release name. Changes should be committed locally.
-   1. Update `CHANGELOG.md` with the new release's information. Changes should be committed locally.
-   1. Copy contract deployment files from the old release. This can be done doing
+   2. Change use of `master-goerli` in `packages/avado/Dockerfile` to the new release name. Changes should be committed locally.
+   3. Update `CHANGELOG.md` with the new release's information. Changes should be committed locally.
+   4. Copy contract deployment files from the old release. This can be done doing
 
    ```
    mkdir -p packages/ethereum/deployments/${RELEASE_NAME}/xdai
@@ -164,29 +164,30 @@ particular branch to deploy on every change.
 
    Changes should be committed locally.
 
-1. (on `release/${RELEASE_NAME}`) Now everything is ready and can be pushed to Github: `git push origin`. Wait until the deployment of the basic cluster has completed by the CD.
-1. Create a release tracking PR which can be used to follow CD builds. However, the PR should never be merged! As a reference take a look at https://github.com/hoprnet/hoprnet/pull/3048
-1. (on `release/${RELEASE_NAME}`) Start a topology cluster using the script mentioned at the end of this document.
-1. Create a release testnet page in the wiki at: https://www.notion.so/Testnets-e53255f7003f4c8eae2f1b6644a676e0
+5. (on `release/${RELEASE_NAME}`) Now everything is ready and can be pushed to Github: `git push origin`. Wait until the deployment of the basic cluster has completed by the CD.
+6. Create a release tracking PR which can be used to follow CD builds. However, the PR should never be merged! As a reference take a look at https://github.com/hoprnet/hoprnet/pull/3048
+7. (on `release/${RELEASE_NAME}`) Start a topology cluster using the script mentioned at the end of this document.
+8. Create a release testnet page in the wiki at: https://www.notion.so/Testnets-e53255f7003f4c8eae2f1b6644a676e0
    You may use previous testnet pages as templates. Ensure all started nodes are documented.
-1. Share the links to the release tracking issue, tracking PR and testnet wiki page in the `#release` Element channel.
+9. Share the links to the release tracking issue, tracking PR and testnet wiki page in the `#release` Element channel.
    On the `#testing` channel, members are expected to run their own nodes (either AVADO or via their workstation) to participate in the release.
-1. Patches to the release are created via `hotfix/RELEASE_NAME/**` branches.
-   Each of these merges will trigger a new release version, and re-build our infrastructure
-   for that version. Upon successfullly testing a release
-1. Once the first release version has been built and is running, the release branch should be merged-back into `master` once to trigger version upgrades on `master`. See the next section for details.
+10. Patches to the release are created via `hotfix/RELEASE_NAME/**` branches.
+    Each of these merges will trigger a new release version, and re-build our infrastructure
+    for that version. Upon successfullly testing a release
+11. Once the first release version has been built and is running, the release branch should be merged-back into `master` once to trigger version upgrades on `master`. See the next section for details.
 
 Once the release testing has concluded, or if any signifant amount of patches were applied to the release branch, the release branch should be merged back into `master` again.
 
 #### Release merge-back
 
 1. (on `release/${RELEASE_NAME}`) Create a PR branch off of the release branch: `git checkout -b merge-back-release-${RELEASE_NAME}`
-1. (on `merge-back-release-${RELEASE_NAME}`) Merge `master` into the branch: `git merge master`.
+2. (on `merge-back-release-${RELEASE_NAME}`) Merge `master` into the branch: `git merge master`.
    For an example of a merge-back, take a look at older releases: https://github.com/hoprnet/hoprnet/pull/2956
    In case of conflicts (which is expected) changes from `master` have preference in the following cases:
    1. Revert changes in `packages/avado/docker-compose.yml`
-   1. Revert any chain specific changes.
-   1. Revert changes made to Avado configuration files as part of the initial release creation.
+   2. Revert any chain specific changes.
+   3. Revert changes made to Avado configuration files as part of the initial release creation.
+3. merge the `merge-back-release-${RELEASE_NAME}` PR back to `master` (ask someone to review first) 
 
 ### Actions
 


### PR DESCRIPTION
During the last release `prague` missing documentation was identified. This PR tries to expand the release steps to make most changes clear. As a next improvement most release steps could be automated, but this is out of scope for this change.