### PR TITLE
Fix event listener leak on failed connection 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - Ping & DHT query timeout increased ([#3780](https://github.com/hoprnet/hoprnet/pull/3780))
 - Dial refactoring and optimization ([#3780](https://github.com/hoprnet/hoprnet/pull/3780))
 - onAbort unhandled promise rejection workaround fix ([#3780](https://github.com/hoprnet/hoprnet/pull/3780))
+- Fix event listener leak and increase maximum number of event listeners to 20 ([#3790](https://github.com/hoprnet/hoprnet/pull/3790))
 
 ---
 

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -304,6 +304,9 @@ async function main() {
   // the rejected promise can be detected.
   addUnhandledPromiseRejectionHandler()
 
+  // Increase the default maximum number of event listeners
+  require('events').EventEmitter.defaultMaxListeners = 20;
+
   let node: Hopr
   let logs = new LogStream(argv.forwardLogs)
   let adminServer: AdminServer = undefined

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -305,7 +305,7 @@ async function main() {
   addUnhandledPromiseRejectionHandler()
 
   // Increase the default maximum number of event listeners
-  require('events').EventEmitter.defaultMaxListeners = 20;
+  require('events').EventEmitter.defaultMaxListeners = 20
 
   let node: Hopr
   let logs = new LogStream(argv.forwardLogs)

--- a/packages/utils/src/libp2p/dialHelper.ts
+++ b/packages/utils/src/libp2p/dialHelper.ts
@@ -170,6 +170,8 @@ async function establishNewConnection(
   }
 
   if (!conn) {
+    // Do not forget to remove event listener, to prevent leakage
+    opts.signal?.removeEventListener('abort', onAbort)
     return
   }
 


### PR DESCRIPTION
This PR fixes the event listener leak and increases maximum number of listeners to 20.

Fixes #3065 and should improve OOM situations like one described in #3502 