### PR TITLE
export xHoprToken type

### DIFF
--- a/packages/ethereum/src/index.ts
+++ b/packages/ethereum/src/index.ts
@@ -11,7 +11,9 @@ export type {
   HoprStake2,
   HoprStakeSeason3,
   HoprStakeSeason4,
-  HoprWhitehat
+  HoprWhitehat,
+  // used by libraries that want to interact with xHOPR
+  ERC677 as xHoprToken
 } from './types'
 export type { TypedEventFilter, TypedEvent } from './types/common'
 


### PR DESCRIPTION
Related to https://github.com/hoprnet/hoprnet/issues/3687

While we have moved hopr-stake smart contract to the monorepo, devrel/stake still uses hopr-stake repository.
The website depends on some types which the monorepo doesn't export.