### PR TITLE
Added missing syntax highlighting to docs

### DIFF
--- a/docs/hopr-documentation/docs/developers/connecting-node.md
+++ b/docs/hopr-documentation/docs/developers/connecting-node.md
@@ -28,7 +28,7 @@ so make sure to change it when running your own node in a public network.
 
 Make sure to export your `apiToken` to be used in the incoming commands, and every time you open a new terminal.
 
-```
+```bash
 export apiToken="^^LOCAL-testing-123^^"
 ```
 
@@ -153,13 +153,13 @@ If your node is running properly, you should see an image similar to this one:
 Given your node's `apiToken` and your `HOPR_NODE_1_HTTP_URL` from the ["Running a local HOPR Cluster"](/developers/starting-local-cluster) section (likely `127.0.0.1:3001` or `127.0.0.1:13301`), try to send a REST command to query its address with the following `curl`
 command. If you don’t have `jq` installed, just remove it at the end of the command.
 
-```
+```bash
 echo -n $apiToken | base64 | xargs -I {} curl -s -H "Authorization: Basic {}" $HOPR_NODE_1_HTTP_URL/api/v2/account/address | jq
 ```
 
 If successful, you should get a response similar to this one:
 
-```
+```json
 {
   "nativeAddress": "0x3a54dDE3ee5ACfd43C902cbecC8ED0CBA10Ff326",
   "hoprAddress": "16Uiu2HAmE9b3TSHeF25uJS1Ecf2Js3TutnaSnipdV9otEpxbRN8Q"
@@ -168,7 +168,7 @@ If successful, you should get a response similar to this one:
 
 In case you have made a mistake, like forgotten to use `-n` in your `echo` or have the wrong `apiToken`, you’ll see the following instead:
 
-```
+```json
 {
   "status": 403,
   "challenge": "Basic realm=hoprd",
@@ -186,19 +186,19 @@ open to listen to all messages sent to our HOPR node.
 With `websocat` installed, run the following command to connect to your HOPR node WebSocket server. Please pay attention that we are now using
 our `HOPR_NODE_1_WS_URL` (likely `127.0.0.1:3000` or `127.0.0.1:19501`) instead of the `HOPR_NODE_1_HTTP_URL` from last step, which is also referred as `Admin URL` in our tools.
 
-```
+```bash
 .bin/websocat "$(echo "$HOPR_NODE_1_WS_URL" | sed "s/http/ws/")/?apiToken=$apiToken"
 ```
 
 If worked correctly, you should see a dump of messages, the last one being:
 
-```
+```json
 {"type":"log","msg":"ws client connected [ authentication ENABLED ]","ts":"2022-02-01T19:42:34.152Z"}
 ```
 
 Now that you are connected, try typing `balance` in the same terminal, which should output as follows:
 
-```
+```json
 {"type":"log","msg":"admin > balance\n","ts":"2022-02-01T19:42:35.417Z"}
 {"type":"log","msg":"HOPR Balance:  9.6 txHOPR\nETH Balance:   0.99871794476851171 xDAI","ts":"2022-02-01T19:42:35.421Z"}
 ```
@@ -218,13 +218,13 @@ need to know your `apiToken`.
   you need to change the `http` protocol to `ws`. For instance, here's how this would look like
   in a `Gitpod.io` instance. After it's connected, you can type `balance` to see your node response.
 
-```
+```bash
 ws://127.0.0.1:19501/?apiToken=^^LOCAL-testing-123^^
 ```
 
 If you are using a Gitpod public URL, you can simply use the output of `gp url` for that particular port (`19501`) and paste it in the website.
 
-```
+```bash
 gp url 19501
 ```
 
@@ -245,13 +245,13 @@ For a different `apiToken` value, you can use the `btoa` function of your browse
 
 **Gitpod command (paste output in the URL section of `reqbin`)**
 
-```
+```bash
 gp url 13302
 ```
 
 **Custom Header**
 
-```
+```bash
 Basic Xl5MT0NBTC10ZXN0aW5nLTEyM15e
 ```
 

--- a/docs/hopr-documentation/docs/developers/starting-local-cluster.md
+++ b/docs/hopr-documentation/docs/developers/starting-local-cluster.md
@@ -40,7 +40,7 @@ assume this local IP, so using the app will make things easier for you to read o
 If you do not want to use the Gitpod Companion App, just remember to replace the URLs in the documentation to your Gitpod service URL. You
 can obtain the specific URL per port running the tool `gp`. For knowing the URL behind port `13301` you run the following:
 
-```
+```bash
 gp url 13301
 ```
 
@@ -55,7 +55,7 @@ this configuration allows you to develop HOPR apps offline.
 1. **Download the latest version of the repository**: Download a local version of our [GitHub repository monorepo](https://github.com/hoprnet/hoprnet)[^2]
    and unzip it in your local folder (roughly `~30 Mbs` at the time of writing). For the next tasks, we will assume you are within that folder.
 
-```
+```bash
 wget https://github.com/hoprnet/hoprnet/archive/refs/heads/master.zip
 unzip master.zip
 cd hoprnet-master
@@ -64,7 +64,7 @@ cd hoprnet-master
 2. **Install the dependencies of the project and build it**: Make sure you have `nodejs@16` (we suggest installing it via [nvm](https://github.com/nvm-sh/nvm), ie `nvm install lts/gallium`), and `yarn` (included in `nodejs@16` by running `corepack enable`)
    to install and build the required packages and project modules. Ideally, you also have setup your computer with basic development toolset[^3]. Please bear in mind that this process will take at least 5-10 minutes depending on your computer.
 
-```
+```bash
 yarn && yarn build
 ```
 
@@ -75,7 +75,7 @@ yarn && yarn build
    before running the script, as both are used. Please be aware you also need a version of `bash` of `5.x` or superior,
    which in most macOS devices require an upgrade, the easiest being via `brew bash`.
 
-```
+```bash
 ./scripts/setup-local-cluster.sh -m "http://app.myne.chat" -i scripts/topologies/full_interconnected_cluster.sh
 ```
 
@@ -83,13 +83,8 @@ Afterwards, a set off accounts with their respective HTTP REST API, HOPR Admin, 
 in your screen. For the next steps, we recommend copying and pasting these URLs and `export` them to your terminal so you can
 make use of them in the following pages.
 
-```
-export apiToken=^^LOCAL-testing-123^^ \
-HOPR_NODE_1_HTTP_URL=http://127.0.0.1:13301 HOPR_NODE_1_WS_URL=http://127.0.0.1:19501 \
-HOPR_NODE_2_HTTP_URL=http://127.0.0.1:13302 HOPR_NODE_2_WS_URL=http://127.0.0.1:19502 \
-HOPR_NODE_3_HTTP_URL=http://127.0.0.1:13303 HOPR_NODE_3_WS_URL=http://127.0.0.1:19503 \
-HOPR_NODE_4_HTTP_URL=http://127.0.0.1:13304 HOPR_NODE_4_WS_URL=http://127.0.0.1:19504 \
-HOPR_NODE_5_HTTP_URL=http://127.0.0.1:13305 HOPR_NODE_5_WS_URL=http://127.0.0.1:19505
+```bash
+export apiToken=^^LOCAL-testing-123^^ HOPR_NODE_1_HTTP_URL=http://127.0.0.1:13301 HOPR_NODE_1_WS_URL=http://127.0.0.1:19501 HOPR_NODE_2_HTTP_URL=http://127.0.0.1:13302 HOPR_NODE_2_WS_URL=http://127.0.0.1:19502 HOPR_NODE_3_HTTP_URL=http://127.0.0.1:13303 HOPR_NODE_3_WS_URL=http://127.0.0.1:19503 HOPR_NODE_4_HTTP_URL=http://127.0.0.1:13304 HOPR_NODE_4_WS_URL=http://127.0.0.1:19504 HOPR_NODE_5_HTTP_URL=http://127.0.0.1:13305 HOPR_NODE_5_WS_URL=http://127.0.0.1:19505
 ```
 
 [^1]:

--- a/docs/hopr-documentation/docs/developers/tutorial-hello-world.md
+++ b/docs/hopr-documentation/docs/developers/tutorial-hello-world.md
@@ -89,19 +89,19 @@ Using `websocat` or any other WebSocket client, connect to your `node 2` until y
 
 **Connecting to `node 2` via `websocat`**
 
-```
+```bash
 .bin/websocat "$(echo "$HOPR_NODE_2_WS_URL" | sed "s/http/ws/")/?apiToken=$apiToken"
 ```
 
 **Connecting to `node 2` via [Piesocket WebSocket Tester](https://www.piesocket.com/websocket-tester)**
 
-```
+```bash
 ws://127.0.0.1:19502/?apiToken=^^LOCAL-testing-123^^
 ```
 
 You can verify that you are connected by typing the command `address` and seeing an output similar to this:
 
-```
+```json
 {"type":"log","msg":"admin > address\n","ts":"2022-02-02T19:17:48.431Z"}
 {"type":"log","msg":"HOPR Address:  16Uiu2HAmKhrwGWcvaZ3ic5dgy7oFawmnELJGBrySSsNo4bzGBxHW\nETH Address:   0x4cD95E1deF16D5913255Fe0af208EdDe2e04d720","ts":"2022-02-02T19:17:48.435Z"}
 ```
@@ -112,7 +112,7 @@ Using `curl` or any other HTTP client, verify you can reach your `node 1`'s API
 
 **Obtaining the `node 1` address using `curl`**
 
-```
+```bash
 echo -n $apiToken | base64 | xargs -I {} curl -s -H "Authorization: Basic {}" $HOPR_NODE_1_HTTP_URL/api/v2/account/address | jq
 ```
 
@@ -120,19 +120,19 @@ echo -n $apiToken | base64 | xargs -I {} curl -s -H "Authorization: Basic {}" $H
 
 _URL_
 
-```
+```bash
 http://127.0.0.1:13301/api/v2/account/address
 ```
 
 _Custom Header (default `apiToken` `base64`-encoded)_
 
-```
+```bash
 Basic Xl5MT0NBTC10ZXN0aW5nLTEyM15e
 ```
 
 If you sent a successful request, the response will look something like this:
 
-```
+```json
 {
   "nativeAddress": "0x3a54dDE3ee5ACfd43C902cbecC8ED0CBA10Ff326",
   "hoprAddress": "16Uiu2HAmE9b3TSHeF25uJS1Ecf2Js3TutnaSnipdV9otEpxbRN8Q"
@@ -155,13 +155,13 @@ WebSocket client connection.
 
 Using `node 2`, type in your terminal with `websocat` running or WebSocket client interface the following command:
 
-```
+```bash
 address
 ```
 
 You should see a response like the following:
 
-```
+```json
 {"type":"log","msg":"admin > address\n","ts":"2022-02-02T19:17:48.431Z"}
 {"type":"log","msg":"HOPR Address:  16Uiu2HAmKhrwGWcvaZ3ic5dgy7oFawmnELJGBrySSsNo4bzGBxHW\nETH Address:   0x4cD95E1deF16D5913255Fe0af208EdDe2e04d720","ts":"2022-02-02T19:17:48.435Z"}
 ```
@@ -174,7 +174,7 @@ information to send a message from `node 1`. Make sure to keep your WebSocket cl
 To send a message from `node 1` to `node 2`, we need to use `node 1`'s REST API, particularly the `/messages` endpoint. Using `curl`
 or any other HTTP client, send the following request:
 
-```
+```bash
 echo -n $apiToken | base64 | xargs -I {} curl -s -H "Authorization: Basic {}" \
 -H 'Content-Type: application/json' \
 -d '{"body":"Hello world","recipient":"16Uiu2HAmKhrwGWcvaZ3ic5dgy7oFawmnELJGBrySSsNo4bzGBxHW"}' \
@@ -183,7 +183,7 @@ $HOPR_NODE_1_HTTP_URL/api/v2/messages
 
 In the terminal of `node 2`, you will see something similar to this:
 
-```
+```json
 {"type":"log","msg":"#### NODE RECEIVED MESSAGE [2022-02-03T21:48:13.845Z] ####","ts":"2022-02-03T21:48:13.845Z"}
 {"type":"log","msg":"Message: Hello world","ts":"2022-02-03T21:48:13.846Z"}
 {"type":"log","msg":"Latency: 668ms","ts":"2022-02-03T21:48:13.846Z"}
@@ -203,13 +203,13 @@ The previous message worked because a cluster has been configured by default to 
 tokens to send messages to at least `2` relayers. When a path used to relay has depleted (empty) or closed `channels`,
 your message will no longer be forwarded. You can always see your open `channels` and ther balance with the following command.
 
-```
+```bash
 channels
 ```
 
 Likewise, you can see your balance via the following command.
 
-```
+```bash
 balance
 ```
 


### PR DESCRIPTION
- Defaulted to `bash` whenever language does not fit
- Fixes hoprnet/hopr-devrel#186