### PR TITLE
disable peerstore persistence

### DIFF
--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -64,6 +64,7 @@ export async function createLibp2pInstance(
       connEncryption: [NOISE as any],
       dht: KadDHT
     },
+    // Currently disabled due to problems with serialization and deserialization
     // Configure peerstore to be persisted using LevelDB, also requires config
     // persistence to be set.
     // datastore,

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -68,7 +68,7 @@ export async function createLibp2pInstance(
     // persistence to be set.
     datastore,
     peerStore: {
-      persistence: true
+      persistence: false
     },
     config: {
       protocolPrefix: `hopr/${options.environment.id}`,

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -1,8 +1,8 @@
 import path from 'path'
-import { mkdir } from 'fs/promises'
+// import { mkdir } from 'fs/promises'
 
 import { default as LibP2P, type Connection } from 'libp2p'
-import { LevelDatastore } from 'datastore-level'
+// import { LevelDatastore } from 'datastore-level'
 import { type AddressSorter, expandVars, HoprDB, localAddressesFirst, PublicKey } from '@hoprnet/hopr-utils'
 import HoprCoreEthereum from '@hoprnet/hopr-core-ethereum'
 const Mplex = require('libp2p-mplex')

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -47,12 +47,12 @@ export async function createLibp2pInstance(
 
   // Store the peerstore on-disk under the main data path. Ensure store is
   // opened before passing it to libp2p.
-  const datastorePath = path.join(options.dataPath, 'peerstore')
-  await mkdir(datastorePath, { recursive: true })
-  const datastore = new LevelDatastore(datastorePath, { createIfMissing: true })
-  await datastore.open()
+  // const datastorePath = path.join(options.dataPath, 'peerstore')
+  // await mkdir(datastorePath, { recursive: true })
+  // const datastore = new LevelDatastore(datastorePath, { createIfMissing: true })
+  // await datastore.open()
 
-  log(`using peerstore at ${datastorePath}`)
+  // log(`using peerstore at ${datastorePath}`)
 
   const libp2p = await LibP2P.create({
     peerId,
@@ -66,7 +66,7 @@ export async function createLibp2pInstance(
     },
     // Configure peerstore to be persisted using LevelDB, also requires config
     // persistence to be set.
-    datastore,
+    // datastore,
     peerStore: {
       persistence: false
     },


### PR DESCRIPTION
Disables peerstore persistence due to issues with serialization and deserialization of PeerIds