### PR TITLE
Replace Dummy Proxy with StakingProxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,9 +114,9 @@ endif
    --recipient $(recipient) \
    --privatekey "$(PRIVATE_KEY)"
    
-.PHONY: request-devnft
-request-devnft: ensure-environment-is-set
-request-devnft: ## Request one HoprBoost Dev NFT for the recipient given it has none and hasn't staked Dev NFT
+.PHONY: request-nrnft
+request-nrnft: ensure-environment-is-set
+request-nrnft: ## Request one HoprBoost Network_registry NFT for the recipient given it has none and hasn't staked Network_registry NFT
 ifeq ($(recipient),)
 	echo "parameter <recipient> missing" >&2 && exit 1
 endif
@@ -130,7 +130,7 @@ endif
 	HOPR_ENVIRONMENT_ID="$(environment)" \
 	  yarn workspace @hoprnet/hopr-ethereum run hardhat request-test-tokens \
    --network $(network) \
-   --type devnft \
+   --type nrnft \
    --nftrank $(nftrank) \
    --recipient $(recipient) \
    --privatekey "$(PRIVATE_KEY)"
@@ -149,9 +149,9 @@ endif
 		--amount 1000000000000000000000 \
 		--privatekey "$(PRIVATE_KEY)"
 
-.PHONY: stake-devnft
-stake-devnft: ensure-environment-is-set
-stake-devnft: ## stake Dev NFTs (idempotent operation)
+.PHONY: stake-nrnft
+stake-nrnft: ensure-environment-is-set
+stake-nrnft: ## stake Network_registry NFTs (idempotent operation)
 ifeq ($(origin PRIVATE_KEY),undefined)
 	echo "<PRIVATE_KEY> environment variable missing" >&2 && exit 1
 endif
@@ -162,7 +162,7 @@ endif
 	HOPR_ENVIRONMENT_ID="$(environment)" \
 		yarn workspace @hoprnet/hopr-ethereum run hardhat stake \
 		--network $(network) \
-		--type devnft \
+		--type nrnft \
 		--nftrank $(nftrank) \
 		--privatekey "$(PRIVATE_KEY)"
 
@@ -298,8 +298,8 @@ endif
 ifeq ($(origin DEV_BANK_PRIVKEY),undefined)
 	echo "<DEV_BANK_PRIVKEY> environment variable missing" >&2 && exit 1
 endif
-	PRIVATE_KEY=${DEV_BANK_PRIVKEY} make request-devnft recipient=${account} nftrank=${nftrank}
-	PRIVATE_KEY=${ACCOUNT_PRIVKEY} make stake-devnft nftrank=${nftrank}
+	PRIVATE_KEY=${DEV_BANK_PRIVKEY} make request-nrnft recipient=${account} nftrank=${nftrank}
+	PRIVATE_KEY=${ACCOUNT_PRIVKEY} make stake-nrnft nftrank=${nftrank}
 	PRIVATE_KEY=${ACCOUNT_PRIVKEY} make self-register-node peer_ids=$(shell eval ./scripts/get-hopr-address.sh "$(api_token)" "$(endpoint)")
 
 .PHONY: register-node-with-stake

--- a/Makefile
+++ b/Makefile
@@ -253,6 +253,7 @@ endif
    --privatekey "$(PRIVATE_KEY)"
 
 .PHONY: register-node-when-dummy-proxy
+# DEPRECATED. Only use it when a dummy network registry proxy is in use
 # Register a node when a dummy proxy is in place of staking proxy
 # node_api?=localhost:3001 provide endpoint of hoprd, with a default value 'localhost:3001'
 register-node-when-dummy-proxy: ensure-environment-is-set

