### PR TITLE
Athens hotfix: Add a try-catch block around each admin command call

### DIFF
--- a/packages/hoprd/src/commands/index.ts
+++ b/packages/hoprd/src/commands/index.ts
@@ -89,7 +89,12 @@ export class Commands {
     let cmd = this.find(command)
 
     if (cmd) {
-      return await cmd.execute(log, query || '', this.state)
+      try {
+        return await cmd.execute(log, query || '', this.state)
+      }
+      catch (err) {
+        return log(`${cmd} execution failed with error: ${err.message}`)
+      }
     }
 
     return log(`${cmd}: Unknown command!`)

--- a/packages/hoprd/src/commands/index.ts
+++ b/packages/hoprd/src/commands/index.ts
@@ -91,8 +91,7 @@ export class Commands {
     if (cmd) {
       try {
         return await cmd.execute(log, query || '', this.state)
-      }
-      catch (err) {
+      } catch (err) {
         return log(`${cmd} execution failed with error: ${err.message}`)
       }
     }


### PR DESCRIPTION
Merge to Athens release, see #3402 and the related issue #3398 