### PR TITLE
Fix accidently ignore Dockerfiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -32,7 +32,6 @@ logs.txt
 **/*.tsbuildinfo
 
 .dockerignore
-Dockerfile
 .git
 .gitignore
 


### PR DESCRIPTION
This prevents GCP Cloud Build to build Docker images because the
Dockerfiles are missing.