### PR TITLE
ci: Ensure instances are not replaced when updated

### DIFF
--- a/scripts/setup-gcloud-cluster.sh
+++ b/scripts/setup-gcloud-cluster.sh
@@ -109,7 +109,7 @@ if [ "${show_prestartinfo}" = "1" ] || [ "${show_prestartinfo}" = "true" ]; then
 fi
 # }}}
 
-# create test specific instance template
+# create instance template
 # announce on-chain with routable address
 gcloud_create_instance_template_if_not_exists \
   "${instance_template_name}" \


### PR DESCRIPTION
Replacing leads to new IP assignments, which we don't need. Thus,
instances should only be updated without being replaced. Moreover, this
change ensure we clean up old intstance templates.
