### PR TITLE
Improve start-nat-node.sh - make sure container is stopped

### DIFF
--- a/scripts/gcloud.sh
+++ b/scripts/gcloud.sh
@@ -232,7 +232,7 @@ gcloud_create_or_update_instance_template() {
       --container-env=^,@^DEBUG=hopr\*,@NODE_OPTIONS=--max-old-space-size=4096,@GCLOUD=1 \
       --container-mount-host-path=mount-path="${mount_path}",host-path="${host_path}" \
       --container-mount-host-path=mount-path=/var/run/docker.sock,host-path=/var/run/docker.sock \
-      --container-restart-policy=always \
+      --container-restart-policy=on-failure \
       ${args} \
       ${extra_args}
   else
@@ -249,7 +249,7 @@ gcloud_create_or_update_instance_template() {
       --container-env=^,@^DEBUG=hopr\*,@NODE_OPTIONS=--max-old-space-size=4096,@GCLOUD=1 \
       --container-mount-host-path=mount-path="${mount_path}",host-path="${host_path}" \
       --container-mount-host-path=mount-path=/var/run/docker.sock,host-path=/var/run/docker.sock \
-      --container-restart-policy=always \
+      --container-restart-policy=on-failure \
       --container-arg="--admin" \
       --container-arg="--adminHost" --container-arg="0.0.0.0" \
       --container-arg="--healthCheck" \

--- a/scripts/nat/start-nat-node.sh
+++ b/scripts/nat/start-nat-node.sh
@@ -25,7 +25,9 @@ fi
 declare admin_port=${HOPRD_ADMIN_PORT:-3000}
 declare rest_port=${HOPRD_REST_PORT:-3001}
 declare healthcheck_port=${HOPRD_HEALTHCHECK_PORT:-8080}
+
 declare network_name="hopr-nat"
+declare container_name="hoprd-behind-nat"
 
 # Create an isolated network to force NAT
 if [ "$(docker network ls | grep -c "${network_name}" )" = "0" ] ; then
@@ -35,8 +37,12 @@ if [ "$(docker network ls | grep -c "${network_name}" )" = "0" ] ; then
   fi
 fi
 
+# Stop the Docker container if it was running already
+docker stop ${container_name} 2> /dev/null || true
+
 # Fork here and pass all the environment variables down into the forked image
 docker run --pull always -v /var/hoprd/:/app/db -p ${admin_port}:3000 -p ${rest_port}:3001 -p ${healthcheck_port}:8080 \
+ --name=${container_name} --rm \
  --network=${network_name} \
  --env-file <(env) \
  "gcr.io/hoprassociation/hoprd:$HOPRD_RELEASE" "$@"

--- a/scripts/nat/start-nat-node.sh
+++ b/scripts/nat/start-nat-node.sh
@@ -26,8 +26,8 @@ declare admin_port=${HOPRD_ADMIN_PORT:-3000}
 declare rest_port=${HOPRD_REST_PORT:-3001}
 declare healthcheck_port=${HOPRD_HEALTHCHECK_PORT:-8080}
 
+declare container_name=${HOPRD_CONTAINER_NAME:-hoprd-behind-nat}
 declare network_name="hopr-nat"
-declare container_name="hoprd-behind-nat"
 
 # Create an isolated network to force NAT
 if [ "$(docker network ls | grep -c "${network_name}" )" = "0" ] ; then
@@ -42,7 +42,7 @@ docker stop ${container_name} 2> /dev/null || true
 
 # Fork here and pass all the environment variables down into the forked image
 docker run --pull always -v /var/hoprd/:/app/db -p ${admin_port}:3000 -p ${rest_port}:3001 -p ${healthcheck_port}:8080 \
- --name=${container_name} --rm \
+ --name=${container_name} --rm --restart=unless-stopped \
  --network=${network_name} \
  --env-file <(env) \
  "gcr.io/hoprassociation/hoprd:$HOPRD_RELEASE" "$@"

--- a/scripts/nat/start-nat-node.sh
+++ b/scripts/nat/start-nat-node.sh
@@ -41,8 +41,8 @@ fi
 docker stop ${container_name} 2> /dev/null || true
 
 # Fork here and pass all the environment variables down into the forked image
-docker run --pull always -v /var/hoprd/:/app/db -p ${admin_port}:3000 -p ${rest_port}:3001 -p ${healthcheck_port}:8080 \
- --name=${container_name} --rm --restart=unless-stopped \
+docker run -d --pull always -v /var/hoprd/:/app/db -p ${admin_port}:3000 -p ${rest_port}:3001 -p ${healthcheck_port}:8080 \
+ --name=${container_name} --rm --restart=on-failure \
  --network=${network_name} \
  --env-file <(env) \
  "gcr.io/hoprassociation/hoprd:$HOPRD_RELEASE" "$@"


### PR DESCRIPTION
Fixes `start-nat-node.sh` script: assign a name to the NAT'd container and make sure it is stopped.

Refs #3296 