### PR TITLE
Add missing api token to gcloud cluster creation script

### DIFF
--- a/scripts/setup-gcloud-cluster.sh
+++ b/scripts/setup-gcloud-cluster.sh
@@ -121,7 +121,7 @@ declare node_ips_arr=( ${node_ips} )
 declare eth_address
 for ip in ${node_ips}; do
   wait_until_node_is_ready "${ip}"
-  eth_address=$(get_native_address "${ip}:3001")
+  eth_address=$(get_native_address "${api_token}@${ip}:3001")
   fund_if_empty "${eth_address}" "${environment}"
 done
 


### PR DESCRIPTION
This change is needed, to get the helper script working which is used to start a topology cluster.