### PR TITLE
Hotfix/fix starvation in transaction tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Fix connection parameters to prevent stalling of the Node.js process and update maximal number of relays ([#3471](https://github.com/hoprnet/hoprnet/pull/3471))
 - Fix locking issues in various parts of the code ([#3515](https://github.com/hoprnet/hoprnet/pull/3515))
 - Fix unhandled promise rejection in strategy code and infinite loop in ticket redemption logic ([#3515](https://github.com/hoprnet/hoprnet/pull/3515))
+- Fixed locking issues in transaction processing ([#3568](https://github.com/hoprnet/hoprnet/pull/3568))
 
 ---
 

--- a/packages/core-ethereum/src/ethereum.ts
+++ b/packages/core-ethereum/src/ethereum.ts
@@ -171,7 +171,7 @@ export async function createChainWrapper(
         log('Transaction with nonce %d and hash failed to send: %s', nonce, transaction.hash, error)
       }
 
-      throw new Error(`Failed in mining transaction. ${error}`)
+      throw new Error(`Failed in publishing transaction. ${error}`)
     }
 
     log('Transaction with nonce %d successfully sent %s, waiting for confimation', nonce, transaction.hash)
@@ -190,6 +190,8 @@ export async function createChainWrapper(
           done = true
 
           provider.off(transaction.hash, onTransaction)
+          // Give other tasks time to get scheduled before
+          // processing the result
           if (err) {
             setImmediate(reject, Error(err))
           } else {
@@ -206,7 +208,6 @@ export async function createChainWrapper(
 
         provider.on(transaction.hash, onTransaction)
       })
-      await provider.waitForTransaction(transaction.hash, 1, timeout)
     } catch (error) {
       log(`Error while waiting for transaction ${transaction.hash}`, error)
       // remove listener but not throwing error message

--- a/packages/core-ethereum/src/transaction-manager.ts
+++ b/packages/core-ethereum/src/transaction-manager.ts
@@ -1,4 +1,4 @@
-import { TransactionRequest } from '@ethersproject/abstract-provider'
+import type { TransactionRequest } from '@ethersproject/abstract-provider'
 import { debug } from '@hoprnet/hopr-utils'
 import { BigNumber } from 'ethers'
 import { isDeepStrictEqual } from 'util'


### PR DESCRIPTION
Re #3513 

Fixed starvation:

- [x] [core-ethereum] `sendTransaction` creates two event listeners, one on `provider.on(txHash)` and another one on `indexer.on(txHash)`. Both are now properly scheduled to handle other requests in between