### PR TITLE
Fix endless startup loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,10 @@
     "typescript": "4.5.4",
     "yargs": "17.2.1"
   },
+  "resolutions": {
+    "@overnightjs/logger": "1.2.1",
+    "colors": "1.3.3"
+  },
   "prettier": {
     "tabWidth": 2,
     "semi": false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1764,7 +1764,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@overnightjs/logger@npm:^1.2.0":
+"@overnightjs/logger@npm:1.2.1":
   version: 1.2.1
   resolution: "@overnightjs/logger@npm:1.2.1"
   dependencies:
@@ -5405,10 +5405,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"colors@npm:^1.1.2, colors@npm:^1.3.3":
-  version: 1.4.0
-  resolution: "colors@npm:1.4.0"
-  checksum: 98aa2c2418ad87dedf25d781be69dc5fc5908e279d9d30c34d8b702e586a0474605b3a189511482b9d5ed0d20c867515d22749537f7bc546256c6014f3ebdcec
+"colors@npm:1.3.3":
+  version: 1.3.3
+  resolution: "colors@npm:1.3.3"
+  checksum: c57f0aa2b71a836435fb0cd8ac4b9f4025ff5411cb027ffcbaa2274347fd00ed52b9d66904f46be73086c27ac31bad9500da675250c95182568454b392f87ee5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes #3249

The faulty dependencies are pinned so Yarn doesn't add them by dependency resolution.