### PR TITLE
Fix error in module injection & unregister timeouts

### DIFF
--- a/packages/connect/src/base/listener.ts
+++ b/packages/connect/src/base/listener.ts
@@ -219,8 +219,8 @@ class Listener extends EventEmitter<ListenerEvents> implements InterfaceListener
     const tcpTimeout = setTimeout(() => {
       abort.abort()
       waitForIncomingTcpPacket.reject()
-    }, TIMEOUT)
-    const udpTimeout = setTimeout(waitForIncomingUdpPacket.reject.bind(waitForIncomingUdpPacket), TIMEOUT)
+    }, TIMEOUT).unref()
+    const udpTimeout = setTimeout(waitForIncomingUdpPacket.reject.bind(waitForIncomingUdpPacket), TIMEOUT).unref()
 
     const checkTcpMessage = (socket: TCPSocket) => {
       socket.on('data', (data: Buffer) => {

--- a/packages/connect/src/base/stun.ts
+++ b/packages/connect/src/base/stun.ts
@@ -245,7 +245,7 @@ function decodeIncomingSTUNResponses(addrs: Request[], socket: Socket, ms: numbe
         } selected STUN servers replied.`
       )
       done()
-    }, ms)
+    }, ms).unref()
 
     // Receiving a Buffer, not a Uint8Array
     listener = (msg: Buffer) => {

--- a/packages/connect/src/relay/handshake.spec.ts
+++ b/packages/connect/src/relay/handshake.spec.ts
@@ -62,7 +62,11 @@ describe('test relay handshake', function () {
           protocol: 'test'
         }
       },
-      getRelayState()
+      getRelayState(),
+      {
+        // We don't need the upgrader for this purpose
+        upgrader: undefined as any
+      }
     )
 
     await initiatorReceived.promise
@@ -99,7 +103,11 @@ describe('test relay handshake', function () {
           protocol: 'test'
         }
       },
-      getRelayState()
+      getRelayState(),
+      {
+        // We don't need the upgrader for this purpose
+        upgrader: undefined as any
+      }
     )
 
     await Promise.all([handshakePromise, destinationHandshake])
@@ -127,7 +135,11 @@ describe('test relay handshake', function () {
           protocol: 'test'
         }
       },
-      getRelayState(true)
+      getRelayState(true),
+      {
+        // We don't need the upgrader for this purpose
+        upgrader: undefined as any
+      }
     )
 
     const [initiatorResult, destinationResult] = await Promise.all([

--- a/packages/connect/src/relay/handshake.ts
+++ b/packages/connect/src/relay/handshake.ts
@@ -13,6 +13,7 @@ import type { Relay } from './index.js'
 
 import debug from 'debug'
 import { DELIVERY_PROTOCOL } from '../constants.js'
+import { Components } from '@libp2p/interfaces/components'
 
 export enum RelayHandshakeMessage {
   OK,
@@ -166,6 +167,7 @@ class RelayHandshake {
     source: PeerId,
     getStreamToCounterparty: InstanceType<typeof Relay>['dialNodeDirectly'],
     state: Pick<RelayState, 'exists' | 'isActive' | 'updateExisting' | 'createNew'>,
+    upgrader: Components['upgrader'],
     __relayFreeTimeout?: number
   ): Promise<void> {
     log(`handling relay request`)
@@ -233,7 +235,9 @@ class RelayHandshake {
 
     let toDestinationStruct: Awaited<ReturnType<typeof getStreamToCounterparty>>
     try {
-      toDestinationStruct = await getStreamToCounterparty(destination, DELIVERY_PROTOCOL(this.options.environment))
+      toDestinationStruct = await getStreamToCounterparty(destination, DELIVERY_PROTOCOL(this.options.environment), {
+        upgrader
+      })
     } catch (err) {
       error(err)
     }

--- a/packages/connect/src/relay/index.ts
+++ b/packages/connect/src/relay/index.ts
@@ -334,7 +334,8 @@ class Relay implements Initializable, ConnectInitializable, Startable {
         shaker.negotiate(
           conn.connection.remotePeer,
           this._dialNodeDirectly as Relay['dialNodeDirectly'],
-          this.relayState
+          this.relayState,
+          this.getComponents().getUpgrader()
         )
       }
     } catch (e) {
@@ -439,11 +440,7 @@ class Relay implements Initializable, ConnectInitializable, Startable {
    * @param opts
    * @returns a stream to the given peer
    */
-  private async dialNodeDirectly(
-    destination: PeerId,
-    protocol: string,
-    opts?: DialOptions
-  ): Promise<ConnResult | void> {
+  private async dialNodeDirectly(destination: PeerId, protocol: string, opts: DialOptions): Promise<ConnResult | void> {
     let connResult = await tryExistingConnections(this.getComponents(), destination, protocol)
 
     // Only establish a new connection if we don't have any.
@@ -467,7 +464,7 @@ class Relay implements Initializable, ConnectInitializable, Startable {
   private async establishDirectConnection(
     destination: PeerId,
     protocol: string,
-    opts?: DialOptions
+    opts: DialOptions
   ): Promise<ConnResult | undefined> {
     const usableAddresses: Multiaddr[] = []
 
@@ -490,7 +487,7 @@ class Relay implements Initializable, ConnectInitializable, Startable {
 
     for (const usable of usableAddresses) {
       try {
-        conn = await this.dialDirectly(usable, opts as any)
+        conn = await this.dialDirectly(usable, opts)
       } catch (err) {
         await attemptClose(conn, error)
         continue


### PR DESCRIPTION
## Changes

- Correctly pass libp2p upgrader instance when extending a connection to a relayed connection
- do not await timeouts when closing node process