### PR TITLE
utility function to close connections

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -773,7 +773,7 @@ class Hopr extends EventEmitter {
    * Closes all open connections to a peer. Used to temporarily or permanently
    * disconnect from a peer.
    * Similar to `libp2p.hangUp` but catching all errors.
-   * @param peer PeerId of the peer to whom we want to disconnect
+   * @param peer PeerId of the peer from whom we want to disconnect
    */
   private async closeConnectionsTo(peer: PeerId): Promise<void> {
     const connections = this.libp2p.connectionManager.getAll(peer)

--- a/packages/core/src/network/heartbeat.ts
+++ b/packages/core/src/network/heartbeat.ts
@@ -42,7 +42,7 @@ export default class Heartbeat {
     private networkPeers: NetworkPeers,
     private subscribe: Subscribe,
     protected sendMessage: SendMessage,
-    private hangUp: (addr: PeerId) => Promise<void>,
+    private closeConnectionsTo: (peer: PeerId) => Promise<void>,
     environmentId: string,
     config?: Partial<HeartbeatConfig>
   ) {
@@ -117,11 +117,8 @@ export default class Heartbeat {
 
     if (pingResponse == null || pingResponse.length != 1 || !u8aEquals(expectedResponse, pingResponse[0])) {
       log(`Mismatched challenge. Got ${u8aToHex(pingResponse[0])} but expected ${u8aToHex(expectedResponse)}`)
-      try {
-        await this.hangUp(destination)
-      } catch (err) {
-        log(`Hang up connection to ${destination.toB58String()} failed: ${err?.message}`)
-      }
+
+      await this.closeConnectionsTo(destination)
 
       return {
         destination,


### PR DESCRIPTION
Adds a utility function that closes all (existing) open connections to a peer *and* catches errors that might occur when closing the connection(s).