### PR TITLE
Enhance backoff and waitForFunds functionality 

### DIFF
--- a/packages/connect/src/base/entry.ts
+++ b/packages/connect/src/base/entry.ts
@@ -29,7 +29,7 @@ import {
   retimer,
   u8aEquals,
   tryExistingConnections,
-  retryWithBackoff
+  retryWithBackoffThenThrow
 } from '@hoprnet/hopr-utils'
 import { attemptClose, relayFromRelayAddress } from '../utils/index.js'
 import { compareDirectConnectionInfo } from '../utils/index.js'
@@ -183,7 +183,7 @@ export class EntryNodes extends EventEmitter implements Initializable, Startable
       if (u8aEquals(tuples[2][1], relayTuples[2][1])) {
         let attempt = 0
 
-        retryWithBackoff(
+        retryWithBackoffThenThrow(
           async () => {
             attempt++
             const result = await this.connectToRelay(peer, usedRelay.relayDirectAddress, ENTRY_NODE_CONTACT_TIMEOUT)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -449,7 +449,9 @@ class Hopr extends EventEmitter {
       } catch (err) {
         // @TODO what to do here? E.g. delete channel from db?
         error(
-          `Couldn't set commitment in channel to ${c.destination.toPeerId().toString()} (channelId ${c.getId().toHex()})`
+          `Couldn't set commitment in channel to ${c.destination.toPeerId().toString()} (channelId ${c
+            .getId()
+            .toHex()})`
         )
       }
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,11 +33,16 @@ import {
   ChannelStatus,
   MIN_NATIVE_BALANCE,
   isMultiaddrLocal,
-  retryWithBackoff,
+  retryWithBackoffThenThrow,
   durations,
   isErrorOutOfFunds,
   debug,
   retimer,
+  createRelayerKey,
+  createCircuitAddress,
+  convertPubKeyFromPeerId,
+  getBackoffRetryTimeout,
+  getBackoffRetries,
   type LibP2PHandlerFunction,
   type AcknowledgedTicket,
   type ChannelEntry,
@@ -45,10 +50,7 @@ import {
   type DialOpts,
   type Hash,
   type HalfKeyChallenge,
-  type Ticket,
-  createRelayerKey,
-  createCircuitAddress,
-  convertPubKeyFromPeerId
+  type Ticket
 } from '@hoprnet/hopr-utils'
 import HoprCoreEthereum, { type Indexer } from '@hoprnet/hopr-core-ethereum'
 
@@ -442,7 +444,14 @@ class Hopr extends EventEmitter {
   private async onChannelWaitingForCommitment(c: ChannelEntry): Promise<void> {
     if (this.strategy.shouldCommitToChannel(c)) {
       log(`Found channel ${c.getId().toHex()} to us with unset commitment. Setting commitment`)
-      retryWithBackoff(() => this.connector.commitToChannel(c))
+      try {
+        await retryWithBackoffThenThrow(() => this.connector.commitToChannel(c))
+      } catch (err) {
+        // @TODO what to do here? E.g. delete channel from db?
+        error(
+          `Could set commitment in channel to ${c.destination.toPeerId().toString()} (channelId ${c.getId().toHex()})`
+        )
+      }
     }
   }
 
@@ -1251,10 +1260,13 @@ class Hopr extends EventEmitter {
    * MAX_DELAY is reached, this function will reject.
    */
   public async waitForFunds(): Promise<void> {
+    const minDelay = durations.seconds(1)
+    const maxDelay = durations.seconds(200)
+    const delayMultiple = 1.05
     try {
-      return retryWithBackoff(
-        () => {
-          return new Promise<void>(async (resolve, reject) => {
+      await retryWithBackoffThenThrow(
+        () =>
+          new Promise<void>(async (resolve, reject) => {
             try {
               // call connector directly and don't use cache, since this is
               // most likely outdated during node startup
@@ -1269,17 +1281,24 @@ class Hopr extends EventEmitter {
               log('error with native balance call, trying again soon')
               reject()
             }
-          })
-        },
+          }),
         {
-          minDelay: durations.seconds(1),
-          maxDelay: durations.seconds(200),
-          delayMultiple: 1.05
+          minDelay,
+          maxDelay,
+          delayMultiple
         }
       )
     } catch {
-      log(`unfunded for more than 200 seconds, shutting down`)
+      log(
+        `unfunded for more than ${getBackoffRetryTimeout(
+          minDelay,
+          maxDelay,
+          delayMultiple
+        )} seconds and ${getBackoffRetries(minDelay, maxDelay, delayMultiple)} retries, shutting down`
+      )
+      // Close DB etc.
       await this.stop()
+      process.exit(1)
     }
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -449,7 +449,7 @@ class Hopr extends EventEmitter {
       } catch (err) {
         // @TODO what to do here? E.g. delete channel from db?
         error(
-          `Could set commitment in channel to ${c.destination.toPeerId().toString()} (channelId ${c.getId().toHex()})`
+          `Couldn't set commitment in channel to ${c.destination.toPeerId().toString()} (channelId ${c.getId().toHex()})`
         )
       }
     }

--- a/packages/utils/src/async/backoff.spec.ts
+++ b/packages/utils/src/async/backoff.spec.ts
@@ -1,24 +1,22 @@
 import assert from 'assert'
-import sinon from 'sinon'
-import { wait, retryWithBackoff as backoff } from './backoff.js'
+import { wait, retryWithBackoffThenThrow as backoff, getBackoffRetries, getBackoffRetryTimeout } from './backoff.js'
 
-const getRoundedDiff = (startTime: number, endTime: number): number => {
-  return Math.round((endTime - startTime) / 100) * 100
-}
+// Additional time that Node.js takes to compute functions
+// and process timeouts
+const PROPAGATION_DELAY = 50
 
 describe('test wait', function () {
   it('should resolve after 100 ms', async function () {
     const startTime = Date.now()
-    await wait(100)
-    const endTime = Date.now()
-    const roundedDiff = getRoundedDiff(startTime, endTime)
-    assert.strictEqual(roundedDiff, 100)
+    const expectedWait = 100
+    await wait(expectedWait)
+    assert(Date.now() - startTime - expectedWait <= PROPAGATION_DELAY)
   })
 })
 
 describe('test backoff', function () {
   it('should validate options', async function () {
-    const fn = sinon.fake(() => Promise.resolve())
+    const fn = () => Promise.resolve()
 
     assert.rejects(
       backoff(fn, {
@@ -40,10 +38,12 @@ describe('test backoff', function () {
     this.timeout(3000)
 
     const ticks: number[] = []
-    const fn = sinon.fake(() => {
+    let callCount = 0
+    const fn = () => {
+      callCount++
       ticks.push(Date.now())
       return Promise.reject()
-    })
+    }
 
     let timedout = false
     try {
@@ -57,20 +57,61 @@ describe('test backoff', function () {
     }
 
     assert(timedout)
-    assert.strictEqual(fn.callCount, 5)
-    assert.strictEqual(getRoundedDiff(ticks[0], ticks[1]), 100)
-    assert.strictEqual(getRoundedDiff(ticks[1], ticks[2]), 200)
-    assert.strictEqual(getRoundedDiff(ticks[2], ticks[3]), 400)
-    assert.strictEqual(getRoundedDiff(ticks[3], ticks[4]), 800)
+    assert(callCount == 5)
+    assert(ticks[0] - ticks[1] - 100 <= PROPAGATION_DELAY)
+    assert(ticks[1] - ticks[2] - 200 <= PROPAGATION_DELAY)
+    assert(ticks[2] - ticks[3] - 400 <= PROPAGATION_DELAY)
+    assert(ticks[3] - ticks[4] - 800 <= PROPAGATION_DELAY)
+  })
+
+  it('should timeout after computed retries', async function () {
+    this.timeout(3000)
+    const start = Date.now()
+
+    let callCount = 0
+
+    const fn = () => {
+      callCount++
+      return Promise.reject()
+    }
+
+    const minDelay = 100
+    const maxDelay = 500
+    const delayMultiple = 2
+    let timedout = false
+    try {
+      await backoff(fn, {
+        minDelay,
+        maxDelay,
+        delayMultiple
+      })
+    } catch {
+      timedout = true
+    }
+
+    assert(
+      getBackoffRetries(minDelay, maxDelay, delayMultiple) == callCount - 1,
+      'Expected call count must be equal to computed call count'
+    )
+
+    const PROPAGATION_DELAY = 50
+    assert(Date.now() - start - getBackoffRetryTimeout(minDelay, maxDelay, delayMultiple) <= PROPAGATION_DELAY)
+    assert(timedout)
   })
 
   it('should resolve after 4th try', async function () {
     const ticks: number[] = []
-    const fn = sinon.fake(() => {
+    let callCount = 0
+
+    const fn = () => {
       ticks.push(Date.now())
-      if (fn.callCount === 4) return Promise.resolve()
+      callCount++
+      if (callCount == 4) {
+        return Promise.resolve()
+      }
+
       return Promise.reject()
-    })
+    }
 
     let timedout = false
     try {
@@ -84,9 +125,9 @@ describe('test backoff', function () {
     }
 
     assert(!timedout)
-    assert.strictEqual(fn.callCount, 4)
-    assert.strictEqual(getRoundedDiff(ticks[0], ticks[1]), 100)
-    assert.strictEqual(getRoundedDiff(ticks[1], ticks[2]), 200)
-    assert.strictEqual(getRoundedDiff(ticks[2], ticks[3]), 400)
+    assert(callCount == 4)
+    assert(ticks[0] - ticks[1] - 100 <= PROPAGATION_DELAY)
+    assert(ticks[1] - ticks[2] - 200 <= PROPAGATION_DELAY)
+    assert(ticks[2] - ticks[3] - 400 <= PROPAGATION_DELAY)
   })
 })

--- a/packages/utils/src/async/backoff.ts
+++ b/packages/utils/src/async/backoff.ts
@@ -4,8 +4,64 @@ import { setTimeout, setImmediate } from 'timers/promises'
 
 const log = debug('hopr:utils:retry')
 
+// Throws after ~170 minutes (2 hours 50 minutes, 50 seconds)
+// and 10 retries if function has not been successful
+export const DEFAULT_BACKOFF_PARAMETERS = {
+  minDelay: durations.seconds(1),
+  maxDelay: durations.minutes(10),
+  delayMultiple: 2
+}
+
 export async function wait(milliseconds: number): Promise<void> {
   await setTimeout(milliseconds)
+}
+
+/**
+ * Returns the maximal number of retries after which the `retryWithBackoff` throws
+ * @param minDelay initial delay
+ * @param maxDelay maximal delay to retry
+ * @param delayMultiple factor by which last delay got multiplied
+ * @returns
+ */
+export function getBackoffRetries(minDelay: number, maxDelay: number, delayMultiple: number) {
+  //
+  //     ┌─                      ─┐
+  //     │        maxDelay        │
+  //     │ log_2( ───────────── ) │
+  //     │        delayMultiple   │
+  // n = │ ────────────────────── │
+  //     │ log_2( delayMultiple ) │
+  //     │                        │
+  //
+  return Math.ceil(Math.log2(maxDelay / minDelay) / Math.log2(delayMultiple))
+}
+
+/**
+ * Returns the *total* amount of time between calling `retryWithBackoff` and
+ * once it throws because it ran out of retries.
+ *
+ * @param minDelay initial delay
+ * @param maxDelay maximal delay to retry
+ * @param delayMultiple factor by which last delay got multiplied
+ * @returns
+ */
+export function getBackoffRetryTimeout(minDelay: number, maxDelay: number, delayMultiple: number) {
+  const retries = getBackoffRetries(minDelay, maxDelay, delayMultiple) - 1
+
+  if (delayMultiple == 1) {
+    throw Error(`boom`)
+    return minDelay * (retries + 1)
+  } else {
+    // n-th partial sum of geometric series
+    // see https://en.wikipedia.org/wiki/Geometric_series#Sum
+    //
+    //                                retries + 1
+    //                    delayMultple            - 1
+    // s_n = minDelay * ( ─────────────────────────── )
+    //                         delayMultiple - 1
+    //
+    return minDelay * ((delayMultiple ** (retries + 1) - 1) / (delayMultiple - 1))
+  }
 }
 
 /**
@@ -15,13 +71,13 @@ export async function wait(milliseconds: number): Promise<void> {
  * @param options.maxDelay maximum delay, we reject once we reach this
  * @param options.delayMultiple multiplier to apply to increase running delay
  */
-export async function retryWithBackoff<T>(
+export async function retryWithBackoffThenThrow<T>(
   fn: () => Promise<T>,
   options: {
     minDelay?: number
     maxDelay?: number
     delayMultiple?: number
-  } = { minDelay: durations.seconds(1), maxDelay: durations.minutes(10), delayMultiple: 2 }
+  } = DEFAULT_BACKOFF_PARAMETERS
 ): Promise<T> {
   let delay = options.minDelay
 


### PR DESCRIPTION
## Changes

- rename `retryWithBackoff` to `retryWithBackoffThenThrow` to highlight *that* it will throw if none of the retries were successful
- add convenience functions to precompute *when* and after *how many* retries the function *will eventually* throw.
- simplify unit tests

## Out of scope

- add try / catch block to indexer restart functionality