### PR TITLE
Generate sourceable file for easier environment setup in setup-local-cluster.sh

### DIFF
--- a/scripts/init-gitpod.sh
+++ b/scripts/init-gitpod.sh
@@ -6,19 +6,19 @@ test "$?" -eq "0" || { echo "This script should only be sourced." >&2; exit 1; }
 
 export apiToken="^^LOCAL-testing-123^^"
 export HOPR_NODE_1_HTTP_URL=$(gp url 13301)
-export HOPR_NODE_1_WS_URL=$(gp url 19501)
+export HOPR_NODE_1_WS_URL=$(gp url 19501 | sed 's/https/wss/')
 export HOPR_NODE_1_ADDR=$(curl --silent -H "x-auth-token: $apiToken" "$HOPR_NODE_1_HTTP_URL/api/v2/account/addresses" | jq -r '.hopr')
 export HOPR_NODE_2_HTTP_URL=$(gp url 13302)
-export HOPR_NODE_2_WS_URL=$(gp url 19502)
+export HOPR_NODE_2_WS_URL=$(gp url 19502 | sed 's/https/wss/')
 export HOPR_NODE_2_ADDR=$(curl --silent -H "x-auth-token: $apiToken" "$HOPR_NODE_2_HTTP_URL/api/v2/account/addresses" | jq -r '.hopr')
 export HOPR_NODE_3_HTTP_URL=$(gp url 13303)
-export HOPR_NODE_3_WS_URL=$(gp url 19503)
+export HOPR_NODE_3_WS_URL=$(gp url 19503 | sed 's/https/wss/')
 export HOPR_NODE_3_ADDR=$(curl --silent -H "x-auth-token: $apiToken" "$HOPR_NODE_3_HTTP_URL/api/v2/account/addresses" | jq -r '.hopr')
 export HOPR_NODE_4_HTTP_URL=$(gp url 13304)
-export HOPR_NODE_4_WS_URL=$(gp url 19504)
+export HOPR_NODE_4_WS_URL=$(gp url 19504 | sed 's/https/wss/')
 export HOPR_NODE_4_ADDR=$(curl --silent -H "x-auth-token: $apiToken" "$HOPR_NODE_4_HTTP_URL/api/v2/account/addresses" | jq -r '.hopr')
 export HOPR_NODE_5_HTTP_URL=$(gp url 13305)
-export HOPR_NODE_5_WS_URL=$(gp url 19505)
+export HOPR_NODE_5_WS_URL=$(gp url 19505 | sed 's/https/wss/')
 export HOPR_NODE_5_ADDR=$(curl --silent -H "x-auth-token: $apiToken" "$HOPR_NODE_5_HTTP_URL/api/v2/account/addresses" | jq -r '.hopr')
 
 echo -e "\n"

