### PR TITLE
Remove unnecessary abort signal checks

### DIFF
--- a/packages/connect/src/base/tcp.ts
+++ b/packages/connect/src/base/tcp.ts
@@ -139,7 +139,6 @@ class TCPConnection implements MultiaddrConnection {
    * @returns Resolves a TCP Socket
    */
   public static create(ma: Multiaddr, self: PeerId, options?: HoprConnectDialOptions): Promise<TCPConnection> {
-
     return new Promise<TCPConnection>((resolve, reject) => {
       const start = Date.now()
       const cOpts = ma.toOptions()

--- a/packages/connect/src/base/tcp.ts
+++ b/packages/connect/src/base/tcp.ts
@@ -1,5 +1,5 @@
 import net, { type Socket, type AddressInfo } from 'net'
-import abortable, { AbortError } from 'abortable-iterator'
+import abortable from 'abortable-iterator'
 import Debug from 'debug'
 import { nodeToMultiaddr } from '../utils'
 
@@ -139,9 +139,6 @@ class TCPConnection implements MultiaddrConnection {
    * @returns Resolves a TCP Socket
    */
   public static create(ma: Multiaddr, self: PeerId, options?: HoprConnectDialOptions): Promise<TCPConnection> {
-    if (options?.signal?.aborted) {
-      return Promise.reject(new AbortError())
-    }
 
     return new Promise<TCPConnection>((resolve, reject) => {
       const start = Date.now()

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,6 +1,5 @@
 import Debug from 'debug'
 import { CODE_DNS4, CODE_DNS6, CODE_IP4, CODE_IP6, CODE_P2P } from './constants'
-import { AbortError } from 'abortable-iterator'
 import type { Multiaddr } from 'multiaddr'
 import PeerId from 'peer-id'
 import type Connection from 'libp2p-interfaces/src/connection/connection'
@@ -146,9 +145,6 @@ class HoprConnect implements Transport<HoprConnectDialOptions, HoprConnectListen
    * @returns An upgraded Connection
    */
   async dial(ma: Multiaddr, options: HoprConnectDialOptions = {}): Promise<Connection> {
-    if (options.signal?.aborted) {
-      throw new AbortError()
-    }
 
     const maTuples = ma.tuples()
 

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -145,7 +145,6 @@ class HoprConnect implements Transport<HoprConnectDialOptions, HoprConnectListen
    * @returns An upgraded Connection
    */
   async dial(ma: Multiaddr, options: HoprConnectDialOptions = {}): Promise<Connection> {
-
     const maTuples = ma.tuples()
 
     // This works because destination peerId is for both address

--- a/packages/connect/src/relay/index.ts
+++ b/packages/connect/src/relay/index.ts
@@ -8,7 +8,6 @@ import type HoprConnect from '..'
 
 import type { Stream, HoprConnectOptions, HoprConnectDialOptions, HoprConnectTestingOptions } from '../types'
 
-import { AbortError } from 'abortable-iterator'
 import debug from 'debug'
 
 import { WebRTCUpgrader, WebRTCConnection } from '../webrtc'
@@ -176,10 +175,6 @@ class Relay {
         }
       }
       return
-    }
-
-    if (options?.signal?.aborted) {
-      throw new AbortError()
     }
 
     const conn = this.upgradeOutbound(relay, destination, handshakeResult.stream, options)


### PR DESCRIPTION
Some checks for `signal.aborted` are completely unnecessary and can cause issue with timeouts.