### PR TITLE
Automatically renew relay key entries in the DHT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Use a relay tag to announce in the DHT that a node acts as a relayer for a specific node ([#3237](https://github.com/hoprnet/hoprnet/pull/3237))
 - Added simulated NAT to E2E tests ([#3237](https://github.com/hoprnet/hoprnet/pull/3237))
 - Automatic deployment of NAT nodes to GCloud ([#3165](https://github.com/hoprnet/hoprnet/issues/3165))
+- Automatically extend TTL of relay tokens in the DHT ([#3304](https://github.com/hoprnet/hoprnet/issues/3304))
 
 ---
 

--- a/packages/connect/src/base/entry.ts
+++ b/packages/connect/src/base/entry.ts
@@ -106,12 +106,12 @@ export class EntryNodes extends EventEmitter {
     const renewDHTEntries = async function (this: EntryNodes) {
       for (const usedRelay of this.usedRelays) {
         const relay = relayFromRelayAddress(usedRelay)
-        const entry = this.availableEntryNodes.find((entry: EntryNodeData) => entry.id.equals(relay))
+        const relayEntry = this.availableEntryNodes.find((entry: EntryNodeData) => entry.id.equals(relay))
 
-        if (entry == undefined) {
+        if (relayEntry == undefined) {
           throw Error(`Unknown relay`)
         }
-        await this.connectToRelay(relay, entry.multiaddrs[0], 5e3)
+        await this.connectToRelay(relay, relayEntry.multiaddrs[0], 5e3)
       }
     }.bind(this)
 

--- a/packages/connect/src/base/entry.ts
+++ b/packages/connect/src/base/entry.ts
@@ -3,23 +3,23 @@ import type { HoprConnectOptions, PeerStoreType, Stream } from '../types'
 import Debug from 'debug'
 
 import {
-  CODE_P2P,
   CODE_IP4,
   CODE_IP6,
   CODE_TCP,
   CODE_UDP,
   MAX_RELAYS_PER_NODE,
   CAN_RELAY_PROTCOL,
-  OK
+  OK,
+  DEFAULT_DHT_ENTRY_RENEWAL
 } from '../constants'
 import type { Connection } from 'libp2p-interfaces/connection'
 
 import type PeerId from 'peer-id'
 import { Multiaddr } from 'multiaddr'
 
-import { nAtATime, u8aEquals, u8aToHex } from '@hoprnet/hopr-utils'
+import { nAtATime, retimer, u8aEquals, u8aToHex } from '@hoprnet/hopr-utils'
 import type HoprConnect from '..'
-import { attemptClose } from '../utils'
+import { attemptClose, relayFromRelayAddress } from '../utils'
 
 const DEBUG_PREFIX = 'hopr-connect:entry'
 const log = Debug(DEBUG_PREFIX)
@@ -54,6 +54,7 @@ export const ENTRY_NODES_MAX_PARALLEL_DIALS = 14
 export class EntryNodes extends EventEmitter {
   protected availableEntryNodes: EntryNodeData[]
   protected uncheckedEntryNodes: PeerStoreType[]
+  private stopDHTRenewal: (() => void) | undefined
 
   protected usedRelays: Multiaddr[]
 
@@ -84,6 +85,8 @@ export class EntryNodes extends EventEmitter {
       this.options.publicNodes.on('addPublicNode', this._onNewRelay)
       this.options.publicNodes.on('removePublicNode', this._onRemoveRelay)
     }
+
+    this.startDHTRenewInterval()
   }
 
   /**
@@ -95,6 +98,24 @@ export class EntryNodes extends EventEmitter {
 
       this.options.publicNodes.removeListener('removePublicNode', this._onRemoveRelay as EntryNodes['onRemoveRelay'])
     }
+
+    this.stopDHTRenewal?.()
+  }
+
+  private startDHTRenewInterval() {
+    const renewDHTEntries = async function (this: EntryNodes) {
+      for (const usedRelay of this.usedRelays) {
+        const relay = relayFromRelayAddress(usedRelay)
+        const entry = this.availableEntryNodes.find((entry: EntryNodeData) => entry.id.equals(relay))
+
+        if (entry == undefined) {
+          throw Error(`Unknown relay`)
+        }
+        await this.connectToRelay(relay, entry.multiaddrs[0], 5e3)
+      }
+    }.bind(this)
+
+    this.stopDHTRenewal = retimer(renewDHTEntries, () => this.options.dhtRenewalTimeout ?? DEFAULT_DHT_ENTRY_RENEWAL)
   }
 
   /**
@@ -167,10 +188,9 @@ export class EntryNodes extends EventEmitter {
     }
 
     let inUse = false
-    const peerB58String = peer.toB58String()
     for (const relayAddr of this.usedRelays) {
       // remove second part of relay address to get relay peerId
-      if (relayAddr.decapsulateCode(CODE_P2P).getPeerId() === peerB58String) {
+      if (relayFromRelayAddress(relayAddr).equals(peer)) {
         inUse = true
       }
     }
@@ -240,8 +260,6 @@ export class EntryNodes extends EventEmitter {
       args[index] = [nodeToCheck.id, nodeToCheck.multiaddrs[0], TIMEOUT]
     }
 
-    // const CONCURRENCY = 14 // connections
-
     const results = (await nAtATime(connectToRelay, args, ENTRY_NODES_MAX_PARALLEL_DIALS))
       .filter(
         // Filter all unsuccessful dials that cause an error
@@ -266,7 +284,7 @@ export class EntryNodes extends EventEmitter {
     // Reset list of unchecked nodes
     this.uncheckedEntryNodes = []
 
-    const previous = new Set(this.usedRelays.map((ma) => ma.decapsulateCode(CODE_P2P).toString()))
+    const previous = new Set<string>(this.usedRelays.map((ma) => relayFromRelayAddress(ma).toB58String()))
 
     this.usedRelays = this.availableEntryNodes
       // select only those entry nodes with smallest latencies
@@ -282,7 +300,7 @@ export class EntryNodes extends EventEmitter {
       isDifferent = true
     } else {
       for (const usedRelay of this.usedRelays) {
-        if (!previous.has(usedRelay.toString())) {
+        if (!previous.has(relayFromRelayAddress(usedRelay).toB58String())) {
           isDifferent = true
           break
         }
@@ -313,8 +331,13 @@ export class EntryNodes extends EventEmitter {
   ): Promise<{ entry: EntryNodeData; conn?: Connection }> {
     const abort = new AbortController()
     const start = Date.now()
+    let finished = false
 
-    const timeoutHandle = setTimeout(abort.abort.bind(abort), timeout)
+    setTimeout(() => {
+      if (!finished) {
+        abort.abort()
+      }
+    }, timeout)
 
     let conn: Connection | undefined
     try {
@@ -322,7 +345,8 @@ export class EntryNodes extends EventEmitter {
     } catch (err: any) {
       error(`error while contacting entry node.`, err.message)
     } finally {
-      clearTimeout(timeoutHandle)
+      // Prevent timeout from doing anything
+      finished = true
     }
 
     if (conn == undefined) {

--- a/packages/connect/src/constants.ts
+++ b/packages/connect/src/constants.ts
@@ -21,9 +21,12 @@ export const CLOSE_TIMEOUT = 6000 // ms
 export const RELAY_CIRCUIT_TIMEOUT = 6000 // ms
 export const RELAY_CONTACT_TIMEOUT = 3000 // ms
 
-// Either set on ALL nodes to true or NONE
-// @dev mixed operation is neither tested nor implemented
 export const WEBRTC_TIMEOUT = 2400 // ms
+
+// Keys in the DHT have a TTL of 24 hours, hence
+// relay keys need to be reset on daily base.
+// Interval to renew the DHT entry
+export const DEFAULT_DHT_ENTRY_RENEWAL = 8 * 60 * 60 * 1000 // 8 hours
 
 // Use default UTF-8 text encoding
 const encoder = new TextEncoder()

--- a/packages/connect/src/types.ts
+++ b/packages/connect/src/types.ts
@@ -64,6 +64,7 @@ export type HoprConnectOptions = {
   maxRelayedConnections?: number
   environment?: string
   relayFreeTimeout?: number
+  dhtRenewalTimeout?: number
 }
 
 export type HoprConnectTestingOptions = {

--- a/packages/connect/src/utils/index.spec.ts
+++ b/packages/connect/src/utils/index.spec.ts
@@ -1,0 +1,131 @@
+import { Multiaddr } from 'multiaddr'
+import assert from 'assert'
+
+import { privKeyToPeerId } from '@hoprnet/hopr-utils'
+import { relayFromRelayAddress, nodeToMultiaddr } from '.'
+
+const SELF = privKeyToPeerId('0x7519c19fd624599c0f97c89913b277a7d1b932d77100f4bbb2bc01969249add3')
+const RELAY = privKeyToPeerId('0x152c95bd36e6ada51309558756d5f901853d45ab94336a0bd7bae1453e98ffd6')
+
+describe(`test util functions`, function () {
+  it('relay extraction from relay address', function () {
+    const extracted = relayFromRelayAddress(
+      new Multiaddr(`/p2p/${RELAY.toB58String()}/p2p-circuit/p2p/${SELF.toB58String()}`)
+    )
+
+    assert(extracted.equals(RELAY))
+
+    // Incorrect size
+    assert.throws(() => relayFromRelayAddress(new Multiaddr(`/p2p/${SELF.toB58String()}`)))
+
+    // Incorrect protocol
+    assert.throws(() => relayFromRelayAddress(new Multiaddr(`/ip4/127.0.0.1`)))
+
+    // Incorrect size and missing protocol
+    assert.throws(() => relayFromRelayAddress(new Multiaddr(`/p2p/${SELF.toB58String()}/p2p/${SELF.toB58String()}`)))
+  })
+
+  it('Node.js AddressInfo to Multiaddr', function () {
+    const tests = [
+      [
+        new Multiaddr(`/ip4/127.0.0.1/tcp/12345`),
+        nodeToMultiaddr(
+          {
+            address: '127.0.0.1',
+            port: 12345,
+            family: 'IPv4'
+          },
+          undefined
+        )
+      ],
+      [
+        new Multiaddr(`/ip4/127.0.0.1/tcp/12345/p2p/${SELF.toB58String()}`),
+        nodeToMultiaddr(
+          {
+            address: '127.0.0.1',
+            port: 12345,
+            family: 'IPv4'
+          },
+          SELF
+        )
+      ],
+      // Accept any *any* address
+      [
+        new Multiaddr(`/ip4/0.0.0.0/tcp/12345`),
+        nodeToMultiaddr(
+          {
+            address: '::',
+            port: 12345,
+            family: 'IPv4'
+          },
+          undefined
+        )
+      ],
+      [
+        new Multiaddr(`/ip4/0.0.0.0/tcp/12345`),
+        nodeToMultiaddr(
+          {
+            address: '0.0.0.0',
+            port: 12345,
+            family: 'IPv4'
+          },
+          undefined
+        )
+      ],
+      [
+        new Multiaddr(`/ip6/::1/tcp/12345`),
+        nodeToMultiaddr(
+          {
+            address: '::1',
+            port: 12345,
+            family: 'IPv6'
+          },
+          undefined
+        )
+      ],
+      [
+        new Multiaddr(`/ip6/::1/tcp/12345/p2p/${SELF.toB58String()}`),
+        nodeToMultiaddr(
+          {
+            address: '::1',
+            port: 12345,
+            family: 'IPv6'
+          },
+          SELF
+        )
+      ],
+      // Accecpt any *any* address
+      [
+        new Multiaddr(`/ip6/::/tcp/12345`),
+        nodeToMultiaddr(
+          {
+            address: '0.0.0.0',
+            port: 12345,
+            family: 'IPv6'
+          },
+          undefined
+        )
+      ],
+      [
+        new Multiaddr(`/ip6/::/tcp/12345`),
+        nodeToMultiaddr(
+          {
+            address: '::',
+            port: 12345,
+            family: 'IPv6'
+          },
+          undefined
+        )
+      ]
+    ]
+
+    for (const test of tests) {
+      assert(
+        test[0].equals(test[1]),
+        `Expected Multiaddr ${test[0].toString()} must be equal to computed ${test[1].toString()}`
+      )
+    }
+
+    assert.throws(() => nodeToMultiaddr({ address: '0.0.0.0', family: 'wrongFamily', port: 12345 }, undefined))
+  })
+})

--- a/packages/core/src/network/heartbeat.ts
+++ b/packages/core/src/network/heartbeat.ts
@@ -17,7 +17,7 @@ const error = debug('hopr-core:heartbeat:error')
 const PING_HASH_ALGORITHM = 'blake2s256'
 
 export default class Heartbeat {
-  private timeout: NodeJS.Timeout
+  private stopHeartbeatInterval: (() => void) | undefined
   private protocolHeartbeat: string
 
   constructor(
@@ -91,7 +91,7 @@ export default class Heartbeat {
       }
     }.bind(this)
 
-    this.timeout = retimer(
+    this.stopHeartbeatInterval = retimer(
       periodicCheck,
       // Prevent nodes from querying each other at the very same time
       () => randomInteger(HEARTBEAT_INTERVAL, HEARTBEAT_INTERVAL + HEARTBEAT_INTERVAL_VARIANCE)
@@ -106,7 +106,7 @@ export default class Heartbeat {
   }
 
   public stop() {
-    clearTimeout(this.timeout)
+    this.stopHeartbeatInterval?.()
     log(`Heartbeat stopped`)
   }
 

--- a/packages/utils/src/process/retimer.spec.ts
+++ b/packages/utils/src/process/retimer.spec.ts
@@ -5,16 +5,16 @@ import { setTimeout } from 'timers/promises'
 describe('test retimer', function () {
   it('return a timeout', async function () {
     const INITIAL_TIMEOUT = 100
-    const timeout = retimer(
+    const stopRetimer = retimer(
       () => {
         assert.fail(`timeout must be cleared before function call`)
       },
       () => INITIAL_TIMEOUT
     )
 
-    assert(timeout != undefined, `returned timeout must not be undefined`)
+    assert(stopRetimer != undefined, `returned timeout must not be undefined`)
 
-    clearTimeout(timeout)
+    stopRetimer()
 
     // Give the timeout time to fire
     await setTimeout(INITIAL_TIMEOUT + 50)
@@ -24,11 +24,11 @@ describe('test retimer', function () {
     let i = 0
     const func = () => i++
 
-    const timeout = retimer(func, () => 0)
+    const stopRetimer = retimer(func, () => 0)
 
     await setTimeout(1e3)
 
-    clearTimeout(timeout)
+    stopRetimer()
 
     assert(i > 500, `function must be efficient`)
   })

--- a/packages/utils/src/process/retimer.ts
+++ b/packages/utils/src/process/retimer.ts
@@ -3,7 +3,7 @@
  * @param fn function to apply after every timeout
  * @param newTimeout function that returns the new timeout
  */
-export function retimer(fn: () => void, newTimeout: () => number): NodeJS.Timeout {
+export function retimer(fn: () => void, newTimeout: () => number): () => void {
   let timeout: NodeJS.Timeout
 
   const again = () => {
@@ -12,5 +12,5 @@ export function retimer(fn: () => void, newTimeout: () => number): NodeJS.Timeou
   }
   timeout = setTimeout(again, newTimeout())
 
-  return timeout
+  return () => clearTimeout(timeout)
 }


### PR DESCRIPTION
Fixes #3280 

Additional changes:

- refactor `retimer` to return the right timeout, not the first one
- add some unit tests for `connect` util functions