### PR TITLE
Pass the private key rather as an env variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,21 +88,21 @@ request-dev-nft: ## Request one HoprBoost Dev NFT for the recipient given it has
 ifeq ($(recipient),)
 	echo "parameter <recipient> missing" >&2 && exit 1
 endif
-ifeq ($(privkey),)
-	echo "parameter <privkey> missing" >&2 && exit 1
+ifeq($(origin PRIVATE_KEY),undefined)
+	echo "<PRIVATE_KEY> environment variable missing" >&2 && exit 1
 endif
 	TS_NODE_PROJECT=./tsconfig.hardhat.json \
 	HOPR_ENVIRONMENT_ID="$(environment)" \
 	  yarn workspace @hoprnet/hopr-ethereum run hardhat request-dev-nft \
    --network $(network) \
    --recipient $(recipient) \
-   --privatekey "$(privkey)"
+   --privatekey "$(PRIVATE_KEY)"
 
 .PHONY: stake-funds
 stake-funds: ensure-environment-is-set
 stake-funds: ## stake funds (idempotent operation)
-ifeq ($(privkey),)
-	echo "parameter <privkey> missing" >&2 && exit 1
+ifeq($(origin PRIVATE_KEY),undefined)
+	echo "<PRIVATE_KEY> environment variable missing" >&2 && exit 1
 endif
 	@TS_NODE_PROJECT=./tsconfig.hardhat.json \
 	HOPR_ENVIRONMENT_ID="$(environment)" \
@@ -110,20 +110,20 @@ endif
 		--network $(network) \
 		--type xhopr \
 		--amount 1000000000000000000000 \
-		--privatekey "$(privkey)"
+		--privatekey "$(PRIVATE_KEY)"
 
 .PHONY: stake-devnft
 stake-devnft: ensure-environment-is-set
 stake-devnft: ## stake Dev NFTs (idempotent operation)
-ifeq ($(privkey),)
-	echo "parameter <privkey> missing" >&2 && exit 1
+ifeq($(origin PRIVATE_KEY),undefined)
+	echo "<PRIVATE_KEY> environment variable missing" >&2 && exit 1
 endif
 	@TS_NODE_PROJECT=./tsconfig.hardhat.json \
 	HOPR_ENVIRONMENT_ID="$(environment)" \
 		yarn workspace @hoprnet/hopr-ethereum run hardhat stake \
 		--network $(network) \
 		--type devnft \
-		--privatekey "$(privkey)"
+		--privatekey "$(PRIVATE_KEY)"
 
 register-nodes: ensure-environment-is-set
 register-nodes: ## owner register given nodes in network registry contract
@@ -147,8 +147,8 @@ self-register-node: ## staker register a node in network registry contract
 ifeq ($(peer_id),)
 	echo "parameter <peer_id> missing" >&2 && exit 1
 endif
-ifeq ($(privkey),)
-	echo "parameter <privkey> missing" >&2 && exit 1
+ifeq($(origin PRIVATE_KEY),undefined)
+	echo "<PRIVATE_KEY> environment variable missing" >&2 && exit 1
 endif
 	TS_NODE_PROJECT=./tsconfig.hardhat.json \
 	HOPR_ENVIRONMENT_ID="$(environment)" \
@@ -156,7 +156,7 @@ endif
    --network $(network) \
    --task add \
    --peer-id "$(peer_id)" \
-   --privatekey "$(privkey)"
+   --privatekey "$(PRIVATE_KEY)"
 
 .PHONY: self-deregister-node
 self-deregister-node: ensure-environment-is-set

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ request-dev-nft: ## Request one HoprBoost Dev NFT for the recipient given it has
 ifeq ($(recipient),)
 	echo "parameter <recipient> missing" >&2 && exit 1
 endif
-ifeq($(origin PRIVATE_KEY),undefined)
+ifeq ($(origin PRIVATE_KEY),undefined)
 	echo "<PRIVATE_KEY> environment variable missing" >&2 && exit 1
 endif
 	TS_NODE_PROJECT=./tsconfig.hardhat.json \
@@ -101,7 +101,7 @@ endif
 .PHONY: stake-funds
 stake-funds: ensure-environment-is-set
 stake-funds: ## stake funds (idempotent operation)
-ifeq($(origin PRIVATE_KEY),undefined)
+ifeq ($(origin PRIVATE_KEY),undefined)
 	echo "<PRIVATE_KEY> environment variable missing" >&2 && exit 1
 endif
 	@TS_NODE_PROJECT=./tsconfig.hardhat.json \
@@ -115,7 +115,7 @@ endif
 .PHONY: stake-devnft
 stake-devnft: ensure-environment-is-set
 stake-devnft: ## stake Dev NFTs (idempotent operation)
-ifeq($(origin PRIVATE_KEY),undefined)
+ifeq ($(origin PRIVATE_KEY),undefined)
 	echo "<PRIVATE_KEY> environment variable missing" >&2 && exit 1
 endif
 	@TS_NODE_PROJECT=./tsconfig.hardhat.json \
@@ -147,7 +147,7 @@ self-register-node: ## staker register a node in network registry contract
 ifeq ($(peer_id),)
 	echo "parameter <peer_id> missing" >&2 && exit 1
 endif
-ifeq($(origin PRIVATE_KEY),undefined)
+ifeq ($(origin PRIVATE_KEY),undefined)
 	echo "<PRIVATE_KEY> environment variable missing" >&2 && exit 1
 endif
 	TS_NODE_PROJECT=./tsconfig.hardhat.json \

--- a/scripts/setup-gcloud-cluster.sh
+++ b/scripts/setup-gcloud-cluster.sh
@@ -162,9 +162,9 @@ for staking_addr in "${!staking_addrs_dict[@]}" ; do
   fund_if_empty "${staking_addr}" "${environment}"
   # we alternate between staking funds or NFT
   if [[ "$((staking_index%2))" = "0" ]]; then
-    make -C "${mydir}/.." stake-funds privkey="${staking_addrs_dict[${staking_addr}]}" environment="${environment}"
+    PRIVATE_KEY="${staking_addrs_dict[${staking_addr}]}" make -C "${mydir}/.." stake-funds environment="${environment}"
   else
-    make -C "${mydir}/.." stake-devnft privkey="${staking_addrs_dict[${staking_addr}]}" environment="${environment}"
+    PRIVATE_KEY="${staking_addrs_dict[${staking_addr}]}" make -C "${mydir}/.." stake-devnft environment="${environment}"
   fi
   ((++staking_index))
 done


### PR DESCRIPTION
In the `Makefile` - use only `PRIVATE_KEY` environment variable to pass the private key to the NR related targets.