### PR TITLE
improve `/api/v2/channels/{peerid}`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
 
 - New API v2 endpoint `/api/v2/node/stream/websockets` ([#3514](https://github.com/hoprnet/hoprnet/issues/3514))
 - New API v2 endpoint `/api/v2/node/peers` ([#3617](https://github.com/hoprnet/hoprnet/pull/3617))
-- Various performance & cosmetic improvements
+- Bug fix endpoint `/api/v2/channels/{peerId}` ([#3627](https://github.com/hoprnet/hoprnet/issues/3627))
+- Various bug fixes in `core`
+- Performance improvements in `core`
 
 ---
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -998,7 +998,7 @@ class Hopr extends EventEmitter {
   public async getTickets(peerId: PeerId): Promise<Ticket[]> {
     const selfPubKey = new PublicKey(this.getId().pubKey.marshal())
     const counterpartyPubKey = new PublicKey(peerId.pubKey.marshal())
-    const channel = await this.db.getChannelX(selfPubKey, counterpartyPubKey)
+    const channel = await this.db.getChannelX(counterpartyPubKey, selfPubKey)
     return this.db
       .getAcknowledgedTickets({
         channel
@@ -1034,7 +1034,7 @@ class Hopr extends EventEmitter {
   public async redeemTicketsInChannel(peerId: PeerId) {
     const selfPubKey = new PublicKey(this.getId().pubKey.marshal())
     const counterpartyPubKey = new PublicKey(peerId.pubKey.marshal())
-    const channel = await this.db.getChannelX(selfPubKey, counterpartyPubKey)
+    const channel = await this.db.getChannelX(counterpartyPubKey, selfPubKey)
     await this.connector.redeemTicketsInChannel(channel)
   }
 

--- a/packages/hoprd/src/api/v2/paths/channels/peerid.spec.ts
+++ b/packages/hoprd/src/api/v2/paths/channels/peerid.spec.ts
@@ -1,17 +1,66 @@
 import assert from 'assert'
 import sinon from 'sinon'
+import { ChannelEntry } from '@hoprnet/hopr-utils'
 import { STATUS_CODES } from '../../utils'
-import { invalidTestPeerId, testPeerId } from '../../fixtures'
-import { closeChannel } from './{peerid}'
+import { invalidTestPeerId, testPeerId, testPeerIdInstance, ALICE_PEER_ID as COUNTERPARTY } from '../../fixtures'
+import { getChannel, closeChannel } from './{peerid}'
+import { formatIncomingChannel, formatOutgoingChannel } from '.'
 
 let node = sinon.fake() as any
+
+describe('getChannel', function () {
+  const outgoingMock = ChannelEntry.createMock()
+  const incomingMock = ChannelEntry.createMock()
+  node.getId = sinon.fake.returns(testPeerIdInstance)
+
+  it('should return no channels', async function () {
+    assert.rejects(
+      () => {
+        return getChannel(node, COUNTERPARTY.toB58String(), 'incoming')
+      },
+      (err: Error) => {
+        return err.message.includes(STATUS_CODES.CHANNEL_NOT_FOUND)
+      }
+    )
+    assert.rejects(
+      () => {
+        return getChannel(node, COUNTERPARTY.toB58String(), 'outgoing')
+      },
+      (err: Error) => {
+        return err.message.includes(STATUS_CODES.CHANNEL_NOT_FOUND)
+      }
+    )
+  })
+
+  it('should return outgoing channel', async function () {
+    node.getChannel = sinon.stub()
+    node.getChannel.withArgs(testPeerIdInstance, COUNTERPARTY).resolves(outgoingMock)
+
+    const outgoing = await getChannel(node, COUNTERPARTY.toB58String(), 'outgoing')
+    assert.notEqual(outgoing, undefined)
+    assert.deepEqual(outgoing, formatOutgoingChannel(outgoingMock))
+  })
+
+  it('should return outgoing and incoming channels', async function () {
+    node.getChannel = sinon.stub()
+    node.getChannel.withArgs(testPeerIdInstance, COUNTERPARTY).resolves(outgoingMock)
+    node.getChannel.withArgs(COUNTERPARTY, testPeerIdInstance).resolves(incomingMock)
+
+    const outgoing = await getChannel(node, COUNTERPARTY.toB58String(), 'outgoing')
+    assert.notEqual(outgoing, undefined)
+    assert.deepEqual(outgoing, formatOutgoingChannel(outgoingMock))
+    const incoming = await getChannel(node, COUNTERPARTY.toB58String(), 'incoming')
+    assert.notEqual(incoming, undefined)
+    assert.deepEqual(incoming, formatIncomingChannel(incomingMock))
+  })
+})
 
 describe('closeChannel', () => {
   it('should close channel', async () => {
     const expectedStatus = { channelStatus: 2, receipt: 'receipt' }
     node.closeChannel = sinon.fake.returns({ status: expectedStatus.channelStatus, receipt: expectedStatus.receipt })
 
-    const closureStatus = await closeChannel(node, testPeerId)
+    const closureStatus = await closeChannel(node, testPeerId, 'outgoing')
     assert.deepEqual(closureStatus, expectedStatus)
   })
 
@@ -21,7 +70,7 @@ describe('closeChannel', () => {
 
     assert.rejects(
       () => {
-        return closeChannel(node, invalidTestPeerId)
+        return closeChannel(node, invalidTestPeerId, 'outgoing')
       },
       (err: Error) => {
         return err.message.includes(STATUS_CODES.INVALID_PEERID)
@@ -34,7 +83,7 @@ describe('closeChannel', () => {
 
     assert.rejects(
       () => {
-        return closeChannel(node, testPeerId)
+        return closeChannel(node, testPeerId, 'outgoing')
       },
       // we only care if it throws
       (_err: Error) => {

--- a/packages/hoprd/src/api/v2/paths/channels/{peerid}.ts
+++ b/packages/hoprd/src/api/v2/paths/channels/{peerid}.ts
@@ -2,13 +2,13 @@ import type Hopr from '@hoprnet/hopr-core'
 import type { Operation } from 'express-openapi'
 import PeerId from 'peer-id'
 import { STATUS_CODES } from '../../utils'
-import { channelStatusToString, getChannels } from '.'
+import { ChannelInfo, channelStatusToString, formatIncomingChannel, formatOutgoingChannel } from '.'
 
 /**
  * Closes a channel with provided peerId.
  * @returns Channel status and receipt.
  */
-export const closeChannel = async (node: Hopr, peerIdStr: string) => {
+export const closeChannel = async (node: Hopr, peerIdStr: string, direction: ChannelInfo['type']) => {
   let peerId: PeerId
   try {
     peerId = PeerId.createFromB58String(peerIdStr)
@@ -16,7 +16,7 @@ export const closeChannel = async (node: Hopr, peerIdStr: string) => {
     throw Error(STATUS_CODES.INVALID_PEERID)
   }
 
-  const { status: channelStatus, receipt } = await node.closeChannel(peerId)
+  const { status: channelStatus, receipt } = await node.closeChannel(peerId, direction)
 
   return {
     channelStatus,
@@ -27,14 +27,10 @@ export const closeChannel = async (node: Hopr, peerIdStr: string) => {
 export const DELETE: Operation = [
   async (req, res, _next) => {
     const { node } = req.context
-    const { peerid } = req.params
-
-    if (!peerid) {
-      return res.status(400).send({ status: STATUS_CODES.INVALID_PEERID })
-    }
+    const { peerid, direction } = req.params
 
     try {
-      const { receipt, channelStatus } = await closeChannel(node, peerid)
+      const { receipt, channelStatus } = await closeChannel(node, peerid, direction as any)
       return res.status(200).send({ receipt, channelStatus: channelStatusToString(channelStatus) })
     } catch (err) {
       if (err.message.includes(STATUS_CODES.INVALID_PEERID)) {
@@ -60,6 +56,16 @@ DELETE.apiDoc = {
         type: 'string',
         description: 'PeerId attached to the channel that we want to close.',
         example: '16Uiu2HAmUsJwbECMroQUC29LQZZWsYpYZx1oaM1H9DBoZHLkYn12'
+      }
+    },
+    {
+      in: 'path',
+      name: 'direction',
+      description: 'Specify which channel should be fetched, incoming or outgoing.',
+      required: true,
+      schema: {
+        type: 'string',
+        enum: ['incoming', 'outgoing'] as ChannelInfo['type'][]
       }
     }
   ],
@@ -113,35 +119,56 @@ DELETE.apiDoc = {
   }
 }
 
+/**
+ * Fetches channel between node and counterparty in the direction provided.
+ * @returns the channel between node and counterparty
+ */
+export const getChannel = async (
+  node: Hopr,
+  counterparty: string,
+  direction: ChannelInfo['type']
+): Promise<ChannelInfo> => {
+  let counterpartyPeerId: PeerId
+  try {
+    counterpartyPeerId = PeerId.createFromB58String(counterparty)
+  } catch (err) {
+    throw Error(STATUS_CODES.INVALID_PEERID)
+  }
+
+  const selfPeerId = node.getId()
+
+  try {
+    return direction === 'outgoing'
+      ? await node.getChannel(selfPeerId, counterpartyPeerId).then(formatOutgoingChannel)
+      : await node.getChannel(counterpartyPeerId, selfPeerId).then(formatIncomingChannel)
+  } catch {
+    throw Error(STATUS_CODES.CHANNEL_NOT_FOUND)
+  }
+}
+
 export const GET: Operation = [
   async (req, res, _next) => {
     const { node } = req.context
-    const { peerid } = req.params
-
-    let peerIdStr: string
-    try {
-      peerIdStr = PeerId.createFromB58String(peerid).toB58String()
-    } catch (err) {
-      return res.status(400).send({ status: STATUS_CODES.INVALID_PEERID })
-    }
+    const { peerid, direction } = req.params
 
     try {
-      const channels = await getChannels(node, true)
-      const incoming = channels.incoming.filter((channel) => channel.peerId === peerIdStr)
-      const outgoing = channels.outgoing.filter((channel) => channel.peerId === peerIdStr)
-      const channel = incoming[0] || outgoing[0]
-      if (!channel) {
-        return res.status(404).send({ status: STATUS_CODES.CHANNEL_NOT_FOUND })
-      }
+      const channel = await getChannel(node, peerid, direction as any)
       return res.status(200).send(channel)
     } catch (err) {
-      return res.status(422).send({ status: STATUS_CODES.UNKNOWN_FAILURE, error: err.message })
+      console.log(err)
+      if (err.message === STATUS_CODES.INVALID_PEERID) {
+        return res.status(400).send({ status: STATUS_CODES.INVALID_PEERID })
+      } else if (err.message === STATUS_CODES.CHANNEL_NOT_FOUND) {
+        return res.status(404).send({ status: STATUS_CODES.CHANNEL_NOT_FOUND })
+      } else {
+        return res.status(422).send({ status: STATUS_CODES.UNKNOWN_FAILURE, error: err.message })
+      }
     }
   }
 ]
 
 GET.apiDoc = {
-  description: 'Returns information about the channel between this node and provided peerId.',
+  description: 'Returns information about the channels between this node and provided peerId.',
   tags: ['Channels'],
   operationId: 'channelsGetChannel',
   parameters: [
@@ -149,18 +176,31 @@ GET.apiDoc = {
       in: 'path',
       name: 'peerid',
       description: 'Counterparty peerId assigned to the channel you want to fetch.',
+      required: true,
       schema: {
         $ref: '#/components/schemas/HoprAddress'
+      }
+    },
+    {
+      in: 'path',
+      name: 'direction',
+      description: 'Specify which channel should be fetched, incoming or outgoing.',
+      required: true,
+      schema: {
+        type: 'string',
+        enum: ['incoming', 'outgoing'] as ChannelInfo['type'][]
       }
     }
   ],
   responses: {
     '200': {
-      description: 'Channel fetched succesfully.',
+      description: 'Channels fetched succesfully.',
       content: {
         'application/json': {
           schema: {
-            $ref: '#/components/schemas/Channel'
+            items: {
+              $ref: '#/components/schemas/Channel'
+            }
           }
         }
       }

--- a/packages/hoprd/src/api/v2/paths/channels/{peerid}/direction.spec.ts
+++ b/packages/hoprd/src/api/v2/paths/channels/{peerid}/direction.spec.ts
@@ -1,10 +1,10 @@
 import assert from 'assert'
 import sinon from 'sinon'
 import { ChannelEntry } from '@hoprnet/hopr-utils'
-import { STATUS_CODES } from '../../utils'
-import { invalidTestPeerId, testPeerId, testPeerIdInstance, ALICE_PEER_ID as COUNTERPARTY } from '../../fixtures'
-import { getChannel, closeChannel } from './{peerid}'
-import { formatIncomingChannel, formatOutgoingChannel } from '.'
+import { STATUS_CODES } from '../../../utils'
+import { invalidTestPeerId, testPeerId, testPeerIdInstance, ALICE_PEER_ID as COUNTERPARTY } from '../../../fixtures'
+import { getChannel, closeChannel } from './{direction}'
+import { formatIncomingChannel, formatOutgoingChannel } from '..'
 
 let node = sinon.fake() as any
 

--- a/packages/hoprd/src/api/v2/paths/channels/{peerid}/{direction}.ts
+++ b/packages/hoprd/src/api/v2/paths/channels/{peerid}/{direction}.ts
@@ -168,7 +168,7 @@ export const GET: Operation = [
 ]
 
 GET.apiDoc = {
-  description: 'Returns information about the channels between this node and provided peerId.',
+  description: 'Returns information about the channel between this node and provided peerId.',
   tags: ['Channels'],
   operationId: 'channelsGetChannel',
   parameters: [
@@ -194,7 +194,7 @@ GET.apiDoc = {
   ],
   responses: {
     '200': {
-      description: 'Channels fetched succesfully.',
+      description: 'Channel fetched succesfully.',
       content: {
         'application/json': {
           schema: {

--- a/packages/hoprd/src/api/v2/paths/channels/{peerid}/{direction}.ts
+++ b/packages/hoprd/src/api/v2/paths/channels/{peerid}/{direction}.ts
@@ -1,8 +1,8 @@
 import type Hopr from '@hoprnet/hopr-core'
 import type { Operation } from 'express-openapi'
 import PeerId from 'peer-id'
-import { STATUS_CODES } from '../../utils'
-import { ChannelInfo, channelStatusToString, formatIncomingChannel, formatOutgoingChannel } from '.'
+import { STATUS_CODES } from '../../../utils'
+import { ChannelInfo, channelStatusToString, formatIncomingChannel, formatOutgoingChannel } from '..'
 
 /**
  * Closes a channel with provided peerId.

--- a/packages/hoprd/src/commands/closeChannel.ts
+++ b/packages/hoprd/src/commands/closeChannel.ts
@@ -34,7 +34,7 @@ export default class CloseChannel extends AbstractCommand {
     log('Closing channel...')
 
     try {
-      const { status, receipt } = await this.node.closeChannel(peerId)
+      const { status, receipt } = await this.node.closeChannel(peerId, 'outgoing')
       const smartContractInfo = this.node.smartContractInfo()
       const channelClosureMins = Math.ceil(smartContractInfo.channelClosureSecs / 60) // convert to minutes
 


### PR DESCRIPTION
Fixes https://github.com/hoprnet/hoprnet/issues/3627

- fix `/api/v2/channels/{peerid}` by requiring a `direction` to be specified `/api/v2/channels/{peerid}/{direction}`
- fix functions `getTickets` and `redeemTicketsInChannel` to use the incoming channel of the node and a counterparty, not the outgoing, since tickets can only exist and redeemed in incoming channels
- update `CHANGELOG.md`