### PR TITLE
Fix various issues in CT

### DIFF
--- a/packages/cover-traffic-daemon/src/constants.ts
+++ b/packages/cover-traffic-daemon/src/constants.ts
@@ -1,5 +1,4 @@
 import { PRICE_PER_PACKET } from '@hoprnet/hopr-utils'
-import BN from 'bn.js'
 
 export const CHANNELS_PER_COVER_TRAFFIC_NODE = 10
 export const CT_INTERMEDIATE_HOPS = 2 // 3  // NB. min is 2

--- a/packages/cover-traffic-daemon/src/constants.ts
+++ b/packages/cover-traffic-daemon/src/constants.ts
@@ -2,8 +2,8 @@ import { PRICE_PER_PACKET } from '@hoprnet/hopr-utils'
 import BN from 'bn.js'
 
 export const CHANNELS_PER_COVER_TRAFFIC_NODE = 10
-export const MINIMUM_STAKE_BEFORE_CLOSURE = new BN('0')
 export const CT_INTERMEDIATE_HOPS = 2 // 3  // NB. min is 2
+export const MINIMUM_STAKE_BEFORE_CLOSURE = PRICE_PER_PACKET.muln(CT_INTERMEDIATE_HOPS) // at least one more traffic
 export const CHANNEL_STAKE = PRICE_PER_PACKET.muln(CT_INTERMEDIATE_HOPS).muln(50) // Fund for new CT channels for 50 packets
 export const MESSAGE_FAIL_THRESHOLD = 10 // Failed sends to channel before we autoclose
 export const CT_PATH_RANDOMNESS = 0.2

--- a/packages/cover-traffic-daemon/src/constants.ts
+++ b/packages/cover-traffic-daemon/src/constants.ts
@@ -1,9 +1,10 @@
+import { PRICE_PER_PACKET } from '@hoprnet/hopr-utils'
 import BN from 'bn.js'
 
 export const CHANNELS_PER_COVER_TRAFFIC_NODE = 10
-export const CHANNEL_STAKE = new BN('1000') // Minimum HOPR token balance of the cover traffic node to remain working.
 export const MINIMUM_STAKE_BEFORE_CLOSURE = new BN('0')
 export const CT_INTERMEDIATE_HOPS = 2 // 3  // NB. min is 2
+export const CHANNEL_STAKE = PRICE_PER_PACKET.muln(CT_INTERMEDIATE_HOPS).muln(50) // Fund for new CT channels for 50 packets
 export const MESSAGE_FAIL_THRESHOLD = 10 // Failed sends to channel before we autoclose
 export const CT_PATH_RANDOMNESS = 0.2
 export const CT_NETWORK_QUALITY_THRESHOLD = 0.15 // Minimum channel quality to keep a channel open.

--- a/packages/cover-traffic-daemon/src/strategy.ts
+++ b/packages/cover-traffic-daemon/src/strategy.ts
@@ -67,7 +67,7 @@ export class CoverTrafficStrategy extends SaneDefaults {
         toClose.push(c.destination)
       }
       // If the HOPR token balance of the current CT node is no larger than the `MINIMUM_STAKE_BEFORE_CLOSURE`, close all the non-closed channels.
-      if (c.balance.toBN().lte(MINIMUM_STAKE_BEFORE_CLOSURE)) {
+      if (c.balance.toBN().lt(MINIMUM_STAKE_BEFORE_CLOSURE)) {
         log(`closing channel with balance too low ${c.destination.toB58String()}`)
         toClose.push(c.destination)
       }


### PR DESCRIPTION
1. Fix minimum channel stake. CT node opened channels with too little stake (1e-15), which is clearly too smaller than what messages with 2 intermediate hops would need (0.02). Change the constant so that CT node fund CT channel with tokens for 50 cover traffic.