### PR TITLE
core + ctd refactoring & efficiency enhancements

### DIFF
--- a/packages/core/src/channel-strategy.ts
+++ b/packages/core/src/channel-strategy.ts
@@ -1,20 +1,27 @@
-import type { ChannelEntry } from '@hoprnet/hopr-core-ethereum'
+import { type default as HoprCoreEthereum, type ChannelEntry } from '@hoprnet/hopr-core-ethereum'
 import {
-  AcknowledgedTicket,
+  type AcknowledgedTicket,
   PublicKey,
   MINIMUM_REASONABLE_CHANNEL_STAKE,
   MAX_AUTO_CHANNELS,
-  PRICE_PER_PACKET
+  PRICE_PER_PACKET,
+  debug
 } from '@hoprnet/hopr-utils'
 import BN from 'bn.js'
 import { MAX_NEW_CHANNELS_PER_TICK, NETWORK_QUALITY_THRESHOLD, INTERMEDIATE_HOPS, CHECK_TIMEOUT } from './constants'
-import { debug } from '@hoprnet/hopr-utils'
 import type NetworkPeers from './network/network-peers'
-import type HoprCoreEthereum from '@hoprnet/hopr-core-ethereum'
+
 const log = debug('hopr-core:channel-strategy')
 
-export type ChannelsToOpen = [PublicKey, BN]
-export type ChannelsToClose = PublicKey
+export type StrategyTickResult = {
+  toOpen: {
+    destination: PublicKey
+    stake: BN
+  }[]
+  toClose: {
+    destination: PublicKey
+  }[]
+}
 
 /**
  * Staked nodes will likely want to automate opening and closing of channels. By
@@ -25,7 +32,7 @@ export type ChannelsToClose = PublicKey
  * - Churn is expensive
  * - Path finding will prefer high stakes, and high availability of nodes.
  */