--- a/NETWORK_REGISTRY.md
+++ b/NETWORK_REGISTRY.md
@@ -152,7 +152,7 @@ source .env
   make register-node-with-stake endpoint=<hoprd_endpoint> account=<staking_account> environment=master-goerli network=goerli
   ```
 
-### Production
+### [DEPRECATED] Production (with dummy proxy)
 
 Before "Network_registry" NFT gets minted in production environment, "Dummy proxy" is used to faciliate the process.
 Deployer wallet in the CI/CD registers node and its peerId when calling `make register-nodes` (followed by more flags and arguments). Developers must follow these steps to register their node in the registry:
@@ -182,3 +182,47 @@ e.g.
 ```
 make register-node-when-dummy-proxy endpoint="localhost:3001" api_token="^MYtoken4testing^" account=0x35A3e15A2E2C297686A4fac5999647312fdDfa3f environment=paleochora network=xdai
 ```
+
+### Production
+
+For nodes running in the upcoming "monte rosa" environment, only wallets with one "Network_registry" HoprBoost NFT (be `developer` or `community` rank) staked in the staking program are eligible to spin up HOPR nodes.
+
+""
+To register one (`community` rank) or many (`developer` rank) eligible node in the NR, please follow:
+
+#### Procedure
+
+1. Create a MetaMask wallet (note as “account”)
+2. Fund “account” with some xDAI (e.g 0.1 xDAI)
+3. Start your local HOPR node
+4. Save private keys (`ACCOUNT_PRIVKEY` and `DEV_BANK_PRIVKEY`) into `.env` file
+
+   ```
+   export ACCOUNT_PRIVKEY=<account_private_key>
+   ```
+
+   and
+
+   ```
+   source .env
+   ```
+
+5. Request "Network_registry" NFT. Either by requesting from TECH (or COM) team, or by obtaining directly from "Dev Bank". For the latter, add the following line into `.env` file
+
+   ```
+   export DEV_BANK_PRIVKEY=<dev_bank_private_key>
+   ```
+
+   and
+
+   ```
+   source .env
+   ```
+
+   run
+
+   ```
+   make register-node-with-nft endpoint=<hoprd_endpoint> nftrank=<"Network_registry" NFT Rank ("developer" or "community")> account=<staking_account> environment=<release_name> network=xdai
+   ```
+
+   Note: please provide `endpoint=<hoprd_endpoint>` when the node exposes port different from `localhost:3001`.

--- a/NETWORK_REGISTRY.md
+++ b/NETWORK_REGISTRY.md
@@ -49,7 +49,7 @@ There are 10 "Network_registry" NFTs being minted to the "Dev Bank" account per 
 For the <mark>staging environment</mark>, please call the following function where the `PRIVATE_KEY` is the private key of the node runner's account. This call can only succeed if the caller (i.e. the `PRIVATE_KEY` or the node runner) has "Network_registry" NFT (on goerli staging environment).
 
 ```
-PRIVATE_KEY<private key of "account"> make stake-devnft environment=master-goerli network=goerli nftrank <rank of "Network_registry" nft>
+PRIVATE_KEY<private key of "account"> make stake-nrnft environment=master-goerli network=goerli nftrank <rank of "Network_registry" nft>
 ```
 
 ### Register the peer ID

--- a/NETWORK_REGISTRY.md
+++ b/NETWORK_REGISTRY.md
@@ -9,7 +9,7 @@ There are two ways of registering a node:
 - By the node runner itself, providing the node runner is eligible; or
 - By the owner of the `HoprNetworkRegistry` smart contract
 
-Relevant smart contracts are listed below, per environment:
+Relevant smart contracts are listed below, per environment **(to be updated)**:
 
 | Contract                 | Staging                                                                                                                      | Production                                                                                                                           |
 | ------------------------ | ---------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
@@ -25,7 +25,7 @@ Relevant smart contracts are listed below, per environment:
 
 A node can be registered by its runner if the runner is eligible. There are two ways to become an eligible account:
 
-- A node runner's Ethereum account is staking in the HOPR stake program for a minimum stake of 1000 xHOPR token
+- A node runner's Ethereum account is staking in the HOPR stake program for a minimum stake of 1000 xHOPR token and one of the NFTs from the "allowed list"
 - A node runner's Ethereum account is staking a "HOPR Boost NFT" of type `Network_registry`
 
 #### Stake xHOPR tokens in staging environment
@@ -44,17 +44,17 @@ If there's not enough xHOPR token, please use "Dev Bank" account to transfer som
 
 <mark>When not in production</mark>, CI/CD will mint "Network_registry" NFTs to `CLUSTER_NETWORK_REGISTERY_LINKED_ADDRESSES[1]` and `CLUSTER_NETWORK_REGISTERY_LINKED_ADDRESSES[3]` on deployment.
 
-There are 10 "Network_registry" NFTs being minted to the "Dev Bank" account per deployment, where you can transfer some tokens from.
+There are 6 "Network_registry" NFTs (3 "developer" rank and 3 of "community" rank) being minted to the "Dev Bank" account per deployment, where you can transfer some tokens from.
 
 For the <mark>staging environment</mark>, please call the following function where the `PRIVATE_KEY` is the private key of the node runner's account. This call can only succeed if the caller (i.e. the `PRIVATE_KEY` or the node runner) has "Network_registry" NFT (on goerli staging environment).
 
 ```
-PRIVATE_KEY<private key of "account"> make stake-nrnft environment=master-goerli network=goerli nftrank <rank of "Network_registry" nft>
+PRIVATE_KEY<private key of "account"> make stake-nrnft environment=master-goerli network=goerli nftrank=<rank of "Network_registry" nft>
 ```
 
 ### Register the peer ID
 
-An eligible node runner can call `selfRegister(string[] hoprPeerIds)` method from `HoprNetworkRegistry` smart contract to register one or multiple HOPR node(s).
+An eligible node runner can call `selfRegister(string[] hoprPeerIds)` method from `HoprNetworkRegistry` smart contract to register one or multiple HOPR node(s). The number of nodes one account is allowed to register is subject to the `rank` of the "Network Registry" NFT the account has staked.
 
 For the <mark>staging environment</mark>, please call the following function where the `PRIVATE_KEY` is the private key of the node runner's account. This call can only succeed if the caller (i.e. the `PRIVATE_KEY` of the node runner) is eligible (having enough stake or a "Network_registry" NFT).
 
@@ -64,7 +64,7 @@ PRIVATE_KEY=<private key of “account”> make self-register-node environment=m
 
 ## Deregister a node
 
-A node runner can call `selfDeregister(string[] hoprPeerIds)` method from `HoprNetworkRegistry` smart contract to de-register old HOPR node(s).
+A node runner can call `selfDeregister(string[] hoprPeerIds)` method from `HoprNetworkRegistry` smart contract to remove previously registered HOPR nodes.
 
 For the <mark>staging environment</mark>, please call the following function where the `PRIVATE_KEY` is the private key of the node runner's account.
 
@@ -88,7 +88,7 @@ make register-nodes environment=master-goerli network=goerli --native-addresses=
 
 ## Deregister a node
 
-Owner can call `ownerDeregister(string[] hoprPeerIds)` method from `HoprNetworkRegistry` smart contract to de-register for a list of peers.
+Owner can call `ownerDeregister(string[] hoprPeerIds)` method from `HoprNetworkRegistry` smart contract to remove a list of nodes.
 
 ```
 make deregister-nodes environment=master-goerli network=goerli --peer_ids=<peerId1,peerId2,peerId3,peerId4>

