### PR TITLE
Whitelist efficiency enhancements + bugfix

### DIFF
--- a/packages/core-ethereum/src/indexer/fixtures.ts
+++ b/packages/core-ethereum/src/indexer/fixtures.ts
@@ -230,7 +230,7 @@ export const PARTY_A_REGISTERED = {
   logIndex: 0,
   args: {
     account: PARTY_A.toAddress().toHex(),
-    HoprPeerId: PARTY_B.toPeerId().toB58String()
+    hoprPeerId: PARTY_B.toPeerId().toB58String()
   } as any
 } as RegistryEvent<'Registered'>
 

--- a/packages/core-ethereum/src/indexer/index.ts
+++ b/packages/core-ethereum/src/indexer/index.ts
@@ -786,6 +786,7 @@ class Indexer extends EventEmitter {
   ): Promise<void> {
     const account = Address.fromString(event.args.account)
     await this.db.setEligible(account, event.args.eligibility, lastSnapshot)
+    verbose(`network-registry: account ${account} is ${event.args.eligibility ? 'eligible' : 'not eligible'}`)
     // emit event only when eligibility changes on accounts with a HoprNode associated
     try {
       const hoprNode = await this.db.findHoprNodeUsingAccountInNetworkRegistry(account)
@@ -796,14 +797,15 @@ class Indexer extends EventEmitter {
   private async onRegistered(event: RegistryEvent<'Registered'>, lastSnapshot: Snapshot): Promise<void> {
     let hoprNode: PeerId
     try {
-      hoprNode = PeerId.createFromB58String(event.args.HoprPeerId)
+      hoprNode = PeerId.createFromB58String(event.args.hoprPeerId)
     } catch (error) {
-      log(`Invalid peer Id '${event.args.HoprPeerId}' given in event 'onRegistered'`)
+      log(`Invalid peer Id '${event.args.hoprPeerId}' given in event 'onRegistered'`)
       log(error)
       return
     }
     const account = Address.fromString(event.args.account)
     await this.db.addToNetworkRegistry(PublicKey.fromPeerId(hoprNode), account, lastSnapshot)
+    verbose(`network-registry: node ${event.args.hoprPeerId} is allowed to connect`)
   }
 
   private async onDeregistered(event: RegistryEvent<'DeregisteredByOwner'>, lastSnapshot: Snapshot): Promise<void> {

--- a/packages/ethereum/contracts/HoprNetworkRegistry.sol
+++ b/packages/ethereum/contracts/HoprNetworkRegistry.sol
@@ -177,8 +177,11 @@ contract HoprNetworkRegistry is Ownable {
       string memory hoprPeerId = accountToNodePeerId[account];
       delete accountToNodePeerId[account];
       delete nodePeerIdToAccount[hoprPeerId];
-      emit DeregisteredByOwner(account);
+      // Eligibility update should have a logindex strictly smaller
+      // than the deregister event to make sure it always gets processed
+      // before the deregister event
       emit EligibilityUpdated(account, false);
+      emit DeregisteredByOwner(account);
     }
   }
 

--- a/packages/ethereum/contracts/HoprNetworkRegistry.sol
+++ b/packages/ethereum/contracts/HoprNetworkRegistry.sol
@@ -129,8 +129,11 @@ contract HoprNetworkRegistry is Ownable {
       string memory hoprAddress = accountToNodeMultiaddr[account];
       delete accountToNodeMultiaddr[account];
       delete nodeMultiaddrToAccount[hoprAddress];
-      emit DeregisteredByOwner(account);
+      // Eligibility update should have a logindex strictly smaller
+      // than the deregister event to make sure it always gets processed
+      // before the deregister event
       emit EligibilityUpdated(account, false);
+      emit DeregisteredByOwner(account);
     }
   }
 

--- a/packages/ethereum/contracts/HoprNetworkRegistry.sol
+++ b/packages/ethereum/contracts/HoprNetworkRegistry.sol
@@ -29,9 +29,9 @@ contract HoprNetworkRegistry is Ownable {
 
   event EnabledNetworkRegistry(bool indexed isEnabled); // Global toggle of the network registry
   event RequirementUpdated(address indexed requirementImplementation); // Emit when the network registry proxy is updated
-  event Registered(address indexed account, string HoprPeerId); // Emit when an account register a node peer id for itself
+  event Registered(address indexed account, string hoprPeerId); // Emit when an account register a node peer id for itself
   event Deregistered(address indexed account); // Emit when an account deregister a node peer id for itself
-  event RegisteredByOwner(address indexed account, string HoprPeerId); // Emit when the contract owner register a node peer id for an account
+  event RegisteredByOwner(address indexed account, string hoprPeerId); // Emit when the contract owner register a node peer id for an account
   event DeregisteredByOwner(address indexed account); // Emit when the contract owner deregister a node peer id for an account
   event EligibilityUpdated(address indexed account, bool indexed eligibility); // Emit when the eligibility of an account is updated
 

--- a/packages/ethereum/hardhat.config.ts
+++ b/packages/ethereum/hardhat.config.ts
@@ -173,7 +173,7 @@ task<RegisterOpts>(
 )
   .addParam<RegisterOpts['task']>('task', 'The task to run', undefined, types.string)
   .addOptionalParam<string>('nativeAddresses', 'A list of native addresses', undefined, types.string)
-  .addOptionalParam<string>('multiaddresses', 'A list of multiaddresses', undefined, types.string)
+  .addOptionalParam<string>('peerIds', 'A list of peerIds', undefined, types.string)
 
 function getSortedFiles(dependenciesGraph) {
   const tsort = require('tsort')

--- a/packages/ethereum/tasks/register.ts
+++ b/packages/ethereum/tasks/register.ts
@@ -1,11 +1,12 @@
 import type { HardhatRuntimeEnvironment, RunSuperFunction } from 'hardhat/types'
 import { utils } from 'ethers'
+import type { HoprNetworkRegistry, HoprDummyProxyForNetworkRegistry } from '../src/types'
 
 export type RegisterOpts =
   | {
       task: 'add'
       nativeAddresses: string
-      multiaddresses: string
+      peerIds: string
     }
   | {
       task: 'disable'
@@ -49,19 +50,19 @@ async function main(
 
   const hoprDummyProxy = (await ethers.getContractFactory('HoprDummyProxyForNetworkRegistry'))
     .connect(signer)
-    .attach(hoprDummyProxyAddress)
+    .attach(hoprDummyProxyAddress) as HoprDummyProxyForNetworkRegistry
 
   const hoprNetworkRegistry = (await ethers.getContractFactory('HoprNetworkRegistry'))
     .connect(signer)
-    .attach(hoprNetworkRegistryAddress)
+    .attach(hoprNetworkRegistryAddress) as HoprNetworkRegistry
 
   try {
     if (opts.task === 'add') {
       const nativeAddresses = opts.nativeAddresses.split(',')
-      const multiaddresses = opts.multiaddresses.split(',')
+      const peerIds = opts.peerIds.split(',')
 
       // ensure lists match in length
-      if (nativeAddresses.length !== multiaddresses.length) {
+      if (nativeAddresses.length !== peerIds.length) {
         console.error('Given native and multiaddress lists do not match in length.')
         process.exit(1)
       }
@@ -73,7 +74,7 @@ async function main(
       }
 
       await (await hoprDummyProxy.ownerBatchAddAccounts(nativeAddresses)).wait()
-      await (await hoprNetworkRegistry.ownerRegister(nativeAddresses, multiaddresses)).wait()
+      await (await hoprNetworkRegistry.ownerRegister(nativeAddresses, peerIds)).wait()
     } else {
       await (await hoprNetworkRegistry.disableRegistry()).wait()
     }

--- a/packages/utils/src/db/db.spec.ts
+++ b/packages/utils/src/db/db.spec.ts
@@ -305,7 +305,7 @@ describe(`database tests`, function () {
     await db.removeFromNetworkRegistry(account, TestingSnapshot)
     assert.rejects(
       () => db.findHoprNodeUsingAccountInNetworkRegistry(account),
-      'should throw when HoprNode is not linke to an account'
+      'should throw when HoprNode is not linked to an account'
     )
     assert.rejects(() => db.getAccountFromNetworkRegistry(hoprNode), 'should throw when account is deregistered')
   })

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -394,24 +394,24 @@ native_addr5="$(get_native_address "${api_token}@${api5}")"
 native_addr7="$(get_native_address "${api_token}@${api7}")"
 native_addr8="$(get_native_address "${api_token}@${api8}")"
 
-declare multiaddr1 multiaddr2 multiaddr3 multiaddr4 multiaddr5 multiaddr7 multiaddr8
-multiaddr1="$(get_multiaddress "${api_token}@${api1}")"
-multiaddr2="$(get_multiaddress "${api_token}@${api2}")"
-multiaddr3="$(get_multiaddress "${api_token}@${api3}")"
-multiaddr4="$(get_multiaddress "${api_token}@${api4}")"
-multiaddr5="$(get_multiaddress "${api_token}@${api5}")"
+declare hopr_addr1 hopr_addr2 hopr_addr3 hopr_addr4 hopr_addr5 hopr_addr7 hopr_addr8
+hopr_addr1="$(get_hopr_address "${api_token}@${api1}")"
+hopr_addr2="$(get_hopr_address "${api_token}@${api2}")"
+hopr_addr3="$(get_hopr_address "${api_token}@${api3}")"
+hopr_addr4="$(get_hopr_address "${api_token}@${api4}")"
+hopr_addr5="$(get_hopr_address "${api_token}@${api5}")"
 # we don't need node6 because it's short-living
-multiaddr7="$(get_multiaddress "${api_token}@${api7}")"
-multiaddr8="$(get_multiaddress "${api_token}@${api8}")"
+hopr_addr7="$(get_hopr_address "${api_token}@${api7}")"
+hopr_addr8="$(get_hopr_address "${api_token}@${api8}")"
 
-log "hopr addr1: ${addr1} ${native_addr1} ${multiaddr1}"
-log "hopr addr2: ${addr2} ${native_addr2} ${multiaddr2}"
-log "hopr addr3: ${addr3} ${native_addr3} ${multiaddr3}"
-log "hopr addr4: ${addr4} ${native_addr4} ${multiaddr4}"
-log "hopr addr5: ${addr5} ${native_addr5} ${multiaddr5}"
+log "hopr addr1: ${addr1} ${native_addr1} ${hopr_addr1}"
+log "hopr addr2: ${addr2} ${native_addr2} ${hopr_addr2}"
+log "hopr addr3: ${addr3} ${native_addr3} ${hopr_addr3}"
+log "hopr addr4: ${addr4} ${native_addr4} ${hopr_addr4}"
+log "hopr addr5: ${addr5} ${native_addr5} ${hopr_addr5}"
 # we don't need node6 because it's short-living
-log "hopr addr7: ${addr7} ${native_addr7} ${multiaddr7}"
-log "hopr addr8: ${addr8} ${native_addr8} ${multiaddr8}"
+log "hopr addr7: ${addr7} ${native_addr7} ${hopr_addr7}"
+log "hopr addr8: ${addr8} ${native_addr8} ${hopr_addr8}"
 
 # add nodes 1,2,3,4,5,7 in register, do NOT add node 8
 log "Adding nodes to register"
@@ -421,7 +421,7 @@ yarn workspace @hoprnet/hopr-ethereum hardhat register \
   --network hardhat \
   --task add \
   --native-addresses "$native_addr1,$native_addr2,$native_addr3,$native_addr4,$native_addr5,$native_addr7" \
-  --multiaddresses "$multiaddr1,$multiaddr2,$multiaddr3,$multiaddr4,$multiaddr5,$multiaddr7"
+  --peer-ids "$hopr_addr1,$hopr_addr2,$hopr_addr3,$hopr_addr4,$hopr_addr5,$hopr_addr7"
 log "Nodes added to register"
 
 # running withdraw and checking it results at the end of this test run


### PR DESCRIPTION
# Main changes

- use compressed representation as keys for storing network registry entries, see below why
- add a mapping from eligible Ethereum accounts to public key (hopr address)

# Other changes

- Finish migration from allowing multiaddrs to PeerIds, as started by #3783

# Database storage

The Network Registry is used as follows:

## On new connections

Check if incoming connection identified by the `PeerId` of the counterparty is allowed to connect

Input; PeerId (from TLS-like library) -> compressed public key representation

## On new network registry entry

Once there is a new node that became eligible to connect, add it to the database

Input: PeerId (hopr address) from Multiaddr + Ethereum account -> compressed public key representation

## Get Ethereum account

Get the Ethereum account that fulfills the requirements to be allowed to establish a connection.

Input: PeerId (hopr address) from Multiaddr -> compressed public key representation

## Delete network registry entry

Ban a node from the network

Input: Ethereum account -> add mapping from Ethereum account to hopr address, hence reduce method complexity from O(n) to O(1)