### PR TITLE
ci: Replace use of priv key with faucet api token

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -353,9 +353,9 @@ jobs:
         run: |
           ./scripts/deploy.sh "gcr.io/hoprassociation/hoprd" 3
         env:
-          FUNDING_PRIV_KEY: ${{ secrets.FUNDING_WALLET_PRIVATE_KEY }}
           HOPRD_PASSWORD: ${{ secrets.BS_PASSWORD }}
           HOPRD_API_TOKEN: ${{ secrets.HOPRD_API_TOKEN }}
+          FAUCET_SECRET_API_KEY: ${{ secrets.FAUCET_SECRET_API_KEY }}
 
       - name: Send cluster info to Matrix
         if: ${{ success() && !env.ACT }}
@@ -415,9 +415,9 @@ jobs:
         run: |
           ./scripts/deploy.sh "gcr.io/hoprassociation/hoprd-nat" 2 "-nat"
         env:
-          FUNDING_PRIV_KEY: ${{ secrets.FUNDING_WALLET_PRIVATE_KEY }}
           HOPRD_PASSWORD: ${{ secrets.BS_PASSWORD }}
           HOPRD_API_TOKEN: ${{ secrets.HOPRD_API_TOKEN }}
+          FAUCET_SECRET_API_KEY: ${{ secrets.FAUCET_SECRET_API_KEY }}
 
       - name: Send cluster info to Matrix
         if: ${{ success() && !env.ACT }}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -18,7 +18,7 @@ declare branch cluster_size package_version docker_image
 
 : ${HOPRD_API_TOKEN:?"env var missing"}
 : ${HOPRD_PASSWORD:?"env var missing"}
-: ${FUNDING_PRIV_KEY:?"env var missing"}
+: ${FAUCET_SECRET_API_KEY:?"env var missing"}
 
 # docker_image and cluster_size are configurable through script arguments
 docker_image="${1:-gcr.io/hoprassociation/hoprd}"

--- a/scripts/run-integration-tests-gcloud.sh
+++ b/scripts/run-integration-tests-gcloud.sh
@@ -28,7 +28,7 @@ usage() {
   msg "Required environment variables"
   msg "------------------------------"
   msg
-  msg "FUNDING_PRIV_KEY\t\tsets the account which is used to fund nodes"
+  msg "FAUCET_SECRET_API_KEY\t\tsets the api key used to authenticate with the funding faucet"
   msg
   msg "Optional environment variables"
   msg "------------------------------"
@@ -56,7 +56,7 @@ declare skip_cleanup="${HOPRD_SKIP_CLEANUP:-false}"
 declare show_prestartinfo="${HOPRD_SHOW_PRESTART_INFO:-false}"
 declare run_cleanup_only="${HOPRD_RUN_CLEANUP_ONLY:-false}"
 
-test -z "${FUNDING_PRIV_KEY:-}" && { msg "Missing FUNDING_PRIV_KEY"; usage; exit 1; }
+: ${FAUCET_SECRET_API_KEY?"Missing environment variable FAUCET_SECRET_API_KEY"}
 
 function cleanup {
   local EXIT_CODE=$?

--- a/scripts/setup-gcloud-cluster.sh
+++ b/scripts/setup-gcloud-cluster.sh
@@ -37,7 +37,7 @@ usage() {
   msg "Required environment variables"
   msg "------------------------------"
   msg
-  msg "FUNDING_PRIV_KEY\t\tsets the account which is used to fund nodes"
+  msg "FAUCET_SECRET_API_KEY\t\tsets the api key used to authenticate with the funding faucet"
   msg
   msg "Optional environment variables"
   msg "------------------------------"
@@ -53,7 +53,7 @@ usage() {
 { [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; } && { usage; exit 0; }
 
 # verify and set parameters
-: ${FUNDING_PRIV_KEY?"Missing environment variable FUNDING_PRIV_KEY"}
+: ${FAUCET_SECRET_API_KEY?"Missing environment variable FAUCET_SECRET_API_KEY"}
 
 declare environment="${1?"missing parameter <environment>"}"
 declare init_script=${2:-}


### PR DESCRIPTION
The recent change to use an API to fund nodes requires the
authentication for that API to be set instead of using a private key
directly.

Fixes recent failures in CI deployment workflows.