--- a/docs/hopr-documentation/docs/developers/network-registry.md
+++ b/docs/hopr-documentation/docs/developers/network-registry.md
@@ -19,9 +19,9 @@ There are two ways of registering a node:
 A node can be registered by its runner if the runner is eligible. There are two ways to become an eligible account:
 
 - A node runner's Ethereum account is staking in the HOPR stake program for a minimum stake of 1000 xHOPR token
-- A node runner's Ethereum account is staking a "HOPR Boost NFT" of type `Dev`
+- A node runner's Ethereum account is staking a "HOPR Boost NFT" of type `Network_registry`
 
-To stake xHOPR tokens or "Dev" HoprBoost NFT, you can interact directly with the staking contract of the environment your HOPR node is running on. For production network, there is even a [web application](/staking/how-to-stake) for such a purpose.
+To stake xHOPR tokens or "Network_registry" HoprBoost NFT, you can interact directly with the staking contract of the environment your HOPR node is running on. For production network, there is even a [web application](/staking/how-to-stake) for such a purpose.
 
 #### Register the peer ID
 

--- a/docs/hopr-documentation/docs/developers/network-registry.md
+++ b/docs/hopr-documentation/docs/developers/network-registry.md
@@ -16,20 +16,20 @@ There are two ways of registering a node:
 
 #### Eligibility
 
-A node can be registered by its runner if the runner is eligible. There are two ways to become an eligible account:
+A node can be registered by its runner if the runner account is eligible. There are two ways to become an eligible account:
 
-- A node runner's Ethereum account is staking in the HOPR stake program for a minimum stake of 1000 xHOPR token
+- A node runner's Ethereum account is staking in the HOPR stake program for a minimum stake of 1000 xHOPR token and one of the NFTs from the "allowed list" _(Currently disabled)_
 - A node runner's Ethereum account is staking a "HOPR Boost NFT" of type `Network_registry`
 
 To stake xHOPR tokens or "Network_registry" HoprBoost NFT, you can interact directly with the staking contract of the environment your HOPR node is running on. For production network, there is even a [web application](/staking/how-to-stake) for such a purpose.
 
 #### Register the peer ID
 
-An eligible node runner can call `selfRegister(string hoprPeerId)` method from `HoprNetworkRegistry` smart contract to register its HOPR node. Note that only one node per account is allowed for registration. If a node has been registered by the caller, the caller must deregister the old peerId before registering a new one.
+An eligible node runner can call `selfRegister(string[] hoprPeerIds)` method from `HoprNetworkRegistry` smart contract to register one or more HOPR node. The number of nodes one account is allowed to register is subject to the `rank` of the "Network Registry" NFT the account has staked.
 
 ### Deregister a node
 
-A node runner can call `selfDeregister()` method from `HoprNetworkRegistry` smart contract to de-register an old HOPR node.
+A node runner can call `selfDeregister(string[] hoprPeerIds)` method from `HoprNetworkRegistry` smart contract to remove previously registered HOPR nodes.
 
 ### Register a node by the Network Registry contract owner
 
@@ -43,4 +43,4 @@ Owner can call `ownerRegister(address[] accounts, string[] hoprPeerIds)` method 
 
 ### Deregister a node
 
-Owner can call `ownerDeregister(address[] accounts)` method from `HoprNetworkRegistry` smart contract to de-register for a list of accounts.
+Owner can call `ownerDeregister(string[] hoprPeerIds)` method from `HoprNetworkRegistry` smart contract to remove a list of nodes.

--- a/packages/ethereum/contracts/proxy/HoprStakingProxyForNetworkRegistry.sol
+++ b/packages/ethereum/contracts/proxy/HoprStakingProxyForNetworkRegistry.sol
@@ -44,7 +44,7 @@ contract HoprStakingProxyForNetworkRegistry is IHoprNetworkRegistryRequirement, 
   uint256 public stakeThreshold;
   NftTypeAndRank[] public eligibleNftTypeAndRank; // list of NFTs whose owner are considered as eligible to the network if the `stakeThreshold` is also met
   uint256[] public maxRegistrationsPerSpecialNft; // for holders of special NFT, it's the cap of peer ids one address can register.
