### PR TITLE
Fix npm lockfile generation

### DIFF
--- a/.processes/tokens.md
+++ b/.processes/tokens.md
@@ -5,14 +5,14 @@ usage.
 
 ## Tokens
 
-| Address                                                    | Network          | Name         | Symbol | Description                                                           |
-| ---------------------------------------------------------- | ---------------- | ------------ | ------ | --------------------------------------------------------------------- |
-| [`0xf5581dfefd8fb0e4aec526be659cfab1f8c781da`][es_hopr]    | Ethereum Mainnet | Hopr         | Hopr   | Main token.                                                           |
-| [`0xD057604A14982FE8D88c5fC25Aac3267eA142a08`][bs_xhopr]   | Gnosis Chain     | Hopr         | xHopr  | Bridged token from Ethereum Mainnet.                                  |
-| [`0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1`][bs_wxhopr]  | Gnosis Chain     | Wrapped Hopr | wxHopr | ERC777 version of xHopr. E.g. used in staking rewards.                |
-| [`0xe8aD2ac347dA7549Aaca8F5B1c5Bf979d85bC78F`][bs_txhopr]  | Gnosis Chain     | Test Hopr    | txHopr | Used for integration testing by vbarious systems. Minted as required. |
+| Address                                                   | Network          | Name         | Symbol | Description                                                           |
+| --------------------------------------------------------- | ---------------- | ------------ | ------ | --------------------------------------------------------------------- |
+| [`0xf5581dfefd8fb0e4aec526be659cfab1f8c781da`][es_hopr]   | Ethereum Mainnet | Hopr         | Hopr   | Main token.                                                           |
+| [`0xD057604A14982FE8D88c5fC25Aac3267eA142a08`][bs_xhopr]  | Gnosis Chain     | Hopr         | xHopr  | Bridged token from Ethereum Mainnet.                                  |
+| [`0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1`][bs_wxhopr] | Gnosis Chain     | Wrapped Hopr | wxHopr | ERC777 version of xHopr. E.g. used in staking rewards.                |
+| [`0xe8aD2ac347dA7549Aaca8F5B1c5Bf979d85bC78F`][bs_txhopr] | Gnosis Chain     | Test Hopr    | txHopr | Used for integration testing by vbarious systems. Minted as required. |
 
-[es_hopr]:   https://etherscan.io/token/0xf5581dfefd8fb0e4aec526be659cfab1f8c781da
+[es_hopr]: https://etherscan.io/token/0xf5581dfefd8fb0e4aec526be659cfab1f8c781da
 [bs_txhopr]: https://blockscout.com/xdai/mainnet/address/0xe8aD2ac347dA7549Aaca8F5B1c5Bf979d85bC78F
 [bs_wxhopr]: https://blockscout.com/xdai/mainnet/address/0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1
-[bs_xhopr]:  https://blockscout.com/xdai/mainnet/address/0xD057604A14982FE8D88c5fC25Aac3267eA142a08
+[bs_xhopr]: https://blockscout.com/xdai/mainnet/address/0xD057604A14982FE8D88c5fC25Aac3267eA142a08

--- a/.processes/tokens.md
+++ b/.processes/tokens.md
@@ -5,11 +5,11 @@ usage.
 
 ## Tokens
 
-| Address                                                   | Network          | Name         | Symbol | Description                                                           |
-| --------------------------------------------------------- | ---------------- | ------------ | ------ | --------------------------------------------------------------------- |
-| [`0xf5581dfefd8fb0e4aec526be659cfab1f8c781da`][es_hopr]   | Ethereum Mainnet | Hopr         | Hopr   | Main token.                                                           |
-| [`0xD057604A14982FE8D88c5fC25Aac3267eA142a08`][bs_xhopr]  | Gnosis Chain     | Hopr         | xHopr  | Bridged token from Ethereum Mainnet.                                  |
-| [`0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1`][bs_wxhopr] | Gnosis Chain     | Wrapped Hopr | wxHopr | ERC777 version of xHopr. E.g. used in staking rewards.                |
+| Address                                                   | Network          | Name         | Symbol | Description                                                          |
+| --------------------------------------------------------- | ---------------- | ------------ | ------ | -------------------------------------------------------------------- |
+| [`0xf5581dfefd8fb0e4aec526be659cfab1f8c781da`][es_hopr]   | Ethereum Mainnet | Hopr         | Hopr   | Main token.                                                          |
+| [`0xD057604A14982FE8D88c5fC25Aac3267eA142a08`][bs_xhopr]  | Gnosis Chain     | Hopr         | xHopr  | Bridged token from Ethereum Mainnet.                                 |
+| [`0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1`][bs_wxhopr] | Gnosis Chain     | Wrapped Hopr | wxHopr | ERC777 version of xHopr. E.g. used in staking rewards.               |
 | [`0xe8aD2ac347dA7549Aaca8F5B1c5Bf979d85bC78F`][bs_txhopr] | Gnosis Chain     | Test Hopr    | txHopr | Used for integration testing by various systems. Minted as required. |
 
 [es_hopr]: https://etherscan.io/token/0xf5581dfefd8fb0e4aec526be659cfab1f8c781da

