### PR TITLE
Fix package naming so workspace can build properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -31,18 +31,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-real"
-version = "0.1.0"
-dependencies = [
- "wasm-bindgen",
- "wasm-bindgen-test",
-]
-
-[[package]]
 name = "hoprd-misc"
 version = "0.1.0"
 dependencies = [
- "hopr-real",
+ "real-base",
  "serde",
  "serde_json",
  "wasm-bindgen",
@@ -108,6 +100,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "real-base"
+version = "0.1.0"
+dependencies = [
+ "wasm-bindgen",
+ "wasm-bindgen-test",
 ]
 
 [[package]]

--- a/packages/hoprd/crates/hoprd-misc/Cargo.toml
+++ b/packages/hoprd/crates/hoprd-misc/Cargo.toml
@@ -12,21 +12,17 @@ license = "LGPL-3.0-only"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-
-# Workspace dependencies
-hopr-real = { path = "../../../real/crates/real-base" }
-
-# 3rd party dependencies
-wasm-bindgen = { version = "0.2.80", features = ["serde-serialize"] }
-wasm-bindgen-test = "0.3.30"
+real-base = { path = "../../../real/crates/real-base" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+wasm-bindgen = { version = "0.2.80", features = ["serde-serialize"] }
+wasm-bindgen-test = "0.3.30"
 
 # Unfortunately, `wee_alloc` requires nightly Rust when targeting real for now.
 wee_alloc = { version = "0.4.5", optional = true }
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.13"
+wasm-bindgen-test = "0.3.30"
 
 [profile.release]
 # Tell `rustc` to optimize for small code size.

--- a/packages/real/crates/real-base/Cargo.toml
+++ b/packages/real/crates/real-base/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "hopr-real"
+name = "real-base"
 version = "0.1.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
@@ -9,17 +9,12 @@ repository = "https://github.com/hoprnet/hoprnet"
 license = "LGPL-3.0-only"
 
 [lib]
-name = "hopr_real"
 path = "src/lib.rs"
 crate-type = ["cdylib", "rlib"] # rlib is necessary to run integration tests
-
-[[test]]
-name = "real_base_tests"
-path = "tests/node.rs"
 
 [dependencies]
 wasm-bindgen = "0.2.80"
 wasm-bindgen-test = "0.3.30"
 
 [dev-dependencies]
-wasm-bindgen-test = "0.3.0"
+wasm-bindgen-test = "0.3.30"


### PR DESCRIPTION
`real-base` Rust package had a wrong name in it's Cargo.toml file