### PR TITLE
gcloud: use smaller instances with less memory

### DIFF
--- a/scripts/gcloud.sh
+++ b/scripts/gcloud.sh
@@ -25,7 +25,7 @@ declare gcloud_region="--region=europe-west1"
 declare gcloud_disk_name="hoprd-data-disk"
 
 # use CPU optimized machine type
-GCLOUD_MACHINE="--machine-type=c2-standard-4"
+GCLOUD_MACHINE="--machine-type=c2d-highcpu-2"
 GCLOUD_META="--metadata=google-logging-enabled=true,google-monitoring-enabled=true,enable-oslogin=true --maintenance-policy=MIGRATE"
 GCLOUD_TAGS="--tags=hopr-node,web-client,rest-client,portainer,healthcheck"
 GCLOUD_BOOTDISK="--boot-disk-size=20GB --boot-disk-type=pd-standard"
@@ -227,7 +227,7 @@ gcloud_create_or_update_instance_template() {
 
   if [ "${no_args}" = "true" ]; then
     eval gcloud compute instance-templates create-with-container "${name}" \
-      --machine-type=c2-standard-4 \
+      --machine-type=c2d-highcpu-2 \
       --metadata=google-logging-enabled=true,google-monitoring-enabled=true,enable-oslogin=true \
       --maintenance-policy=MIGRATE \
       --tags=hopr-node,web-client,rest-client,portainer,healthcheck \


### PR DESCRIPTION
We don't need 16GB of memory. Thus, the smaller 4GB will provide a useful hard limit and make sure memory leaks don't overrun for too long.

