### PR TITLE
Add API endpoint & token to Avado URL, backport environment ID fix

### DIFF
--- a/packages/avado/dappnode_package.json
+++ b/packages/avado/dappnode_package.json
@@ -12,7 +12,7 @@
   "links": {
     "OnboardingWizard": "http://hopr.my.ava.do:3000/",
     "homepage": "https://hoprnet.org",
-    "Admin interface": "http://hopr.my.ava.do:3000",
+    "Admin interface": "http://hopr.my.ava.do:3000?apiEndpoint=http://hopr.my.ava.do:3001&apiToken=%TOKEN%",
     "Rest API V2": "http://hopr.my.ava.do:3001/api/v2/_swagger/"
   },
   "ui": {

--- a/scripts/build_avado.sh
+++ b/scripts/build_avado.sh
@@ -47,6 +47,8 @@ if [[ "${1}" == "-h" ]] || [[ "${1}" == "--help" ]]; then
   exit 0
 fi
 
+msg "Building Avado for ${environment_id} with default provider ${provider_url}"
+
 declare AVADO_VERSION="${1}"
 
 if ! [[ $AVADO_VERSION =~ [0-9]{1,}\.[0-9]{1,}\.[0-9]{1,}$ ]]; then
@@ -86,8 +88,8 @@ cp ./build/Dockerfile ./build/Dockerfile.bak
 trap cleanup SIGINT SIGTERM ERR EXIT
 
 # Write AVADO docker build version & used provider
-sed -e "s/image:[ ]'hopr\.avado\.dnp\.dappnode\.eth:[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/image: 'hopr.avado.dnp.dappnode.eth:${AVADO_VERSION}/ ;\
- s/HOPRD_ENVIRONMENT=.+/HOPRD_ENVIRONMENT=${environment_id}/ ; s|HOPRD_PROVIDER=.+|HOPRD_PROVIDER=${provider_url}|" ./docker-compose.yml \
+sed -E "s/image:[ ]'hopr\.avado\.dnp\.dappnode\.eth:[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}/image: 'hopr.avado.dnp.dappnode.eth:${AVADO_VERSION}/ ;\
+ s/(.+HOPRD_ENVIRONMENT=).+'(,?)/\1${environment_id}'\2/ ; s|(.+HOPRD_PROVIDER=).+'(,?)|\1${provider_url}'\2|" ./docker-compose.yml \
   > ./docker-compose.yml.tmp && mv ./docker-compose.yml.tmp ./docker-compose.yml
 
 # Copy sections between *_JSON_EXPORT of docker-compose.yaml to dappnode_package.json

--- a/scripts/build_avado.sh
+++ b/scripts/build_avado.sh
@@ -99,6 +99,10 @@ sed -n '/BEGIN_JSON_EXPORT/,/END_JSON_EXPORT/{//!p}' ./docker-compose.yml \
   | jq -s ".[0].image += .[1] | .[0] | .version = \"${AVADO_VERSION}\"" ./dappnode_package.json /dev/stdin \
   > ./dappnode_package.json.tmp && mv ./dappnode_package.json.tmp ./dappnode_package.json
 
+# Replace API token in the json manifest
+declare api_token=$(sed -rn "s/.+HOPRD_API_TOKEN=(.+)',/\1/p" ./docker-compose.yml)
+sed -E "s/%TOKEN%/${api_token}/" ./dappnode_package.json  > ./dappnode_package.json.tmp && mv ./dappnode_package.json.tmp ./dappnode_package.json
+
 # Overwrite default environment in Dockerfile with the one currently used
 sed -e "s/${default_development_environment}/${environment_id}/" ./build/Dockerfile \
   > ./build/Dockerfile.tmp && mv ./build/Dockerfile.tmp ./build/Dockerfile


### PR DESCRIPTION
This PR fixes the following:

- API endpoint and token are statically embedded into the URL that appears in the Avado UI for HOPR. This is a temp fix, because if the user decides to change the token, the token in the URL won't change and they'll have to enter it manually in the UI.
- Backport a fix from `master` (see #4014 ): environment ID and provider env variables were incorrectly populated in the CI build