--- a/.processes/tokens.md
+++ b/.processes/tokens.md
@@ -10,7 +10,7 @@ usage.
 | [`0xf5581dfefd8fb0e4aec526be659cfab1f8c781da`][es_hopr]   | Ethereum Mainnet | Hopr         | Hopr   | Main token.                                                           |
 | [`0xD057604A14982FE8D88c5fC25Aac3267eA142a08`][bs_xhopr]  | Gnosis Chain     | Hopr         | xHopr  | Bridged token from Ethereum Mainnet.                                  |
 | [`0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1`][bs_wxhopr] | Gnosis Chain     | Wrapped Hopr | wxHopr | ERC777 version of xHopr. E.g. used in staking rewards.                |
-| [`0xe8aD2ac347dA7549Aaca8F5B1c5Bf979d85bC78F`][bs_txhopr] | Gnosis Chain     | Test Hopr    | txHopr | Used for integration testing by vbarious systems. Minted as required. |
+| [`0xe8aD2ac347dA7549Aaca8F5B1c5Bf979d85bC78F`][bs_txhopr] | Gnosis Chain     | Test Hopr    | txHopr | Used for integration testing by various systems. Minted as required. |
 
 [es_hopr]: https://etherscan.io/token/0xf5581dfefd8fb0e4aec526be659cfab1f8c781da
 [bs_txhopr]: https://blockscout.com/xdai/mainnet/address/0xe8aD2ac347dA7549Aaca8F5B1c5Bf979d85bC78F

