### PR TITLE
Use transport manager to directly dial peers

### DIFF
--- a/packages/utils/src/libp2p/dialHelper.spec.ts
+++ b/packages/utils/src/libp2p/dialHelper.spec.ts
@@ -57,14 +57,15 @@ async function getNode(id: PeerId, withDHT = false, maDestination?: Multiaddr): 
     }
   })
 
-  const dial = node.transportManager.dial.bind(node)
+  const dialOrig = node.transportManager.dial.bind(node.transportManager)
 
   node.transportManager.dial = async (peer: PeerId | Multiaddr, options: any) => {
-    if (PeerId.isPeerId(peer)) {
-      return dial(peer, options)
+
+    if (maDestination) {
+      return dialOrig(maDestination, options)
     }
 
-    return dial(maDestination, options)
+    return dialOrig(peer, options)
   }
 
   node.handle(TEST_PROTOCOL, async ({ stream }) => {

--- a/packages/utils/src/libp2p/dialHelper.spec.ts
+++ b/packages/utils/src/libp2p/dialHelper.spec.ts
@@ -76,6 +76,7 @@ async function getNode(id: PeerId, withDHT = false, maDestination?: Multiaddr): 
   return node
 }
 
+
 function getPeerStore() {
   const peerStore = new Map<PeerId, Set<Address>>()
 
@@ -209,7 +210,9 @@ describe('test dialHelper', function () {
         findProviders: () => (async function* () {})()
       },
       connectionManager: getConnectionManager(),
-      dial: () => Promise.resolve<Connection>(undefined),
+      transportManager: {
+        dial: () => Promise.resolve<Connection>(undefined)
+      },
       peerStore: getPeerStore()
     }
 
@@ -232,7 +235,9 @@ describe('test dialHelper', function () {
             throw Error(`boom`)
           })()
       },
-      dial: () => Promise.resolve<Connection>(undefined),
+      transportManager: {
+        dial: () => Promise.resolve<Connection>(undefined)
+      },
       connectionManager: getConnectionManager(),
       peerStore: getPeerStore()
     }

--- a/packages/utils/src/libp2p/dialHelper.spec.ts
+++ b/packages/utils/src/libp2p/dialHelper.spec.ts
@@ -60,7 +60,6 @@ async function getNode(id: PeerId, withDHT = false, maDestination?: Multiaddr): 
   const dialOrig = node.transportManager.dial.bind(node.transportManager)
 
   node.transportManager.dial = async (peer: PeerId | Multiaddr, options: any) => {
-
     if (maDestination) {
       return dialOrig(maDestination, options)
     }

--- a/packages/utils/src/libp2p/dialHelper.spec.ts
+++ b/packages/utils/src/libp2p/dialHelper.spec.ts
@@ -57,9 +57,9 @@ async function getNode(id: PeerId, withDHT = false, maDestination?: Multiaddr): 
     }
   })
 
-  const dial = node.dial.bind(node)
+  const dial = node.transportManager.dial.bind(node)
 
-  node.dial = async (peer: PeerId | Multiaddr, options: any) => {
+  node.transportManager.dial = async (peer: PeerId | Multiaddr, options: any) => {
     if (PeerId.isPeerId(peer)) {
       return dial(peer, options)
     }

--- a/packages/utils/src/libp2p/dialHelper.spec.ts
+++ b/packages/utils/src/libp2p/dialHelper.spec.ts
@@ -76,7 +76,6 @@ async function getNode(id: PeerId, withDHT = false, maDestination?: Multiaddr): 
   return node
 }
 
-
 function getPeerStore() {
   const peerStore = new Map<PeerId, Set<Address>>()
 

--- a/packages/utils/src/libp2p/dialHelper.ts
+++ b/packages/utils/src/libp2p/dialHelper.ts
@@ -159,6 +159,7 @@ async function establishNewConnection(
 
   let conn: Connection
   try {
+    // NOTE: This bypasses the dial filter in HOPR Connect
     conn = await libp2p.transportManager.dial(destination, { signal: opts.signal })
   } catch (err) {
     logError(
@@ -277,8 +278,9 @@ async function doDial(
   // Fetch known addresses for the given destination peer
   const knownAddressesForPeer = await libp2p.peerStore.addressBook.get(destination)
   log(`There are ${knownAddressesForPeer.length} already known addresses for ${destination.toB58String()}:`)
+
+  // Try using each known address to reach the destination
   for (const knownAddress of knownAddressesForPeer) {
-    // Let's try using the known addresses by connecting directly
     log(`Trying address ${knownAddress.multiaddr.toString()}`)
     struct = await establishNewConnection(libp2p, knownAddress.multiaddr, protocol, opts)
     if (struct) {

--- a/packages/utils/src/libp2p/dialHelper.ts
+++ b/packages/utils/src/libp2p/dialHelper.ts
@@ -65,8 +65,8 @@ type ReducedDHT = { contentRouting: Pick<LibP2P['contentRouting'], 'routers' | '
 type ReducedTransportManager = { transportManager: Pick<LibP2P['transportManager'], 'dial'> }
 type ReducedLibp2p = ReducedDHT &
   ReducedTransportManager & { peerStore: ReducedPeerStore } & {
-  connectionManager: ReducedConnectionManager
-}
+    connectionManager: ReducedConnectionManager
+  }
 
 async function printPeerStoreAddresses(msg: string, destination: PeerId, peerStore: ReducedPeerStore): Promise<void> {
   logError(msg)

--- a/packages/utils/src/libp2p/index.spec.ts
+++ b/packages/utils/src/libp2p/index.spec.ts
@@ -91,6 +91,7 @@ function getFakeLibp2p(
     | undefined
 ) {
   return {
+    transportManager: {
     dial(destination: PeerId, ..._opts: any[]): Promise<Connection> {
       return Promise.resolve<Connection>({
         newStream: (protocol: string) =>
@@ -120,6 +121,7 @@ function getFakeLibp2p(
           }),
         remotePeer: destination
       } as Connection)
+    }
     },
     peerStore: {
       addressBook: {


### PR DESCRIPTION
This PR ports changes by @robertkiel to the refactored `dialHelper` - see #3721 .

The improvement is aimed to optimize the dialing processes when reaching out to a different node.