### PR TITLE
Network Connectivity Indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Improvements in our API v2 unit tests ([#3643](https://github.com/hoprnet/hoprnet/pull/3643))
 - Improvements in our integration E2E tests ([#3643](https://github.com/hoprnet/hoprnet/pull/3643))
 - API v2 `/api/v2/node/peers` now returns `multiaddr` for connected peers ([#3643](https://github.com/hoprnet/hoprnet/pull/3643))
+- Add connectivity health indicator updates to the logs ([#3816](https://github.com/hoprnet/hoprnet/pull/3816))
 
 ---
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -473,6 +473,13 @@ class Hopr extends EventEmitter {
 
         await this.libp2p.peerStore.addressBook.add(peer.id, dialables)
       }
+
+      // Mark the corresponding entry as public & recalculate network health indicator
+      if (this.networkPeers.has(peer.id)) {
+        this.networkPeers.setPublicOnEntry(peer.id, true)
+        this.heartbeat.recalculateNetworkHealth()
+      }
+
     } catch (err) {
       log(`Failed to update peer-store with new peer ${peer.id.toB58String()} info`, err)
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -303,6 +303,7 @@ class Hopr extends EventEmitter {
       sendMessage,
       this.closeConnectionsTo.bind(this),
       accessControl.reviewConnection.bind(accessControl),
+      this,
       this.environment.id,
       this.options
     )

--- a/packages/core/src/network/heartbeat.spec.ts
+++ b/packages/core/src/network/heartbeat.spec.ts
@@ -118,6 +118,7 @@ async function getPeer(
     }) as any,
     () => Promise.resolve(true),
     netStatEvents,
+    (_) => true,
     TESTING_ENVIRONMENT,
     {
       ...SHORT_TIMEOUTS,
@@ -144,6 +145,7 @@ describe('unit test heartbeat', async () => {
       }) as any,
       () => Promise.resolve(true),
       new EventEmitter(),
+      (_) => true,
       TESTING_ENVIRONMENT,
       SHORT_TIMEOUTS
     )

--- a/packages/core/src/network/heartbeat.spec.ts
+++ b/packages/core/src/network/heartbeat.spec.ts
@@ -214,10 +214,9 @@ describe('unit test heartbeat', async () => {
     network.unsubscribe(Charly)
     peerC.heartbeat.stop()
 
-    for (let i = 0; i < 10;i++) {
-      await peerA.heartbeat.checkNodes()
-    }
+    await Promise.all(Array.from({length: 6}, (_) => peerA.heartbeat.checkNodes()))
 
+    assert.equal(peerA.heartbeat.recalculateNetworkHealth(), NetworkHealthIndicator.YELLOW)
     assert.equal(netHealthA.state, NetworkHealthIndicator.YELLOW)
 
     ;[peerA, peerB].map((peer) => peer.heartbeat.stop())

--- a/packages/core/src/network/heartbeat.spec.ts
+++ b/packages/core/src/network/heartbeat.spec.ts
@@ -212,7 +212,7 @@ describe('unit test heartbeat', async () => {
     network.unsubscribe(Charly)
     peerC.heartbeat.stop()
 
-    await Promise.all(Array.from({length: 6}, (_) => peerA.heartbeat.checkNodes()))
+    await Promise.all(Array.from({ length: 6 }, (_) => peerA.heartbeat.checkNodes()))
 
     assert.equal(peerA.heartbeat.recalculateNetworkHealth(), NetworkHealthIndicator.YELLOW)
     assert.equal(netHealthA.state, NetworkHealthIndicator.YELLOW)

--- a/packages/core/src/network/heartbeat.ts
+++ b/packages/core/src/network/heartbeat.ts
@@ -173,10 +173,10 @@ export default class Heartbeat {
    */
   public recalculateNetworkHealth(): NetworkHealthIndicator {
     let newHealthValue = NetworkHealthIndicator.RED
-    let lowQualityPublic = 0,
-      lowQualityNonPublic = 0
-    let highQualityPublic = 0,
-      highQualityNonPublic = 0
+    let lowQualityPublic = 0
+    let lowQualityNonPublic = 0
+    let highQualityPublic = 0
+    let highQualityNonPublic = 0
 
     // Count quality of public/non-public nodes
     for (let entry of this.networkPeers.allEntries()) {

--- a/packages/core/src/network/heartbeat.ts
+++ b/packages/core/src/network/heartbeat.ts
@@ -45,7 +45,9 @@ export default class Heartbeat {
 
   private _pingNode: Heartbeat['pingNode'] | undefined
 
+  // Initial network health is always RED
   private currentHealth: NetworkHealthIndicator = NetworkHealthIndicator.RED
+
   private config: HeartbeatConfig
 
   constructor(

--- a/packages/core/src/network/heartbeat.ts
+++ b/packages/core/src/network/heartbeat.ts
@@ -32,6 +32,10 @@ export type HeartbeatConfig = {
   heartbeatThreshold: number
 }
 
+/**
+ * Indicator of the current state of the P2P network
+ * based on the different node types we can ping.
+ */
 export enum NetworkHealthIndicator {
   UNKNOWN = 'Unknown',
   RED = 'Red', // No connection, default
@@ -156,7 +160,12 @@ export default class Heartbeat {
     }
   }
 
-  public recalculateNetworkHealth() {
+  /**
+   * Recalculates the network health indicator based on the
+   * current network state knowledge.
+   * @returns Value of the current network health indicator (possibly updated).
+   */
+  public recalculateNetworkHealth(): NetworkHealthIndicator {
     let newHealthValue = NetworkHealthIndicator.RED
     let lowQualityPublic = 0,
       lowQualityNonPublic = 0
@@ -188,6 +197,8 @@ export default class Heartbeat {
       this.currentHealth = newHealthValue
       this.stateChangeEmitter.emit('hopr:network-health-changed', oldValue, this.currentHealth)
     }
+
+    return this.currentHealth
   }
 
   /**

--- a/packages/core/src/network/heartbeat.ts
+++ b/packages/core/src/network/heartbeat.ts
@@ -104,6 +104,7 @@ export default class Heartbeat {
       this.networkPeers.register(remotePeer, 'incoming heartbeat')
     }
 
+    // Recalculate network health when incoming heartbeat has been received
     this.recalculateNetworkHealth()
 
     log(`received heartbeat from ${remotePeer.toB58String()}`)
@@ -246,7 +247,9 @@ export default class Heartbeat {
       }
     }
 
+    // Recalculate the network health indicator state after checking nodes
     this.recalculateNetworkHealth()
+
     log(`finished checking nodes since ${thresholdTime} ${this.networkPeers.length()} nodes`)
     log(this.networkPeers.debugLog())
   }

--- a/packages/core/src/network/heartbeat.ts
+++ b/packages/core/src/network/heartbeat.ts
@@ -4,7 +4,12 @@ import type NetworkPeers from './network-peers'
 import type AccessControl from './access-control'
 import type PeerId from 'peer-id'
 import { randomInteger, u8aEquals, debug, retimer, nAtATime, u8aToHex } from '@hoprnet/hopr-utils'
-import { HEARTBEAT_INTERVAL, HEARTBEAT_TIMEOUT, HEARTBEAT_INTERVAL_VARIANCE } from '../constants'
+import {
+  HEARTBEAT_INTERVAL,
+  HEARTBEAT_TIMEOUT,
+  HEARTBEAT_INTERVAL_VARIANCE,
+  NETWORK_QUALITY_THRESHOLD
+} from '../constants'
 import { createHash, randomBytes } from 'crypto'
 
 import type { Subscribe, SendMessage } from '../index'
@@ -177,9 +182,9 @@ export default class Heartbeat {
     for (let entry of this.networkPeers.allEntries()) {
       let quality = this.networkPeers.qualityOf(entry.id)
       if (this.publicNodeLookup(entry.id)) {
-        quality > 0.5 ? ++highQualityPublic : ++lowQualityPublic
+        quality > NETWORK_QUALITY_THRESHOLD ? ++highQualityPublic : ++lowQualityPublic
       } else {
-        quality > 0.5 ? ++highQualityNonPublic : ++lowQualityNonPublic
+        quality > NETWORK_QUALITY_THRESHOLD ? ++highQualityNonPublic : ++lowQualityNonPublic
       }
     }
 

--- a/packages/core/src/network/network-peers.ts
+++ b/packages/core/src/network/network-peers.ts
@@ -7,7 +7,6 @@ const log = debug('hopr-core:network-peers')
 
 export type Entry = {
   id: PeerId
-  isPublic: boolean // Indicates whether the node is known to be public
   heartbeatsSent: number
   heartbeatsSuccess: number
   lastSeen: number
@@ -93,7 +92,6 @@ class NetworkPeers {
       // failed ping
       newEntry = {
         id: pingResult.destination,
-        isPublic: previousEntry.isPublic,
         heartbeatsSent: previousEntry.heartbeatsSent + 1,
         lastSeen: Date.now(),
         heartbeatsSuccess: previousEntry.heartbeatsSuccess,
@@ -119,7 +117,6 @@ class NetworkPeers {
       // successful ping
       newEntry = {
         id: pingResult.destination,
-        isPublic: previousEntry.isPublic,
         heartbeatsSent: previousEntry.heartbeatsSent + 1,
         lastSeen: Date.now(),
         heartbeatsSuccess: previousEntry.heartbeatsSuccess + 1,
@@ -156,7 +153,6 @@ class NetworkPeers {
     if (!hasEntry && !isExcluded && !isDenied) {
       this.entries.set(id, {
         id: peerId,
-        isPublic: false,
         heartbeatsSent: 0,
         heartbeatsSuccess: 0,
         lastSeen: now,
@@ -199,10 +195,6 @@ class NetworkPeers {
 
   public all(): PeerId[] {
     return this.allEntries().map((entry) => entry.id)
-  }
-
-  public setPublicOnEntry(peerId: PeerId, isPublic: boolean) {
-    this.entries[peerId.toB58String()].isPublic = isPublic
   }
 
   /**

--- a/packages/core/src/network/network-peers.ts
+++ b/packages/core/src/network/network-peers.ts
@@ -5,8 +5,10 @@ import { NETWORK_QUALITY_THRESHOLD } from '../constants'
 
 const log = debug('hopr-core:network-peers')
 
+
 export type Entry = {
   id: PeerId
+  isPublic: boolean // Indicates whether the node is known to be public
   heartbeatsSent: number
   heartbeatsSuccess: number
   lastSeen: number
@@ -92,6 +94,7 @@ class NetworkPeers {
       // failed ping
       newEntry = {
         id: pingResult.destination,
+        isPublic: previousEntry.isPublic,
         heartbeatsSent: previousEntry.heartbeatsSent + 1,
         lastSeen: Date.now(),
         heartbeatsSuccess: previousEntry.heartbeatsSuccess,
@@ -117,6 +120,7 @@ class NetworkPeers {
       // successful ping
       newEntry = {
         id: pingResult.destination,
+        isPublic: previousEntry.isPublic,
         heartbeatsSent: previousEntry.heartbeatsSent + 1,
         lastSeen: Date.now(),
         heartbeatsSuccess: previousEntry.heartbeatsSuccess + 1,
@@ -153,6 +157,7 @@ class NetworkPeers {
     if (!hasEntry && !isExcluded && !isDenied) {
       this.entries.set(id, {
         id: peerId,
+        isPublic: false,
         heartbeatsSent: 0,
         heartbeatsSuccess: 0,
         lastSeen: now,

--- a/packages/core/src/network/network-peers.ts
+++ b/packages/core/src/network/network-peers.ts
@@ -202,6 +202,10 @@ class NetworkPeers {
     return this.allEntries().map((entry) => entry.id)
   }
 
+  public setPublicOnEntry(peerId: PeerId, isPublic: boolean) {
+    this.entries[peerId.toB58String()].isPublic = isPublic
+  }
+
   /**
    * @returns a string describing the connection quality of all connected peers
    */

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -330,6 +330,7 @@ async function main() {
   }
 
   function networkHealthChanged(oldState: NetworkHealthIndicator, newState: NetworkHealthIndicator) {
+    // Log the network health indicator state change (goes over the WS as well)
     logs.log(`Network health indicator changed: ${oldState} -> ${newState}`)
     logs.log(`NETWORK HEALTH: ${newState}`)
   }

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -331,6 +331,7 @@ async function main() {
 
   function networkHealthChanged(oldState: NetworkHealthIndicator, newState: NetworkHealthIndicator) {
     logs.log(`Network health indicator changed: ${oldState} -> ${newState}`)
+    logs.log(`NETWORK HEALTH: ${newState}`)
   }
 
   function logMessageToNode(msg: Uint8Array) {

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -21,6 +21,7 @@ import { getIdentity } from './identity'
 
 import type { HoprOptions } from '@hoprnet/hopr-core'
 import { setLogger } from 'trace-unhandled'
+import { NetworkHealthIndicator } from '@hoprnet/hopr-core/lib/network/heartbeat'
 
 const DEFAULT_ID_PATH = path.join(process.env.HOME, '.hopr-identity')
 
@@ -328,6 +329,10 @@ async function main() {
     return state
   }
 
+  function networkHealthChanged(oldState: NetworkHealthIndicator, newState: NetworkHealthIndicator) {
+    logs.log(`Network health indicator changed: ${oldState} -> ${newState}`)
+  }
+
   function logMessageToNode(msg: Uint8Array) {
     logs.log(`#### NODE RECEIVED MESSAGE [${new Date().toISOString()}] ####`)
     try {
@@ -396,6 +401,7 @@ async function main() {
     node = await createHoprNode(peerId, options, false)
     logs.logStatus('PENDING')
     node.on('hopr:message', logMessageToNode)
+    node.on('hopr:network-health-changed', networkHealthChanged)
     node.subscribeOnConnector('hopr:connector:created', () => {
       // 2.b - Connector has been created, and we can now trigger the next set of steps.
       logs.log('Connector has been loaded properly.')


### PR DESCRIPTION
This PR creates necessary backend changes to implement Network Connectivity Indicator ("Semaphore") as described in #3758. This is the first step improve the user's understanding of when their node has a good connection to the rest of the P2P network.

## Semaphore states

The Semaphore currently supports 5 possible states (semaphore values):
- ❔  `Unknown`: initial value when the node is started. Means the connectivity could not be assessed.
- 🔴  `Red`: No connection to any nodes at all.
- 🟠  `Orange`: Low-quality (<= 0.5) connection to at least 1 public node.
- 🟡  `Yellow`: High-quality connection to at least 1 public node.
- 🟢  `Green`: High-quality connection to at least 1 public node and at least 1 non-public node.

The "connection" in this case means the ability to do ping/pong with a node, no matter which side initiated the ping.

State transition _from_ `Unknown` is only possible to a state other than `Unknown`. Transition _to_ `Unknown` from a state other than `Unknown` is not possible. All other state transitions are possible in both directions.

## Implementation details

Since `Heartbeat` class is periodically pinging remote nodes and monitoring incoming pings as well, it contains most information needed to implement the Semaphore. 

However, the states defined for the Semaphore additionally rely on knowing which nodes are Public and which are behind NAT. 

Therefore, we implement a cache of peer IDs of nodes that were at any point recognized as announced on-chain and are therefore assumed to be public. This cache is maintained within the `Hopr` class and updated whenever a new public node is announced. The purpose of this cache is to avoid doing expensive indexer DB query to determine which node is public.

The `Heartbeat` class uses the cache on each ping/incoming ping to re-calculate the Semaphore value and emits a new event on the `Hopr` class (`hopr:network-health-changed`) whenever the value of the Semaphore has changed.

In the current implementation of `hoprd`, the Semaphore value changes are logged into the general log and therefore are transmitted over the WebSocket connection to clients. 

Two log entries are emitted when the Semaphore value change happens, e.g.:
````
Network health indicator changed: Red -> Orange
NETWORK HEALTH: Orange
````

## Follow-up

A follow-up PR might be able to implement logic within HOPR Admin panel to look for these changes in the WS stream and create a visible representation of the Semaphore value in the UI.

