### PR TITLE
Update db path used in Docker images to new default path prefix.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ docker pull gcr.io/hoprassociation/hoprd:ouagadougou
 For ease of use you can set up a shell alias to run the latest release as a docker container:
 
 ```sh
-alias hoprd='docker run --pull always -ti -v ${HOPRD_DATA_DIR:-$HOME/.hoprd-db}:/app/db -p 9091:9091 -p 3000:3000 -p 3001:3001 gcr.io/hoprassociation/hoprd:ouagadougou'
+alias hoprd='docker run --pull always -ti -v ${HOPRD_DATA_DIR:-$HOME/.hoprd-db}:/app/hoprd-db -p 9091:9091 -p 3000:3000 -p 3001:3001 gcr.io/hoprassociation/hoprd:ouagadougou'
 ```
 
 **IMPORTANT:** Using the above command will map the database folder used by hoprd to a local folder called `.hoprd-db` in your home directory. You can customize the location of that folder further by executing the following command:
@@ -185,14 +185,14 @@ hoprd
 The following command assumes you've setup an alias like described in [Install via Docker](#install-via-docker).
 
 ```sh
-hoprd --identity /app/db/.hopr-identity --password switzerland --init --announce --host "0.0.0.0:9091" --admin --adminHost 0.0.0.0 --forwardLogs --apiToken <MY_TOKEN> --environment jungfrau
+hoprd --identity /app/hoprd-db/.hopr-identity --password switzerland --init --announce --host "0.0.0.0:9091" --admin --adminHost 0.0.0.0 --forwardLogs --apiToken <MY_TOKEN> --environment jungfrau
 ```
 
 Here is a short break-down of each argument.
 
 ```sh
 hoprd
-  --identity /app/db/.hopr-identity      # store your node identity information in the persisted database folder
+  --identity /app/hoprd-db/.hopr-identity      # store your node identity information in the persisted database folder
   --password switzerland   		 # set the encryption password for your identity
   --init 				 # initialize the database and identity if not present
   --announce 				 # announce the node to other nodes in the network and act as relay if publicly reachable

--- a/docs/hopr-documentation/docs/node/using-docker.md
+++ b/docs/hopr-documentation/docs/node/using-docker.md
@@ -75,7 +75,13 @@ This ensures the node cannot be accessed by a malicious user residing in the sam
 :::
 
 ```bash
