### PR TITLE
Various minor fixes to issues found during Paleochora release tests

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -998,7 +998,7 @@ class Hopr extends EventEmitter {
   /**
    * Open a payment channel
    *
-   * @param counterparty the counter party's peerId
+   * @param counterparty the counterparty's peerId
    * @param amountToFund the amount to fund in HOPR(wei)
    */
   public async openChannel(
@@ -1008,6 +1008,10 @@ class Hopr extends EventEmitter {
     channelId: Hash
     receipt: string
   }> {
+    if (this.id.equals(counterparty)) {
+      throw Error('Cannot open channel to self!')
+    }
+
     const counterpartyPubKey = PublicKey.fromPeerId(counterparty)
     const myAvailableTokens = await this.connector.getBalance(true)
 

--- a/packages/hoprd/hopr-admin/src/commands/channels.ts
+++ b/packages/hoprd/hopr-admin/src/commands/channels.ts
@@ -30,7 +30,7 @@ export default class Channels extends Command {
    */
   private getChannelLog(prefix, channel) {
     return toPaddedString([
-      [ prefix + ' Channel:', channel.channelId],
+      [prefix + ' Channel:', channel.channelId],
       ['To:', channel.peerId],
       ['Status:', channel.status],
       ['Balance:', ethersUtils.formatEther(channel.balance)]

--- a/packages/hoprd/hopr-admin/src/commands/channels.ts
+++ b/packages/hoprd/hopr-admin/src/commands/channels.ts
@@ -28,9 +28,9 @@ export default class Channels extends Command {
    * Creates the log output for a channel
    * @returns a channel log
    */
-  private getChannelLog(channel) {
+  private getChannelLog(prefix, channel) {
     return toPaddedString([
-      ['Outgoing Channel:', channel.channelId],
+      [ prefix + ' Channel:', channel.channelId],
       ['To:', channel.peerId],
       ['Status:', channel.status],
       ['Balance:', ethersUtils.formatEther(channel.balance)]
@@ -62,7 +62,7 @@ export default class Channels extends Command {
         log(`\nNo channels opened to you.`)
       } else {
         for (const channel of incomingChannels) {
-          log(this.getChannelLog(channel))
+          log(this.getChannelLog('Incoming', channel))
         }
       }
     }
@@ -76,7 +76,7 @@ export default class Channels extends Command {
         log(`\nNo channels opened by you.`)
       } else {
         for (const channel of channelsOutgoing) {
-          log(this.getChannelLog(channel))
+          log(this.getChannelLog('Outgoing', channel))
         }
       }
     }

--- a/packages/hoprd/hopr-admin/src/commands/openChannel.ts
+++ b/packages/hoprd/hopr-admin/src/commands/openChannel.ts
@@ -58,7 +58,7 @@ export default class OpenChannel extends Command {
     const response = await this.api.openChannel(counterpartyStr, amountToFund.toString())
     if (!response.ok) return log(this.invalidResponse(`open a channel to ${counterpartyStr}`))
 
-    const channelId = response.json().then((res) => res.channelId)
+    const channelId = await response.json().then((res) => res.channelId)
     return log(`Successfully opened channel "${channelId}" to node "${counterpartyStr}".`)
   }
 }

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -306,7 +306,7 @@ function addUnhandledPromiseRejectionHandler() {
 
   // See https://github.com/hoprnet/hoprnet/issues/3755
   process.on('unhandledRejection', (reason: any, _promise: Promise<any>) => {
-    if (reason.message && reason.message.toString) {
+    if (reason && reason.message && reason.message.toString) {
       const msgString = reason.toString()
 
       // Only silence very specific errors


### PR DESCRIPTION
This PR addresses following issues:

- `Successfully opened channel "[object Promise]" to node "qBh8y".` (missing `await` on channel ID retrieval)
- Prevent opening channel to self (fixes #3994)
- The `channels` command prints `Outgoing channels` text for channels that are incoming
- Unhandled rejection handler in `hoprd` checks if `reason` is not `undefined` before printing `reason.message` (refs #3995 

Refs #3803 