### PR TITLE
export all contract types

### DIFF
--- a/packages/ethereum/src/index.ts
+++ b/packages/ethereum/src/index.ts
@@ -1,7 +1,18 @@
 import { join } from 'path'
 
 export * from './constants'
-export type { HoprChannels, HoprToken, HoprNetworkRegistry } from './types'
+export type {
+  HoprToken,
+  HoprChannels,
+  HoprDistributor,
+  HoprNetworkRegistry,
+  HoprBoost,
+  HoprStake,
+  HoprStake2,
+  HoprStakeSeason3,
+  HoprStakeSeason4,
+  HoprWhitehat
+} from './types'
 export type { TypedEventFilter, TypedEvent } from './types/common'
 
 export type ContractNames =


### PR DESCRIPTION
Related to https://github.com/hoprnet/hoprnet/issues/3687

While we have moved `hopr-stake` smart contract to the monorepo, `devrel/stake` still uses `hopr-stake` repository.
The website depends on some types which the monorepo doesn't export.