### PR TITLE
pin node.js version to 16.15

### DIFF
--- a/packages/hoprd/package.json
+++ b/packages/hoprd/package.json
@@ -19,7 +19,7 @@
     "rest-api-v2-spec.yaml"
   ],
   "engines": {
-    "node": "16"
+    "node": "16.15"
   },
   "scripts": {
     "clean:wasm": "make -C crates clean",


### PR DESCRIPTION
`hopr` uses the builtin JSON-loader based on ECMAScript modules to load JSON files, which is the new de-facto standard to import JSON files.

Loaded JSON files using `import` statements has been added to Node.js 16.15, hence `hoprd` requires Node.js 16.15 +