### PR TITLE
hopr-admin: Fix conversion of https to wss protocol string

### DIFF
--- a/packages/hoprd/hopr-admin/src/state/useWS.ts
+++ b/packages/hoprd/hopr-admin/src/state/useWS.ts
@@ -61,7 +61,7 @@ const useWebsocket = (config: Configuration, apiPath: ApiPath) => {
 
     // need to set the token in the query parameters, to enable websocket authentication
     const wsUrl = new URL(apiPath, config.apiEndpoint)
-    wsUrl.protocol = wsUrl.protocol === 'https' ? 'wss' : 'ws'
+    wsUrl.protocol = wsUrl.protocol === 'https:' ? 'wss' : 'ws'
     if (config.apiToken) {
       wsUrl.search = `?apiToken=${config.apiToken}`
     }


### PR DESCRIPTION
This bug made the HOPR admin not load if an endpoint behind `https` is used.