### PR TITLE
use make to initiate build of WASM packages

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -46,9 +46,12 @@ jobs:
           registry-url: https://registry.npmjs.org/
           cache: yarn
 
-      - name: Build
+      - name: Install dependencies
         run: |
           make -j deps
+
+      - name: Build
+        run: |
           make -j build
 
       - name: Install websocat

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,30 +42,24 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
 
 [[package]]
 name = "js-sys"
-version = "0.3.57"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+checksum = "258451ab10b34f8af53416d1fdab72c22e805f0c92a1136d59470ec0b11138b2"
 dependencies = [
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
-
-[[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "505e71a4706fa491e9b1b55f51b95d4037d0821ee40131190475f692b35b009b"
 
 [[package]]
 name = "log"
@@ -83,19 +77,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.39"
+name = "once_cell"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
+checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.18"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
@@ -110,9 +110,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
 
 [[package]]
 name = "scoped-tls"
@@ -122,18 +122,18 @@ checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
 
 [[package]]
 name = "serde"
-version = "1.0.137"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
+checksum = "53e8e5d5b70924f74ff5c6d64d9a5acd91422117c60f48c4e07855238a254553"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.137"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
+checksum = "d3d8e8de557aee63c26b85b947f5e59b690d0454c753f3adeb5cd7835ab88391"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.81"
+version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
+checksum = "38dd04e3c8279e75b31ef29dbdceebfe5ad89f4d0937213c53f7d49d01b3d5a7"
 dependencies = [
  "itoa",
  "ryu",
@@ -153,9 +153,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.96"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0748dd251e24453cb8717f0354206b91557e4ec8703673a4b30208f2abaf1ebf"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -164,9 +164,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d22af068fba1eb5edcb4aea19d382b2a3deb4c8f9d475c589b6ada9e0fd493ee"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
 
 [[package]]
 name = "utils-misc"
@@ -182,9 +182,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c53b543413a17a202f4be280a7e5c62a1c69345f5de525ee64f8cfdbc954994"
+checksum = "fc7652e3f6c4706c8d9cd54832c4a4ccb9b5336e2c3bd154d5cccfbf1c1f5f7d"
 dependencies = [
  "cfg-if 1.0.0",
  "serde",
@@ -194,13 +194,13 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5491a68ab4500fa6b4d726bd67408630c3dbe9c4fe7bda16d5c82a1fd8c7340a"
+checksum = "662cd44805586bd52971b9586b1df85cdbbd9112e4ef4d8f41559c334dc6ac3f"
 dependencies = [
  "bumpalo",
- "lazy_static",
  "log",
+ "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.30"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f741de44b75e14c35df886aff5f1eb73aa114fa5d4d00dcd37b5e01259bf3b2"
+checksum = "fa76fb221a1f8acddf5b54ace85912606980ad661ac7a503b4570ffd3a624dad"
 dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
@@ -221,9 +221,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c441e177922bc58f1e12c022624b6216378e5febc2f0533e41ba443d505b80aa"
+checksum = "b260f13d3012071dfb1512849c033b1925038373aea48ced3012c09df952c602"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -231,9 +231,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
+checksum = "5be8e654bdd9b79216c2929ab90721aa82faf65c48cdf08bdc4e7f51357b80da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -244,15 +244,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.81"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a89911bd99e5f3659ec4acf9c4d93b0a90fe4a2a11f15328472058edc5261be"
+checksum = "6598dd0bd3c7d51095ff6531a5b23e02acdc81804e30d8f07afb77b7215a140a"
 
 [[package]]
 name = "wasm-bindgen-test"
-version = "0.3.30"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4464b3f74729a25f42b1a0cd9e6a515d2f25001f3535a6cfaf35d34a4de3bab"
+checksum = "513df541345bb9fcc07417775f3d51bbb677daf307d8035c0afafd87dc2e6599"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
@@ -264,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-test-macro"
-version = "0.3.30"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c5a6f82cc6093a321ca5fb3dc9327fe51675d477b3799b4a9375bac3b7b4c"
+checksum = "6150d36a03e90a3cf6c12650be10626a9902d70c5270fd47d7a47e5389a10d56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -274,9 +274,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.57"
+version = "0.3.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
+checksum = "ed055ab27f941423197eb86b2035720b1a3ce40504df082cac2ecc6ed73335a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,7 @@ members = [
     "packages/hoprd/crates/hoprd-misc",
     "packages/utils/crates/utils-misc"
 ]
+
+[profile.release]
+# Tell `rustc` to optimize for small code size.
+opt-level = "s"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,13 @@
+WORKSPACES_WITH_RUST_MODULES := $(wildcard $(addsuffix /crates, $(wildcard ./packages/*)))
+
 .POSIX:
 
 all: help
+
+.PHONY: $(WORKSPACES_WITH_RUST_MODULES) ## build all WASM modules
+$(WORKSPACES_WITH_RUST_MODULES):
+	$(MAKE) -C $@ all 
+	$(MAKE) -C $@ install
 
 .PHONY: deps
 deps: ## install dependencies
@@ -18,8 +25,6 @@ build-hopr-admin: ## build hopr admin React frontend
 
 .PHONY: build-solidity-types
 build-solidity-types: ## generate Solidity typings
-build-solidity-types: build-cargo
-	npx tsc -p packages/utils/tsconfig.json
 	yarn workspace @hoprnet/hopr-ethereum run build:sol:types
 
 .PHONY: build-yarn
@@ -30,7 +35,7 @@ build-yarn: build-solidity-types build-cargo
 .PHONY: build-cargo
 build-cargo: ## build cargo packages
 	cargo build --release --target wasm32-unknown-unknown
-	yarn workspaces foreach --exclude hoprnet --exclude hopr-docs run build:wasm
+	$(MAKE) $(WORKSPACES_WITH_RUST_MODULES)
 
 .PHONY: build-yellowpaper
 build-yellowpaper: ## build the yellowpaper in docs/yellowpaper

--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,7 @@ all: help
 
 .PHONY: $(WORKSPACES_WITH_RUST_MODULES) ## build all WASM modules
 $(WORKSPACES_WITH_RUST_MODULES):
-	$(MAKE) -C $@ all
-	$(MAKE) -C $@ install
-
-.PHONY: rust-modules
-rust-modules: $(WORKSPACES_WITH_RUST_MODULES)
+	$(MAKE) -j 1 -C $@ all install
 
 .PHONY: deps
 deps: ## install dependencies
@@ -36,9 +32,9 @@ build-yarn: build-solidity-types build-cargo
 	npx tsc --build tsconfig.build.json
 
 .PHONY: build-cargo
-build-cargo: ## build cargo packages
+build-cargo: ## build cargo packages and create boilerplate JS code
 	cargo build --release --target wasm32-unknown-unknown
-	$(MAKE) -j 1 rust-modules
+	$(MAKE) -j 1 $(WORKSPACES_WITH_RUST_MODULES)
 
 .PHONY: build-yellowpaper
 build-yellowpaper: ## build the yellowpaper in docs/yellowpaper

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all: help
 
 .PHONY: $(WORKSPACES_WITH_RUST_MODULES) ## build all WASM modules
 $(WORKSPACES_WITH_RUST_MODULES):
-	$(MAKE) -C $@ all 
+	$(MAKE) -C $@ all
 	$(MAKE) -C $@ install
 
 .PHONY: rust-modules
@@ -38,7 +38,7 @@ build-yarn: build-solidity-types build-cargo
 .PHONY: build-cargo
 build-cargo: ## build cargo packages
 	cargo build --release --target wasm32-unknown-unknown
-	$(MAKE) rust-modules
+	$(MAKE) -j 1 rust-modules
 
 .PHONY: build-yellowpaper
 build-yellowpaper: ## build the yellowpaper in docs/yellowpaper

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ $(WORKSPACES_WITH_RUST_MODULES):
 	$(MAKE) -C $@ all 
 	$(MAKE) -C $@ install
 
+.PHONY: rust-modules
+rust-modules: $(WORKSPACES_WITH_RUST_MODULES)
+
 .PHONY: deps
 deps: ## install dependencies
 	corepack enable
@@ -35,7 +38,7 @@ build-yarn: build-solidity-types build-cargo
 .PHONY: build-cargo
 build-cargo: ## build cargo packages
 	cargo build --release --target wasm32-unknown-unknown
-	$(MAKE) $(WORKSPACES_WITH_RUST_MODULES)
+	$(MAKE) rust-modules
 
 .PHONY: build-yellowpaper
 build-yellowpaper: ## build the yellowpaper in docs/yellowpaper

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ HOPR contains modules written in Rust, therefore a Rust toolchain is needed to s
 To install Rust toolchain (at least version 1.60) please follow instructions at [https://www.rust-lang.org/tools/install](https://www.rust-lang.org/tools/install) first.
 
 ```sh
-make -j deps build
+make -j deps && make -j build
 
 # starting network
 HOPR_ENVIRONMENT_ID=hardhat-localhost yarn run:network

--- a/SETUP_LOCAL_CLUSTER.md
+++ b/SETUP_LOCAL_CLUSTER.md
@@ -29,7 +29,7 @@ cd hoprnet-master
    to install and build the required packages and project modules. Ideally, you also have setup your computer with basic development toolset[^5]. Please bear in mind that this process will take at least 5-10 minutes depending on your computer.
 
 ```
-make -j deps build
+make -j deps && make -j build
 ```
 
 3. **Run the one-line setup script**: Proceed to run the following script. If you are planning to run [MyneChat](http://app.myne.chat/)

--- a/docs/hopr-documentation/docs/developers/starting-local-cluster.md
+++ b/docs/hopr-documentation/docs/developers/starting-local-cluster.md
@@ -93,7 +93,7 @@ cd hoprnet-release-lisbon
    to install and build the required packages and project modules. Ideally you will also have basic development toolsets[^2] set up on your computer. Please bear in mind that this process will take at least 5-10 minutes depending on your computer.
 
 ```bash
-make -j deps build
+make -j deps && make -j build
 ```
 
 3. **Run the one-line setup script**: Run the following script:

--- a/packages/hoprd/crates/hoprd-misc/Cargo.toml
+++ b/packages/hoprd/crates/hoprd-misc/Cargo.toml
@@ -21,7 +21,3 @@ wee_alloc = { version = "0.4.5", optional = true }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.30"
-
-[profile.release]
-# Tell `rustc` to optimize for small code size.
-opt-level = "s"

--- a/packages/real/crates/real-base/Cargo.toml
+++ b/packages/real/crates/real-base/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/lib.rs"
 crate-type = ["cdylib", "rlib"] # rlib is necessary to run integration tests
 
 [dependencies]
-wasm-bindgen = "0.2.80"
+wasm-bindgen = "0.2.81"
 wasm-bindgen-test = "0.3.30"
 
 [dev-dependencies]

--- a/packages/utils/crates/utils-misc/Cargo.toml
+++ b/packages/utils/crates/utils-misc/Cargo.toml
@@ -23,7 +23,3 @@ wee_alloc = { version = "0.4.5", optional = true }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.30"
-
-[profile.release]
-# Tell `rustc` to optimize for small code size.
-opt-level = "s"

--- a/scripts/publish-version.sh
+++ b/scripts/publish-version.sh
@@ -67,7 +67,7 @@ git pull origin "${branch}" --rebase --tags
 mydir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 
 # ensure the build is up-to-date
-make -C -j "${mydir}/.." deps && make -C -j "${mydir}/.." build
+make -j -C "${mydir}/.." deps && make -j -C "${mydir}/.." build
 
 declare current_version
 current_version="$("${mydir}/get-package-version.sh")"

--- a/scripts/publish-version.sh
+++ b/scripts/publish-version.sh
@@ -67,7 +67,7 @@ git pull origin "${branch}" --rebase --tags
 mydir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 
 # ensure the build is up-to-date
-make -C "${mydir}/.." deps build
+make -C -j "${mydir}/.." deps && make -C -j "${mydir}/.." build
 
 declare current_version
 current_version="$("${mydir}/get-package-version.sh")"

--- a/scripts/vm-nat-testing/README.md
+++ b/scripts/vm-nat-testing/README.md
@@ -72,7 +72,7 @@ On each code change, the following steps are repeatable.
 On host machine, you can build HOPR, e.g. using standard:
 
 ```shell
-make -j deps build
+make -j deps && make -j build
 ```
 
 Once HOPR is built, public and NAT nodes can be restarted using the following command for the changes to take effect:


### PR DESCRIPTION
## Changes 

- use `make` to build WASM boilerplate code
- remove `utils` dependency from Makefile from Typechain generation because `ethereum/hardhat` package no longer requires built utils
- move Rust `release.profile` to top-level `cargo.toml` as it is ignored otherwise - according to cargo