### PR TITLE
must accept api token when registering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -262,7 +262,7 @@ endif
 
 .PHONY: register-node-with-stake
 # node_api?=localhost:3001 provide endpoint of hoprd, with a default value 'localhost:3001'
-register-node-with-stake: ensure-environment-is-set, get-hopr-address-from-script
+register-node-with-stake: ensure-environment-is-set
 ifeq ($(account),)
 	echo "parameter <account> missing" >&2 && exit 1
 endif

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 WORKSPACES_WITH_RUST_MODULES := $(wildcard $(addsuffix /crates, $(wildcard ./packages/*)))
-PEER_ID := $(shell eval ./scripts/get-hopr-address.sh "$(api_token)" "$(endpoint)")
 
 .POSIX:
 
@@ -230,14 +229,13 @@ endif
 ifeq ($(origin CI_DEPLOYER_PRIVKEY),undefined)
 	echo "<CI_DEPLOYER_PRIVKEY> environment variable missing" >&2 && exit 1
 endif
-	$(GET_PEER_ID)
 	TS_NODE_PROJECT=./tsconfig.hardhat.json \
 	HOPR_ENVIRONMENT_ID="$(environment)" \
 	  yarn workspace @hoprnet/hopr-ethereum run hardhat register \
    --network $(network) \
    --task add \
    --native-addresses "$(account)" \
-   --peer-ids "${PEER_ID}" \
+   --peer-ids "$(shell eval ./scripts/get-hopr-address.sh "$(api_token)" "$(endpoint)")" \
    --privatekey "$(CI_DEPLOYER_PRIVKEY)"
 
 .PHONY: register-node-with-nft
@@ -258,10 +256,9 @@ endif
 ifeq ($(origin DEV_BANK_PRIVKEY),undefined)
 	echo "<DEV_BANK_PRIVKEY> environment variable missing" >&2 && exit 1
 endif
-	$(GET_PEER_ID)
 	PRIVATE_KEY=${DEV_BANK_PRIVKEY} make request-devnft recipient=${account}
 	PRIVATE_KEY=${ACCOUNT_PRIVKEY} make stake-devnft
-	PRIVATE_KEY=${ACCOUNT_PRIVKEY} make self-register-node peer_id=${PEER_ID}
+	PRIVATE_KEY=${ACCOUNT_PRIVKEY} make self-register-node peer_id=$(shell eval ./scripts/get-hopr-address.sh "$(api_token)" "$(endpoint)")
 
 .PHONY: register-node-with-stake
 # node_api?=localhost:3001 provide endpoint of hoprd, with a default value 'localhost:3001'
@@ -275,10 +272,9 @@ endif
 ifeq ($(origin DEV_BANK_PRIVKEY),undefined)
 	echo "<DEV_BANK_PRIVKEY> environment variable missing" >&2 && exit 1
 endif
-	$(GET_PEER_ID)
 	PRIVATE_KEY=${DEV_BANK_PRIVKEY} make request-funds recipient=${account}
 	PRIVATE_KEY=${ACCOUNT_PRIVKEY} make stake-funds
-	PRIVATE_KEY=${ACCOUNT_PRIVKEY} make self-register-node peer_id=${PEER_ID}
+	PRIVATE_KEY=${ACCOUNT_PRIVKEY} make self-register-node peer_id=$(shell eval ./scripts/get-hopr-address.sh "$(api_token)" "$(endpoint)")
 
 ensure-environment-is-set:
 ifeq ($(environment),)

--- a/NETWORK_REGISTRY.md
+++ b/NETWORK_REGISTRY.md
@@ -174,5 +174,11 @@ source .env
 4. Run command
 
 ```
-make register-node-when-dummy-proxy endpoint=<hoprd_endpoint> account=<staking_account> environment=master-goerli network=goerli
+make register-node-when-dummy-proxy endpoint=<hoprd_endpoint> api_token=<api_token> account=<staking_account> environment=<release name> network=xdai
+```
+
+e.g.
+
+```
+make register-node-when-dummy-proxy endpoint="localhost:3001" api_token="^MYtoken4testing^" account=0x35A3e15A2E2C297686A4fac5999647312fdDfa3f environment=paleochora network=xdai
 ```

--- a/scripts/get-hopr-address.sh
+++ b/scripts/get-hopr-address.sh
@@ -11,11 +11,21 @@ declare mydir
 mydir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 source "${mydir}/utils.sh"
 
-: ${1:?"No <endpoint> is set, use default value localhost:3001"}
+# $1 = optional: apitoken, defaults to ""
+declare apitoken="${1:-}"
+# $2 = optional: endpoint, defaults to http://localhost:3001
+declare endpoint="${2:-localhost:3001}"
 
-# $1 = optional: endpoint, defaults to http://localhost:3001
-declare endpoint="${1:-localhost:3001}"
-declare url="${endpoint}/api/v2/account/addresses"
+if [[ -z "${apitoken}" ]]; then
+    msg "No <apitoken> is set"
+    exit 1
+fi
+if [[ -z "${endpoint}" ]]; then
+    msg "No <endpoint> is set, use default value localhost:3001"
+fi
+
+declare url="${apitoken}@${endpoint}/api/v2/account/addresses"
+
 declare cmd="$(get_authenticated_curl_cmd ${url})"
 
 try_cmd "${cmd}" 30 5 | jq -r ".hopr"


### PR DESCRIPTION
- When registering node to NR, it must pass an additional field `api_token` in the make target when registering a node in order to retrieve peerId automatically
- update readme

Fixes #3993