### PR TITLE
Add helper script to get account info from gcloud nodes

### DIFF
--- a/scripts/gcloud.sh
+++ b/scripts/gcloud.sh
@@ -43,7 +43,7 @@ wait_until_node_is_ready() {
 
   # try every 10 seconds for 5 minutes
   log "waiting for VM with IP $1 to have HOPR node up and running"
-  try_cmd "${cmd}" 30 10 true
+  try_cmd "${cmd}" 30 10
 }
 
 # Get external IP for running node or die
@@ -54,7 +54,7 @@ gcloud_get_ip() {
 }
 
 # $1=VM name
-gcloud_find_vm_with_name() {  
+gcloud_find_vm_with_name() {
   local vm_name="${1}"
   gcloud compute instances list | grep "${vm_name}" | grep 'RUNNING'
 }

--- a/scripts/get-gcloud-instances-accounts-info.sh
+++ b/scripts/get-gcloud-instances-accounts-info.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# prevent souring of this script, only allow execution
+$(return >/dev/null 2>&1)
+test "$?" -eq "0" && { echo "This script should only be executed." >&2; exit 1; }
+
+# exit on errors, undefined variables, ensure errors in pipes are not hidden
+set -Eeuo pipefail
+
+# set log id and use shared log function for readable logs
+declare mydir
+mydir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+declare -x HOPR_LOG_ID="get-gcloud-instances-accounts-info"
+source "${mydir}/utils.sh"
+source "${mydir}/gcloud.sh"
+source "${mydir}/testnet.sh"
+
+usage() {
+  msg
+  msg "This script can be used to get the accounts info (native and ERC20) for"
+  msg "each node in the given gcloud instance group."
+  msg
+  msg "Usage: $0 <instance_group>"
+  msg
+  msg "where <instance_group>\t\tthe name of the GCP instance group"
+  msg
+  msg "Required environment variables"
+  msg "------------------------------"
+  msg
+  msg "HOPRD_API_TOKEN\t\t\tused as api token for all nodes"
+  msg
+}
+
+# return early with help info when requested
+{ [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; } && { usage; exit 0; }
+
+# verify and set parameters
+: ${HOPRD_API_TOKEN?"Missing environment variable HOPRD_API_TOKEN"}
+
+declare instance_group="${1?"missing parameter <instance_group>"}"
+declare api_token="${HOPRD_API_TOKEN}"
+
+# get IPs of newly started VMs which run hoprd
+declare node_ips
+node_ips=$(gcloud_get_managed_instance_group_instances_ips "${instance_group}")
+declare node_ips_arr=( ${node_ips} )
+
+log "IP\t\t\tNATIVE ADDRESS\t\tHOPR ADDRESS\n"
+
+declare native_address hopr_address
+for ip in ${node_ips}; do
+  native_address=$(get_native_address "${api_token}@${ip}:3001")
+  hopr_address=$(get_hopr_address "${api_token}@${ip}:3001")
+
+  log "${ip}\t${native_address}\t${hopr_address}"
+done

--- a/scripts/setup-gcloud-cluster.sh
+++ b/scripts/setup-gcloud-cluster.sh
@@ -46,6 +46,7 @@ usage() {
   msg "HOPRD_PASSWORD\t\t\tused as password for all nodes, defaults to a random value"
   msg "HOPRD_SHOW_PRESTART_INFO\tset to 'true' to print used parameter values before starting"
   msg "HOPRD_PERFORM_CLEANUP\t\tset to 'true' to perform the cleanup process for the given cluster id"
+  msg "HOPRD_SKIP_SETUP\t\tset to 'true' to perform post setup operations only, that is funding and setting up topology"
   msg
 }
 
@@ -67,6 +68,7 @@ declare api_token="${HOPRD_API_TOKEN:-Token${RANDOM}^${RANDOM}^${RANDOM}Token}"
 declare password="${HOPRD_PASSWORD:-pw${RANDOM}${RANDOM}${RANDOM}pw}"
 declare perform_cleanup="${HOPRD_PERFORM_CLEANUP:-false}"
 declare show_prestartinfo="${HOPRD_SHOW_PRESTART_INFO:-false}"
+declare skip_setup="${HOPRD_SKIP_SETUP:-false}"
 
 # Append environment as Docker image version, if not specified
 [[ "${docker_image}" != *:* ]] && docker_image="${docker_image}:${environment}"

--- a/scripts/setup-gcloud-cluster.sh
+++ b/scripts/setup-gcloud-cluster.sh
@@ -46,7 +46,6 @@ usage() {
   msg "HOPRD_PASSWORD\t\t\tused as password for all nodes, defaults to a random value"
   msg "HOPRD_SHOW_PRESTART_INFO\tset to 'true' to print used parameter values before starting"
   msg "HOPRD_PERFORM_CLEANUP\t\tset to 'true' to perform the cleanup process for the given cluster id"
-  msg "HOPRD_SKIP_SETUP\t\tset to 'true' to perform post setup operations only, that is funding and setting up topology"
   msg
 }
 
@@ -68,7 +67,6 @@ declare api_token="${HOPRD_API_TOKEN:-Token${RANDOM}^${RANDOM}^${RANDOM}Token}"
 declare password="${HOPRD_PASSWORD:-pw${RANDOM}${RANDOM}${RANDOM}pw}"
 declare perform_cleanup="${HOPRD_PERFORM_CLEANUP:-false}"
 declare show_prestartinfo="${HOPRD_SHOW_PRESTART_INFO:-false}"
-declare skip_setup="${HOPRD_SKIP_SETUP:-false}"
 
 # Append environment as Docker image version, if not specified
 [[ "${docker_image}" != *:* ]] && docker_image="${docker_image}:${environment}"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -105,15 +105,13 @@ msg() {
 # $1 command to execute
 # $2 optional: number of retries, defaults to 0
 # $3 optional: seconds between retries, defaults to 1
-# $4 optional: print command before execution, defaults to false
 try_cmd() {
   local cmd="${1}"
   local retries_left=${2:-0}
   local wait_in_sec="${3:-1}"
-  local verbose="${4:-false}"
   local cmd_exit_code result
 
-  if [ "${verbose}" = "true" ]; then
+  if [ "${HOPR_VERBOSE:-false}" = "true" ]; then
     log "Executing command: ${cmd}"
   fi
 
@@ -141,7 +139,7 @@ try_cmd() {
         sleep ${wait_in_sec}
       fi
       log "Retrying command ${retries_left} more time(s)"
-      try_cmd "${cmd}" ${retries_left} ${wait_in_sec} ${verbose}
+      try_cmd "${cmd}" ${retries_left} ${wait_in_sec}
     fi
   fi
 }
@@ -207,7 +205,7 @@ get_native_address(){
 
   # try every 5 seconds for 5 minutes
   local result
-  result=$(try_cmd "${cmd}" 30 5 true)
+  result=$(try_cmd "${cmd}" 30 5)
 
   echo $(echo ${result} | jq -r ".nativeAddress")
 }
@@ -219,7 +217,7 @@ get_hopr_address() {
 
   # try every 5 seconds for 5 minutes
   local result
-  result=$(try_cmd "${cmd}" 30 5 true)
+  result=$(try_cmd "${cmd}" 30 5)
 
   echo $(echo ${result} | jq -r ".hoprAddress")
 }


### PR DESCRIPTION
The script can be useful during release deployments to acquire the account of multiple cluster nodes faster.