### PR TITLE
Add git binary to Docker image builder

### DIFF
--- a/packages/hoprd/Dockerfile
+++ b/packages/hoprd/Dockerfile
@@ -6,6 +6,7 @@ FROM node:16-buster-slim@sha256:269885d847d382df99cc93ab5c37d3aea9f81fd8add895a9
 # python is used by some nodejs dependencies as an installation requirement
 RUN apt-get update && \
     apt-get install -y \
+    git \
     python3 \
     build-essential
 


### PR DESCRIPTION
This is required because some dependencies loaded by Yarn might refer to
Git repositories instead of NPM packages. At that point Yarn tries to
use the Git binary locally.

Fixes #3185