### PR TITLE
Fix NPM package versioning

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -84,7 +84,7 @@ jobs:
       - name: '[SMART-CONTRACTS] Commit & push changes'
         if: ${{ !env.ACT }}
         run: |
-          yarn lint:fix
+          make lint-fix
           ./scripts/commit-and-push-all-changes.sh
         env:
           HOPR_GIT_MSG: 'chore(release): update smart contract deployments'

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -47,7 +47,7 @@ jobs:
         run: ./scripts/build-rest-api-spec.sh
 
       - name: Format newly created files
-        run: yarn lint:fix
+        run: make lint-fix
 
       - name: Move OpenAPI spec file into documentation directory
         run: |

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,7 +28,9 @@ jobs:
           cache: yarn
 
       - name: Run linter
-        run: yarn && yarn lint:fix
+        run: |
+          make deps
+          make lint-fix
 
       - name: Commit and push changes
         run: ./scripts/commit-and-push-all-changes.sh

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,14 @@ else
 	yarn workspaces foreach -pv run test
 endif
 
+.PHONY: lint-check
+lint-check: ## run linter in check mode
+	npx prettier --check .
+
+.PHONY: lint-check
+lint-fix: ## run linter in fix mode
+	npx prettier --write .
+
 .PHONY: help
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/package.json
+++ b/package.json
@@ -18,8 +18,6 @@
     "build:hoprd": "yarn workspace @hoprnet/hoprd run build",
     "build:utils": "yarn workspace @hoprnet/hopr-utils run build",
     "build:chain": "yarn workspace @hoprnet/hopr-core-ethereum run build",
-    "lint": "prettier --check .",
-    "lint:fix": "prettier --write .",
     "run:network": "yarn workspace @hoprnet/hopr-ethereum run network",
     "run:ctd": "yarn workspace @hoprnet/hopr-cover-traffic-daemon run start",
     "run:hoprd": "yarn workspace @hoprnet/hoprd run start --password='d3f4uL+!' --identity=/tmp/default-identity --testNoAuthentication",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hopr-connect",
-  "version": "1.89.0-next.21",
+  "version": "1.89.0-next.22",
   "description": "A libp2p-complaint transport module that handles NAT traversal by using WebRTC",
   "repository": "https://github.com/hoprnet/hopr-connect.git",
   "homepage": "https://github.com/hoprnet/hopr-connect",

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hopr-connect",
-  "version": "1.89.0-next.22",
+  "version": "1.89.0-next.23",
   "description": "A libp2p-complaint transport module that handles NAT traversal by using WebRTC",
   "repository": "https://github.com/hoprnet/hopr-connect.git",
   "homepage": "https://github.com/hoprnet/hopr-connect",

--- a/packages/core-ethereum/package.json
+++ b/packages/core-ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hopr-core-ethereum",
-  "version": "1.89.0-next.21",
+  "version": "1.89.0-next.22",
   "description": "",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",

--- a/packages/core-ethereum/package.json
+++ b/packages/core-ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hopr-core-ethereum",
-  "version": "1.89.0-next.22",
+  "version": "1.89.0-next.23",
   "description": "",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",

--- a/packages/core-ethereum/package.json
+++ b/packages/core-ethereum/package.json
@@ -62,6 +62,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "stableVersion": "1.76.0-next.31"
+  }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hopr-core",
-  "version": "1.89.0-next.21",
+  "version": "1.89.0-next.22",
   "description": "Privacy-preserving messaging protocol with incentivations for relay operators",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hopr-core",
-  "version": "1.89.0-next.22",
+  "version": "1.89.0-next.23",
   "description": "Privacy-preserving messaging protocol with incentivations for relay operators",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -78,6 +78,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "stableVersion": "1.76.0-next.31"
+  }
 }

--- a/packages/core/protocol-config.json
+++ b/packages/core/protocol-config.json
@@ -47,10 +47,10 @@
       "minted_token_receiver_address": "0x8C9877a1279192448cAbeC9e8C4697b159cF645e",
       "stake_contract_address": "0x208Bd0F5Bd13357Ba077dd4888a76D40d947F9f4",
       "network_registry_contract_address": "0x69C201Df0b4c54f600d49Dde1953F46b89EBa23B",
-      "tags": ["development"],
       "xhopr_contract_address": "0x552aBf0EBCd6B6162519132A831C181f87e46874",
       "boost_contract_address": "0x20d7182F9f16E0eda619bBe1Fe8732169B90fab5",
