### PR TITLE
`connect` bugfix

### DIFF
--- a/packages/connect/src/base/entry.spec.ts
+++ b/packages/connect/src/base/entry.spec.ts
@@ -10,7 +10,6 @@ import type { PeerId } from '@libp2p/interface-peer-id'
 import type { DialOptions } from '@libp2p/interface-transport'
 import { Multiaddr } from '@multiformats/multiaddr'
 import type { Connection } from '@libp2p/interface-connection'
-import type { ConnectionManager } from '@libp2p/interface-connection-manager'
 import type { Components } from '@libp2p/interfaces/components'
 import type { AbortOptions } from '@libp2p/interfaces'
 
@@ -48,11 +47,18 @@ function createFakeComponents(peerId: PeerId) {
       getConnections(_peer: PeerId | undefined, _options?: AbortOptions): Connection[] {
         return []
       }
-    } as ConnectionManager as Components['connectionManager'])
+    } as Components['connectionManager'])
+
+  const getUpgrader = () =>
+    ({
+      upgradeInbound: (x: any) => x,
+      upgradeOutbound: (x: any) => x
+    } as Components['upgrader'])
 
   return {
     getPeerId,
-    getConnectionManager
+    getConnectionManager,
+    getUpgrader
   } as Components
 }
 

--- a/packages/connect/src/base/entry.ts
+++ b/packages/connect/src/base/entry.ts
@@ -492,7 +492,8 @@ export class EntryNodes extends EventEmitter implements Initializable, Startable
     try {
       conn = await this.dialDirectly(destinationAddress, {
         signal: abort.signal,
-        upgrader: undefined as any,
+        // libp2p interface type clash
+        upgrader: this.getComponents().getUpgrader() as any,
         onDisconnect
       })
     } catch (err: any) {

--- a/packages/connect/src/base/tcp.spec.ts
+++ b/packages/connect/src/base/tcp.spec.ts
@@ -175,7 +175,7 @@ describe('test TCP connection', function () {
   })
 })
 
-describe.only('test TCP connection - socket errors', function () {
+describe('test TCP connection - socket errors', function () {
   it('throw on write attempts', async function () {
     const socket = new Writable()
 

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -47,8 +47,8 @@ class HoprConnect implements Transport, Initializable, Startable {
   private options: HoprConnectOptions
   private testingOptions: HoprConnectTestingOptions
 
-  private components: Components | undefined
-  private connectComponents: ConnectComponents | undefined
+  components: Components | undefined
+  connectComponents: ConnectComponents | undefined
 
   constructor(opts: HoprConnectConfig) {
     this.options = opts.config ?? {}
@@ -240,7 +240,7 @@ class HoprConnect implements Transport, Initializable, Startable {
     let conn: Connection
 
     try {
-      conn = await this.getComponents().getUpgrader().upgradeOutbound(maConn)
+      conn = await options.upgrader.upgradeOutbound(maConn)
       log(`Successfully established relayed connection to ${destination.toString()}`)
     } catch (err) {
       error(err)
@@ -269,7 +269,7 @@ class HoprConnect implements Transport, Initializable, Startable {
       `Establishing a direct connection to ${maConn.remoteAddr.toString()} was successful. Continuing with the handshake.`
     )
 
-    const conn = await this.getComponents().getUpgrader().upgradeOutbound(maConn)
+    const conn = await options.upgrader.upgradeOutbound(maConn)
 
     // Assign various connection properties once we're sure that public keys match,
     // i.e. dialed node == desired destination

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -47,8 +47,8 @@ class HoprConnect implements Transport, Initializable, Startable {
   private options: HoprConnectOptions
   private testingOptions: HoprConnectTestingOptions
 
-  components: Components | undefined
-  connectComponents: ConnectComponents | undefined
+  private components: Components | undefined
+  private connectComponents: ConnectComponents | undefined
 
   constructor(opts: HoprConnectConfig) {
     this.options = opts.config ?? {}
@@ -240,7 +240,7 @@ class HoprConnect implements Transport, Initializable, Startable {
     let conn: Connection
 
     try {
-      conn = await options.upgrader.upgradeOutbound(maConn)
+      conn = await this.getComponents().getUpgrader().upgradeOutbound(maConn)
       log(`Successfully established relayed connection to ${destination.toString()}`)
     } catch (err) {
       error(err)
@@ -269,7 +269,7 @@ class HoprConnect implements Transport, Initializable, Startable {
       `Establishing a direct connection to ${maConn.remoteAddr.toString()} was successful. Continuing with the handshake.`
     )
 
-    const conn = await options.upgrader.upgradeOutbound(maConn)
+    const conn = await this.getComponents().getUpgrader().upgradeOutbound(maConn)
 
     // Assign various connection properties once we're sure that public keys match,
     // i.e. dialed node == desired destination

--- a/packages/connect/src/relay/connection.ts
+++ b/packages/connect/src/relay/connection.ts
@@ -267,7 +267,7 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
       type: ConnectionEventTypes.SINK_SOURCE_ATTACHED,
       value: async function* (this: RelayConnection) {
         try {
-          yield* toU8aStream(source)
+          yield* toU8aStream(source) as StreamSourceAsync
           deferred.resolve()
         } catch (err: any) {
           this.queueStatusMessage(Uint8Array.of(RelayPrefix.CONNECTION_STATUS, ConnectionStatusMessages.STOP))

--- a/packages/connect/src/relay/index.ts
+++ b/packages/connect/src/relay/index.ts
@@ -199,7 +199,8 @@ class Relay implements Initializable, ConnectInitializable, Startable {
   ): Promise<MultiaddrConnection | undefined> {
     const baseConnection = await this.dialNodeDirectly(relay, RELAY_PROTCOL(this.options.environment), {
       signal: options?.signal,
-      upgrader: undefined as any
+      // libp2p interface type clash
+      upgrader: this.getComponents().getUpgrader() as any
     }).catch(error)
 
     if (baseConnection == undefined) {
@@ -252,7 +253,8 @@ class Relay implements Initializable, ConnectInitializable, Startable {
     if (!this.testingOptions.__noWebRTCUpgrade) {
       return new WebRTCConnection(conn, {
         __noWebRTCUpgrade: this.testingOptions.__noWebRTCUpgrade,
-        upgrader: undefined as any,
+        // libp2p interface type clash
+        upgrader: this.getComponents().getUpgrader() as any,
         ...opts
       })
     } else {
@@ -273,7 +275,8 @@ class Relay implements Initializable, ConnectInitializable, Startable {
 
     if (!this.testingOptions.__noWebRTCUpgrade) {
       return new WebRTCConnection(conn, this.testingOptions, {
-        upgrader: undefined as any
+        // libp2p interface type clash
+        upgrader: this.getComponents().getUpgrader() as any
       })
     } else {
       return conn
@@ -397,7 +400,8 @@ class Relay implements Initializable, ConnectInitializable, Startable {
           .getUpgrader()
           .upgradeInbound(
             new WebRTCConnection(relayConn, this.testingOptions, {
-              upgrader: undefined as any
+              // libp2p interface type clash
+              upgrader: this.getComponents().getUpgrader() as any
             })
           )
       } else {


### PR DESCRIPTION
Fixes

```
hopr-connect:entry:error error while contacting entry node 16Uiu2HAmKfEux3LUxxKHf6gTebTDSEaTZvaSVZk3aTUKjgqA9usk. Cannot read properties of undefined (reading 'upgradeOutbound') +1ms
```