### PR TITLE
hopr-admin: Fix regression in commands in v2

### DIFF
--- a/packages/ethereum/contracts/HoprNetworkRegistry.sol
+++ b/packages/ethereum/contracts/HoprNetworkRegistry.sol
@@ -12,7 +12,7 @@ import './IHoprNetworkRegistryRequirement.sol';
  * HOPR node address. If an account wants to change its registerd HOPR node address, it must
  * firstly deregister itself before registering new node.
  *
- * Note that HOPR node address refers to `PeerId.toB58String()`
+ * Note that HOPR node address refers to `PeerId.toString()`
  *
  * This network registry can be globally enabled/disabled by the owner
  *

--- a/packages/hoprd/hopr-admin/src/commands/sendMessage.ts
+++ b/packages/hoprd/hopr-admin/src/commands/sendMessage.ts
@@ -46,7 +46,7 @@ export default class SendMessage extends Command {
       try {
         const [valid, peerId] = validatePeerIdOrAlias(pIdString, { aliases })
         if (!valid) throw Error()
-        path.push(peerId.toB58String())
+        path.push(peerId.toString())
       } catch (err) {
         return [false, `<${pIdString}> is neither a valid alias nor a valid Hopr address string`, undefined]
       }
@@ -57,14 +57,14 @@ export default class SendMessage extends Command {
   }
 
   public async execute(log: (msg: string) => void, query: string): Promise<void> {
-    const [error, use, pathOrRecipeint, message] = this.assertUsage(query) as [string | undefined, string, any, string]
+    const [error, use, pathOrRecipient, message] = this.assertUsage(query) as [string | undefined, string, any, string]
     if (error) return log(error)
 
     let path: string[] | undefined
-    let recipient: string = pathOrRecipeint
+    let recipient: string = pathOrRecipient
 
     if (use === 'manual') {
-      const [valid, error, result] = this.parsePathStr(pathOrRecipeint)
+      const [valid, error, result] = this.parsePathStr(pathOrRecipient)
       if (!valid) return log(`${error}\n${this.usage()}`)
       path = result.intermediateNodes
       recipient = result.recipient

--- a/packages/hoprd/hopr-admin/src/commands/withdraw.ts
+++ b/packages/hoprd/hopr-admin/src/commands/withdraw.ts
@@ -9,7 +9,7 @@ export default class Withdraw extends Command {
         default: [
           [
             ['number', 'amount to withdraw', false],
-            ['hoprOrNative', 'withdraw "hopr" or "native"', false],
+            ['hoprOrNative', 'withdraw "HOPR" or "NATIVE"', false],
             ['nativeAddress', 'recipient', false]
           ],
           'withdraw'

--- a/packages/hoprd/hopr-admin/src/utils/command.spec.ts
+++ b/packages/hoprd/hopr-admin/src/utils/command.spec.ts
@@ -78,13 +78,13 @@ describe('test Command class', function () {
     )
 
     // @ts-ignore
-    const primaryResult = cmd.assertUsage(HOPR_ADDRESS_MOCK.toB58String())
+    const primaryResult = cmd.assertUsage(HOPR_ADDRESS_MOCK.toString())
     assert.equal(primaryResult[0], undefined)
     assert.equal(primaryResult[1], 'primary')
     assert(HOPR_ADDRESS_MOCK.equals(primaryResult[2]))
 
     // @ts-ignore
-    const secondaryResult = cmd.assertUsage(`${HOPR_ADDRESS_MOCK.toB58String()} true`)
+    const secondaryResult = cmd.assertUsage(`${HOPR_ADDRESS_MOCK.toString()} true`)
     assert.equal(secondaryResult[0], undefined)
     assert.equal(secondaryResult[1], 'secondary')
     assert(HOPR_ADDRESS_MOCK.equals(secondaryResult[2]))

--- a/packages/hoprd/hopr-admin/src/utils/command.ts
+++ b/packages/hoprd/hopr-admin/src/utils/command.ts
@@ -173,13 +173,18 @@ export const CMD_PARAMS: Record<CmdTypes, CmdArg<any, any, any>> = {
       // try PeerId
       try {
         peerId = peerIdFromString(peerIdStrOrAlias)
-      } catch {}
+      } catch {
+        console.log(`Could not create peer id from '${peerIdStrOrAlias}'`)
+      }
 
       // try aliases
       if (!peerId && aliases) {
+        const alias = aliases[peerIdStrOrAlias]
         try {
-          peerId = peerIdFromString(aliases[peerIdStrOrAlias])
-        } catch {}
+          peerId = peerIdFromString(alias)
+        } catch {
+          console.log(`Could not create peer id from alias '${alias}' for '${peerIdStrOrAlias}'`)
+        }
       }
 
       if (peerId) return [true, peerId]
@@ -187,9 +192,9 @@ export const CMD_PARAMS: Record<CmdTypes, CmdArg<any, any, any>> = {
     }
   ] as CmdArg<string, { aliases: Record<string, string> }, PeerId>,
   hoprOrNative: [
-    "'hopr' or 'native'",
+    "'HOPR' or 'NATIVE'",
     (v) => {
-      return [v === 'hopr' || v === 'native', v]
+      return [v === 'HOPR' || v === 'NATIVE', v]
     }
   ],
   number: [

--- a/packages/hoprd/src/admin.ts
+++ b/packages/hoprd/src/admin.ts
@@ -85,11 +85,11 @@ export class AdminServer {
     this.node = node
 
     this.node.on('hopr:channel:opened', (channel) => {
-      this.logs.log(`Opened channel to ${channel[0].toB58String()}`)
+      this.logs.log(`Opened channel to ${channel[0].toString()}`)
     })
 
     this.node.on('hopr:channel:closed', (peer) => {
-      this.logs.log(`Closed channel to ${peer.toB58String()}`)
+      this.logs.log(`Closed channel to ${peer.toString()}`)
     })
 
     this.node.on('hopr:warning:unfunded', (addr) => {

--- a/packages/hoprd/src/api/v2/paths/messages/sign.ts
+++ b/packages/hoprd/src/api/v2/paths/messages/sign.ts
@@ -5,7 +5,7 @@ import { STATUS_CODES } from '../../utils.js'
 const POST: Operation = [
   async (req, res, _next) => {
     try {
-      const signature = await req.context.node.signMessage(new TextEncoder().encode(req.body.message))
+      const signature = req.context.node.signMessage(new TextEncoder().encode(req.body.message))
       return res.status(200).send({ signature: u8aToHex(signature) })
     } catch (err) {
       return res


### PR DESCRIPTION
- Fixes command sign message to create proper signature
- Fixes command withdraw to use currency spelling required by APIv2
- Fixes command send for multi-hop manual path usage

Fixes #3967 