### PR TITLE
Smaller refactoring within Rust code

### DIFF
--- a/packages/hoprd/crates/Makefile
+++ b/packages/hoprd/crates/Makefile
@@ -16,7 +16,7 @@ test: $(JS_FILES)
 $(JS_FILES):
 	@echo "--- Building WASM module to '$(@D)' ... ---"
 	mkdir -p $(@D)
-	cd $(@D)/.. && wasm-pack build --target=bundler
+	cd $(@D)/.. && wasm-pack build --target=nodejs
 	@echo "--- Built WASM module in '$(@D)' ---"
 
 install:

--- a/packages/hoprd/crates/hoprd-misc/src/lib.rs
+++ b/packages/hoprd/crates/hoprd-misc/src/lib.rs
@@ -1,9 +1,8 @@
 mod utils;
 
+use std::fmt::Display;
 use wasm_bindgen::prelude::*;
-
 use hopr_real::real;
-
 use serde::{Deserialize};
 
 // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
@@ -18,14 +17,19 @@ struct PackageJsonFile {
     version: String
 }
 
+/// Helper function to convert string-convertible types (like errors) to JsValue
+fn as_jsvalue<T>(v: T) -> JsValue where T: Display {
+    JsValue::from(v.to_string())
+}
+
 /// Reads the package.json file of hoprd and determines it's version.
 #[wasm_bindgen]
-pub fn get_hoprd_version(package_file: &str) -> Result<String, JsValue> {
+pub fn get_package_version(package_file: &str) -> Result<String, JsValue> {
 
-    let file_data = real::read_file(package_file);
+    let file_data = Vec::from(real::read_file(package_file)?);
 
-    return serde_json::from_slice::<PackageJsonFile>(Result::from(file_data)?.as_slice())
+    return serde_json::from_slice::<PackageJsonFile>(file_data.as_slice())
         .map(|v| v.version)
-        .map_err(|e| JsValue::from(e.to_string()));
+        .map_err(as_jsvalue);
 }
 

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -416,7 +416,7 @@ async function main() {
 
   try {
     let packageFile = path.normalize(new URL('../package.json', import.meta.url).pathname)
-    logs.log(`This is hoprd version ${wasm.get_hoprd_version(packageFile)}`)
+    logs.log(`This is hoprd version ${wasm.get_package_version(packageFile)}`)
 
     // 1. Find or create an identity
     const peerId = await getIdentity({

--- a/packages/real/crates/real-base/src/real.rs
+++ b/packages/real/crates/real-base/src/real.rs
@@ -3,37 +3,10 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen(module = "@hoprnet/hopr-real")]
 extern "C" {
 
-    /*
-    DataOrError type is a workaround for the temporary impossibility of
-    having Result<Box<[u8]>>,JsValue> as a return value on a function imported
-    from JS with the "catch" attribute to handle exceptions.
-
-    Right now, the exceptions must be properly and fully handled in JS.
-     */
-
-    #[wasm_bindgen(js_name = DataOrError , typescript_type = "DataOrError")]
-    pub type DataOrError;
-
-    #[wasm_bindgen(method, getter)]
-    fn data(this: &DataOrError) -> Box<[u8]>;
-
-    #[wasm_bindgen(method, getter)]
-    fn error(this: &DataOrError) -> JsValue;
-
-    #[wasm_bindgen(method)]
-    fn hasError(this: &DataOrError) -> bool;
-
     // Reads the given file and returns it as array of bytes.
-    pub fn read_file(file: &str) -> DataOrError;
-}
+    #[wasm_bindgen(catch)]
+    pub fn read_file(file: &str) -> Result<Box<[u8]>, JsValue>;
 
-impl From<DataOrError> for Result<Vec<u8>, JsValue> {
-    fn from(d: DataOrError) -> Self {
-        if !d.hasError() {
-            Ok(Vec::from(d.data()))
-        }
-        else {
-            Err(d.error())
-        }
-    }
+    #[wasm_bindgen(catch)]
+    pub fn write_file(file: &str, data: &[u8]) -> Result<(), JsValue>;
 }

--- a/packages/real/src/io.spec.ts
+++ b/packages/real/src/io.spec.ts
@@ -6,18 +6,6 @@ describe('test io abstraction for real', async function () {
   it('test reading files', async function () {
     let file = 'package.json'
     let data = read_file(file)
-
-    assert.equal(data.hasError(), false)
-    assert.equal(data.error, undefined)
-    assert.deepEqual(data.data, fs.readFileSync(file))
-  })
-
-  it('test reading error', async function () {
-    let file = 'package-non-existent.json'
-    let data = read_file(file)
-
-    assert.equal(data.data, undefined)
-    assert.equal(data.hasError(), true)
-    assert.notEqual(data.error, undefined)
+    assert.deepEqual(data, fs.readFileSync(file))
   })
 })

--- a/packages/real/src/io.ts
+++ b/packages/real/src/io.ts
@@ -16,5 +16,5 @@ export function read_file(file: string): Uint8Array {
  * @param data Data to write to the file
  */
 export function write_file(file: string, data: Uint8Array) {
-  fs.writeFileSync(file, data);
+  fs.writeFileSync(file, data)
 }

--- a/packages/real/src/io.ts
+++ b/packages/real/src/io.ts
@@ -3,55 +3,18 @@ import fs from 'fs'
 // This file will contain the Runtime Environment Abstraction Layer (REAL) for Node.js or browser
 
 /**
- * Simple base class for working-around the impossibility of Rust wasm_bindgen to handle
- * Result<X, JsValue> return type for bound JS functions which can throw an exception.
- *
- * Create a subclass of this base class to return value or error when exception is being caught
- * in the JS function. See `DataOrError` and `read_file` function in this module as an example/
- */
-abstract class XOrError<X> {
-  private d: X
-  private e: any
-
-  public get data() {
-    return this.d
-  }
-
-  public set data(val) {
-    this.d = val
-    this.e = undefined
-  }
-
-  public get error() {
-    return this.e
-  }
-
-  public set error(val) {
-    this.e = val
-    this.d = undefined
-  }
-
-  public hasError(): boolean {
-    return this.e != undefined
-  }
-}
-
-/**
- * Class wrapping Uint8Array or error.
- */
-export class DataOrError extends XOrError<Uint8Array> {}
-
-/**
  * Wrapper for reading file via WASM
  * @param file File path
  */
-export function read_file(file: string): DataOrError {
-  let ret = new DataOrError()
-  try {
-    ret.data = fs.readFileSync(file)
-  } catch (e) {
-    ret.error = e
-  }
+export function read_file(file: string): Uint8Array {
+  return fs.readFileSync(file)
+}
 
-  return ret
+/**
+ * Wrapper for reading file via WASM.
+ * @param file File path
+ * @param data Data to write to the file
+ */
+export function write_file(file: string, data: Uint8Array) {
+  fs.writeFileSync(file, data);
 }


### PR DESCRIPTION
This PR implements small refactoring of the Rust code, mainly:

- removal of `DataOrError` due to corrected `#[wasm_bindgen]` application
- unified JS code generation during build (usage of `nodejs` target instead of `bundler` in hoprd package)

This mostly simplifies code.