### PR TITLE
Fix & unify message encoding and decoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Refactor and simplify stream handover functionality to be more robust ([#3898](https://github.com/hoprnet/hoprnet/pull/3898))
 - Added possibility to specify custom RPC provider in Avado
 - Add connectivity health indicator & NR eligibility status of the node to the `info` command ([#3921](https://github.com/hoprnet/hoprnet/pull/3921))
+- Fix message encoding/decoding in HOPRd ([#3943](https://github.com/hoprnet/hoprnet/pull/3943))
 
 # Breaking changes
 

--- a/packages/avado/releases.json
+++ b/packages/avado/releases.json
@@ -908,10 +908,10 @@
     }
   },
   "0.100.0": {
-    "hash": "/ipfs/QmZeQ59FCToGYWnXC2SBPFKRRpQfw262qn17qzjbLbgjrg",
+    "hash": "/ipfs/QmYELsjupDbR37yuKWgZ1cDc6mYHSzFG2MkKGMWLBjvdfv",
     "type": "manifest",
     "uploadedTo": {
-      "http://80.208.229.228:5001": "Thu, 28 Jul 2022 21:28:09 GMT"
+      "http://80.208.229.228:5001": "Fri, 29 Jul 2022 09:01:13 GMT"
     }
   },
   "1.64.0": {

--- a/packages/hoprd/src/commands/utils/message.spec.ts
+++ b/packages/hoprd/src/commands/utils/message.spec.ts
@@ -6,10 +6,10 @@ describe('Message encoding & decoding', () => {
     let msg = 'some test message!'
     let encodedMsg = encodeMessage(msg)
 
-    await new Promise((r) => setTimeout(r, 2000))
+    await new Promise((r) => setTimeout(r, 500))
 
     let decodedMsg = decodeMessage(encodedMsg)
     assert.deepEqual(decodedMsg.msg, msg)
-    assert(decodedMsg.latency >= 2000)
+    assert(decodedMsg.latency >= 500)
   })
 })

--- a/packages/hoprd/src/commands/utils/message.spec.ts
+++ b/packages/hoprd/src/commands/utils/message.spec.ts
@@ -1,0 +1,15 @@
+import { decodeMessage, encodeMessage } from './message.js'
+import assert from 'assert'
+
+describe('Message encoding & decoding', () => {
+  it('check if message can be encoded and then decoded', async () => {
+    let msg = "some test message!"
+    let encodedMsg = encodeMessage(msg)
+
+    await new Promise(r => setTimeout(r, 2000));
+
+    let decodedMsg = decodeMessage(encodedMsg)
+    assert.deepEqual(decodedMsg.msg, msg)
+    assert(decodedMsg.latency >= 2000)
+  })
+})

--- a/packages/hoprd/src/commands/utils/message.ts
+++ b/packages/hoprd/src/commands/utils/message.ts
@@ -19,13 +19,13 @@ export function decodeMessage(encoded: Uint8Array): {
   latency: number
   msg: string
 } {
-  let msg: Buffer, time: Buffer
+  let msg: Uint8Array, time: Uint8Array
   try {
-    ;[msg, time] = RLP.decode(encoded) as [Buffer, Buffer]
+    ;[msg, time] = RLP.decode(encoded) as [Uint8Array, Uint8Array]
 
     return {
-      latency: Date.now() - parseInt(time.toString('hex'), 16),
-      msg: msg.toString()
+      latency: Date.now() - Buffer.from(time).readUintBE(0, time.length),
+      msg: new TextDecoder().decode(msg)
     }
   } catch (err) {
     styleValue(

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -374,11 +374,11 @@ async function main() {
     logs.log(`#### NODE RECEIVED MESSAGE [${new Date().toISOString()}] ####`)
     try {
       let decodedMsg = decodeMessage(msg)
-      logs.log(`Message: ${decodedMsg.msg.toString()}`)
+      logs.log(`Message: ${decodedMsg.msg}`)
       logs.log(`Latency: ${decodedMsg.latency} ms`)
 
       // also send it tagged as message for apps to use
-      logs.logMessage(decodedMsg.msg.toString())
+      logs.logMessage(decodedMsg.msg)
     } catch (err) {
       logs.log('Could not decode message', err instanceof Error ? err.message : 'Unknown error')
       logs.log(msg.toString())

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -1,5 +1,4 @@
 import { passwordStrength } from 'check-password-strength'
-import RLP from 'rlp'
 import path from 'path'
 import yargs from 'yargs'
 import { hideBin } from 'yargs/helpers'
@@ -29,6 +28,7 @@ import { Commands } from './commands/index.js'
 import { LogStream } from './logs.js'
 import { getIdentity } from './identity.js'
 import { register as registerUnhandled, setLogger } from 'trace-unhandled'
+import { decodeMessage } from './commands/utils/index.js'
 
 const DEFAULT_ID_PATH = path.join(process.env.HOME, '.hopr-identity')
 
@@ -373,12 +373,12 @@ async function main() {
   const logMessageToNode = (msg: Uint8Array): void => {
     logs.log(`#### NODE RECEIVED MESSAGE [${new Date().toISOString()}] ####`)
     try {
-      let [decoded, time] = RLP.decode(msg) as [Buffer, Buffer]
-      logs.log(`Message: ${decoded.toString()}`)
-      logs.log(`Latency: ${Date.now() - parseInt(time.toString('hex'), 16)}ms`)
+      let decodedMsg = decodeMessage(msg)
+      logs.log(`Message: ${decodedMsg.msg.toString()}`)
+      logs.log(`Latency: ${decodedMsg.latency} ms`)
 
       // also send it tagged as message for apps to use
-      logs.logMessage(decoded.toString())
+      logs.logMessage(decodedMsg.msg.toString())
     } catch (err) {
       logs.log('Could not decode message', err instanceof Error ? err.message : 'Unknown error')
       logs.log(msg.toString())


### PR DESCRIPTION
This PR:
- adds proper unit test for `encodeMessage` and `decodeMessage` in HOPRd
- unifies code in HOPRd to use these functions
- fixes decoding

Closes #3935 