### PR TITLE
Move yarn resolution hints into hoprd package

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,10 @@
     "typescript": "4.5.4",
     "yargs": "17.2.1"
   },
+  "resolutions": {
+    "@overnightjs/logger": "1.2.1",
+    "colors": "1.3.3"
+  },
   "prettier": {
     "tabWidth": 2,
     "semi": false,

--- a/package.json
+++ b/package.json
@@ -50,10 +50,6 @@
     "typescript": "4.5.4",
     "yargs": "17.2.1"
   },
-  "resolutions": {
-    "@overnightjs/logger": "1.2.1",
-    "colors": "1.3.3"
-  },
   "prettier": {
     "tabWidth": 2,
     "semi": false,

--- a/packages/hoprd/package.json
+++ b/packages/hoprd/package.json
@@ -86,5 +86,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "resolutions": {
+    "@overnightjs/logger": "1.2.1",
+    "colors": "1.3.3"
+  },
   "stableVersion": "1.76.0-next.31"
 }


### PR DESCRIPTION
Refs #3249

This ensures the hints are packages and usable upon package
installation. Previously, the hints were only available in development
setups.