### PR TITLE
Hotfix release/athens:  Ensure node crashes when the provider chain object cannot be created

### DIFF
--- a/packages/core-ethereum/src/index.ts
+++ b/packages/core-ethereum/src/index.ts
@@ -91,7 +91,7 @@ export default class HoprCoreEthereum extends EventEmitter {
     } catch (err) {
       const errMsg = 'failed to create provider chain wrapper'
       log(`error: ${errMsg}`, err)
-      throw(errMsg)
+      throw errMsg
     }
   }
 

--- a/packages/core-ethereum/src/index.ts
+++ b/packages/core-ethereum/src/index.ts
@@ -91,7 +91,7 @@ export default class HoprCoreEthereum extends EventEmitter {
     } catch (err) {
       const errMsg = 'failed to create provider chain wrapper'
       log(`error: ${errMsg}`, err)
-      throw errMsg
+      throw Error(errMsg)
     }
   }
 

--- a/packages/core-ethereum/src/index.ts
+++ b/packages/core-ethereum/src/index.ts
@@ -89,7 +89,9 @@ export default class HoprCoreEthereum extends EventEmitter {
       // Emit event to make sure connector is aware the chain was created properly.
       this.emit('connector:created')
     } catch (err) {
-      log('error: failed to create provider chain wrapper', err)
+      const errMsg = 'failed to create provider chain wrapper'
+      log(`error: ${errMsg}`, err)
+      throw(errMsg)
     }
   }
 


### PR DESCRIPTION
This prevents startup stalls when there is a problem in the communication with the provider.

Problem observed in https://github.com/hoprnet/hoprnet/runs/4950701074?check_suite_focus=true

Release: #3220 

PR on `master`: #3327 