### PR TITLE
core-ethereum: Fix use of array when undefined

### DIFF
--- a/packages/core-ethereum/src/indexer/index.ts
+++ b/packages/core-ethereum/src/indexer/index.ts
@@ -266,19 +266,18 @@ class Indexer extends EventEmitter {
     }
 
     const events = await Promise.all(queries)
+    const normalizedEvents = events
+      .flat(1)
+      .sort(snapshotComparator)
+      // @TODO fix type clash
+      .map((event) => {
+        if (event.event == undefined) {
+          return Object.assign(event, { event: event.name })
+        }
+        return event
+      })
 
-    return (
-      events
-        .flat(1)
-        .sort(snapshotComparator)
-        // @TODO fix type clash
-        .map((event) => {
-          if (event.event == undefined) {
-            return Object.assign(event, { event: event.name })
-          }
-          return event
-        })
-    )
+    return normalizedEvents
   }
 
   /**
@@ -417,7 +416,7 @@ class Indexer extends EventEmitter {
     if (fetchEvents) {
       // Don't fail immediately when one block is temporarily not available
       const RETRIES = 3
-      let events: TypedEvent<any, any>[]
+      let events: TypedEvent<any, any>[] = []
 
       for (let i = 0; i < RETRIES; i++) {
         try {
@@ -451,7 +450,7 @@ class Indexer extends EventEmitter {
    * @param events new unprocessed events
    */
   private onNewEvents(events: Event<any>[] | TokenEvent<any>[]): void {
-    if (events.length == 0) {
+    if (events === undefined || events.length == 0) {
       // Nothing to do
       return
     }

--- a/packages/core-ethereum/src/indexer/index.ts
+++ b/packages/core-ethereum/src/indexer/index.ts
@@ -449,7 +449,7 @@ class Indexer extends EventEmitter {
    * @dev ignores events that have been processed before.
    * @param events new unprocessed events
    */
-  private onNewEvents(events: Event<any>[] | TokenEvent<any>[]): void {
+  private onNewEvents(events: Event<any>[] | TokenEvent<any>[] | undefined): void {
     if (events === undefined || events.length == 0) {
       // Nothing to do
       return

--- a/packages/core-ethereum/src/indexer/index.ts
+++ b/packages/core-ethereum/src/indexer/index.ts
@@ -450,7 +450,7 @@ class Indexer extends EventEmitter {
    * @param events new unprocessed events
    */
   private onNewEvents(events: Event<any>[] | TokenEvent<any>[] | undefined): void {
-    if (events === undefined || events.length == 0) {
+    if (events == undefined || events.length == 0) {
       // Nothing to do
       return
     }


### PR DESCRIPTION
Fixes the following error:

```
(node:4140541) UnhandledPromiseRejectionWarning
TypeError: Cannot read property 'length' of undefined
    at Indexer.onNewEvents (/somewhere/work/hopr/hoprnet/packages/core-ethereum/lib/indexer/index.js:338:20)
    at Indexer.onNewBlock (/somewhere/work/hopr/hoprnet/packages/core-ethereum/lib/indexer/index.js:328:18)
    at async Indexer.<anonymous> (/somewhere/work/hopr/hoprnet/packages/core-ethereum/lib/indexer/index.js:63:17)
2022-02-17T07:05:26.207Z hoprd { type: 'log', msg: 'Process exiting with signal 1', ts: '2022-02-17T07:05:26.207Z' }
```

Refs #3513 