### PR TITLE
fix syntax in lockfile script and update regions

### DIFF
--- a/scripts/build_lockfiles.sh
+++ b/scripts/build_lockfiles.sh
@@ -21,7 +21,7 @@ usage() {
 }
 
 # return early with help info when requested
-{[ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]} && { usage; exit 0; }
+{ [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; } && { usage; exit 0; }
 
 if [ -z "${1:-}" ]; then
   msg "Missing package name"

--- a/scripts/gcloud.sh
+++ b/scripts/gcloud.sh
@@ -20,8 +20,8 @@ source "${mydir}/utils.sh"
 
 GCLOUD_INCLUDED=1 # So we can test for inclusion
 # using Belgium for better access to more VM types
-ZONE="--zone=europe-west1-d"
-declare gcloud_region="--region=europe-west1"
+ZONE="--zone=europe-west4-c"
+declare gcloud_region="--region=europe-west4"
 declare gcloud_disk_name="hoprd-data-disk"
 
 # use CPU optimized machine type


### PR DESCRIPTION
## Changes

- Correctly use bash syntax http://www.gnu.org/savannah-checkouts/gnu/bash/manual/bash.html#Command-Grouping in `build_lockfiles` script
- Fix GCloud machine region