### PR TITLE
Install yarn using Node.js corepack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ all: help
 
 .PHONY: deps
 deps: ## install dependencies
+	corepack enable
 	yarn
 	command -v rustup && rustup update || echo "No rustup installed, ignoring"
 


### PR DESCRIPTION
According to the default installation docs from `yarn`, it should be installed using `corepack`