### PR TITLE
Do not await message acknowledgements in the API, code refactoring

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -354,7 +354,7 @@ class Hopr extends EventEmitter {
       this.getId(),
       (ackChallenge: HalfKeyChallenge) =>
       {
-        // Can subscribe both per specific message or all message acknowledgment
+        // Can subscribe both per specific message or all message acknowledgments
         this.emit(`hopr:message-acknowledged:${ackChallenge.toHex()}`)
         this.emit('hopr:message-acknowledged', ackChallenge.toHex())
       },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -353,7 +353,7 @@ class Hopr extends EventEmitter {
       this.db,
       this.getId(),
       (ackChallenge: HalfKeyChallenge) => {
-        // Can subscribe both per specific message or all message acknowledgments
+        // Can subscribe to both: per specific message or all message acknowledgments
         this.emit(`hopr:message-acknowledged:${ackChallenge.toHex()}`)
         this.emit('hopr:message-acknowledged', ackChallenge.toHex())
       },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,5 @@
 import { setImmediate } from 'timers/promises'
-import EventEmitter, { once } from 'events'
+import EventEmitter from 'events'
 
 import { protocols, Multiaddr } from '@multiformats/multiaddr'
 
@@ -352,8 +352,11 @@ class Hopr extends EventEmitter {
       subscribe,
       this.db,
       this.getId(),
-      (ackChallenge: HalfKeyChallenge) => {
-        this.emit(`message-acknowledged:${ackChallenge.toHex()}`)
+      (ackChallenge: HalfKeyChallenge) =>
+      {
+        // Can subscribe both per specific message or all message acknowledgment
+        this.emit(`hopr:message-acknowledged:${ackChallenge.toHex()}`)
+        this.emit('hopr:message-acknowledged', ackChallenge.toHex())
       },
       (ack: AcknowledgedTicket) => this.connector.emit('ticket:win', ack),
       // TODO: automatically reinitialize commitments
@@ -717,11 +720,41 @@ class Hopr extends EventEmitter {
   }
 
   /**
+   * Validates the manual intermediate path by checking if it does not contain
+   * channels that are not opened.
+   * Throws an error if some channel is not opened.
+   * @param intermediatePath
+   */
+  private async validateIntermediatePath(intermediatePath: PublicKey[]) {
+    // checking if path makes sense
+    for (let i = 0; i < intermediatePath.length; i++) {
+      let ticketIssuer: PublicKey
+      let ticketReceiver: PublicKey
+
+      if (i == 0) {
+        ticketIssuer = PublicKey.fromPeerId(this.getId())
+        ticketReceiver = intermediatePath[0]
+      } else {
+        ticketIssuer = intermediatePath[i - 1]
+        ticketReceiver = intermediatePath[i]
+      }
+
+      if (ticketIssuer.eq(ticketReceiver)) log(`WARNING: duplicated adjacent path entries.`)
+
+      const channel = await this.db.getChannelX(ticketIssuer, ticketReceiver)
+
+      if (channel.status !== ChannelStatus.Open) {
+        throw Error(`Channel ${channel.getId().toHex()} is not open`)
+      }
+    }
+  }
+
+  /**
    * @param msg message to send
    * @param destination PeerId of the destination
    * @param intermediatePath optional set path manually
    */
-  public async sendMessage(msg: Uint8Array, destination: PeerId, intermediatePath?: PublicKey[]): Promise<void> {
+  public async sendMessage(msg: Uint8Array, destination: PeerId, intermediatePath?: PublicKey[]) {
     if (this.status != 'RUNNING') {
       throw new Error('Cannot send message until the node is running')
     }
@@ -731,27 +764,8 @@ class Hopr extends EventEmitter {
     }
 
     if (intermediatePath != undefined) {
-      // checking if path makes sense
-      for (let i = 0; i < intermediatePath.length; i++) {
-        let ticketIssuer: PublicKey
-        let ticketReceiver: PublicKey
-
-        if (i == 0) {
-          ticketIssuer = PublicKey.fromPeerId(this.getId())
-          ticketReceiver = intermediatePath[0]
-        } else {
-          ticketIssuer = intermediatePath[i - 1]
-          ticketReceiver = intermediatePath[i]
-        }
-
-        if (ticketIssuer.eq(ticketReceiver)) log(`WARNING: duplicated adjacent path entries.`)
-
-        const channel = await this.db.getChannelX(ticketIssuer, ticketReceiver)
-
-        if (channel.status !== ChannelStatus.Open) {
-          throw Error(`Channel ${channel.getId().toHex()} is not open`)
-        }
-      }
+      // Validate the manually specified intermediate path
+      await this.validateIntermediatePath(intermediatePath)
     } else {
       intermediatePath = await this.getIntermediateNodes(PublicKey.fromPeerId(destination))
 
@@ -776,15 +790,13 @@ class Hopr extends EventEmitter {
 
     await packet.storePendingAcknowledgement(this.db)
 
-    const acknowledged: Promise<void> = once(this, 'message-acknowledged:' + packet.ackChallenge.toHex()) as any
-
     try {
       await this.forward.interact(path[0].toPeerId(), packet)
     } catch (err) {
       throw Error(`Error while trying to send final packet ${JSON.stringify(err)}`)
     }
 
-    return acknowledged
+    return packet.ackChallenge.toHex()
   }
 
   /**

--- a/packages/hoprd/hopr-admin/src/commands/sendMessage.spec.ts
+++ b/packages/hoprd/hopr-admin/src/commands/sendMessage.spec.ts
@@ -11,7 +11,7 @@ import { PEER_A as HOP_1, PEER_B as HOP_2, PEER_C as RECIPIENT } from '../utils/
 
 type Response = Awaited<ReturnType<API['sendMessage']>>
 
-const BODY = 'hello world'
+const CHALLENGE = '011223344556677889900aabbccddeeff'
 
 const createCommand = (sendMessageResponse: Response, getCachedAliasesResponse?: Record<any, any> | undefined) => {
   const api = sinon.fake() as unknown as API
@@ -40,26 +40,15 @@ const createCommand = (sendMessageResponse: Response, getCachedAliasesResponse?:
 describe('test SendMessage command', function () {
   const cmdWithOkApiAuto = createCommand({
     ok: true,
-    json: async () => ({
-      body: BODY,
-      recipient: RECIPIENT
-    })
+    text: async () => CHALLENGE
   } as Response)
   const cmdWithOkApiDirect = createCommand({
     ok: true,
-    json: async () => ({
-      body: BODY,
-      recipient: RECIPIENT,
-      path: []
-    })
+    text: async () => CHALLENGE
   } as Response)
   const cmdWithOkApiManual = createCommand({
     ok: true,
-    json: async () => ({
-      body: BODY,
-      recipient: RECIPIENT,
-      path: [HOP_1, HOP_2]
-    })
+    text: async () => CHALLENGE
   } as Response)
   const cmdWithBadRes = createCommand({
     ok: false
@@ -69,15 +58,15 @@ describe('test SendMessage command', function () {
   shouldFailExecutionOnApiError(cmdWithBadRes, `${RECIPIENT} hello`)
   shouldSucceedExecution(cmdWithOkApiAuto, [
     `${RECIPIENT} hello world 1 2 3`,
-    [`Sending message to ${RECIPIENT} using automatic path finding ..`, `Message to ${RECIPIENT} sent`]
+    [`Sending message to ${RECIPIENT} using automatic path finding ..`, `Message to ${RECIPIENT} sent (ack challenge ${CHALLENGE})`]
   ])
   shouldSucceedExecution(cmdWithOkApiDirect, [
     `,${RECIPIENT} hello directly`,
-    [`Sending direct message to ${RECIPIENT} ..`, `Message to ${RECIPIENT} sent`]
+    [`Sending direct message to ${RECIPIENT} ..`, `Message to ${RECIPIENT} sent (ack challenge ${CHALLENGE})`]
   ])
   shouldSucceedExecution(cmdWithOkApiManual, [
     `${HOP_1},${HOP_2},${RECIPIENT} hello manually`,
-    [`Sending message to ${RECIPIENT} via ${HOP_1}->${HOP_2} ..`, `Message to ${RECIPIENT} sent`]
+    [`Sending message to ${RECIPIENT} via ${HOP_1}->${HOP_2} ..`, `Message to ${RECIPIENT} sent (ack challenge ${CHALLENGE})`]
   ])
   shouldFailExecution(cmdWithBadRes, [`${HOP_1},${HOP_1},${RECIPIENT} hello manually`, 'to construct path'])
 })

--- a/packages/hoprd/hopr-admin/src/commands/sendMessage.ts
+++ b/packages/hoprd/hopr-admin/src/commands/sendMessage.ts
@@ -115,7 +115,7 @@ export default class SendMessage extends Command {
         })
       )
     } else {
-      return log(`Message to ${recipient} sent`)
+      return log(`Message to ${recipient} sent (ack challenge ${await response.text()})`)
     }
   }
 }

--- a/packages/hoprd/hopr-admin/src/utils/api.ts
+++ b/packages/hoprd/hopr-admin/src/utils/api.ts
@@ -114,7 +114,7 @@ export default class API {
   public async signMessage(msg: string): ExpandedJsonResponse {
     return this.postReq('/api/v2/messages/sign', { message: msg })
   }
-  public async sendMessage(body: string, recipient: string, path: string[]): ExpandedJsonResponse {
+  public async sendMessage(body: string, recipient: string, path: string[]): ExpandedTextResponse {
     return this.postReq('/api/v2/messages', { body: body, recipient: recipient, path: path })
   }
 

--- a/packages/hoprd/src/api/v2.ts
+++ b/packages/hoprd/src/api/v2.ts
@@ -247,7 +247,7 @@ export function setupWsApi(
       node.on('hopr:message', (msg: Uint8Array) => {
         socket.send(msg.toString())
       })
-      node.on(`horp:message-acknowledged`, (ackChallenge: string) => {
+      node.on(`hopr:message-acknowledged`, (ackChallenge: string) => {
         socket.send(`ack:${ackChallenge}`)
       })
     } else if (path === WS_PATHS.LEGACY_STREAM) {

--- a/packages/hoprd/src/api/v2.ts
+++ b/packages/hoprd/src/api/v2.ts
@@ -247,6 +247,9 @@ export function setupWsApi(
       node.on('hopr:message', (msg: Uint8Array) => {
         socket.send(msg.toString())
       })
+      node.on(`horp:message-acknowledged`, (ackChallenge: string) => {
+        socket.send(`ack:${ackChallenge}`)
+      })
     } else if (path === WS_PATHS.LEGACY_STREAM) {
       logStream.addMessageListener((msg) => {
         if (msg.type !== 'message') {

--- a/packages/hoprd/src/api/v2.ts
+++ b/packages/hoprd/src/api/v2.ts
@@ -248,7 +248,7 @@ export function setupWsApi(
         socket.send(msg.toString())
       })
       node.on(`hopr:message-acknowledged`, (ackChallenge: string) => {
-        socket.send(`ack:${ackChallenge}`)
+        socket.send(`ack:'${ackChallenge}'`)
       })
     } else if (path === WS_PATHS.LEGACY_STREAM) {
       logStream.addMessageListener((msg) => {

--- a/packages/hoprd/src/api/v2/paths/messages/index.ts
+++ b/packages/hoprd/src/api/v2/paths/messages/index.ts
@@ -17,7 +17,7 @@ const POST: Operation = [
 
     try {
       let ackChallenge = await req.context.node.sendMessage(message, recipient, path)
-      return res.status(204).json(ackChallenge)
+      return res.status(202).json(ackChallenge)
     } catch (err) {
       return res
         .status(422)
@@ -68,7 +68,7 @@ POST.apiDoc = {
     }
   },
   responses: {
-    '204': {
+    '202': {
       description: 'The message was sent successfully. NOTE: This does not imply successful delivery.',
       content: {
         'application/json': {

--- a/packages/hoprd/src/api/v2/paths/messages/index.ts
+++ b/packages/hoprd/src/api/v2/paths/messages/index.ts
@@ -17,7 +17,7 @@ const POST: Operation = [
 
     try {
       let ackChallenge = await req.context.node.sendMessage(message, recipient, path)
-      return res.status(204).json(ackChallenge).send()
+      return res.status(204).json(ackChallenge)
     } catch (err) {
       return res
         .status(422)

--- a/packages/hoprd/src/api/v2/paths/messages/index.ts
+++ b/packages/hoprd/src/api/v2/paths/messages/index.ts
@@ -16,8 +16,10 @@ const POST: Operation = [
     }
 
     try {
-      await req.context.node.sendMessage(message, recipient, path)
-      return res.status(204).send()
+      let ackChallenge = await req.context.node.sendMessage(message, recipient, path)
+      return res.status(204)
+        .json(ackChallenge)
+        .send()
     } catch (err) {
       return res
         .status(422)
@@ -69,7 +71,16 @@ POST.apiDoc = {
   },
   responses: {
     '204': {
-      description: 'The message was sent successfully. NOTE: This does not imply successful delivery.'
+      description: 'The message was sent successfully. NOTE: This does not imply successful delivery.',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'string',
+            description: 'Challenge token used to poll for the acknowledgment of the sent message by the first hop.',
+            example: 'e61bbdda74873540c7244fe69c39f54e5270bd46709c1dcb74c8e3afce7b9e616d'
+          }
+        }
+      }
     },
     '422': {
       description: 'Unknown failure.',

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -381,7 +381,7 @@ async function main() {
   }
 
   const messageAcknowledged = (ackChallenge: string): void => {
-    logs.log(`Message challenge ${ackChallenge} acknowledged`)
+    logs.log(`MSG ACKNOWLEDGED: ${ackChallenge}`)
   }
 
   if (!argv.testNoAuthentication && argv.api) {

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -504,7 +504,7 @@ async function main() {
         }
 
         // Wait for actions to take place
-        setTimeout(1e3)
+        await setTimeout(1e3)
         await node.stop()
       }
     })

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -380,10 +380,6 @@ async function main() {
     }
   }
 
-  const messageAcknowledged = (ackChallenge: string): void => {
-    logs.log(`MSG ACKNOWLEDGED: ${ackChallenge}`)
-  }
-
   if (!argv.testNoAuthentication && argv.api) {
     if (argv.apiToken == null) {
       throw Error(`Must provide --apiToken when --api is specified`)
@@ -438,7 +434,6 @@ async function main() {
     // Subscribe to node events
     node.on('hopr:message', logMessageToNode)
     node.on('hopr:network-health-changed', networkHealthChanged)
-    node.on('hopr:message-acknowledged', messageAcknowledged)
     node.subscribeOnConnector('hopr:connector:created', () => {
       // 2.b - Connector has been created, and we can now trigger the next set of steps.
       logs.log('Connector has been loaded properly.')

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -380,6 +380,10 @@ async function main() {
     }
   }
 
+  const messageAcknowledged = (ackChallenge: string): void => {
+    logs.log(`Message challenge ${ackChallenge} acknowledged`)
+  }
+
   if (!argv.testNoAuthentication && argv.api) {
     if (argv.apiToken == null) {
       throw Error(`Must provide --apiToken when --api is specified`)
@@ -430,8 +434,11 @@ async function main() {
     logs.log('Creating HOPR Node')
     node = await createHoprNode(peerId, options, false)
     logs.logStatus('PENDING')
+
+    // Subscribe to node events
     node.on('hopr:message', logMessageToNode)
     node.on('hopr:network-health-changed', networkHealthChanged)
+    node.on('hopr:message-acknowledged', messageAcknowledged)
     node.subscribeOnConnector('hopr:connector:created', () => {
       // 2.b - Connector has been created, and we can now trigger the next set of steps.
       logs.log('Connector has been loaded properly.')
@@ -504,7 +511,6 @@ async function main() {
         // Wait for actions to take place
         setTimeout(1e3)
         await node.stop()
-        return
       }
     })
 


### PR DESCRIPTION
This PR changes the following:

- removes waiting by the API for message acknowledgment after sending
- adds global event handler for message acknowledgments
- sends per-message acknowledgments via WS: `ack:'aabbccddeeff...'`
- refactoring in `sendMessage`

Closes #3599 