### PR TITLE
Remove wasm-opt JS wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "prettier": "2.7.1",
     "ts-node": "10.8.1",
     "typescript": "4.7.4",
-    "wasm-opt": "1.3.0",
     "wasm-pack": "0.10.3",
     "yargs": "17.5.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -14328,7 +14328,6 @@ __metadata:
     prettier: 2.7.1
     ts-node: 10.8.1
     typescript: 4.7.4
-    wasm-opt: 1.3.0
     wasm-pack: 0.10.3
     yargs: 17.5.1
   languageName: unknown
@@ -26434,18 +26433,6 @@ __metadata:
   bin:
     wait-on: bin/wait-on
   checksum: e4d62aa4145d99fe34747ccf7506d4b4d6e60dd677c0eb18a51e316d38116ace2d194e4b22a9eb7b767b0282f39878ddcc4ae9440dcb0c005c9150668747cf5b
-  languageName: node
-  linkType: hard
-
-"wasm-opt@npm:1.3.0":
-  version: 1.3.0
-  resolution: "wasm-opt@npm:1.3.0"
-  dependencies:
-    node-fetch: ^2.6.7
-    tar: ^6.1.11
-  bin:
-    wasm-opt: bin/wasm-opt.js
-  checksum: 4164979bc8884484198e402b464832076ca94e422c83ad41664f7d90bde0013ea13dbb1fad0447067883f8ecda1d6f6924b55459e12693cc72e19ed13331edda
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This wrapper exposes the library as a JS executable. However,
installation is broken on some platforms. Thus, since we don't use it
yet, its better to remove it and later use native installation
mthods instead of yarn/npm.