### PR TITLE
Add shortcut for --version, fix NAT node start determinism

### DIFF
--- a/scripts/nat/start-nat-node.sh
+++ b/scripts/nat/start-nat-node.sh
@@ -21,6 +21,11 @@ if [ ! -S "/var/run/docker.sock" ]; then
   exit 1
 fi
 
+if [[ $# = 1 && "$1" = "--version" ]]; then
+  docker run --pull always --rm "gcr.io/hoprassociation/hoprd:$HOPRD_RELEASE" --version 2> /dev/null
+  exit $?
+fi
+
 # Default hoprd ports, configurable using env variables passed to the container
 declare admin_port=${HOPRD_ADMIN_PORT:-3000}
 declare rest_port=${HOPRD_REST_PORT:-3001}
@@ -37,12 +42,12 @@ if [ "$(docker network ls | grep -c "${network_name}" )" = "0" ] ; then
   fi
 fi
 
-# Stop the Docker container if it was running already
-docker stop ${container_name} 2> /dev/null || true
+# Stop & remove the Docker container if it was running already
+docker stop ${container_name} > /dev/null 2>&1 || true && docker rm ${container_name} > /dev/null 2>&1 || true
 
 # Fork here and pass all the environment variables down into the forked image
 docker run -d --pull always -v /var/hoprd/:/app/db -p ${admin_port}:3000 -p ${rest_port}:3001 -p ${healthcheck_port}:8080 \
- --name=${container_name} --rm --restart=on-failure \
+ --name=${container_name} --restart=on-failure \
  --network=${network_name} \
  --env-file <(env) \
  "gcr.io/hoprassociation/hoprd:$HOPRD_RELEASE" "$@"


### PR DESCRIPTION
Fixes start-nat-node.sh script so `--version` runs as a shortcut.

Refs #3296 