-      "network_registry_proxy_contract_address": "0x913bF9D5bd22eD468b628c1212EAF3a06C8fF3b6"
+      "network_registry_proxy_contract_address": "0x913bF9D5bd22eD468b628c1212EAF3a06C8fF3b6",
+      "tags": ["development"]
     },
     "tuttlingen": {
       "network_id": "xdai",

--- a/packages/cover-traffic-daemon/package.json
+++ b/packages/cover-traffic-daemon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hoprnet/hopr-cover-traffic-daemon",
   "description": "Generate chaffing traffic",
-  "version": "1.89.0-next.21",
+  "version": "1.89.0-next.22",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",
   "license": "GPL-3.0",

--- a/packages/cover-traffic-daemon/package.json
+++ b/packages/cover-traffic-daemon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hoprnet/hopr-cover-traffic-daemon",
   "description": "Generate chaffing traffic",
-  "version": "1.89.0-next.22",
+  "version": "1.89.0-next.23",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",
   "license": "GPL-3.0",

--- a/packages/ethereum/deploy/02_HoprToken.ts
+++ b/packages/ethereum/deploy/02_HoprToken.ts
@@ -4,21 +4,25 @@ import type { HoprToken } from '../src/types'
 
 const PROTOCOL_CONFIG = require('../../core/protocol-config.json')
 
-const main: DeployFunction = async function ({
-  ethers,
-  deployments,
-  network,
-  getNamedAccounts,
-  environment
-}: HardhatRuntimeEnvironment) {
+const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { ethers, deployments, getNamedAccounts, network, environment } = hre
   const environmentConfig = PROTOCOL_CONFIG.environments[environment]
   const mintedTokenReceiver = environmentConfig['minted_token_receiver_address']
 
   const deployer = await getNamedAccounts().then((o) => ethers.getSigner(o.deployer))
 
+  const deployOptions = {
+    log: true
+  }
+
+  // don't wait when using local hardhat because its using auto-mine
+  if (!environment.match('hardhat')) {
+    deployOptions['waitConfirmations'] = 2
+  }
+
   const tokenContract = await deployments.deploy('HoprToken', {
     from: deployer.address,
-    log: true
+    ...deployOptions
   })
 
   if (network.tags.testing || network.tags.development) {
@@ -28,16 +32,26 @@ const main: DeployFunction = async function ({
 
     if (!isDeployerMinter) {
       console.log('Granting MINTER role to', deployer.address)
-      await hoprToken.grantRole(MINTER_ROLE, deployer.address)
+      const grantTx = await hoprToken.grantRole(MINTER_ROLE, deployer.address)
+
+      // don't wait when using local hardhat because its using auto-mine
+      if (!environment.match('hardhat')) {
+        await ethers.provider.waitForTransaction(grantTx.hash, 2)
+      }
 
       if (mintedTokenReceiver) {
         console.log('Minting tokens to', mintedTokenReceiver)
-        await hoprToken.mint(
+        const mintTx = await hoprToken.mint(
           mintedTokenReceiver,
           ethers.utils.parseEther('130000000'),
           ethers.constants.HashZero,
           ethers.constants.HashZero
         )
+
+        // don't wait when using local hardhat because its using auto-mine
+        if (!environment.match('hardhat')) {
+          await ethers.provider.waitForTransaction(mintTx.hash, 2)
+        }
       }
     }
   }

--- a/packages/ethereum/deploy/03_HoprDistributor.ts
+++ b/packages/ethereum/deploy/03_HoprDistributor.ts
@@ -22,16 +22,20 @@ const maxMintAmounts: {
   production: ethers.utils.parseEther('100000000').toString()
 }
 
-const main: DeployFunction = async function ({
-  ethers,
-  deployments,
-  getNamedAccounts,
-  network
-}: HardhatRuntimeEnvironment) {
+const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
+  const { ethers, deployments, getNamedAccounts, network, environment } = hre
   const deployer = await getNamedAccounts().then((o) => ethers.getSigner(o.deployer))
   const deploymentType = Object.keys(network.tags).find((tag) => startTimes[tag])
 
   const hoprToken = await deployments.get('HoprToken')
+
+  const deployOptions = {
+    log: true
+  }
+  // don't wait when using local hardhat because its using auto-mine
+  if (!environment.match('hardhat')) {
+    deployOptions['waitConfirmations'] = 2
+  }
 
   await deployments.deploy('HoprDistributor', {
     from: deployer.address,
@@ -40,7 +44,7 @@ const main: DeployFunction = async function ({
       Math.floor(startTimes[deploymentType] ?? startTimes.testing / 1e3),
       maxMintAmounts[deploymentType] ?? maxMintAmounts.testing
     ],
-    log: true
+    ...deployOptions
   })
 }
 

--- a/packages/ethereum/deploy/04_HoprWrapper.ts
+++ b/packages/ethereum/deploy/04_HoprWrapper.ts
@@ -4,14 +4,22 @@ import type { DeployFunction } from 'hardhat-deploy/types'
 const XHOPR_ADDRESS = '0xD057604A14982FE8D88c5fC25Aac3267eA142a08'
 
 const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { ethers, deployments, getNamedAccounts } = hre
+  const { ethers, deployments, getNamedAccounts, environment } = hre
   const deployer = await getNamedAccounts().then((o) => ethers.getSigner(o.deployer))
   const hoprToken = await deployments.get('HoprToken')
+
+  const deployOptions = {
+    log: true
+  }
+  // don't wait when using local hardhat because its using auto-mine
+  if (!environment.match('hardhat')) {
+    deployOptions['waitConfirmations'] = 2
+  }
 
   await deployments.deploy('HoprWrapper', {
     from: deployer.address,
     args: [XHOPR_ADDRESS, hoprToken.address],
-    log: true
+    ...deployOptions
   })
 }
 

--- a/packages/ethereum/deploy/06_xHoprMock.ts
+++ b/packages/ethereum/deploy/06_xHoprMock.ts
@@ -5,20 +5,32 @@ import type { ERC677Mock } from '../src/types'
 const MINTED_AMOUNT = '5000000'
 
 const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { ethers, deployments, getNamedAccounts } = hre
+  const { ethers, deployments, getNamedAccounts, environment } = hre
   const { admin } = await getNamedAccounts()
   const deployer = await getNamedAccounts().then((o) => ethers.getSigner(o.deployer))
+
+  const deployOptions = {
+    log: true
+  }
+  // don't wait when using local hardhat because its using auto-mine
+  if (!environment.match('hardhat')) {
+    deployOptions['waitConfirmations'] = 2
+  }
 
   const xHoprContract = await deployments.deploy('xHoprMock', {
     contract: 'ERC677Mock',
     from: deployer.address,
-    log: true
+    ...deployOptions
   })
 
   // mint xHOPR to admin
   const xhoprToken = (await ethers.getContractFactory('ERC677Mock')).attach(xHoprContract.address) as ERC677Mock
   const mintTx = await xhoprToken.batchMintInternal([admin], ethers.utils.parseUnits(MINTED_AMOUNT, 'ether'))
-  await ethers.provider.waitForTransaction(mintTx.hash, 10)
+
+  // don't wait when using local hardhat because its using auto-mine
+  if (!environment.match('hardhat')) {
+    await ethers.provider.waitForTransaction(mintTx.hash, 2)
+  }
 
   console.log(`Admin minted ${MINTED_AMOUNT} xHOPR (mock) tokens`)
 }

--- a/packages/ethereum/deploy/07_HoprBoost.ts
+++ b/packages/ethereum/deploy/07_HoprBoost.ts
@@ -2,13 +2,21 @@ import { HardhatRuntimeEnvironment } from 'hardhat/types'
 import { DeployFunction } from 'hardhat-deploy/types'
 
 const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { ethers, deployments, getNamedAccounts } = hre
+  const { ethers, deployments, getNamedAccounts, environment } = hre
   const deployer = await getNamedAccounts().then((o) => ethers.getSigner(o.deployer))
+
+  const deployOptions = {
+    log: true
+  }
+  // don't wait when using local hardhat because its using auto-mine
+  if (!environment.match('hardhat')) {
+    deployOptions['waitConfirmations'] = 2
+  }
 
   await deployments.deploy('HoprBoost', {
     from: deployer.address,
     args: [deployer.address, ''],
-    log: true
+    ...deployOptions
   })
 }
 

--- a/packages/ethereum/package.json
+++ b/packages/ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hopr-ethereum",
-  "version": "1.89.0-next.21",
+  "version": "1.89.0-next.22",
   "description": "On-chain logic for hoprnet.org",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "license": "GPL-3.0",

--- a/packages/ethereum/package.json
+++ b/packages/ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hopr-ethereum",
-  "version": "1.89.0-next.22",
+  "version": "1.89.0-next.23",
   "description": "On-chain logic for hoprnet.org",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "license": "GPL-3.0",

--- a/packages/ethereum/package.json
+++ b/packages/ethereum/package.json
@@ -67,6 +67,5 @@
   },
   "engines": {
     "node": "16"
-  },
-  "stableVersion": "1.76.0-next.31"
+  }
 }

