### PR TITLE
Hotfix/disable dht client mode

### DIFF
--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -105,7 +105,9 @@ export async function createLibp2pInstance(
         enabled: true,
         // Feed DHT with all previously announced nodes
         // @ts-ignore
-        bootstrapPeers: initialNodes
+        bootstrapPeers: initialNodes,
+        // Answer requests from other peers
+        clientMode: false
       },
       relay: {
         // Conflicts with HoprConnect's own mechanism


### PR DESCRIPTION
Enable full-featured DHT on all nodes (currently enabled on **none** of the nodes)

See https://github.com/libp2p/js-libp2p/blob/master/doc/CONFIGURATION.md#customizing-dht 

For in-depth understanding, see https://github.com/libp2p/js-libp2p-kad-dht/blob/v0.28.6/src/kad-dht.js#L337-L350

Client mode means that the node *does not* respond to DHT queries, i.e. there is no `node.handle('dht-query')`

Server mode (as previously known) means that the node *does* respond to DHT queries, i.e. there is a `node.handle('dht-query')`