--- a/scripts/setup-local-cluster.sh
+++ b/scripts/setup-local-cluster.sh
@@ -318,6 +318,7 @@ log "\t\tMyne Chat:\t${myne_chat_url}/?httpEndpoint=http://localhost:13305&wsEnd
 
 declare env_file=$(mktemp)
 {
+echo "#!/usr/bin/env bash" ;
 echo "\$(return >/dev/null 2>&1)" ;
 echo "test \"\$?\" -eq \"0\" || { echo \"This script should only be sourced.\" >&2; exit 1; }" ;
 echo "export apiToken=${api_token}" ;

--- a/scripts/setup-local-cluster.sh
+++ b/scripts/setup-local-cluster.sh
@@ -337,3 +337,4 @@ fi
 
 log "Terminating this script will clean up the running local cluster"
 wait
+rm "${env_file}"

--- a/scripts/setup-local-cluster.sh
+++ b/scripts/setup-local-cluster.sh
@@ -316,9 +316,21 @@ log "\t\tRest API:\thttp://localhost:13305/api/v2/_swagger"
 log "\t\tAdmin UI:\thttp://localhost:19505/"
 log "\t\tMyne Chat:\t${myne_chat_url}/?httpEndpoint=http://localhost:13305&wsEndpoint=ws://localhost:19505&securityToken=${api_token}"
 
+declare env_file=$(mktemp)
+{
+echo "export apiToken=${api_token}" ;
+echo "export HOPR_NODE_1_ADDR=${peers[0]} HOPR_NODE_1_HTTP_URL=http://127.0.0.1:13301 HOPR_NODE_1_WS_URL=http://127.0.0.1:19501" ;
+echo "export HOPR_NODE_2_ADDR=${peers[1]} HOPR_NODE_2_HTTP_URL=http://127.0.0.1:13301 HOPR_NODE_2_WS_URL=http://127.0.0.1:19501" ;
+echo "export HOPR_NODE_3_ADDR=${peers[2]} HOPR_NODE_3_HTTP_URL=http://127.0.0.1:13301 HOPR_NODE_3_WS_URL=http://127.0.0.1:19501" ;
+echo "export HOPR_NODE_4_ADDR=${peers[3]} HOPR_NODE_4_HTTP_URL=http://127.0.0.1:13301 HOPR_NODE_4_WS_URL=http://127.0.0.1:19501" ;
+echo "export HOPR_NODE_5_ADDR=${peers[4]} HOPR_NODE_5_HTTP_URL=http://127.0.0.1:13301 HOPR_NODE_5_WS_URL=http://127.0.0.1:19501" ;
+} > ${env_file}
+
 # GitPod related barrier
 if command -v gp; then
   gp sync-done "local-cluster"
+else
+  log "Run: 'source ${env_file}' in your shell to setup environment variables for this cluster (HOPR_NODE_1_ADDR, HOPR_NODE_1_HTTP_URL,... etc.)"
 fi
 
 log "Terminating this script will clean up the running local cluster"

--- a/scripts/setup-local-cluster.sh
+++ b/scripts/setup-local-cluster.sh
@@ -322,11 +322,11 @@ echo "#!/usr/bin/env bash" ;
 echo "\$(return >/dev/null 2>&1)" ;
 echo "test \"\$?\" -eq \"0\" || { echo \"This script should only be sourced.\" >&2; exit 1; }" ;
 echo "export apiToken=${api_token}" ;
-echo "export HOPR_NODE_1_ADDR=${peers[0]} HOPR_NODE_1_HTTP_URL=http://127.0.0.1:13301 HOPR_NODE_1_WS_URL=http://127.0.0.1:19501" ;
-echo "export HOPR_NODE_2_ADDR=${peers[1]} HOPR_NODE_2_HTTP_URL=http://127.0.0.1:13301 HOPR_NODE_2_WS_URL=http://127.0.0.1:19501" ;
-echo "export HOPR_NODE_3_ADDR=${peers[2]} HOPR_NODE_3_HTTP_URL=http://127.0.0.1:13301 HOPR_NODE_3_WS_URL=http://127.0.0.1:19501" ;
-echo "export HOPR_NODE_4_ADDR=${peers[3]} HOPR_NODE_4_HTTP_URL=http://127.0.0.1:13301 HOPR_NODE_4_WS_URL=http://127.0.0.1:19501" ;
-echo "export HOPR_NODE_5_ADDR=${peers[4]} HOPR_NODE_5_HTTP_URL=http://127.0.0.1:13301 HOPR_NODE_5_WS_URL=http://127.0.0.1:19501" ;
+echo "export HOPR_NODE_1_ADDR=${peers[0]} HOPR_NODE_1_HTTP_URL=http://127.0.0.1:13301 HOPR_NODE_1_WS_URL=ws://127.0.0.1:19501" ;
+echo "export HOPR_NODE_2_ADDR=${peers[1]} HOPR_NODE_2_HTTP_URL=http://127.0.0.1:13301 HOPR_NODE_2_WS_URL=ws://127.0.0.1:19501" ;
+echo "export HOPR_NODE_3_ADDR=${peers[2]} HOPR_NODE_3_HTTP_URL=http://127.0.0.1:13301 HOPR_NODE_3_WS_URL=ws://127.0.0.1:19501" ;
+echo "export HOPR_NODE_4_ADDR=${peers[3]} HOPR_NODE_4_HTTP_URL=http://127.0.0.1:13301 HOPR_NODE_4_WS_URL=ws://127.0.0.1:19501" ;
+echo "export HOPR_NODE_5_ADDR=${peers[4]} HOPR_NODE_5_HTTP_URL=http://127.0.0.1:13301 HOPR_NODE_5_WS_URL=ws://127.0.0.1:19501" ;
 } > ${env_file}
 
 # GitPod related barrier

--- a/scripts/setup-local-cluster.sh
+++ b/scripts/setup-local-cluster.sh
@@ -318,6 +318,8 @@ log "\t\tMyne Chat:\t${myne_chat_url}/?httpEndpoint=http://localhost:13305&wsEnd
 
 declare env_file=$(mktemp)
 {
+echo "\$(return >/dev/null 2>&1)" ;
+echo "test \"\$?\" -eq \"0\" || { echo \"This script should only be sourced.\" >&2; exit 1; }" ;
 echo "export apiToken=${api_token}" ;
 echo "export HOPR_NODE_1_ADDR=${peers[0]} HOPR_NODE_1_HTTP_URL=http://127.0.0.1:13301 HOPR_NODE_1_WS_URL=http://127.0.0.1:19501" ;
 echo "export HOPR_NODE_2_ADDR=${peers[1]} HOPR_NODE_2_HTTP_URL=http://127.0.0.1:13301 HOPR_NODE_2_WS_URL=http://127.0.0.1:19501" ;


### PR DESCRIPTION
When local cluster setup is done, a file specific for this cluster is generated and can be sourced by the developer in their shell to setup useful environment variables:

- `HOPR_NODE_x_ADDR` (HOPR address)
- `HOPR_NODE_x_HTTP_URL` (REST API URL)
- `HOPR_NODE_x_WS_URL` (WebSocket URL)

for all local cluster nodes x = 1,2...5