### PR TITLE
Script for request txhopr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,7 @@ docker-build-gcb: ## build Docker images on Google Cloud Build
 
 .PHONY: request-funds
 request-funds: ensure-environment-is-set
-request-funds: ## Request one HoprBoost Dev NFT for the recipient given it has none and hasn't staked Dev NFT
+request-funds: ## Request 1000 xHOPR tokens for the recipient
 ifeq ($(recipient),)
 	echo "parameter <recipient> missing" >&2 && exit 1
 endif

--- a/Makefile
+++ b/Makefile
@@ -82,9 +82,9 @@ endif
 docker-build-gcb: ## build Docker images on Google Cloud Build
 	./scripts/build-docker.sh --no-tags --force
 
-.PHONY: request-dev-nft
-request-dev-nft: ensure-environment-is-set
-request-dev-nft: ## Request one HoprBoost Dev NFT for the recipient given it has none and hasn't staked Dev NFT
+.PHONY: request-funds
+request-funds: ensure-environment-is-set
+request-funds: ## Request one HoprBoost Dev NFT for the recipient given it has none and hasn't staked Dev NFT
 ifeq ($(recipient),)
 	echo "parameter <recipient> missing" >&2 && exit 1
 endif
@@ -93,8 +93,27 @@ ifeq ($(origin PRIVATE_KEY),undefined)
 endif
 	TS_NODE_PROJECT=./tsconfig.hardhat.json \
 	HOPR_ENVIRONMENT_ID="$(environment)" \
-	  yarn workspace @hoprnet/hopr-ethereum run hardhat request-dev-nft \
+	  yarn workspace @hoprnet/hopr-ethereum run hardhat request-test-tokens \
    --network $(network) \
+   --type xhopr \
+   --amount 1000000000000000000000 \
+   --recipient $(recipient) \
+   --privatekey "$(PRIVATE_KEY)"
+   
+.PHONY: request-devnft
+request-devnft: ensure-environment-is-set
+request-devnft: ## Request one HoprBoost Dev NFT for the recipient given it has none and hasn't staked Dev NFT
+ifeq ($(recipient),)
+	echo "parameter <recipient> missing" >&2 && exit 1
+endif
+ifeq ($(origin PRIVATE_KEY),undefined)
+	echo "<PRIVATE_KEY> environment variable missing" >&2 && exit 1
+endif
+	TS_NODE_PROJECT=./tsconfig.hardhat.json \
+	HOPR_ENVIRONMENT_ID="$(environment)" \
+	  yarn workspace @hoprnet/hopr-ethereum run hardhat request-test-tokens \
+   --network $(network) \
+   --type devnft \
    --recipient $(recipient) \
    --privatekey "$(PRIVATE_KEY)"
 
@@ -195,7 +214,7 @@ endif
 ifeq ($(origin DEV_BANK_PRIVKEY),undefined)
 	echo "<DEV_BANK_PRIVKEY> environment variable missing" >&2 && exit 1
 endif
-	PRIVATE_KEY=${DEV_BANK_PRIVKEY} make request-dev-nft recipient=${account}
+	PRIVATE_KEY=${DEV_BANK_PRIVKEY} make request-devnft recipient=${account}
 	PRIVATE_KEY=${ACCOUNT_PRIVKEY} make stake-devnft
 	PRIVATE_KEY=${ACCOUNT_PRIVKEY} make self-register-node peer_id=$(shell ./scripts/get-hopr-address.sh "$(endpoint)")
 

--- a/Makefile
+++ b/Makefile
@@ -199,9 +199,9 @@ self-deregister-node: ## staker deregister a node in network registry contract
    --task remove \
    --privatekey "$(PRIVATE_KEY)"
 
-.PHONY: register-node
+.PHONY: register-node-with-nft
 # node_api?=localhost:3001 provide endpoint of hoprd, with a default value 'localhost:3001'
-register-node: ensure-environment-is-set
+register-node-with-nft: ensure-environment-is-set
 ifeq ($(endpoint),)
 	echo "parameter <endpoint> is default to localhost:3001" >&2
 endif
@@ -230,6 +230,10 @@ endif
 ifeq ($(origin ACCOUNT_PRIVKEY),undefined)
 	echo "<ACCOUNT_PRIVKEY> environment variable missing" >&2 && exit 1
 endif
