### PR TITLE
Hotfix/log CIDR addresses

### DIFF
--- a/packages/connect/src/filter.ts
+++ b/packages/connect/src/filter.ts
@@ -11,7 +11,8 @@ import {
   isLinkLocaleAddress,
   u8aAddrToString,
   getPrivateAddresses,
-  isLocalhost
+  isLocalhost,
+  u8aAddressToCIDR
 } from '@hoprnet/hopr-utils'
 import { parseAddress } from './utils'
 
@@ -205,7 +206,7 @@ export class Filter {
           `Prevented dialing private address ${u8aAddrToString(address.address, address.type)}:${
             address.port
           } because not in our network(s): ${this.myPrivateNetworks
-            .map((network) => `${u8aAddrToString(network.networkPrefix, network.family)}`)
+            .map((network) => `${u8aAddressToCIDR(network.networkPrefix, network.subnet, network.family)}`)
             .join(', ')}`
         )
         return false

--- a/packages/utils/src/network/addrs.ts
+++ b/packages/utils/src/network/addrs.ts
@@ -129,24 +129,15 @@ export function ipToU8aAddress(address: string, family: NetworkInterfaceInfo['fa
  * @returns the prefix length, e.g. 24
  */
 export function prefixLength(prefix: Uint8Array) {
-  const masks: number[] = [128, 192, 224, 240, 248, 252, 254, 255]
+  const masks: number[] = [0, 128, 192, 224, 240, 248, 252, 254, 255]
 
   let prefixLength = 0
-  let done = false
 
   for (let i = 0; i < prefix.length; i++) {
-    for (let bit = 0; bit < 8; bit++) {
-      if ((prefix[i] & masks[bit]) == masks[bit]) {
-        prefixLength++
-      } else {
-        done = true
-        break
-      }
-    }
+    let bit = 0
+    for (; (prefix[i] & masks[bit]) == masks[bit]; bit++) {}
 
-    if (done) {
-      break
-    }
+    prefixLength += bit - 1
   }
 
   return prefixLength

--- a/packages/utils/src/network/addrs.ts
+++ b/packages/utils/src/network/addrs.ts
@@ -129,7 +129,7 @@ export function ipToU8aAddress(address: string, family: NetworkInterfaceInfo['fa
  * @returns the prefix length, e.g. 24
  */
 export function prefixLength(prefix: Uint8Array) {
-  const masks: number[] = [0, 128, 192, 224, 240, 248, 252, 254, 255]
+  const masks: number[] = [128, 192, 224, 240, 248, 252, 254, 255]
 
   let prefixLength = 0
 
@@ -137,7 +137,7 @@ export function prefixLength(prefix: Uint8Array) {
     let bit = 0
     for (; (prefix[i] & masks[bit]) == masks[bit]; bit++) {}
 
-    prefixLength += bit - 1
+    prefixLength += bit
   }
 
   return prefixLength


### PR DESCRIPTION
The debug logs in GCloud look suspicious and there is probably a bug in the address filter.

Changes:

- log CIDR address strings to see if address filter is working properly

Sample debug log from GCloud nodes

![Screenshot from 2022-01-31 14-40-33](https://user-images.githubusercontent.com/12514844/151822812-835161d8-1a06-430e-89db-75e342d1bd92.png)
