### PR TITLE
Minor fixes on abortableTimeout

### DIFF
--- a/packages/utils/src/async/abortableTimeout.ts
+++ b/packages/utils/src/async/abortableTimeout.ts
@@ -1,4 +1,3 @@
-import { defer } from './defer'
 import { debug } from '../process'
 
 const logError = debug('hopr:lateTimeout')
@@ -19,44 +18,54 @@ export type TimeoutOpts = {
  * @param opts options to pass to worker function
  * @returns
  */
-export async function abortableTimeout<Result, AbortMsg, TimeoutMsg>(
+export function abortableTimeout<Result, AbortMsg, TimeoutMsg>(
   fn: (opts: Required<TimeoutOpts>) => Promise<Result>,
   abortMsg: AbortMsg,
   timeoutMsg: TimeoutMsg,
   opts: TimeoutOpts
 ): Promise<Result | AbortMsg | TimeoutMsg> {
-  const abort = new AbortController()
+  return new Promise<Result | AbortMsg | TimeoutMsg>(async (resolve, reject) => {
+    const abort = new AbortController()
 
-  let done = false
-
-  const onceDone = defer<AbortMsg | TimeoutMsg>()
-
-  const cleanUp = () => {
-    done = true
-    abort.signal.removeEventListener('abort', onAbort)
-  }
-
-  const onTimeout = () => {
-    if (done) {
-      return
-    }
-    cleanUp()
-    abort.abort()
-    onceDone.resolve(timeoutMsg)
-  }
-
-  const onAbort = () => {
-    if (done) {
-      return
-    }
-    cleanUp()
-    onceDone.resolve(abortMsg)
-  }
-
-  abort.signal.addEventListener('abort', onAbort)
-
-  const resultFunction = async (): Promise<Result> => {
     let result: Result
+
+    let done = false
+
+    // forward outer abort
+    const innerAbort = abort.abort.bind(abort)
+
+    const cleanUp = () => {
+      done = true
+      abort.signal.removeEventListener('abort', onInnerAbort)
+      opts.signal?.removeEventListener('abort', innerAbort)
+    }
+
+    const onTimeout = () => {
+      if (done) {
+        return
+      }
+      cleanUp()
+      innerAbort()
+      resolve(timeoutMsg)
+    }
+
+    const onInnerAbort = () => {
+      if (done) {
+        return
+      }
+      cleanUp()
+      resolve(abortMsg)
+    }
+
+    abort.signal.addEventListener('abort', onInnerAbort)
+
+    opts.signal?.addEventListener('abort', innerAbort)
+
+    // Let the timeout run through and let the handler do nothing, i.e. `done = true`
+    // instead of clearing the timeout with `clearTimeout` which becomes an expensive
+    // operation when using many timeouts
+    setTimeout(onTimeout, opts.timeout)
+
     try {
       result = await fn({
         timeout: opts.timeout,
@@ -64,8 +73,11 @@ export async function abortableTimeout<Result, AbortMsg, TimeoutMsg>(
       })
     } catch (err) {
       if (!done) {
-        throw err
+        cleanUp()
+        reject(err)
+        return
       } else {
+        cleanUp()
         // The function has thrown an error after there
         // was a timeout or the call has been aborted.
         // The abortableTimeout has returned a value, hence
@@ -78,21 +90,12 @@ export async function abortableTimeout<Result, AbortMsg, TimeoutMsg>(
       }
     }
 
+    if (done) {
+      return
+    }
+
     cleanUp()
-    return result
-  }
 
-  // forward abort request
-  const onOuterAbort = abort.abort.bind(abort)
-  opts.signal?.addEventListener('abort', () => {
-    onOuterAbort()
-    opts.signal?.removeEventListener('abort', onOuterAbort)
+    resolve(result)
   })
-
-  // Let the timeout run through and let the handler do nothing, i.e. `done = true`
-  // instead of clearing the timeout with `clearTimeout` which becomes an expensive
-  // operation when using many timeouts
-  setTimeout(onTimeout, opts.timeout)
-
-  return Promise.race([onceDone.promise, resultFunction()])
 }


### PR DESCRIPTION
Changes:
- unassign outer abort listener after timeout / error thrown
- simplify control flow
- cleanup event listener if an error is thrown
