### PR TITLE
disable hardhat automining after deployment

### DIFF
--- a/packages/ethereum/hardhat.config.ts
+++ b/packages/ethereum/hardhat.config.ts
@@ -21,6 +21,7 @@ import '@typechain/hardhat'
 import faucet, { type FaucetCLIOPts } from './tasks/faucet'
 import parallelTest, { type ParallelTestCLIOpts } from './tasks/parallelTest'
 import register, { type RegisterOpts } from './tasks/register'
+import disableAutoMine from './tasks/disableAutoMine'
 import getAccounts from './tasks/getAccounts'
 
 import { expandVars } from '@hoprnet/hopr-utils'
@@ -75,6 +76,7 @@ function networkToHardhatNetwork(name: String, input: ResolvedEnvironment['netwo
   }
   if (cfg.tags && cfg.tags.indexOf('development') >= 0) {
     ;(cfg as HardhatNetworkUserConfig).mining = {
+      // Disabled using hardhat-specific RPC call after deployment
       auto: true, // every transaction will trigger a new block (without this deployments fail)
       interval: [1000, 3000] // mine new block every 1 - 3s
     }
@@ -179,6 +181,8 @@ task<FaucetCLIOPts>('faucet', 'Faucets a local development HOPR node account wit
   .addOptionalParam<string>('identityPrefix', `only use identity files with prefix`, undefined, types.string)
 
 task('accounts', 'View unlocked accounts', getAccounts)
+
+task('disable-automine', 'Used by E2E tests to disable auto-mining once setup is done', disableAutoMine)
 
 task<RegisterOpts>(
   'register',

--- a/packages/ethereum/tasks/disableAutoMine.ts
+++ b/packages/ethereum/tasks/disableAutoMine.ts
@@ -1,0 +1,18 @@
+import type { HardhatRuntimeEnvironment, RunSuperFunction } from 'hardhat/types'
+
+async function main(
+  _opts: {},
+  { network, ethers }: HardhatRuntimeEnvironment,
+  _runSuper: RunSuperFunction<any>
+): Promise<void> {
+  if (!network.tags.testing && !network.tags.development) {
+    throw Error(`Auto-mining is only present in testing or development networks`)
+  }
+
+  const provider = new ethers.providers.JsonRpcProvider()
+  // Use hardhat-specific EVM call to stop auto-mining in order
+  // to get more accurate testing behavior
+  await provider.send('evm_setAutomine', [false])
+}
+
+export default main

--- a/scripts/testnet.sh
+++ b/scripts/testnet.sh
@@ -156,3 +156,11 @@ add_keys() {
     echo "Authorized keys file not found"
   fi
 }
+
+disable_hardhat_auto_mining() {
+  log "Disabling hardhat automining"
+  HOPR_ENVIRONMENT_ID=hardhat-localhost \
+  TS_NODE_PROJECT="$(yarn workspace @hoprnet/hopr-ethereum exec pwd)/tsconfig.hardhat.json" \
+  yarn workspace @hoprnet/hopr-ethereum hardhat disable-automine \
+    --network hardhat
+}

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -354,6 +354,10 @@ get_tickets_statistics() {
 
 log "Running full E2E test with ${api1}, ${api2}, ${api3}, ${api4}, ${api5}, ${api6}, ${api7}, ${api8}"
 
+# Setup is done, so disable hardhat's auto-mining to correctly mimic 
+# real blockchain networks
+disable_hardhat_auto_mining
+
 validate_native_address "${api1}" "${api_token}"
 validate_native_address "${api2}" "${api_token}"
 validate_native_address "${api3}" "${api_token}"


### PR DESCRIPTION
# Main change

- add CLI utility method to disable hardhat automining at runtime
- within integration test, disable automining *after* deployment

# Rationale

When automining is enabled, hardhat creates a new block whenever it receives a transaction. This turns into a problem when using timestamps within the smart contract, such as in HoprChannel because the client cannot estimate the upcoming timestamp. Due to the implementation of hardhat, the block timestamp is in general strictly smaller than the time when the timestamp when the transaction got generated.

Second benefit: on-chain state changes become visible *after* the *next* block got mined, which happens in current config every *1-3 seconds* and therefore *not immediately*. This improves the accuracy of the simulated blockchain network and helps to make e2e tests more realistic.