### PR TITLE
e2e test fix and unit test fix

### DIFF
--- a/packages/core-ethereum/src/indexer/index.spec.ts
+++ b/packages/core-ethereum/src/indexer/index.spec.ts
@@ -158,7 +158,8 @@ describe('test indexer', function () {
 
     provider.emit('error', new Error('MOCK'))
 
-    assert.strictEqual(indexer.status, 'stopped')
+    // Indexer is either stopped or restarting
+    assert(['stopped', 'restarting'].includes(indexer.status))
 
     const started = defer<void>()
     indexer.on('status', (status: string) => {
@@ -177,7 +178,8 @@ describe('test indexer', function () {
     await indexer.start(chain, 0)
     provider.emit('error', new Error('ECONNRESET'))
 
-    assert.strictEqual(indexer.status, 'stopped')
+    // Indexer is either stopped or restarting
+    assert(['stopped', 'restarting'].includes(indexer.status))
 
     const started = defer<void>()
     indexer.on('status', (status: string) => {

--- a/packages/core-ethereum/src/indexer/index.ts
+++ b/packages/core-ethereum/src/indexer/index.ts
@@ -480,7 +480,6 @@ class Indexer extends EventEmitter {
     }
 
     this.blockProcessingLock.resolve()
-    this.blockProcessingLock = undefined
 
     this.emit('block-processed', currentBlock)
   }


### PR DESCRIPTION
Fixes release block processing lock and enhances indexer tests that tackle indexer restarts to match all states that might occur during an indexer restart