### PR TITLE
fix unintended aborts

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "@ethersproject/providers": "https://github.com/hoprnet/ethers-js-provider/archive/refs/tags/fixed-memory-leak.tar.gz",
     "@overnightjs/logger": "1.2.1",
     "colors": "1.4.0",
-    "eth-sig-util": "3.0.1"
+    "eth-sig-util": "3.0.1",
+    "libp2p": "https://github.com/hoprnet/js-libp2p/archive/refs/tags/v0.36.3.tar.gz"
   },
   "prettier": {
     "tabWidth": 2,

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@overnightjs/logger": "1.2.1",
     "colors": "1.4.0",
     "eth-sig-util": "3.0.1",
-    "libp2p": "https://github.com/hoprnet/js-libp2p/archive/refs/tags/v0.36.3.tar.gz"
+    "libp2p": "https://github.com/hoprnet/js-libp2p/archive/refs/tags/v0.36.4.tar.gz"
   },
   "prettier": {
     "tabWidth": 2,

--- a/yarn.lock
+++ b/yarn.lock
@@ -16666,9 +16666,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"libp2p@npm:0.36.2":
+"libp2p@https://github.com/hoprnet/js-libp2p/archive/refs/tags/v0.36.3.tar.gz":
   version: 0.36.2
-  resolution: "libp2p@npm:0.36.2"
+  resolution: "libp2p@https://github.com/hoprnet/js-libp2p/archive/refs/tags/v0.36.3.tar.gz"
   dependencies:
     "@vascosantos/moving-average": ^1.1.0
     abortable-iterator: ^3.0.0
@@ -16724,7 +16724,7 @@ __metadata:
     varint: ^6.0.0
     wherearewe: ^1.0.0
     xsalsa20: ^1.1.0
-  checksum: 66d9ed9f370cbfed65aab4c6085bba1fae220249f59f52bd3417b7b021b0efdd7cb8615cf57b5f760b11f44033854d1408bba025877bed771d40878bee45bf6b
+  checksum: 6ca574b491bf16a1b8ea50fe6cc744b71407498e86eb9cad91ff0751b834104bbc4f0d4ddfc94028c43c3f59f18e7b09c91b69211ba4ae3efa817a6070d82159
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -16666,9 +16666,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"libp2p@https://github.com/hoprnet/js-libp2p/archive/refs/tags/v0.36.3.tar.gz":
+"libp2p@https://github.com/hoprnet/js-libp2p/archive/refs/tags/v0.36.4.tar.gz":
   version: 0.36.2
-  resolution: "libp2p@https://github.com/hoprnet/js-libp2p/archive/refs/tags/v0.36.3.tar.gz"
+  resolution: "libp2p@https://github.com/hoprnet/js-libp2p/archive/refs/tags/v0.36.4.tar.gz"
   dependencies:
     "@vascosantos/moving-average": ^1.1.0
     abortable-iterator: ^3.0.0
@@ -16724,7 +16724,7 @@ __metadata:
     varint: ^6.0.0
     wherearewe: ^1.0.0
     xsalsa20: ^1.1.0
-  checksum: 6ca574b491bf16a1b8ea50fe6cc744b71407498e86eb9cad91ff0751b834104bbc4f0d4ddfc94028c43c3f59f18e7b09c91b69211ba4ae3efa817a6070d82159
+  checksum: eb12d23fe9920f51355ccf818c13692a5f2b6f823e5f4c5ac093f245dffd66af4a1749fb5b1a5bd9e1a8c246506140252d9e6ef6f425be3f4b189054ada1871d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes an error in libp2p which causes its `Dialer` to abort unrelated connection attempts

Relevant commit:

https://github.com/hoprnet/js-libp2p/commit/7d1badcb3d001629523b4ab39ce3f3e4adfa4639