--- a/packages/hoprd/package.json
+++ b/packages/hoprd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hoprd",
-  "version": "1.89.0-next.21",
+  "version": "1.89.0-next.22",
   "description": "",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",

--- a/packages/hoprd/package.json
+++ b/packages/hoprd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hoprd",
-  "version": "1.89.0-next.22",
+  "version": "1.89.0-next.23",
   "description": "",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",

--- a/packages/hoprd/package.json
+++ b/packages/hoprd/package.json
@@ -87,6 +87,5 @@
   },
   "publishConfig": {
     "access": "public"
-  },
-  "stableVersion": "1.76.0-next.31"
+  }
 }

--- a/packages/real/package.json
+++ b/packages/real/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hopr-real",
-  "version": "1.89.0-next.21",
+  "version": "1.89.0-next.22",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",
   "license": "GPL-3.0-only",

--- a/packages/real/package.json
+++ b/packages/real/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hopr-real",
-  "version": "1.89.0-next.22",
+  "version": "1.89.0-next.23",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",
   "license": "GPL-3.0-only",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hoprnet/hopr-utils",
   "description": "HOPR-based utilities to process multiple data structures",
-  "version": "1.89.0-next.21",
+  "version": "1.89.0-next.22",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",
   "license": "GPL-3.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hoprnet/hopr-utils",
   "description": "HOPR-based utilities to process multiple data structures",
