### PR TITLE
fail on non-zero exit codes

### DIFF
--- a/packages/core-ethereum/src/index.ts
+++ b/packages/core-ethereum/src/index.ts
@@ -241,8 +241,14 @@ export default class HoprCoreEthereum extends EventEmitter {
       log('skipping redeemAllTickets because another operation is still in progress')
       return this.redeemingAll
     }
-    this.redeemingAll = this.redeemAllTicketsInternalLoop()
-    return this.redeemingAll
+
+    return new Promise((resolve, reject) => {
+      try {
+        this.redeemingAll = this.redeemAllTicketsInternalLoop().then(resolve, reject)
+      } catch (err) {
+        reject(err)
+      }
+    })
   }
 
   private async redeemAllTicketsInternalLoop(): Promise<void> {
@@ -273,8 +279,16 @@ export default class HoprCoreEthereum extends EventEmitter {
     }
 
     // start new operation and store it
-    this.ticketRedemtionInChannelOperations[channelId] = this.redeemTicketsInChannelLoop(channel)
-    return this.ticketRedemtionInChannelOperations[channelId]
+    return new Promise((resolve, reject) => {
+      try {
+        this.ticketRedemtionInChannelOperations[channelId] = this.redeemTicketsInChannelLoop(channel).then(
+          resolve,
+          reject
+        )
+      } catch (err) {
+        reject(err)
+      }
+    })
   }
 
   private async redeemTicketsInChannelLoop(channel: ChannelEntry): Promise<void> {

--- a/scripts/run-integration-tests-npm.sh
+++ b/scripts/run-integration-tests-npm.sh
@@ -119,7 +119,29 @@ function cleanup {
   log "Remove default environment setting"
   rm -f "${mydir}/../packages/hoprd/default-environment.json"
 
-  exit $EXIT_CODE
+  local log exit_code non_zero
+  for node_log in "${node1_log}" "${node2_log}" "${node3_log}" "${node4_log}" "${node5_log}" "${node6_log}" "${node7_log}"; do
+    log=$(wait_for_regex ${node_log} "Process exiting with signal [0-9]")
+
+    if [ -z "${log}" ]; then
+      log "${node_log}"
+      log "Process did not exit properly"
+      exit 1
+    fi
+
+    exit_code=$(echo ${log} | sed -E "s/.*signal[ ]([0-9]+).*/\1/")
+    if [ ${exit_code} != "0" ]; then
+      non_zero=true
+      log "${node_log}"
+      log "terminated with non-zero exit code ${exit_code}"
+    fi
+  done
+
+  if [ ${non_zero} ]; then
+    exit 1
+  else
+    exit $EXIT_CODE
+  fi
 }
 
 if [ "${skip_cleanup}" != "1" ] && [ "${skip_cleanup}" != "true" ]; then

--- a/scripts/run-integration-tests-source.sh
+++ b/scripts/run-integration-tests-source.sh
@@ -108,7 +108,29 @@ function cleanup {
     lsof -i ":${port}" -s TCP:LISTEN -t | xargs -I {} -n 1 kill {}
   done
 
-  exit $EXIT_CODE
+  local log exit_code non_zero
+  for node_log in "${node1_log}" "${node2_log}" "${node3_log}" "${node4_log}" "${node5_log}" "${node6_log}" "${node7_log}"; do
+    log=$(wait_for_regex ${node_log} "Process exiting with signal [0-9]")
+
+    if [ -z "${log}" ]; then
+      log "${node_log}"
+      log "Process did not exit properly"
+      exit 1
+    fi
+
+    exit_code=$(echo ${log} | sed -E "s/.*signal[ ]([0-9]+).*/\1/")
+    if [ ${exit_code} != "0" ]; then
+      non_zero=true
+      log "${node_log}"
+      log "terminated with non-zero exit code ${exit_code}"
+    fi
+  done
+
+  if [ ${non_zero} ]; then
+    exit 1
+  else
+    exit $EXIT_CODE
+  fi
 }
 
 if [ "${skip_cleanup}" != "1" ] && [ "${skip_cleanup}" != "true" ]; then


### PR DESCRIPTION
Re #3544 

Changes the e2e test scripts to fail with non-zero exit code if any of the started subprocesses fails with a non-zero exit code.

**This makes the e2e tests way stricter**

## Other changes

- Fix unhandled promise rejection in ticket redemption code