### PR TITLE
fix broken info call

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,7 +15,7 @@ import { PACKET_SIZE, INTERMEDIATE_HOPS, VERSION, FULL_VERSION } from './constan
 
 import AccessControl from './network/access-control.js'
 import NetworkPeers, { Entry } from './network/network-peers.js'
-import Heartbeat, { type HeartbeatPingResult, type NetworkHealthIndicator } from './network/heartbeat.js'
+import Heartbeat, { type HeartbeatPingResult, NetworkHealthIndicator } from './network/heartbeat.js'
 
 import { findPath } from './path/index.js'
 
@@ -1295,7 +1295,7 @@ export {
   SaneDefaults,
   findPath,
   type StrategyTickResult,
-  type NetworkHealthIndicator,
+  NetworkHealthIndicator,
   type ChannelStrategyInterface
 }
 export { resolveEnvironment, supportedEnvironments, type ResolvedEnvironment } from './environment.js'

--- a/packages/hoprd/src/api/v2/paths/node/info.integration.spec.ts
+++ b/packages/hoprd/src/api/v2/paths/node/info.integration.spec.ts
@@ -3,8 +3,25 @@ import sinon from 'sinon'
 import chaiResponseValidator from 'chai-openapi-response-validator'
 import chai, { expect } from 'chai'
 import { createTestApiInstance } from '../../fixtures.js'
+import { privKeyToPeerId } from '@hoprnet/hopr-utils'
+import type Hopr from '@hoprnet/hopr-core'
+import { NetworkHealthIndicator, ResolvedEnvironment } from '@hoprnet/hopr-core'
+import { Multiaddr } from '@multiformats/multiaddr'
 
