### PR TITLE
Prevent duplicate peer ids in the manual path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
   - uses `typescript`
   - command parsing has been overhauled to support more complex commands
   - improved user experience with more consistent messages
-- Manual path selection should not contain duplicate entries
+- Warn when manual path selection contains duplicate adjacent entries
 
 # Breaking changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
   - uses `typescript`
   - command parsing has been overhauled to support more complex commands
   - improved user experience with more consistent messages
+- Manual path selection should not contain duplicate entries
 
 # Breaking changes
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -733,8 +733,7 @@ class Hopr extends EventEmitter {
           ticketReceiver = intermediatePath[i]
         }
 
-        if (ticketIssuer.eq(ticketReceiver))
-          log(`WARNING: duplicated adjacent path entries.`)
+        if (ticketIssuer.eq(ticketReceiver)) log(`WARNING: duplicated adjacent path entries.`)
 
         const channel = await this.db.getChannelX(ticketIssuer, ticketReceiver)
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -733,6 +733,9 @@ class Hopr extends EventEmitter {
           ticketReceiver = intermediatePath[i]
         }
 
+        if (ticketIssuer.eq(ticketReceiver))
+          log(`WARNING: duplicated adjacent path entries.`)
+
         const channel = await this.db.getChannelX(ticketIssuer, ticketReceiver)
 
         if (channel.status !== ChannelStatus.Open) {

--- a/packages/core/src/messages/packet.ts
+++ b/packages/core/src/messages/packet.ts
@@ -296,7 +296,7 @@ export class Packet {
 
   static async create(msg: Uint8Array, path: PeerId[], privKey: PeerId, db: HoprDB): Promise<Packet> {
     if (new Set<PeerId>(path).size != path.length) {
-      throw new Error("Path contains duplicate peer ids")
+      throw new Error('Path contains duplicate peer ids')
     }
 
     const isDirectMessage = path.length == 1

--- a/packages/core/src/messages/packet.ts
+++ b/packages/core/src/messages/packet.ts
@@ -295,10 +295,6 @@ export class Packet {
   }
 
   static async create(msg: Uint8Array, path: PeerId[], privKey: PeerId, db: HoprDB): Promise<Packet> {
-    if (new Set<PeerId>(path).size != path.length) {
-      throw new Error('Path contains duplicate peer ids')
-    }
-
     const isDirectMessage = path.length == 1
     const { alpha, secrets } = generateKeyShares(path)
     const { ackChallenge, ticketChallenge } = createPoRValuesForSender(secrets[0], secrets[1])

--- a/packages/core/src/messages/packet.ts
+++ b/packages/core/src/messages/packet.ts
@@ -295,6 +295,10 @@ export class Packet {
   }
 
   static async create(msg: Uint8Array, path: PeerId[], privKey: PeerId, db: HoprDB): Promise<Packet> {
+    if (new Set<PeerId>(path).size != path.length) {
+      throw new Error("Path contains duplicate peer ids")
+    }
+
     const isDirectMessage = path.length == 1
     const { alpha, secrets } = generateKeyShares(path)
     const { ackChallenge, ticketChallenge } = createPoRValuesForSender(secrets[0], secrets[1])


### PR DESCRIPTION
Warn when duplicate peer id entries in the manual path selection

Closes #4006 