### PR TITLE
Hotfix release/lisbon: avado: Revert docker tag to master-goerli

### DIFF
--- a/packages/avado/build/Dockerfile
+++ b/packages/avado/build/Dockerfile
@@ -1,3 +1,3 @@
-FROM gcr.io/hoprassociation/hoprd:lisbon
+FROM gcr.io/hoprassociation/hoprd:master-goerli
 
-ENTRYPOINT [ "/usr/bin/tini", "--", "yarn", "hoprd", "--password='open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0'", "--init", "--admin", "--adminHost", "0.0.0.0", "--rest", "--restHost", "0.0.0.0", "--healthCheck", "--healthCheckHost", "0.0.0.0", "--data", "/app/db/data-lisbon", "--identity", "/app/db/.hopr-identity", "--apiToken='!5qxc9Lp1BE7IFQ-nrtttU'" ]
+ENTRYPOINT [ "/usr/bin/tini", "--", "yarn", "hoprd", "--password='open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0'", "--init", "--admin", "--adminHost", "0.0.0.0", "--rest", "--restHost", "0.0.0.0", "--healthCheck", "--healthCheckHost", "0.0.0.0", "--data", "/app/db/data-master-goerli", "--identity", "/app/db/.hopr-identity", "--apiToken='!5qxc9Lp1BE7IFQ-nrtttU'" ]


### PR DESCRIPTION
I accidentally changed it when doing the release.