+ifeq ($(origin DEV_BANK_PRIVKEY),undefined)
+	echo "<DEV_BANK_PRIVKEY> environment variable missing" >&2 && exit 1
+endif
+	PRIVATE_KEY=${DEV_BANK_PRIVKEY} make request-funds recipient=${account}
 	PRIVATE_KEY=${ACCOUNT_PRIVKEY} make stake-funds
 	PRIVATE_KEY=${ACCOUNT_PRIVKEY} make self-register-node peer_id=$(shell ./scripts/get-hopr-address.sh "$(endpoint)")
 

--- a/NETWORK_REGISTRY.md
+++ b/NETWORK_REGISTRY.md
@@ -126,7 +126,7 @@ The procedure for both options are very similar, which only some differences in 
 4. Save private keys (`ACCOUNT_PRIVKEY` and `DEV_BANK_PRIVKEY`) into `.env` file
 
 ```
-export ACCOUNT_PRIVKEY=<account_private_key
+export ACCOUNT_PRIVKEY=<account_private_key>
 export DEV_BANK_PRIVKEY=<dev_bank_private_key>
 ```
 

--- a/NETWORK_REGISTRY.md
+++ b/NETWORK_REGISTRY.md
@@ -132,7 +132,7 @@ source .env
 4. Run
 
 ```
-make register-node endpoint=<hoprd_endpoint> account=<staking_account> environment=master-goerli network=goerli
+make register-node-with-nft endpoint=<hoprd_endpoint> account=<staking_account> environment=master-goerli network=goerli
 ```
 
 provide `<hoprd_endpoint>` when it's different from `localhost:3001`
@@ -141,12 +141,12 @@ provide `<hoprd_endpoint>` when it's different from `localhost:3001`
 
 1. Create a MetaMask wallet (note as “account”)
 2. Fund 1 Goerli ETH (from “DevBank” or from the faucet) to the “account”
-3. Fund 1000 txHOPR from “DevBank” to the “account”
-4. Start your local HOPR node
-5. Save private keys (`ACCOUNT_PRIVKEY`) into `.env` file
+3. Start your local HOPR node
+4. Save private keys (`ACCOUNT_PRIVKEY` and `DEV_BANK_PRIVKEY`) into `.env` file
 
 ```
-ACCOUNT_PRIVKEY=<account_private_key>
+export ACCOUNT_PRIVKEY=<account_private_key>
+export DEV_BANK_PRIVKEY=<dev_bank_private_key>
 ```
 
 and
@@ -158,5 +158,5 @@ source .env
 4. Run
 
 ```
-make register-node-with-stake environment=master-goerli network=goerli
+make register-node-with-stake endpoint=<hoprd_endpoint> account=<staking_account> environment=master-goerli network=goerli
 ```

--- a/NETWORK_REGISTRY.md
+++ b/NETWORK_REGISTRY.md
@@ -111,7 +111,14 @@ yarn workspace @hoprnet/hopr-ethereum hardhat register --network goerli --task e
 
 ## Internal NR testing
 
-### Option 1: obtain a dev NFT and register your node on NR
+To register an eligible node in the NR, there are two options:
+
+- obtain a dev NFT and register your node on NR
+- stake tokens and register your node on NR
+
+The procedure for both options are very similar, which only some differences in the last step.
+
+### Procedure
 
 1. Create a MetaMask wallet (note as “account”)
 2. Fund 1 Goerli ETH (from “DevBank” or from the faucet) to the “account”
@@ -119,7 +126,7 @@ yarn workspace @hoprnet/hopr-ethereum hardhat register --network goerli --task e
 4. Save private keys (`ACCOUNT_PRIVKEY` and `DEV_BANK_PRIVKEY`) into `.env` file
 
 ```
-export ACCOUNT_PRIVKEY=<account_private_key>
+export ACCOUNT_PRIVKEY=<account_private_key
 export DEV_BANK_PRIVKEY=<dev_bank_private_key>
 ```
 
