### PR TITLE
add api token to address getter in deploy script

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -89,7 +89,7 @@ for git_ref in $(cat "${mydir}/../packages/hoprd/releases.json" | jq -r "to_entr
       declare eth_address
       for ip in ${node_ips}; do
         wait_until_node_is_ready "${ip}"
-        eth_address=$(get_native_address "${ip}:3001")
+        eth_address=$(get_native_address "${api_token}@${ip}:3001")
         fund_if_empty "${eth_address}" "${environment_id}"
       done
     done


### PR DESCRIPTION
The api token was missing when passing the endpoint to the get function.