### PR TITLE
do not await dht call

### DIFF
--- a/packages/connect/src/relay/index.ts
+++ b/packages/connect/src/relay/index.ts
@@ -219,10 +219,20 @@ class Relay {
         async function* (this: Relay) {
           // @TODO check if there is a relay slot available
 
-          const key = await createRelayerKey(conn.connection.remotePeer)
+          // Initiate the DHT query but does not await the result which easily
+          // takes more than 10 seconds
+          ;(async function (this: Relay) {
+            try {
+              const key = await createRelayerKey(conn.connection.remotePeer)
 
-          await this.libp2p.contentRouting.provide(key)
-          log(`announced in the DHT as relayer for node ${conn.connection.remotePeer.toB58String()}`, key)
+              await this.libp2p.contentRouting.provide(key)
+
+              log(`announced in the DHT as relayer for node ${conn.connection.remotePeer.toB58String()}`, key)
+            } catch (err) {
+              error(`error while attempting to provide relayer key for ${conn.connection.remotePeer}`)
+            }
+          }.call(this))
+
           yield OK
         }.call(this)
       )


### PR DESCRIPTION
## Context

Whenever a node intends to use another node as a relay, it asks that node whether it wants to act as a relay, i.e.

Alice -> Relay:
```
CAN_RELAY?
```
Relay -> Alice:
```
OK
```

## Current situation

_Before_ replying with `OK`, the relay publishes this information to the DHT and await the result of that query. This easily takes > 10 seconds and unnecessarily increases the latency of the query.

When receiving the response, nodes will latencies > the threshold and therefore unnecessarily consider the node offline.

## New behavior

The relay replies with `OK` before awaiting the result of the DHT `provide` query.