@@ -129,34 +136,16 @@ and
 source .env
 ```
 
-4. Run
+5. Run either command. In both cases, provide `<hoprd_endpoint>` when it's different from `localhost:3001`
 
-```
-make register-node-with-nft endpoint=<hoprd_endpoint> account=<staking_account> environment=master-goerli network=goerli
-```
+- Option 1: obtain a dev NFT and register your node on NR
 
-provide `<hoprd_endpoint>` when it's different from `localhost:3001`
+  ```
+  make register-node-with-nft endpoint=<hoprd_endpoint> account=<staking_account> environment=master-goerli network=goerli
+  ```
 
-### Option 2: stake tokens and register your node on NR
+- Option 2: stake tokens and register your node on NR
 
-1. Create a MetaMask wallet (note as “account”)
-2. Fund 1 Goerli ETH (from “DevBank” or from the faucet) to the “account”
-3. Start your local HOPR node
-4. Save private keys (`ACCOUNT_PRIVKEY` and `DEV_BANK_PRIVKEY`) into `.env` file
-
-```
-export ACCOUNT_PRIVKEY=<account_private_key>
-export DEV_BANK_PRIVKEY=<dev_bank_private_key>
-```
-
-and
-
-```
-source .env
-```
-
-4. Run
-
-```
-make register-node-with-stake endpoint=<hoprd_endpoint> account=<staking_account> environment=master-goerli network=goerli
-```
+  ```
+  make register-node-with-stake endpoint=<hoprd_endpoint> account=<staking_account> environment=master-goerli network=goerli
+  ```

--- a/packages/ethereum/hardhat.config.ts
+++ b/packages/ethereum/hardhat.config.ts
@@ -22,7 +22,7 @@ import faucet, { type FaucetCLIOPts } from './tasks/faucet'
 import parallelTest, { type ParallelTestCLIOpts } from './tasks/parallelTest'
 import register, { type RegisterOpts } from './tasks/register'
 import selfRegister, { type SelfRegisterOpts } from './tasks/selfRegister'
-import requestDevNft, { type RequestDevNftOpts } from './tasks/requestDevNft'
+import requestTestTokens, { type RequestTestTokensOpts } from './tasks/requestTestTokens'
 import disableAutoMine from './tasks/disableAutoMine'
 import getAccounts from './tasks/getAccounts'
 import type { NetworkOptions } from './types'
@@ -246,7 +246,14 @@ task<SelfRegisterOpts>(
   .addOptionalParam<string>('peerId', 'HOPR peer ID to be registered', undefined, types.string)
   .addOptionalParam<string>('privatekey', 'Private key of the signer', undefined, types.string)
 
-task<RequestDevNftOpts>('request-dev-nft', 'Request Dev NFT for a staker', requestDevNft)
+task<RequestTestTokensOpts>('request-test-tokens', 'Request test tokens ("Dev NFT" or "txHOPR") for a staker', requestTestTokens)
+  .addParam<RequestTestTokensOpts['type']>('type', 'Token type to request', undefined, types.string)
+  .addOptionalParam<string>(
+    'amount',
+    'target txHOPR token amount (in wei) to request for',
+    MIN_STAKE.toString(),
+    types.string
+  )
   .addParam<string>('recipient', 'Address of the NFT recipient', undefined, types.string)
   .addParam<string>('privatekey', 'Private key of the current owner of NFTs', undefined, types.string)
 

--- a/packages/ethereum/hardhat.config.ts
+++ b/packages/ethereum/hardhat.config.ts
@@ -246,7 +246,11 @@ task<SelfRegisterOpts>(
   .addOptionalParam<string>('peerId', 'HOPR peer ID to be registered', undefined, types.string)
   .addOptionalParam<string>('privatekey', 'Private key of the signer', undefined, types.string)
 
-task<RequestTestTokensOpts>('request-test-tokens', 'Request test tokens ("Dev NFT" or "txHOPR") for a staker', requestTestTokens)
+task<RequestTestTokensOpts>(
+  'request-test-tokens',
+  'Request test tokens ("Dev NFT" or "txHOPR") for a staker',
+  requestTestTokens
+)
   .addParam<RequestTestTokensOpts['type']>('type', 'Token type to request', undefined, types.string)
   .addOptionalParam<string>(
     'amount',

--- a/packages/ethereum/tasks/requestTestTokens.ts
+++ b/packages/ethereum/tasks/requestTestTokens.ts
@@ -44,7 +44,12 @@ async function requestXhopr(hre: HardhatRuntimeEnvironment, signer: Signer, amou
   }
 }
 
-async function requestDevNft(hre: HardhatRuntimeEnvironment, signer: Signer, hoprStake: Contract, recipientAddress: string) {
+async function requestDevNft(
+  hre: HardhatRuntimeEnvironment,
+  signer: Signer,
+  hoprStake: Contract,
+  recipientAddress: string
+) {
   const { ethers, deployments } = hre
   const signerAddress = await signer.getAddress()
 

--- a/packages/ethereum/tasks/requestTestTokens.ts
+++ b/packages/ethereum/tasks/requestTestTokens.ts
@@ -1,52 +1,52 @@
-import { Signer, Wallet } from 'ethers'
+import { type Signer, type Contract, Wallet } from 'ethers'
 import type { HardhatRuntimeEnvironment, RunSuperFunction } from 'hardhat/types'
 import { DEV_NFT_BOOST, DEV_NFT_TYPE } from '../utils/constants'
 
-export type RequestDevNftOpts = {
+export type RequestTestTokensOpts = {
+  type: 'devnft' | 'xhopr'
+  amount?: string // target amount in wei
   recipient: string // address of the recipient
   privatekey: string // private key of the Boost NFT owner
 }
 
-/**
- * As a prerequisite for staking, the staker must request Dev NFT. Staker is the recipient. privatekey should
- * be the private key of an account that owns some Dev NFTs
- */
-async function main(opts: RequestDevNftOpts, hre: HardhatRuntimeEnvironment, _runSuper: RunSuperFunction<any>) {
-  const { ethers, deployments, environment } = hre
-  // get envirionment
-  if (environment == undefined) {
-    console.error(`HOPR_ENVIRONMENT_ID is not set. Run with "HOPR_ENVIRONMENT_ID=<environment> ..."`)
+async function requestXhopr(hre: HardhatRuntimeEnvironment, signer: Signer, amount: string, recipientAddress: string) {
+  const { ethers, deployments } = hre
+  // must provide amount when token type is 'xhopr'
+  const tokenContract = await deployments.get('xHoprMock')
+  const hoprToken = (await ethers.getContractFactory('ERC677Mock')).connect(signer).attach(tokenContract.address)
+
+  const signerAddress = await signer.getAddress()
+  const balanceNativeToken = await ethers.provider.getBalance(signerAddress)
+  let balanceHoprToken
+  try {
+    balanceHoprToken = await hoprToken.balanceOf(signerAddress)
+  } catch (_) {
+    balanceHoprToken = ethers.constants.Zero
+  }
+  console.log(`DevBank account ${signerAddress} has ${balanceHoprToken} HOPR tokens`)
+  console.log(`DevBank account ${signerAddress} has ${balanceNativeToken} native tokens`)
+
+  if (balanceNativeToken.lte(0)) {
+    console.log(`DevBank account ${signerAddress} does not have enough native tokens to proceed`)
     process.exit(1)
   }
 
-  let provider
-  if (environment == 'hardhat-localhost') {
-    // we use a custom ethers provider here instead of the ethers object from the
-    // hre which is managed by hardhat-ethers, because that one seems to
-    // run its own in-memory hardhat instance, which is undesirable
-    provider = new ethers.providers.JsonRpcProvider()
-  } else {
-    provider = ethers.provider
+  if (ethers.BigNumber.from(amount).gt(ethers.BigNumber.from(balanceHoprToken))) {
+    console.log(`DevBank account ${signerAddress} does not have enough HOPR tokens to fulfill the request`)
+    process.exit(1)
   }
 
-  // get the provider and signer
-  let signer: Signer
-  if (!opts.privatekey) {
-    signer = provider.getSigner()
-  } else {
-    signer = new Wallet(opts.privatekey, provider)
+  try {
+    await (await hoprToken.transferAndCall(recipientAddress, amount, ethers.constants.HashZero)).wait()
+    console.log(`DevBank account ${signerAddress} transferred ${amount} HOPR tokens successfully`)
+  } catch (error) {
+    console.error(`Requesting HOPR tokens failed due to ${error}`)
   }
+}
+
+async function requestDevNft(hre: HardhatRuntimeEnvironment, signer: Signer, hoprStake: Contract, recipientAddress: string) {
+  const { ethers, deployments } = hre
   const signerAddress = await signer.getAddress()
-  console.log('Signer Address', signerAddress)
-
-  const recipientAddress = opts.recipient
-  console.log('Recipient Address', recipientAddress)
-
-  // get staking contract
-  const stakingContract = await deployments.get('HoprStake')
-  const hoprStake = (await ethers.getContractFactory('HoprStakeSeason3'))
-    .connect(signer)
-    .attach(stakingContract.address)
 
   // check if dev nft exists
   const nftContract = await deployments.get('HoprBoost')
@@ -139,6 +139,62 @@ async function main(opts: RequestDevNftOpts, hre: HardhatRuntimeEnvironment, _ru
     await hoprBoost['safeTransferFrom(address,address,uint256)'](signerAddress, recipientAddress, signerOwnedNFTTokenId)
   ).wait()
   console.log(`Address ${recipientAddress} succeeded in receiving Dev NFT from ${signerAddress}.`)
+}
+
+/**
+ * As a prerequisite for staking, the staker must request Dev NFT. Staker is the recipient. privatekey should
+ * be the private key of an account that owns some Dev NFTs
+ */
+async function main(opts: RequestTestTokensOpts, hre: HardhatRuntimeEnvironment, _runSuper: RunSuperFunction<any>) {
+  const { ethers, deployments, environment } = hre
+  // get envirionment
+  if (environment == undefined) {
+    console.error(`HOPR_ENVIRONMENT_ID is not set. Run with "HOPR_ENVIRONMENT_ID=<environment> ..."`)
+    process.exit(1)
+  }
+
+  let provider
+  if (environment == 'hardhat-localhost') {
+    // we use a custom ethers provider here instead of the ethers object from the
+    // hre which is managed by hardhat-ethers, because that one seems to
+    // run its own in-memory hardhat instance, which is undesirable
+    provider = new ethers.providers.JsonRpcProvider()
+  } else {
+    provider = ethers.provider
+  }
+
+  // get the provider and signer
+  let signer: Signer
+  if (!opts.privatekey) {
+    signer = provider.getSigner()
+  } else {
+    signer = new Wallet(opts.privatekey, provider)
+  }
+  const signerAddress = await signer.getAddress()
+  console.log('Signer Address', signerAddress)
+
+  const recipientAddress = opts.recipient
+  console.log('Recipient Address', recipientAddress)
+
+  // get staking contract
+  const stakingContract = await deployments.get('HoprStake')
+  const hoprStake = (await ethers.getContractFactory('HoprStakeSeason3'))
+    .connect(signer)
+    .attach(stakingContract.address)
+
+  if (opts.type === 'devnft') {
+    await requestDevNft(hre, signer, hoprStake, recipientAddress)
+  } else if (opts.type === 'xhopr') {
+    if (opts.amount) {
+      await requestXhopr(hre, signer, opts.amount, recipientAddress)
+    } else {
+      console.error('Missing argument --amount when requesting xHOPR tokens')
+      process.exit(1)
+    }
+  } else {
+    console.error(`Unsupported requesting type ${opts.type}`)
+    process.exit(1)
+  }
 }
 
 export default main

--- a/scripts/get-hopr-address.sh
+++ b/scripts/get-hopr-address.sh
@@ -11,7 +11,7 @@ declare mydir
 mydir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 source "${mydir}/utils.sh"
 
-: ${endpoint:?"No <endpoint> is set, use default value localhost:3001"}
+: ${1:?"No <endpoint> is set, use default value localhost:3001"}
 
 # $1 = optional: endpoint, defaults to http://localhost:3001
 declare endpoint="${1:-localhost:3001}"

--- a/scripts/register-node.sh
+++ b/scripts/register-node.sh
@@ -45,7 +45,7 @@ declare dev_bank_privkey="${DEV_BANK_PRIVKEY:-}"
 declare peer_id="$(get_hopr_address "${api_token}@${node_api}")"
 
 # Request a Dev NFT from DevBank
-PRIVATE_KEY="${dev_bank_privkey}" make request-dev-nft \
+PRIVATE_KEY="${dev_bank_privkey}" make request-devnft \
     environment=master-goerli \
     network=goerli \
     recipient="${account}"


### PR DESCRIPTION
When deployment multiple txHOPR contracts on the network, it is confusing to distinguish which contract is currently in use, especially when NR is introduced and txHOPR tokens can be used for staking and making accounts eligible.

Add `register-node-with-stake` make target to streamline the process of
- requesting txHOPR
- stake txHOPR
- register node to NR