### PR TITLE
Connection persistence improvements

### DIFF
--- a/packages/connect/src/base/entry.ts
+++ b/packages/connect/src/base/entry.ts
@@ -170,7 +170,7 @@ export class EntryNodes extends EventEmitter {
             const result = await this.connectToRelay(peer, usedRelay.relayDirectAddress, ENTRY_NODE_CONTACT_TIMEOUT)
             log(
               `Reconnect attempt ${attempt} to entry node ${peer.toB58String()} was ${
-                result.entry.latency >= 0 ? 'succesful' : 'not successful'
+                result.entry.latency >= 0 ? 'successful' : 'not successful'
               }`
             )
 
@@ -190,8 +190,8 @@ export class EntryNodes extends EventEmitter {
           if (err.message !== KNOWN_DISCONNECT_ERROR) {
             throw err
           } else {
-            // Remove relay because we certainly can't connect to it
-            this.onRemoveRelay(peer)
+            //this.onRemoveRelay(peer)
+            log(`connection to relay ${peer.toB58String()} failed permanently`)
           }
         })
 

--- a/packages/connect/src/base/entry.ts
+++ b/packages/connect/src/base/entry.ts
@@ -190,8 +190,9 @@ export class EntryNodes extends EventEmitter {
           if (err.message !== KNOWN_DISCONNECT_ERROR) {
             throw err
           } else {
+            // Keep the entry node on the list, to avoid losing information about ALL of them
             //this.onRemoveRelay(peer)
-            log(`connection to relay ${peer.toB58String()} failed permanently`)
+            error(`Re-connection to relay ${peer.toB58String()} failed.`)
           }
         })
 

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -262,6 +262,8 @@ class HoprConnect implements Transport<HoprConnectDialOptions, HoprConnectListen
       `Establishing a direct connection to ${maConn.remoteAddr.toString()} was successful. Continuing with the handshake.`
     )
 
+    maConn.conn.setKeepAlive(true, 1000)
+
     const conn = await this._upgradeOutbound(maConn)
 
     // Assign disconnect handler once we're sure that public keys match,

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -268,6 +268,7 @@ class HoprConnect implements Transport<HoprConnectDialOptions, HoprConnectListen
     // Assign various connection properties once we're sure that public keys match,
     // i.e. dialed node == desired destination
 
+    // Set the SO_KEEPALIVE flag on socket to tell kernel to be more aggressive on keeping the connection up
     maConn.conn.setKeepAlive(true, 1000)
 
     maConn.conn.on('end', function () {

--- a/packages/core/src/network/network-peers.ts
+++ b/packages/core/src/network/network-peers.ts
@@ -206,20 +206,21 @@ class NetworkPeers {
     // Sort a copy of peers in-place
     peers.sort((a, b) => this.qualityOf(b) - this.qualityOf(a))
 
-    const bestAvailabilityIndex = peers.reverse().findIndex((peer) => this.qualityOf(peer).toFixed(1) === '1.0')
-    const badAvailabilityIndex = peers.findIndex((peer) => this.qualityOf(peer) < NETWORK_QUALITY_THRESHOLD)
-
-    const bestAvailabilityNodes = bestAvailabilityIndex < 0 ? 0 : peers.length - bestAvailabilityIndex
-    const badAvailabilityNodes = badAvailabilityIndex < 0 ? 0 : peers.length - badAvailabilityIndex
-    const msgTotalNodes = `${peers.length} node${peers.length == 1 ? '' : 's'} in total`
-    const msgBestNodes = `${bestAvailabilityNodes} node${bestAvailabilityNodes == 1 ? '' : 's'} with quality 1.0`
-    const msgBadNodes = `${badAvailabilityNodes} node${badAvailabilityNodes == 1 ? '' : 's'} with quality below 0.5`
-
-    let out = `network peers status: ${msgTotalNodes}, ${msgBestNodes}, ${msgBadNodes}\n`
+    let bestAvailabilityNodes = 0
+    let badAvailabilityNodes = 0
+    let out = ''
 
     for (const peer of peers) {
       if (!this.has(peer)) {
         continue
+      }
+
+      const quality = this.qualityOf(peer)
+      if (quality.toFixed(1) === '1.0') {
+        bestAvailabilityNodes++
+      }
+      else if (quality < NETWORK_QUALITY_THRESHOLD) {
+        badAvailabilityNodes++
       }
 
       const entry = this.peers.get(peer.toB58String())
@@ -232,6 +233,11 @@ class NetworkPeers {
       out += `origin: ${entry.origin}`
       out += '\n'
     }
+
+    const msgTotalNodes = `${peers.length} node${peers.length == 1 ? '' : 's'} in total`
+    const msgBestNodes = `${bestAvailabilityNodes} node${bestAvailabilityNodes == 1 ? '' : 's'} with quality 1.0`
+    const msgBadNodes = `${badAvailabilityNodes} node${badAvailabilityNodes == 1 ? '' : 's'} with quality below 0.5`
+    out += `network peers status: ${msgTotalNodes}, ${msgBestNodes}, ${msgBadNodes}\n`
 
     return out
   }

--- a/packages/core/src/network/network-peers.ts
+++ b/packages/core/src/network/network-peers.ts
@@ -218,8 +218,7 @@ class NetworkPeers {
       const quality = this.qualityOf(peer)
       if (quality.toFixed(1) === '1.0') {
         bestAvailabilityNodes++
-      }
-      else if (quality < NETWORK_QUALITY_THRESHOLD) {
+      } else if (quality < NETWORK_QUALITY_THRESHOLD) {
         badAvailabilityNodes++
       }
 

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -48,6 +48,7 @@ process.on('unhandledRejection', (reason: any, _promise: Promise<any>) => {
 
     // Only silence very specific errors
     if (msgString.match(/write ECONNRESET/) || msgString.match(/The operation was aborted/)) {
+      console.error('Unhandled promise rejection silenced')
       return
     }
   }

--- a/packages/utils/src/libp2p/dialHelper.ts
+++ b/packages/utils/src/libp2p/dialHelper.ts
@@ -154,7 +154,7 @@ async function establishNewConnection(
     conn = await libp2p.dial(destination, { signal: opts.signal })
   } catch (err) {
     logError(
-      `Error while establising relayed connection using ${
+      `Error while establishing relayed connection using ${
         PeerId.isPeerId(destination) ? destination.toB58String() : destination.toString()
       }.`
     )


### PR DESCRIPTION
This PR improves connection persistence:
- set system keep-alive flag for all direct TCP connections
- better handling of socket events and errors
- do not remove entry nodes on the list for the time being
- fixed heartbeat message values in the period log printout

Fixes #3770