### PR TITLE
Hotfix/tcp handler enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Automatically cleanup stale connections to correctly handle reconnects ([#3688](https://github.com/hoprnet/hoprnet/pull/3688))
 - Add `--provider` flag for setting a custom blockchain RPC provider
 - Use a default address sorter for all address classes ([#3731](https://github.com/hoprnet/hoprnet/pull/3731))
+- Enhance TCP socket listening logic and cleanup keepAlice interval ([#3750]https://github.com/hoprnet/hoprnet/pull/3750))
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint": "prettier --check .",
     "lint:fix": "prettier --write .",
     "test": "yarn workspaces foreach -pv run test",
-    "test:without:transport": "yarn workspaces foreach -pv --exclude @hoprnet/hopr-connect run test",
+    "test:connect": "yarn workspace @hoprnet/hopr-connect run test",
     "test:core": "yarn workspace @hoprnet/hopr-core run test",
     "test:connector": "yarn workspace @hoprnet/hopr-core-ethereum run test",
     "test:hoprd": "yarn workspace @hoprnet/hoprd run test",

--- a/packages/connect/src/base/listener.ts
+++ b/packages/connect/src/base/listener.ts
@@ -68,14 +68,16 @@ class Listener extends EventEmitter implements InterfaceListener {
   }
 
   /**
-   * @param dialDirectly
-   * @param upgradeInbound
+   * @param onClose called once listener is closed
+   * @param onListening called once listener is listening
+   * @param dialDirectly utility to establish a direct connection
+   * @param upgradeInbound forward inbound connections to libp2p
    * @param peerId own id
-   * @param options
-   * @param testingOptions
-   * @param filter
-   * @param relay
-   * @param libp2p
+   * @param options connection Options, e.g. AbortSignal
+   * @param testingOptions turn on / off modules for testing
+   * @param filter allow Listener to populate address filter
+   * @param relay allow Listener to populate list of utilized relays
+   * @param libp2p libp2p instance for various purposes
    */
   constructor(
     private onClose: () => void,

--- a/packages/connect/src/base/listener.ts
+++ b/packages/connect/src/base/listener.ts
@@ -78,8 +78,8 @@ class Listener extends EventEmitter implements InterfaceListener {
    * @param libp2p
    */
   constructor(
-    private onListening: () => void,
     private onClose: () => void,
+    private onListening: () => void,
     dialDirectly: HoprConnect['dialDirectly'],
     private upgradeInbound: Upgrader['upgradeInbound'],
     private peerId: PeerId,
@@ -355,6 +355,11 @@ class Listener extends EventEmitter implements InterfaceListener {
 
     this.attachSocketHandlers()
 
+    // Need to be called before _emitListening
+    // because _emitListening() sets an attribute in
+    // the relay object
+    this.onListening()
+
     this._emitListening()
 
     // Only add relay nodes if node is not directly reachable or running locally
@@ -368,7 +373,6 @@ class Listener extends EventEmitter implements InterfaceListener {
       this.entry.updatePublicNodes()
     }
 
-    this.onListening()
     this.state = State.LISTENING
   }
 

--- a/packages/connect/src/base/listener.ts
+++ b/packages/connect/src/base/listener.ts
@@ -78,6 +78,8 @@ class Listener extends EventEmitter implements InterfaceListener {
    * @param libp2p
    */
   constructor(
+    private onListening: () => void,
+    private onClose: () => void,
     dialDirectly: HoprConnect['dialDirectly'],
     private upgradeInbound: Upgrader['upgradeInbound'],
     private peerId: PeerId,
@@ -366,6 +368,7 @@ class Listener extends EventEmitter implements InterfaceListener {
       this.entry.updatePublicNodes()
     }
 
+    this.onListening()
     this.state = State.LISTENING
   }
 
@@ -388,6 +391,7 @@ class Listener extends EventEmitter implements InterfaceListener {
     ])
 
     this.state = State.CLOSED
+    this.onClose()
     this.emit('close')
   }
 

--- a/packages/connect/src/base/tcp.ts
+++ b/packages/connect/src/base/tcp.ts
@@ -145,8 +145,13 @@ class TCPConnection implements MultiaddrConnection {
 
       let rawSocket: Socket
 
-      const onError = (err: Error) => {
-        verbose(`Error connecting to ${ma.toString()}.`, err)
+      const onError = (err: any) => {
+        if (err.code === 'ABORT_ERR') {
+          verbose(`Abort to ${ma.toString()} after ${Date.now() - start} ms`, err)
+        } else {
+          verbose(`Error connecting to ${ma.toString()}.`, err)
+        }
+
         done(err)
       }
 

--- a/packages/connect/src/base/tcp.ts
+++ b/packages/connect/src/base/tcp.ts
@@ -1,4 +1,4 @@
-import net, { Socket, type AddressInfo } from 'net'
+import net, { type Socket, type AddressInfo } from 'net'
 import abortable from 'abortable-iterator'
 import Debug from 'debug'
 import { nodeToMultiaddr, toU8aStream } from '../utils'

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -180,7 +180,7 @@ class HoprConnect implements Transport<HoprConnectDialOptions, HoprConnectListen
    * Creates a TCP listener. The provided `handler` function will be called
    * anytime a new incoming Connection has been successfully upgraded via
    * `upgrader.upgradeInbound`.
-   * @param handler
+   * @param _handler
    * @returns A TCP listener
    */
   public createListener(_options: HoprConnectListeningOptions, _handler?: Function): Listener {

--- a/packages/connect/src/relay/index.spec.ts
+++ b/packages/connect/src/relay/index.spec.ts
@@ -134,6 +134,10 @@ describe('test relay', function () {
       await new Promise((resolve) => setTimeout(resolve))
     }
 
+    Alice.stop()
+    Bob.stop()
+    Charly.stop()
+
     network.removeAllListeners()
   })
 
@@ -164,6 +168,10 @@ describe('test relay', function () {
       // Let I/O happen
       await new Promise((resolve) => setTimeout(resolve))
     }
+
+    Alice.stop()
+    Bob.stop()
+    Charly.stop()
 
     network.removeAllListeners()
   })

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
     "clean": "rimraf ./lib ./tsconfig.tsbuildinfo ./tsconfig.spec.tsbuildinfo",
     "coverage": "nyc --reporter=html mocha",
     "build": "yarn clean && tsc -p .",
-    "test": "NODE_OPTIONS=\"--trace-warnings --unhandled-rejections=strict\" mocha --reporter=tap --full-trace",
+    "test": "mocha --reporter=tap --full-trace",
     "docs:generate": "typedoc",
     "docs:watch": "typedoc --watch"
   },

--- a/packages/core/src/index.spec.ts
+++ b/packages/core/src/index.spec.ts
@@ -9,7 +9,7 @@ const log = debug('hopr-core:test:index')
 
 const peerId = privKeyToPeerId('0x1c28c7f301658b4807a136e9fcf5798bc37e24b70f257fd3e6ee5adcf83a8c1f')
 
-describe('hopr core (instance)', async function () {
+describe.only('hopr core (instance)', async function () {
   it('should be able to start a hopr node instance without crashing', async function () {
     this.timeout(5000)
     log('Clean up data folder from previous attempts')

--- a/packages/core/src/index.spec.ts
+++ b/packages/core/src/index.spec.ts
@@ -9,7 +9,7 @@ const log = debug('hopr-core:test:index')
 
 const peerId = privKeyToPeerId('0x1c28c7f301658b4807a136e9fcf5798bc37e24b70f257fd3e6ee5adcf83a8c1f')
 
-describe.only('hopr core (instance)', async function () {
+describe('hopr core (instance)', async function () {
   it('should be able to start a hopr node instance without crashing', async function () {
     this.timeout(5000)
     log('Clean up data folder from previous attempts')


### PR DESCRIPTION
Changes:

- when establishing a TCP connection, make sure that `socket.destroy()` is only called once
- log time after which an abort to a connection attempt happened
- cleanups in unit tests
- clean `keepAlive` interval once listener gets closed