### PR TITLE
add default environment to AVADO build

### DIFF
--- a/.processes/release.md
+++ b/.processes/release.md
@@ -150,9 +150,8 @@ particular branch to deploy on every change.
 4. (on `release/${RELEASE_NAME}`) Before pushing the branch to Github, some release-specific changes should be applied to ensure the resulting CD artifacts actually are proper release artifacts.
 
    1. Change all occurences of the last release name to the new release name within documentation files and Docker files. Don't touch the `protocol-config.json` and `releases.json` files in this step. Changes should be committed locally.
-   2. Change use of `master-goerli` in `packages/avado/Dockerfile` to the new release name. Changes should be committed locally.
-   3. Update `CHANGELOG.md` with the new release's information. Changes should be committed locally.
-   4. Copy contract deployment files from the old release. This can be done doing
+   2. Update `CHANGELOG.md` with the new release's information. Changes should be committed locally.
+   3. Copy contract deployment files from the old release. This can be done doing
 
    ```
    mkdir -p packages/ethereum/deployments/${RELEASE_NAME}/xdai

--- a/packages/avado/build/Dockerfile
+++ b/packages/avado/build/Dockerfile
@@ -1,3 +1,3 @@
-FROM gcr.io/hoprassociation/hoprd:athens
+FROM gcr.io/hoprassociation/hoprd:master-goerli
 
-ENTRYPOINT [ "/usr/bin/tini", "--", "yarn", "hoprd", "--password='open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0'", "--init", "--admin", "--adminHost", "0.0.0.0", "--rest", "--restHost", "0.0.0.0", "--healthCheck", "--healthCheckHost", "0.0.0.0", "--data", "/app/db/data", "--identity", "/app/db/.hopr-identity", "--apiToken='!5qxc9Lp1BE7IFQ-nrtttU'" ]
+ENTRYPOINT [ "/usr/bin/tini", "--", "yarn", "hoprd", "--password='open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0'", "--init", "--admin", "--adminHost", "0.0.0.0", "--rest", "--restHost", "0.0.0.0", "--healthCheck", "--healthCheckHost", "0.0.0.0", "--data", "/app/db/data-master-goerli", "--identity", "/app/db/.hopr-identity", "--apiToken='!5qxc9Lp1BE7IFQ-nrtttU'" ]

--- a/scripts/build_avado.sh
+++ b/scripts/build_avado.sh
@@ -77,3 +77,6 @@ npm install -g git+https://github.com/AvadoDServer/AVADOSDK.git#${AVADO_SDK_COMM
 sudo avadosdk build --provider http://80.208.229.228:5001
 
 # http://go.ava.do/install/<IPFS HASH>
+
+# Undo changes to Avado Dockerfile
+sed -i "s/${environment_id}/master-goerli" ./build/Dockerfile

--- a/scripts/build_avado.sh
+++ b/scripts/build_avado.sh
@@ -40,7 +40,6 @@ if [[ "${1}" == "-h" ]] || [[ "${1}" == "--help" ]]; then
   exit 0
 fi
 
-
 declare AVADO_VERSION="${1}"
 
 if ! [[ $AVADO_VERSION =~ [0-9]{1,}\.[0-9]{1,}\.[0-9]{1,}$ ]]; then
@@ -57,7 +56,6 @@ sed -i "s/image:[ ]'hopr\.avado\.dnp\.dappnode\.eth:[0-9]\{1,\}\.[0-9]\{1,\}\.[0
 # Write dappnode version
 sed -i "s/\"version\":[ ]\"[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\"/\"version\": \"${AVADO_VERSION}\"/" ./dappnode_package.json
 
-
 declare default_development_environment="master-goerli"
 
 if [[ -z $(grep -E "${default_development_environment}" "./build/Dockerfile") ]]; then
@@ -66,8 +64,8 @@ if [[ -z $(grep -E "${default_development_environment}" "./build/Dockerfile") ]]
   exit 1
 fi
 
+# Overwrite default environmnet in Dockerfile with currently used one
 sed -i "s/master-goerli/${environment_id}/" ./build/Dockerfile
-
 
 # AVADO SDK does not do proper releases, therefore using GitHub + git commit hashes
 declare AVADO_SDK_COMMIT="de9f16d"

--- a/scripts/build_avado.sh
+++ b/scripts/build_avado.sh
@@ -50,12 +50,6 @@ fi
 
 cd "${mydir}/../packages/avado"
 
-# Write AVADO docker build version
-sed -i "s/image:[ ]'hopr\.avado\.dnp\.dappnode\.eth:[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/image: 'hopr.avado.dnp.dappnode.eth:${AVADO_VERSION}/" ./docker-compose.yml
-
-# Write dappnode version
-sed -i "s/\"version\":[ ]\"[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\"/\"version\": \"${AVADO_VERSION}\"/" ./dappnode_package.json
-
 declare default_development_environment="master-goerli"
 
 if [[ -z $(grep -E "${default_development_environment}" "./build/Dockerfile") ]]; then
@@ -64,8 +58,17 @@ if [[ -z $(grep -E "${default_development_environment}" "./build/Dockerfile") ]]
   exit 1
 fi
 
+# Write AVADO docker build version
+sed -e "s/image:[ ]'hopr\.avado\.dnp\.dappnode\.eth:[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/image: 'hopr.avado.dnp.dappnode.eth:${AVADO_VERSION}/" ./docker-compose.yml \
+  > ./docker-compose.yml.tmp && mv ./docker-compose.yml.tmp ./docker-compose.yml
+
+# Write dappnode version
+sed -e "s/\"version\":[ ]\"[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\"/\"version\": \"${AVADO_VERSION}\"/" ./dappnode_package.json \
+  > ./dappnode_package.json.tmp && mv ./dappnode_package.json.tmp ./dappnode_package.json
+
+
 # Overwrite default environmnet in Dockerfile with currently used one
-sed -i "s/master-goerli/${environment_id}/" ./build/Dockerfile
+sed -e "s/master-goerli/${environment_id}/" ./build/Dockerfile > ./build/Dockerfile.tmp && mv ./build/Dockerfile.tmp ./build/Dockerfile 
 
 # AVADO SDK does not do proper releases, therefore using GitHub + git commit hashes
 declare AVADO_SDK_COMMIT="de9f16d"
@@ -79,4 +82,4 @@ sudo avadosdk build --provider http://80.208.229.228:5001
 # http://go.ava.do/install/<IPFS HASH>
 
 # Undo changes to Avado Dockerfile
-sed -i "s/${environment_id}/master-goerli" ./build/Dockerfile
+sed -e "s/${environment_id}/master-goerli/" ./build/Dockerfile > ./build/Dockerfile.tmp && mv ./build/Dockerfile.tmp ./build/Dockerfile 

--- a/scripts/build_avado.sh
+++ b/scripts/build_avado.sh
@@ -67,7 +67,7 @@ sed -e "s/\"version\":[ ]\"[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\"/\"version\": 
   > ./dappnode_package.json.tmp && mv ./dappnode_package.json.tmp ./dappnode_package.json
 
 
-# Overwrite default environmnet in Dockerfile with currently used one
+# Overwrite default environmnet in Dockerfile with the one currently used
 sed -e "s/master-goerli/${environment_id}/" ./build/Dockerfile > ./build/Dockerfile.tmp && mv ./build/Dockerfile.tmp ./build/Dockerfile 
 
 # AVADO SDK does not do proper releases, therefore using GitHub + git commit hashes

--- a/scripts/get-default-environment.sh
+++ b/scripts/get-default-environment.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# prevent sourcing of this script, only allow execution
+$(return >/dev/null 2>&1)
+test "$?" -eq "0" && { echo "This script should only be executed." >&2; exit 1; }
+
+# exit on errors, undefined variables, ensure errors in pipes are not hidden
+set -Eeuo pipefail
+
+# set log id and use shared log function for readable logs
+declare mydir
+mydir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+declare HOPR_LOG_ID="get-npm-package-info"
+source "${mydir}/utils.sh"
+
+usage() {
+  msg
+  msg "Usage: $0"
+  msg
+  msg "\t<pkg> must be one of packages under packages/, defaults to 'hoprd'"
+  msg "\t<pkg_version> must be a valid semver version which shall be checked, defaults to the latest tag"
+  msg
+}
+
+
+log "get default environment id"
+declare branch=$(git rev-parse --abbrev-ref HEAD)
+
+declare environment_id
+for git_ref in $(cat "${mydir}/../packages/hoprd/releases.json" | jq -r "to_entries[] | .value.git_ref" | uniq); do
+  if [[ "${branch}" =~ ${git_ref} ]]; then
+    environment_id=$(cat "${mydir}/../packages/hoprd/releases.json" | jq -r "to_entries[] | select(.value.git_ref==\"${git_ref}\" and .value.default==true) | .key")
+    # if no default is set we take the first entry
+    if [ -z "${environment_id}" ]; then
+      environment_id=$(cat "${mydir}/../packages/hoprd/releases.json" | jq -r "to_entries[] | select(.value.git_ref==\"${git_ref}\") | .key" | sed q)
+    fi
+    break
+  fi
+done
+
+: ${environment_id:?"Could not read value for default environment id"}
+
+log "found default environment: ${environment_id}"
+
+echo ${environment_id}

--- a/scripts/get-default-environment.sh
+++ b/scripts/get-default-environment.sh
@@ -10,18 +10,8 @@ set -Eeuo pipefail
 # set log id and use shared log function for readable logs
 declare mydir
 mydir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
-declare HOPR_LOG_ID="get-npm-package-info"
+
 source "${mydir}/utils.sh"
-
-usage() {
-  msg
-  msg "Usage: $0"
-  msg
-  msg "\t<pkg> must be one of packages under packages/, defaults to 'hoprd'"
-  msg "\t<pkg_version> must be a valid semver version which shall be checked, defaults to the latest tag"
-  msg
-}
-
 
 log "get default environment id"
 declare branch=$(git rev-parse --abbrev-ref HEAD)

--- a/scripts/publish-version.sh
+++ b/scripts/publish-version.sh
@@ -59,18 +59,7 @@ fi
 
 log "get default environment id"
 
-declare environment_id
-for git_ref in $(cat "${mydir}/../packages/hoprd/releases.json" | jq -r "to_entries[] | .value.git_ref" | uniq); do
-  if [[ "${branch}" =~ ${git_ref} ]]; then
-    environment_id=$(cat "${mydir}/../packages/hoprd/releases.json" | jq -r "to_entries[] | select(.value.git_ref==\"${git_ref}\" and .value.default==true) | .key")
-    # if no default is set we take the first entry
-    if [ -z "${environment_id}" ]; then
-      environment_id=$(cat "${mydir}/../packages/hoprd/releases.json" | jq -r "to_entries[] | select(.value.git_ref==\"${git_ref}\") | .key" | sed q)
-    fi
-    break
-  fi
-done
-: ${environment_id:?"Could not read value for default environment id"}
+declare environment_id="$(${mydir}/get-default-environment.sh)"
 
 log "creating new version ${current_version} + ${version_type}"
 


### PR DESCRIPTION
Fixes AVADO build:

- use environment_id as docker Docker database folder
- automatically adjust AVADO Dockerfile according to default environment