### PR TITLE
Fix use of CJS for WASM in hoprd

### DIFF
--- a/packages/hoprd/crates/Makefile
+++ b/packages/hoprd/crates/Makefile
@@ -20,7 +20,7 @@ $(JS_FILES):
 	cp $@ $(subst .js,.cjs,$@)
 	@echo "--- Built WASM module in '$(@D)' ---"
 
-install: $(CJS_FILES)
+install:
 ifneq ($(PACKAGES),)
 	@mkdir -p ../lib
 	install $(foreach pkg, $(PKG_DIRS), $(pkg)/*.cjs) ../lib/

--- a/packages/hoprd/crates/Makefile
+++ b/packages/hoprd/crates/Makefile
@@ -17,12 +17,13 @@ $(JS_FILES):
 	@echo "--- Building WASM module to '$(@D)' ... ---"
 	mkdir -p $(@D)
 	cd $(@D)/.. && wasm-pack build --target=nodejs
+	cp $@ $(subst .js,.cjs,$@)
 	@echo "--- Built WASM module in '$(@D)' ---"
 
-install:
+install: $(CJS_FILES)
 ifneq ($(PACKAGES),)
 	@mkdir -p ../lib
-	install $(foreach pkg, $(PKG_DIRS), $(pkg)/*.js) ../lib/
+	install $(foreach pkg, $(PKG_DIRS), $(pkg)/*.cjs) ../lib/
 	install $(foreach pkg, $(PKG_DIRS), $(pkg)/*.ts) ../lib/
 	install $(foreach pkg, $(PKG_DIRS), $(pkg)/*.wasm) ../lib/
 endif

--- a/packages/hoprd/crates/hoprd-misc/src/lib.rs
+++ b/packages/hoprd/crates/hoprd-misc/src/lib.rs
@@ -26,9 +26,9 @@ fn as_jsvalue<T>(v: T) -> JsValue where T: Display {
 #[wasm_bindgen]
 pub fn get_package_version(package_file: &str) -> Result<String, JsValue> {
 
-    let file_data = Vec::from(real::read_file(package_file)?);
+    let file_data = real::read_file(package_file)?;
 
-    return serde_json::from_slice::<PackageJsonFile>(file_data.as_slice())
+    return serde_json::from_slice::<PackageJsonFile>(&*file_data)
         .map(|v| v.version)
         .map_err(as_jsvalue);
 }

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -32,7 +32,7 @@ import { register as registerUnhandled } from 'trace-unhandled'
 
 import { setLogger } from 'trace-unhandled'
 
-import * as wasm from '../lib/hoprd_misc.js'
+import * as wasm from '../lib/hoprd_misc.cjs'
 
 const DEFAULT_ID_PATH = path.join(process.env.HOME, '.hopr-identity')
 


### PR DESCRIPTION
Fix `hoprd` not starting due to missing CJS extension on WASM module.