### PR TITLE
Add deterministic announce address sorting

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,7 +24,7 @@ import {
   MIN_NATIVE_BALANCE,
   u8aConcat,
   isMultiaddrLocal,
-  getIpv4LocalAddressClass
+  multiaddressCompareByClassFunction
 } from '@hoprnet/hopr-utils'
 import type {
   LibP2PHandlerFunction,
@@ -694,17 +694,15 @@ class Hopr extends EventEmitter {
 
     if (includeRouting) {
       let multiaddrs = await this.getAnnouncedAddresses()
-      multiaddrs.sort((a, b) => {
-        if (isMultiaddrLocal(a) && !isMultiaddrLocal(b)) return this.options.preferLocalAddresses ? -1 : 1
-        else if (!isMultiaddrLocal(a) && isMultiaddrLocal(b)) return this.options.preferLocalAddresses ? 1 : -1
-        else if (isMultiaddrLocal(a) && isMultiaddrLocal(b)) {
-          const clsA = getIpv4LocalAddressClass(a)
-          const clsB = getIpv4LocalAddressClass(b)
-          if (clsA == undefined) return 1
-          if (clsB == undefined) return -1
-          return clsA.localeCompare(clsB)
-        } else return 0
-      })
+
+      // If we need local addresses, sort them first according to their class
+      if (this.options.preferLocalAddresses) {
+        multiaddrs.sort(multiaddressCompareByClassFunction)
+      }
+      else {
+        // If we don't need local addresses, just throw them away
+        multiaddrs = multiaddrs.filter((ma) => !isMultiaddrLocal(ma))
+      }
 
       log(`available multiaddresses ${multiaddrs}`)
 

--- a/packages/utils/src/libp2p/addressSorters.ts
+++ b/packages/utils/src/libp2p/addressSorters.ts
@@ -2,6 +2,7 @@ import { Address } from 'libp2p/src/peer-store'
 import { isPrivateAddress, isLocalhost, ipToU8aAddress } from '../network'
 import { Multiaddr } from 'multiaddr'
 import type { NetworkInterfaceInfo } from 'os'
+import { log } from 'debug'
 
 /**
  * Checks if given Multiaddr encodes a private address
@@ -26,7 +27,8 @@ export function isMultiaddrLocal(multiaddr: Multiaddr): boolean {
 
     const u8aAddr = ipToU8aAddress(address, ipFamily)
     return isLocalhost(u8aAddr, ipFamily) || isPrivateAddress(u8aAddr, ipFamily)
-  } catch (e: any) {
+  } catch (err) {
+    log(`failed to determine address locality: ${err}`)
     return false
   }
 }

--- a/packages/utils/src/libp2p/addressSorters.ts
+++ b/packages/utils/src/libp2p/addressSorters.ts
@@ -31,6 +31,25 @@ export function isMultiaddrLocal(multiaddr: Multiaddr): boolean {
   }
 }
 
+export function getIpv4LocalAddressClass(address: Multiaddr): 'A' | 'B' | 'C' | 'D' | undefined {
+
+  if (isMultiaddrLocal(address)) {
+    if (address.toString().startsWith("/ip4/10."))
+      return 'A'
+
+    if (address.toString().startsWith("/ip4/172.16"))
+      return 'B'
+
+    if (address.toString().startsWith("/ip4/192.168."))
+      return 'C'
+
+    if (address.toString().startsWith("/ip4/127.0.0.1"))
+      return 'D'
+  }
+
+  return undefined
+}
+
 function addressesLocalFirstCompareFunction(a: Address, b: Address) {
   const isAPrivate = isMultiaddrLocal(a.multiaddr)
   const isBPrivate = isMultiaddrLocal(b.multiaddr)

--- a/packages/utils/src/libp2p/addressSorters.ts
+++ b/packages/utils/src/libp2p/addressSorters.ts
@@ -21,7 +21,7 @@ export function isMultiaddrLocal(multiaddr: Multiaddr): boolean {
         ipFamily = 'IPv6'
         break
       default:
-        throw Error(`Invalid address family in Multiaddr. Got ${family} but expected either '4' or '6'.`)
+        return false
     }
 
     const u8aAddr = ipToU8aAddress(address, ipFamily)

--- a/packages/utils/src/libp2p/addressSorters.ts
+++ b/packages/utils/src/libp2p/addressSorters.ts
@@ -46,6 +46,31 @@ export function getIpv4LocalAddressClass(address: Multiaddr): 'A' | 'B' | 'C' | 
   return undefined
 }
 
+
+/**
+ * Compare two multiaddresses based on their class: A class first, B class second, ...
+ * Local addresses take precedence over remote addresses.
+ * @param a
+ * @param b
+ */
+export function multiaddressCompareByClassFunction(a: Multiaddr, b: Multiaddr) {
+  if (isMultiaddrLocal(a) && isMultiaddrLocal(b)) {
+    // Sort based on private address class
+    const clsA = getIpv4LocalAddressClass(a)
+    const clsB = getIpv4LocalAddressClass(b)
+    if (clsA == undefined) return 1
+    if (clsB == undefined) return -1
+    return clsA.localeCompare(clsB)
+  }
+  else if (isMultiaddrLocal(a) && !isMultiaddrLocal(b)) {
+    return -1 // Local address takes precedence
+  }
+  else if (!isMultiaddrLocal(a) && isMultiaddrLocal(b)) {
+    return 1 // Local address takes precedence
+  }
+  else return 0
+}
+
 function addressesLocalFirstCompareFunction(a: Address, b: Address) {
   const isAPrivate = isMultiaddrLocal(a.multiaddr)
   const isBPrivate = isMultiaddrLocal(b.multiaddr)

--- a/packages/utils/src/libp2p/addressSorters.ts
+++ b/packages/utils/src/libp2p/addressSorters.ts
@@ -37,7 +37,7 @@ export function getIpv4LocalAddressClass(address: Multiaddr): 'A' | 'B' | 'C' | 
     if (address.toString().startsWith("/ip4/10."))
       return 'A'
 
-    if (address.toString().startsWith("/ip4/172.16"))
+    if (/\/ip4\/172\.((1[6-9])|(2\d)|(3[0-1]))\./.test(address.toString()))
       return 'B'
 
     if (address.toString().startsWith("/ip4/192.168."))


### PR DESCRIPTION
Always sort announced addressed deterministically.

- if preferLocalAddresses is set, addresses are sorted by their class (class A first, class B second,...)
- otherwise only non-local addresses are used and local addresses are discarded