### PR TITLE
start NATed nodes without announce flag

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -73,11 +73,21 @@ for git_ref in $(cat "${mydir}/../packages/hoprd/releases.json" | jq -r "to_entr
       log "\tcluster name: ${cluster_name}"
       log "\tcluster template name: ${cluster_template_name}"
 
-      gcloud_create_or_update_instance_template "${cluster_template_name}" \
-        "${docker_image_full}" \
-        "${environment_id}" \
-        "${api_token}" \
-        "${password}"
+      if [ "${cluster-tag}" = "-nat" ]; then
+        gcloud_create_or_update_instance_template "${cluster_template_name}" \
+          "${docker_image_full}" \
+          "${environment_id}" \
+          "${api_token}" \
+          "${password}"
+      else 
+        # announce on-chain with routable address
+        gcloud_create_or_update_instance_template "${cluster_template_name}" \
+          "${docker_image_full}" \
+          "${environment_id}" \
+          "${api_token}" \
+          "${password}" \
+          "true"
+      fi
 
       gcloud_create_or_update_managed_instance_group "${cluster_name}" \
         ${cluster_size} \

--- a/scripts/gcloud.sh
+++ b/scripts/gcloud.sh
@@ -160,10 +160,11 @@ gcloud_cleanup_docker_images() {
 # $3 - optional: environment id
 # $4 - optional: api token
 # $5 - optional: password
-# $6 - optional: private key
-# $7 - optional: no args
+# $6 - optional: announce
+# $7 - optional: private key
+# $8 - optional: no args
 gcloud_create_or_update_instance_template() {
-  local args name mount_path image rpc api_token password host_path no_args private_key
+  local args name mount_path image rpc api_token password host_path no_args private_key announce
   local extra_args=""
 
   name="${1}"
@@ -174,12 +175,15 @@ gcloud_create_or_update_instance_template() {
   api_token="${4:-}"
   password="${5:-}"
 
+  # if set, let the node announce with a routable address on-chain
+  announce="${6:-}"
+
   # this parameter is mostly used on by CT nodes, although hoprd nodes also
   # support it
-  private_key="${6:-}"
+  private_key="${7:-}"
 
   # if set no additional arguments are used to start the container
-  no_args="${7:-}"
+  no_args="${8:-}"
 
   args=""
   # the environment is optional, since each docker image has a default environment set
@@ -196,7 +200,11 @@ gcloud_create_or_update_instance_template() {
   fi
 
   if [ -n "${private_key}" ]; then
-    extra_args="${extra_args} --container-arg=--privateKey --container-arg=\"${private_key}\""
+    extra_args="${extra_args} --container-arg=\"--privateKey\" --container-arg=\"${private_key}\""
+  fi
+
+  if [ -n "${announce}" ]; then
+    extra_args="${extra_args} --container-arg=\"--announce\""
   fi
 
   mount_path="/app/db"
@@ -244,7 +252,6 @@ gcloud_create_or_update_instance_template() {
       --container-restart-policy=always \
       --container-arg="--admin" \
       --container-arg="--adminHost" --container-arg="0.0.0.0" \
-      --container-arg="--announce" \
       --container-arg="--healthCheck" \
       --container-arg="--healthCheckHost" --container-arg="0.0.0.0" \
       --container-arg="--identity" --container-arg="${mount_path}/.hopr-identity" \

--- a/scripts/run-integration-tests-gcloud.sh
+++ b/scripts/run-integration-tests-gcloud.sh
@@ -97,11 +97,13 @@ fi
 # }}}
 
 # create test specific instance template
+# announce on-chain with routable address
 gcloud_create_or_update_instance_template "${test_id}" \
   "${docker_image}" \
   "${environment}" \
   "${api_token}" \
-  "${password}"
+  "${password}" \
+  "true"
 
 # create test specific instance template for NAT nodes
 gcloud_create_or_update_instance_template "${test_id}-nat" \

--- a/scripts/setup-ct-gcloud-cluster.sh
+++ b/scripts/setup-ct-gcloud-cluster.sh
@@ -90,12 +90,14 @@ fi
 
 # create test specific instance template
 # the empty values are placeholders for optional parameters which are not used
+# announce on-chain with routable address
 gcloud_create_or_update_instance_template \
   "${cluster_id}" \
   "${docker_image}" \
   "${environment}" \
   "" \
   "" \
+  "true" \
   "${CT_PRIV_KEY}" \
   "true"
 

--- a/scripts/setup-gcloud-cluster.sh
+++ b/scripts/setup-gcloud-cluster.sh
@@ -104,12 +104,14 @@ fi
 # }}}
 
 # create test specific instance template
+# announce on-chain with routable address
 gcloud_create_or_update_instance_template \
   "${cluster_id}" \
   "${docker_image}" \
   "${environment}" \
   "${api_token}" \
-  "${password}"
+  "${password}" \
+  "true"
 
 # start nodes
 gcloud_create_or_update_managed_instance_group  \

--- a/yarn.lock
+++ b/yarn.lock
@@ -5366,25 +5366,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abortable-iterator@npm:3.0.2":
-  version: 3.0.2
-  resolution: "abortable-iterator@npm:3.0.2"
-  dependencies:
-    get-iterator: ^1.0.2
-  checksum: 949ec28b43b08959ee7d1e963f7cec28a2f5ca4e6d3fb0bb1fb5965968e3606fd8465cac6fcff4388ef3d791886881ef4fd6116d399f6c0cd1e17704cde320c4
-  languageName: node
-  linkType: hard
-
-"abortable-iterator@npm:^3.0.0":
-  version: 3.0.1
-  resolution: "abortable-iterator@npm:3.0.1"
-  dependencies:
-    get-iterator: ^1.0.2
-  checksum: 1c4e0379f0c0aaab15c975bf7ef175bc5900bcd85955d60f9c68a526c6f150b7ec2a87f642b6022ebe7dd2dbf630a690a2c0cc8211cd800ba16a4d3380f19b2e
-  languageName: node
-  linkType: hard
-
-"abortable-iterator@npm:^3.0.2":
+"abortable-iterator@npm:3.0.2, abortable-iterator@npm:^3.0.0, abortable-iterator@npm:^3.0.2":
   version: 3.0.2
   resolution: "abortable-iterator@npm:3.0.2"
   dependencies:


### PR DESCRIPTION
Previously, NATed cloud were started with the `--announce` flag, such that they try to announce themselves.

This PR changes the default behavior to start without the `--announce` flag.