### PR TITLE
refactor address filtering

### DIFF
--- a/packages/connect/src/filter.ts
+++ b/packages/connect/src/filter.ts
@@ -159,15 +159,13 @@ export class Filter {
           return false
         }
 
-        // Prevent dialing any link-locale addresses or reserved addresses
         if (
           isLinkLocaleAddress(parsed.address.address, parsed.address.type) ||
           isReservedAddress(parsed.address.address, parsed.address.type)
         ) {
+          // Prevent dialing any link-locale addresses or reserved addresses
           return false
-        }
-
-        if (isLocalhost(parsed.address.address, parsed.address.type)) {
+        } else if (isLocalhost(parsed.address.address, parsed.address.type)) {
           // If localhost connections are explicitly allowed, do not dial them
           if (!this.opts.allowLocalConnections) {
             // Do not pollute logs by rejecting localhost connections attempts
@@ -187,9 +185,7 @@ export class Filter {
             // Do not log anything to prevent too much log pollution
             return false
           }
-        }
-
-        if (isPrivateAddress(parsed.address.address, parsed.address.type)) {
+        } else if (isPrivateAddress(parsed.address.address, parsed.address.type)) {
           // If private address connections are explicitly allowed, do not dial them
           if (!this.opts.allowPrivateConnections) {
             // Do not pollute logs by rejecting private address connections attempts

--- a/packages/connect/src/utils/addrs.ts
+++ b/packages/connect/src/utils/addrs.ts
@@ -13,14 +13,14 @@ export enum AddressType {
   P2P = 'p2p'
 }
 
-type DirectAddress = {
+export type DirectAddress = {
   type: AddressType.IPv4 | AddressType.IPv6
   address: Uint8Array
   port: number
   node?: Uint8Array
 }
 
-type CircuitAddress = {
+export type CircuitAddress = {
   type: AddressType.P2P
   relayer: Uint8Array
   node: Uint8Array

--- a/packages/connect/src/utils/addrs.ts
+++ b/packages/connect/src/utils/addrs.ts
@@ -1,22 +1,27 @@
 import type { Multiaddr } from 'multiaddr'
 import { CODE_IP4, CODE_IP6, CODE_P2P, CODE_CIRCUIT, CODE_TCP } from '../constants'
 import { decode } from 'multihashes'
-import type { NetworkInterfaceInfo } from 'os'
 import { u8aEquals, u8aToNumber } from '@hoprnet/hopr-utils'
 import Debug from 'debug'
 
 const MULTIHASH_LENGTH = 37
 const MULTIHASH_TYPE = 'identity'
 
+export enum AddressType {
+  IPv4 = 'IPv4',
+  IPv6 = 'IPv6',
+  P2P = 'p2p'
+}
+
 type DirectAddress = {
-  type: NetworkInterfaceInfo['family']
+  type: AddressType.IPv4 | AddressType.IPv6
   address: Uint8Array
   port: number
   node?: Uint8Array
 }
 
 type CircuitAddress = {
-  type: 'p2p'
+  type: AddressType.P2P
   relayer: Uint8Array
   node: Uint8Array
 }
@@ -97,7 +102,7 @@ function parseCircuitAddress(maTuples: [code: number, addr: Uint8Array][]): Pars
   return {
     valid: true,
     address: {
-      type: 'p2p',
+      type: AddressType.P2P,
       relayer: decoded[0],
       node: decoded[1]
     }
@@ -120,14 +125,14 @@ function parseDirectAddress(maTuples: [code: number, addr: Uint8Array][]): Parse
     return { valid: false }
   }
 
-  let family: NetworkInterfaceInfo['family']
+  let family: AddressType.IPv4 | AddressType.IPv6
 
   switch (maTuples[0][0]) {
     case CODE_IP4:
-      family = 'IPv4'
+      family = AddressType.IPv4
       break
     case CODE_IP6:
-      family = 'IPv6'
+      family = AddressType.IPv6
       break
     default:
       return { valid: false }

--- a/packages/connect/src/utils/index.ts
+++ b/packages/connect/src/utils/index.ts
@@ -10,7 +10,7 @@ import { isAnyAddress } from '@hoprnet/hopr-utils'
 import { Multiaddr } from 'multiaddr'
 import { CODE_CIRCUIT, CODE_P2P } from '../constants'
 
-export { parseAddress, type ValidAddress } from './addrs'
+export { parseAddress, type ValidAddress, AddressType } from './addrs'
 export { encodeWithLengthPrefix, decodeWithLengthPrefix } from './lengthPrefix'
 
 function isAsyncStream<T>(iterator: AsyncIterable<T> | Iterable<T>): iterator is AsyncIterable<T> {

--- a/packages/connect/src/utils/index.ts
+++ b/packages/connect/src/utils/index.ts
@@ -10,7 +10,7 @@ import { isAnyAddress } from '@hoprnet/hopr-utils'
 import { Multiaddr } from 'multiaddr'
 import { CODE_CIRCUIT, CODE_P2P } from '../constants'
 
-export { parseAddress, type ValidAddress, AddressType } from './addrs'
+export * from './addrs'
 export { encodeWithLengthPrefix, decodeWithLengthPrefix } from './lengthPrefix'
 
 function isAsyncStream<T>(iterator: AsyncIterable<T> | Iterable<T>): iterator is AsyncIterable<T> {


### PR DESCRIPTION
Minor refactoring of the AddressFilter using enums and case distinction rather than plenty of `if` conditions