-  "version": "1.89.0-next.22",
+  "version": "1.89.0-next.23",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",
   "license": "GPL-3.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -70,6 +70,5 @@
     ],
     "spec": "src/**/*.spec.ts",
     "require": "ts-node/register"
-  },
-  "stableVersion": "1.76.0-next.30"
+  }
 }

--- a/scripts/build_lockfiles.sh
+++ b/scripts/build_lockfiles.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # prevent sourcing of this script, only allow execution
+# shellcheck disable=SC2091
 $(return >/dev/null 2>&1)
 test "$?" -eq "0" && { echo "This script should only be executed." >&2; exit 1; }
 
@@ -9,7 +10,9 @@ set -Eeuo pipefail
 
 declare mydir
 mydir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
-
+# shellcheck disable=SC2034
+declare HOPR_LOG_ID="build-lockfiles"
+# shellcheck disable=SC1091
 source "${mydir}/utils.sh"
 
 usage() {
@@ -31,7 +34,8 @@ fi
 
 declare package_name="${1}"
 
-declare build_dir="$(find_tmp_dir)/hopr_lockfile_generation"
+declare build_dir
+build_dir="$(find_tmp_dir)/hopr_lockfile_generation"
 
 log "Creating temporary build directory ${build_dir} (will be removed)"
 mkdir "${build_dir}"
@@ -50,7 +54,8 @@ trap restore SIGINT SIGTERM ERR
 
 log "Install workspace package in temporary directory"
 
-declare package_npm_name=$(jq -r '.name' "${package_dir}/package.json")
+declare package_npm_name
+package_npm_name=$(jq -r '.name' "${package_dir}/package.json")
 
 # Resolve workspace links by packing a NPM package
 yarn workspace "${package_npm_name}" pack
@@ -62,7 +67,7 @@ tar -xf "${package_dir}/package.tgz"
 
 # Turn yarn `resolutions` from workspace root into npm `overrides` for selected package
 jq -s '.[1] * (.[0].resolutions | { "overrides": . ,"resolutions": . })' "${mydir}/../package.json" "${build_dir}/package/package.json" > "${build_dir}/package.json"
- 
+
 # # NPM package is now useless
 rm "${package_dir}/package.tgz"
 rm -R "${build_dir}/package"

--- a/scripts/publish-version.sh
+++ b/scripts/publish-version.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 # prevent sourcing of this script, only allow execution
+# shellcheck disable=SC2091
 $(return >/dev/null 2>&1)
 test "$?" -eq "0" && { echo "This script should only be executed." >&2; exit 1; }
 
@@ -10,7 +11,9 @@ set -Eeuo pipefail
 # set log id and use shared log function for readable logs
 declare mydir
 mydir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+# shellcheck disable=SC2034
 declare HOPR_LOG_ID="publish-version"
+# shellcheck disable=SC1091
 source "${mydir}/utils.sh"
 
 usage() {
@@ -39,7 +42,7 @@ cleanup() {
 }
 
 # return early with help info when requested
-([ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]) && { usage; exit 0; }
+{ [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; } && { usage; exit 0; }
 
 # verify and set parameters
 declare branch version_type
@@ -54,7 +57,7 @@ if [ ! "${version_type}" = "patch" ] &&
 fi
 
 # define packages
-declare -A versioned_packages=(utils connect ethereum core-ethereum core real hoprd cover-traffic-daemon)
+declare -a versioned_packages=( utils connect ethereum core-ethereum core real hoprd cover-traffic-daemon )
 
 # ensure local copy is up-to-date with origin
 branch=$(git rev-parse --abbrev-ref HEAD)
@@ -67,7 +70,7 @@ mydir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 make -C "${mydir}/.." deps build
 
 declare current_version
-current_version=$(${mydir}/get-package-version.sh)
+current_version="$("${mydir}/get-package-version.sh")"
 if [[ "${version_type}" = "prerelease" ]]; then
   # turn prerelease into preminor if the current version is not a prerelease
   # already, thus update from a patch version to a new minor prerelease
@@ -78,18 +81,20 @@ fi
 
 log "get default environment id"
 
-declare environment_id="$(${mydir}/get-default-environment.sh)"
+declare environment_id
+environment_id="$("${mydir}/get-default-environment.sh")"
 
 log "using version template ${current_version} + ${version_type}"
 declare new_version
-new_version=$(npx semver --preid next -i ${version_type} ${current_version})
+new_version=$(npx semver --preid next -i "${version_type}" "${current_version}")
 log "creating new version ${new_version}"
 
 # create new version in each package
-for p in ${versioned_packages}; do
-  cd packages/${p} && \
-    jq ".version = \"${new_version}\"" < package.json > package.json.new && \
-    mv package.json.new package.json
+for p in "${versioned_packages[@]}"; do
+  cd "${mydir}/../packages/${p}"
+  jq ".version = \"${new_version}\"" package.json > package.json.new
+  mv package.json.new package.json
+  cd "${mydir}/.."
 done
 
 # commit changes and create Git tag
@@ -100,7 +105,7 @@ git commit -m "chore(release): publish ${new_version}"
 git pull origin "${branch}" --rebase --tags
 
 # now tag and proceed
-git tag v${new_version}
+git tag "v${new_version}"
 
 # only make remote changes if running in CI
 if [ "${CI:-}" = "true" ] && [ -z "${ACT:-}" ]; then
@@ -120,12 +125,12 @@ if [ "${CI:-}" = "true" ] && [ -z "${ACT:-}" ]; then
     --exclude @hoprnet/hoprd --exclude @hoprnet/hopr-cover-traffic-daemon \
     npm publish --access public
 
-  ${mydir}/wait-for-npm-package.sh utils
-  ${mydir}/wait-for-npm-package.sh connect
-  ${mydir}/wait-for-npm-package.sh ethereum
-  ${mydir}/wait-for-npm-package.sh core-ethereum
-  ${mydir}/wait-for-npm-package.sh core
-  ${mydir}/wait-for-npm-package.sh real
+  "${mydir}/wait-for-npm-package.sh" utils
+  "${mydir}/wait-for-npm-package.sh" connect
+  "${mydir}/wait-for-npm-package.sh" ethereum
+  "${mydir}/wait-for-npm-package.sh" core-ethereum
+  "${mydir}/wait-for-npm-package.sh" core
+  "${mydir}/wait-for-npm-package.sh" real
 
   trap cleanup SIGINT SIGTERM ERR
 
@@ -136,8 +141,8 @@ if [ "${CI:-}" = "true" ] && [ -z "${ACT:-}" ]; then
 
   # special treatment for end-of-chain packages
   # to create lockfiles with resolution overrides
-  ${mydir}/build_lockfiles.sh hoprd
-  ${mydir}/build_lockfiles.sh cover-traffic-daemon
+  "${mydir}/build_lockfiles.sh" hoprd
+  "${mydir}/build_lockfiles.sh" cover-traffic-daemon
 
   yarn workspace @hoprnet/hoprd npm publish --access public
   yarn workspace @hoprnet/hopr-cover-traffic-daemon npm publish --access public


### PR DESCRIPTION
Replaced use of `npm version` with directly using the underlying `semver` tool, which reduces reliance on `npm`.

Also improved waiting for transactions during hardhat deploy.

Refs #3833 

### Still broken

- lockfile generation fails in CI