### PR TITLE
Hotfix/webrtc control flow

### DIFF
--- a/packages/connect/src/base/tcp.ts
+++ b/packages/connect/src/base/tcp.ts
@@ -54,8 +54,10 @@ class TCPConnection implements MultiaddrConnection {
 
     this.sink = this._sink.bind(this)
 
-    // @ts-ignore
-    this.source = this._signal != undefined ? abortable(this._stream.source, this._signal) : this._stream.source
+    this.source =
+      this._signal != undefined
+        ? abortable(this._stream.source, this._signal)
+        : (this._stream.source as AsyncIterable<StreamType>)
   }
 
   public close(): Promise<void> {

--- a/packages/connect/src/webrtc/connection.ts
+++ b/packages/connect/src/webrtc/connection.ts
@@ -184,7 +184,7 @@ class WebRTCConnection implements MultiaddrConnection {
     this._webRTCAvailable = false
     this._switchPromise.resolve()
 
-    setImmediate(() => this.channel.destroy.bind(this.channel))
+    setImmediate(this.channel.destroy.bind(this.channel))
   }
 
   /**

--- a/packages/connect/src/webrtc/connection.ts
+++ b/packages/connect/src/webrtc/connection.ts
@@ -94,8 +94,16 @@ class WebRTCConnection implements MultiaddrConnection {
     // Give each WebRTC connection instance a unique identifier
     this._id = u8aToHex(randomBytes(4), false)
 
-    this.channel.on('error', this.onWebRTCError.bind(this))
-    this.channel.once('connect', this.onWebRTCConnect.bind(this))
+    this.channel.on(
+      'error',
+      // not supposed to produce any errors
+      this.onWebRTCError.bind(this)
+    )
+    this.channel.once(
+      'connect',
+      // not supposed to produce any errors
+      this.onWebRTCConnect.bind(this)
+    )
 
     // Attach a listener to WebRTC to cleanup state
     // and remove stale connection from internal libp2p state


### PR DESCRIPTION
Re #3727 

should prevent some unhandled promise rejections

## Changes:

- minor refactoring
- do not unassign WebRTC `error` handler as `channel.destroy()` might lead to an error and thus creates unhandled promise rejections