--- a/.processes/tokens.md
+++ b/.processes/tokens.md
@@ -1,0 +1,18 @@
+# Tokens Process
+
+The purpose of this process is to document how the deployed tokens and their
+usage.
+
+## Tokens
+
+| Address                                                    | Network          | Name         | Symbol | Description                                                           |
+| ---------------------------------------------------------- | ---------------- | ------------ | ------ | --------------------------------------------------------------------- |
+| [`0xf5581dfefd8fb0e4aec526be659cfab1f8c781da`][es_hopr]    | Ethereum Mainnet | Hopr         | Hopr   | Main token.                                                           |
+| [`0xD057604A14982FE8D88c5fC25Aac3267eA142a08`][bs_xhopr]   | Gnosis Chain     | Hopr         | xHopr  | Bridged token from Ethereum Mainnet.                                  |
+| [`0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1`][bs_wxhopr]  | Gnosis Chain     | Wrapped Hopr | wxHopr | ERC777 version of xHopr. E.g. used in staking rewards.                |
+| [`0xe8aD2ac347dA7549Aaca8F5B1c5Bf979d85bC78F`][bs_txhopr]  | Gnosis Chain     | Test Hopr    | txHopr | Used for integration testing by vbarious systems. Minted as required. |
+
+[es_hopr]:   https://etherscan.io/token/0xf5581dfefd8fb0e4aec526be659cfab1f8c781da
+[bs_txhopr]: https://blockscout.com/xdai/mainnet/address/0xe8aD2ac347dA7549Aaca8F5B1c5Bf979d85bC78F
+[bs_wxhopr]: https://blockscout.com/xdai/mainnet/address/0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1
+[bs_xhopr]:  https://blockscout.com/xdai/mainnet/address/0xD057604A14982FE8D88c5fC25Aac3267eA142a08

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "yargs": "17.4.0"
   },
   "resolutions": {
-    "express-openapi": "https://github.com/hoprnet/open-api/raw/robertkiel/built-esm-support/packages/express-openapi/express-openapi-11.0.4.tgz",
     "openapi-framework": "https://github.com/hoprnet/open-api/raw/robertkiel/built-esm-support/packages/openapi-framework/openapi-framework-11.0.4.tgz",
     "@ethersproject/providers": "https://github.com/hoprnet/ethers-js-provider/archive/refs/tags/fixed-memory-leak.tar.gz",
     "@overnightjs/logger": "1.2.1",

--- a/packages/avado/releases.json
+++ b/packages/avado/releases.json
@@ -908,10 +908,10 @@
     }
   },
   "0.100.0": {
-    "hash": "/ipfs/QmPV4cvB94gUhCaVTkCb5jwEHX3guF7wJRxz9nKfnwfFLT",
+    "hash": "/ipfs/QmPseFdxs4QkDBctmRtLq7zvGxYbNyYLWXjPmKGWPi5Gk5",
     "type": "manifest",
     "uploadedTo": {
-      "http://80.208.229.228:5001": "Fri, 13 May 2022 11:38:17 GMT"
+      "http://80.208.229.228:5001": "Mon, 20 Jun 2022 09:37:39 GMT"
     }
   },
   "1.64.0": {

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hopr-connect",
-  "version": "1.89.0-next.24",
+  "version": "1.89.0-next.25",
   "description": "A libp2p-complaint transport module that handles NAT traversal by using WebRTC",
   "repository": "https://github.com/hoprnet/hopr-connect.git",
   "homepage": "https://github.com/hoprnet/hopr-connect",

--- a/packages/core-ethereum/package.json
+++ b/packages/core-ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hopr-core-ethereum",
-  "version": "1.89.0-next.24",
+  "version": "1.89.0-next.25",
   "description": "",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hopr-core",
-  "version": "1.89.0-next.24",
+  "version": "1.89.0-next.25",
   "description": "Privacy-preserving messaging protocol with incentivations for relay operators",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",

--- a/packages/cover-traffic-daemon/Dockerfile
+++ b/packages/cover-traffic-daemon/Dockerfile
@@ -1,7 +1,7 @@
 # Run hopr-cover-traffic-daemon within a single container using npm
 
-# use slim version of node on Debian buster for smaller image sizes
-FROM node:16-buster-slim@sha256:380112b3f3df96ae593b0b89f4c44e501e9ae0ec1580b270b50f8ac52688256e as build
+# use slim version of node on Debian for smaller image sizes
+FROM node:16-bullseye-slim@sha256:8265ac132f720998222008355e11535caf53d6bccecbb562a055605138975b4e as build
 
 # python is used by some nodejs dependencies as an installation requirement
 RUN apt-get update && \
@@ -28,8 +28,8 @@ ENV npm_config_build_from_source false
 # install hoprd as a local module
 RUN yarn add @hoprnet/hopr-cover-traffic-daemon@${PACKAGE_VERSION}
 
-# use slim version of node on Debian buster for smaller image sizes
-FROM node:16-buster-slim@sha256:380112b3f3df96ae593b0b89f4c44e501e9ae0ec1580b270b50f8ac52688256e as runtime
+# use slim version of node on Debian for smaller image sizes
+FROM node:16-bullseye-slim@sha256:8265ac132f720998222008355e11535caf53d6bccecbb562a055605138975b4e as runtime
 
 # we use tini as process 1 to catch signals properly, which is also built into
 # D<Plug>_ocker by default

--- a/packages/cover-traffic-daemon/package.json
+++ b/packages/cover-traffic-daemon/package.json
@@ -6,8 +6,10 @@
   "homepage": "https://hoprnet.org",
   "license": "GPL-3.0",
   "types": "lib/index.d.ts",
-  "main": "lib/main.js",
-  "bin": "lib/main.js",
+  "main": "lib/main.cjs",
+  "bin": {
+    "hopr-cover-traffic-daemon": "lib/main.cjs"
+  },
   "type": "module",
   "scripts": {
     "clean:wasm": "make -C crates clean",

--- a/packages/cover-traffic-daemon/package.json
+++ b/packages/cover-traffic-daemon/package.json
@@ -7,9 +7,7 @@
   "license": "GPL-3.0",
   "types": "lib/index.d.ts",
   "main": "lib/main.cjs",
-  "bin": {
-    "hopr-cover-traffic-daemon": "lib/main.cjs"
-  },
+  "bin": "lib/main.cjs",
   "type": "module",
   "scripts": {
     "clean:wasm": "make -C crates clean",

--- a/packages/cover-traffic-daemon/package.json
+++ b/packages/cover-traffic-daemon/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hoprnet/hopr-cover-traffic-daemon",
   "description": "Generate chaffing traffic",
-  "version": "1.89.0-next.24",
+  "version": "1.89.0-next.25",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",
   "license": "GPL-3.0",

--- a/packages/ethereum/package.json
+++ b/packages/ethereum/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hopr-ethereum",
-  "version": "1.89.0-next.24",
+  "version": "1.89.0-next.25",
   "description": "On-chain logic for hoprnet.org",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "license": "GPL-3.0",

--- a/packages/hoprd/Dockerfile
+++ b/packages/hoprd/Dockerfile
@@ -1,7 +1,7 @@
 # Run HOPRd  within a single container using npm
 
 # use slim version of node on Debian buster for smaller image sizes
-FROM node:16-buster-slim@sha256:380112b3f3df96ae593b0b89f4c44e501e9ae0ec1580b270b50f8ac52688256e as build
+FROM node:16-bullseye-slim@sha256:8265ac132f720998222008355e11535caf53d6bccecbb562a055605138975b4e as build
 
 # python is used by some nodejs dependencies as an installation requirement
 RUN apt-get update && \
@@ -30,7 +30,7 @@ ENV npm_config_build_from_source false
 RUN yarn add @hoprnet/hoprd@${PACKAGE_VERSION}
 
 # use slim version of node on Debian buster for smaller image sizes
-FROM node:16-buster-slim@sha256:380112b3f3df96ae593b0b89f4c44e501e9ae0ec1580b270b50f8ac52688256e as runtime
+FROM node:16-bullseye-slim@sha256:8265ac132f720998222008355e11535caf53d6bccecbb562a055605138975b4e as runtime
 
 # we use tini as process 1 to catch signals properly, which is also built into
 # D<Plug>_ocker by default

--- a/packages/hoprd/package.json
+++ b/packages/hoprd/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hoprd",
-  "version": "1.89.0-next.24",
+  "version": "1.89.0-next.25",
   "description": "",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",

--- a/packages/hoprd/package.json
+++ b/packages/hoprd/package.json
@@ -8,9 +8,7 @@
   "types": "lib/main.d.cts",
   "type": "module",
   "main": "lib/main.cjs",
-  "bin": {
-    "hoprd": "lib/main.cjs"
-  },
+  "bin": "lib/main.cjs",
   "files": [
     "lib",
     "npm-shrinkwrap.json",

--- a/packages/hoprd/package.json
+++ b/packages/hoprd/package.json
@@ -50,7 +50,7 @@
     "debug": "4.3.4",
     "dids": "2.4.3",
     "express": "4.17.3",
-    "express-openapi": "9.3.1",
+    "express-openapi": "https://github.com/hoprnet/open-api/raw/robertkiel/built-esm-support/packages/express-openapi/express-openapi-11.0.4.tgz",
     "jazzicon": "1.5.0",
     "js-cookie": "3.0.1",
     "key-did-provider-ed25519": "1.1.0",

--- a/packages/hoprd/package.json
+++ b/packages/hoprd/package.json
@@ -7,7 +7,10 @@
   "license": "LGPL-3.0-only",
   "types": "lib/main.d.cts",
   "type": "module",
-  "bin": "lib/main.cjs",
+  "main": "lib/main.cjs",
+  "bin": {
+    "hoprd": "lib/main.cjs"
+  },
   "files": [
     "lib",
     "npm-shrinkwrap.json",

--- a/packages/real/package.json
+++ b/packages/real/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hoprnet/hopr-real",
-  "version": "1.89.0-next.24",
+  "version": "1.89.0-next.25",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",
   "license": "GPL-3.0-only",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hoprnet/hopr-utils",
   "description": "HOPR-based utilities to process multiple data structures",
-  "version": "1.89.0-next.24",
+  "version": "1.89.0-next.25",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",
   "license": "GPL-3.0",

--- a/scripts/publish-version.sh
+++ b/scripts/publish-version.sh
@@ -141,8 +141,8 @@ if [ "${CI:-}" = "true" ] && [ -z "${ACT:-}" ]; then
 
   # special treatment for end-of-chain packages
   # to create lockfiles with resolution overrides
-  "${mydir}/build_lockfiles.sh" hoprd
-  "${mydir}/build_lockfiles.sh" cover-traffic-daemon
+  "${mydir}/build-lockfiles.sh" hoprd
+  "${mydir}/build-lockfiles.sh" cover-traffic-daemon
 
   yarn workspace @hoprnet/hoprd npm publish --access public
   yarn workspace @hoprnet/hopr-cover-traffic-daemon npm publish --access public

--- a/yarn.lock
+++ b/yarn.lock
@@ -3620,7 +3620,7 @@ __metadata:
     debug: 4.3.4
     dids: 2.4.3
     express: 4.17.3
-    express-openapi: 9.3.1
+    express-openapi: "https://github.com/hoprnet/open-api/raw/robertkiel/built-esm-support/packages/express-openapi/express-openapi-11.0.4.tgz"
     jazzicon: 1.5.0
     js-cookie: 3.0.1
     key-did-provider-ed25519: 1.1.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -3506,7 +3506,7 @@ __metadata:
     typedoc-plugin-markdown: 3.11.14
     yargs: 17.4.0
   bin:
-    hopr-cover-traffic-daemon: lib/main.js
+    hopr-cover-traffic-daemon: lib/main.cjs
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
This unblocks the npm package publishing process. The problem was caused
by using a resolution to override a direct dependency.

Refs #3833 