### PR TITLE
Hotfix/debuglog analytics

### DIFF
--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -230,7 +230,7 @@ class HoprConnect implements Transport<HoprConnectDialOptions, HoprConnectListen
 
     try {
       conn = await this._upgradeOutbound(maConn as any)
-      log(conn)
+      log(`Successfully established relayed connection to ${destination.toB58String()}`)
     } catch (err) {
       error(err)
       // libp2p needs this error to understand that this connection attempt failed but we

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -444,7 +444,7 @@ class Hopr extends EventEmitter {
     }
 
     const currentChannels: ChannelEntry[] | undefined = await this.getAllChannels()
-    verbose('Channels obtained', currentChannels)
+    verbose('Channels obtained', currentChannels.map((entry) => entry.toString()).join(`\n`))
 
     if (currentChannels === undefined) {
       throw new Error('invalid channels retrieved from database')

--- a/packages/core/src/network/network-peers.ts
+++ b/packages/core/src/network/network-peers.ts
@@ -141,7 +141,7 @@ class NetworkPeers {
 
   public debugLog(): string {
     if (this.peers.length == 0) {
-      return 'no connectd peers'
+      return 'no connected peers'
     }
 
     const peers = this.peers.map((entry) => entry.id)

--- a/packages/core/src/network/network-peers.ts
+++ b/packages/core/src/network/network-peers.ts
@@ -141,21 +141,38 @@ class NetworkPeers {
 
   public debugLog(): string {
     if (this.peers.length == 0) {
-      return 'no connected peers'
+      return 'no connectd peers'
     }
-    let out = ''
-    out += `current nodes:\n`
-    this.peers
-      .sort((a, b) => {
-        return this.qualityOf(b.id) - this.qualityOf(a.id)
-      })
-      .forEach((e: Entry) => {
-        const success =
-          e.heartbeatsSent > 0 ? ((e.heartbeatsSuccess / e.heartbeatsSent) * 100).toFixed() + '%' : '<new>'
-        out += `- id: ${e.id.toB58String()}, quality: ${this.qualityOf(e.id).toFixed(
-          2
-        )} (backoff ${e.backoff.toFixed()}, ${success} of ${e.heartbeatsSent}) \n`
-      })
+
+    const peers = this.peers.map((entry) => entry.id)
+
+    // Sort a copy of peers in-place
+    peers.sort((a, b) => this.qualityOf(b) - this.qualityOf(a))
+
+    const goodAvailabilityIndex = peers.findIndex((peer) => this.qualityOf(peer) == 1.0)
+
+    const worstAvailabilityIndex = peers.findIndex((peer) => this.qualityOf(peer) == 0.0)
+
+    let out = `current: ${peers.length} nodes and ${goodAvailabilityIndex + 1} nodes with availability 1.0 and ${
+      peers.length - worstAvailabilityIndex
+    } nodes with availability 0.0:\n`
+
+    for (const peer of peers) {
+      const entryIndex = this.findIndex(peer)
+
+      if (entryIndex < 0) {
+        continue
+      }
+
+      const entry = this.peers[entryIndex]
+
+      const success =
+        entry.heartbeatsSent > 0 ? ((entry.heartbeatsSuccess / entry.heartbeatsSent) * 100).toFixed() + '%' : '<new>'
+      out += `- id: ${entry.id.toB58String()}, quality: ${this.qualityOf(entry.id).toFixed(
+        2
+      )} (backoff ${entry.backoff.toFixed()}, ${success} of ${entry.heartbeatsSent}) \n`
+    }
+
     return out
   }
 }


### PR DESCRIPTION
Improve connectivity debug log to show:

- how many nodes we're querying
- how many have best availability
- how many appear to be unreachable

```
  hopr-core:heartbeat finished checking nodes since 1644502722140 5 nodes +0ms
  hopr-core:heartbeat current: 5 nodes and 1 nodes with availability 1.0 and 4 nodes with 0.0 availability:
  hopr-core:heartbeat - id: 16Uiu2HAm1gu1QrxBKYsPk1xQ4ZctgmszMoqJ3hGCVeGXx8HLGcG2, quality: 1.00 (backoff 2, 93% of 15) 
  hopr-core:heartbeat - id: 16Uiu2HAkwAnCRtQ2GPNR6jx4D3JHUgvRjXdBZ8oSR2fmwvjGmfGA, quality: 0.70 (backoff 3, 67% of 15) 
  hopr-core:heartbeat - id: 16Uiu2HAm2vtZZTrcBuoJtF9Hc142eNz9BGMorExChL1etZg63EWP, quality: 0.00 (backoff 10, 25% of 12) 
  hopr-core:heartbeat - id: 16Uiu2HAmMFthJNUrMf5nJ3hca7wUn9kAhMLWAE5ZY2SL4Sztv5Vb, quality: 0.00 (backoff 193, 14% of 7) 
  hopr-core:heartbeat - id: 16Uiu2HAm4rbsiRdimKpxJQcKYxVVESnvPjqbD6XSWxgokv2dFe5x, quality: 0.00 (backoff 300, 0% of 6) 
  hopr-core:heartbeat  +0ms
```