### PR TITLE
Wrong type for `sign`

### DIFF
--- a/packages/hoprd/src/api/v2/paths/message/sign.ts
+++ b/packages/hoprd/src/api/v2/paths/message/sign.ts
@@ -6,7 +6,7 @@ export const parameters = []
 export const POST: Operation = [
   async (req, res, _next) => {
     try {
-      const signature = await req.context.node.signMessage(req.body.message)
+      const signature = await req.context.node.signMessage(new TextEncoder().encode(req.body.message))
       res.status(200).send({ signature: u8aToHex(signature) })
     } catch (err) {
       res.status(422).json({ error: err.message })


### PR DESCRIPTION
Sadly API doesn't provide automatic type to requested parameters from schema, so `req.body.message` was passed as `any` and missed the fact we needed to encode it for `core.sign`.

Related to hoprnet/myne-chat#92