### PR TITLE
Fix ticket redemption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Expanded API v2, covering most of the legacy hopr-admin commands ([#3367](https://github.com/hoprnet/hoprnet/pull/3367))
 - New API v2 endpoints allow fetching and redeeming tickets from specific channels ([#3367](https://github.com/hoprnet/hoprnet/pull/3367))
 - Flags `--rest`, `--restHost`, and `--restPort` are being deprecated in favor of `--api`, `--apiHost`, and `--apiPort`
+- Fixed automatic and manual ticket redemption ([#3395](https://github.com/hoprnet/hoprnet/pull/3395))
 
 ---
 

--- a/packages/core-ethereum/src/commitment.spec.ts
+++ b/packages/core-ethereum/src/commitment.spec.ts
@@ -30,7 +30,7 @@ describe('commitment', function () {
     assert.strictEqual(fakeGet.callCount, 1, 'should look on chain')
     assert(fakeSet.callCount == 1, 'should set a new commitment on chain')
 
-    await bumpCommitment(fakeDB, fakeCommInfo.channelId)
+    await bumpCommitment(fakeDB, fakeCommInfo.channelId, c1)
     let c2 = await findCommitmentPreImage(fakeDB, fakeCommInfo.channelId)
     assert(c2, 'gives current commitment')
     assert(c2.hash().eq(c1), 'c2 is commitment of c1')

--- a/packages/core-ethereum/src/commitment.ts
+++ b/packages/core-ethereum/src/commitment.ts
@@ -36,8 +36,8 @@ export async function findCommitmentPreImage(db: HoprDB, channelId: Hash): Promi
   return new Hash(Uint8Array.from(result.preImage))
 }
 
-export async function bumpCommitment(db: HoprDB, channelId: Hash) {
-  await db.setCurrentCommitment(channelId, await findCommitmentPreImage(db, channelId))
+export async function bumpCommitment(db: HoprDB, channelId: Hash, newCommitment: Hash) {
+  await db.setCurrentCommitment(channelId, newCommitment)
 }
 
 type GetCommitment = () => Promise<Hash>

--- a/packages/core-ethereum/src/ethereum.ts
+++ b/packages/core-ethereum/src/ethereum.ts
@@ -198,6 +198,14 @@ export async function createChainWrapper(
     }
   }
 
+  /*
+   * Sends announce transaction on-chain synchronously.
+   * Throws when an error during transaction sending is encountered.
+   *
+   * @param the address to be announced
+   * @param callback transaction handler
+   * @returns a Promise that resolve to the hash of the on-chain transaction
+   */
   async function announce(multiaddr: Multiaddr, txHandler: (tx: string) => DeferType<string>): Promise<string> {
     try {
       const confirmation = await sendTransaction(

--- a/packages/core-ethereum/src/index.ts
+++ b/packages/core-ethereum/src/index.ts
@@ -239,17 +239,16 @@ export default class HoprCoreEthereum extends EventEmitter {
   }
 
   private async redeemAllTicketsInternalLoop(): Promise<void> {
-      try {
+    try {
       for (const ce of await this.db.getChannelsTo(this.publicKey.toAddress())) {
-          await this.redeemTicketsInChannel(ce)
-        }
+        await this.redeemTicketsInChannel(ce)
       }
-        catch (err) {
-          log(`error during redeeming all tickets`, err)
-        }
+    } catch (err) {
+      log(`error during redeeming all tickets`, err)
+    }
 
-        // whenever we finish this loop we clear the reference
-      this.redeemingAll = undefined
+    // whenever we finish this loop we clear the reference
+    this.redeemingAll = undefined
   }
 
   public async redeemTicketsInChannel(channel: ChannelEntry) {
@@ -268,7 +267,11 @@ export default class HoprCoreEthereum extends EventEmitter {
     log('tickets to be redeemed with indices', indices)
 
     for (const ticket of tickets) {
-      log(`redeeming ticket in channel from ${channel.source} to ${channel.destination}`, ticket, ticket.ticket.toString())
+      log(
+        `redeeming ticket in channel from ${channel.source} to ${channel.destination}`,
+        ticket,
+        ticket.ticket.toString()
+      )
       const result = await this.redeemTicket(channel.source, ticket)
 
       if (result.status !== 'SUCCESS') {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -911,18 +911,17 @@ class Hopr extends EventEmitter {
       await this.strategy.onChannelWillClose(channel, this.connector)
     }
 
-    log('closing channel', channel.getId())
     let txHash: string
     try {
       if (channel.status === ChannelStatus.Open || channel.status == ChannelStatus.WaitingForCommitment) {
-        log('initiating closure')
+        log('initiating closure of channel', channel.getId())
         txHash = await this.connector.initializeClosure(counterpartyPubKey)
       } else {
         // verify that we passed the closure waiting period to prevent failing
         // on-chain transactions
 
         if (channel.closureTimePassed()) {
-          log('finalizing closure')
+          log('finalizing closure of channel', channel.getId())
           txHash = await this.connector.finalizeClosure(counterpartyPubKey)
         } else {
           log('ignoring finalizing closure because closure window is still active', channel.getId())
@@ -934,7 +933,6 @@ class Hopr extends EventEmitter {
       throw new Error(`Failed to closeChannel: ${err}`)
     }
 
-    log(`closed channel, ${channel.getId()}`)
     return { receipt: txHash, status: channel.status }
   }
 

--- a/packages/core/src/messages/packet.ts
+++ b/packages/core/src/messages/packet.ts
@@ -425,6 +425,7 @@ export class Packet {
           })
       )
     } catch (e) {
+      log(`mark ticket as rejected`, this.ticket)
       await db.markRejected(this.ticket)
       throw e
     }

--- a/packages/ethereum/tasks/faucet.ts
+++ b/packages/ethereum/tasks/faucet.ts
@@ -169,7 +169,7 @@ async function main(
   const txs: UnsignedTransaction[] = []
   for (const identity of identities) {
     txs.push(
-      ...(await createTransaction(hoprToken, identity, utils.parseEther('1.0'), utils.parseEther('10.0'), network.name))
+      ...(await createTransaction(hoprToken, identity, utils.parseEther('1.0'), utils.parseEther('20.0'), network.name))
     )
   }
 

--- a/packages/utils/src/async/concurrency.spec.ts
+++ b/packages/utils/src/async/concurrency.spec.ts
@@ -12,16 +12,23 @@ describe('concurrency', function () {
     const CALLS = 3
 
     for (let i = 0; i < CALLS; i++) {
-      limitter(async () => {
-        const promise = new Promise<number>((resolve) => setTimeout(resolve, 50, i))
-        promises.push(promise)
-        results.push(await promise)
-      })
+      const promise = new Promise<void>((resolve) =>
+        setTimeout(
+          (result) => {
+            results.push(result)
+            resolve()
+          },
+          50,
+          i
+        )
+      )
+      promises.push(promise)
+      limitter(() => promise)
     }
 
     await Promise.all(promises)
 
-    assert(results.length == CALLS, `must contain all results`)
+    assert(results.length == CALLS, `must contain all results instead of just ${results.length}`)
     assert(
       results.every((value: number, index: number) => value == index),
       `must contain the right results`
@@ -33,33 +40,46 @@ describe('concurrency', function () {
 
     const results: number[] = []
 
-    let promise: Promise<number>
-    limitter(async () => {
-      promise = new Promise<number>((resolve) => setTimeout(setImmediate, 20, resolve, 0))
-      results.push(await promise)
-    })
+    let promise = new Promise<void>((resolve) =>
+      setTimeout(
+        (result) => {
+          results.push(result)
+          resolve()
+        },
+        20,
+        0
+      )
+    )
+    limitter(() => promise)
 
     await promise
 
-    assert(results.length == 1, `must contain one result`)
+    assert(results.length == 1, `must contain one result instead of ${results.length}`)
     assert(results[0] == 0)
 
-    const promises: Promise<number>[] = []
+    const promises = []
 
     const CALLS = 3
 
     for (let i = 0; i < CALLS; i++) {
-      limitter(async () => {
-        const promise = new Promise<number>((resolve) => setTimeout(setImmediate, 20, resolve, i + 1))
-        promises.push(promise)
-        results.push(await promise)
-      })
+      promise = new Promise<void>((resolve) =>
+        setTimeout(
+          (result) => {
+            results.push(result)
+            resolve()
+          },
+          20,
+          i + 1
+        )
+      )
+      promises.push(promise)
+      limitter(() => promise)
     }
 
     await Promise.all(promises)
 
     // @ts-ignore
-    assert(results.length == 4, `must contain all results`)
+    assert(results.length == 4, `must contain all results instead of just ${results.length}`)
     assert(
       results.every((value: number, index: number) => value == index),
       `must contain the right results`
@@ -76,11 +96,18 @@ describe('concurrency', function () {
     const CALLS = 3
 
     for (let i = 0; i < CALLS; i++) {
-      limitter(async () => {
-        const promise = new Promise<number>((_, reject) => setTimeout(setImmediate, 20, reject, i))
-        promises.push(promise)
-        results.push(await promise)
-      })
+      const promise = new Promise<void>((_, reject) =>
+        setTimeout(
+          (result) => {
+            results.push(result)
+            reject()
+          },
+          20,
+          i + 1
+        )
+      )
+      promises.push(promise)
+      limitter(() => promise)
     }
 
     assert.rejects(async () => await Promise.all(promises))

--- a/packages/utils/src/async/concurrency.ts
+++ b/packages/utils/src/async/concurrency.ts
@@ -13,16 +13,18 @@ const log = debug('hopr:concurrency-limitter')
  */
 export function oneAtATime<ReturnType>(): (fn: () => Promise<ReturnType>) => void {
   const queue = FIFO<() => Promise<ReturnType>>()
+  let isRunning: boolean = false
 
   function push(fn: () => Promise<ReturnType>): void {
     queue.push(fn)
 
-    if (queue.size() == 1) {
+    if (queue.size() == 1 && !isRunning) {
       start()
     }
   }
 
   async function start(): Promise<void> {
+    isRunning = true
     while (queue.size() > 0) {
       try {
         await queue.shift()()
@@ -30,6 +32,7 @@ export function oneAtATime<ReturnType>(): (fn: () => Promise<ReturnType>) => voi
         log(err)
       }
     }
+    isRunning = false
   }
 
   return push

--- a/packages/utils/src/async/concurrency.ts
+++ b/packages/utils/src/async/concurrency.ts
@@ -17,7 +17,10 @@ export function oneAtATime<ReturnType>(): (fn: () => Promise<ReturnType>) => voi
 
   function push(fn: () => Promise<ReturnType>): void {
     queue.push(fn)
+    maybeStart()
+  }
 
+  function maybeStart(): void {
     if (queue.size() == 1 && !isRunning) {
       start()
     }

--- a/packages/utils/src/crypto/por/index.ts
+++ b/packages/utils/src/crypto/por/index.ts
@@ -132,7 +132,6 @@ export function validatePoRHalfKeys(ethereumChallenge: EthereumChallenge, ownKey
 // @TODO add description
 export function validatePoRResponse(ethereumChallenge: EthereumChallenge, response: Response): boolean {
   const challenge = response.toChallenge().toEthereumChallenge()
-  console.log(`validate PoR response ${challenge} against ${ethereumChallenge}`)
   return challenge.eq(ethereumChallenge)
 }
 

--- a/packages/utils/src/crypto/por/index.ts
+++ b/packages/utils/src/crypto/por/index.ts
@@ -131,7 +131,9 @@ export function validatePoRHalfKeys(ethereumChallenge: EthereumChallenge, ownKey
 
 // @TODO add description
 export function validatePoRResponse(ethereumChallenge: EthereumChallenge, response: Response): boolean {
-  return response.toChallenge().toEthereumChallenge().eq(ethereumChallenge)
+  const challenge = response.toChallenge().toEthereumChallenge()
+  console.log(`validate PoR response ${challenge} against ${ethereumChallenge}`)
+  return challenge.eq(ethereumChallenge)
 }
 
 // @TODO add description

--- a/packages/utils/src/db.ts
+++ b/packages/utils/src/db.ts
@@ -329,8 +329,8 @@ export class HoprDB {
       if (
         filter?.channel &&
         (!a.signer.eq(filter.channel.source) ||
-         !filter.channel.destination.eq(this.id) ||
-         !a.ticket.channelEpoch.eq(filter.channel.channelEpoch))
+          !filter.channel.destination.eq(this.id) ||
+          !a.ticket.channelEpoch.eq(filter.channel.channelEpoch))
       ) {
         return false
       }

--- a/packages/utils/src/db.ts
+++ b/packages/utils/src/db.ts
@@ -185,7 +185,8 @@ export class HoprDB {
   private async getAll<T>(
     prefix: Uint8Array,
     deserialize: (u: Uint8Array) => T,
-    filter: (o: T) => boolean
+    filter?: (o: T) => boolean,
+    sorter?: (e1: T, e2: T) => number
   ): Promise<T[]> {
     const res: T[] = []
     const prefixKeyed = this.keyOf(prefix)
@@ -198,11 +199,22 @@ export class HoprDB {
             return
           }
           const obj = deserialize(Uint8Array.from(value))
-          if (filter(obj)) {
+          // filter if a filter function was given
+          if (filter) {
+            if (filter(obj)) {
+              res.push(obj)
+            }
+          } else {
             res.push(obj)
           }
         })
-        .on('end', () => resolve(res))
+        .on('end', () => {
+          // sort if a sorter function was given
+          if (sorter) {
+            res.sort(sorter)
+          }
+          resolve(res)
+        })
     })
   }
 
@@ -300,7 +312,7 @@ export class HoprDB {
   }
 
   /**
-   * Get acknowledged tickets
+   * Get acknowledged tickets sorted by ticket index in ascending order.
    * @param filter optionally filter by signer
    * @returns an array of all acknowledged tickets
    */
@@ -316,15 +328,24 @@ export class HoprDB {
 
       if (
         filter?.channel &&
-        !a.signer.eq(filter.channel.source) &&
-        !a.ticket.channelEpoch.eq(filter.channel.channelEpoch)
+        (!a.signer.eq(filter.channel.source) ||
+         !filter.channel.destination.eq(this.id) ||
+         !a.ticket.channelEpoch.eq(filter.channel.channelEpoch))
       ) {
         return false
       }
+
       return true
     }
+    // sort in ascending order by ticket index: 1,2,3,4,...
+    const sortFunc = (t1: AcknowledgedTicket, t2: AcknowledgedTicket): number => t1.ticket.index.cmp(t2.ticket.index)
 
-    return this.getAll<AcknowledgedTicket>(ACKNOWLEDGED_TICKETS_PREFIX, AcknowledgedTicket.deserialize, filterFunc)
+    return this.getAll<AcknowledgedTicket>(
+      ACKNOWLEDGED_TICKETS_PREFIX,
+      AcknowledgedTicket.deserialize,
+      filterFunc,
+      sortFunc
+    )
   }
 
   public async deleteAcknowledgedTicketsFromChannel(channel: ChannelEntry): Promise<void> {
@@ -452,7 +473,6 @@ export class HoprDB {
   }
 
   async getChannels(filter?: (channel: ChannelEntry) => boolean): Promise<ChannelEntry[]> {
-    filter = filter || (() => true)
     return this.getAll<ChannelEntry>(CHANNEL_PREFIX, ChannelEntry.deserialize, filter)
   }
 
@@ -470,7 +490,6 @@ export class HoprDB {
   }
 
   async getAccounts(filter?: (account: AccountEntry) => boolean) {
-    filter = filter || (() => true)
     return this.getAll<AccountEntry>(ACCOUNT_PREFIX, AccountEntry.deserialize, filter)
   }
 

--- a/packages/utils/src/types/acknowledgedTicket.ts
+++ b/packages/utils/src/types/acknowledgedTicket.ts
@@ -25,7 +25,6 @@ export class AcknowledgedTicket {
   public verify(ticketIssuer: PublicKey): boolean {
     const check1 = validatePoRResponse(this.ticket.challenge, this.response)
     const check2 = this.ticket.verify(ticketIssuer)
-    console.log(`ticket verify check 1 is ${check1}, check 2 is ${check2}`)
     return check1 && check2
   }
 

--- a/packages/utils/src/types/acknowledgedTicket.ts
+++ b/packages/utils/src/types/acknowledgedTicket.ts
@@ -23,7 +23,10 @@ export class AcknowledgedTicket {
   }
 
   public verify(ticketIssuer: PublicKey): boolean {
-    return validatePoRResponse(this.ticket.challenge, this.response) && this.ticket.verify(ticketIssuer)
+    const check1 = validatePoRResponse(this.ticket.challenge, this.response)
+    const check2 = this.ticket.verify(ticketIssuer)
+    console.log(`ticket verify check 1 is ${check1}, check 2 is ${check2}`)
+    return check1 && check2
   }
 
   static deserialize(arr: Uint8Array) {

--- a/packages/utils/src/types/solidity.ts
+++ b/packages/utils/src/types/solidity.ts
@@ -23,6 +23,10 @@ class UINT256 {
     return this.toBN().eq(b.toBN())
   }
 
+  public cmp(b: UINT256): number {
+    return this.toBN().cmp(b.toBN())
+  }
+
   static fromString(str: string): UINT256 {
     return new UINT256(new BN(str))
   }

--- a/packages/utils/src/types/ticket.ts
+++ b/packages/utils/src/types/ticket.ts
@@ -156,7 +156,6 @@ export class Ticket {
 
   verify(pubKey: PublicKey): boolean {
     const signer = this.recoverSigner()
-    console.log(`ticket verify pubkey ${pubKey} against signer ${signer}, ${this}`)
     return pubKey.eq(signer)
   }
 

--- a/packages/utils/src/types/ticket.ts
+++ b/packages/utils/src/types/ticket.ts
@@ -155,7 +155,9 @@ export class Ticket {
   }
 
   verify(pubKey: PublicKey): boolean {
-    return pubKey.eq(this.recoverSigner())
+    const signer = this.recoverSigner()
+    console.log(`ticket verify pubkey ${pubKey} against signer ${signer}, ${this}`)
+    return pubKey.eq(signer)
   }
 
   getLuck(preImage: Hash, challengeResponse: Response): UINT256 {

--- a/scripts/run-integration-tests-source.sh
+++ b/scripts/run-integration-tests-source.sh
@@ -344,7 +344,7 @@ HOPRD_API_TOKEN="${api_token}" ${mydir}/../test/integration-test.sh \
 
 # -- Verify node6 has executed the commands {{{
 log "Verifying node6 log output"
-grep -E "HOPR Balance: +10 txHOPR" "${node6_log}"
+grep -E "HOPR Balance: +20 txHOPR" "${node6_log}"
 grep -E "ETH Balance: +1 xDAI" "${node6_log}"
 grep -E "Running on: hardhat" "${node6_log}"
 # }}}

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -354,27 +354,27 @@ wait
 
 # initiate channel closures
 log "Node 1 close channel to Node 2"
-result=$(run_command "${api1}" "close ${addr2}" "Initiated channel closure" 600)
+result=$(run_command "${api1}" "close ${addr2}" "" 600)
 log "-- ${result}"
 
 log "Node 2 close channel to Node 3"
-result=$(run_command "${api2}" "close ${addr3}" "Initiated channel closure" 600)
+result=$(run_command "${api2}" "close ${addr3}" "" 600)
 log "-- ${result}"
 
 log "Node 3 close channel to Node 4"
-result=$(run_command "${api3}" "close ${addr4}" "Initiated channel closure" 600)
+result=$(run_command "${api3}" "close ${addr4}" "" 600)
 log "-- ${result}"
 
 log "Node 4 close channel to Node 5"
-result=$(run_command "${api4}" "close ${addr5}" "Initiated channel closure" 600)
+result=$(run_command "${api4}" "close ${addr5}" "" 600)
 log "-- ${result}"
 
 log "Node 5 close channel to Node 1"
-result=$(run_command "${api5}" "close ${addr1}" "Initiated channel closure" 600)
+result=$(run_command "${api5}" "close ${addr1}" "" 600)
 log "-- ${result}"
 
 # close channels
-echo "Waiting 1 minure for cool-off period"
+log "Waiting 1 minure for cool-off period"
 sleep 60
 
 log "Node 1 close channel to Node 2"

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -227,6 +227,10 @@ log "Node 1 open channel to Node 2"
 result=$(run_command "${api1}" "open ${addr2} 1" "Successfully opened channel" 600)
 log "-- ${result}"
 
+log "Node 1 open channel to Node 5 (used for channel close test later)"
+result=$(run_command "${api1}" "open ${addr5} 1" "Successfully opened channel" 600)
+log "-- ${result}"
+
 log "Node 2 open channel to Node 3"
 result=$(run_command "${api2}" "open ${addr3} 1" "Successfully opened channel" 600)
 log "-- ${result}"
@@ -352,47 +356,39 @@ redeem_tickets "5" "${api2}" &
 log "Waiting for nodes to finish ticket redemption (long running)"
 wait
 
-# initiate channel closures
+# initiate channel closures, but don't wait because this will trigger ticket
+# redemption as well
 log "Node 1 close channel to Node 2"
-result=$(run_command "${api1}" "close ${addr2}" "" 600)
+result=$(run_command "${api1}" "close ${addr2}" "" 20 20)
 log "-- ${result}"
 
 log "Node 2 close channel to Node 3"
-result=$(run_command "${api2}" "close ${addr3}" "" 600)
+result=$(run_command "${api2}" "close ${addr3}" "" 20 20)
 log "-- ${result}"
 
 log "Node 3 close channel to Node 4"
-result=$(run_command "${api3}" "close ${addr4}" "" 600)
+result=$(run_command "${api3}" "close ${addr4}" "" 20 20)
 log "-- ${result}"
 
 log "Node 4 close channel to Node 5"
-result=$(run_command "${api4}" "close ${addr5}" "" 600)
+result=$(run_command "${api4}" "close ${addr5}" "" 20 20)
 log "-- ${result}"
 
 log "Node 5 close channel to Node 1"
-result=$(run_command "${api5}" "close ${addr1}" "" 600)
+result=$(run_command "${api5}" "close ${addr1}" "" 20 20)
+log "-- ${result}"
+
+# initiate channel closures for channels without tickets so we can check
+# completeness
+
+log "Node 1 close channel to Node 5"
+result=$(run_command "${api1}" "close ${addr5}" "" 600)
 log "-- ${result}"
 
 # close channels
 log "Waiting 1 minure for cool-off period"
 sleep 60
 
-log "Node 1 close channel to Node 2"
-result=$(run_command "${api1}" "close ${addr2}" "Channel is already closed" 600)
-log "--${result}"
-
-log "Node 2 close channel to Node 3"
-result=$(run_command "${api2}" "close ${addr3}" "Channel is already closed" 600)
-log "--${result}"
-
-log "Node 3 close channel to Node 4"
-result=$(run_command "${api3}" "close ${addr4}" "Channel is already closed" 600)
-log "--${result}"
-
-log "Node 4 close channel to Node 5"
-result=$(run_command "${api4}" "close ${addr5}" "Channel is already closed" 600)
-log "--${result}"
-
-log "Node 5 close channel to Node 1"
-result=$(run_command "${api5}" "close ${addr1}" "Channel is already closed" 600)
+log "Node 1 close channel to Node 5"
+result=$(run_command "${api1}" "close ${addr5}" "Channel is already closed" 600)
 log "--${result}"

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -157,6 +157,92 @@ validate_node_balance_gt0() {
   fi
 }
 
+# $1 = source node id
+# $2 = destination node id
+# $3 = channel source api endpoint
+# $4 = channel destination peer id
+# $5 = OPTIONAL: verify closure strictly
+close_channel() {
+  local source_id="${1}"
+  local destination_id="${2}"
+  local source_api="${3}"
+  local destination_peer_id="${4}"
+  local strict_check="${5:-false}"
+  local result
+
+  log "Node ${source_id} close channel to Node ${destination_id}"
+  if [ "${strict_check}" = "true" ]; then
+    result=$(run_command "${source_api}" "close ${destination_peer_id}" "Channel is already closed" 600)
+  else
+    result=$(run_command "${source_api}" "close ${destination_peer_id}" "" 20 20)
+  fi
+  log "Node ${source_id} close channel to Node ${destination_id} result -- ${result}"
+}
+
+# $1 = source node id
+# $2 = destination node id
+# $3 = channel source api endpoint
+# $4 = channel destination peer id
+open_channel() {
+  local source_id="${1}"
+  local destination_id="${2}"
+  local source_api="${3}"
+  local destination_peer_id="${4}"
+  local result
+
+  log "Node ${source_id} open channel to Node ${destination_id}"
+  result=$(run_command "${source_api}" "open ${destination_peer_id} 2" "Successfully opened channel" 600 60)
+  log "Node ${source_id} open channel to Node ${destination_id} result -- ${result}"
+}
+
+
+# $1 = node id
+# $2 = node api endpoint
+redeem_tickets() {
+  local node_id="${1}"
+  local node_api="${2}"
+  local rejected redeemed prev_redeemed
+
+  # First get the inital ticket statistics for reference
+  result=$(run_command "${node_api}" "tickets" "" 600)
+  log "Node ${node_id} ticket information (before redemption) -- ${result}"
+  rejected=$(echo "${result}" | grep "Rejected:" | awk '{ print $3; }' | tr -d '\n')
+  redeemed=$(echo "${result}" | grep "Redeemed:" | awk '{ print $3; }' | tr -d '\n')
+  [[ ${rejected} -gt 0 ]] && { msg "rejected tickets count on node ${node_id} is ${rejected}"; exit 1; }
+  last_redeemed="${redeemed}"
+
+  # Trigger a redemption run, but cap it at 1 minute. We only want to measure
+  # progress, not redeeem all tickets which takes too long.
+  log "Node ${node_id} should redeem all tickets"
+  result=$(run_command "${node_api}" "redeemTickets" "" 60 60)
+  log "--${result}"
+
+  # Get ticket statistics again and compare with previous state. Ensure we
+  # redeemed tickets.
+  result=$(run_command "${node_api}" "tickets" "" 600)
+  log "Node ${node_id} ticket information (after redemption) -- ${result}"
+  rejected=$(echo "${result}" | grep "Rejected:" | awk '{ print $3; }' | tr -d '\n')
+  redeemed=$(echo "${result}" | grep "Redeemed:" | awk '{ print $3; }' | tr -d '\n')
+  [[ ${rejected} -gt 0 ]] && { msg "rejected tickets count on node ${node_id} is ${rejected}"; exit 1; }
+  [[ ${redeemed} -gt 0 && ${redeemed} -gt ${last_redeemed} ]] || { msg "redeemed tickets count on node ${node_id} is ${redeemed}, previously ${last_redeemed}"; exit 1; }
+  last_redeemed="${redeemed}"
+
+  # Trigger another redemption run, but cap it at 1 minute. We only want to measure
+  # progress, not redeeem all tickets which takes too long.
+  log "Node ${node_id} should redeem all tickets (again to ensure re-run of operation)"
+  result=$(run_command "${node_api}" "redeemTickets" "" 60 60)
+  log "--${result}"
+
+  # Get final ticket statistics
+  result=$(run_command "${node_api}" "tickets" "" 600)
+  log "Node ${node_id} ticket information (after second redemption) -- ${result}"
+  rejected=$(echo "${result}" | grep "Rejected:" | awk '{ print $3; }' | tr -d '\n')
+  redeemed=$(echo "${result}" | grep "Redeemed:" | awk '{ print $3; }' | tr -d '\n')
+  [[ ${rejected} -gt 0 ]] && { msg "rejected tickets count on node ${node_id} is ${rejected}"; exit 1; }
+  [[ ${redeemed} -gt 0 && ${redeemed} -gt ${last_redeemed} ]] || { msg "redeemed tickets count on node ${node_id} is ${redeemed}, previously ${last_redeemed}"; exit 1; }
+}
+
+
 log "Running full E2E test with ${api1}, ${api2}, ${api3}, ${api4}, ${api5}, ${api6}, ${api7}"
 
 validate_native_address "${api1}" "${api_token}"
@@ -223,29 +309,18 @@ log "-- ${result}"
 log "Node 1 send 0-hop message to node 2"
 run_command "${api1}" "send ,${addr2} 'hello, world'" "Message sent" 600
 
-log "Node 1 open channel to Node 2"
-result=$(run_command "${api1}" "open ${addr2} 1" "Successfully opened channel" 600)
-log "-- ${result}"
+# opening channels in parallel
+open_channel 1 2 "${api1}" "${addr2}" &
+open_channel 2 3 "${api2}" "${addr3}" &
+open_channel 3 4 "${api3}" "${addr4}" &
+open_channel 4 5 "${api4}" "${addr5}" &
+open_channel 5 1 "${api5}" "${addr1}" &
 
-log "Node 1 open channel to Node 5 (used for channel close test later)"
-result=$(run_command "${api1}" "open ${addr5} 1" "Successfully opened channel" 600)
-log "-- ${result}"
+#used for channel close test later
+open_channel 1 5 "${api1}" "${addr5}" &
 
-log "Node 2 open channel to Node 3"
-result=$(run_command "${api2}" "open ${addr3} 1" "Successfully opened channel" 600)
-log "-- ${result}"
-
-log "Node 3 open channel to Node 4"
-result=$(run_command "${api3}" "open ${addr4} 1" "Successfully opened channel" 600)
-log "-- ${result}"
-
-log "Node 4 open channel to Node 5"
-result=$(run_command "${api4}" "open ${addr5} 1" "Successfully opened channel" 600)
-log "-- ${result}"
-
-log "Node 5 open channel to Node 1"
-result=$(run_command "${api5}" "open ${addr1} 0.001" "Successfully opened channel" 600)
-log "-- ${result}"
+log "Waiting for nodes to finish open channel (long running)"
+wait
 
 for i in `seq 1 10`; do
   log "Node 1 send 1 hop message to self via node 2"
@@ -303,51 +378,6 @@ for i in `seq 1 10`; do
   send_message "${api1}" "${addr5}" "hello, world" "" 600
 done
 
-# redeem tickets in parallel
-redeem_tickets() {
-  local node_id="${1}"
-  local node_api="${2}"
-  local rejected redeemed prev_redeemed
-
-  # First get the inital ticket statistics for reference
-  result=$(run_command "${node_api}" "tickets" "" 600)
-  log "Node ${node_id} ticket information (before redemption) -- ${result}"
-  rejected=$(echo "${result}" | grep "Rejected:" | awk '{ print $3; }' | tr -d '\n')
-  redeemed=$(echo "${result}" | grep "Redeemed:" | awk '{ print $3; }' | tr -d '\n')
-  [[ ${rejected} -gt 0 ]] && { msg "rejected tickets count on node ${node_id} is ${rejected}"; exit 1; }
-  last_redeemed="${redeemed}"
-
-  # Trigger a redemption run, but cap it at 1 minute. We only want to measure
-  # progress, not redeeem all tickets which takes too long.
-  log "Node ${node_id} should redeem all tickets"
-  result=$(run_command "${node_api}" "redeemTickets" "" 60 60)
-  log "--${result}"
-
-  # Get ticket statistics again and compare with previous state. Ensure we
-  # redeemed tickets.
-  result=$(run_command "${node_api}" "tickets" "" 600)
-  log "Node ${node_id} ticket information (after redemption) -- ${result}"
-  rejected=$(echo "${result}" | grep "Rejected:" | awk '{ print $3; }' | tr -d '\n')
-  redeemed=$(echo "${result}" | grep "Redeemed:" | awk '{ print $3; }' | tr -d '\n')
-  [[ ${rejected} -gt 0 ]] && { msg "rejected tickets count on node ${node_id} is ${rejected}"; exit 1; }
-  [[ ${redeemed} -gt 0 && ${redeemed} -gt ${last_redeemed} ]] || { msg "redeemed tickets count on node ${node_id} is ${redeemed}, previously ${last_redeemed}"; exit 1; }
-  last_redeemed="${redeemed}"
-
-  # Trigger another redemption run, but cap it at 1 minute. We only want to measure
-  # progress, not redeeem all tickets which takes too long.
-  log "Node ${node_id} should redeem all tickets (again to ensure re-run of operation)"
-  result=$(run_command "${node_api}" "redeemTickets" "" 60 60)
-  log "--${result}"
-
-  # Get final ticket statistics
-  result=$(run_command "${node_api}" "tickets" "" 600)
-  log "Node ${node_id} ticket information (after second redemption) -- ${result}"
-  rejected=$(echo "${result}" | grep "Rejected:" | awk '{ print $3; }' | tr -d '\n')
-  redeemed=$(echo "${result}" | grep "Redeemed:" | awk '{ print $3; }' | tr -d '\n')
-  [[ ${rejected} -gt 0 ]] && { msg "rejected tickets count on node ${node_id} is ${rejected}"; exit 1; }
-  [[ ${redeemed} -gt 0 && ${redeemed} -gt ${last_redeemed} ]] || { msg "redeemed tickets count on node ${node_id} is ${redeemed}, previously ${last_redeemed}"; exit 1; }
-}
-
 redeem_tickets "2" "${api2}" &
 redeem_tickets "3" "${api2}" &
 redeem_tickets "4" "${api2}" &
@@ -358,37 +388,21 @@ wait
 
 # initiate channel closures, but don't wait because this will trigger ticket
 # redemption as well
-log "Node 1 close channel to Node 2"
-result=$(run_command "${api1}" "close ${addr2}" "" 20 20)
-log "-- ${result}"
-
-log "Node 2 close channel to Node 3"
-result=$(run_command "${api2}" "close ${addr3}" "" 20 20)
-log "-- ${result}"
-
-log "Node 3 close channel to Node 4"
-result=$(run_command "${api3}" "close ${addr4}" "" 20 20)
-log "-- ${result}"
-
-log "Node 4 close channel to Node 5"
-result=$(run_command "${api4}" "close ${addr5}" "" 20 20)
-log "-- ${result}"
-
-log "Node 5 close channel to Node 1"
-result=$(run_command "${api5}" "close ${addr1}" "" 20 20)
-log "-- ${result}"
+close_channel 1 2 "${api1}" "${addr2}" &
+close_channel 2 3 "${api2}" "${addr3}" &
+close_channel 3 4 "${api3}" "${addr4}" &
+close_channel 4 5 "${api4}" "${addr5}" &
+close_channel 5 1 "${api5}" "${addr1}" &
 
 # initiate channel closures for channels without tickets so we can check
 # completeness
+close_channel 1 5 "${api1}" "${addr5}" &
 
-log "Node 1 close channel to Node 5"
-result=$(run_command "${api1}" "close ${addr5}" "" 600)
-log "-- ${result}"
+log "Waiting for nodes to finish handling close channels calls"
+wait
 
-# close channels
-log "Waiting 1 minure for cool-off period"
-sleep 60
+log "Waiting 70 seconds for cool-off period"
+sleep 70
 
-log "Node 1 close channel to Node 5"
-result=$(run_command "${api1}" "close ${addr5}" "Channel is already closed" 600)
-log "--${result}"
+# verify channel has been closed
+close_channel 1 5 "${api1}" "${addr5}" "true"

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -317,7 +317,7 @@ redeem_tickets() {
   log "--${result}"
 
   log "Node ${node_id} should redeem all tickets (again to ensure re-run of operation)"
-  result=$(run_command "${node_api}" "redeemTickets" "Redeemed all tickets" 600 600)
+  result=$(run_command "${node_api}" "redeemTickets" "" 60 60)
   log "--${result}"
 
   log "Node ${node_id} ticket information (after second redemption)"

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -346,23 +346,23 @@ wait
 
 # initiate channel closures
 log "Node 1 close channel to Node 2"
-result=$(run_command "${api1}" "close ${addr2}" "Closing channel..." 600)
+result=$(run_command "${api1}" "close ${addr2}" "Initiated channel closure" 600)
 log "-- ${result}"
 
 log "Node 2 close channel to Node 3"
-result=$(run_command "${api2}" "close ${addr3}" "Closing channel..." 600)
+result=$(run_command "${api2}" "close ${addr3}" "Initiated channel closure" 600)
 log "-- ${result}"
 
 log "Node 3 close channel to Node 4"
-result=$(run_command "${api3}" "close ${addr4}" "Closing channel..." 600)
+result=$(run_command "${api3}" "close ${addr4}" "Initiated channel closure" 600)
 log "-- ${result}"
 
 log "Node 4 close channel to Node 5"
-result=$(run_command "${api4}" "close ${addr5}" "Closing channel..." 600)
+result=$(run_command "${api4}" "close ${addr5}" "Initiated channel closure" 600)
 log "-- ${result}"
 
 log "Node 5 close channel to Node 1"
-result=$(run_command "${api5}" "close ${addr1}" "Closing channel..." 600)
+result=$(run_command "${api5}" "close ${addr1}" "Initiated channel closure" 600)
 log "-- ${result}"
 
 # close channels

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -363,7 +363,7 @@ for i in `seq 1 10`; do
   run_command "${api3}" "send ${addr4},${addr5} 'hello, world'" "Message sent" 600
 
   log "Node 5 send 1 hop message to node 2 via node 1"
-  run_command "${api5}" "send ${addr1},${addr2} 'hello, world'" "Could not send message" 600
+  run_command "${api5}" "send ${addr1},${addr2} 'hello, world'" "Message sent" 600
 done
 
 # for the last send tests we use Rest API v2 instead of the older command-based Rest API v1


### PR DESCRIPTION
Fixes #3365 
Fixes #3306
Fixes #3172

Multiple issues impacted the correctness of ticket redemption:

- Ordering of tickets read from the database wasn't guaranteed, therefore we added explicit sorting.
- Tickets read from the database used an incorrect channel filter, which was fixed.
- The `oneAtATime` concurreny queue didn't block when an operation was executed, which was fixed.
- When redeeming tickets, all tickets were read in one chunk from the database and processed. This could lead to early race-conditions when tickets would arrive late to the database. This has been fixed by reading and processing tickets one-by-one.

Moreover, smoke tests were extended to cover ticket rejection and successful ticket redemption.

This PR includes changes from #3318 