### PR TITLE
Release Athens hotfix: Add CLI argument to explicitly allow localhost connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Automatic deployment of NAT nodes to GCloud ([#3165](https://github.com/hoprnet/hoprnet/issues/3165))
 - Automatically extend TTL of relay tokens in the DHT ([#3304](https://github.com/hoprnet/hoprnet/issues/3304))
 - Do not dial localhost unless the port is different from the ones we're listening on ([#3321](https://github.com/hoprnet/hoprnet/pull/3321))
-
+- Add CLI parameter `--allowLocalNodeConnections` to explicitly allow connections to localhost ([#3349](https://github.com/hoprnet/hoprnet/pull/3349))
 ---
 
 <a name="1.85"></a>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Automatically extend TTL of relay tokens in the DHT ([#3304](https://github.com/hoprnet/hoprnet/issues/3304))
 - Do not dial localhost unless the port is different from the ones we're listening on ([#3321](https://github.com/hoprnet/hoprnet/pull/3321))
 - Add CLI parameter `--allowLocalNodeConnections` to explicitly allow connections to localhost ([#3349](https://github.com/hoprnet/hoprnet/pull/3349))
+
 ---
 
 <a name="1.85"></a>

--- a/packages/connect/src/filter.spec.ts
+++ b/packages/connect/src/filter.spec.ts
@@ -22,9 +22,11 @@ class TestFilter extends Filter {
 
 describe('test addr filtering', function () {
   let filter: TestFilter
+  let filter_no_local: TestFilter
 
   beforeEach(function () {
-    filter = new TestFilter(firstPeer)
+    filter = new TestFilter(firstPeer, { allowLocalConnections: true })
+    filter_no_local = new TestFilter(firstPeer, { allowLocalConnections: false })
   })
 
   it('should accept valid circuit addresses', function () {
@@ -87,6 +89,31 @@ describe('test addr filtering', function () {
     assert(
       filter.filter(new Multiaddr(`/ip6/::1/tcp/1/p2p/${secondPeer.toB58String()}`)) == false,
       'Refuse dialing IPv6'
+    )
+  })
+
+  it('refuse localhost connections', function () {
+    filter.setAddrs(
+      [new Multiaddr(`/ip4/1.1.1.1/tcp/123/p2p/${firstPeer.toB58String()}`)],
+      [new Multiaddr(`/ip4/0.0.0.0/tcp/0/p2p/${firstPeer.toB58String()}`)]
+    )
+
+    filter_no_local.setAddrs(
+      [new Multiaddr(`/ip4/1.1.1.1/tcp/123/p2p/${firstPeer.toB58String()}`)],
+      [new Multiaddr(`/ip4/0.0.0.0/tcp/0/p2p/${firstPeer.toB58String()}`)]
+    )
+
+    assert(filter.addrsSet)
+    assert(filter_no_local.addrsSet)
+
+    assert(
+      filter_no_local.filter(new Multiaddr(`/ip4/127.0.0.1/tcp/456/p2p/${secondPeer.toB58String()}`)) == false,
+      'Refuse dialing localhost'
+    )
+
+    assert(
+      filter.filter(new Multiaddr(`/ip4/127.0.0.1/tcp/456/p2p/${secondPeer.toB58String()}`)) == true,
+      'Allow dialing localhost'
     )
   })
 

--- a/packages/connect/src/filter.ts
+++ b/packages/connect/src/filter.ts
@@ -18,6 +18,7 @@ import { parseAddress } from './utils'
 import Debug from 'debug'
 import { green } from 'chalk'
 import assert from 'assert'
+import { HoprConnectOptions } from './types'
 
 const log = Debug('hopr-connect:filter')
 
@@ -29,7 +30,7 @@ export class Filter {
 
   protected myPrivateNetworks: Network[]
 
-  constructor(private peerId: PeerId) {
+  constructor(private peerId: PeerId, private opts: HoprConnectOptions) {
     this.myPrivateNetworks = getPrivateAddresses()
   }
 
@@ -141,6 +142,12 @@ export class Filter {
 
     if (address.node != undefined && u8aEquals(address.node, this.peerId.marshalPubKey())) {
       log(`Prevented self-dial. Used addr: ${ma.toString()}`)
+      return false
+    }
+
+    // If localhost connections are explicitly allowed, do not dial it
+    if (isLocalhost(address.address, address.type) && !(this.opts.allowLocalConnections ?? false)) {
+      // Do not pollute logs by rejecting localhost connections attempts
       return false
     }
 

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -72,7 +72,7 @@ class HoprConnect implements Transport<HoprConnectDialOptions, HoprConnectListen
     this._peerId = opts.libp2p.peerId
     this._libp2p = opts.libp2p
 
-    this._addressFilter = new Filter(this._peerId)
+    this._addressFilter = new Filter(this._peerId, this.options)
 
     this.discovery = new Discovery()
 

--- a/packages/connect/src/types.ts
+++ b/packages/connect/src/types.ts
@@ -59,6 +59,7 @@ export type StreamResult = IteratorResult<StreamType>
 
 export type HoprConnectOptions = {
   publicNodes?: PublicNodesEmitter
+  allowLocalConnections?: boolean
   initialNodes?: PeerStoreType[]
   interface?: string
   maxRelayedConnections?: number

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -80,6 +80,7 @@ export type HoprOptions = {
   dbPath?: string
   createDbIfNotExist?: boolean
   forceCreateDB?: boolean
+  allowLocalConnections?: boolean
   password?: string
   connector?: HoprCoreEthereum
   strategy?: ChannelStrategy

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -58,7 +58,8 @@ export async function createLibp2pInstance(
           config: {
             initialNodes,
             publicNodes,
-            environment: options.environment.id
+            environment: options.environment.id,
+            allowLocalConnections: options.allowLocalConnections
           },
           testing: {
             // Treat local and private addresses as public addresses

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -149,6 +149,11 @@ const argv = yargs(process.argv.slice(2))
     describe: 'Port to listen to for admin console',
     default: 3000
   })
+  .option('allowLocalNodeConnections', {
+    boolean: true,
+    describe: 'Allow connections to other nodes running on localhost.',
+    default: false
+  })
   .option('testAnnounceLocalAddresses', {
     boolean: true,
     describe: 'For testing local testnets. Announce local addresses.',
@@ -213,6 +218,7 @@ function generateNodeOptions(environment: ResolvedEnvironment): HoprOptions {
     announce: argv.announce,
     hosts: parseHosts(),
     environment,
+    allowLocalConnections: argv.allowLocalNodeConnections,
     testing: {
       announceLocalAddresses: argv.testAnnounceLocalAddresses,
       preferLocalAddresses: argv.testPreferLocalAddresses,

--- a/scripts/run-integration-tests-npm.sh
+++ b/scripts/run-integration-tests-npm.sh
@@ -167,6 +167,7 @@ function setup_node() {
     --testPreferLocalAddresses \
     --testUseWeakCrypto \
     --testNoUPNP \
+    --allowLocalNodeConnections \
     ${additional_args} \
     > "${log}" 2>&1 &
 

--- a/scripts/run-integration-tests-source.sh
+++ b/scripts/run-integration-tests-source.sh
@@ -158,6 +158,7 @@ function setup_node() {
     --testPreferLocalAddresses \
     --testUseWeakCrypto \
     --testNoUPNP \
+    --allowLocalNodeConnections \
     ${additional_args} \
     > "${log}" 2>&1 &
 }

--- a/scripts/setup-local-cluster.sh
+++ b/scripts/setup-local-cluster.sh
@@ -150,6 +150,7 @@ function setup_node() {
     --testAnnounceLocalAddresses \
     --testPreferLocalAddresses \
     --testUseWeakCrypto \
+    --allowLocalNodeConnections \
     ${additional_args} \
     > "${log}" 2>&1 &
 }


### PR DESCRIPTION
Resolves #3336  and might be related to #3362 

Already merged to `master` as #3349 