### PR TITLE
ci: Add missing api token in env for notification script

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -363,6 +363,7 @@ jobs:
           ./scripts/notify-matrix-cluster-info.sh
         env:
           MATRIX_ROOM: ${{ env.MATRIX_CLUSTER_INFO_ROOM }}
+          HOPRD_API_TOKEN: ${{ secrets.HOPRD_API_TOKEN }}
 
       - name: Send notification if anything failed on master or release branches
         if: ${{ failure() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && !env.ACT }}
@@ -424,6 +425,7 @@ jobs:
           ./scripts/notify-matrix-cluster-info.sh "-nat"
         env:
           MATRIX_ROOM: ${{ env.MATRIX_CLUSTER_INFO_ROOM }}
+          HOPRD_API_TOKEN: ${{ secrets.HOPRD_API_TOKEN }}
 
       - name: Send notification if anything failed on master or release branches
         if: ${{ failure() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && !env.ACT }}


### PR DESCRIPTION
The secret must be assigned to the environment, which wasn't the case before.