### PR TITLE
shrink Docker container

### DIFF
--- a/packages/hoprd/Dockerfile
+++ b/packages/hoprd/Dockerfile
@@ -56,8 +56,17 @@ RUN make -j build
 # Remove all typescript files
 RUN find ./packages -type f -name '*.ts' -delete
 
+# Remove node_modules as they contain devDependencies
+RUN rm -R node_modules
+
 # Remove all other directories and files that we don't need
-RUN rm -R target packages/*/src test docs .github .processes .vscode *.md tsconfig* flake* shell.nix scripts cloudbuild.yaml Makefile Dockerfile.hardhat Cargo.* rust-toolchain.toml Brewfile 
+RUN rm -R target packages/*/src packages/*/docs test docs .github .processes .vscode *.md tsconfig* flake* shell.nix scripts cloudbuild.yaml Makefile Dockerfile.hardhat Cargo.* rust-toolchain.toml Brewfile .actrc .editorconfig .gitpod* .nvmrc .prettierignore .readthedocs.yml .snyk .gitignore .envrc
+
+# No need for these packages
+RUN rm -R packages/avado packages/cover-traffic-daemon
+
+# Everything that we don't need in ethereum package
+RUN rm -R packages/ethereum/contracts packages/ethereum/deploy packages/ethereum/hardhat packages/ethereum/tasks packages/ethereum/test
 
 # use slim version of node on Debian buster for smaller image sizes
 FROM node:16-bullseye-slim@sha256:8265ac132f720998222008355e11535caf53d6bccecbb562a055605138975b4e as runtime
@@ -86,8 +95,17 @@ RUN apt-get update \
 
 WORKDIR /app
 
-# copy over the contents of node_modules etc
+# copy over built artifacts
 COPY --from=build /app/hoprnet .
+
+# As we are on Debian, use hardlinks in node_modules to save space
+RUN yarn config set nmMode hardlinks-local
+
+# Install without devDependencies
+RUN CI=true yarn workspaces focus --production @hoprnet/hoprd
+
+# Remove yarn cache globally
+RUN yarn cache clean --all
 
 WORKDIR /app/packages/hoprd
 
@@ -101,6 +119,8 @@ RUN mkdir -p hoprd-db
 
 # set volume which can be mapped by users on the host system
 VOLUME ["/app/hoprd-db"]
+
+# RUN yarn hoprd
 
 # DISABLED temporarily until a migration path has been tested
 # finally set the non-root user so the process also run un-privilidged

--- a/packages/hoprd/Dockerfile
+++ b/packages/hoprd/Dockerfile
@@ -120,8 +120,6 @@ RUN mkdir -p hoprd-db
 # set volume which can be mapped by users on the host system
 VOLUME ["/app/hoprd-db"]
 
-# RUN yarn hoprd
-
 # DISABLED temporarily until a migration path has been tested
 # finally set the non-root user so the process also run un-privilidged
 # USER node


### PR DESCRIPTION
Removes unnecessary stuff from the Docker container

## Changes in detail

- don't install `devDependencies`
- remove all unused packages, such as `avado` and `cover-traffic-daemon`
- remove lots of unused files
- cleans yarn cache