### PR TITLE
Fix indexer and entry node code

### DIFF
--- a/packages/connect/src/base/listener.ts
+++ b/packages/connect/src/base/listener.ts
@@ -332,10 +332,11 @@ class Listener extends EventEmitter implements InterfaceListener {
     // Only add relay nodes if node is not directly reachable or running locally
     if (this.testingOptions.__runningLocally || natSituation.bidirectionalNAT || !natSituation.isExposed) {
       this.entry.on(RELAY_CHANGED_EVENT, this._emitListening)
-      await this.entry.updatePublicNodes()
 
-      // Attach listeners
+      // Finish startup
       this.entry.start()
+
+      await this.entry.updatePublicNodes()
     }
 
     this.state = State.LISTENING


### PR DESCRIPTION
Fixes #3455 

Fixes two logical errors:

- remove slippage between querying old events and new events
- finish startup of entry node code before starting to query entry nodes