### PR TITLE
add entryNodes command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
   - improved user experience with more consistent messages
 - Warn when manual path selection contains duplicate adjacent entries
 - Correctly recognize Avado/Dappnode private subnet ([#4032](https://github.com/hoprnet/hoprnet/pull/4032))
+- Add `entryNodes` command to API and `hopr-admin` ([#4049](https://github.com/hoprnet/hoprnet/pull/4049))
 
 # Breaking changes
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1196,6 +1196,10 @@ class Hopr extends EventEmitter {
     return await this.connector.getPublicKeyOf(addr)
   }
 
+  public async getEntryNodes(): Promise<{ id: PeerId; multiaddrs: Multiaddr[] }[]> {
+    return this.connector.waitForPublicNodes()
+  }
+
   // @TODO remove this
   // NB: The prefix "HOPR Signed Message: " is added as a security precaution.
   // Without it, the node could be convinced to sign a message like an Ethereum

--- a/packages/hoprd/hopr-admin/src/commands/entryNodes.ts
+++ b/packages/hoprd/hopr-admin/src/commands/entryNodes.ts
@@ -1,0 +1,46 @@
+import type API from '../utils/api'
+import { Command, type CacheFunctions } from '../utils/command'
+
+const COLLAPSED_PEER_ID_LENGTH = 5
+const ELIGIBLE_PREFIX = 'Eligible'
+const MULTIADDRS_PREFIX = 'Multiaddrs'
+const PREFIX = `${'Id'.padEnd(COLLAPSED_PEER_ID_LENGTH, ' ')}  ${ELIGIBLE_PREFIX}  ${MULTIADDRS_PREFIX}`
+
+export default class EntryNodes extends Command {
+  constructor(api: API, cache: CacheFunctions) {
+    super({}, api, cache, true)
+  }
+
+  public name() {
+    return 'entryNodes'
+  }
+
+  public description() {
+    return 'Lists announced entry nodes and their eligibility status'
+  }
+
+  public async execute(log: (msg: string) => void, _query: string): Promise<void> {
+    const entryNodesRes = await this.api.getEntryNodes()
+    if (!entryNodesRes.ok) {
+      return log(this.failedCommand('get entryNodes'))
+    }
+
+    const peers = await entryNodesRes.json()
+
+    let out = `${PREFIX}\n`
+    for (const [id, entry] of Object.entries(peers)) {
+      if (out.length > PREFIX.length + 1) {
+        out += '\n'
+      }
+      out += `${id}  `
+      out += `${String(entry.isEligible).padEnd(ELIGIBLE_PREFIX.length)}  `
+      out += entry.multiaddrs.join(',')
+    }
+
+    if (out.length === PREFIX.length + 1) {
+      return log('No entry nodes known.')
+    } else {
+      return log(out)
+    }
+  }
+}

--- a/packages/hoprd/hopr-admin/src/commands/help.ts
+++ b/packages/hoprd/hopr-admin/src/commands/help.ts
@@ -34,6 +34,8 @@ export default class Help extends Command {
         return !cmd.hidden
       })
       .map<[string, string]>((cmd) => [cmd.name(), cmd.description()])
+      // Sort commands alphabetically
+      .sort((a, b) => a[0].localeCompare(b[0], 'en'))
 
     if (!showAll) arr.push(['', "* Display hidden commands by running 'help all'"])
 

--- a/packages/hoprd/hopr-admin/src/commands/index.ts
+++ b/packages/hoprd/hopr-admin/src/commands/index.ts
@@ -19,6 +19,7 @@ import PeerInfo from './peerInfo'
 import Info from './info'
 import Version from './version'
 import Help from './help'
+import EntryNodes from './entryNodes'
 
 export default class Commands {
   private commandMap: Map<string, Command> = new Map()
@@ -30,6 +31,7 @@ export default class Commands {
       new Balances(this.api, this.cache),
       new Sign(this.api, this.cache),
       new Peers(this.api, this.cache),
+      new EntryNodes(this.api, this.cache),
       new Ping(this.api, this.cache),
       new Channels(this.api, this.cache),
       new OpenChannel(this.api, this.cache),

--- a/packages/hoprd/hopr-admin/src/utils/api.ts
+++ b/packages/hoprd/hopr-admin/src/utils/api.ts
@@ -168,6 +168,16 @@ export default class API {
   public async setSetting(key: string, value: string | boolean): ExpandedJsonResponse {
     return this.putReq(`/api/v2/settings/${key}`, { settingValue: value })
   }
+
+  // entryNodes API
+  public async getEntryNodes(): ExpandedJsonResponse<{
+    [id: string]: {
+      multiaddrs: string[]
+      isEligible: boolean
+    }
+  }> {
+    return this.getReq('/api/v2/node/entryNodes')
+  }
 }
 
 // some types

--- a/packages/hoprd/src/api/v2/paths/node/entryNodes.integration.spec.ts
+++ b/packages/hoprd/src/api/v2/paths/node/entryNodes.integration.spec.ts
@@ -27,7 +27,7 @@ node.isAllowedAccessToNetwork = (peer: PeerId) => {
   }
 }
 
-describe.only('GET /node/entryNodes', function () {
+describe('GET /node/entryNodes', function () {
   let service: any
   before(async function () {
     const loaded = await createTestApiInstance(node)

--- a/packages/hoprd/src/api/v2/paths/node/entryNodes.integration.spec.ts
+++ b/packages/hoprd/src/api/v2/paths/node/entryNodes.integration.spec.ts
@@ -1,0 +1,67 @@
+import request from 'supertest'
+import sinon from 'sinon'
+import chaiResponseValidator from 'chai-openapi-response-validator'
+import chai, { expect } from 'chai'
+import { createTestApiInstance, ALICE_PEER_ID, ALICE_MULTI_ADDR, BOB_PEER_ID, BOB_MULTI_ADDR } from '../../fixtures.js'
+import { STATUS_CODES } from '../../utils.js'
+import type { PeerId } from '@libp2p/interface-peer-id'
+import type Hopr from '@hoprnet/hopr-core'
+
+const ALICE_ENTRY_INFO = {
+  id: ALICE_PEER_ID,
+  multiaddrs: [ALICE_MULTI_ADDR]
+}
+
+const BOB_ENTRY_INFO = {
+  id: BOB_PEER_ID,
+  multiaddrs: [BOB_MULTI_ADDR]
+}
+
+let node = sinon.fake() as any as Hopr
+node.isAllowedAccessToNetwork = (peer: PeerId) => {
+  switch (peer.toString()) {
+    case ALICE_PEER_ID.toString():
+      return Promise.resolve(false)
+    case BOB_PEER_ID.toString():
+      return Promise.resolve(true)
+  }
+}
+
+describe.only('GET /node/entryNodes', function () {
+  let service: any
+  before(async function () {
+    const loaded = await createTestApiInstance(node)
+
+    service = loaded.service
+
+    // @ts-ignore ESM / CommonJS compatibility issue
+    chai.use(chaiResponseValidator.default(loaded.api.apiDoc))
+  })
+
+  it('should return invalid quality when quality is not a number', async function () {
+    node.getEntryNodes = sinon.fake.resolves([ALICE_ENTRY_INFO, BOB_ENTRY_INFO])
+    const res = await request(service).get(`/api/v2/node/entryNodes`).send()
+    expect(res.status).to.equal(200)
+    expect(res).to.satisfyApiSpec
+    expect(res.body).to.deep.equal({
+      [ALICE_PEER_ID.toString()]: {
+        multiaddrs: [ALICE_MULTI_ADDR.toString()],
+        isEligible: false
+      },
+      [BOB_PEER_ID.toString()]: {
+        multiaddrs: [BOB_MULTI_ADDR.toString()],
+        isEligible: true
+      }
+    })
+  })
+
+  it('should handle error', async function () {
+    node.getEntryNodes = () => {
+      throw Error(`boom`)
+    }
+
+    const res = await request(service).get(`/api/v2/node/entryNodes`).send()
+    expect(res.status).to.equal(422)
+    expect(res.body.status).to.equal(STATUS_CODES.UNKNOWN_FAILURE)
+  })
+})

--- a/packages/hoprd/src/api/v2/paths/node/entryNodes.ts
+++ b/packages/hoprd/src/api/v2/paths/node/entryNodes.ts
@@ -1,0 +1,94 @@
+import type { Operation } from 'express-openapi'
+import type { Multiaddr } from '@multiformats/multiaddr'
+import type Hopr from '@hoprnet/hopr-core'
+import { STATUS_CODES } from '../../utils.js'
+import type { PeerId } from '@libp2p/interface-peer-id'
+
+export type EntryNodeInfo = {
+  [index: string]: {
+    multiaddrs: string[]
+    isEligible: boolean
+  }
+}
+
+export async function getEntryNodes(node: Hopr): Promise<EntryNodeInfo> {
+  const entryNodes = (await node.getEntryNodes()) as { id: PeerId; multiaddrs: Multiaddr[]; isEligible: boolean }[]
+
+  const result: EntryNodeInfo = {}
+  for (const entryNode of entryNodes) {
+    result[entryNode.id.toString()] = {
+      multiaddrs: entryNode.multiaddrs.map((ma: Multiaddr) => ma.toString()),
+      isEligible: await node.isAllowedAccessToNetwork(entryNode.id)
+    }
+  }
+
+  return result
+}
+
+const GET: Operation = [
+  async (req, res, _next) => {
+    const { node } = req.context
+
+    try {
+      const info = await getEntryNodes(node)
+      return res.status(200).send(info)
+    } catch (err) {
+      const errString = err instanceof Error ? err.message : err?.toString?.() ?? 'Unknown error'
+
+      return res.status(422).send({ status: STATUS_CODES.UNKNOWN_FAILURE, error: errString })
+    }
+  }
+]
+
+const PEER_INFO_DOC: any = {
+  type: 'object',
+  properties: {
+    multiaddrs: {
+      type: 'array',
+      items: {
+        type: 'string'
+      },
+      description: 'Known Multiaddrs of the node'
+    },
+    isEligible: {
+      type: 'boolean',
+      description: 'true if peer is allowed to access network, otherwise false'
+    }
+  }
+}
+
+GET.apiDoc = {
+  description: 'List all known entry nodes and their multiaddrs and their eligibility state',
+  tags: ['Node'],
+  operationId: 'nodeGetEntryNodes',
+  responses: {
+    '200': {
+      description: 'Entry node information fetched successfuly.',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            additionalProperties: PEER_INFO_DOC
+          }
+        }
+      }
+    },
+    '422': {
+      description: 'Unknown failure.',
+      content: {
+        'application/json': {
+          schema: {
+            type: 'object',
+            properties: {
+              status: { type: 'string', example: STATUS_CODES.UNKNOWN_FAILURE },
+              error: { type: 'string', example: 'Full error message.' }
+            }
+          },
+          example: { status: STATUS_CODES.UNKNOWN_FAILURE, error: 'Full error message.' }
+        }
+      }
+    }
+  }
+}
+
+export default { GET }

--- a/packages/hoprd/src/api/v2/paths/node/peers.integration.spec.ts
+++ b/packages/hoprd/src/api/v2/paths/node/peers.integration.spec.ts
@@ -12,6 +12,7 @@ import {
 } from '../../fixtures.js'
 import { STATUS_CODES } from '../../utils.js'
 import type { PeerId } from '@libp2p/interface-peer-id'
+import type Hopr from '@hoprnet/hopr-core'
 
 const ALICE_ENTRY = {
   id: ALICE_PEER_ID,
@@ -19,7 +20,8 @@ const ALICE_ENTRY = {
   heartbeatsSuccess: 10,
   lastSeen: 1646410980793,
   backoff: 0,
-  quality: 1
+  quality: 1,
+  origin: 'unit test'
 }
 const ALICE_PEER_INFO = {
   peerId: ALICE_PEER_ID.toString(),
@@ -40,7 +42,8 @@ const BOB_ENTRY = {
   heartbeatsSuccess: 0,
   lastSeen: 1646410680793,
   backoff: 0,
-  quality: 0.2
+  quality: 0.2,
+  origin: 'unit test'
 }
 const BOB_PEER_INFO = {
   peerId: BOB_PEER_ID.toString(),
@@ -61,7 +64,8 @@ const CHARLIE_ENTRY = {
   heartbeatsSuccess: 8,
   lastSeen: 1646410980993,
   backoff: 0,
-  quality: 0.8
+  quality: 0.8,
+  origin: 'unit test'
 }
 const CHARLIE_PEER_INFO = {
   peerId: CHARLIE_PEER_ID.toString(),
@@ -75,7 +79,7 @@ const CHARLIE_PEER_INFO = {
   isNew: false
 }
 
-let node = sinon.fake() as any
+let node = sinon.fake() as any as Hopr
 node.getConnectedPeers = sinon.fake.returns([ALICE_PEER_ID, BOB_PEER_ID, CHARLIE_PEER_ID])
 node.getAddressesAnnouncedOnChain = sinon.fake.resolves([ALICE_MULTI_ADDR, BOB_MULTI_ADDR])
 node.getConnectionInfo = (peer: PeerId) => {

--- a/packages/hoprd/src/api/v2/paths/peerInfo/{peerid}.spec.ts
+++ b/packages/hoprd/src/api/v2/paths/peerInfo/{peerid}.spec.ts
@@ -7,10 +7,10 @@ let node = sinon.fake() as any
 node.getAddressesAnnouncedToDHT = sinon.fake.resolves([ALICE_MULTI_ADDR, BOB_MULTI_ADDR])
 node.getObservedAddresses = sinon.fake.returns([ALICE_MULTI_ADDR])
 
-describe('peersInfo', function () {
+describe('peerInfo', function () {
   it('should resolve with all data', async function () {
     const peers = await getPeerInfo(node, CHARLIE_PEER_ID)
-    assert.equal(peers.announced.length, 2, 'getPeersInfo did not return correct amount of multiaddresses')
-    assert.equal(peers.observed.length, 1, 'getPeersInfo did not return correct amount of multiaddresses')
+    assert.equal(peers.announced.length, 2, 'getPeerInfo did not return correct amount of multiaddresses')
+    assert.equal(peers.observed.length, 1, 'getPeerInfo did not return correct amount of multiaddresses')
   })
 })


### PR DESCRIPTION
![Screenshot from 2022-08-30 13-43-20](https://user-images.githubusercontent.com/12514844/187429532-921b962d-5d0b-4331-96aa-92d1497472fc.png)


## Main change

- adds `entryNodes` API to `hoprd` to show known entry nodes
- adds `entryNodes` command to `hopr-admin`

## Other changes

- sort commands on help page alphabetically
- stronger typing
- some typos