-docker run --pull always -ti -v $HOME/.hoprd-db:/app/db -p 9091:9091 -p 3000:3000 -p 3001:3001 gcr.io/hoprassociation/hoprd:ouagadougou --admin --password 'open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0' --init --rest --restHost "0.0.0.0" --restPort 3001 --identity /app/db/.hopr-id-ouagadougou --apiToken 'YOUR_SECURITY_TOKEN' --adminHost "0.0.0.0" --adminPort 3000 --host "0.0.0.0:9091"
+docker run --pull always -ti -v $HOME/.hoprd-db:/app/hoprd-db \
+	-p 9091:9091 -p 3000:3000 -p 3001:3001 \
+	gcr.io/hoprassociation/hoprd:ouagadougou --admin \
+	--password 'open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0' --init --rest \
+	--restHost "0.0.0.0" --restPort 3001 \
+	--identity /app/hoprd-db/.hopr-id-ouagadougou --apiToken 'YOUR_SECURITY_TOKEN' \
+	--adminHost "0.0.0.0" --adminPort 3000 --host "0.0.0.0:9091"
 ```
 
 Also all ports are mapped to your local host, assuming you stick to the default port numbers.

--- a/packages/avado/build/Dockerfile
+++ b/packages/avado/build/Dockerfile
@@ -1,3 +1,3 @@
 FROM gcr.io/hoprassociation/hoprd:master-goerli
 
-ENTRYPOINT [ "/usr/bin/tini", "--", "yarn", "hoprd", "--password='open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0'", "--init", "--admin", "--adminHost", "0.0.0.0", "--rest", "--restHost", "0.0.0.0", "--healthCheck", "--healthCheckHost", "0.0.0.0", "--data", "/app/db/data-master-goerli", "--identity", "/app/db/.hopr-identity", "--apiToken='!5qxc9Lp1BE7IFQ-nrtttU'" ]
+ENTRYPOINT [ "/usr/bin/tini", "--", "yarn", "hoprd", "--password='open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0'", "--init", "--admin", "--adminHost", "0.0.0.0", "--rest", "--restHost", "0.0.0.0", "--healthCheck", "--healthCheckHost", "0.0.0.0", "--data", "/app/hoprd-db/data-master-goerli", "--identity", "/app/hoprd-db/.hopr-identity", "--apiToken='!5qxc9Lp1BE7IFQ-nrtttU'" ]

--- a/packages/avado/dappnode_package.json
+++ b/packages/avado/dappnode_package.json
@@ -7,7 +7,7 @@
   "autoupdate": true,
   "image": {
     "volumes": [
-      "db:/app/db"
+      "db:/app/hoprd-db"
     ],
     "environment": [
       "DEBUG=hopr*"

--- a/packages/avado/docker-compose.yml
+++ b/packages/avado/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     volumes:
       - type: volume
         source: db
-        target: /app/db
+        target: /app/hoprd-db
     ports:
       - '9091'
       - '3000'

--- a/packages/cover-traffic-daemon/Dockerfile
+++ b/packages/cover-traffic-daemon/Dockerfile
@@ -46,10 +46,10 @@ COPY --from=build /app .
 
 # create directory which is later used for the database, so that it inherits
 # permissions when mapped to a volume
-RUN mkdir db
+RUN mkdir hoprd-db
 
 # set volume which can be mapped by users on the host system
-VOLUME ["/app/db"]
+VOLUME ["/app/hoprd-db"]
 
 # making sure some standard environment variables are set for production use
 ENV NODE_ENV production

--- a/packages/hoprd/Dockerfile
+++ b/packages/hoprd/Dockerfile
@@ -47,14 +47,14 @@ COPY --from=build /app .
 
 # create directory which is later used for the database, so that it inherits
 # permissions when mapped to a volume
-RUN mkdir db
+RUN mkdir hoprd-db
 
 # DISABLED temporarily until a migration path has been tested
 # switch to normal user, to prevent dangerous root access
 # RUN chown -R node:node .
 
 # set volume which can be mapped by users on the host system
-VOLUME ["/app/db"]
+VOLUME ["/app/hoprd-db"]
 
 # DISABLED temporarily until a migration path has been tested
 # finally set the non-root user so the process also run un-privilidged

--- a/scripts/gcloud.sh
+++ b/scripts/gcloud.sh
@@ -208,7 +208,7 @@ gcloud_create_or_update_instance_template() {
     extra_args="${extra_args} --container-arg=\"--announce\""
   fi
 
-  mount_path="/app/db"
+  mount_path="/app/hoprd-db"
   host_path="/var/hoprd"
 
   log "checking for instance template ${name}"

--- a/scripts/nat/start-nat-node.sh
+++ b/scripts/nat/start-nat-node.sh
@@ -46,7 +46,7 @@ fi
 docker stop ${container_name} > /dev/null 2>&1 || true && docker rm ${container_name} > /dev/null 2>&1 || true
 
 # Fork here and pass all the environment variables down into the forked image
-docker run -d --pull always -v /var/hoprd/:/app/db -p ${admin_port}:3000 -p ${rest_port}:3001 -p ${healthcheck_port}:8080 \
+docker run -d --pull always -v /var/hoprd/:/app/hoprd-db -p ${admin_port}:3000 -p ${rest_port}:3001 -p ${healthcheck_port}:8080 \
  --name=${container_name} --restart=on-failure \
  --network=${network_name} \
  --env-file <(env) \

--- a/scripts/testnet.sh
+++ b/scripts/testnet.sh
@@ -138,68 +138,6 @@ run_command(){
 }
 
 # $1=vm name
-# $2=docker image
-# $3=environment id
-update_if_existing() {
-  local vm_name=${1}
-  local docker_image=${2}
-  local environment_id=${3}
-
-  if [[ $(gcloud_find_vm_with_name $1) ]]; then
-    log "Container exists, updating" 1>&2
-    PREV=$(gcloud_get_image_running_on_vm $1)
-    if [ "$PREV" == "$2" ]; then
-      log "Same version of image is currently running. Skipping update to $PREV" 1>&2
-      return 0
-    fi
-    log "Previous GCloud VM Image: $PREV"
-    gcloud_update_container_with_image "${vm_name}" "${docker_image}" "$(disk_name ${vm_name})" "/app/db" "${environment_id}"
-
-    # prevent docker images overloading the disk space
-    gcloud_cleanup_docker_images "${vm_name}"
-  else
-    echo "no container"
-  fi
-
-}
-
-# $1=vm name
-# $2=docker image
-# $3=environment id
-# NB: --run needs to be at the end or it will ignore the other arguments.
-start_testnode_vm() {
-  local vm_name=${1}
-  local docker_image=${2}
-  local environment_id=${3}
-  local api_token="${HOPRD_API_TOKEN}"
-  local password="${BS_PASSWORD}"
-
-  local rpc=$(get_rpc "${environment_id}")
-
-  if [ "$(update_if_existing ${vm_name} ${docker_image} ${environment_id})"="no container" ]; then
-    gcloud compute instances create-with-container ${vm_name} $GCLOUD_DEFAULTS \
-      --create-disk name=$(disk_name ${vm_name}),size=10GB,type=pd-standard,mode=rw \
-      --container-mount-disk mount-path="/app/db" \
-      --container-env=^,@^DEBUG=hopr\*,@NODE_OPTIONS=--max-old-space-size=4096,@GCLOUD=1 \
-      --container-image=${docker_image} \
-      --container-arg="--admin" \
-      --container-arg="--adminHost" --container-arg="0.0.0.0" \
-      --container-arg="--announce" \
-      --container-arg="--apiToken" --container-arg="${api_token}" \
-      --container-arg="--healthCheck" \
-      --container-arg="--healthCheckHost" --container-arg="0.0.0.0" \
-      --container-arg="--identity" --container-arg="/app/db/.hopr-identity" \
-      --container-arg="--init" \
-      --container-arg="--password" --container-arg="${password}" \
-      --container-arg="--environment" --container-arg="${environment_id}" \
-      --container-arg="--rest" \
-      --container-arg="--restHost" --container-arg="0.0.0.0" \
-      --container-arg="--run" --container-arg="\"cover-traffic start;daemonize\"" \
-      --container-restart-policy=always
-  fi
-}
-
-# $1=vm name
 # Run a VM with a hardhat instance
 start_chain_provider(){
   gcloud compute instances create-with-container $1-provider $GCLOUD_DEFAULTS \
@@ -207,30 +145,6 @@ start_chain_provider(){
       --container-image='hopr-provider'
 
   #hardhat node --config packages/ethereum/hardhat.config.ts
-}
-
-# $1=testnet name
-# $2=docker image
-# $3=node number
-# $4=environment id
-start_testnode() {
-  local vm ip eth_address
-
-  local testnet_name=${1}
-  local docker_image=${2}
-  local node_number=${3}
-  local environment_id=${4}
-
-  # start or update vm
-  vm=$(vm_name "node-${node_number}" ${testnet_name})
-  log "- Starting test node ${vm} with ${docker_image} ${environment_id}"
-  start_testnode_vm ${vm} ${docker_image} ${environment_id}
-
-  # ensure node has funds, even after just updating a release
-  ip=$(gcloud_get_ip "${vm}")
-  wait_until_node_is_ready ${ip}
-  eth_address=$(get_native_address "${ip}:3001")
-  fund_if_empty "${eth_address}" "${environment_id}"
 }
 
 # $1 authorized keys file


### PR DESCRIPTION
Fixes #3733 

The default path was changed as part of introducing the on-disk peer-store. Therefore, all uses of the path must be adapted as well.