-let node = sinon.fake() as any
+const node = sinon.fake() as any as Hopr
+const nodePeerId = privKeyToPeerId('0x9135f358f94b59e8cdee5545eb9ecc8ff32bc3a79227a09ee2bb6b50f1ad8159')
+
+// Use random checksummed addresses to correctly mimic outputs
+const HOPR_TOKEN_ADDRESS = '0x2be12eE6D553319F01Ea85A353203feC6444928F'
+const HOPR_CHANNELS_ADDRESS = '0x39344CE336712bD0280c2C374c60A42F16a84B20'
+const HOPR_NEWTWORK_REGISTRY_ADDRESS = '0xBEE1F5d64b562715E749771408d06D57EE0892A7'
+
+const DHT_ADDRESSES = [
+  new Multiaddr(`/ip4/1.2.3.4/tcp/23/p2p/${nodePeerId.toString()}`),
+  new Multiaddr(`/p2p/${nodePeerId.toString()}`)
+]
+
+const LISTENING_ADDRS = [new Multiaddr(`/ip4/0.0.0.0/tcp/23`)]
 
 describe('GET /node/info', () => {
   let service: any
@@ -17,29 +34,34 @@ describe('GET /node/info', () => {
     chai.use(chaiResponseValidator.default(loaded.api.apiDoc))
   })
 
-  it('should get info', async () => {
-    node.environment = { id: 'hardhat-localhost' }
+  it.only('should get info', async () => {
+    node.environment = { id: 'hardhat-localhost' } as ResolvedEnvironment
     node.smartContractInfo = sinon.fake.returns({
       network: 'a',
-      hoprTokenAddress: 'b',
-      hoprChannelsAddress: 'c',
+      hoprTokenAddress: HOPR_TOKEN_ADDRESS,
+      hoprChannelsAddress: HOPR_CHANNELS_ADDRESS,
+      hoprNetworkRegistryAddress: HOPR_NEWTWORK_REGISTRY_ADDRESS,
       channelClosureSecs: 60
     })
-    node.getAddressesAnnouncedToDHT = sinon.fake.returns([1, 2])
-    node.getListeningAddresses = sinon.fake.returns([3, 4])
+    node.getAddressesAnnouncedToDHT = sinon.fake.resolves(DHT_ADDRESSES)
+    node.getListeningAddresses = sinon.fake.returns(LISTENING_ADDRS)
+    node.getId = sinon.fake.returns(nodePeerId)
+    node.isAllowedAccessToNetwork = sinon.fake.returns(Promise.resolve(true))
+    node.getConnectivityHealth = sinon.fake.returns(NetworkHealthIndicator.GREEN)
 
     const res = await request(service).get(`/api/v2/node/info`)
     expect(res.status).to.equal(200)
     expect(res).to.satisfyApiSpec
     expect(res.body).to.deep.equal({
       environment: 'hardhat-localhost',
-      announcedAddress: ['1', '2'],
-      listeningAddress: ['3', '4'],
+      announcedAddress: DHT_ADDRESSES.map((addr: Multiaddr) => addr.toString()),
+      listeningAddress: LISTENING_ADDRS.map((addr: Multiaddr) => addr.toString()),
       network: 'a',
-      hoprToken: 'b',
-      hoprChannels: 'c',
-      isEligible: 'true',
-      connectivityStatus: 'green',
+      hoprToken: HOPR_TOKEN_ADDRESS,
+      hoprChannels: HOPR_CHANNELS_ADDRESS,
+      hoprNetworkRegistry: HOPR_NEWTWORK_REGISTRY_ADDRESS,
+      isEligible: true,
+      connectivityStatus: NetworkHealthIndicator.GREEN,
       channelClosurePeriod: 1
     })
   })

--- a/packages/hoprd/src/api/v2/paths/node/info.ts
+++ b/packages/hoprd/src/api/v2/paths/node/info.ts
@@ -7,7 +7,8 @@ import { STATUS_CODES } from '../../utils.js'
  */
 export const getInfo = async ({ node }: { node: Hopr }) => {
   try {
-    const { network, hoprTokenAddress, hoprChannelsAddress, channelClosureSecs } = node.smartContractInfo()
+    const { network, hoprTokenAddress, hoprChannelsAddress, channelClosureSecs, hoprNetworkRegistryAddress } =
+      node.smartContractInfo()
 
     return {
       environment: node.environment.id,
@@ -16,7 +17,8 @@ export const getInfo = async ({ node }: { node: Hopr }) => {
       network: network,
       hoprToken: hoprTokenAddress,
       hoprChannels: hoprChannelsAddress,
-      isEligible: node.isAllowedAccessToNetwork(node.getId()),
+      hoprNetworkRegistry: hoprNetworkRegistryAddress,
+      isEligible: await node.isAllowedAccessToNetwork(node.getId()),
       connectivityStatus: node.getConnectivityHealth().toString(),
       channelClosurePeriod: Math.ceil(channelClosureSecs / 60)
     }
@@ -98,6 +100,12 @@ GET.apiDoc = {
                 description:
                   'Contract address of the HoprChannels smart contract on ethereum network. This smart contract is used to open payment channels between nodes on blockchain.'
               },
+              hoprNetworkRegistryAddress: {
+                type: 'string',
+                example: '0xBEE1F5d64b562715E749771408d06D57EE0892A7',
+                description:
+                  'Contract address of the contract that allows to control the number of nodes in the network'
+              },
               connectivityStatus: {
                 type: 'string',
                 example: 'GREEN',
@@ -106,7 +114,7 @@ GET.apiDoc = {
               },
               isEligible: {
                 type: 'boolean',
-                example: 'true',
+                example: true,
                 description:
                   'Determines whether the staking account associated with this node is eligible for accessing the HOPR network. Always true if network registry is disabled.'
               },

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -319,6 +319,7 @@ function addUnhandledPromiseRejectionHandler() {
         // HOPR uses the `stream-to-it` library to convert streams from Node.js sockets
         // to async iterables. This library has shown to have issues with runtime errors,
         // mainly ECONNRESET and EPIPE
+        msgString.match(/read ECONNRESET/) ||
         msgString.match(/write ECONNRESET/) ||
         msgString.match(/write EPIPE/)
       ) {


### PR DESCRIPTION
Fixes `/info` REST method that got broken with #3921 

Silence `read ECONNRESET` errors coming from `stream-to-it` library