### PR TITLE
[Hotfix release/athens] Fix ethers.js http provider memory leak

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "yargs": "17.3.1"
   },
   "resolutions": {
-    "@ethersproject/providers": "hoprnet/ethers-js-provider",
+    "@ethersproject/providers": "hoprnet/ethers-js-provider#41feae79c102f17b5509600dd9dcfa236eda2707",
     "@overnightjs/logger": "1.2.1",
     "colors": "1.3.3"
   },

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "yargs": "17.3.1"
   },
   "resolutions": {
-    "@ethersproject/providers": "hoprnet/ethers-js-provider#41feae79c102f17b5509600dd9dcfa236eda2707",
+    "@ethersproject/providers": "hoprnet/ethers-js-provider#fa6b1f743ff3fe67c1e9a2207a67d79a854fc34c",
     "@overnightjs/logger": "1.2.1",
     "colors": "1.3.3"
   },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "yargs": "17.3.1"
   },
   "resolutions": {
+    "@ethersproject/providers": "hoprnet/ethers-js-provider",
     "@overnightjs/logger": "1.2.1",
     "colors": "1.3.3"
   },

--- a/packages/hoprd/package.json
+++ b/packages/hoprd/package.json
@@ -87,7 +87,7 @@
     "access": "public"
   },
   "resolutions": {
-    "@ethersproject/providers": "hoprnet/ethers-js-provider",
+    "@ethersproject/providers": "hoprnet/ethers-js-provider#41feae79c102f17b5509600dd9dcfa236eda2707",
     "@overnightjs/logger": "1.2.1",
     "colors": "1.3.3"
   },

--- a/packages/hoprd/package.json
+++ b/packages/hoprd/package.json
@@ -87,6 +87,7 @@
     "access": "public"
   },
   "resolutions": {
+    "@ethersproject/providers": "hoprnet/ethers-js-provider",
     "@overnightjs/logger": "1.2.1",
     "colors": "1.3.3"
   },

