### PR TITLE
Add back peerstore functionality

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -265,7 +265,7 @@ class Hopr extends EventEmitter {
         this.publicNodesEmitter.emit('removePublicNode', peer)
       }
     )
-    peers.forEach(peer => log(`peer store: loaded peer ${peer.id.toB58String()}`))
+    peers.forEach((peer) => log(`peer store: loaded peer ${peer.id.toB58String()}`))
 
     this.heartbeat = new Heartbeat(this.networkPeers, subscribe, sendMessage, hangup, this.environment.id, this.options)
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -10,7 +10,6 @@ import type { default as LibP2P, Connection } from 'libp2p'
 import type { Peer } from 'libp2p/src/peer-store/types'
 import type PeerId from 'peer-id'
 
-import { convertPubKeyFromPeerId } from '@hoprnet/hopr-utils'
 import type { HoprConnectConfig } from '@hoprnet/hopr-connect'
 
 import { PACKET_SIZE, INTERMEDIATE_HOPS, VERSION, FULL_VERSION } from './constants'
@@ -47,7 +46,8 @@ import {
   type Ticket,
   multiaddressCompareByClassFunction,
   createRelayerKey,
-  createCircuitAddress
+  createCircuitAddress,
+  convertPubKeyFromPeerId
 } from '@hoprnet/hopr-utils'
 import { type default as HoprCoreEthereum, type Indexer } from '@hoprnet/hopr-core-ethereum'
 
@@ -260,8 +260,13 @@ class Hopr extends EventEmitter {
     this.networkPeers = new NetworkPeers(
       peers.map((p) => p.id),
       [this.id],
-      (peer: PeerId) => this.publicNodesEmitter.emit('removePublicNode', peer)
+      (peer: PeerId) => {
+        this.libp2p.peerStore.delete(peer)
+        this.publicNodesEmitter.emit('removePublicNode', peer)
+      }
     )
+    peers.forEach(peer => log(`peer store: loaded peer ${peer.id.toB58String()}`))
+
     this.heartbeat = new Heartbeat(this.networkPeers, subscribe, sendMessage, hangup, this.environment.id, this.options)
 
     this.libp2p.connectionManager.on('peer:connect', (conn: Connection) => {

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -1,15 +1,14 @@
 import path from 'path'
-// import { mkdir } from 'fs/promises'
+import { mkdir } from 'fs/promises'
 
 import { default as LibP2P, type Connection } from 'libp2p'
-// import { LevelDatastore } from 'datastore-level'
-import { type AddressSorter, expandVars, HoprDB, localAddressesFirst, PublicKey } from '@hoprnet/hopr-utils'
+import { LevelDatastore } from 'datastore-level'
+import { type AddressSorter, expandVars, HoprDB, localAddressesFirst, PublicKey, debug } from '@hoprnet/hopr-utils'
 import HoprCoreEthereum from '@hoprnet/hopr-core-ethereum'
 const Mplex = require('libp2p-mplex')
 import KadDHT from 'libp2p-kad-dht'
 import { NOISE } from '@chainsafe/libp2p-noise'
 import type PeerId from 'peer-id'
-import { debug } from '@hoprnet/hopr-utils'
 import Hopr, { type HoprOptions } from '.'
 import { getAddrs } from './identity'
 import HoprConnect, { type HoprConnectConfig, type PublicNodesEmitter } from '@hoprnet/hopr-connect'
@@ -47,12 +46,12 @@ export async function createLibp2pInstance(
 
   // Store the peerstore on-disk under the main data path. Ensure store is
   // opened before passing it to libp2p.
-  // const datastorePath = path.join(options.dataPath, 'peerstore')
-  // await mkdir(datastorePath, { recursive: true })
-  // const datastore = new LevelDatastore(datastorePath, { createIfMissing: true })
-  // await datastore.open()
+   const datastorePath = path.join(options.dataPath, 'peerstore')
+   await mkdir(datastorePath, { recursive: true })
+   const datastore = new LevelDatastore(datastorePath, { createIfMissing: true })
+   await datastore.open()
 
-  // log(`using peerstore at ${datastorePath}`)
+  log(`using peerstore at ${datastorePath}`)
 
   const libp2p = await LibP2P.create({
     peerId,
@@ -67,9 +66,9 @@ export async function createLibp2pInstance(
     // Currently disabled due to problems with serialization and deserialization
     // Configure peerstore to be persisted using LevelDB, also requires config
     // persistence to be set.
-    // datastore,
+    datastore,
     peerStore: {
-      persistence: false
+      persistence: true
     },
     config: {
       protocolPrefix: `hopr/${options.environment.id}`,
@@ -200,6 +199,5 @@ export async function createHoprNode(
   // Initialize connection to the blockchain
   await chain.initializeChainWrapper()
 
-  const node = new Hopr(peerId, db, chain, options)
-  return node
+  return new Hopr(peerId, db, chain, options)
 }

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -46,10 +46,10 @@ export async function createLibp2pInstance(
 
   // Store the peerstore on-disk under the main data path. Ensure store is
   // opened before passing it to libp2p.
-   const datastorePath = path.join(options.dataPath, 'peerstore')
-   await mkdir(datastorePath, { recursive: true })
-   const datastore = new LevelDatastore(datastorePath, { createIfMissing: true })
-   await datastore.open()
+  const datastorePath = path.join(options.dataPath, 'peerstore')
+  await mkdir(datastorePath, { recursive: true })
+  const datastore = new LevelDatastore(datastorePath, { createIfMissing: true })
+  await datastore.open()
 
   log(`using peerstore at ${datastorePath}`)
 

--- a/scripts/run-integration-tests-npm.sh
+++ b/scripts/run-integration-tests-npm.sh
@@ -390,8 +390,7 @@ for node_dir in ${node1_dir} ${node2_dir} ${node3_dir} ${node4_dir} ${node5_dir}
   declare node_dir_db="${node_dir}/db/LOG"
   declare node_dir_peerstore="${node_dir}/peerstore/LOG"
   [ -f "${node_dir_db}" ] || { echo "Data file ${node_dir_db} missing"; exit 1; }
-  # See https://github.com/hoprnet/hoprnet/issues/3692
-  # [ -f "${node_dir_peerstore}" ] || { echo "Data file ${node_dir_peerstore} missing"; exit 1; }
+  [ -f "${node_dir_peerstore}" ] || { echo "Data file ${node_dir_peerstore} missing"; exit 1; }
 done
 # }}}
 

--- a/scripts/run-integration-tests-source.sh
+++ b/scripts/run-integration-tests-source.sh
@@ -359,8 +359,7 @@ for node_dir in ${node1_dir} ${node2_dir} ${node3_dir} ${node4_dir} ${node5_dir}
   declare node_dir_db="${node_dir}/db/LOG"
   declare node_dir_peerstore="${node_dir}/peerstore/LOG"
   [ -f "${node_dir_db}" ] || { echo "Data file ${node_dir_db} missing"; exit 1; }
-  # See https://github.com/hoprnet/hoprnet/issues/3692
-  # [ -f "${node_dir_peerstore}" ] || { echo "Data file ${node_dir_peerstore} missing"; exit 1; }
+  [ -f "${node_dir_peerstore}" ] || { echo "Data file ${node_dir_peerstore} missing"; exit 1; }
 done
 # }}}
 


### PR DESCRIPTION
This PR contains following changes:
- `peerstore` support has been added back
- peers removed from the `peerstore` via `NetworkPeers`
- small code tweaks

Refs #3692 