### PR TITLE
Allow creating database dump file

### DIFF
--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -169,6 +169,12 @@ export async function createHoprNode(
   try {
     const dbPath = path.join(options.dataPath, 'db')
     await db.init(options.createDbIfNotExist, dbPath, options.forceCreateDB, options.environment.id)
+
+    // Dump entire database to a file if given by the env variable
+    const dump_file = process.env.DB_DUMP ?? ''
+    if (dump_file.length > 0)
+      db.dumpDatabase(dump_file)
+
   } catch (err: unknown) {
     log(`failed init db:`, err)
     throw err

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -172,9 +172,7 @@ export async function createHoprNode(
 
     // Dump entire database to a file if given by the env variable
     const dump_file = process.env.DB_DUMP ?? ''
-    if (dump_file.length > 0)
-      db.dumpDatabase(dump_file)
-
+    if (dump_file.length > 0) db.dumpDatabase(dump_file)
   } catch (err: unknown) {
     log(`failed init db:`, err)
     throw err

--- a/packages/utils/src/db/db.ts
+++ b/packages/utils/src/db/db.ts
@@ -22,6 +22,7 @@ import {
 } from '../types/index.js'
 import BN from 'bn.js'
 import { u8aToNumber, u8aConcat, toU8a } from '../u8a/index.js'
+import fs from 'fs'
 
 const log = debug(`hopr-core:db`)
 
@@ -217,6 +218,29 @@ export class HoprDB {
 
   protected async put(key: Uint8Array, value: Uint8Array): Promise<void> {
     await this.db.put(Buffer.from(this.keyOf(key)), Buffer.from(value))
+  }
+
+  public async dumpDatabase(destFile: string) {
+    let dumpFile = fs.createWriteStream(destFile, { flags: 'a' })
+    this.db.createReadStream({keys: true, keyAsBuffer: true, values: true, valueAsBuffer: false})
+     .on('data', (d) => {
+       let keyString = ''
+       let isHex = false;
+       for (const b of d.key) {
+         if (b >= 32 && b <= 126) {
+           // Print sequences of ascii chars normally
+           keyString += (isHex ? ' ' : '') + String.fromCharCode(b)
+           isHex = false
+         }
+         else {
+           // Print sequences of non-ascii chars as hex
+           keyString += (!isHex ? '0x' : '') + (b as number).toString(16)
+           isHex = true
+         }
+       }
+       dumpFile.write(keyString + ":" + d.value)
+     })
+     dumpFile.close()
   }
 
   private async touch(key: Uint8Array): Promise<void> {

--- a/packages/utils/src/db/db.ts
+++ b/packages/utils/src/db/db.ts
@@ -222,25 +222,23 @@ export class HoprDB {
 
   public async dumpDatabase(destFile: string) {
     let dumpFile = fs.createWriteStream(destFile, { flags: 'a' })
-    this.db.createReadStream({keys: true, keyAsBuffer: true, values: true, valueAsBuffer: false})
-     .on('data', (d) => {
-       let keyString = ''
-       let isHex = false;
-       for (const b of d.key) {
-         if (b >= 32 && b <= 126) {
-           // Print sequences of ascii chars normally
-           keyString += (isHex ? ' ' : '') + String.fromCharCode(b)
-           isHex = false
-         }
-         else {
-           // Print sequences of non-ascii chars as hex
-           keyString += (!isHex ? '0x' : '') + (b as number).toString(16)
-           isHex = true
-         }
-       }
-       dumpFile.write(keyString + ":" + d.value)
-     })
-     dumpFile.close()
+    this.db.createReadStream({ keys: true, keyAsBuffer: true, values: true, valueAsBuffer: false }).on('data', (d) => {
+      let keyString = ''
+      let isHex = false
+      for (const b of d.key) {
+        if (b >= 32 && b <= 126) {
+          // Print sequences of ascii chars normally
+          keyString += (isHex ? ' ' : '') + String.fromCharCode(b)
+          isHex = false
+        } else {
+          // Print sequences of non-ascii chars as hex
+          keyString += (!isHex ? '0x' : '') + (b as number).toString(16)
+          isHex = true
+        }
+      }
+      dumpFile.write(keyString + ':' + d.value)
+    })
+    dumpFile.close()
   }
 
   private async touch(key: Uint8Array): Promise<void> {


### PR DESCRIPTION
Allows dumping of the LevelDB into a text file for diagnostic purposes if `DUMP_DB` env variable is specified.