### PR TITLE
Add arm64 support to the Vagrant NAT testing setup

### DIFF
--- a/scripts/vm-nat-testing/Vagrantfile
+++ b/scripts/vm-nat-testing/Vagrantfile
@@ -1,10 +1,17 @@
 Vagrant.configure("2") do |config|
 
+  # on macOS M1 machines we must use the arm64 image
+  arch = %x( uname -m )
+  if arch.match(/arm64/) then
+    config.vm.box = "bento/ubuntu-20.04-arm64"
+  else
+    config.vm.box = "bento/ubuntu-20.04"
+  end
+
   # shared configuration for all VMs
-  config.vm.box = "generic/ubuntu2004"
-  config.vm.box_version = "3.6.4"
-  config.vm.provision "shell", path: "setup-vm.sh"
+  config.vm.provision "shell", path: "setup-vm.sh", privileged: true
   config.vm.synced_folder "../../", "/opt/hopr"
+  config.vm.box_version = "202112.19.0"
 
   config.vm.define "hoprd-hardhat" do |hat|
     hat.vm.hostname = "hardhat.box"

--- a/scripts/vm-nat-testing/setup-vm.sh
+++ b/scripts/vm-nat-testing/setup-vm.sh
@@ -5,8 +5,8 @@ apt-get -y install ca-certificates curl gnupg lsb-release net-tools iputils-ping
 
 # Install NodeJS
 if ! command -v npm; then
-	curl -fsSL https://deb.nodesource.com/setup_16.x | sudo -E bash -
-	sudo apt-get -y install nodejs
+	curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+	apt-get -y install nodejs
 
 	npm install -g npm
 	npm install -g yarn
@@ -14,16 +14,22 @@ fi
 
 # Install Docker
 if ! command -v docker; then
-	curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-	echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+	curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+	echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
 
 	apt-get update
 	apt-get -y install docker-ce docker-ce-cli containerd.io
 fi
 
+declare os=$(uname -s | tr -s "[:upper:]" "[:lower:]")
+declare arch=$(uname -m)
+if [[ "${arch}" = *arm64* ]]; then
+	arch="aarch64"
+fi
+
 # Install docker-compose
 if ! command -v docker-compose; then
-	curl -sSL "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+	curl -sSL "https://github.com/docker/compose/releases/download/v2.2.3/docker-compose-${os}-${arch}" -o /usr/local/bin/docker-compose
 	chmod +x /usr/local/bin/docker-compose
 	ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose
 fi


### PR DESCRIPTION
This is needed to run the setup scripts on macOS M1 machines.