### PR TITLE
Fix connectivity

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -55,7 +55,7 @@
     "it-pair": "1.0.0",
     "it-pipe": "1.1.0",
     "it-pushable": "1.4.2",
-    "libp2p": "0.35.5",
+    "libp2p": "github:hoprnet/js-libp2p#0d4ea4a2750936ac5138c644caad29408f69cd72",
     "libp2p-interfaces": "2.0.0",
     "libp2p-mplex": "0.10.5",
     "mocha": "9.1.3",

--- a/packages/connect/src/base/listener.spec.ts
+++ b/packages/connect/src/base/listener.spec.ts
@@ -1,684 +1,610 @@
-// @TODO adjust tests
-// import assert from 'assert'
-// import { Listener } from './listener'
-// import { Multiaddr } from 'multiaddr'
-// import type { MultiaddrConnection, Upgrader } from 'libp2p-interfaces/transport'
-// import dgram, { type Socket } from 'dgram'
-// import PeerId from 'peer-id'
-// import { createConnection } from 'net'
-// import * as stun from 'webrtc-stun'
-// import { once, on, EventEmitter } from 'events'
-
-// import { type NetworkInterfaceInfo, networkInterfaces } from 'os'
-// import { u8aEquals, defer, type DeferType, toNetworkPrefix, u8aAddrToString } from '@hoprnet/hopr-utils'
-
-// import type { PublicNodesEmitter, PeerStoreType } from '../types'
-
-// import { waitUntilListening, stopNode, startStunServer } from './utils.spec'
-
-// /**
-//  * Decorated Listener class that emits events after
-//  * updating list of potential relays
-//  */
-// class TestingListener extends Listener {
-//   public emitter: EventEmitter
-//   constructor(...args: ConstructorParameters<typeof Listener>) {
-//     super(...args)
-
-//     this.emitter = new EventEmitter()
-//   }
-
-//   protected onRemoveRelay(peer: PeerId) {
-//     super.onRemoveRelay(peer)
-
-//     this.emitter.emit(`_nodeOffline`, peer)
-//   }
-
-//   protected async updatePublicNodes(peer: PeerId) {
-//     await super.updatePublicNodes(peer)
-
-//     this.emitter.emit(`_newNodeRegistered`, peer)
-//   }
-// }
-
-// async function getPeerStoreEntry(addr: string): Promise<PeerStoreType> {
-//   return {
-//     id: await PeerId.create({ keyType: 'secp256k1' }),
-//     multiaddrs: [new Multiaddr(addr)]
-//   }
-// }
-
-// /**
-//  * Creates a node and attaches message listener to it.
-//  * @param publicNodes emitter that emit an event on new public nodes
-//  * @param initialNodes nodes that are initially known
-//  * @param state check message reception and content of message
-//  * @param expectedMessage message to check for, or undefined to skip this check
-//  * @param peerId peerId of the node
-//  * @returns
-//  */
-// async function startNode(
-//   initialNodes: PeerStoreType[],
-//   state?: { msgReceived?: DeferType<void>; expectedMessageReceived?: DeferType<void> },
-//   expectedMessage?: Uint8Array,
-//   peerId?: PeerId,
-//   upgrader?: Upgrader,
-//   handler?: (conn: any) => any | Promise<any>,
-//   runningLocally?: boolean
-// ) {
-//   peerId = peerId ?? (await PeerId.create({ keyType: 'secp256k1' }))
-//   const publicNodesEmitter = new EventEmitter() as PublicNodesEmitter
-
-//   const listener = new TestingListener(
-//     handler,
-//     upgrader ??
-//       ({
-//         upgradeInbound: async (conn: MultiaddrConnection) => {
-//           if (expectedMessage != undefined) {
-//             for await (const msg of conn.source) {
-//               if (u8aEquals(msg.slice(), expectedMessage)) {
-//                 state?.expectedMessageReceived?.resolve()
-//               }
-//             }
-//           }
-
-//           state?.msgReceived?.resolve()
-//           return conn
-//         },
-//         upgradeOutbound: async (conn: MultiaddrConnection) => conn
-//       } as any),
-//     publicNodesEmitter,
-//     initialNodes,
-//     peerId,
-//     undefined,
-//     runningLocally ?? false
-//   )
-
-//   process.nextTick(() =>
-//     waitUntilListening(listener, new Multiaddr(`/ip4/127.0.0.1/tcp/0/p2p/${peerId!.toB58String()}`))
-//   )
-
-//   const initialNodesRegistered: PeerId[] = []
-
-//   for await (const initialNode of on(listener.emitter, '_newNodeRegistered')) {
-//     if (initialNodesRegistered.push(initialNode[0]) == initialNodes.length) {
-//       break
-//     }
-//   }
-
-//   assert(
-//     initialNodes.every((entry: PeerStoreType) => initialNodesRegistered.some((peer: PeerId) => peer.equals(entry.id)))
-//   )
-
-//   return {
-//     peerId,
-//     listener,
-//     publicNodesEmitter
-//   }
-// }
-
-// describe('check listening to sockets', function () {
-//   it('recreate the socket and perform STUN requests', async function () {
-//     this.timeout(10e3) // 3 seconds should be more than enough
-
-//     let listener: Listener
-//     const peerId = await PeerId.create({ keyType: 'secp256k1' })
-
-//     const AMOUNT = 3
-
-//     const msgReceived = Array.from({ length: AMOUNT }, (_) => defer<void>())
-
-//     const stunServers = await Promise.all(
-//       Array.from({ length: AMOUNT }, (_, index: number) =>
-//         startStunServer(undefined, { msgReceived: msgReceived[index] })
-//       )
-//     )
-
-//     const peerStoreEntries = await Promise.all(
-//       stunServers.map((s: Socket) => getPeerStoreEntry(`/ip4/127.0.0.1/tcp/${s.address().port}`))
-//     )
-
-//     let port: number | undefined
-
-//     for (let i = 0; i < 3; i++) {
-//       listener = new Listener(undefined, undefined as any, undefined, [peerStoreEntries[i]], peerId, undefined, false)
-
-//       let listeningMultiaddr: Multiaddr
-//       if (port != undefined) {
-//         listeningMultiaddr = new Multiaddr(`/ip4/127.0.0.1/tcp/0/p2p/${peerId.toB58String()}`)
-//       } else {
-//         // Listen to previously used port
-//         listeningMultiaddr = new Multiaddr(`/ip4/127.0.0.1/tcp/${port}/p2p/${peerId.toB58String()}`)
-//       }
-
-//       await waitUntilListening(listener, listeningMultiaddr)
-//       if (port == undefined) {
-//         // Store the port to which we have listened before
-//         port = listener.getPort()
-//       }
-//       assert(port != undefined)
-//       await stopNode(listener)
-//     }
-
-//     await Promise.all(msgReceived.map((received) => received.promise))
-//     await Promise.all(stunServers.map(stopNode))
-//   })
-
-//   it('should contact potential relays and expose relay addresses', async function () {
-//     this.timeout(4e3)
-
-//     const relayContacted = defer<void>()
-
-//     const stunServer = await startStunServer(undefined)
-
-//     const stunPeer = await getPeerStoreEntry(`/ip4/127.0.0.1/udp/${stunServer.address().port}`)
-
-//     const relay = await startNode([stunPeer], {
-//       msgReceived: relayContacted
-//     })
-
-//     const node = await startNode([stunPeer], { msgReceived: defer<void>() })
-
-//     const eventPromise = once(node.listener.emitter, '_newNodeRegistered')
-
-//     node.publicNodesEmitter.emit(`addPublicNode`, {
-//       id: relay.peerId,
-//       multiaddrs: [new Multiaddr(`/ip4/127.0.0.1/tcp/${relay.listener.getPort()}/p2p/${relay.peerId.toB58String()}`)]
-//     })
-
-//     // Checks that relay and STUN got contacted, otherwise timeout
-//     await Promise.all([relayContacted.promise, eventPromise])
-
-//     const addrs = node.listener.getAddrs().map((ma: Multiaddr) => ma.toString())
-
-//     assert(
-//       addrs.includes(`/p2p/${relay.peerId.toB58String()}/p2p-circuit/p2p/${node.peerId.toB58String()}`),
-//       `Listener must expose circuit address`
-//     )
-
-//     await Promise.all([stopNode(node.listener), stopNode(relay.listener), stopNode(stunServer)])
-//   })
-
-//   it('check that node is reachable', async function () {
-//     const stunServer = await startStunServer(undefined)
-//     const msgReceived = defer<void>()
-//     const expectedMessageReceived = defer<void>()
-
-//     const testMessage = new TextEncoder().encode('test')
-
-//     const node = await startNode(
-//       [await getPeerStoreEntry(`/ip4/127.0.0.1/udp/${stunServer.address().port}`)],
-//       {
-//         msgReceived,
-//         expectedMessageReceived
-//       },
-//       testMessage
-//     )
-
-//     const socket = createConnection(
-//       {
-//         host: '127.0.0.1',
-//         port: node.listener.getPort()
-//       },
-//       () => {
-//         socket.write(testMessage, () => {
-//           socket.end()
-//         })
-//       }
-//     )
-
-//     await msgReceived.promise
-
-//     await Promise.all([stopNode(node.listener), stopNode(stunServer)])
-//   })
-
-//   it('should bind to specific interfaces', async function () {
-//     // Test does do not do anything if there are only IPv6 addresses
-//     const usableInterfaces = networkInterfaces()
-
-//     for (const iface of Object.keys(usableInterfaces)) {
-//       const osIface = usableInterfaces[iface]
-
-//       if (osIface == undefined || osIface.some((x) => x.internal) || !osIface.some((x) => x.family == 'IPv4')) {
-//         delete usableInterfaces[iface]
-//       }
-//     }
-
-//     if (Object.keys(usableInterfaces).length == 0) {
-//       // Cannot test without any available interfaces
-//       return
-//     }
-
-//     const firstUsableInterfaceName = Object.keys(usableInterfaces)[0]
-
-//     const address = (usableInterfaces[firstUsableInterfaceName] as NetworkInterfaceInfo[]).filter((addr) => {
-//       if (addr.internal) {
-//         return false
-//       }
-
-//       if (addr.family == 'IPv6') {
-//         return false
-//       }
-
-//       return true
-//     })[0]
-
-//     const network = toNetworkPrefix(address)
-
-//     const notUsableAddress = network.networkPrefix.slice()
-//     // flip first bit of the address
-//     notUsableAddress[0] ^= 128
-
-//     const stunServer = await startStunServer(undefined)
-//     const peerId = await PeerId.create({ keyType: 'secp256k1' })
-
-//     const listener = new Listener(
-//       undefined,
-//       {
-//         upgradeInbound: async (conn: MultiaddrConnection) => conn
-//       } as any,
-//       undefined,
-//       [await getPeerStoreEntry(`/ip4/127.0.0.1/udp/${stunServer.address().port}`)],
-//       peerId,
-//       firstUsableInterfaceName,
-//       false
-//     )
-
-//     await assert.rejects(
-//       () =>
-//         listener.listen(
-//           new Multiaddr(`/ip4/${u8aAddrToString(notUsableAddress, address.family)}/tcp/0/p2p/${peerId.toB58String()}`)
-//         ),
-//       `Must throw if we can't bind to an unusable address`
-//     )
-
-//     await assert.doesNotReject(
-//       async () => await listener.listen(new Multiaddr(`/ip4/${address.address}/tcp/0/p2p/${peerId.toB58String()}`)),
-//       `Must be able to bind to correct address`
-//     )
-
-//     await Promise.all([stopNode(listener), stopNode(stunServer)])
-//   })
-
-//   it('check that node speaks STUN', async function () {
-//     const msgReceived = defer<void>()
-//     const stunServer = await startStunServer(undefined)
-
-//     const node = await startNode([await getPeerStoreEntry(`/ip4/127.0.0.1/udp/${stunServer.address().port}`)])
-
-//     const socket = dgram.createSocket({ type: 'udp4' })
-//     const tid = stun.generateTransactionId()
-
-//     socket.on('message', (msg) => {
-//       const res = stun.createBlank()
-
-//       // if msg is valid STUN message
-//       if (res.loadBuffer(msg)) {
-//         // if msg is BINDING_RESPONSE_SUCCESS and valid content
-//         if (res.isBindingResponseSuccess({ transactionId: tid })) {
-//           const attr = res.getXorMappedAddressAttribute()
-//           // if msg includes attr
-//           if (attr) {
-//             msgReceived.resolve()
-//           }
-//         }
-//       }
-
-//       socket.close()
-//     })
-
-//     const req = stun.createBindingRequest(tid).setFingerprintAttribute()
-
-//     const addrs = node.listener.getAddrs()
-
-//     const localAddress = addrs.find((ma: Multiaddr) => ma.toString().match(/127.0.0.1/))
-
-//     assert(localAddress != null, `Listener must be available on localhost`)
-
-//     socket.send(req.toBuffer(), localAddress.toOptions().port, `localhost`)
-
-//     await msgReceived.promise
-
-//     await stopNode(node.listener)
-//     await stopNode(stunServer)
-//   })
-
-//   it('get the right addresses', async function () {
-//     const stunServer = await startStunServer(undefined)
-
-//     const stunPeer = await getPeerStoreEntry(`/ip4/127.0.0.1/udp/${stunServer.address().port}`)
-//     const relay = await startNode([stunPeer])
-
-//     const node = await startNode([stunPeer])
-
-//     let eventPromise = once(node.listener.emitter, '_newNodeRegistered')
-//     node.publicNodesEmitter.emit('addPublicNode', {
-//       id: relay.peerId,
-//       multiaddrs: [new Multiaddr(`/ip4/127.0.0.1/tcp/${relay.listener.getPort()}/p2p/${relay.peerId.toB58String()}`)]
-//     })
-
-//     await eventPromise
-
-//     eventPromise = once(node.listener.emitter, '_newNodeRegistered')
-//     node.publicNodesEmitter.emit('addPublicNode', {
-//       id: relay.peerId,
-//       multiaddrs: [new Multiaddr(`/ip4/127.0.0.1/tcp/${relay.listener.getPort()}/p2p/${relay.peerId.toB58String()}`)]
-//     })
-
-//     await eventPromise
-
-//     const addrsFromListener = node.listener.getAddrs()
-
-//     const uniqueAddresses = new Set<string>(addrsFromListener.map((ma: Multiaddr) => ma.toString()))
-
-//     assert(
-//       uniqueAddresses.has(`/p2p/${relay.peerId.toB58String()}/p2p-circuit/p2p/${node.peerId.toB58String()}`),
-//       `Addresses must include relay address`
-//     )
-
-//     assert(
-//       uniqueAddresses.has(`/ip4/127.0.0.1/tcp/${node.listener.getPort()}/p2p/${node.peerId.toB58String()}`),
-//       `Addresses must include relay address`
-//     )
-
-//     assert(addrsFromListener.length == uniqueAddresses.size, `Addresses must not appear twice`)
-
-//     await Promise.all([stopNode(relay.listener), stopNode(node.listener), stopNode(stunServer)])
-//   })
-
-//   it('check connection tracking', async function () {
-//     const stunServer = await startStunServer(undefined)
-//     const stunPeer = await getPeerStoreEntry(`/ip4/127.0.0.1/udp/${stunServer.address().port}`)
-//     const msgReceived = defer<void>()
-//     const expectedMessageReceived = defer<void>()
-
-//     const node = await startNode([stunPeer], {
-//       msgReceived,
-//       expectedMessageReceived
-//     })
-
-//     const bothConnectionsOpened = defer()
-//     let connections = 0
-
-//     node.listener.on('connection', () => {
-//       connections++
-
-//       if (connections == 2) {
-//         bothConnectionsOpened.resolve()
-//       }
-//     })
-
-//     const socketOne = createConnection({
-//       host: '127.0.0.1',
-//       port: node.listener.getPort()
-//     })
-
-//     const socketTwo = createConnection({
-//       host: '127.0.0.1',
-//       port: node.listener.getPort()
-//     })
-
-//     await bothConnectionsOpened.promise
-
-//     assert(node.listener.getConnections() == 2)
-
-//     // Add event listener at the end of the event listeners array
-//     const socketOneClosePromise = once(socketOne, 'close')
-//     const socketTwoClosePromise = once(socketTwo, 'close')
-
-//     socketOne.end()
-//     socketTwo.end()
-
-//     await Promise.all([socketOneClosePromise, socketTwoClosePromise])
-
-//     // let I/O actions happen
-//     await new Promise((resolve) => setImmediate(resolve))
-
-//     assert(node.listener.getConnections() == 0, `Connection must have been removed`)
-
-//     await Promise.all([stopNode(node.listener), stopNode(stunServer)])
-//   })
-
-//   it('add relay node only once', async function () {
-//     const stunServer = await startStunServer(undefined)
-//     const stunPeer = await getPeerStoreEntry(`/ip4/127.0.0.1/udp/${stunServer.address().port}`)
-
-//     const relay = await startNode([stunPeer])
-
-//     const node = await startNode([stunPeer])
-
-//     let eventPromise = once(node.listener.emitter, '_newNodeRegistered')
-
-//     node.publicNodesEmitter.emit(`addPublicNode`, {
-//       id: relay.peerId,
-//       multiaddrs: [new Multiaddr(`/ip4/127.0.0.1/tcp/${relay.listener.getPort()}/p2p/${relay.peerId.toB58String()}`)]
-//     })
-
-//     await eventPromise
-
-//     let addrs = node.listener.getAddrs().map((ma: Multiaddr) => ma.toString())
-
-//     assert(
-//       addrs.includes(`/p2p/${relay.peerId.toB58String()}/p2p-circuit/p2p/${node.peerId.toB58String()}`),
-//       'Addrs should include new relay node'
-//     )
-
-//     eventPromise = once(node.listener.emitter, '_newNodeRegistered')
-//     node.publicNodesEmitter.emit(`addPublicNode`, {
-//       id: relay.peerId,
-//       multiaddrs: [new Multiaddr(`/ip4/127.0.0.1/tcp/${relay.listener.getPort()}/p2p/${relay.peerId.toB58String()}`)]
-//     })
-
-//     await eventPromise
-
-//     let addrsAfterSecondEvent = node.listener.getAddrs().map((ma: Multiaddr) => ma.toString())
-
-//     assert(addrs.length == addrsAfterSecondEvent.length)
-
-//     assert(
-//       addrsAfterSecondEvent.includes(`/p2p/${relay.peerId.toB58String()}/p2p-circuit/p2p/${node.peerId.toB58String()}`),
-//       'Addrs should include new relay node'
-//     )
-
-//     await Promise.all([stopNode(node.listener), stopNode(relay.listener), stopNode(stunServer)])
-//   })
-
-//   it('overwrite existing relays', async function () {
-//     this.timeout(3e3) // 3 seconds should be more than enough
-//     const stunServer = await startStunServer(undefined)
-//     const stunPeer = await getPeerStoreEntry(`/ip4/127.0.0.1/udp/${stunServer.address().port}`)
-
-//     const relay = await startNode([stunPeer])
-
-//     const node = await startNode([stunPeer])
-
-//     let eventPromise = once(node.listener.emitter, '_newNodeRegistered')
-
-//     node.publicNodesEmitter.emit(`addPublicNode`, {
-//       id: relay.peerId,
-//       multiaddrs: [new Multiaddr(`/ip4/127.0.0.1/tcp/${relay.listener.getPort()}/p2p/${relay.peerId.toB58String()}`)]
-//     })
-
-//     await eventPromise
-
-//     eventPromise = once(node.listener.emitter, '_newNodeRegistered')
-
-//     let addrs = node.listener.getAddrs().map((ma: Multiaddr) => ma.toString())
-
-//     assert(addrs.includes(`/p2p/${relay.peerId.toB58String()}/p2p-circuit/p2p/${node.peerId.toB58String()}`))
-
-//     node.publicNodesEmitter.emit(`addPublicNode`, {
-//       id: relay.peerId,
-//       multiaddrs: [new Multiaddr(`/ip4/127.0.0.1/tcp/${relay.listener.getPort()}/p2p/${relay.peerId.toB58String()}`)]
-//     })
-
-//     await eventPromise
-
-//     // Stop first relay and let it attach to different port
-//     await stopNode(relay.listener)
-
-//     const newRelay = await startNode([stunPeer], undefined, undefined, relay.peerId)
-
-//     eventPromise = once(node.listener.emitter, '_newNodeRegistered')
-//     node.publicNodesEmitter.emit(`addPublicNode`, {
-//       id: relay.peerId,
-//       multiaddrs: [new Multiaddr(`/ip4/127.0.0.1/tcp/${newRelay.listener.getPort()}/p2p/${relay.peerId.toB58String()}`)]
-//     })
-
-//     await eventPromise
-
-//     const addrsAfterThirdEvent = node.listener.getAddrs()
-
-//     assert(addrs.length == addrsAfterThirdEvent.length)
-
-//     await Promise.all([stopNode(node.listener), stopNode(newRelay.listener), stopNode(stunServer)])
-//   })
-
-//   it('remove offline relay nodes', async function () {
-//     const stunServer = await startStunServer(undefined)
-//     const stunPeer = await getPeerStoreEntry(`/ip4/127.0.0.1/udp/${stunServer.address().port}`)
-
-//     const relay = await startNode([stunPeer])
-
-//     const node = await startNode([stunPeer])
-
-//     let eventPromise = once(node.listener.emitter, '_newNodeRegistered')
-
-//     node.publicNodesEmitter.emit(`addPublicNode`, {
-//       id: relay.peerId,
-//       multiaddrs: [new Multiaddr(`/ip4/127.0.0.1/tcp/${relay.listener.getPort()}/p2p/${relay.peerId.toB58String()}`)]
-//     })
-
-//     await eventPromise
-
-//     let addrs = node.listener.getAddrs().map((ma: Multiaddr) => ma.toString())
-
-//     assert(addrs.includes(`/p2p/${relay.peerId.toB58String()}/p2p-circuit/p2p/${node.peerId.toB58String()}`))
-
-//     eventPromise = once(node.listener.emitter, '_nodeOffline')
-
-//     node.publicNodesEmitter.emit(`removePublicNode`, relay.peerId)
-
-//     await eventPromise
-
-//     let addrsAfterRemoval = node.listener.getAddrs().map((ma: Multiaddr) => ma.toString())
-
-//     assert(addrs.length - 1 == addrsAfterRemoval.length, 'Addr should be removed, hence size should be reduced by one.')
-//     assert(
-//       !addrsAfterRemoval.includes(`/p2p/${relay.peerId.toB58String()}/p2p-circuit/p2p/${node.peerId.toB58String()}`),
-//       'Addrs should not contain removed node'
-//     )
-
-//     await Promise.all([stopNode(node.listener), stopNode(relay.listener), stopNode(stunServer)])
-//   })
-
-//   it('remove offline relay nodes - edge cases', async function () {
-//     const stunServer = await startStunServer(undefined)
-//     const stunPeer = await getPeerStoreEntry(`/ip4/127.0.0.1/udp/${stunServer.address().port}`)
-
-//     const relay = await startNode([stunPeer])
-
-//     const node = await startNode([stunPeer])
-
-//     let addrs = node.listener.getAddrs().map((ma: Multiaddr) => ma.toString())
-
-//     let eventPromise = once(node.listener.emitter, '_nodeOffline')
-
-//     node.publicNodesEmitter.emit(`removePublicNode`, relay.peerId)
-
-//     await eventPromise
-
-//     let addrsAfterRemoval = node.listener.getAddrs().map((ma: Multiaddr) => ma.toString())
-
-//     assert(
-//       addrs.length == addrsAfterRemoval.length,
-//       'Number of addresses should stay same after removing invalid multiaddr'
-//     )
-//     assert(
-//       !addrsAfterRemoval.includes(`/p2p/${relay.peerId.toB58String()}/p2p-circuit/p2p/${node.peerId.toB58String()}`),
-//       'Addrs should not include addr of invalid node'
-//     )
-//     assert(
-//       addrs.every((addr: string) => addrsAfterRemoval.some((addrAfterRemoval: string) => addr === addrAfterRemoval)),
-//       'Addrs should stay same after trying remove invalid multiaddr'
-//     )
-
-//     await Promise.all([stopNode(node.listener), stopNode(relay.listener), stopNode(stunServer)])
-//   })
-// })
-
-// describe('error cases', function () {
-//   it('throw error while upgrading the connection', async () => {
-//     const peer = await PeerId.create({ keyType: 'secp256k1' })
-//     const stunServer = await startStunServer(undefined)
-
-//     const node = await startNode(
-//       [await getPeerStoreEntry(`/ip4/127.0.0.1/udp/${stunServer.address().port}`)],
-//       undefined,
-//       undefined,
-//       peer,
-//       {
-//         upgradeInbound: async (_maConn: MultiaddrConnection) => {
-//           await new Promise((resolve) => setTimeout(resolve, 100))
-
-//           throw Error('foo')
-//         }
-//       } as any
-//     )
-
-//     const socket = createConnection(
-//       {
-//         host: '127.0.0.1',
-//         port: node.listener.getPort()
-//       },
-//       async () => {
-//         await new Promise((resolve) => setTimeout(resolve, 200))
-
-//         socket.end()
-//       }
-//     )
-
-//     await new Promise((resolve) => setTimeout(resolve, 300))
-
-//     await Promise.all([node.listener, stunServer].map(stopNode))
-//   })
-
-//   it('throw unexpected error', async function () {
-//     // This unit test case produces an uncaught error in case there
-//     // is no "global" try / catch on incoming socket connections
-//     const peer = await PeerId.create({ keyType: 'secp256k1' })
-//     const stunServer = await startStunServer(undefined)
-
-//     const node = await startNode(
-//       [await getPeerStoreEntry(`/ip4/127.0.0.1/udp/${stunServer.address().port}`)],
-//       undefined,
-//       undefined,
-//       peer,
-//       {
-//         upgradeInbound: async (_maConn: MultiaddrConnection) => {
-//           await new Promise((resolve) => setTimeout(resolve, 100))
-
-//           return {}
-//         }
-//       } as any,
-//       // Simulate an unexpected error while processing data
-//       (conn: any) => conn.nonExisting()
-//     )
-
-//     const socket = createConnection(
-//       {
-//         host: '127.0.0.1',
-//         port: node.listener.getPort()
-//       },
-//       async () => {
-//         await new Promise((resolve) => setTimeout(resolve, 200))
-
-//         socket.end()
-//       }
-//     )
-
-//     await new Promise((resolve) => setTimeout(resolve, 300))
-
-//     await Promise.all([node.listener, stunServer].map(stopNode))
-//   })
-// })
+import assert from 'assert'
+import { Listener, MAX_RELAYS_PER_NODE } from './listener'
+import { Multiaddr } from 'multiaddr'
+import type { MultiaddrConnection, Upgrader } from 'libp2p-interfaces/transport'
+import dgram, { type Socket } from 'dgram'
+import PeerId from 'peer-id'
+import { createConnection } from 'net'
+import * as stun from 'webrtc-stun'
+import { once, EventEmitter } from 'events'
+import { randomBytes } from 'crypto'
+import type { AddressInfo } from 'net'
+
+import { type NetworkInterfaceInfo, networkInterfaces } from 'os'
+import {
+  u8aEquals,
+  defer,
+  type DeferType,
+  toNetworkPrefix,
+  u8aAddrToString,
+  privKeyToPeerId,
+  u8aToHex
+} from '@hoprnet/hopr-utils'
+
+import type { PublicNodesEmitter, PeerStoreType } from '../types'
+
+import { waitUntilListening, stopNode, startStunServer } from './utils.spec'
+
+/**
+ * Decorated Listener class that allows access to
+ * private class properties
+ */
+class TestingListener extends Listener {
+  // @ts-ignore
+  public uncheckedNodes: InstanceType<typeof Listener>['uncheckedNodes']
+  // @ts-ignore
+  public publicNodes: InstanceType<typeof Listener>['publicNodes']
+
+  // @ts-ignore
+  public addrs: InstanceType<typeof Listener>['addrs']
+
+  // @ts-ignore
+  public tcpSocket: InstanceType<typeof Listener>['tcpSocket']
+
+  public onNewRelay(...args: Parameters<InstanceType<typeof Listener>['onNewRelay']>) {
+    return super.onNewRelay(...args)
+  }
+  public onRemoveRelay(peer: PeerId) {
+    return super.onRemoveRelay(peer)
+  }
+
+  public async updatePublicNodes() {
+    return super.updatePublicNodes()
+  }
+
+  public getPort(): number {
+    return (this.tcpSocket.address() as AddressInfo)?.port ?? -1
+  }
+}
+
+function getPeerStoreEntry(addr: string, id = createPeerId()): PeerStoreType {
+  return {
+    id,
+    multiaddrs: [new Multiaddr(addr)]
+  }
+}
+
+/**
+ * Synchronous function to sample PeerIds
+ * @returns a PeerId
+ */
+function createPeerId(): PeerId {
+  return privKeyToPeerId(u8aToHex(randomBytes(32)))
+}
+
+/**
+ * Creates a node and attaches message listener to it.
+ * @param publicNodes emitter that emit an event on new public nodes
+ * @param initialNodes nodes that are initially known
+ * @param state check message reception and content of message
+ * @param expectedMessage message to check for, or undefined to skip this check
+ * @param peerId peerId of the node
+ * @returns
+ */
+async function startNode(
+  initialNodes: PeerStoreType[] = [],
+  state: { msgReceived?: DeferType<void>; expectedMessageReceived?: DeferType<void> } = {},
+  expectedMessage: Uint8Array | undefined = undefined,
+  peerId = createPeerId(),
+  upgrader?: Upgrader,
+  handler?: (conn: any) => any | Promise<any>,
+  runningLocally?: boolean
+) {
+  const publicNodesEmitter = new EventEmitter() as PublicNodesEmitter
+
+  const listener = new TestingListener(
+    handler,
+    upgrader ??
+      ({
+        upgradeInbound: async (conn: MultiaddrConnection) => {
+          if (expectedMessage != undefined) {
+            for await (const msg of conn.source) {
+              if (u8aEquals(msg.slice(), expectedMessage)) {
+                state?.expectedMessageReceived?.resolve()
+              }
+            }
+          }
+
+          state?.msgReceived?.resolve()
+          return conn
+        },
+        upgradeOutbound: async (conn: MultiaddrConnection) => conn
+      } as any),
+    publicNodesEmitter,
+    initialNodes,
+    peerId,
+    undefined,
+    runningLocally ?? false
+  )
+
+  await waitUntilListening(listener, new Multiaddr(`/ip4/127.0.0.1/tcp/0/p2p/${peerId.toB58String()}`))
+
+  return {
+    peerId,
+    listener,
+    publicNodesEmitter
+  }
+}
+
+describe('check listening to sockets', function () {
+  it('recreate the socket and perform STUN requests', async function () {
+    this.timeout(10e3) // 3 seconds should be more than enough
+
+    let listener: TestingListener
+    const peerId = createPeerId()
+
+    const AMOUNT = 3
+
+    const msgReceived = Array.from({ length: AMOUNT }, (_) => defer<void>())
+
+    const stunServers = await Promise.all(
+      Array.from({ length: AMOUNT }, (_, index: number) =>
+        startStunServer(undefined, { msgReceived: msgReceived[index] })
+      )
+    )
+
+    const peerStoreEntries = stunServers.map((s: Socket) => getPeerStoreEntry(`/ip4/127.0.0.1/tcp/${s.address().port}`))
+
+    let port: number | undefined
+
+    for (let i = 0; i < 3; i++) {
+      listener = new TestingListener(
+        undefined,
+        undefined as any,
+        undefined,
+        [peerStoreEntries[i]],
+        peerId,
+        undefined,
+        false
+      )
+
+      let listeningMultiaddr: Multiaddr
+      if (port != undefined) {
+        listeningMultiaddr = new Multiaddr(`/ip4/127.0.0.1/tcp/0/p2p/${peerId.toB58String()}`)
+      } else {
+        // Listen to previously used port
+        listeningMultiaddr = new Multiaddr(`/ip4/127.0.0.1/tcp/${port}/p2p/${peerId.toB58String()}`)
+      }
+
+      await waitUntilListening(listener, listeningMultiaddr)
+      if (port == undefined) {
+        // Store the port to which we have listened before
+        port = listener.getPort()
+      }
+      assert(port != undefined)
+      await stopNode(listener)
+    }
+
+    await Promise.all(msgReceived.map((received) => received.promise))
+    await Promise.all(stunServers.map(stopNode))
+  })
+
+  it('check that node is reachable', async function () {
+    const stunServer = await startStunServer(undefined)
+    const msgReceived = defer<void>()
+    const expectedMessageReceived = defer<void>()
+
+    const testMessage = new TextEncoder().encode('test')
+
+    const node = await startNode(
+      [getPeerStoreEntry(`/ip4/127.0.0.1/udp/${stunServer.address().port}`)],
+      {
+        msgReceived,
+        expectedMessageReceived
+      },
+      testMessage
+    )
+
+    const socket = createConnection(
+      {
+        host: '127.0.0.1',
+        port: node.listener.getPort()
+      },
+      () => {
+        socket.write(testMessage, () => {
+          socket.end()
+        })
+      }
+    )
+
+    await msgReceived.promise
+
+    await Promise.all([stopNode(node.listener), stopNode(stunServer)])
+  })
+
+  it('should bind to specific interfaces', async function () {
+    // Test does do not do anything if there are only IPv6 addresses
+    const usableInterfaces = networkInterfaces()
+
+    for (const iface of Object.keys(usableInterfaces)) {
+      const osIface = usableInterfaces[iface]
+
+      if (osIface == undefined || osIface.some((x) => x.internal) || !osIface.some((x) => x.family == 'IPv4')) {
+        delete usableInterfaces[iface]
+      }
+    }
+
+    if (Object.keys(usableInterfaces).length == 0) {
+      // Cannot test without any available interfaces
+      return
+    }
+
+    const firstUsableInterfaceName = Object.keys(usableInterfaces)[0]
+
+    const address = (usableInterfaces[firstUsableInterfaceName] as NetworkInterfaceInfo[]).filter((addr) => {
+      if (addr.internal) {
+        return false
+      }
+
+      if (addr.family == 'IPv6') {
+        return false
+      }
+
+      return true
+    })[0]
+
+    const network = toNetworkPrefix(address)
+
+    const notUsableAddress = network.networkPrefix.slice()
+    // flip first bit of the address
+    notUsableAddress[0] ^= 128
+
+    const stunServer = await startStunServer(undefined)
+    const peerId = createPeerId()
+
+    const listener = new Listener(
+      undefined,
+      {
+        upgradeInbound: async (conn: MultiaddrConnection) => conn
+      } as any,
+      undefined,
+      [getPeerStoreEntry(`/ip4/127.0.0.1/udp/${stunServer.address().port}`)],
+      peerId,
+      firstUsableInterfaceName,
+      false
+    )
+
+    await assert.rejects(
+      () =>
+        listener.listen(
+          new Multiaddr(`/ip4/${u8aAddrToString(notUsableAddress, address.family)}/tcp/0/p2p/${peerId.toB58String()}`)
+        ),
+      `Must throw if we can't bind to an unusable address`
+    )
+
+    await assert.doesNotReject(
+      async () => await listener.listen(new Multiaddr(`/ip4/${address.address}/tcp/0/p2p/${peerId.toB58String()}`)),
+      `Must be able to bind to correct address`
+    )
+
+    await Promise.all([stopNode(listener), stopNode(stunServer)])
+  })
+
+  it('check that node speaks STUN', async function () {
+    const msgReceived = defer<void>()
+    const stunServer = await startStunServer(undefined)
+
+    const node = await startNode([getPeerStoreEntry(`/ip4/127.0.0.1/udp/${stunServer.address().port}`)])
+
+    const socket = dgram.createSocket({ type: 'udp4' })
+    const tid = stun.generateTransactionId()
+
+    socket.on('message', (msg) => {
+      const res = stun.createBlank()
+
+      // if msg is valid STUN message
+      if (res.loadBuffer(msg)) {
+        // if msg is BINDING_RESPONSE_SUCCESS and valid content
+        if (res.isBindingResponseSuccess({ transactionId: tid })) {
+          const attr = res.getXorMappedAddressAttribute()
+          // if msg includes attr
+          if (attr) {
+            msgReceived.resolve()
+          }
+        }
+      }
+
+      socket.close()
+    })
+
+    const req = stun.createBindingRequest(tid).setFingerprintAttribute()
+
+    const addrs = node.listener.getAddrs()
+
+    const localAddress = addrs.find((ma: Multiaddr) => ma.toString().match(/127.0.0.1/))
+
+    assert(localAddress != null, `Listener must be available on localhost`)
+
+    socket.send(req.toBuffer(), localAddress.toOptions().port, `localhost`)
+
+    await msgReceived.promise
+
+    await stopNode(node.listener)
+    await stopNode(stunServer)
+  })
+
+  it('check connection tracking', async function () {
+    const stunServer = await startStunServer(undefined)
+    const stunPeer = getPeerStoreEntry(`/ip4/127.0.0.1/udp/${stunServer.address().port}`)
+    const msgReceived = defer<void>()
+    const expectedMessageReceived = defer<void>()
+
+    const node = await startNode([stunPeer], {
+      msgReceived,
+      expectedMessageReceived
+    })
+
+    const bothConnectionsOpened = defer()
+    let connections = 0
+
+    node.listener.on('connection', () => {
+      connections++
+
+      if (connections == 2) {
+        bothConnectionsOpened.resolve()
+      }
+    })
+
+    const socketOne = createConnection({
+      host: '127.0.0.1',
+      port: node.listener.getPort()
+    })
+
+    const socketTwo = createConnection({
+      host: '127.0.0.1',
+      port: node.listener.getPort()
+    })
+
+    await bothConnectionsOpened.promise
+
+    assert(node.listener.getConnections() == 2)
+
+    // Add event listener at the end of the event listeners array
+    const socketOneClosePromise = once(socketOne, 'close')
+    const socketTwoClosePromise = once(socketTwo, 'close')
+
+    socketOne.end()
+    socketTwo.end()
+
+    await Promise.all([socketOneClosePromise, socketTwoClosePromise])
+
+    // let I/O actions happen
+    await new Promise((resolve) => setImmediate(resolve))
+
+    assert(node.listener.getConnections() == 0, `Connection must have been removed`)
+
+    await Promise.all([stopNode(node.listener), stopNode(stunServer)])
+  })
+})
+
+describe('entry node functionality', function () {
+  it('add public nodes', async function () {
+    const node = await startNode()
+
+    const peerStoreEntry = getPeerStoreEntry(`/ip4/127.0.0.1/tcp/0`)
+
+    node.listener.onNewRelay(peerStoreEntry)
+    // Should filter duplicate
+    node.listener.onNewRelay(peerStoreEntry)
+
+    assert(node.listener.uncheckedNodes.length == 1, `Unchecked nodes must contain one entry`)
+    assert(node.listener.uncheckedNodes[0].id.equals(peerStoreEntry.id), `id must match the generated one`)
+    assert(
+      node.listener.uncheckedNodes[0].multiaddrs.length == peerStoreEntry.multiaddrs.length,
+      `must not contain more multiaddrs`
+    )
+
+    assert(
+      node.listener.addrs.relays == undefined || node.listener.addrs.relays.length == 0,
+      `must not expose any internal addrs`
+    )
+
+    await stopNode(node.listener)
+  })
+
+  it('remove an offline node', async function () {
+    const node = await startNode()
+
+    const peerStoreEntry = getPeerStoreEntry(`/ip4/127.0.0.1/tcp/0`)
+
+    node.listener.publicNodes.push({
+      ...peerStoreEntry,
+      latency: 23
+    })
+
+    node.listener.onRemoveRelay(peerStoreEntry.id)
+
+    assert(node.listener.publicNodes.length == 0, `must remove node from public nodes`)
+
+    assert(
+      node.listener.addrs.relays == undefined || node.listener.addrs.relays.length == 0,
+      `must not expose any internal addrs`
+    )
+
+    await stopNode(node.listener)
+  })
+
+  it('contact potential relays and update relay addresses', async function () {
+    const relayContacted = defer<void>()
+
+    const relay = await startNode(undefined, {
+      msgReceived: relayContacted
+    })
+
+    const node = await startNode([getPeerStoreEntry(`/ip4/127.0.0.1/tcp/${relay.listener.getPort()}`, relay.peerId)])
+
+    await relayContacted.promise
+
+    assert(node.listener.publicNodes.length == 1, `must contain exactly one public node`)
+    assert(node.listener.publicNodes[0].id.equals(relay.peerId), `must contain correct peerId`)
+    assert(node.listener.publicNodes[0].latency >= 0, `latency must be non-negative`)
+
+    assert(node.listener.addrs.relays != undefined, `must expose relay addrs`)
+    assert(node.listener.addrs.relays.length == 1, `must expose exactly one relay addrs`)
+    assert(
+      node.listener.addrs.relays[0].equals(
+        new Multiaddr(`/p2p/${relay.peerId.toB58String()}/p2p-circuit/p2p/${node.peerId.toB58String()}`)
+      ),
+      `must expose the right relay address`
+    )
+
+    await Promise.all([stopNode(relay.listener), stopNode(node.listener)])
+  })
+
+  it('expose limited number of relay addresses', async function () {
+    this.timeout(10e3)
+
+    const relayNodes = await Promise.all(
+      Array.from<any, Promise<[DeferType<void>, Awaited<ReturnType<typeof startNode>>]>>(
+        { length: MAX_RELAYS_PER_NODE },
+        async () => {
+          const relayContacted = defer<void>()
+
+          const relay = await startNode(undefined, {
+            msgReceived: relayContacted
+          })
+
+          return [relayContacted, relay]
+        }
+      )
+    )
+
+    const node = await startNode(
+      relayNodes.map((relayNode) =>
+        getPeerStoreEntry(`/ip4/127.0.0.1/tcp/${relayNode[1].listener.getPort()}`, relayNode[1].peerId)
+      )
+    )
+
+    await Promise.all(relayNodes.map((relayNode) => relayNode[0].promise))
+
+    assert(node.listener.addrs.relays != undefined, `must expose relay addresses`)
+    assert(
+      node.listener.addrs.relays.length == MAX_RELAYS_PER_NODE,
+      `must expose ${MAX_RELAYS_PER_NODE} relay addresses`
+    )
+
+    assert(
+      relayNodes.every((relayNode) =>
+        node.listener.publicNodes.some((publicNode) => publicNode.id.equals(relayNode[1].peerId))
+      ),
+      `must contain all relay nodes`
+    )
+
+    await Promise.all(
+      relayNodes
+        .map((relayNode) => relayNode[1])
+        .concat(node)
+        .map((node) => stopNode(node.listener))
+    )
+  })
+
+  it('update nodes once node became offline', async function () {
+    const node = await startNode()
+
+    const newNode = getPeerStoreEntry(`/ip4/127.0.0.1`)
+
+    const relayContacted = defer<void>()
+
+    const relay = await startNode(undefined, {
+      msgReceived: relayContacted
+    })
+
+    node.listener.publicNodes.push({
+      ...newNode,
+      latency: 23
+    })
+
+    assert(node.listener.publicNodes.length == 1)
+
+    node.listener.uncheckedNodes.push(getPeerStoreEntry(`/ip4/127.0.0.1/tcp/${relay.listener.getPort()}`, relay.peerId))
+
+    node.listener.onRemoveRelay(newNode.id)
+
+    // @ts-ignore
+    assert(node.listener.publicNodes.length == 0)
+
+    await relayContacted.promise
+
+    // Add some propagtion delay
+    await new Promise((resolve) => setTimeout(resolve, 50))
+    assert(node.listener.publicNodes.length == 1)
+
+    await Promise.all([stopNode(node.listener), stopNode(relay.listener)])
+  })
+})
+
+describe('error cases', function () {
+  it('throw error while upgrading the connection', async () => {
+    const peer = createPeerId()
+    const stunServer = await startStunServer(undefined)
+
+    const node = await startNode(
+      [getPeerStoreEntry(`/ip4/127.0.0.1/udp/${stunServer.address().port}`)],
+      undefined,
+      undefined,
+      peer,
+      {
+        upgradeInbound: async (_maConn: MultiaddrConnection) => {
+          await new Promise((resolve) => setTimeout(resolve, 100))
+
+          throw Error('foo')
+        }
+      } as any
+    )
+
+    const socket = createConnection(
+      {
+        host: '127.0.0.1',
+        port: node.listener.getPort()
+      },
+      async () => {
+        await new Promise((resolve) => setTimeout(resolve, 200))
+
+        socket.end()
+      }
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    await Promise.all([node.listener, stunServer].map(stopNode))
+  })
+
+  it('throw unexpected error', async function () {
+    // This unit test case produces an uncaught error in case there
+    // is no "global" try / catch on incoming socket connections
+    const peer = createPeerId()
+    const stunServer = await startStunServer(undefined)
+
+    const node = await startNode(
+      [getPeerStoreEntry(`/ip4/127.0.0.1/udp/${stunServer.address().port}`)],
+      undefined,
+      undefined,
+      peer,
+      {
+        upgradeInbound: async (_maConn: MultiaddrConnection) => {
+          await new Promise((resolve) => setTimeout(resolve, 100))
+
+          return {}
+        }
+      } as any,
+      // Simulate an unexpected error while processing data
+      (conn: any) => conn.nonExisting()
+    )
+
+    const socket = createConnection(
+      {
+        host: '127.0.0.1',
+        port: node.listener.getPort()
+      },
+      async () => {
+        await new Promise((resolve) => setTimeout(resolve, 200))
+
+        socket.end()
+      }
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    await Promise.all([node.listener, stunServer].map(stopNode))
+  })
+})

--- a/packages/connect/src/base/listener.ts
+++ b/packages/connect/src/base/listener.ts
@@ -4,14 +4,13 @@ import { createSocket } from 'dgram'
 import type { RemoteInfo, Socket as UDPSocket } from 'dgram'
 
 import { once, EventEmitter } from 'events'
-import type { PeerStoreType, PublicNodesEmitter, DialOptions } from '../types'
+import type { PeerStoreType, PublicNodesEmitter } from '../types'
 import Debug from 'debug'
-import { green, red } from 'chalk'
+import { red } from 'chalk'
 import { networkInterfaces } from 'os'
 import type { NetworkInterfaceInfo } from 'os'
 
-import AbortController from 'abort-controller'
-import { CODE_P2P, CODE_IP4, CODE_IP6, CODE_TCP, CODE_UDP, RELAY_CONTACT_TIMEOUT } from '../constants'
+import { CODE_P2P, CODE_IP4, CODE_IP6, CODE_TCP, CODE_UDP } from '../constants'
 import type { Connection } from 'libp2p-interfaces/connection'
 import type { MultiaddrConnection, Upgrader, Listener as InterfaceListener } from 'libp2p-interfaces/transport'
 
@@ -81,6 +80,7 @@ class Listener extends EventEmitter implements InterfaceListener {
   private listeningAddr?: Multiaddr
 
   private publicNodes: NodeEntry[]
+  private uncheckedNodes: PeerStoreType[]
 
   private addrs: {
     interface: Multiaddr[]
@@ -109,6 +109,7 @@ class Listener extends EventEmitter implements InterfaceListener {
     super()
 
     this.publicNodes = []
+    this.uncheckedNodes = initialNodes
 
     this.__connections = []
     this.upgrader = upgrader
@@ -157,8 +158,6 @@ class Listener extends EventEmitter implements InterfaceListener {
       relays: []
     }
 
-    initialNodes?.forEach(this.onNewRelay.bind(this))
-
     publicNodes?.on('addPublicNode', this.onNewRelay.bind(this))
 
     publicNodes?.on('removePublicNode', this.onRemoveRelay.bind(this))
@@ -169,42 +168,14 @@ class Listener extends EventEmitter implements InterfaceListener {
    * @param ma Multiaddr of node that is added as a relay opportunity
    */
   private onNewRelay(peer: PeerStoreType) {
-    if (this.publicNodes.length > MAX_RELAYS_PER_NODE || peer.id.equals(this.peerId)) {
+    if (peer.id.equals(this.peerId)) {
       return
     }
 
-    const usableAddresses = peer.multiaddrs.filter(isUsableRelay)
-
-    if (usableAddresses.length == 0) {
-      return
-    }
-
-    let entry = this.publicNodes.find((entry: NodeEntry) => entry.id.equals(peer.id))
-
-    if (entry != undefined) {
-      const newAddresses = usableAddresses.filter((ma: Multiaddr) => !entry!.multiaddrs.includes(ma))
-
-      if (newAddresses.length == 0) {
-        // Nothing added so we can stop
-        return
-      }
-
-      entry.multiaddrs = newAddresses.concat(entry.multiaddrs)
-    } else {
-      entry = {
-        id: peer.id,
-        multiaddrs: peer.multiaddrs,
-        latency: Infinity
-      }
-
-      this.publicNodes.push(entry)
-    }
-
-    if (this.state != State.LISTENING) {
-      once(this, 'listening').then(() => this.updatePublicNodes(peer.id))
-    } else {
-      setImmediate(() => this.updatePublicNodes(peer.id))
-    }
+    this.uncheckedNodes.push({
+      id: peer.id,
+      multiaddrs: peer.multiaddrs.filter(isUsableRelay)
+    })
   }
 
   /**
@@ -212,50 +183,86 @@ class Listener extends EventEmitter implements InterfaceListener {
    * @param ma Multiaddr of node that is considered to be offline now
    */
   protected onRemoveRelay(peer: PeerId) {
-    this.publicNodes = this.publicNodes.filter((entry: NodeEntry) => !entry.id.equals(peer))
+    for (const [index, publicNode] of this.publicNodes.entries()) {
+      if (publicNode.id.equals(peer)) {
+        // Remove node without changing order
+        this.publicNodes.splice(index, 1)
+      }
+    }
 
-    this.addrs.relays = this.publicNodes.map(this.publicNodesToRelayMultiaddr.bind(this))
+    const peerB58String = peer.toB58String()
+    for (const [index, relayAddr] of this.addrs.relays.entries()) {
+      if (relayAddr.getPeerId() === peerB58String) {
+        // Remove node without changing order
+        this.addrs.relays.splice(index, 1)
+      }
+    }
 
     log(
       `relay ${peer.toB58String()} ${red(`removed`)}. Current addrs:\n\t${this.addrs.relays
         .map((addr: Multiaddr) => addr.toString())
         .join(`\n\t`)}`
     )
+
+    // Rebuild later
+    setImmediate(this.updatePublicNodes.bind(this))
   }
 
-  protected async updatePublicNodes(peer: PeerId): Promise<void> {
-    // Get previously known nodes and filter all nodes that have
-    // either the same address (ip:port) or the same peerId
-    const entry = this.publicNodes.find((entry: NodeEntry) => entry.id.equals(peer))
+  protected async updatePublicNodes(): Promise<void> {
+    const nodesToCheck: PeerStoreType[] = []
 
-    if (entry == undefined) {
-      return
+    for (const uncheckedNode of this.uncheckedNodes) {
+      if (uncheckedNode.id.equals(this.peerId)) {
+        return
+      }
+
+      for (const publicNode of this.publicNodes) {
+        if (publicNode.id.equals(uncheckedNode.id)) {
+          // Peer is already a public node, so nothing to do
+          return
+        }
+      }
+
+      const usableAddresses: Multiaddr[] = uncheckedNode.multiaddrs.filter(isUsableRelay)
+
+      // Ignore if entry nodes have more than one address
+      nodesToCheck.push({
+        id: uncheckedNode.id,
+        multiaddrs: [usableAddresses[0]]
+      })
     }
 
-    const abort = new AbortController()
-    const timeout = setTimeout(abort.abort.bind(abort), RELAY_CONTACT_TIMEOUT)
+    const TIMEOUT = 5e3
 
-    const latency = await this.connectToRelay(entry.multiaddrs[0], { signal: abort.signal })
+    const results = (
+      await Promise.allSettled(
+        nodesToCheck.map(async (entry: PeerStoreType): Promise<NodeEntry> => {
+          let latency = await this.connectToRelay(entry.multiaddrs[0], TIMEOUT)
 
-    clearTimeout(timeout)
+          return {
+            ...entry,
+            latency
+          }
+        })
+      )
+    )
+      .filter<PromiseFulfilledResult<NodeEntry>>(
+        (entry): entry is PromiseFulfilledResult<NodeEntry> => entry.status === 'fulfilled'
+      )
+      .map<NodeEntry>((entry) => entry.value)
 
-    // Negative latency === timeout
-    if (latency < 0) {
-      this.publicNodes = this.publicNodes.filter((entry: NodeEntry) => !entry.id.equals(peer.id))
-      return
-    }
+    const sorted = results.concat(this.publicNodes).sort(latencyCompare)
 
-    entry.latency = latency
+    this.publicNodes = sorted.slice(0, MAX_RELAYS_PER_NODE)
 
-    this.publicNodes = this.publicNodes.sort(latencyCompare)
+    this.uncheckedNodes = []
 
     this.addrs.relays = this.publicNodes.map(this.publicNodesToRelayMultiaddr.bind(this))
 
-    log(
-      `relay ${peer.toB58String()} ${green(`added`)}. Current addrs:\n\t${this.addrs.relays
-        .map((addr: Multiaddr) => addr.toString())
-        .join(`\n\t`)}`
-    )
+    log(`Current relay addresses:`)
+    for (const ma of this.addrs.relays) {
+      log(`\t${ma.toString()}`)
+    }
   }
 
   private publicNodesToRelayMultiaddr(entry: NodeEntry) {
@@ -332,6 +339,7 @@ class Listener extends EventEmitter implements InterfaceListener {
     // Prevent from sending a STUN request to self
     let usableStunServers = this.getUsableStunServers(address.port, address.address)
     await this.determinePublicIpAddress(usableStunServers)
+    await this.updatePublicNodes()
 
     this.state = State.LISTENING
     this.emit('listening')
@@ -714,14 +722,14 @@ class Listener extends EventEmitter implements InterfaceListener {
     return usableInterfaces[0].address
   }
 
-  private async connectToRelay(relay: Multiaddr, opts?: DialOptions): Promise<number> {
+  private async connectToRelay(relay: Multiaddr, timeout: number): Promise<number> {
     let conn: Connection | undefined
     let maConn: TCPConnection | undefined
 
     const start = Date.now()
 
     try {
-      maConn = await TCPConnection.create(relay, this.peerId, opts)
+      maConn = await TCPConnection.create(relay, this.peerId, { timeout })
     } catch (err) {
       if (maConn != undefined) {
         await attemptClose(maConn as any)

--- a/packages/connect/src/base/listener.ts
+++ b/packages/connect/src/base/listener.ts
@@ -258,7 +258,7 @@ class Listener extends EventEmitter implements InterfaceListener {
       )
     )
       .filter<PromiseFulfilledResult<NodeEntry>>(
-        (entry): entry is PromiseFulfilledResult<NodeEntry> => entry.status === 'fulfilled'
+        (entry): entry is PromiseFulfilledResult<NodeEntry> => entry.status === 'fulfilled' && entry.value.latency >= 0
       )
       .map<NodeEntry>((entry) => entry.value)
 

--- a/packages/connect/src/base/tcp.ts
+++ b/packages/connect/src/base/tcp.ts
@@ -126,7 +126,11 @@ class TCPConnection implements MultiaddrConnection<StreamType> {
    * @param options.signal Used to abort dial requests
    * @returns Resolves a TCP Socket
    */
-  public static create(ma: Multiaddr, self: PeerId, options?: DialOptions): Promise<TCPConnection> {
+  public static create(
+    ma: Multiaddr,
+    self: PeerId,
+    options?: DialOptions & { timeout?: number }
+  ): Promise<TCPConnection> {
     if (options?.signal?.aborted) {
       throw new AbortError()
     }
@@ -183,6 +187,10 @@ class TCPConnection implements MultiaddrConnection<StreamType> {
         .on('error', onError)
         .on('timeout', onTimeout)
         .on('connect', onConnect)
+
+      if (options?.timeout) {
+        rawSocket.setTimeout(options.timeout)
+      }
 
       options?.signal?.addEventListener('abort', onAbort)
     })

--- a/packages/connect/src/filter.spec.ts
+++ b/packages/connect/src/filter.spec.ts
@@ -27,7 +27,7 @@ describe('test addr filtering', function () {
     filter = new TestFilter(firstPeer)
   })
 
-  it.only('should accept valid circuit addresses', function () {
+  it('should accept valid circuit addresses', function () {
     assert(
       filter.filter(new Multiaddr(`/p2p/${firstPeer.toB58String()}`)) == false,
       'Should not accept relay addrs without recipient'

--- a/packages/connect/src/filter.spec.ts
+++ b/packages/connect/src/filter.spec.ts
@@ -1,10 +1,13 @@
 import type { Network } from '@hoprnet/hopr-utils'
 
 import { Multiaddr } from 'multiaddr'
-import PeerId from 'peer-id'
 import { Filter } from './filter'
 import assert from 'assert'
-import { toNetworkPrefix } from '@hoprnet/hopr-utils'
+import { toNetworkPrefix, privKeyToPeerId } from '@hoprnet/hopr-utils'
+
+let firstPeer = privKeyToPeerId(`0x22f7c3c101db7a73c42d3adecbd2700173f19a249b5ef115c25020b091822083`)
+let secondPeer = privKeyToPeerId(`0xbb25701334f6f989ab51322d0064b3755fc3a65770e4a240df163c355bd8cd26`)
+let thirdPeer = privKeyToPeerId(`0x175590e95d378e66572e09bc9d8badffe087ae962fc7551f17380293d1ca2fc5`)
 
 class TestFilter extends Filter {
   /**
@@ -18,19 +21,13 @@ class TestFilter extends Filter {
 }
 
 describe('test addr filtering', function () {
-  let firstPeer: PeerId, secondPeer: PeerId
   let filter: TestFilter
-
-  before(async function () {
-    firstPeer = await PeerId.create({ keyType: 'secp256k1' })
-    secondPeer = await PeerId.create({ keyType: 'secp256k1' })
-  })
 
   beforeEach(function () {
     filter = new TestFilter(firstPeer)
   })
 
-  it('should accept valid circuit addresses', function () {
+  it.only('should accept valid circuit addresses', function () {
     assert(
       filter.filter(new Multiaddr(`/p2p/${firstPeer.toB58String()}`)) == false,
       'Should not accept relay addrs without recipient'
@@ -46,6 +43,16 @@ describe('test addr filtering', function () {
       filter.filter(new Multiaddr(`/p2p/${secondPeer.toB58String()}/p2p-circuit/p2p/${secondPeer.toB58String()}`)) ==
         false,
       'Should not accept loopbacks'
+    )
+
+    filter.setAddrs(
+      [new Multiaddr(`/ip4/1.1.1.1/tcp/123/p2p/${firstPeer.toB58String()}`)],
+      [new Multiaddr(`/ip4/0.0.0.0/tcp/0/p2p/${firstPeer.toB58String()}`)]
+    )
+
+    assert(
+      filter.filter(new Multiaddr(`/p2p/${secondPeer.toB58String()}/p2p-circuit/p2p/${thirdPeer.toB58String()}`)) ==
+        true
     )
   })
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -40,7 +40,7 @@
     "heap-js": "2.1.6",
     "leveldown": "6.1.0",
     "levelup": "5.1.1",
-    "libp2p": "0.35.5",
+    "libp2p": "github:hoprnet/js-libp2p#0d4ea4a2750936ac5138c644caad29408f69cd72",
     "libp2p-kad-dht": "0.27.4",
     "libp2p-mplex": "0.10.5",
     "multiaddr": "10.0.1",

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -14,7 +14,7 @@ export const HEARTBEAT_INTERVAL_VARIANCE = 2000
 
 export const MAX_PARALLEL_CONNECTIONS = 5
 
-export const HEARTBEAT_TIMEOUT = 4000
+export const HEARTBEAT_TIMEOUT = 8000
 
 export const MAX_PACKET_DELAY = 200
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -546,7 +546,17 @@ class Hopr extends EventEmitter {
    * @param peer peer to query for
    */
   public getObservedAddresses(peer: PeerId): Multiaddr[] {
-    return (this.libp2p.peerStore.get(peer).addresses ?? []).map((addr) => addr.multiaddr)
+    const observedAddresses = this.libp2p.peerStore.get(peer)
+
+    if (
+      observedAddresses == undefined ||
+      observedAddresses.addresses == undefined ||
+      observedAddresses.addresses.length == 0
+    ) {
+      return []
+    }
+
+    return observedAddresses.addresses.map((addr) => addr.multiaddr)
   }
 
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -546,17 +546,7 @@ class Hopr extends EventEmitter {
    * @param peer peer to query for
    */
   public getObservedAddresses(peer: PeerId): Multiaddr[] {
-    const observedAddresses = this.libp2p.peerStore.get(peer)
-
-    if (
-      observedAddresses == undefined ||
-      observedAddresses.addresses == undefined ||
-      observedAddresses.addresses.length == 0
-    ) {
-      return []
-    }
-
-    return observedAddresses.addresses.map((addr) => addr.multiaddr)
+    return (this.libp2p.peerStore.get(peer)?.addresses ?? []).map((addr) => addr.multiaddr)
   }
 
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -219,8 +219,6 @@ class Hopr extends EventEmitter {
 
     recentlyAnnouncedNodes.forEach(this.onPeerAnnouncement.bind(this))
 
-    initialNodes.forEach(this.onPeerAnnouncement.bind(this))
-
     this.libp2p.connectionManager.on('peer:connect', (conn: Connection) => {
       this.emit('hopr:peer:connection', conn.remotePeer)
       this.networkPeers.register(conn.remotePeer)

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -68,9 +68,6 @@ export async function createLibp2pInstance(
       },
       relay: {
         enabled: false
-      },
-      peerDiscovery: {
-        autoDial: false
       }
     },
     dialer: {

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -64,7 +64,9 @@ export async function createLibp2pInstance(
         } as HoprConnectOptions
       },
       dht: {
-        enabled: true
+        enabled: true,
+        // @ts-ignore
+        bootstrapPeers: initialNodes
       },
       relay: {
         enabled: false

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -50,7 +50,7 @@
     "@types/pino": "7.0.4",
     "bl": "5.0.0",
     "chai": "4.3.4",
-    "libp2p": "0.35.5",
+    "libp2p": "github:hoprnet/js-libp2p#0d4ea4a2750936ac5138c644caad29408f69cd72",
     "libp2p-kad-dht": "0.27.4",
     "libp2p-mplex": "0.10.5",
     "libp2p-tcp": "0.17.2",

--- a/packages/utils/src/libp2p/dialHelper.ts
+++ b/packages/utils/src/libp2p/dialHelper.ts
@@ -59,8 +59,13 @@ type ReducedPeerStore = {
 type ReducedDHT = { peerRouting: Pick<LibP2P['peerRouting'], '_routers' | 'findPeer'> }
 type ReducedLibp2p = ReducedDHT & ReducedPeerStore & Pick<LibP2P, 'dialProtocol'>
 
-function printPeerStoreAddresses(msg: string, addresses: Address[], delimiter: string = '\n  '): string {
-  return msg.concat(addresses.map((addr: Address) => addr.multiaddr.toString()).join(delimiter))
+function printPeerStoreAddresses(msg: string, addresses: Address[]): void {
+  logError(msg)
+  logError(`Known addresses:`)
+
+  for (const address of addresses) {
+    logError(address.multiaddr.toString())
+  }
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1165,7 +1165,7 @@ __metadata:
     it-pair: 1.0.0
     it-pipe: 1.1.0
     it-pushable: 1.4.2
-    libp2p: 0.35.5
+    libp2p: "github:hoprnet/js-libp2p#0d4ea4a2750936ac5138c644caad29408f69cd72"
     libp2p-interfaces: 2.0.0
     libp2p-mplex: 0.10.5
     mocha: 9.1.3
@@ -1235,7 +1235,7 @@ __metadata:
     heap-js: 2.1.6
     leveldown: 6.1.0
     levelup: 5.1.1
-    libp2p: 0.35.5
+    libp2p: "github:hoprnet/js-libp2p#0d4ea4a2750936ac5138c644caad29408f69cd72"
     libp2p-kad-dht: 0.27.4
     libp2p-mplex: 0.10.5
     libp2p-tcp: 0.17.2
@@ -1337,7 +1337,7 @@ __metadata:
     jsonschema: 1.4.0
     leveldown: 6.1.0
     levelup: 5.1.1
-    libp2p: 0.35.5
+    libp2p: "github:hoprnet/js-libp2p#0d4ea4a2750936ac5138c644caad29408f69cd72"
     libp2p-crypto: 0.21.0
     libp2p-kad-dht: 0.27.4
     libp2p-mplex: 0.10.5
@@ -11425,9 +11425,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"libp2p@npm:0.35.5":
-  version: 0.35.5
-  resolution: "libp2p@npm:0.35.5"
+"libp2p@github:hoprnet/js-libp2p#0d4ea4a2750936ac5138c644caad29408f69cd72":
+  version: 0.35.6
+  resolution: "libp2p@https://github.com/hoprnet/js-libp2p.git#commit=0d4ea4a2750936ac5138c644caad29408f69cd72"
   dependencies:
     "@vascosantos/moving-average": ^1.1.0
     abort-controller: ^3.0.0
@@ -11480,7 +11480,7 @@ __metadata:
     varint: ^6.0.0
     wherearewe: ^1.0.0
     xsalsa20: ^1.1.0
-  checksum: 2a0d4c8af0431187e1b741a41e3803f3eb51b2cbc8ced60396cc5fd62a1002736ef3b2968231a403bd66bae4efd7521b984e9b885beea190577ef4085c3a9827
+  checksum: 1e589804b198ce3ea636c717b5bc547e280786eca6cce3716d55c4c81a5535003cd70be45e349b169738fe0b251a39c0c11f58cc82b57d943a1a92bdaceb1ba7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes:

- check *all* entry nodes and not the first 7, closes #3180
- allow DHT to dial other peers, i.e. set `autoDial: true`
- fixes an error in libp2p that forwards only one DHT entry, relevant commit https://github.com/hoprnet/js-libp2p/commit/d5c5777df948cb00f016ee3a82830a652cbc246b
- directly feed DHT with bootstrap peers aka *entry nodes*
- fixes #3184 

~~TODO:
adjust unit tests to match changed functionality~~