### PR TITLE
Rendering actual buttons for `<ClusterHelper>`

### DIFF
--- a/docs/hopr-documentation/docs/developers/components/atoms/ClusterHelper.jsx
+++ b/docs/hopr-documentation/docs/developers/components/atoms/ClusterHelper.jsx
@@ -20,7 +20,7 @@ export default function ClusterHelper({
   return (
     <div style={{ display: 'inline-block ' }}>
       Preload Cluster Node -
-      {[...Array(CLUSTER_NODES)].map((_, index) => (
+      {Array.from({ length: 5 }, (_, index) => (
         <button
           style={{
             background: selectedNode == index + 1 && 'blue',


### PR DESCRIPTION
- For some reason unbeknownst to me `[...Array(5)]` return `undefined` in production, so we used `Array.from({ length: 5 })` instead.
- Fixes #3526