### PR TITLE
Release Athens hotfix: Fix the heartbeat timeout and interval values

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -9,7 +9,7 @@ export const VERSION = pickVersion(pkg.version)
 
 export const DEFAULT_STUN_PORT = 3478
 
-export const HEARTBEAT_TIMEOUT  = 4000
+export const HEARTBEAT_TIMEOUT = 4000
 export const HEARTBEAT_INTERVAL = 30000
 export const HEARTBEAT_INTERVAL_VARIANCE = 2000
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -9,12 +9,11 @@ export const VERSION = pickVersion(pkg.version)
 
 export const DEFAULT_STUN_PORT = 3478
 
-export const HEARTBEAT_INTERVAL = 3000
+export const HEARTBEAT_TIMEOUT  = 4000
+export const HEARTBEAT_INTERVAL = 30000
 export const HEARTBEAT_INTERVAL_VARIANCE = 2000
 
 export const MAX_PARALLEL_CONNECTIONS = 5
-
-export const HEARTBEAT_TIMEOUT = 8000
 
 export const MAX_PACKET_DELAY = 200
 


### PR DESCRIPTION
The timeout for heartbeat needs to be strictly smaller than the interval of heartbeat attempts.

New values (ms): 
 - `HEARTBEAT_TIMEOUT = 4000`
 - `HEARTBEAT_INTERVAL = 30000`

Relates to #3334 