### PR TITLE
devops: Add use of static IPs to all gcloud cluster instances

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -313,7 +313,7 @@ jobs:
           project_id: ${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}
           service_account_key: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
           export_default_credentials: true
-        
+
       - name: Initialize, install packages and build
         run: |
           # get latest version

--- a/.processes/release.md
+++ b/.processes/release.md
@@ -256,5 +256,6 @@ CT_PRIV_KEY=14e6...a6a5 \
 HOPRD_PERFORM_CLEANUP=false \
 FUNDING_PRIV_KEY=0xa77a...21b8 \
 HOPRD_SHOW_PRESTART_INFO=true \
-  ./scripts/setup-gcloud-cluster.sh athens `pwd`/scripts/topologies/full_interconnected_cluster.sh
+  ./scripts/setup-gcloud-cluster.sh athens `pwd`/scripts/topologies/full_interconnected_cluster.sh \
+    athens-topology-1-86 gcr.io/hoprassociation/hoprd:athens 6 athens-topology-1-86 true
 ```

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -75,37 +75,22 @@ for git_ref in $(cat "${mydir}/../packages/hoprd/releases.json" | jq -r "to_entr
 
       if [ "${cluster_tag}" = "-nat" ]; then
         log "\tNATed node, no announcements"
-        gcloud_create_or_update_instance_template "${cluster_template_name}" \
-          "${docker_image_full}" \
+        ${mydir}/setup-gcloud-cluster.sh \
           "${environment_id}" \
-          "${api_token}" \
-          "${password}"
-      else 
+          "" \
+          "${cluster_name}" \
+          "${docker_image_full}" \
+          "${cluster_template_name}"
+      else
         # announce on-chain with routable address
-        gcloud_create_or_update_instance_template "${cluster_template_name}" \
-          "${docker_image_full}" \
+        ${mydir}/setup-gcloud-cluster.sh \
           "${environment_id}" \
-          "${api_token}" \
-          "${password}" \
+          "" \
+          "${cluster_name}" \
+          "${docker_image_full}" \
+          "${cluster_template_name}" \
           "true"
       fi
-
-      gcloud_create_or_update_managed_instance_group "${cluster_name}" \
-        ${cluster_size} \
-        "${cluster_template_name}"
-
-      # get IPs of VMs which run hoprd
-      declare node_ips
-      node_ips=$(gcloud_get_managed_instance_group_instances_ips "${cluster_name}")
-      declare node_ips_arr=( ${node_ips} )
-
-      # fund nodes
-      declare eth_address
-      for ip in ${node_ips}; do
-        wait_until_node_is_ready "${ip}"
-        eth_address=$(get_native_address "${api_token}@${ip}:3001")
-        fund_if_empty "${eth_address}" "${environment_id}"
-      done
     done
   fi
 done

--- a/scripts/gcloud.sh
+++ b/scripts/gcloud.sh
@@ -34,22 +34,6 @@ GCLOUD_DEFAULTS="$ZONE $GCLOUD_MACHINE $GCLOUD_META $GCLOUD_TAGS $GCLOUD_BOOTDIS
 # let keys expire after 1 hour
 alias gssh="gcloud compute ssh --force-key-file-overwrite --ssh-key-expire-after=1h --ssh-flag='-t' $ZONE"
 
-# NB: This is useless for getting an IP of a VM
-# Get or create an IP address
-# $1=VM name
-gcloud_get_address() {
-  local vm_name="${1}"
-
-  local ip=$(gcloud compute addresses describe ${vm_name} $gcloud_region 2>&1)
-  # Google does not return an appropriate exit code :(
-  if [ "$(echo "$ip" | grep 'ERROR')" ]; then
-    log "No address, creating"
-    gcloud compute addresses create ${vm_name} $gcloud_region
-    ip=$(gcloud compute addresses describe ${vm_name} $gcloud_region 2>&1)
-  fi
-  echo $ip | awk '{ print $2 }'
-}
-
 # $1=ip
 # $2=optional: healthcheck port, defaults to 8080
 wait_until_node_is_ready() {
@@ -163,8 +147,21 @@ gcloud_cleanup_docker_images() {
 # $6 - optional: announce
 # $7 - optional: private key
 # $8 - optional: no args
+gcloud_create_instance_template_if_not_exists() {
+  gcloud_create_or_update_instance_template "${1}" "${2}" "${3:-}" "${4:-}" "${5:-}" "${6:-}" "${7:-}" "${8:-}" "true"
+}
+
+# $1 - template name
+# $2 - container image
+# $3 - optional: environment id
+# $4 - optional: api token
+# $5 - optional: password
+# $6 - optional: announce
+# $7 - optional: private key
+# $8 - optional: no args
+# $9 - optional: skip_update if exists already
 gcloud_create_or_update_instance_template() {
-  local args name mount_path image rpc api_token password host_path no_args private_key announce
+  local args name mount_path image rpc api_token password host_path no_args private_key announce skip_update_if_exists
   local extra_args=""
 
   name="${1}"
@@ -184,6 +181,8 @@ gcloud_create_or_update_instance_template() {
 
   # if set no additional arguments are used to start the container
   no_args="${8:-}"
+
+  skip_update_if_exists="${9:-false}"
 
   args=""
   # the environment is optional, since each docker image has a default environment set
@@ -213,6 +212,12 @@ gcloud_create_or_update_instance_template() {
   log "checking for instance template ${name}"
   if gcloud compute instance-templates describe "${name}" --quiet >/dev/null; then
     log "instance template ${name} already present"
+
+    if [ "${skip_update_if_exists}" = "true" ]; then
+      # short-circuit, stop operation
+      return
+    fi
+
     gcloud_delete_instance_template "${name}"
   fi
 
@@ -300,11 +305,31 @@ gcloud_create_or_update_managed_instance_group() {
   gcloud compute instance-groups managed wait-until "${name}" \
     --stable \
     ${gcloud_region}
+
+  log "reserve all external addresses of the instance group ${name} instances"
+  for instance_uri in $(gcloud compute instance-groups list-instances "${name}" ${gcloud_region} --uri); do
+    local instance_name=$(gcloud compute instances describe ${instance_uri} --format 'csv[no-heading](name)')
+    local instance_ip=$(gcloud compute instances describe ${instance_uri} \
+      --flatten 'networkInterfaces[].accessConfigs[]' \
+      --format 'csv[no-heading](networkInterfaces.accessConfigs.natIP)')
+
+    gcloud_reserve_static_ip_address "${instance_name}" "${instance_ip}"
+  done
 }
 
 # $1=group name
 gcloud_delete_managed_instance_group() {
   local name="${1}"
+
+  log "un-reserve all external addresses of the instance group ${name} instances"
+  for instance_uri in $(gcloud compute instance-groups list-instances "${name}" ${gcloud_region} --uri); do
+    local instance_name=$(gcloud compute instances describe ${instance_uri} --format 'csv[no-heading](name)')
+    local isntance_ip=$(gcloud compute instances describe ${instance_uri} \
+      --flatten 'networkInterfaces[].accessConfigs[]' \
+      --format 'csv[no-heading](networkInterfaces.accessConfigs.natIP)')
+
+    gcloud_delete_static_ip_address "${instance_name}"
+  done
 
   log "deleting managed instance group ${name}"
   gcloud compute instance-groups managed delete "${name}" \
@@ -321,4 +346,33 @@ gcloud_get_managed_instance_group_instances_ips() {
     xargs -P `nproc` -I '{}' gcloud compute instances describe '{}' \
       --flatten 'networkInterfaces[].accessConfigs[]' \
       --format 'csv[no-heading](networkInterfaces.accessConfigs.natIP)'
+}
+
+gcloud_get_unused_static_ip_addresses() {
+  local json
+
+  json=$(gcloud compute addresses list --filter='status != IN_USE' --format=json ${gcloud_region})
+
+  echo "${json}"
+}
+
+# $1=address name
+gcloud_delete_static_ip_address() {
+  local address="${1}"
+
+  gcloud compute addresses delete "${address}" --quiet ${gcloud_region}
+}
+
+# $1=address name
+# $2=ip
+gcloud_reserve_static_ip_address() {
+  local address="${1}"
+  local ip="${2}"
+
+  if gcloud compute addresses describe "${address}" ${gcloud_region}; then
+    # already reserved, no-op
+    :
+  else
+    gcloud compute addresses create "${address}" --addresses="${ip}" ${gcloud_region}
+  fi
 }

--- a/scripts/setup-gcloud-cluster.sh
+++ b/scripts/setup-gcloud-cluster.sh
@@ -103,21 +103,24 @@ if [ "${show_prestartinfo}" = "1" ] || [ "${show_prestartinfo}" = "true" ]; then
 fi
 # }}}
 
-# create test specific instance template
-# announce on-chain with routable address
-gcloud_create_or_update_instance_template \
-  "${cluster_id}" \
-  "${docker_image}" \
-  "${environment}" \
-  "${api_token}" \
-  "${password}" \
-  "true"
+if [ "${skip_setup}" != "true" ]; then
 
-# start nodes
-gcloud_create_or_update_managed_instance_group  \
-  "${cluster_id}" \
-  ${cluster_size} \
-  "${cluster_id}"
+  # create test specific instance template
+  # announce on-chain with routable address
+  gcloud_create_instance_template_if_not_exists \
+    "${cluster_id}" \
+    "${docker_image}" \
+    "${environment}" \
+    "${api_token}" \
+    "${password}"
+    "true"
+
+  # start nodes
+  gcloud_create_or_update_managed_instance_group  \
+    "${cluster_id}" \
+    ${cluster_size} \
+    "${cluster_id}"
+fi
 
 # get IPs of newly started VMs which run hoprd
 declare node_ips


### PR DESCRIPTION
Previously every reboot would result in the instance receive a new IP
address. This change reserves the external addresses upon creation so
reboots don't cycle these IP addresses. Before the cluster is deleted
the IP addresses are released.

Fixes:
 - #3054
 - #3195 

### Test Instructions

1. Create cluster

```
HOPRD_PERFORM_CLEANUP=false HOPRD_SHOW_PRESTART_INFO=true ./scripts/setup-gcloud-cluster.sh athens "" my-test-cluster-random-NUMBER
```

2. Check reserved IP addresses

```
gcloud compute addresses list
```

3. Delete cluster

```
HOPRD_PERFORM_CLEANUP=true HOPRD_SHOW_PRESTART_INFO=true ./scripts/setup-gcloud-cluster.sh athens "" my-test-cluster-random-NUMBER
```

4. Check reserved IP addresses again, ensure IPs were released

```
gcloud compute addresses list
```