### PR TITLE
Add NR and connectivity information to `info` WS command as well

### DIFF
--- a/packages/hoprd/src/commands/commands.spec.ts
+++ b/packages/hoprd/src/commands/commands.spec.ts
@@ -2,6 +2,7 @@ import type { State, StateOps } from '../types.js'
 import * as mod from './index.js'
 import assert from 'assert'
 import sinon from 'sinon'
+import { NetworkHealthIndicator } from '@hoprnet/hopr-core'
 
 const assertMatch = async (cmds: mod.Commands, command: string, pattern: RegExp) => {
   let response = ''
@@ -134,6 +135,9 @@ describe('Commands', () => {
   it('info', async () => {
     let mockNode: any = sinon.fake()
     mockNode.getAddressesAnnouncedToDHT = async () => []
+    mockNode.getId = () => '16Uiu2HAkyXRaL7fKu4qcjaKuo4WXizrpK63Ltd6kG2tH6oSV58AW'
+    mockNode.isAllowedAccessToNetwork = () => true
+    mockNode.getConnectivityHealth = () => NetworkHealthIndicator.GREEN
     mockNode.getListeningAddresses = () => []
     mockNode.smartContractInfo = () => ({
       channelClosureSecs: 300

--- a/packages/hoprd/src/commands/commands.spec.ts
+++ b/packages/hoprd/src/commands/commands.spec.ts
@@ -136,7 +136,7 @@ describe('Commands', () => {
     let mockNode: any = sinon.fake()
     mockNode.getAddressesAnnouncedToDHT = async () => []
     mockNode.getId = () => '16Uiu2HAkyXRaL7fKu4qcjaKuo4WXizrpK63Ltd6kG2tH6oSV58AW'
-    mockNode.isAllowedAccessToNetwork = () => true
+    mockNode.isAllowedAccessToNetwork = () => Promise.resolve(true)
     mockNode.getConnectivityHealth = () => NetworkHealthIndicator.GREEN
     mockNode.getListeningAddresses = () => []
     mockNode.smartContractInfo = () => ({

--- a/packages/hoprd/src/commands/info.ts
+++ b/packages/hoprd/src/commands/info.ts
@@ -28,6 +28,8 @@ export class Info extends AbstractCommand {
         `HOPR Token: ${smartContractInfo.hoprTokenAddress}`,
         `HOPR Channels: ${smartContractInfo.hoprChannelsAddress}`,
         `HOPR NetworkRegistry: ${smartContractInfo.hoprNetworkRegistryAddress}`,
+        `Eligibility: ${await this.node.isAllowedAccessToNetwork(this.node.getId())}`,
+        `Connectivity Indicator: ${this.node.getConnectivityHealth().toString()}`,
         `Channel closure period: ${channelClosureMins} minutes`
       ].join('\n')
     )


### PR DESCRIPTION
Changes introduced in #3921 added also to the `info` command for WebSocket interface.