### PR TITLE
Fix multiaddr to 10.3.3 in hoprd

### DIFF
--- a/packages/hoprd/package.json
+++ b/packages/hoprd/package.json
@@ -43,6 +43,7 @@
     "@hoprnet/hopr-utils": "workspace:packages/utils",
     "@libp2p/interface-peer-id": "1.0.2",
     "@libp2p/peer-id": "1.1.13",
+    "@multiformats/multiaddr": "10.3.3",
     "bn.js": "5.2.0",
     "body-parser": "1.19.2",
     "check-password-strength": "2.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3798,6 +3798,7 @@ __metadata:
     "@hoprnet/hopr-utils": "workspace:packages/utils"
     "@libp2p/interface-peer-id": 1.0.2
     "@libp2p/peer-id": 1.1.13
+    "@multiformats/multiaddr": 10.3.3
     "@types/chai": 4.3.3
     "@types/cors": 2.8.12
     "@types/js-cookie": ^3.0.1


### PR DESCRIPTION
Forces `hoprd` to use `@multiformats/multiaddr` at `10.3.3`