### PR TITLE
Deploy NAT nodes after Public nodes have been deployed

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -345,7 +345,7 @@ jobs:
         rust: ['stable']
 
     runs-on: ${{ matrix.os }}
-    needs: [  deploy_public_instances ] # Public nodes need to be deployed first
+    needs: [deploy_public_instances] # Public nodes need to be deployed first
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -345,7 +345,7 @@ jobs:
         rust: ['stable']
 
     runs-on: ${{ matrix.os }}
-    needs: [build_docker]
+    needs: [  deploy_public_instances ] # Public nodes need to be deployed first
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Makes sure GH Actions deploy nodes to GCP in-order (public first, then NAT nodes).