-export interface ChannelStrategy {
+export interface ChannelStrategyInterface {
   name: string
 
   tick(
@@ -33,7 +40,7 @@ export interface ChannelStrategy {
     currentChannels: ChannelEntry[],
     networkPeers: NetworkPeers,
     getRandomChannel: () => Promise<ChannelEntry>
-  ): Promise<[ChannelsToOpen[], ChannelsToClose[]]>
+  ): Promise<StrategyTickResult>
   // TBD: Include ChannelsToClose as well.
 
   onChannelWillClose(channel: ChannelEntry, chain: HoprCoreEthereum): Promise<void> // Before a channel closes
@@ -77,16 +84,16 @@ export abstract class SaneDefaults {
 }
 
 // Don't auto open any channels
-export class PassiveStrategy extends SaneDefaults implements ChannelStrategy {
+export class PassiveStrategy extends SaneDefaults implements ChannelStrategyInterface {
   name = 'passive'
 
-  async tick(_balance: BN, _c: ChannelEntry[], _p: NetworkPeers): Promise<[ChannelsToOpen[], ChannelsToClose[]]> {
-    return [[], []]
+  async tick(_balance: BN, _c: ChannelEntry[], _p: NetworkPeers): Promise<StrategyTickResult> {
+    return { toOpen: [], toClose: [] }
   }
 }
 
 // Open channel to as many peers as possible
-export class PromiscuousStrategy extends SaneDefaults implements ChannelStrategy {
+export class PromiscuousStrategy extends SaneDefaults implements ChannelStrategyInterface {
   name = 'promiscuous'
 
   async tick(
@@ -94,36 +101,37 @@ export class PromiscuousStrategy extends SaneDefaults implements ChannelStrategy
     currentChannels: ChannelEntry[],
     peers: NetworkPeers,
     getRandomChannel: () => Promise<ChannelEntry>
-  ): Promise<[ChannelsToOpen[], ChannelsToClose[]]> {
+  ): Promise<StrategyTickResult> {
     log(
       'currently open',
       currentChannels.map((x) => x.toString())
     )
-    let toOpen: ChannelsToOpen[] = []
+    let toOpen: StrategyTickResult['toOpen'] = []
 
     let i = 0
-    let toClose = currentChannels
-      .filter((x: ChannelEntry) => {
-        return (
-          peers.qualityOf(x.destination.toPeerId()) < 0.1 ||
-          // Lets append channels with less balance than a full hop messageto toClose.
-          // NB: This is based on channel balance, not expected balance so may not be
-          // aggressive enough.
-          x.balance.toBN().lte(PRICE_PER_PACKET.muln(INTERMEDIATE_HOPS))
-        )
-      })
-      .map((x) => x.destination)
+    let toClose = currentChannels.filter((x: ChannelEntry) => {
+      return (
+        peers.qualityOf(x.destination.toPeerId()) < 0.1 ||
+        // Lets append channels with less balance than a full hop messageto toClose.
+        // NB: This is based on channel balance, not expected balance so may not be
+        // aggressive enough.
+        x.balance.toBN().lte(PRICE_PER_PACKET.muln(INTERMEDIATE_HOPS))
+      )
+    })
 
     // First let's open channels to any interesting peers we have
     peers.all().forEach((peerId) => {
       if (
         balance.gtn(0) &&
         currentChannels.length + toOpen.length < MAX_AUTO_CHANNELS &&
-        !toOpen.find((x) => x[0].eq(PublicKey.fromPeerId(peerId))) &&
+        !toOpen.find((x: typeof toOpen[number]) => x.destination.eq(PublicKey.fromPeerId(peerId))) &&
         !currentChannels.find((x) => x.destination.toPeerId().equals(peerId)) &&
         peers.qualityOf(peerId) > NETWORK_QUALITY_THRESHOLD
       ) {
-        toOpen.push([PublicKey.fromPeerId(peerId), MINIMUM_REASONABLE_CHANNEL_STAKE])
+        toOpen.push({
+          destination: PublicKey.fromPeerId(peerId),
+          stake: MINIMUM_REASONABLE_CHANNEL_STAKE
+        })
         balance.isub(MINIMUM_REASONABLE_CHANNEL_STAKE)
       }
     })
@@ -146,7 +154,10 @@ export class PromiscuousStrategy extends SaneDefaults implements ChannelStrategy
         !currentChannels.find((x) => x.destination.eq(randomChannel.source)) &&
         peers.qualityOf(randomChannel.source.toPeerId()) > NETWORK_QUALITY_THRESHOLD
       ) {
-        toOpen.push([randomChannel.source, MINIMUM_REASONABLE_CHANNEL_STAKE])
+        toOpen.push({
+          destination: randomChannel.source,
+          stake: MINIMUM_REASONABLE_CHANNEL_STAKE
+        })
         balance.isub(MINIMUM_REASONABLE_CHANNEL_STAKE)
       }
     }
@@ -154,6 +165,6 @@ export class PromiscuousStrategy extends SaneDefaults implements ChannelStrategy
       'Promiscuous toOpen: ',
       toOpen.map((p) => p.toString())
     )
-    return [toOpen, toClose]
+    return { toOpen, toClose }
   }
 }

--- a/packages/core/src/network/access-control.ts
+++ b/packages/core/src/network/access-control.ts
@@ -36,8 +36,11 @@ export default class AccessControl {
 
     try {
       allowed = await this.isAllowedAccessToNetwork(peerId)
-      if (allowed) await this.allowConnectionWithPeer(peerId, origin)
-      else await this.denyConnectionWithPeer(peerId, origin)
+      if (allowed) {
+        await this.allowConnectionWithPeer(peerId, origin)
+      } else {
+        await this.denyConnectionWithPeer(peerId, origin)
+      }
     } catch (error) {
       logError(`unexpected error when reviewing connection ${peerId.toB58String()} from ${origin}`, error)
     }
@@ -49,7 +52,14 @@ export default class AccessControl {
    * Iterate all peers and update their connection status.
    */
   public async reviewConnections(): Promise<void> {
-    const allPeers = [...this.networkPeers.allEntries(), ...this.networkPeers.getAllDenied()]
-    for (const { id, origin } of allPeers) await this.reviewConnection(id, origin)
+    // Use iterator to prevent from cloning elements
+    for (const { id, origin } of this.networkPeers.allEntries()) {
+      await this.reviewConnection(id, origin)
+    }
+
+    // Use iterator to prevent from cloning elements
+    for (const { id, origin } of this.networkPeers.getAllDenied()) {
+      await this.reviewConnection(id, origin)
+    }
   }
 }

--- a/packages/core/src/network/network-peers.ts
+++ b/packages/core/src/network/network-peers.ts
@@ -189,12 +189,12 @@ class NetworkPeers {
     return this.entries.size
   }
 
-  public allEntries(): Entry[] {
-    return Array.from(this.entries.values())
+  public allEntries(): IterableIterator<Entry> {
+    return this.entries.values()
   }
 
   public all(): PeerId[] {
-    return this.allEntries().map((entry) => entry.id)
+    return Array.from(this.allEntries()).map((entry) => entry.id)
   }
 
   /**
@@ -206,11 +206,11 @@ class NetworkPeers {
     const peers = this.all()
 
     // Sort a copy of peers in-place
-    peers.sort((a, b) => this.qualityOf(b) - this.qualityOf(a))
+    peers.sort((a: PeerId, b: PeerId) => this.qualityOf(b) - this.qualityOf(a))
 
     let bestAvailabilityNodes = 0
     let badAvailabilityNodes = 0
-    let out = ''
+    let out = '\n'
 
     for (const peer of peers) {
       if (!this.has(peer)) {
@@ -262,8 +262,8 @@ class NetworkPeers {
     }
   }
 
-  public getAllDenied(): Pick<Entry, 'id' | 'origin'>[] {
-    return Array.from(this.deniedEntries.values())
+  public getAllDenied(): IterableIterator<Pick<Entry, 'id' | 'origin'>> {
+    return this.deniedEntries.values()
   }
 
   public addPeerToDenied(peerId: PeerId, origin: string): void {
@@ -274,8 +274,11 @@ class NetworkPeers {
 
   public removePeerFromDenied(peerId: PeerId): void {
     const peerIdStr = peerId.toB58String()
-    log('removing peer from denied', peerIdStr)
-    this.deniedEntries.delete(peerIdStr)
+    const existed = this.deniedEntries.delete(peerIdStr)
+
+    if (existed) {
+      log('removing peer from denied', peerIdStr)
+    }
   }
 }
 

--- a/packages/core/src/path/index.ts
+++ b/packages/core/src/path/index.ts
@@ -1,7 +1,6 @@
 import Heap from 'heap-js'
 import { NETWORK_QUALITY_THRESHOLD, MAX_PATH_ITERATIONS } from '../constants'
-import { debug } from '@hoprnet/hopr-utils'
-import type { ChannelEntry, PublicKey } from '@hoprnet/hopr-utils'
+import { debug, randomFloat, type ChannelEntry, type PublicKey } from '@hoprnet/hopr-utils'
 import { PATH_RANDOMNESS, MAX_HOPS } from '../constants'
 
 import BN from 'bn.js'
@@ -13,7 +12,6 @@ type ChannelPath = { weight: BN; path: ChannelEntry[] }
 const sum = (a: BN, b: BN) => a.add(b)
 const pathFrom = (c: ChannelPath): Path => c.path.map((ce) => ce.destination) // Doesn't include ourself [0]
 const filterCycles = (c: ChannelEntry, p: ChannelPath): boolean => !pathFrom(p).find((x) => x.eq(c.destination))
-const rand = () => Math.random() // TODO - swap for something crypto safe
 const debugPath = (p: ChannelPath) =>
   pathFrom(p)
     .map((x) => x.toB58String())
@@ -22,7 +20,7 @@ const debugPath = (p: ChannelPath) =>
 // Weight a node based on stake, and a random component.
 const defaultWeight = async (edge: ChannelEntry): Promise<BN> => {
   // Minimum is 'stake', therefore weight is monotonically increasing
-  const r = 1 + rand() * PATH_RANDOMNESS
+  const r = 1 + randomFloat() * PATH_RANDOMNESS
   // Log scale, but minimum 1 weight per edge
   return edge.balance.toBN().addn(1).muln(r) //log()
 }

--- a/packages/cover-traffic-daemon/src/index.ts
+++ b/packages/cover-traffic-daemon/src/index.ts
@@ -5,7 +5,17 @@ import path from 'path'
 import BN from 'bn.js'
 import yargs from 'yargs/yargs'
 import { terminalWidth } from 'yargs'
-import { createHoprNode, resolveEnvironment, supportedEnvironments, type ResolvedEnvironment } from '@hoprnet/hopr-core'
+import { hideBin } from 'yargs/helpers'
+import {
+  createHoprNode,
+  resolveEnvironment,
+  supportedEnvironments,
+  type ResolvedEnvironment,
+  HEARTBEAT_INTERVAL,
+  HEARTBEAT_THRESHOLD,
+  HEARTBEAT_INTERVAL_VARIANCE
+} from '@hoprnet/hopr-core'
+
 import { type ChannelEntry, privKeyToPeerId, PublicKey, debug } from '@hoprnet/hopr-utils'
 
 import { PersistedState } from './state'
@@ -23,6 +33,8 @@ function stopGracefully(signal: number) {
   console.log(`Process exiting with signal ${signal}`)
   process.exit()
 }
+
+process.title = 'hopr-cover-traffic-daemon'
 
 export type DefaultEnvironment = {
   id?: string
@@ -44,7 +56,7 @@ process.title = 'hopr-cover-traffic-daemon'
 // Use environment-specific default data path
 const defaultDataPath = path.join(process.cwd(), 'hopr-cover-traffic-daemon-db', defaultEnvironment())
 
-const argv = yargs(process.argv.slice(2))
+const argv = yargs(hideBin(process.argv))
   .env('HOPR_CTD') // enable options to be set as environment variables with the HOPR_CTD prefix
   .epilogue(
     'All CLI options can be configured through environment variables as well. CLI parameters have precedence over environment variables.'
@@ -102,10 +114,27 @@ const argv = yargs(process.argv.slice(2))
     describe: 'For testing local testnets. Prefer local peers to remote [env: HOPR_CTD_TEST_PREFER_LOCAL_ADDRESSES]',
     default: false
   })
+  .option('heartbeatInterval', {
+    number: true,
+    describe:
+      'Interval in milliseconds in which the availability of other nodes get measured [env: HOPRD_HEARTBEAT_INTERVAL]',
+    default: HEARTBEAT_INTERVAL
+  })
+  .option('heartbeatThreshold', {
+    number: true,
+    describe:
+      "Timeframe in milliseconds after which a heartbeat to another peer is performed, if it hasn't been seen since [env: HOPRD_HEARTBEAT_THRESHOLD]",
+    default: HEARTBEAT_THRESHOLD
+  })
+  .option('heartbeatVariance', {
+    number: true,
+    describe: 'Upper bound for variance applied to heartbeat interval in milliseconds [env: HOPRD_HEARTBEAT_VARIANCE]',
+    default: HEARTBEAT_INTERVAL_VARIANCE
+  })
   .wrap(Math.min(120, terminalWidth()))
   .parseSync()
 
-async function generateNodeOptions(environment: ResolvedEnvironment): Promise<HoprOptions> {
+function generateNodeOptions(environment: ResolvedEnvironment): HoprOptions {
   const options: HoprOptions = {
     announce: false,
     createDbIfNotExist: true,
@@ -114,6 +143,9 @@ async function generateNodeOptions(environment: ResolvedEnvironment): Promise<Ho
     password: '',
     dataPath: argv.data,
     allowLocalConnections: argv.allowLocalNodeConnections,
+    heartbeatInterval: argv.heartbeatInterval,
+    heartbeatThreshold: argv.heartbeatThreshold,
+    heartbeatVariance: argv.heartbeatVariance,
     testing: {
       announceLocalAddresses: argv.testAnnounceLocalAddresses,
       preferLocalAddresses: argv.testPreferLocalAddresses
@@ -125,7 +157,7 @@ async function generateNodeOptions(environment: ResolvedEnvironment): Promise<Ho
 
 export async function main(update: (State: State) => void, peerId?: PeerId) {
   const environment = resolveEnvironment(argv.environment, argv.provider)
-  const options = await generateNodeOptions(environment)
+  const options = generateNodeOptions(environment)
   if (!peerId) {
     peerId = privKeyToPeerId(argv.privateKey)
   }
@@ -191,7 +223,7 @@ if (require.main === module) {
 
   process.on('uncaughtExceptionMonitor', (err, origin) => {
     // Make sure we get a log.
-    log(`FATAL ERROR, exiting with uncaught exception: ${origin} ${err}`)
+    log(`FATAL ERROR, exiting with uncaught exception:`, origin, err)
   })
 
   main((state: State) => {

--- a/packages/cover-traffic-daemon/src/state.ts
+++ b/packages/cover-traffic-daemon/src/state.ts
@@ -1,6 +1,7 @@
 import BN from 'bn.js'
-import { PublicKey, ChannelEntry, ChannelStatus } from '@hoprnet/hopr-utils'
+import { PublicKey, ChannelEntry, ChannelStatus, randomFloat } from '@hoprnet/hopr-utils'
 import PeerId from 'peer-id'
+import type { Multiaddr } from 'multiaddr'
 import { findChannel, importance } from './utils'
 import fs from 'fs'
 
@@ -10,6 +11,12 @@ export type ChannelData = {
   sendAttempts: number
   // number of attempts of a channel to forward packets (aka as intermediate hops other than the 1st hop).
   forwardAttempts: number
+}
+
+export type PeerData = {
+  id: PeerId
+  pub: PublicKey
+  multiaddrs: Multiaddr[]
 }
 
 export type OpenChannels = {
@@ -31,10 +38,74 @@ export type State = {
   messageTotalSuccess: number
 }
 
-export type PeerData = {
-  id: any //PeerId type, as implemented in IPFS
-  pub: PublicKey
-  multiaddrs: any[] // Multiaddress type
+// serialized representation of State type
+type SerializedState = {
+  nodes: {
+    id: string
+    multiaddrs: string[]
+  }[]
+  channels: {
+    channel: string
+    forwardAttempts: number
+    sendAttempts: number
+  }[]
+  ctChannels: {
+    destination: string
+    openFrom: number
+  }[]
+  block: string
+}
+
+function serializeState(state: State): string {
+  return JSON.stringify({
+    nodes: Object.values(state.nodes).map((node: PeerData) => ({
+      // Using hex representation since deserializing Base58 encoded
+      // strings is complex
+      id: node.id.toHexString(),
+      multiaddrs: node.multiaddrs.map((ma: Multiaddr) => ma.toString())
+    })),
+    channels: Object.values(state.channels).map((c: ChannelData) => ({
+      channel: Buffer.from(c.channel.serialize()).toString('base64'),
+      forwardAttempts: c.forwardAttempts,
+      sendAttempts: c.sendAttempts
+    })),
+    ctChannels: state.ctChannels.map((open: OpenChannels) => ({
+      destination: open.destination.toCompressedPubKeyHex(),
+      openFrom: open.openFrom
+    })),
+    block: state.block.toString()
+  } as SerializedState)
+}
+
+function deserializeState(serialized: string): State {
+  const parsed = JSON.parse(serialized) as SerializedState
+
+  return {
+    nodes: parsed.nodes.reduce((acc, node) => {
+      // Using hex representation since deserializing Base58 encoded
+      // strings is complex
+      const id = PeerId.createFromHexString(node.id)
+      acc[id.toB58String()] = { id, pub: PublicKey.fromPeerId(id), multiaddrs: [] }
+      return acc
+    }, {}),
+    channels: parsed.channels.reduce((acc, c) => {
+      const channel = ChannelEntry.deserialize(Uint8Array.from(Buffer.from(c.channel, 'base64')))
+      acc[channel.getId().toHex()] = {
+        channel,
+        forwardAttempts: c.forwardAttempts,
+        sendAttempts: c.sendAttempts
+      }
+      return acc
+    }, {}),
+    ctChannels: parsed.ctChannels.map((p) => ({
+      destination: PublicKey.fromString(p.destination),
+      latestQualityOf: 0,
+      openFrom: p.openFrom
+    })),
+    messageFails: {},
+    messageTotalSuccess: 0,
+    block: new BN(parsed.block)
+  }
 }
 
 export class PersistedState {
@@ -67,35 +138,8 @@ export class PersistedState {
    * Load the exisitng cover traffic state, where the path is defined in `DB`
    */
   load(): void {
-    const json = JSON.parse(fs.readFileSync(this.db_path, 'utf8'))
-    this._data = {
-      nodes: {},
-      channels: {},
-      ctChannels: json.ctChannels.map((p) => ({
-        destination: PublicKey.fromPeerId(PeerId.createFromB58String(p.destination)),
-        latestQualityOf: 0,
-        openFrom: p.openFrom
-      })),
-      messageFails: {},
-      messageTotalSuccess: 0,
-      block: new BN(json.block)
-    }
-
-    // node ids are encoded in base58 strings
-    json.nodes.forEach((n) => {
-      const id = PeerId.createFromB58String(n.id)
-      this._data.nodes[id.toB58String()] = { id, pub: PublicKey.fromPeerId(id), multiaddrs: [] }
-    })
-
-    // channel entries are encoded in base64 strings
-    json.channels.forEach((c) => {
-      const channel = ChannelEntry.deserialize(Uint8Array.from(Buffer.from(c.channel, 'base64')))
-      this._data.channels[channel.getId().toHex()] = {
-        channel,
-        forwardAttempts: c.forwardAttempts,
-        sendAttempts: c.sendAttempts
-      }
-    })
+    const serialized = fs.readFileSync(this.db_path, 'utf8')
+    this._data = deserializeState(serialized)
   }
 
   /**
@@ -113,26 +157,7 @@ export class PersistedState {
    */
   set(s: State): void {
     this._data = s
-    fs.writeFileSync(
-      this.db_path,
-      JSON.stringify({
-        nodes: Object.values(s.nodes).map((n: PeerData) => ({
-          id: n.id.toB58String(),
-          multiaddrs: n.multiaddrs.map((m) => m.toString())
-        })),
-        channels: Object.values(s.channels).map((c) => ({
-          channel: Buffer.from(c.channel.serialize()).toString('base64'),
-          forwardAttempts: c.forwardAttempts,
-          sendAttempts: c.sendAttempts
-        })),
-        ctChannels: s.ctChannels.map((o: OpenChannels) => ({
-          destination: o.destination.toB58String(),
-          openFrom: o.openFrom
-        })),
-        block: s.block.toString()
-      }),
-      'utf8'
-    )
+    fs.writeFileSync(this.db_path, serializeState(s), 'utf8')
     this.update(s)
     return
   }
@@ -198,9 +223,9 @@ export class PersistedState {
    * @param block Latest block number (a big number) listened by the indexer.
    */
   setBlock(block: BN): void {
-    const s = this.get()
-    s.block = block
-    this.set(s)
+    const state = this.get()
+    state.block = block
+    this.set(state)
   }
 
   /**
@@ -209,8 +234,8 @@ export class PersistedState {
    * @returns PeerData of the given ID.
    */
   getNode(b58String: string): PeerData {
-    const s = this.get()
-    return s.nodes[b58String]
+    const state = this.get()
+    return state.nodes[b58String]
   }
 
   /**
@@ -221,8 +246,8 @@ export class PersistedState {
    * @returns ChannelEntry between `source` and `destination`, undefined otherwise.
    */
   findChannel(src: PublicKey, dest: PublicKey): ChannelEntry {
-    const s = this.get()
-    return findChannel(src, dest, s)
+    const state = this.get()
+    return findChannel(src, dest, state)
   }
 
   /**
@@ -233,25 +258,28 @@ export class PersistedState {
    * weight, throw an error otherwise.
    */
   weightedRandomChoice(): PublicKey {
-    const s = this.get()
-    if (Object.keys(s.nodes).length == 0) {
+    const state = this.get()
+    if (Object.keys(state.nodes).length == 0) {
       throw new Error('no nodes to pick from')
     }
     // key: Public key of a node, value: Importance score of a node
     const weights: Record<string, BN> = {}
     let total = new BN('0')
-    const ind = Math.random()
+    const ind = randomFloat()
 
     // for all the nodes in the network, set importance score as its weight and calculate the sum of all weights
-    for (const p of Object.values(s.nodes)) {
-      weights[p.pub.toUncompressedPubKeyHex()] = importance(p.pub, s)
-      total = total.add(weights[p.pub.toUncompressedPubKeyHex()])
+    for (const node of Object.values(state.nodes)) {
+      // PublicKey might not be decompressed yet, so using compressed
+      // representation makes sure the PublicKey does not get decompressed without need
+      const nodeString = node.pub.toCompressedPubKeyHex()
+      weights[nodeString] = importance(node.pub, state)
+      total = total.add(weights[nodeString])
     }
 
     if (total.lten(0)) {
       // No important nodes - let's pick a random node for now.
-      const index = Math.floor(ind * Object.keys(s.nodes).length)
-      return Object.values(s.nodes)[index].pub
+      const index = Math.floor(ind * Object.keys(state.nodes).length)
+      return Object.values(state.nodes)[index].pub
     }
 
     let interval = total.muln(ind)
@@ -270,13 +298,13 @@ export class PersistedState {
    * @param destination Public key of the message sender.
    */
   async incrementSent(source: PublicKey, destination: PublicKey) {
-    const s = this.get()
-    const channel = findChannel(source, destination, s)
+    const state = this.get()
+    const channel = findChannel(source, destination, state)
     if (channel) {
       const channelId = channel.getId().toHex()
-      const prev = s.channels[channelId].sendAttempts || 0
-      s.channels[channelId].sendAttempts = prev + 1
-      this.set(s)
+      const prev = state.channels[channelId].sendAttempts || 0
+      state.channels[channelId].sendAttempts = prev + 1
+      this.set(state)
     }
   }
 
@@ -286,13 +314,13 @@ export class PersistedState {
    * @param destination Public key of the message sender.
    */
   async incrementForwards(source: PublicKey, destination: PublicKey) {
-    const s = this.get()
-    const channel = findChannel(source, destination, s)
+    const state = this.get()
+    const channel = findChannel(source, destination, state)
     if (channel) {
       const channelId = channel.getId().toHex()
-      const prev = s.channels[channelId].forwardAttempts || 0
-      s.channels[channelId].forwardAttempts = prev + 1
-      this.set(s)
+      const prev = state.channels[channelId].forwardAttempts || 0
+      state.channels[channelId].forwardAttempts = prev + 1
+      this.set(state)
     }
   }
 
@@ -301,8 +329,8 @@ export class PersistedState {
    * @returns number of all the open channels
    */
   openChannelCount(): number {
-    const s = this.get()
-    return Object.values(s.channels).filter((x) => x.channel.status != ChannelStatus.Closed).length
+    const state = this.get()
+    return Object.values(state.channels).filter((x) => x.channel.status != ChannelStatus.Closed).length
   }
 
   /**
@@ -317,10 +345,10 @@ export class PersistedState {
    * Update the total number of sent messages from the current CT node
    */
   incrementMessageTotalSuccess(): void {
-    const s = this.get()
-    const prev = s.messageTotalSuccess || 0
-    s.messageTotalSuccess = prev + 1
-    this.set(s)
+    const state = this.get()
+    const prev = state.messageTotalSuccess || 0
+    state.messageTotalSuccess = prev + 1
+    this.set(state)
   }
 
   /**
@@ -337,10 +365,10 @@ export class PersistedState {
    * @param dest Public key of the destination that supposed to received messages but failed.
    */
   incrementMessageFails(dest: PublicKey): void {
-    const s = this.get()
-    const prev = s.messageFails[dest.toB58String()] || 0
-    s.messageFails[dest.toB58String()] = prev + 1
-    this.set(s)
+    const state = this.get()
+    const prev = state.messageFails[dest.toB58String()] || 0
+    state.messageFails[dest.toB58String()] = prev + 1
+    this.set(state)
   }
 
   /**
@@ -348,8 +376,8 @@ export class PersistedState {
    * @param dest Public key of the destination that supposed to received messages but failed.
    */
   resetMessageFails(dest: PublicKey): void {
-    const s = this.get()
-    s.messageFails[dest.toB58String()] = 0
-    this.set(s)
+    const state = this.get()
+    state.messageFails[dest.toB58String()] = 0
+    this.set(state)
   }
 }

--- a/packages/cover-traffic-daemon/src/strategy.ts
+++ b/packages/cover-traffic-daemon/src/strategy.ts
@@ -1,8 +1,8 @@
-import { ChannelsToOpen, ChannelsToClose, SaneDefaults } from '@hoprnet/hopr-core'
+import { type StrategyTickResult, SaneDefaults, type ChannelStrategyInterface } from '@hoprnet/hopr-core'
 import type Hopr from '@hoprnet/hopr-core'
 import type BN from 'bn.js'
-import { PublicKey, ChannelEntry, ChannelStatus } from '@hoprnet/hopr-utils'
-import type { PersistedState } from './state'
+import { type PublicKey, type ChannelEntry, ChannelStatus } from '@hoprnet/hopr-utils'
+import type { PersistedState, State } from './state'
 import { findCtChannelOpenTime, sendCTMessage } from './utils'
 import {
   CT_INTERMEDIATE_HOPS,
@@ -18,7 +18,13 @@ import { debug } from '@hoprnet/hopr-utils'
 
 const log = debug('hopr:cover-traffic')
 
-export class CoverTrafficStrategy extends SaneDefaults {
+type CtChannel = {
+  destination: PublicKey
+  latestQualityOf: number
+  openFrom: number
+}
+
+export class CoverTrafficStrategy extends SaneDefaults implements ChannelStrategyInterface {
   name = 'covertraffic'
 
   constructor(private selfPub: PublicKey, private node: Hopr, private data: PersistedState) {
@@ -27,6 +33,68 @@ export class CoverTrafficStrategy extends SaneDefaults {
 
   // Interval of the `periodicCheck` in hopr-core
   tickInterval = 10000
+
+  /**
+   * Iterates through the persisted state and the current payment channel
+   * graph and marks channels that should be closed and those that should
+   * be opened.
+   * Also returns a list of ct channels.
+   * @param state current persisted state
+   * @param currentChannels recent payment channel graph
+   * @param peers known peers in the network
+   * @returns
+   */
+  revisitTopology(
+    state: State,
+    currentChannels: ChannelEntry[],
+    peers: Hopr['networkPeers']
+  ): {
+    ctChannels: CtChannel[]
+    tickResult: StrategyTickResult
+  } {
+    const tickResult: StrategyTickResult = { toOpen: [], toClose: [] }
+    const ctChannels: CtChannel[] = []
+
+    for (let channel of currentChannels) {
+      if (channel.status === ChannelStatus.Closed) {
+        continue
+      }
+      const quality = peers.qualityOf(channel.destination.toPeerId())
+      ctChannels.push({
+        destination: channel.destination,
+        latestQualityOf: quality,
+        openFrom: findCtChannelOpenTime(channel.destination, state)
+      })
+
+      // Cover traffic channels with quality below this threshold will be closed
+      if (quality < CT_NETWORK_QUALITY_THRESHOLD) {
+        log(`closing channel ${channel.destination.toB58String()} with quality < ${CT_NETWORK_QUALITY_THRESHOLD}`)
+        tickResult.toClose.push({
+          destination: channel.destination
+        })
+      }
+      // If the HOPR token balance of the current CT node is no larger than the `MINIMUM_STAKE_BEFORE_CLOSURE`, close all the non-closed channels.
+      if (channel.balance.toBN().lt(MINIMUM_STAKE_BEFORE_CLOSURE)) {
+        log(`closing channel with balance too low ${channel.destination.toB58String()}`)
+        tickResult.toClose.push({
+          destination: channel.destination
+        })
+      }
+      // Close the cover-traffic channel when the number of failed messages meets the threshold. Reset the failed message counter.
+      if (this.data.messageFails(channel.destination) > MESSAGE_FAIL_THRESHOLD) {
+        log(`closing channel with too many message fails: ${channel.destination.toB58String()}`)
+        this.data.resetMessageFails(channel.destination)
+        tickResult.toClose.push({
+          destination: channel.destination
+        })
+      }
+    }
+
+    return {
+      tickResult,
+      ctChannels
+    }
+  }
 
   /**
    * Go through network state and get arrays of channels to be opened/closed
@@ -42,46 +110,19 @@ export class CoverTrafficStrategy extends SaneDefaults {
     currentChannels: ChannelEntry[],
     peers: Hopr['networkPeers'],
     _getRandomChannel: () => Promise<ChannelEntry>
-  ): Promise<[ChannelsToOpen[], ChannelsToClose[]]> {
+  ): Promise<StrategyTickResult> {
     log(`tick, balance ${balance.toString()}`)
-    const toOpen = []
-    const toClose = []
     const state = this.data.get()
 
     // Refresh open channels.
-    const ctChannels = []
-    for (let c of currentChannels) {
-      if (c.status === ChannelStatus.Closed) {
-        continue
-      }
-      const q = peers.qualityOf(c.destination.toPeerId())
-      ctChannels.push({
-        destination: c.destination,
-        latestQualityOf: q,
-        openFrom: findCtChannelOpenTime(c.destination, state)
-      })
+    const { tickResult, ctChannels } = this.revisitTopology(state, currentChannels, peers)
 
-      // Cover traffic channels with quality below this threshold will be closed
-      if (q < CT_NETWORK_QUALITY_THRESHOLD) {
-        log(`closing channel ${c.destination.toB58String()} with quality < ${CT_NETWORK_QUALITY_THRESHOLD}`)
-        toClose.push(c.destination)
-      }
-      // If the HOPR token balance of the current CT node is no larger than the `MINIMUM_STAKE_BEFORE_CLOSURE`, close all the non-closed channels.
-      if (c.balance.toBN().lt(MINIMUM_STAKE_BEFORE_CLOSURE)) {
-        log(`closing channel with balance too low ${c.destination.toB58String()}`)
-        toClose.push(c.destination)
-      }
-      // Close the cover-traffic channel when the number of failed messages meets the threshold. Reset the failed message counter.
-      if (this.data.messageFails(c.destination) > MESSAGE_FAIL_THRESHOLD) {
-        log(`closing channel with too many message fails: ${c.destination.toB58String()}`)
-        this.data.resetMessageFails(c.destination)
-        toClose.push(c.destination)
-      }
-    }
     this.data.setCTChannels(ctChannels)
     log(
       'channels',
-      ctChannels.map((c) => `${c.destination.toB58String()} - ${c.latestQualityOf}, ${c.openFrom}`).join('; ')
+      ctChannels
+        .map((c: CtChannel) => `${c.destination.toB58String()} - ${c.latestQualityOf}, ${c.openFrom}`)
+        .join('; ')
     )
 
     // Network must have at least some channels to create a full cover-traffic loop.
@@ -91,30 +132,33 @@ export class CoverTrafficStrategy extends SaneDefaults {
         const channel = this.data.findChannel(this.selfPub, openChannel.destination)
         if (channel && channel.status == ChannelStatus.Open) {
           // send messages for open channels
-          sendCTMessage(
+
+          const success = await sendCTMessage(
             openChannel.destination,
             this.selfPub,
             async (message: Uint8Array, path: PublicKey[]) => {
               await this.node.sendMessage(message, this.selfPub.toPeerId(), path)
             },
             this.data
-          ).then((success) => {
-            if (!success) {
-              log(
-                `failed to send to ${openChannel.destination.toB58String()} fails: ${this.data.messageFails(
-                  openChannel.destination
-                )}`
-              )
-              this.data.incrementMessageFails(openChannel.destination)
-            } else {
-              this.data.incrementMessageTotalSuccess()
-            }
-          })
+          )
+
+          if (!success) {
+            log(
+              `failed to send to ${openChannel.destination.toB58String()} fails: ${this.data.messageFails(
+                openChannel.destination
+              )}`
+            )
+            this.data.incrementMessageFails(openChannel.destination)
+          } else {
+            this.data.incrementMessageTotalSuccess()
+          }
         } else if (channel && channel.status == ChannelStatus.WaitingForCommitment) {
           if (Date.now() - openChannel.openFrom >= CT_CHANNEL_STALL_TIMEOUT) {
             // handle waiting for commitment stalls
             log('channel is stalled in WAITING_FOR_COMMITMENT, closing', openChannel.destination.toB58String())
-            toClose.push(openChannel.destination)
+            tickResult.toClose.push({
+              destination: openChannel.destination
+            })
           } else {
             log('channel is WAITING_FOR_COMMITMENT, waiting', openChannel.destination.toB58String())
           }
@@ -142,35 +186,40 @@ export class CoverTrafficStrategy extends SaneDefaults {
       attempts < 100
     ) {
       attempts++
-      const c = this.data.weightedRandomChoice()
-      const q = peers.qualityOf(c.toPeerId())
+      const choice = this.data.weightedRandomChoice()
+      const quality = peers.qualityOf(choice.toPeerId())
       // Ignore the randomly chosen node, if it's the cover traffic node itself, or a non-closed channel exists
       if (
-        ctChannels.find((x) => x.destination.eq(c)) ||
-        c.eq(this.selfPub) ||
-        toOpen.find((x) => x[0].eq(c)) ||
-        toClose.find((x) => x.eq(c))
+        ctChannels.find((x: CtChannel) => x.destination.eq(choice)) ||
+        choice.eq(this.selfPub) ||
+        tickResult.toOpen.find((x: StrategyTickResult['toOpen'][number]) => x.destination.eq(choice)) ||
+        tickResult.toClose.find((x: StrategyTickResult['toClose'][number]) => x.destination.eq(choice))
       ) {
         //console.error('skipping node', c.toB58String())
         continue
       }
       // It should fulfil the quality threshold
-      if (q < CT_OPEN_CHANNEL_QUALITY_THRESHOLD) {
+      if (quality < CT_OPEN_CHANNEL_QUALITY_THRESHOLD) {
         //log('low quality node skipped', c.toB58String(), q)
         continue
       }
 
-      log(`opening ${c.toB58String()}`)
+      log(`opening ${choice.toB58String()}`)
       currentChannelNum++
-      toOpen.push([c, CHANNEL_STAKE])
+      tickResult.toOpen.push({
+        destination: choice,
+        stake: CHANNEL_STAKE
+      })
     }
 
     log(
-      `strategy tick: ${Date.now()} balance:${balance.toString()} open:${toOpen
-        .map((p) => p[0].toPeerId().toB58String())
-        .join(',')} close: ${toClose.map((p) => p.toPeerId().toB58String()).join(',')}`.replace('\n', ', ')
+      `strategy tick: ${Date.now()} balance:${balance.toString()} open:${tickResult.toOpen
+        .map((p: StrategyTickResult['toOpen'][number]) => p.destination.toPeerId().toB58String())
+        .join(',')} close: ${tickResult.toClose
+        .map((p: StrategyTickResult['toClose'][number]) => p.destination.toPeerId().toB58String())
+        .join(',')}`.replace('\n', ', ')
     )
-    return [toOpen, toClose]
+    return tickResult
   }
 
   async onWinningTicket() {

--- a/packages/cover-traffic-daemon/src/utils.ts
+++ b/packages/cover-traffic-daemon/src/utils.ts
@@ -1,8 +1,8 @@
 import { findPath } from '@hoprnet/hopr-core'
 import BN from 'bn.js'
 import { BigNumber } from 'bignumber.js'
-import type { PublicKey, ChannelEntry } from '@hoprnet/hopr-utils'
-import type { State, ChannelData, PersistedState } from './state'
+import { type PublicKey, type ChannelEntry, randomFloat } from '@hoprnet/hopr-utils'
+import type { State, PersistedState } from './state'
 import { CT_PATH_RANDOMNESS, CT_INTERMEDIATE_HOPS } from './constants'
 import { debug } from '@hoprnet/hopr-utils'
 
@@ -21,25 +21,43 @@ export type UnreleasedSchedule = {
 
 export type UnreleasedTokens = {
   // hopr id to node Ethereum addresses
-  link: Record<string, string[]>
+  link: {
+    [index: string]: string[]
+  }
   // Node Ethereum address to the array of unreleased token schedule
-  allocation: Record<string, UnreleasedSchedule[]>
+  allocation: {
+    [index: string]: UnreleasedSchedule[]
+  }
 }
 
+// @TODO inefficient & does not support runtime updates
 const unreleasedTokens: UnreleasedTokens = require('../unreleasedTokens.json')
 
-export const addBN = (a: BN, b: BN): BN => a.add(b)
-export const sqrtBN = (a: BN): BN => new BN(new BigNumber(a.toString()).squareRoot().integerValue().toFixed(), 10)
+/**
+ * Gets the integer part of the sqaure root of a an integer
+ * @dev squaring the result in general does not lead to the input value
+ * @param int the integer to compute the square root
+ * @returns the rounded square root
+ */
+export function sqrtBN(int: BN): BN {
+  return new BN(new BigNumber(int.toString()).squareRoot().integerValue().toFixed(), 10)
+}
 
 /**
  * Get channels opened from a node with a given public key in the state.
  * @param p Public key of the `source` node
  * @returns a list of channel entries where the `source` is the given public key
  */
-export const findChannelsFrom = (p: PublicKey, state: State): ChannelEntry[] =>
-  Object.values(state.channels)
-    .map((c) => c.channel)
-    .filter((c: ChannelEntry) => c.source.eq(p))
+export function findChannelsFrom(p: PublicKey, state: State): ChannelEntry[] {
+  let result: ChannelEntry[] = []
+  for (const channelId in state.channels) {
+    const channel = state.channels[channelId].channel
+    if (channel.source.eq(p)) {
+      result.push(channel)
+    }
+  }
+  return result
+}
 
 /**
  * Get the total outgoing channel balance of a node, given the network state.
@@ -48,10 +66,13 @@ export const findChannelsFrom = (p: PublicKey, state: State): ChannelEntry[] =>
  * @param state State of the network
  * @returns Total channel balance in big number
  */
-export const totalChannelBalanceFor = (p: PublicKey, state: State): BN =>
-  findChannelsFrom(p, state)
-    .map((c) => c.balance.toBN())
-    .reduce(addBN, new BN('0'))
+export function totalChannelBalanceFor(p: PublicKey, state: State): BN {
+  const result = new BN(0)
+  for (const channel of findChannelsFrom(p, state)) {
+    result.iadd(channel.balance.toBN())
+  }
+  return result
+}
 
 /**
  * Get the stake of a node which consists of the total channel balance
@@ -63,28 +84,38 @@ export const totalChannelBalanceFor = (p: PublicKey, state: State): BN =>
  * @param state State of the network
  * @returns Stake of a node in big number
  */
-export const stakeFor = (p: PublicKey, state: State): BN => {
-  const linkedAccountsIndex = Object.keys(unreleasedTokens.link).findIndex(
-    (id) => id.toLowerCase() == p.toB58String().toLowerCase()
-  )
+export function stakeFor(p: PublicKey, state: State): BN {
+  let linkedAccounts: UnreleasedTokens['link'][string] = null
 
-  if (linkedAccountsIndex < 0) {
+  const b58String = p.toB58String()
+  for (const id in unreleasedTokens.link) {
+    // Base58 encoding is case-sensitive
+    if (id === b58String) {
+      linkedAccounts = unreleasedTokens.link[id]
+    }
+  }
+
+  if (!linkedAccounts) {
     return totalChannelBalanceFor(p, state)
   }
 
   const currentBlockNumber = state.block.toNumber()
 
-  return Object.values(unreleasedTokens.link)
-    [linkedAccountsIndex].map((nodeAddress) => {
-      const scheduleIndex = unreleasedTokens.allocation[nodeAddress].findIndex(
-        (schedule) => schedule.lowerBlock <= currentBlockNumber && currentBlockNumber < schedule.upperBlock
-      )
-      return scheduleIndex < 0
-        ? new BN('0')
-        : new BN(unreleasedTokens.allocation[nodeAddress][scheduleIndex].unreleased)
-    })
-    .reduce(addBN, new BN('0'))
-    .add(totalChannelBalanceFor(p, state))
+  const result = totalChannelBalanceFor(p, state)
+  for (const linkedAccount of linkedAccounts) {
+    let accountSchedule: UnreleasedSchedule = null
+    for (const schedule of unreleasedTokens.allocation[linkedAccount]) {
+      if (schedule.lowerBlock <= currentBlockNumber && currentBlockNumber < schedule.upperBlock) {
+        accountSchedule = schedule
+      }
+    }
+
+    if (accountSchedule) {
+      result.iadd(new BN(accountSchedule.unreleased))
+    }
+  }
+
+  return result
 }
 
 /**
@@ -96,10 +127,13 @@ export const stakeFor = (p: PublicKey, state: State): BN => {
  * @param state State of the network
  * @returns Total channel balance in big number
  */
-export const importance = (p: PublicKey, state: State): BN =>
-  findChannelsFrom(p, state)
-    .map((c: ChannelEntry) => sqrtBN(stakeFor(p, state).mul(c.balance.toBN()).mul(stakeFor(c.destination, state))))
-    .reduce(addBN, new BN('0'))
+export function importance(p: PublicKey, state: State): BN {
+  const result = new BN(0)
+  for (const channel of findChannelsFrom(p, state)) {
+    result.iadd(sqrtBN(stakeFor(p, state).imul(channel.balance.toBN()).imul(stakeFor(channel.destination, state))))
+  }
+  return result
+}
 
 /**
  * Return the randomnized importance score of a node, given the network state.
@@ -107,8 +141,8 @@ export const importance = (p: PublicKey, state: State): BN =>
  * @param state State of the network
  * @returns the randmonized importance score
  */
-export const randomWeightedImportance = (p: PublicKey, state: State): BN => {
-  const randomComponent = 1 + Math.random() * CT_PATH_RANDOMNESS
+export function randomWeightedImportance(p: PublicKey, state: State): BN {
+  const randomComponent = 1 + randomFloat() * CT_PATH_RANDOMNESS
   return importance(p, state).muln(randomComponent)
 }
 
@@ -119,18 +153,24 @@ export const randomWeightedImportance = (p: PublicKey, state: State): BN => {
  * @param dest Public key of the `destination` of the channel
  * @returns ChannelEntry between `source` and `destination`, undefined otherwise.
  */
-export const findChannel = (src: PublicKey, dest: PublicKey, state: State): ChannelEntry =>
-  Object.values(state.channels)
-    .map((c: ChannelData): ChannelEntry => c.channel)
-    .find((c: ChannelEntry) => c.source.eq(src) && c.destination.eq(dest))
+export function findChannel(src: PublicKey, dest: PublicKey, state: State): ChannelEntry | null {
+  for (const channelId in state.channels) {
+    const channel = state.channels[channelId].channel
+    if (channel.source.eq(src) && channel.destination.eq(dest)) {
+      return channel
+    }
+  }
+  return null
+}
 
 /*
  * Find the timestamp at which a CT channel is opened.
+ * Returns current time if channel does not exist.
  * @param dest Public key of the `destination` of the channel
  * @param state State of the network
  */
-export const findCtChannelOpenTime = (dest: PublicKey, state: State): number => {
-  const ctChannel = state.ctChannels.find((ctChannel) => ctChannel.destination === dest)
+export function findCtChannelOpenTime(dest: PublicKey, state: State): number {
+  const ctChannel = state.ctChannels.find((ctChannel) => ctChannel.destination.eq(dest))
   return !ctChannel ? Date.now() : ctChannel.openFrom ?? Date.now()
 }
 
@@ -148,8 +188,6 @@ export const sendCTMessage = async (
   sendMessage: (message: Uint8Array, path: PublicKey[]) => Promise<void>,
   data: PersistedState
 ): Promise<boolean> => {
-  // get the randomized weighted importance score of the destination of a given channel.
-  const weight = async (edge: ChannelEntry): Promise<BN> => randomWeightedImportance(edge.destination, data.get())
   let path: PublicKey[]
 
   // build CT message,
@@ -163,7 +201,8 @@ export const sendCTMessage = async (
       CT_INTERMEDIATE_HOPS - 1, // As us to start is first intermediate
       (_p: PublicKey): number => 1, // TODO: network quality?
       (p: PublicKey) => Promise.resolve(data.findChannelsFrom(p)),
-      weight
+      // get the randomized weighted importance score of the destination of a given channel.
+      (edge: ChannelEntry): Promise<BN> => Promise.resolve(randomWeightedImportance(edge.destination, data.get()))
     )
 
     // update counters in the state

--- a/scripts/run-integration-tests-source.sh
+++ b/scripts/run-integration-tests-source.sh
@@ -217,6 +217,10 @@ function setup_ct_node() {
   fi
   log "Additional args: \"${additional_args}\""
 
+
+  HOPR_CTD_HEARTBEAT_INTERVAL=2500 \
+  HOPR_CTD_HEARTBEAT_THRESHOLD=2500 \
+  HOPR_CTD_HEARTBEAT_VARIANCE=1000 \
   DEBUG="hopr*" NODE_ENV=development node packages/cover-traffic-daemon/lib/index.js \
     --privateKey "${private_key}" \
     --dbFile "${ct_db_file}" \


### PR DESCRIPTION
Cherry-pick from #3836

# Changes

- refactor channel topology StrategyTick API to use stronger typing
- reimplement ctd util function with enhanced complexity and stronger typing
- network peers: reimplement `getAll` + `getAllDenied` to use (synchronous) iterators instead of cloning arrays
- pass Heartbeat environment flags to `ctd` (as already done for `core`)
- use cryptographically sound entropy functions within `core` and `ctd`
- reimplement `ctd` state serialization and deserialization to use *no EC SQRT* operations

# Out of scope

- fix e2e tests, see #3836 
- fix Rust crate test build issue