### PR TITLE
Timeout connection upgrade

### DIFF
--- a/packages/connect/src/base/entry.ts
+++ b/packages/connect/src/base/entry.ts
@@ -497,7 +497,7 @@ export class EntryNodes extends EventEmitter implements Initializable, Startable
         onDisconnect
       })
     } catch (err: any) {
-      error(`error while contacting entry node ${destination.toString()}.`, err.message)
+      error(`error while contacting entry node ${destination.toString()}.`, err?.message)
       await attemptClose(conn, error)
     }
 

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -34,7 +34,7 @@ const verbose = Debug(DEBUG_PREFIX.concat(':verbose'))
 const warn = Debug(DEBUG_PREFIX.concat(':warn'))
 const error = Debug(DEBUG_PREFIX.concat(':error'))
 
-const DEFAULT_CONNECTION_UPGRADE_TIMEOUT = 1000
+const DEFAULT_CONNECTION_UPGRADE_TIMEOUT = 2000
 
 type HoprConnectConfig = {
   config?: HoprConnectOptions

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -26,12 +26,15 @@ import { ConnectComponents } from './components.js'
 import { EntryNodes } from './base/entry.js'
 import { WebRTCUpgrader } from './webrtc/upgrader.js'
 import { UpnpManager } from './base/upnp.js'
+import { timeout } from '@hoprnet/hopr-utils'
 
 const DEBUG_PREFIX = 'hopr-connect'
 const log = Debug(DEBUG_PREFIX)
 const verbose = Debug(DEBUG_PREFIX.concat(':verbose'))
 const warn = Debug(DEBUG_PREFIX.concat(':warn'))
 const error = Debug(DEBUG_PREFIX.concat(':error'))
+
+const DEFAULT_CONNECTION_UPGRADE_TIMEOUT = 1000
 
 type HoprConnectConfig = {
   config?: HoprConnectOptions
@@ -269,7 +272,7 @@ class HoprConnect implements Transport, Initializable, Startable {
       `Establishing a direct connection to ${maConn.remoteAddr.toString()} was successful. Continuing with the handshake.`
     )
 
-    const conn = await options.upgrader.upgradeOutbound(maConn)
+    const conn = await timeout(DEFAULT_CONNECTION_UPGRADE_TIMEOUT, () => options.upgrader.upgradeOutbound(maConn))
 
     // Assign various connection properties once we're sure that public keys match,
     // i.e. dialed node == desired destination


### PR DESCRIPTION
## Context

Establishing a connection to a node goes through two main steps

- finding a way to send raw packets to that node
- negotiating with the node which protocol and which version to use

Due to unclear network conditions, both of the steps need to deal with unexpected behavior, such as nodes suddenly stopping the communication or bugs that prevent correct execution.

## Main change

Add a timeout to the protocol upgrade, which is libp2p's name for protocol negotiation.

## Out of scope

The issue is properly fixed by changing code within `js-libp2p` or `libp2p-noise` (the TLS-like module)