### PR TITLE
Hotfix/race condition in shutdown sequence

### DIFF
--- a/packages/core-ethereum/src/index.ts
+++ b/packages/core-ethereum/src/index.ts
@@ -141,7 +141,7 @@ export default class HoprCoreEthereum extends EventEmitter {
    */
   async stop(): Promise<void> {
     log('Stopping connector...')
-    this.indexer.stop()
+    await this.indexer.stop()
   }
 
   announce(multiaddr: Multiaddr): Promise<string> {

--- a/packages/core-ethereum/src/indexer/index.ts
+++ b/packages/core-ethereum/src/indexer/index.ts
@@ -399,6 +399,7 @@ class Indexer extends EventEmitter {
     // NOTE: This function is also used in event handlers
     // where it cannot be 'awaited', so all exceptions need to be caught.
 
+    // Set a lock during block processing to make sure database does not get closed
     if (this.blockProcessingLock) {
       this.blockProcessingLock.resolve()
     }

--- a/packages/core-ethereum/src/indexer/index.ts
+++ b/packages/core-ethereum/src/indexer/index.ts
@@ -6,6 +6,7 @@ import { EventEmitter } from 'events'
 import { Multiaddr } from 'multiaddr'
 import {
   randomChoice,
+  defer,
   HoprDB,
   stringToU8a,
   ChannelStatus,
@@ -53,6 +54,8 @@ class Indexer extends EventEmitter {
   private chain: ChainWrapper
   private genesisBlock: number
   private lastSnapshot: IndexerSnapshot | undefined
+
+  private blockProcessingLock: DeferType<void> | undefined
 
   private unsubscribeErrors: () => void
   private unsubscribeBlock: () => void
@@ -149,7 +152,7 @@ class Indexer extends EventEmitter {
   /**
    * Stops indexing.
    */
-  public stop(): void {
+  public async stop(): Promise<void> {
     if (this.status === 'stopped') {
       return
     }
@@ -158,6 +161,8 @@ class Indexer extends EventEmitter {
 
     this.unsubscribeBlock()
     this.unsubscribeErrors()
+
+    this.blockProcessingLock && (await this.blockProcessingLock.promise)
 
     this.status = 'stopped'
     this.emit('status', 'stopped')
@@ -394,6 +399,11 @@ class Indexer extends EventEmitter {
     // NOTE: This function is also used in event handlers
     // where it cannot be 'awaited', so all exceptions need to be caught.
 
+    if (this.blockProcessingLock) {
+      this.blockProcessingLock.resolve()
+    }
+    this.blockProcessingLock = defer<void>()
+
     const currentBlock = blockNumber - this.maxConfirmations
 
     if (currentBlock < 0) {
@@ -467,6 +477,9 @@ class Indexer extends EventEmitter {
     } catch (err) {
       log(`error: failed to update database with latest block number ${blockNumber}`, err)
     }
+
+    this.blockProcessingLock.resolve()
+    this.blockProcessingLock = undefined
 
     this.emit('block-processed', currentBlock)
   }


### PR DESCRIPTION
Fixes a race condition in shutdown sequence.

Once `indexer.stop()` is called, the process *waits* until the most recent block processing has been completed. This prevents `core` from closing the db before the indexer has stopped.