### PR TITLE
Reduce eth_getBlockByNumber calls 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="1.90"></a>
+
+## 1.90
+
+### Changes
+
+- Reduce eth_getBlockByNumber calls when indexing and sending transactions ([#3814](https://github.com/hoprnet/hoprnet/pull/3814))
+
 <a name="1.89"></a>
 
 ## [1.89](https://github.com/hoprnet/hoprnet/compare/release/ouagadougou...hoprnet:master)

--- a/packages/core-ethereum/src/ethereum.mock.ts
+++ b/packages/core-ethereum/src/ethereum.mock.ts
@@ -3,7 +3,8 @@ import { ChainOptions } from '.'
 export const sampleChainOptions: ChainOptions = {
   chainId: 1337,
   environment: 'hardhat-localhost',
-  gasPrice: '1 gwei',
+  maxFeePerGas: '10 gwei',
+  maxPriorityFeePerGas: '1 gwei',
   network: 'hardhat',
   provider: 'http://localhost:8545'
 }

--- a/packages/core-ethereum/src/ethereum.ts
+++ b/packages/core-ethereum/src/ethereum.ts
@@ -39,7 +39,14 @@ export type SendTransactionReturn = {
 }
 
 export async function createChainWrapper(
-  networkInfo: { provider: string; chainId: number; maxFeePerGas: string; maxPriorityFeePerGas: string; network: string; environment: string },
+  networkInfo: {
+    provider: string
+    chainId: number
+    maxFeePerGas: string
+    maxPriorityFeePerGas: string
+    network: string
+    environment: string
+  },
   privateKey: Uint8Array,
   checkDuplicate: Boolean = true,
   timeout = TX_CONFIRMATION_WAIT
@@ -150,8 +157,12 @@ export async function createChainWrapper(
 
   const [defaultMaxFeePerGasValue, defaultMaxFeePerGasUnit] = networkInfo.maxFeePerGas.split(' ')
   const defaultMaxFeePerGas = ethers.utils.parseUnits(defaultMaxFeePerGasValue, defaultMaxFeePerGasUnit)
-  const [defaultMaxPriorityFeePerGasValue, defaultMaxPriorityFeePerGasUnit] = networkInfo.maxPriorityFeePerGas.split(' ')
-  const defaultMaxPriorityFeePerGas = ethers.utils.parseUnits(defaultMaxPriorityFeePerGasValue, defaultMaxPriorityFeePerGasUnit)
+  const [defaultMaxPriorityFeePerGasValue, defaultMaxPriorityFeePerGasUnit] =
+    networkInfo.maxPriorityFeePerGas.split(' ')
+  const defaultMaxPriorityFeePerGas = ethers.utils.parseUnits(
+    defaultMaxPriorityFeePerGasValue,
+    defaultMaxPriorityFeePerGasUnit
+  )
 
   /**
    * Update nonce-tracker and transaction-manager, broadcast the transaction on chain, and listen

--- a/packages/core-ethereum/src/ethereum.ts
+++ b/packages/core-ethereum/src/ethereum.ts
@@ -182,7 +182,7 @@ export async function createChainWrapper(
     const nonceLock = await nonceTracker.getNonceLock(address)
     const nonce = nonceLock.nextNonce
 
-    let feeData: providers.FeeData;
+    let feeData: providers.FeeData
 
     try {
       feeData = await provider.getFeeData()

--- a/packages/core-ethereum/src/ethereum.ts
+++ b/packages/core-ethereum/src/ethereum.ts
@@ -182,7 +182,19 @@ export async function createChainWrapper(
     const nonceLock = await nonceTracker.getNonceLock(address)
     const nonce = nonceLock.nextNonce
 
-    const feeData = await provider.getFeeData()
+    let feeData: providers.FeeData;
+
+    try {
+      feeData = await provider.getFeeData()
+    } catch (error) {
+      log('Transaction with nonce %d failed to getFeeData', nonce, error)
+      // TODO: find an API for fee data per environment
+      feeData = {
+        maxFeePerGas: ethers.utils.parseUnits('5', 'gwei'),
+        maxPriorityFeePerGas: ethers.utils.parseUnits('2', 'gwei'),
+        gasPrice: null
+      }
+    }
 
     log('Sending transaction %o', {
       gasLimit,

--- a/packages/core-ethereum/src/ethereum.ts
+++ b/packages/core-ethereum/src/ethereum.ts
@@ -39,7 +39,7 @@ export type SendTransactionReturn = {
 }
 
 export async function createChainWrapper(
-  networkInfo: { provider: string; chainId: number; gasPrice?: string; network: string; environment: string },
+  networkInfo: { provider: string; chainId: number; maxFeePerGas: string; maxPriorityFeePerGas: string; network: string; environment: string },
   privateKey: Uint8Array,
   checkDuplicate: Boolean = true,
   timeout = TX_CONFIRMATION_WAIT
@@ -148,23 +148,10 @@ export async function createChainWrapper(
     durations.minutes(15)
   )
 
-  // comment out legacy tx 0 in favor of EIP-1559
-  // let gasPrice: number | BigNumber
-  // if (networkInfo.gasPrice) {
-  //   const [gasPriceValue, gasPriceUnit] = networkInfo.gasPrice.split(' ')
-  //   gasPrice = ethers.utils.parseUnits(gasPriceValue, gasPriceUnit)
-  // } else {
-  //   gasPrice = await provider.getGasPrice()
-  // }
-
-  let defaultMaxFeePerGas: BigNumber
-  if (networkInfo.network == 'xdai') {
-    defaultMaxFeePerGas = ethers.utils.parseUnits('10', 'gwei')
-  } else if (networkInfo.network == 'goerli') {
-    defaultMaxFeePerGas = ethers.utils.parseUnits('10', 'gwei')
-  } else {
-    defaultMaxFeePerGas = ethers.utils.parseUnits('500', 'gwei')
-  }
+  const [defaultMaxFeePerGasValue, defaultMaxFeePerGasUnit] = networkInfo.maxFeePerGas.split(' ')
+  const defaultMaxFeePerGas = ethers.utils.parseUnits(defaultMaxFeePerGasValue, defaultMaxFeePerGasUnit)
+  const [defaultMaxPriorityFeePerGasValue, defaultMaxPriorityFeePerGasUnit] = networkInfo.maxPriorityFeePerGas.split(' ')
+  const defaultMaxPriorityFeePerGas = ethers.utils.parseUnits(defaultMaxPriorityFeePerGasValue, defaultMaxPriorityFeePerGasUnit)
 
   /**
    * Update nonce-tracker and transaction-manager, broadcast the transaction on chain, and listen
@@ -201,7 +188,7 @@ export async function createChainWrapper(
       // TODO: find an API for fee data per environment
       feeData = {
         maxFeePerGas: defaultMaxFeePerGas,
-        maxPriorityFeePerGas: ethers.utils.parseUnits('2', 'gwei'),
+        maxPriorityFeePerGas: defaultMaxPriorityFeePerGas,
         gasPrice: null
       }
     }

--- a/packages/core-ethereum/src/ethereum.ts
+++ b/packages/core-ethereum/src/ethereum.ts
@@ -157,7 +157,7 @@ export async function createChainWrapper(
   //   gasPrice = await provider.getGasPrice()
   // }
 
-  let defaultMaxFeePerGas:BigNumber;
+  let defaultMaxFeePerGas: BigNumber
   if (networkInfo.network == 'xdai') {
     defaultMaxFeePerGas = ethers.utils.parseUnits('10', 'gwei')
   } else if (networkInfo.network == 'goerli') {
@@ -200,7 +200,7 @@ export async function createChainWrapper(
       log('Transaction with nonce %d failed to getFeeData', nonce, error)
       // TODO: find an API for fee data per environment
       feeData = {
-        maxFeePerGas: defaultMaxFeePerGas, 
+        maxFeePerGas: defaultMaxFeePerGas,
         maxPriorityFeePerGas: ethers.utils.parseUnits('2', 'gwei'),
         gasPrice: null
       }
@@ -240,7 +240,10 @@ export async function createChainWrapper(
     log('essentialTxPayload %o', essentialTxPayload)
 
     if (checkDuplicate) {
-      const [isDuplicate, hash] = transactions.existInMinedOrPendingWithHigherFee(essentialTxPayload, feeData.maxPriorityFeePerGas)
+      const [isDuplicate, hash] = transactions.existInMinedOrPendingWithHigherFee(
+        essentialTxPayload,
+        feeData.maxPriorityFeePerGas
+      )
       // check duplicated pending/mined transaction against transaction manager
       // if transaction manager has a transaction with the same payload that is mined or is pending but with
       // a higher or equal nonce, halt.

--- a/packages/core-ethereum/src/index.ts
+++ b/packages/core-ethereum/src/index.ts
@@ -46,7 +46,8 @@ export type ChainOptions = {
   provider: string
   maxConfirmations?: number
   chainId: number
-  gasPrice?: string
+  maxFeePerGas: string
+  maxPriorityFeePerGas: string
   network: string
   environment: string
 }

--- a/packages/core-ethereum/src/indexer/index.mock.ts
+++ b/packages/core-ethereum/src/indexer/index.mock.ts
@@ -267,7 +267,8 @@ const createChainMock = (
     getPublicKey: () => fixtures.PARTY_A,
     setCommitment: (counterparty: Address, commitment: Hash) =>
       hoprChannels.bumpChannel(counterparty.toHex(), commitment.toHex()),
-    getAllQueuingTransactionRequests: () => [txRequest]
+    getAllQueuingTransactionRequests: () => [txRequest],
+    getAllUnconfirmedHash: () => [fixtures.OPENED_EVENT.transactionHash]
   } as unknown as ChainWrapper
 }
 

--- a/packages/core-ethereum/src/indexer/index.mock.ts
+++ b/packages/core-ethereum/src/indexer/index.mock.ts
@@ -30,7 +30,8 @@ const txRequest = {
   data: '0x0',
   value: 0,
   nonce: 0,
-  gasPrice: 1
+  maxPriorityFeePerGas: utils.parseUnits('1', 'gwei'),
+  maxFeePerGas: utils.parseUnits('1', 'gwei')
 }
 
 const createProviderMock = (ops: { latestBlockNumber?: number } = {}) => {

--- a/packages/core-ethereum/src/nonce-tracker.spec.ts
+++ b/packages/core-ethereum/src/nonce-tracker.spec.ts
@@ -1,9 +1,10 @@
 import { expect } from 'chai'
 import NonceTracker, { Transaction } from './nonce-tracker'
 import { durations, Address } from '@hoprnet/hopr-utils'
+import { BigNumber } from 'ethers'
 
 const USER_ADDRESS = Address.fromString('0x7d3517b0d011698406d6e0aed8453f0be2697926')
-const GAS_PRICE = 100
+const MAZ_PRIORITY_FEE = BigNumber.from('100')
 
 describe('nonce-tracker', function () {
   let nonceTracker: NonceTracker
@@ -277,7 +278,7 @@ describe('nonce-tracker', function () {
 
 const genTx = (opts: { nonce: number; createdAt?: number }): Transaction => {
   const { createdAt = new Date().getTime() } = opts
-  return { ...opts, from: USER_ADDRESS.toHex(), createdAt, gasPrice: GAS_PRICE }
+  return { ...opts, from: USER_ADDRESS.toHex(), createdAt, maxPrority: MAZ_PRIORITY_FEE }
 }
 
 const genMultiTx = (opts: {

--- a/packages/core-ethereum/src/nonce-tracker.spec.ts
+++ b/packages/core-ethereum/src/nonce-tracker.spec.ts
@@ -4,7 +4,7 @@ import { durations, Address } from '@hoprnet/hopr-utils'
 import { BigNumber } from 'ethers'
 
 const USER_ADDRESS = Address.fromString('0x7d3517b0d011698406d6e0aed8453f0be2697926')
-const MAZ_PRIORITY_FEE = BigNumber.from('100')
+const MAX_PRIORITY_FEE = BigNumber.from('100')
 
 describe('nonce-tracker', function () {
   let nonceTracker: NonceTracker
@@ -278,7 +278,7 @@ describe('nonce-tracker', function () {
 
 const genTx = (opts: { nonce: number; createdAt?: number }): Transaction => {
   const { createdAt = new Date().getTime() } = opts
-  return { ...opts, from: USER_ADDRESS.toHex(), createdAt, maxPrority: MAZ_PRIORITY_FEE }
+  return { ...opts, from: USER_ADDRESS.toHex(), createdAt, maxPrority: MAX_PRIORITY_FEE }
 }
 
 const genMultiTx = (opts: {

--- a/packages/core-ethereum/src/transaction-manager.spec.ts
+++ b/packages/core-ethereum/src/transaction-manager.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from 'chai'
 import { BigNumber } from 'ethers'
-import TransactionManager, { TransactionPayload } from './transaction-manager'
+import TransactionManager, { Transaction, TransactionPayload } from './transaction-manager'
 
-const TX: [string, { nonce: number; gasPrice: number }] = ['0', { nonce: 0, gasPrice: 100 }]
+const TX: [string, Omit<Transaction, 'createdAt'>] = ['0', { nonce: 0, maxPrority: BigNumber.from('2000000000') }]
 const PAYLOAD: TransactionPayload = { to: '0x0', data: '0x123', value: BigNumber.from('1') }
 
 describe('transaction-manager', function () {
@@ -94,7 +94,7 @@ describe('transaction-manager', function () {
 
     // generate mock txs
     for (let i = 0; i < 7; i++) {
-      txs.push([String(i), { nonce: i, gasPrice: 1 }])
+      txs.push([String(i), { nonce: i, maxPrority: BigNumber.from('1') }])
     }
 
     // add them to confirmed
@@ -124,7 +124,7 @@ describe('transaction-manager', function () {
       data: PAYLOAD.data,
       value: PAYLOAD.value,
       nonce: TX[1].nonce,
-      gasPrice: TX[1].gasPrice
+      maxPrority: TX[1].maxPrority
     })
   })
 })

--- a/packages/core-ethereum/src/transaction-manager.ts
+++ b/packages/core-ethereum/src/transaction-manager.ts
@@ -12,7 +12,7 @@ export type TransactionPayload = {
 export type Transaction = {
   nonce: number
   createdAt: number
-  gasPrice: number | BigNumber
+  maxPrority: BigNumber
 }
 
 /**
@@ -57,13 +57,13 @@ class TranscationManager {
     const queuingTxHash = Array.from(this.queuing.keys())
     return queuingTxHash.map((txHash) => {
       const { to, data, value } = this.payloads.get(txHash)
-      const { nonce, gasPrice } = this.queuing.get(txHash)
+      const { nonce, maxPrority } = this.queuing.get(txHash)
       return {
         to,
         data,
         value,
         nonce,
-        gasPrice
+        maxPrority
       }
     })
   }
@@ -87,12 +87,12 @@ class TranscationManager {
   /**
    * If a transaction payload exists in mined or pending with a higher/equal gas price
    * @param payload object
-   * @param gasPrice gas price associated with the payload
+   * @param maxPrority Max Priority Fee. Tips paying to the miners, which correlates to the likelyhood of getting transactions included.
    * @returns [true if it exists, transaction hash]
    */
   public existInMinedOrPendingWithHigherFee(
     payload: TransactionPayload,
-    gasPrice: number | BigNumber
+    maxPrority: BigNumber
   ): [boolean, string] {
     // Using isDeepStrictEqual to compare TransactionPayload objects, see
     // https://nodejs.org/api/util.html#util_util_isdeepstrictequal_val1_val2
@@ -104,7 +104,7 @@ class TranscationManager {
     const hash = Array.from(this.payloads.keys())[index]
     if (
       !this.mined.get(hash) &&
-      BigNumber.from((this.pending.get(hash) ?? this.queuing.get(hash)).gasPrice).lt(BigNumber.from(gasPrice))
+      BigNumber.from((this.pending.get(hash) ?? this.queuing.get(hash)).maxPrority).lt(maxPrority)
     ) {
       return [false, hash]
     }
@@ -125,7 +125,7 @@ class TranscationManager {
 
     log('Adding queuing transaction %s %i', hash, transaction.nonce)
     this.payloads.set(hash, transactionPayload)
-    this.queuing.set(hash, { nonce: transaction.nonce, createdAt: 0, gasPrice: transaction.gasPrice })
+    this.queuing.set(hash, { nonce: transaction.nonce, createdAt: 0, maxPrority: transaction.maxPrority })
   }
 
   /**

--- a/packages/core-ethereum/src/transaction-manager.ts
+++ b/packages/core-ethereum/src/transaction-manager.ts
@@ -90,10 +90,7 @@ class TranscationManager {
    * @param maxPrority Max Priority Fee. Tips paying to the miners, which correlates to the likelyhood of getting transactions included.
    * @returns [true if it exists, transaction hash]
    */
-  public existInMinedOrPendingWithHigherFee(
-    payload: TransactionPayload,
-    maxPrority: BigNumber
-  ): [boolean, string] {
+  public existInMinedOrPendingWithHigherFee(payload: TransactionPayload, maxPrority: BigNumber): [boolean, string] {
     // Using isDeepStrictEqual to compare TransactionPayload objects, see
     // https://nodejs.org/api/util.html#util_util_isdeepstrictequal_val1_val2
     const index = Array.from(this.payloads.values()).findIndex((pl) => isDeepStrictEqual(pl, payload))

--- a/packages/core/protocol-config-schema.json
+++ b/packages/core/protocol-config-schema.json
@@ -64,12 +64,13 @@
             "chain_id": {
               "type": "integer"
             },
-            "gas_price": {
+            "max_fee_per_gas": {
               "type": "string",
-              "description": "Gas price as either 'auto', a number '11' or a value which should be converted like '1 gwei'."
+              "description": "Max fee per gas as either a number '11' or a value which should be converted like '1 gwei'."
             },
-            "gas_multiplier": {
-              "type": "number"
+            "max_priority_fee_per_gas": {
+              "type": "string",
+              "description": "Max priority fee per gas as either a number '11' or a value which should be converted like '1 gwei'."
             },
             "default_provider": {
               "type": "string"
@@ -85,7 +86,8 @@
             "chain_id",
             "default_provider",
             "description",
-            "gas_multiplier",
+            "max_fee_per_gas",
+            "max_priority_fee_per_gas",
             "hopr_token_name",
             "native_token_name"
           ],

--- a/packages/core/protocol-config.json
+++ b/packages/core/protocol-config.json
@@ -101,8 +101,8 @@
       "description": "Hardhat is an Ethereum development environment",
       "chain_id": 1,
       "live": false,
-      "gas_price": "1 gwei",
-      "gas_multiplier": 1.1,
+      "max_fee_per_gas": "1 gwei",
+      "max_priority_fee_per_gas": "2 gwei",
       "default_provider": "http://127.0.0.1:8545/",
       "native_token_name": "ETH",
       "hopr_token_name": "wxHOPR"
@@ -111,8 +111,8 @@
       "description": "The xDai chain is a stable payments EVM (Ethereum Virtual Machine) blockchain designed for fast and inexpensive transactions",
       "chain_id": 100,
       "live": true,
-      "gas_price": "2 gwei",
-      "gas_multiplier": 1.1,
+      "max_fee_per_gas": "10 gwei",
+      "max_priority_fee_per_gas": "2 gwei",
       "default_provider": "https://provider-proxy.hoprnet.workers.dev/xdai_mainnet",
       "native_token_name": "xDAI",
       "hopr_token_name": "wxHOPR"
@@ -121,8 +121,8 @@
       "description": "Görli Testnet is the first proof-of-authority cross-client testnet, synching Parity Ethereum, Geth, Nethermind, Hyperledger Besu (formerly Pantheon), and EthereumJS",
       "chain_id": 5,
       "live": true,
-      "gas_price": "1 gwei",
-      "gas_multiplier": 1.3,
+      "max_fee_per_gas": "10 gwei",
+      "max_priority_fee_per_gas": "2 gwei",
       "default_provider": "https://provider-proxy.hoprnet.workers.dev/eth_goerli",
       "native_token_name": "gETH",
       "hopr_token_name": "wxHOPR"

--- a/packages/core/src/environment.ts
+++ b/packages/core/src/environment.ts
@@ -4,8 +4,8 @@ export type NetworkOptions = {
   chain_id: number // >= 0
   live: boolean
   default_provider: string // a valid HTTP url pointing at a RPC endpoint
-  gas_price?: string // e.g. '1 gwei'
-  gas_multiplier: number // e.g. 1.1
+  max_fee_per_gas: string // The absolute maximum you are willing to pay per unit of gas to get your transaction included in a block, e.g. '10 gwei'
+  max_priority_fee_per_gas: string // Tips paid directly to miners, e.g. '2 gwei'
   native_token_name: string
   hopr_token_name: string
   tags: string[]

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -206,7 +206,8 @@ export async function createHoprNode(
     {
       chainId: options.environment.network.chain_id,
       environment: options.environment.id,
-      gasPrice: options.environment.network.gas_price,
+      maxFeePerGas: options.environment.network.max_fee_per_gas,
+      maxPriorityFeePerGas: options.environment.network.max_priority_fee_per_gas,
       network: options.environment.network.id,
       provider: options.environment.network.default_provider
     },

--- a/packages/ethereum/hardhat.config.ts
+++ b/packages/ethereum/hardhat.config.ts
@@ -18,7 +18,6 @@ import 'hardhat-gas-reporter'
 import '@nomiclabs/hardhat-etherscan'
 import 'solidity-coverage'
 import '@typechain/hardhat'
-import { utils } from 'ethers'
 import faucet, { type FaucetCLIOPts } from './tasks/faucet'
 import register, { type RegisterOpts } from './tasks/register'
 import getAccounts from './tasks/getAccounts'
@@ -45,20 +44,10 @@ extendEnvironment((hre: HardhatRuntimeEnvironment) => {
 function networkToHardhatNetwork(name: String, input: ResolvedEnvironment['network']): NetworkUserConfig {
   let cfg: NetworkUserConfig = {
     chainId: input.chain_id,
-    gasMultiplier: input.gas_multiplier,
     live: input.live,
     tags: input.tags,
     // used by hardhat-deploy
     saveDeployments: true
-  }
-
-  if (input.gas_price) {
-    const parsedGasPrice = input.gas_price.split(' ')
-    if (parsedGasPrice.length > 1) {
-      cfg.gasPrice = Number(utils.parseUnits(parsedGasPrice[0], parsedGasPrice[1]))
-    } else {
-      cfg.gasPrice = Number(parsedGasPrice[0])
-    }
   }
 
   if (name !== 'hardhat') {

--- a/scripts/fund-address.ts
+++ b/scripts/fund-address.ts
@@ -146,7 +146,8 @@ async function main() {
   const chainOptions = {
     chainId: environment.network.chain_id,
     environment: environment.id,
-    gasPrice: environment.network.gas_price,
+    maxFeePerGas: environment.network.max_fee_per_gas,
+    maxPriorityFeePerGas: environment.network.max_priority_fee_per_gas,
     network: environment.network.id,
     provider: expandVars(environment.network.default_provider, process.env)
   }


### PR DESCRIPTION
A preliminary solution for https://github.com/hoprnet/hoprnet/issues/3745 and https://github.com/hoprnet/hoprnet/issues/3799.
In both tickets, provider starts to return `503` and `524` status code (where both relate to server overload) in response to `eth_getBlockByNumber` method. This method, as mentioned [in the comment](https://github.com/hoprnet/hoprnet/issues/3745#issuecomment-1127733733), are used by multiple functions in `ethers.js`. In our codebase, there are two places where `eth_getBlockByNumber` are primarily used:
1. `fetchNativeTxs` (that removes the transaction listener when the indexer process it as confirmed)
2. `feeData()` in `sendTransaction` (to get `maxFeePerGas` and `maxPriorityFeePerGas` according to EIP1559)

Changes in this PR includes:
1. Add condition in `fetchNativeTxs`. Only furthur request block data when `transaction-manager` has unconfirmed transactions in memory (pending or mined). With that, indexer won't try to request block details for every new block.
2. `try... catch...` the `getFeeData()` and provide sets of fallback fees per network:
     - default max fee per gas: `10 gwei` in xdai and goerli; `500 gwei` for other networks (mainly for mainnet)  
     - default max priority fee per gas: `2 gwei`
3. Make `transaction-manager` track `priorityFee` the instead of `gasPrice`. This field is relevant in checking duplicate transactions. Transactions with the same payload but a higher `priorityFee` can now be overridden.