### PR TITLE
Selected provider based on environment

### DIFF
--- a/packages/ethereum/tasks/register.ts
+++ b/packages/ethereum/tasks/register.ts
@@ -1,5 +1,5 @@
 import type { HardhatRuntimeEnvironment, RunSuperFunction } from 'hardhat/types'
-import { utils } from 'ethers'
+import { Signer, utils } from 'ethers'
 import type {
   HoprNetworkRegistry,
   HoprDummyProxyForNetworkRegistry,
@@ -53,7 +53,18 @@ async function main(
     process.exit(1)
   }
 
-  const signer = ethers.provider.getSigner()
+  let provider
+  let signer: Signer
+  if (environment == 'hardhat-localhost') {
+    // we use a custom ethers provider here instead of the ethers object from the
+    // hre which is managed by hardhat-ethers, because that one seems to
+    // run its own in-memory hardhat instance, which is undesirable
+    provider = new ethers.providers.JsonRpcProvider()
+    signer = provider.getSigner()
+  } else {
+    provider = ethers.provider
+    signer = ethers.provider.getSigner()
+  }
 
   const hoprProxy = !network.tags.staging
     ? ((await ethers.getContractFactory('HoprDummyProxyForNetworkRegistry'))

--- a/packages/ethereum/tasks/register.ts
+++ b/packages/ethereum/tasks/register.ts
@@ -1,5 +1,5 @@
 import type { HardhatRuntimeEnvironment, RunSuperFunction } from 'hardhat/types'
-import { Signer, utils } from 'ethers'
+import { utils } from 'ethers'
 import type {
   HoprNetworkRegistry,
   HoprDummyProxyForNetworkRegistry,
@@ -54,17 +54,16 @@ async function main(
   }
 
   let provider
-  let signer: Signer
   if (environment == 'hardhat-localhost') {
     // we use a custom ethers provider here instead of the ethers object from the
     // hre which is managed by hardhat-ethers, because that one seems to
     // run its own in-memory hardhat instance, which is undesirable
     provider = new ethers.providers.JsonRpcProvider()
-    signer = provider.getSigner()
   } else {
     provider = ethers.provider
-    signer = ethers.provider.getSigner()
   }
+
+  const signer = provider.getSigner()
 
   const hoprProxy = !network.tags.staging
     ? ((await ethers.getContractFactory('HoprDummyProxyForNetworkRegistry'))

--- a/packages/ethereum/tasks/selfRegister.ts
+++ b/packages/ethereum/tasks/selfRegister.ts
@@ -18,16 +18,26 @@ export type SelfRegisterOpts =
  */
 async function main(
   opts: SelfRegisterOpts,
-  { ethers, deployments }: HardhatRuntimeEnvironment,
+  { ethers, deployments, environment }: HardhatRuntimeEnvironment,
   _runSuper: RunSuperFunction<any>
 ): Promise<void> {
   const hoprNetworkRegistryAddress = (await deployments.get('HoprNetworkRegistry')).address
 
+  let provider
+  if (environment == 'hardhat-localhost') {
+    // we use a custom ethers provider here instead of the ethers object from the
+    // hre which is managed by hardhat-ethers, because that one seems to
+    // run its own in-memory hardhat instance, which is undesirable
+    provider = new ethers.providers.JsonRpcProvider()
+  } else {
+    provider = ethers.provider
+  }
+
   let signer: Signer
   if (!opts.privatekey) {
-    signer = ethers.provider.getSigner()
+    signer = provider.getSigner()
   } else {
-    signer = new Wallet(opts.privatekey, ethers.provider)
+    signer = new Wallet(opts.privatekey, provider)
   }
   const signerAddress = await signer.getAddress()
 

--- a/packages/ethereum/tasks/stake.ts
+++ b/packages/ethereum/tasks/stake.ts
@@ -143,12 +143,22 @@ async function main(opts: StakeOpts, hre: HardhatRuntimeEnvironment, _runSuper: 
     process.exit(1)
   }
 
+  let provider
+  if (environment == 'hardhat-localhost') {
+    // we use a custom ethers provider here instead of the ethers object from the
+    // hre which is managed by hardhat-ethers, because that one seems to
+    // run its own in-memory hardhat instance, which is undesirable
+    provider = new ethers.providers.JsonRpcProvider()
+  } else {
+    provider = ethers.provider
+  }
+
   // get the provider and signer
   let signer: Signer
   if (!opts.privatekey) {
-    signer = ethers.provider.getSigner()
+    signer = provider.getSigner()
   } else {
-    signer = new Wallet(opts.privatekey, ethers.provider)
+    signer = new Wallet(opts.privatekey, provider)
   }
   const signerAddress = await signer.getAddress()
   console.log('Signer Address', signerAddress)

--- a/packages/ethereum/test/HoprNetworkRegistry.test.ts
+++ b/packages/ethereum/test/HoprNetworkRegistry.test.ts
@@ -80,8 +80,7 @@ describe('HoprNetworkRegistry', () => {
       ;({ owner, participants, participantAddresses, hoprNetworkRegistry } = await useFixtures())
     })
     it('is enabled globally', async () => {
-      expect(await hoprNetworkRegistry.enabled()).to.be
-      .true
+      expect(await hoprNetworkRegistry.enabled()).to.be.true
     })
     it('owner to update the registry', async () => {
       // const {deployer, owner, participants, ownerAddress, participantAddresses, stakeV2Fake, hoprNetworkRegistry } = await useFixtures()

--- a/packages/ethereum/test/HoprNetworkRegistry.test.ts
+++ b/packages/ethereum/test/HoprNetworkRegistry.test.ts
@@ -79,6 +79,10 @@ describe('HoprNetworkRegistry', () => {
     beforeEach(async () => {
       ;({ owner, participants, participantAddresses, hoprNetworkRegistry } = await useFixtures())
     })
+    it('is enabled globally', async () => {
+      expect(await hoprNetworkRegistry.enabled()).to.be
+      .true
+    })
     it('owner to update the registry', async () => {
       // const {deployer, owner, participants, ownerAddress, participantAddresses, stakeV2Fake, hoprNetworkRegistry } = await useFixtures()
       await expect(hoprNetworkRegistry.connect(owner).updateRequirementImplementation(constants.AddressZero))


### PR DESCRIPTION
Refs #3899

`ethers.provider` cannot access hardhat-instance. Therefore, all the deployed contracts are not available.