-  NftTypeAndRank[] public specialNftTypeAndRank; // list of NFTs whose owner are considered as eligible to the network without meeting the `stakeThreshold`, e.g. "Dev NFT"
+  NftTypeAndRank[] public specialNftTypeAndRank; // list of NFTs whose owner are considered as eligible to the network without meeting the `stakeThreshold`, e.g. "Network_registry NFT"
 
   event NftTypeAndRankAdded(uint256 indexed nftType, string nftRank); // emit when a new NFT type and rank gets included in the eligibility list
   event NftTypeAndRankRemoved(uint256 indexed nftType, string nftRank); // emit when a NFT type and rank gets removed from the eligibility list

--- a/packages/ethereum/deploy/16_HoprNetworkRegistryProxy.ts
+++ b/packages/ethereum/deploy/16_HoprNetworkRegistryProxy.ts
@@ -13,7 +13,7 @@ const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const stakeAddress = (await deployments.get('HoprStake')).address
 
   // Local development environment uses HoprDummyProxyForNetworkRegistry. All the other network uses HoprStakingProxyForNetworkRegistry
-  // FIXME: Before Dev NFTs are minted in production environment, dummy proxy gets deployed in production
+  // FIXME: Before Network_registry NFTs are minted in production environment, dummy proxy gets deployed in production
   const registryProxyName = network.name == 'hardhat' || network.tags.production ? DUMMY_PROXY : STAKING_PROXY
 
   const deployOptions = {

--- a/packages/ethereum/deploy/16_HoprNetworkRegistryProxy.ts
+++ b/packages/ethereum/deploy/16_HoprNetworkRegistryProxy.ts
@@ -13,8 +13,7 @@ const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const stakeAddress = (await deployments.get('HoprStake')).address
 
   // Local development environment uses HoprDummyProxyForNetworkRegistry. All the other network uses HoprStakingProxyForNetworkRegistry
-  // FIXME: Before Network_registry NFTs are minted in production environment, dummy proxy gets deployed in production
-  const registryProxyName = network.name == 'hardhat' || network.tags.production ? DUMMY_PROXY : STAKING_PROXY
+  const registryProxyName = network.name == 'hardhat' ? DUMMY_PROXY : STAKING_PROXY
 
   const deployOptions = {
     log: true

--- a/packages/ethereum/deploy/20_mintNetworkRegistryNfts.ts
+++ b/packages/ethereum/deploy/20_mintNetworkRegistryNfts.ts
@@ -4,17 +4,17 @@ import type { HoprBoost, ERC677Mock, HoprStakingProxyForNetworkRegistry } from '
 import { type ContractTransaction, utils } from 'ethers'
 import {
   CLUSTER_NETWORK_REGISTERY_LINKED_ADDRESSES,
-  DEV_NFT_BOOST,
-  DEV_NFT_MAX_REGISTRATION_COM,
-  DEV_NFT_MAX_REGISTRATION_TECH,
-  DEV_NFT_RANK_COM,
-  DEV_NFT_RANK_TECH,
-  DEV_NFT_TYPE,
-  DEV_NFT_TYPE_INDEX,
+  NR_NFT_BOOST,
+  NR_NFT_MAX_REGISTRATION_COM,
+  NR_NFT_MAX_REGISTRATION_TECH,
+  NR_NFT_RANK_COM,
+  NR_NFT_RANK_TECH,
+  NR_NFT_TYPE,
+  NR_NFT_TYPE_INDEX,
   MIN_STAKE
 } from '../utils/constants'
 
-const NUM_DEV_NFT = 3
+const NUM_NR_NFT = 3
 const DUMMY_NFT_TYPE = 'Dummy'
 const DUMMY_NFT_BOOST = 10
 const MINTER_ROLE = utils.keccak256(utils.toUtf8Bytes('MINTER_ROLE'))
@@ -49,7 +49,7 @@ const getToCreateDummyNftIndexes = async (
       : Array.from({ length: shouldHaveIndexesBefore - mintedIndex + 1 }, (_, i) => i + mintedIndex)
 
   console.log(
-    `To have HoprBoost NFT of ${DEV_NFT_TYPE} type at index ${shouldHaveIndexesBefore}, ${dummyNftIndexsToMint.length} type(s) of dummy NFTs of indexes ${dummyNftIndexsToMint} should be minted.`
+    `To have HoprBoost NFT of ${NR_NFT_TYPE} type at index ${shouldHaveIndexesBefore}, ${dummyNftIndexsToMint.length} type(s) of dummy NFTs of indexes ${dummyNftIndexsToMint} should be minted.`
   )
 
   return dummyNftIndexsToMint
@@ -83,7 +83,7 @@ const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const hoprBoost = (await ethers.getContractFactory('HoprBoost')).attach(boostDeployment.address) as HoprBoost
 
   // check type index of HoprBoost NFTs
-  const dummyNftTypesToBeMinted = await getToCreateDummyNftIndexes(hoprBoost, DEV_NFT_TYPE_INDEX)
+  const dummyNftTypesToBeMinted = await getToCreateDummyNftIndexes(hoprBoost, NR_NFT_TYPE_INDEX)
 
   const isDeployerMinter = await hoprBoost.hasRole(MINTER_ROLE, deployer)
   if (isDeployerMinter) {
@@ -105,21 +105,21 @@ const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     }
 
     // mint NR NFTs
-    for (const networkRegistryNftRank of [DEV_NFT_RANK_TECH, DEV_NFT_RANK_COM]) {
+    for (const networkRegistryNftRank of [NR_NFT_RANK_TECH, NR_NFT_RANK_COM]) {
       console.log(
-        `... minting ${NUM_DEV_NFT} ${DEV_NFT_TYPE} NFTs type of index ${DEV_NFT_TYPE_INDEX} to ${admin}\n...minting 1 ${DEV_NFT_TYPE} NFTs to CLUSTER_NETWORK_REGISTERY_LINKED_ADDRESSES[1], [3]\n...minting 10 ${DEV_NFT_TYPE} NFTs to dev bank ${DEV_BANK_ADDRESS}`
+        `... minting ${NUM_NR_NFT} ${NR_NFT_TYPE} NFTs type of index ${NR_NFT_TYPE_INDEX} to ${admin}\n...minting 1 ${NR_NFT_TYPE} NFTs to CLUSTER_NETWORK_REGISTERY_LINKED_ADDRESSES[1], [3]\n...minting 10 ${NR_NFT_TYPE} NFTs to dev bank ${DEV_BANK_ADDRESS}`
       )
       await awaitTxConfirmation(
         hoprBoost.batchMint(
           [
-            ...new Array(NUM_DEV_NFT).fill(admin),
+            ...new Array(NUM_NR_NFT).fill(admin),
             CLUSTER_NETWORK_REGISTERY_LINKED_ADDRESSES[1],
             CLUSTER_NETWORK_REGISTERY_LINKED_ADDRESSES[3],
             ...Array(10).fill(DEV_BANK_ADDRESS)
           ],
-          DEV_NFT_TYPE,
+          NR_NFT_TYPE,
           networkRegistryNftRank,
-          DEV_NFT_BOOST,
+          NR_NFT_BOOST,
           0,
           {
             gasLimit: 4e6
@@ -144,17 +144,17 @@ const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
     await awaitTxConfirmation(
       registryProxy.ownerBatchAddNftTypeAndRank(
-        [DEV_NFT_TYPE_INDEX, DEV_NFT_TYPE_INDEX],
-        [DEV_NFT_RANK_TECH, DEV_NFT_RANK_COM]
+        [NR_NFT_TYPE_INDEX, NR_NFT_TYPE_INDEX],
+        [NR_NFT_RANK_TECH, NR_NFT_RANK_COM]
       ),
       environment,
       ethers
     )
     await awaitTxConfirmation(
       registryProxy.ownerBatchAddSpecialNftTypeAndRank(
-        [DEV_NFT_TYPE_INDEX, DEV_NFT_TYPE_INDEX],
-        [DEV_NFT_RANK_TECH, DEV_NFT_RANK_COM],
-        [DEV_NFT_MAX_REGISTRATION_TECH, DEV_NFT_MAX_REGISTRATION_COM]
+        [NR_NFT_TYPE_INDEX, NR_NFT_TYPE_INDEX],
+        [NR_NFT_RANK_TECH, NR_NFT_RANK_COM],
+        [NR_NFT_MAX_REGISTRATION_TECH, NR_NFT_MAX_REGISTRATION_COM]
       ),
       environment,
       ethers
@@ -197,7 +197,7 @@ const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 }
 
 main.dependencies = ['preDeploy', 'HoprNetworkRegistry', 'HoprBoost', 'HoprStake']
-main.tags = ['MintDevNftTransferOwnership']
+main.tags = ['MintNetworkRegistryNfts']
 main.skip = async (env: HardhatRuntimeEnvironment) => !!env.network.tags.production
 
 export default main

--- a/packages/ethereum/hardhat.config.ts
+++ b/packages/ethereum/hardhat.config.ts
@@ -51,7 +51,7 @@ import { writeFileSync, realpathSync } from 'fs'
 import { TASK_TEST_SETUP_TEST_ENVIRONMENT } from 'hardhat/builtin-tasks/task-names'
 import { HARDHAT_NETWORK_NAME } from 'hardhat/plugins'
 import stake, { StakeOpts } from './tasks/stake'
-import { DevNftRank, MIN_STAKE } from './utils/constants'
+import { NetworkRegistryNftRank, MIN_STAKE } from './utils/constants'
 import type { BigNumber } from 'ethers'
 
 const { DEPLOYER_WALLET_PRIVATE_KEY, ETHERSCAN_KEY, BLOCKSCOUT_KEY, HOPR_ENVIRONMENT_ID, HOPR_HARDHAT_TAG } =
@@ -253,7 +253,7 @@ task<SelfRegisterOpts>(
 
 task<RequestTestTokensOpts>(
   'request-test-tokens',
-  'Request test tokens ("Dev NFT" or "txHOPR") for a staker',
+  'Request test tokens ("Network_registry NFT" or "test wxHOPR (HOPR)") for a staker',
   requestTestTokens
 )
   .addParam<RequestTestTokensOpts['type']>('type', 'Token type to request', undefined, types.string)
@@ -264,7 +264,7 @@ task<RequestTestTokensOpts>(
     types.string
   )
   .addParam<string>('recipient', 'Address of the NFT recipient', undefined, types.string)
-  .addOptionalParam<DevNftRank>('nftRank', 'Dev NFT rank ("developer" or "community")', undefined, types.string)
+  .addOptionalParam<NetworkRegistryNftRank>('nftRank', 'Network_registry NFT rank ("developer" or "community")', undefined, types.string)
   .addOptionalParam<string>('privatekey', 'Private key of the current owner of NFTs', undefined, types.string)
 
 task<StakeOpts>('stake', 'Used by CI tests to stake tokens to the running staking program.', stake)
@@ -275,7 +275,7 @@ task<StakeOpts>('stake', 'Used by CI tests to stake tokens to the running stakin
     MIN_STAKE.toString(),
     types.string
   )
-  .addOptionalParam<DevNftRank>('nftRank', 'Dev NFT rank ("developer" or "community")', undefined, types.string)
+  .addOptionalParam<NetworkRegistryNftRank>('nftRank', 'Network_registry NFT rank ("developer" or "community")', undefined, types.string)
   .addOptionalParam<string>('privatekey', 'Private key of the signer', undefined, types.string)
 
 function getSortedFiles(dependenciesGraph) {

--- a/packages/ethereum/hardhat.config.ts
+++ b/packages/ethereum/hardhat.config.ts
@@ -264,7 +264,12 @@ task<RequestTestTokensOpts>(
     types.string
   )
   .addParam<string>('recipient', 'Address of the NFT recipient', undefined, types.string)
-  .addOptionalParam<NetworkRegistryNftRank>('nftRank', 'Network_registry NFT rank ("developer" or "community")', undefined, types.string)
+  .addOptionalParam<NetworkRegistryNftRank>(
+    'nftRank',
+    'Network_registry NFT rank ("developer" or "community")',
+    undefined,
+    types.string
+  )
   .addOptionalParam<string>('privatekey', 'Private key of the current owner of NFTs', undefined, types.string)
 
 task<StakeOpts>('stake', 'Used by CI tests to stake tokens to the running staking program.', stake)
@@ -275,7 +280,12 @@ task<StakeOpts>('stake', 'Used by CI tests to stake tokens to the running stakin
     MIN_STAKE.toString(),
     types.string
   )
-  .addOptionalParam<NetworkRegistryNftRank>('nftRank', 'Network_registry NFT rank ("developer" or "community")', undefined, types.string)
+  .addOptionalParam<NetworkRegistryNftRank>(
+    'nftRank',
+    'Network_registry NFT rank ("developer" or "community")',
+    undefined,
+    types.string
+  )
   .addOptionalParam<string>('privatekey', 'Private key of the signer', undefined, types.string)
 
 function getSortedFiles(dependenciesGraph) {

--- a/packages/ethereum/tasks/register.ts
+++ b/packages/ethereum/tasks/register.ts
@@ -69,14 +69,13 @@ async function main(
   const signerAddress = await signer.getAddress()
   console.log('Signer Address (register task)', signerAddress)
 
-  const hoprProxy =
-    network.tags.development
-      ? ((await ethers.getContractFactory('HoprDummyProxyForNetworkRegistry'))
-          .connect(signer)
-          .attach(hoprProxyAddress) as HoprDummyProxyForNetworkRegistry)
-      : ((await ethers.getContractFactory('HoprStakingProxyForNetworkRegistry'))
-          .connect(signer)
-          .attach(hoprProxyAddress) as HoprStakingProxyForNetworkRegistry)
+  const hoprProxy = network.tags.development
+    ? ((await ethers.getContractFactory('HoprDummyProxyForNetworkRegistry'))
+        .connect(signer)
+        .attach(hoprProxyAddress) as HoprDummyProxyForNetworkRegistry)
+    : ((await ethers.getContractFactory('HoprStakingProxyForNetworkRegistry'))
+        .connect(signer)
+        .attach(hoprProxyAddress) as HoprStakingProxyForNetworkRegistry)
 
   const hoprNetworkRegistry = (await ethers.getContractFactory('HoprNetworkRegistry'))
     .connect(signer)

--- a/packages/ethereum/tasks/register.ts
+++ b/packages/ethereum/tasks/register.ts
@@ -69,7 +69,7 @@ async function main(
   const signerAddress = await signer.getAddress()
   console.log('Signer Address (register task)', signerAddress)
 
-  // FIXME: remove production when Dev NFT is ready in production
+  // FIXME: remove production when Network_registry NFT is ready in production
   const hoprProxy =
     network.tags.development || network.tags.production
       ? ((await ethers.getContractFactory('HoprDummyProxyForNetworkRegistry'))

--- a/packages/ethereum/test/HoprNetworkRegistry.test.ts
+++ b/packages/ethereum/test/HoprNetworkRegistry.test.ts
@@ -35,7 +35,7 @@ const createFakeRegistryProxyContract = async (participants: string[]) => {
 
   participants.slice(0, 2).forEach((participant) => {
     // account 0, 1 return max uint256
-    // DEV NFT like
+    // Network_registry NFT like
     hoprNetworkRegistryRequirementFake.maxAllowedRegistrations.whenCalledWith(participant).returns(constants.MaxUint256)
   })
   participants.slice(2, 4).forEach((participant) => {

--- a/packages/ethereum/test/proxy/HoprStakingProxyForNetworkRegistry.test.ts
+++ b/packages/ethereum/test/proxy/HoprStakingProxyForNetworkRegistry.test.ts
@@ -34,19 +34,18 @@ const checkMaxAllowance = async (
 
 /**
  * Allocation of NFTs and staks
- * |---------------|---|---|---|---|------|-----|-------|
- * | NFT Type      | 0 | 0 | 1 | 1 | Dev  | Dev | Stake |
- * |---------------|---|---|---|---|------|-----|-------|
- * | NFT Rank      | 0 | 1 | 0 | 1 | Tech | Com | --    |
- * |---------------|---|---|---|---|------|-----|-------|
- * | Participant_0 |   | x |   |   |      |     | 2000  |
- * | Participant_1 |   |   | x |   |      |     | 2000  |
- * | Participant_2 |   | x |   |   | x    |     | 100   |
- * | Participant_3 |   |   | x |   |      |     | 100   |
- * | Participant_4 |   |   | x |   |      |     | 2000  |
- * | Participant_5 |   | x |   |   |      |     | 100   |
- * | Participant_6 |   |   | x |   |      | x   | 0     |
- * |---------------|---|---|---|---|------|-----|-------|
+ * | NFT Type      | 0 | 0 | 1 | 1 | Network_registry | Network_registry | Stake |
+ * |---------------|---|---|---|---|------------------|------------------|-------|
+ * | NFT Rank      | 0 | 1 | 0 | 1 | developer        | community        | --    |
+ * |---------------|---|---|---|---|------------------|------------------|-------|
+ * | Participant_0 |   | x |   |   |                  |                  | 2000  |
+ * | Participant_1 |   |   | x |   |                  |                  | 2000  |
+ * | Participant_2 |   | x |   |   | x                |                  | 100   |
+ * | Participant_3 |   |   | x |   |                  |                  | 100   |
+ * | Participant_4 |   |   | x |   |                  |                  | 2000  |
+ * | Participant_5 |   | x |   |   |                  |                  | 100   |
+ * | Participant_6 |   |   | x |   |                  | x                | 0     |
+ * |---------------|---|---|---|---|------------------|------------------|-------|
  * @param participants
  * @returns
  */

--- a/packages/ethereum/utils/constants.ts
+++ b/packages/ethereum/utils/constants.ts
@@ -14,14 +14,14 @@ export const getHoprStakeContractName = (latestBlockTimestamp: number): string =
   }
 }
 
-export const DEV_NFT_BOOST = 0
-export const DEV_NFT_TYPE = 'Network_registry'
-export const DEV_NFT_TYPE_INDEX = 26 // as seen in https://dune.com/queries/837196/1463806
-export const DEV_NFT_RANK_TECH = 'developer'
-export const DEV_NFT_RANK_COM = 'community'
-export const DEV_NFT_MAX_REGISTRATION_TECH = constants.MaxUint256
-export const DEV_NFT_MAX_REGISTRATION_COM = 1
-export type DevNftRank = typeof DEV_NFT_RANK_TECH | typeof DEV_NFT_RANK_COM
+export const NR_NFT_BOOST = 0
+export const NR_NFT_TYPE = 'Network_registry'
+export const NR_NFT_TYPE_INDEX = 26 // as seen in https://dune.com/queries/837196/1463806
+export const NR_NFT_RANK_TECH = 'developer'
+export const NR_NFT_RANK_COM = 'community'
+export const NR_NFT_MAX_REGISTRATION_TECH = constants.MaxUint256
+export const NR_NFT_MAX_REGISTRATION_COM = 1
+export type NetworkRegistryNftRank = typeof NR_NFT_RANK_TECH | typeof NR_NFT_RANK_COM
 
 export const CLUSTER_NETWORK_REGISTERY_LINKED_ADDRESSES = [
   '0x6c150A63941c6d58a2f2687a23d5a8E0DbdE181C', // nat_with_stake

--- a/scripts/register-node.sh
+++ b/scripts/register-node.sh
@@ -44,15 +44,15 @@ declare dev_bank_privkey="${DEV_BANK_PRIVKEY:-}"
 # Get node's peer
 declare peer_id="$(get_hopr_address "${api_token}@${node_api}")"
 
-# Request a Dev (developer) NFT from DevBank
-PRIVATE_KEY="${dev_bank_privkey}" make request-devnft \
+# Request a Network_registry (developer) NFT from DevBank
+PRIVATE_KEY="${dev_bank_privkey}" make request-nrnft \
     environment=master-goerli \
     network=goerli \
     nftrank=developer \
     recipient="${account}"
 
 # Stake NFT
-PRIVATE_KEY="${account_privkey}" make stake-devnft \
+PRIVATE_KEY="${account_privkey}" make stake-nrnft \
     environment=master-goerli \ 
     network=goerli \
     nftrank=developer

--- a/scripts/setup-gcloud-cluster.sh
+++ b/scripts/setup-gcloud-cluster.sh
@@ -158,24 +158,30 @@ else
   )
 fi
 
-# FIXME: Quick hack, in production, due to lack of "Network_registry NFT", currently it uses Dummy proxy 
-# that only requires proxy owner (CI deployer account) to `register-nodes`
-if [[ "${environment}" != "paleochora" ]]; then
-  # This can be called always, because the "stake" task is idempotent given the same arguments
-  declare staking_index=0
-  for staking_addr in "${!staking_addrs_dict[@]}" ; do
-    fund_if_empty "${staking_addr}" "${environment}"
-    # we alternate between staking funds or NFT
-    if [[ "$((staking_index%2))" = "0" ]]; then
-      PRIVATE_KEY="${staking_addrs_dict[${staking_addr}]}" make -C "${mydir}/.." stake-funds environment="${environment}"
-    else
-      PRIVATE_KEY="${staking_addrs_dict[${staking_addr}]}" make -C "${mydir}/.." stake-nrnft environment="${environment}" nftrank=developer
-    fi
-    ((++staking_index))
-  done
-fi
+# Deployer CI wallet should ideally be "eligible". To be eligible: 
+# 1. The wallet should have obtained a "Network_registry" NFT of `developer` rank
+# 2. The wallet should have sent one above-mentioned NFT to the staking contract
+# However, this is not a hard requirement, because the owner of NR can call `ownerRegister` (`make register-nodes ...``)
+# which registers CI nodes' peerIds with the wallet.
+# FIXME: Correctly format the condition (in line with *meta* environment), so that the following lines are skipped for most of the time, and only be executed when: 
+# - the CI nodes wants to perform `selfRegister`
+# if [[ "${environment}" != "valencia" ]] && [[ "${environment}" != "paleochora" ]]; then
+#   # This can be called always, because the "stake" task is idempotent given the same arguments
+#   declare staking_index=0
+#   for staking_addr in "${!staking_addrs_dict[@]}" ; do
+#     fund_if_empty "${staking_addr}" "${environment}"
+#     # we alternate between staking funds or NFT
+#     if [[ "$((staking_index%2))" = "0" ]]; then
+#       PRIVATE_KEY="${staking_addrs_dict[${staking_addr}]}" make -C "${mydir}/.." stake-funds environment="${environment}"
+#     else
+#       PRIVATE_KEY="${staking_addrs_dict[${staking_addr}]}" make -C "${mydir}/.." stake-nrnft environment="${environment}" nftrank=developer
+#     fi
+#     ((++staking_index))
+#   done
+# fi
 
 # Get names of all instances in this cluster
+# TODO: now `native-addresses` (a.k.a. `hopr_addrs`) doesn't need to contain unique values. The array can contain repetitive addresses
 declare instance_names
 instance_names="$(gcloud_get_managed_instance_group_instances_names "${cluster_id}")"
 declare -a instance_names_arr

--- a/scripts/setup-gcloud-cluster.sh
+++ b/scripts/setup-gcloud-cluster.sh
@@ -158,7 +158,7 @@ else
   )
 fi
 
-# FIXME: Quick hack, in production, due to lack of "Dev NFT", currently it uses Dummy proxy 
+# FIXME: Quick hack, in production, due to lack of "Network_registry NFT", currently it uses Dummy proxy 
 # that only requires proxy owner (CI deployer account) to `register-nodes`
 if [[ "${environment}" != "paleochora" ]]; then
   # This can be called always, because the "stake" task is idempotent given the same arguments
@@ -169,7 +169,7 @@ if [[ "${environment}" != "paleochora" ]]; then
     if [[ "$((staking_index%2))" = "0" ]]; then
       PRIVATE_KEY="${staking_addrs_dict[${staking_addr}]}" make -C "${mydir}/.." stake-funds environment="${environment}"
     else
-      PRIVATE_KEY="${staking_addrs_dict[${staking_addr}]}" make -C "${mydir}/.." stake-devnft environment="${environment}" nftrank=developer
+      PRIVATE_KEY="${staking_addrs_dict[${staking_addr}]}" make -C "${mydir}/.." stake-nrnft environment="${environment}" nftrank=developer
     fi
     ((++staking_index))
   done


### PR DESCRIPTION
- Closes https://github.com/hoprnet/hoprnet/issues/4065 (except for contract deployment)
- Fix "remove" in `packages/ethereum/tasks/register.ts`. It should call `ownerDeregister(peerIds)` despite proxy being in usage and only force checking `addresses` when dummy proxy is used, because an additional call of `ownerBatchRemoveAccounts(addresses)` must be done on the proxy contract.