--- a/packages/hoprd/package.json
+++ b/packages/hoprd/package.json
@@ -87,7 +87,7 @@
     "access": "public"
   },
   "resolutions": {
-    "@ethersproject/providers": "hoprnet/ethers-js-provider#41feae79c102f17b5509600dd9dcfa236eda2707",
+    "@ethersproject/providers": "hoprnet/ethers-js-provider#fa6b1f743ff3fe67c1e9a2207a67d79a854fc34c",
     "@overnightjs/logger": "1.2.1",
     "colors": "1.3.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2715,9 +2715,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/providers@hoprnet/ethers-js-provider":
+"@ethersproject/providers@hoprnet/ethers-js-provider#41feae79c102f17b5509600dd9dcfa236eda2707":
   version: 5.5.3
-  resolution: "@ethersproject/providers@https://github.com/hoprnet/ethers-js-provider.git#commit=978bf69847eb8709543d2ec1723bd621ca3989be"
+  resolution: "@ethersproject/providers@https://github.com/hoprnet/ethers-js-provider.git#commit=41feae79c102f17b5509600dd9dcfa236eda2707"
   dependencies:
     "@ethersproject/abstract-provider": ^5.5.0
     "@ethersproject/abstract-signer": ^5.5.0
@@ -2738,7 +2738,7 @@ __metadata:
     "@ethersproject/web": ^5.5.0
     bech32: 1.1.4
     ws: 7.4.6
-  checksum: e691716ad94f9738bcd2ee28a586210be4658341f91e405d0c1750c34674b257bac74b53429f1f28bebd59b7ed2942888e6946c9f2db50dab77ee74b8ed7cf40
+  checksum: b6384e05daa888e819ba2508fda4ab1067e14087a8c069ac9d337b47277b7630ec0368d13b4790b045728fc0c63cdfff0b5356168fee84d6d501f8e9f8199afd
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2715,9 +2715,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/providers@hoprnet/ethers-js-provider#41feae79c102f17b5509600dd9dcfa236eda2707":
+"@ethersproject/providers@hoprnet/ethers-js-provider#fa6b1f743ff3fe67c1e9a2207a67d79a854fc34c":
   version: 5.5.3
-  resolution: "@ethersproject/providers@https://github.com/hoprnet/ethers-js-provider.git#commit=41feae79c102f17b5509600dd9dcfa236eda2707"
+  resolution: "@ethersproject/providers@https://github.com/hoprnet/ethers-js-provider.git#commit=fa6b1f743ff3fe67c1e9a2207a67d79a854fc34c"
   dependencies:
     "@ethersproject/abstract-provider": ^5.5.0
     "@ethersproject/abstract-signer": ^5.5.0
@@ -2738,7 +2738,7 @@ __metadata:
     "@ethersproject/web": ^5.5.0
     bech32: 1.1.4
     ws: 7.4.6
-  checksum: b6384e05daa888e819ba2508fda4ab1067e14087a8c069ac9d337b47277b7630ec0368d13b4790b045728fc0c63cdfff0b5356168fee84d6d501f8e9f8199afd
+  checksum: b83a987f456f1a5b93667c4c4b3c35768c33415d224e5454a306e4f68de0455a532be84d7dd8bb91c7d052fcb7afd42b52267d0cd5bfafd379823615447c7f09
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2715,7 +2715,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/providers@hoprnet/ethers-js-provider#978bf69847eb8709543d2ec1723bd621ca3989be":
+"@ethersproject/providers@hoprnet/ethers-js-provider":
   version: 5.5.3
   resolution: "@ethersproject/providers@https://github.com/hoprnet/ethers-js-provider.git#commit=978bf69847eb8709543d2ec1723bd621ca3989be"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2715,9 +2715,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@ethersproject/providers@npm:5.5.1":
-  version: 5.5.1
-  resolution: "@ethersproject/providers@npm:5.5.1"
+"@ethersproject/providers@hoprnet/ethers-js-provider#978bf69847eb8709543d2ec1723bd621ca3989be":
+  version: 5.5.3
+  resolution: "@ethersproject/providers@https://github.com/hoprnet/ethers-js-provider.git#commit=978bf69847eb8709543d2ec1723bd621ca3989be"
   dependencies:
     "@ethersproject/abstract-provider": ^5.5.0
     "@ethersproject/abstract-signer": ^5.5.0
@@ -2738,34 +2738,7 @@ __metadata:
     "@ethersproject/web": ^5.5.0
     bech32: 1.1.4
     ws: 7.4.6
-  checksum: c2cf3fbf63cef1733416771ccd404c6b53ac47a44470a13d19f250f247ce8e8d5c75b90982d265bb0261a62260054ae9b9ced8323b4e9d9834e2798b19d62f38
-  languageName: node
-  linkType: hard
-
-"@ethersproject/providers@npm:5.5.2, @ethersproject/providers@npm:^5.4.4":
-  version: 5.5.2
-  resolution: "@ethersproject/providers@npm:5.5.2"
-  dependencies:
-    "@ethersproject/abstract-provider": ^5.5.0
-    "@ethersproject/abstract-signer": ^5.5.0
-    "@ethersproject/address": ^5.5.0
-    "@ethersproject/basex": ^5.5.0
-    "@ethersproject/bignumber": ^5.5.0
-    "@ethersproject/bytes": ^5.5.0
-    "@ethersproject/constants": ^5.5.0
-    "@ethersproject/hash": ^5.5.0
-    "@ethersproject/logger": ^5.5.0
-    "@ethersproject/networks": ^5.5.0
-    "@ethersproject/properties": ^5.5.0
-    "@ethersproject/random": ^5.5.0
-    "@ethersproject/rlp": ^5.5.0
-    "@ethersproject/sha2": ^5.5.0
-    "@ethersproject/strings": ^5.5.0
-    "@ethersproject/transactions": ^5.5.0
-    "@ethersproject/web": ^5.5.0
-    bech32: 1.1.4
-    ws: 7.4.6
-  checksum: f03b78017ffa39880508cfb4f811ef3b5983d222303af06b4ab47b6296a3fa67dcd058534e5e167302e4e3af41c4aa44f8c113a974b84fbaa65c62959c098558
+  checksum: e691716ad94f9738bcd2ee28a586210be4658341f91e405d0c1750c34674b257bac74b53429f1f28bebd59b7ed2942888e6946c9f2db50dab77ee74b8ed7cf40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Sets the resolution for `@ethersproject/providers` to a fork that contains **built** source code to solve a memory leak in `base-provder.ts`.

Source code lives in https://github.com/robertkiel/ethers.js.
Changes are:

- https://github.com/robertkiel/ethers.js/commit/0a05998ec821c44220e33a93a879a0e548edd4ca
- https://github.com/robertkiel/ethers.js/commit/fd356081d4e8aee3897c9aca5efa8d40f0a20922
- https://github.com/robertkiel/ethers.js/commit/d8942467d38816080f0710ebb4990df751a8746b

Fork is at https://github.com/hoprnet/ethers-js-provider

## Problem in `ethers.js/providers/base-provider.ts`

HTTP does not support pushes *from* the server, hence in order to get notified about new blockchain events, such as new blocks, the node needs to *poll*.

Ethers.js uses an optimized way to poll latest on-chain changes to keep the number of provider requests small.

The `blockNumber` thereby serves as a base clock, hence it continuously queries `eth_blockNumber`. If there is a new block, it queries additional information, such as event logs.

The intenal function `_getInternalBlockNumber` handles the queries to the provider. It first checks if the current blockNumber is considered outdated and if that is the case, it performs another `eth_blockNumber` request.

*Meanwhile*, as many internal function within `ethers.js` initate calls to `_getInternalBlockNumber`, there might be a newer result to the request. Therefore the function **captures** the entire promise as closure and checks whether the resolved promise is newer than the initial promise. This causes a memory leak.

The solution is to use a request counter *number*, whose semantic is *call-by-value*, and not *call-by-reference* as for the Promise closures.