### PR TITLE
hopr-admin bugs fixes vol 2

### DIFF
--- a/docs/hopr-documentation/docs/developers/starting-local-cluster.md
+++ b/docs/hopr-documentation/docs/developers/starting-local-cluster.md
@@ -99,7 +99,7 @@ make -j deps && make -j build
 3. **Run the one-line setup script**: Run the following script:
 
 ```bash
-./scripts/setup-local-cluster.sh -m "http://app.myne.chat" -i scripts/topologies/full_interconnected_cluster.sh
+./scripts/setup-local-cluster.sh -m "http://app.myne.chat" -i topologies/full_interconnected_cluster.sh
 ```
 
 Please wait while this script creates
@@ -111,7 +111,7 @@ If you are planning to run [MyneChat](http://app.myne.chat/)
 alongside your cluster, then make sure to pass the `-m` flag with your MyneChat instance URL, i.e.:
 
 ```bash
-./scripts/setup-local-cluster.sh -m "http://app.myne.chat" -i scripts/topologies/full_interconnected_cluster.sh
+./scripts/setup-local-cluster.sh -m "http://app.myne.chat" -i topologies/full_interconnected_cluster.sh
 ```
 
 As the script runs, a set of accounts with their respective HTTP REST API, HOPR Admin, and WebSocket interfaces will be displayed

--- a/packages/hoprd/hopr-admin/pages/index.tsx
+++ b/packages/hoprd/hopr-admin/pages/index.tsx
@@ -162,10 +162,8 @@ export default function Home() {
 
   // attach event listener for new streams events
   const handleStreamEvent = (event: MessageEvent<any>) => {
-    const eventLogs = readStreamEvent(event)
-    for (const log of eventLogs) {
-      addLog(log)
-    }
+    const log = readStreamEvent(event)
+    if (log) addLog(log)
   }
   useEffect(() => {
     const socket = app.streamWS.socketRef.current

--- a/packages/hoprd/hopr-admin/pages/index.tsx
+++ b/packages/hoprd/hopr-admin/pages/index.tsx
@@ -180,23 +180,6 @@ export default function Home() {
     }
   }, [app.streamWS.socketRef.current, app.streamWS.state.status])
 
-  // attach event listener for new messages
-  const handleMessageEvent = (event: MessageEvent<any>) => {
-    console.log(event)
-  }
-  useEffect(() => {
-    const socket = app.messagesWS.socketRef.current
-    if (!socket) return
-
-    socket.addEventListener('message', handleMessageEvent)
-
-    return () => {
-      const socket = app.messagesWS.socketRef.current
-      if (!socket) return
-      socket.removeEventListener('message', handleMessageEvent)
-    }
-  }, [app.messagesWS.socketRef.current, app.messagesWS.state.status])
-
   return (
     <div className={styles.container}>
       <Head>

--- a/packages/hoprd/hopr-admin/src/commands/help.ts
+++ b/packages/hoprd/hopr-admin/src/commands/help.ts
@@ -7,7 +7,7 @@ export default class Help extends Command {
     super(
       {
         default: [[], 'displays help'],
-        showAll: [[['constant', "show hidden commands using 'all'"]], 'shows hidden commands']
+        showAll: [[['constant', 'all']], 'shows hidden commands']
       },
       api,
       cache

--- a/packages/hoprd/hopr-admin/src/commands/sendMessage.ts
+++ b/packages/hoprd/hopr-admin/src/commands/sendMessage.ts
@@ -7,7 +7,10 @@ export default class SendMessage extends Command {
       {
         default: [[['hoprAddressOrAlias'], ['arbitrary', 'message']], 'send a message, path is chosen automatically'],
         manual: [
-          [['string'], ['string', "path seperated by ','"], ['arbitrary', 'message']],
+          [
+            ['string', "path seperated by ','"],
+            ['arbitrary', 'message']
+          ],
           'send a message, path is manually specified'
         ]
       },

--- a/packages/hoprd/hopr-admin/src/commands/sendMessage.ts
+++ b/packages/hoprd/hopr-admin/src/commands/sendMessage.ts
@@ -42,7 +42,7 @@ export default class SendMessage extends Command {
         if (!valid) throw Error()
         path.push(peerId.toString())
       } catch (err) {
-        return [false, `'${pIdString}' is neither a valid alias nor a valid Hopr address string`, undefined]
+        return [false, `'${pIdString}' is not an alias or HOPR address`, undefined]
       }
     }
 
@@ -59,7 +59,7 @@ export default class SendMessage extends Command {
 
     if (use === 'manual') {
       const [valid, error, result] = this.parsePathStr(pathOrRecipient)
-      if (!valid) return log(`${error}\n${this.usage()}`)
+      if (!valid) return log(this.invalidParameter(pathOrRecipient, 'path', error))
       path = result.intermediateNodes
       recipient = result.recipient
     }

--- a/packages/hoprd/hopr-admin/src/state/index.ts
+++ b/packages/hoprd/hopr-admin/src/state/index.ts
@@ -31,7 +31,6 @@ const useAppState = () => {
 
   // initialize websocket connections
   const streamWS = useWS(state.config, '/api/v2/node/stream/websocket')
-  const messagesWS = useWS(state.config, '/api/v2/messages/websocket')
 
   /**
    * Updates the app's connectivity config.
@@ -59,15 +58,13 @@ const useAppState = () => {
    * Takes into account all WS connections.
    */
   const status = useMemo<'DISCONNECTED' | 'CONNECTED'>(() => {
-    if (streamWS.state.status === 'CONNECTED' && messagesWS.state.status === 'CONNECTED') return 'CONNECTED'
-    return 'DISCONNECTED'
-  }, [streamWS.state.status, messagesWS.state.status])
+    return streamWS.state.status
+  }, [streamWS.state.status])
 
   return {
     state,
     api,
     streamWS,
-    messagesWS,
     updateConfig,
     updateAliases,
     status

--- a/packages/hoprd/hopr-admin/src/utils/command.ts
+++ b/packages/hoprd/hopr-admin/src/utils/command.ts
@@ -90,8 +90,10 @@ export abstract class Command {
    * Generate 'invalid paramater' message.
    * @returns Specific paramater was invalid.
    */
-  protected invalidParameter(param: string, type: string): string {
-    return `Invalid parameter "${param}" of type "${type}".\n${this.usage()}`
+  protected invalidParameter(param: string, type: string, error?: string): string {
+    return `Invalid parameter "${param}" of type "${type}"${
+      error ? ' with error "' + error + '"' : ''
+    }".\n${this.usage()}`
   }
 
   /**
@@ -153,7 +155,7 @@ export abstract class Command {
       if (arbitraryIndex > -1) {
         const newParam = queryParams.slice(arbitraryIndex).join(' ')
         queryParams = queryParams.slice(0, arbitraryIndex)
-        queryParams.push(newParam)
+        if (newParam.length > 0) queryParams.push(newParam)
       }
 
       // invalid when query params are less than expected params

--- a/packages/hoprd/hopr-admin/src/utils/command.ts
+++ b/packages/hoprd/hopr-admin/src/utils/command.ts
@@ -166,11 +166,11 @@ export abstract class Command {
 
       // validate each parameter
       for (let i = 0; i < params.length; i++) {
-        const [paramType] = params[i]
+        const [paramType, customName] = params[i]
         const [, , validate] = CMD_PARAMS[paramType]
         const queryParam = queryParams[i]
 
-        const [valid, parsedValue] = validate(queryParam, { aliases })
+        const [valid, parsedValue] = validate(queryParam, { aliases, customName })
         if (!valid) {
           result = [this.invalidParameter(queryParam, paramType), use]
         } else {
@@ -275,10 +275,11 @@ export const CMD_PARAMS: Record<CmdTypes, CmdArg<any, any, any>> = {
   constant: [
     'constant',
     'A constant value',
-    (v) => {
-      return [true, v]
+    (v, { customName }) => {
+      if (!customName) return [false, v]
+      return [v === customName, v]
     }
-  ],
+  ] as CmdArg<string, { customName?: string }, any>,
   number: [
     'number',
     'Any number',

--- a/packages/hoprd/hopr-admin/src/utils/command.ts
+++ b/packages/hoprd/hopr-admin/src/utils/command.ts
@@ -150,9 +150,9 @@ export abstract class Command {
       // if one of the params is 'everything', we treat the rest
       // past everything as one string
       const arbitraryIndex = params.findIndex((p) => p[0] === 'arbitrary')
-      if (arbitraryIndex > 0) {
+      if (arbitraryIndex > -1) {
         const newParam = queryParams.slice(arbitraryIndex).join(' ')
-        queryParams = queryParams.slice(0, params.length - 1)
+        queryParams = queryParams.slice(0, arbitraryIndex)
         queryParams.push(newParam)
       }
 

--- a/packages/hoprd/hopr-admin/src/utils/stream.ts
+++ b/packages/hoprd/hopr-admin/src/utils/stream.ts
@@ -21,7 +21,7 @@ export const readStreamEvent = (event: any): Log | undefined => {
 
     // we ignore plain messages, instead print HOPRd logs
     if (data.type === 'message') return undefined
-    // we are only interested in messages which contain 'content'
+    // we are only interested in messages which have a message
     if (!data.msg) return undefined
 
     return createLog(data.msg, +new Date(data.ts))

--- a/packages/hoprd/hopr-admin/src/utils/stream.ts
+++ b/packages/hoprd/hopr-admin/src/utils/stream.ts
@@ -19,6 +19,8 @@ export const readStreamEvent = (event: any): Log | undefined => {
       ts: string
     } = JSON.parse(event.data)
 
+    // we ignore plain messages, instead print HOPRd logs
+    if (data.type === 'message') return undefined
     // we are only interested in messages which contain 'content'
     if (!data.msg) return undefined
 

--- a/packages/hoprd/hopr-admin/src/utils/stream.ts
+++ b/packages/hoprd/hopr-admin/src/utils/stream.ts
@@ -2,35 +2,27 @@ import { type Log, createLog } from '.'
 
 /**
  * Legacy event reader from stream socket.
- * Read incoming stream event and convert it to client logs.
+ * Read incoming stream event and convert it to a client log.
+ * @param event Event coming from '/api/v2/node/stream/websocket'
+ * @returns log readable by hopr-admin
  */
-export const readStreamEvent = (event: any): Log[] => {
+export const readStreamEvent = (event: any): Log | undefined => {
+  console.log('event', event)
   if (event.data === undefined) {
-    return []
+    return undefined
   }
 
-  const logs: Log[] = []
-
   try {
-    const msg: {
+    const data: {
       type: string
-      content: string
-      timestamp: string
+      msg: string
+      ts: string
     } = JSON.parse(event.data)
 
-    switch (msg.type) {
-      case 'log':
-        logs.push(createLog(msg.content, +new Date(msg.timestamp)))
-        break
-      case 'fatal-error':
-        logs.push(createLog(msg.content, +new Date(msg.timestamp)))
-        break
-      case 'auth-failed':
-        logs.push(createLog(msg.content, +new Date(msg.timestamp)))
-        break
-    }
+    // we are only interested in messages which contain 'content'
+    if (!data.msg) return undefined
 
-    return logs
+    return createLog(data.msg, +new Date(data.ts))
   } catch (error) {
     console.log('error reading stream log', error)
   }

--- a/packages/hoprd/src/api/v2.ts
+++ b/packages/hoprd/src/api/v2.ts
@@ -249,15 +249,13 @@ export function setupWsApi(
       })
     } else if (path === WS_PATHS.LEGACY_STREAM) {
       logStream.addMessageListener((msg) => {
-        if (msg.type !== 'message') {
-          socket.send(
-            JSON.stringify({
-              type: msg.type,
-              timestamp: msg.ts,
-              content: msg.msg
-            })
-          )
-        }
+        socket.send(
+          JSON.stringify({
+            type: msg.type,
+            timestamp: msg.ts,
+            content: msg.msg
+          })
+        )
       })
     } else {
       // close connection on unsupported paths

--- a/packages/hoprd/src/api/v2.ts
+++ b/packages/hoprd/src/api/v2.ts
@@ -239,6 +239,10 @@ export function setupWsApi(
     debugLog('WS client connected!')
     const path = removeQueryParams(req.url)
 
+    socket.on('close', () => {
+      logStream.unsubscribe(socket)
+    })
+
     socket.on('error', (err: string) => {
       debugLog('WS error', err.toString())
     })
@@ -248,15 +252,7 @@ export function setupWsApi(
         socket.send(msg.toString())
       })
     } else if (path === WS_PATHS.LEGACY_STREAM) {
-      logStream.addMessageListener((msg) => {
-        socket.send(
-          JSON.stringify({
-            type: msg.type,
-            timestamp: msg.ts,
-            content: msg.msg
-          })
-        )
-      })
+      logStream.subscribe(socket)
     } else {
       // close connection on unsupported paths
       socket.close(1000)

--- a/packages/hoprd/src/api/v2/paths/node/stream/websocket.ts
+++ b/packages/hoprd/src/api/v2/paths/node/stream/websocket.ts
@@ -10,7 +10,7 @@ const GET: Operation = [
 // This endpoint only exists to document the websocket's behaviour.
 GET.apiDoc = {
   description: generateWsApiDescription(
-    'This is a websocket endpoint which streams legacy hopr-admin data excluding messages.',
+    'This is a websocket endpoint which streams legacy hopr-admin data.',
     '/node/stream/websocket'
   ),
   tags: ['Node'],

--- a/scripts/setup-local-cluster.sh
+++ b/scripts/setup-local-cluster.sh
@@ -318,10 +318,10 @@ log "All nodes came up online"
 declare endpoints="localhost:13301 localhost:13302 localhost:13303 localhost:13304 localhost:13305"
 
 # --- Call init script--- {{{
-if [ -n "${init_script}" ] && [ -x "${init_script}" ]; then
+if [ -n "${init_script}" ] && [ -x "${mydir}/${init_script}" ]; then
   log "Calling init script ${init_script}"
   HOPRD_API_TOKEN="${api_token}" \
-    "${init_script}" ${endpoints}
+    "${mydir}/${init_script}" ${endpoints}
 fi
 # }}}
 


### PR DESCRIPTION
- Fixes https://github.com/hoprnet/hoprnet/issues/4001 (manual path issue)
- Improves `constant` command type
- Removes unused `/messages` code in `hopr-admin`
  we will keep using `/legacy` stream since it gives you back the history of the logs upon connection, we don't have an API v2 alternative
- Fixes legacy stream bug
  1. it should behave like legacy, filtering out messages was a mistake
  2. unsubscribe socket when connection is closed
  3. remove unused code
- Fix cluster script and update documentation