### PR TITLE
[Hotfix release/athens] utils: Fix precision of timing check in channel entry

### DIFF
--- a/packages/utils/src/types/channelEntry.ts
+++ b/packages/utils/src/types/channelEntry.ts
@@ -135,7 +135,8 @@ export class ChannelEntry {
    * @returns true if the time window passed, false if not
    */
   public closureTimePassed(): boolean {
-    const now = new BN(new Date().getTime())
+    const nowInSeconds = Math.round(new Date().getTime() / 1000)
+    const now = new BN(nowInSeconds)
     return !!this.closureTime && now.gt(this.closureTime.toBN())
   }
 


### PR DESCRIPTION
Refs #3364 

Previously it used milliseconds instead of seconds. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/getTime