### PR TITLE
Overwrite address sorter

### DIFF
--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -34,6 +34,10 @@ export async function createLibp2pInstance(
     addressSorter = localAddressesFirst
     log('Preferring local addresses')
   } else {
+    // Overwrite address sorter with identity function since
+    // libp2p's own address sorter function is unable to handle
+    // p2p addresses, e.g. /p2p/<RELAY>/p2p-circuit/p2p/<DESTINATION>
+    addressSorter = (addr) => addr
     log('Addresses are sorted by default')
   }
 


### PR DESCRIPTION
Fixes an issue with libp2p's address sorter

![Screenshot from 2022-01-25 12-46-39](https://user-images.githubusercontent.com/12514844/150978534-9f6ecdce-9beb-437c-84cf-05fb07fef0b5.png)
