### PR TITLE
Silence ETIMEDOUT socket errors

### DIFF
--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -314,7 +314,9 @@ function addUnhandledPromiseRejectionHandler() {
         // HOPR uses the `stream-to-it` library to convert streams from Node.js sockets
         // to async iterables. This library has shown to have issues with runtime errors,
         // mainly ECONNRESET and EPIPE
+        msgString.match(/read ETIMEDOUT/) ||
         msgString.match(/read ECONNRESET/) ||
+        msgString.match(/write ETIMEDOUT/) ||
         msgString.match(/write ECONNRESET/) ||
         msgString.match(/write EPIPE/) ||
         // Requires changes in libp2p, tbd in upstream PRs to libp2p


### PR DESCRIPTION
Silences ETIMEDOUT socket errors that lead to unhandled promise rejections.

The error is handled by `connect` code (see debug log) but for some reason it gets treated as an unhandled promise rejection

```
  hopr-connect:error SOCKET ERROR on connection to /ip4/34.91.92.221/tcp/9091/p2p/16Uiu2HAm64wMg8mVM93qTRB71455R7EmS3yrWW78Q2ihYwqorz6C: ' {"errno":-110,"code":"ETIMEDOUT","syscall":"read"} +2ms
  hopr-connect:tcp:error unexpected error in TCP sink function Error: read ETIMEDOUT
    at TCP.onStreamRead (node:internal/stream_base_commons:217:20) {
  errno: -110,
  code: 'ETIMEDOUT',
  syscall: 'read'
} +1ms
(node:433555) UnhandledPromiseRejectionWarning
Error: read ETIMEDOUT
    at TCP.onStreamRead (node:internal/stream_base_commons:217:20)
UnhandledPromiseRejectionWarning
Error: read ETIMEDOUT
    at TCP.onStreamRead (node:internal/stream_base_commons:217:20) {
  errno: -110,
  code: 'ETIMEDOUT',
  syscall: 'read'
}
  hoprd { type: 'log', msg: 'Process exiting with signal 1', ts: '2022-08-24T11:46:38.283Z' } +0ms
```