### PR TITLE
Improvements to NR information visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Add documentations around network registry
 - Refactor and simplify stream handover functionality to be more robust ([#3898](https://github.com/hoprnet/hoprnet/pull/3898))
 - Added possibility to specify custom RPC provider in Avado
+- Add connectivity health indicator & NR eligibility status of the node to the `info` command ([#3921](https://github.com/hoprnet/hoprnet/pull/3921))
 
 # Breaking changes
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -615,6 +615,13 @@ class Hopr extends EventEmitter {
   }
 
   /**
+   * Recalculates and retrieves the current connectivity health indicator.
+   */
+  public getConnectivityHealth() {
+    return this.heartbeat.recalculateNetworkHealth()
+  }
+
+  /**
    * Shuts down the node and saves keys and peerBook in the database
    */
   // @TODO make modules Startable

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -647,6 +647,9 @@ class Hopr extends EventEmitter {
     await new Promise((resolve) => setTimeout(resolve, 100))
   }
 
+  /**
+   * Gets the peer ID of this HOPR node.
+   */
   public getId(): PeerId {
     return this.id
   }

--- a/packages/core/src/network/network-peers.ts
+++ b/packages/core/src/network/network-peers.ts
@@ -2,7 +2,9 @@ import { type HeartbeatPingResult } from './heartbeat.js'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import { randomSubset, debug } from '@hoprnet/hopr-utils'
 
-const log = debug('hopr-core:network-peers')
+const DEBUG_PREFIX = 'hopr-core:network-peers'
+const log = debug(DEBUG_PREFIX)
+const verbose = debug(DEBUG_PREFIX.concat(`:verbose`))
 
 export type Entry = {
   id: PeerId
@@ -268,8 +270,13 @@ class NetworkPeers {
 
   public addPeerToDenied(peerId: PeerId, origin: string): void {
     const peerIdStr = peerId.toString()
-    log('adding peer to denied', peerIdStr)
-    this.deniedEntries.set(peerIdStr, { id: peerId, origin })
+    if (this.deniedEntries.has(peerIdStr)) {
+      log('adding peer to denied', peerIdStr)
+      this.deniedEntries.set(peerIdStr, { id: peerId, origin })
+    }
+    else {
+      verbose('peer is still denied', peerIdStr)
+    }
   }
 
   public removePeerFromDenied(peerId: PeerId): void {

--- a/packages/hoprd/src/api/v2/paths/node/info.integration.spec.ts
+++ b/packages/hoprd/src/api/v2/paths/node/info.integration.spec.ts
@@ -38,6 +38,8 @@ describe('GET /node/info', () => {
       network: 'a',
       hoprToken: 'b',
       hoprChannels: 'c',
+      isEligible: 'true',
+      connectivityStatus: 'green',
       channelClosurePeriod: 1
     })
   })

--- a/packages/hoprd/src/api/v2/paths/node/info.ts
+++ b/packages/hoprd/src/api/v2/paths/node/info.ts
@@ -16,6 +16,7 @@ export const getInfo = async ({ node }: { node: Hopr }) => {
       network: network,
       hoprToken: hoprTokenAddress,
       hoprChannels: hoprChannelsAddress,
+      isEligible: node.isAllowedAccessToNetwork(node.getId()),
       connectivityStatus: node.getConnectivityHealth().toString(),
       channelClosurePeriod: Math.ceil(channelClosureSecs / 60)
     }
@@ -101,6 +102,11 @@ GET.apiDoc = {
                 type: 'string',
                 example: 'GREEN',
                 description: 'Indicates how good is the connectivity of this node to the HOPR network: either RED, ORANGE, YELLOW or GREEN'
+              },
+              isEligible: {
+                type: 'boolean',
+                example: 'true',
+                description: 'Determines whether the staking account associated with this node is eligible for accessing the HOPR network. Always true if network registry is disabled.'
               },
               channelClosurePeriod: {
                 type: 'number',

--- a/packages/hoprd/src/api/v2/paths/node/info.ts
+++ b/packages/hoprd/src/api/v2/paths/node/info.ts
@@ -16,6 +16,7 @@ export const getInfo = async ({ node }: { node: Hopr }) => {
       network: network,
       hoprToken: hoprTokenAddress,
       hoprChannels: hoprChannelsAddress,
+      connectivityStatus: node.getConnectivityHealth().toString(),
       channelClosurePeriod: Math.ceil(channelClosureSecs / 60)
     }
   } catch (error) {
@@ -95,6 +96,11 @@ GET.apiDoc = {
                 example: '0x2a54194c8fe0e3CdeAa39c49B95495aA3b44Db63',
                 description:
                   'Contract address of the HoprChannels smart contract on ethereum network. This smart contract is used to open payment channels between nodes on blockchain.'
+              },
+              connectivityStatus: {
+                type: 'string',
+                example: 'GREEN',
+                description: 'Indicates how good is the connectivity of this node to the HOPR network: either RED, ORANGE, YELLOW or GREEN'
               },
               channelClosurePeriod: {
                 type: 'number',


### PR DESCRIPTION
This PR modifies the `info` command and adds the following information there:

- `isEligible` - indicates if the staking account associated with the current node is eligible for network access
- `connectivityStatus` - either `RED`, `ORANGE`, `YELLOW ` or `GREEN` indicates the connectivity health (see #3758)

Also fixes too much logging verbosity when a peer is denied access.

Fixes #3915 