### PR TITLE
Deploy script registers nodes to NR

### DIFF
--- a/NETWORK_REGISTRY.md
+++ b/NETWORK_REGISTRY.md
@@ -186,9 +186,8 @@ make register-node-when-dummy-proxy endpoint="localhost:3001" api_token="^MYtoke
 
 ### Production
 
-For nodes running in the upcoming "monte rosa" environment, only wallets with one "Network_registry" HoprBoost NFT (be `developer` or `community` rank) staked in the staking program are eligible to spin up HOPR nodes.
+For nodes running in the upcoming "monte_rosa" environment, only wallets with one "Network_registry" HoprBoost NFT (be `developer` or `community` rank) staked in the staking program are eligible to spin up HOPR nodes.
 
-""
 To register one (`community` rank) or many (`developer` rank) eligible node in the NR, please follow:
 
 #### Procedure
@@ -208,22 +207,49 @@ To register one (`community` rank) or many (`developer` rank) eligible node in t
    source .env
    ```
 
-5. Request "Network_registry" NFT. Either by requesting from TECH (or COM) team, or by obtaining directly from "Dev Bank". For the latter, add the following line into `.env` file
+5. Request "Network_registry" NFT. Either by requesting from TECH (or COM) team, or by transferring it directly from "Dev Bank".
+
+6. Register nodes and eligible accounts onto Network Registry. There are three options:
+
+   a. For the **deployer** wallet: Deployer wallet should stake one `developer` NFT and
+   register some peer ids.
+   To stake one `developer` NFT:
 
    ```
-   export DEV_BANK_PRIVKEY=<dev_bank_private_key>
+   HOPR_ENVIRONMENT_ID=monte_rosa \
+   TS_NODE_PROJECT=${mydir}/../packages/ethereum/tsconfig.hardhat.json \
+   yarn workspace @hoprnet/hopr-ethereum run hardhat stake \
+   	--network xdai \
+   	--type nrnft \
+   	--nftrank developer
    ```
 
-   and
+   To register some peers:
+
+   1. When "staking proxy" is used:
+
+      ```
+      HOPR_ENVIRONMENT_ID=monte_rosa \
+      TS_NODE_PROJECT=${mydir}/../packages/ethereum/tsconfig.hardhat.json \
+      yarn workspace @hoprnet/hopr-ethereum run hardhat register:self \
+      --network xdai \
+      --task add \
+      --peer-ids <peerId1,peerId2,peerId3,peerId4...>
+      ```
+
+   2. When "dummy proxy" is used:
+      ```
+      HOPR_ENVIRONMENT_ID=monte_rosa \
+      TS_NODE_PROJECT=${mydir}/../packages/ethereum/tsconfig.hardhat.json \
+      yarn workspace @hoprnet/hopr-ethereum run hardhat register:self \
+      --network xdai \
+      --task sync \
+      --peer-ids <peerId1,peerId2,peerId3,peerId4...>
+      ```
+
+   b. For community/team testing:
 
    ```
-   source .env
+   PRIVATE_KEY=${ACCOUNT_PRIVKEY} make stake-nrnft nftrank=<"developer" or "community"> environment=monte_rosa network=xdai
+   PRIVATE_KEY=${ACCOUNT_PRIVKEY} make self-register-node peer_ids=<peerId1,peerId2,peerId3,peerId4...> environment=monte_rosa network=xdai
    ```
-
-   run
-
-   ```
-   make register-node-with-nft endpoint=<hoprd_endpoint> nftrank=<"Network_registry" NFT Rank ("developer" or "community")> account=<staking_account> environment=<release_name> network=xdai
-   ```
-
-   Note: please provide `endpoint=<hoprd_endpoint>` when the node exposes port different from `localhost:3001`.

--- a/packages/ethereum/contracts/proxy/HoprStakingProxyForNetworkRegistry.sol
+++ b/packages/ethereum/contracts/proxy/HoprStakingProxyForNetworkRegistry.sol
@@ -237,6 +237,7 @@ contract HoprStakingProxyForNetworkRegistry is IHoprNetworkRegistryRequirement, 
       }
     }
     specialNftTypeAndRank.push(NftTypeAndRank({nftType: nftType, nftRank: nftRank}));
+    maxRegistrationsPerSpecialNft.push(maxRegistration);
     emit SpecialNftTypeAndRankAdded(nftType, nftRank, maxRegistration);
   }
 

--- a/packages/ethereum/deploy/02_HoprToken.ts
+++ b/packages/ethereum/deploy/02_HoprToken.ts
@@ -59,8 +59,8 @@ const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   }
 }
 
-// this smart contract should not be redeployed on a production network
-// main.skip = async (env) => !!env.network.tags.production
+// this smart contract should not be redeployed on a production or staging network
+main.skip = async (env) => !!env.network.tags.production || !!env.network.tags.staging
 main.dependencies = ['preDeploy']
 main.tags = ['HoprToken']
 

--- a/packages/ethereum/deploy/16_HoprNetworkRegistryProxy.ts
+++ b/packages/ethereum/deploy/16_HoprNetworkRegistryProxy.ts
@@ -42,15 +42,20 @@ const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   try {
     // if a NetworkRegistry contract instance exists, try to update with the latest proxy implementation
     const networkRegistry = await deployments.get('HoprNetworkRegistry')
-    const registryContract= (await ethers.getContractFactory('HoprNetworkRegistry')).attach(
+    const registryContract = (await ethers.getContractFactory('HoprNetworkRegistry')).attach(
       networkRegistry.address
     ) as HoprNetworkRegistry
-    const isImplementationDifferent = (await registryContract.requirementImplementation()).toLowerCase() !== registryProxy.address.toLowerCase();
-    const isDeployerRegistryOwner = (await registryContract.owner()).toLowerCase() === deployer.toLowerCase();
-    console.log(`Registry proxy implementation is ${isImplementationDifferent ? "": "not "}different; Deployer is ${isDeployerRegistryOwner ? "": "not "}owner.`)
+    const isImplementationDifferent =
+      (await registryContract.requirementImplementation()).toLowerCase() !== registryProxy.address.toLowerCase()
+    const isDeployerRegistryOwner = (await registryContract.owner()).toLowerCase() === deployer.toLowerCase()
+    console.log(
+      `Registry proxy implementation is ${isImplementationDifferent ? '' : 'not '}different; Deployer is ${
+        isDeployerRegistryOwner ? '' : 'not '
+      }owner.`
+    )
     if (isImplementationDifferent && isDeployerRegistryOwner) {
       // update proxy in NR contract
-      const updateTx = await registryContract.updateRequirementImplementation(registryProxy.address);
+      const updateTx = await registryContract.updateRequirementImplementation(registryProxy.address)
 
       // don't wait when using local hardhat because its using auto-mine
       if (!environment.match('hardhat')) {
@@ -59,7 +64,7 @@ const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       }
     }
   } catch (error) {
-    console.log("Cannot update proxy implementation.")
+    console.log('Cannot update proxy implementation.')
   }
 }
 

--- a/packages/ethereum/deploy/16_HoprNetworkRegistryProxy.ts
+++ b/packages/ethereum/deploy/16_HoprNetworkRegistryProxy.ts
@@ -7,7 +7,7 @@ const STAKING_PROXY = 'HoprStakingProxyForNetworkRegistry'
 
 // Deploy directly a HoprNetworkRegistry contract, using hardcoded staking contract.
 const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { deployments, getNamedAccounts, network, environment, maxFeePerGas, maxPriorityFeePerGas } = hre
+  const { deployments, getNamedAccounts, network, ethers, environment, maxFeePerGas, maxPriorityFeePerGas } = hre
   const { deployer } = await getNamedAccounts()
 
   const stakeAddress = (await deployments.get('HoprStake')).address
@@ -37,6 +37,26 @@ const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
       registryProxy.address
     }`
   )
+
+  try {
+    // if a NetworkRegistry contract instance exists, try to update with the latest proxy implementation
+    const registryContract = deployments.get('HoprNetworkRegistry')
+    const isImplementationDifferent = (await registryContract.requirementImplementation()).toLowerCase() === registryProxy.address.toLowerCase();
+    const isDeployerRegistryOwner = (await registryContract.owner()).toLowerCase() === deployer.toLowerCase();
+    console.log(`Registry proxy implementation is ${isImplementationDifferent ? " ": "not "}different; Deployer is ${isDeployerRegistryOwner ? " ": "not "}owner.`)
+    if (isImplementationDifferent && isDeployerRegistryOwner) {
+      // update proxy in NR contract
+      const updateTx = await registryContract.updateRequirementImplementation(registryProxy.address);
+
+      // don't wait when using local hardhat because its using auto-mine
+      if (!environment.match('hardhat')) {
+        console.log(`Wait for minting tx on chain`)
+        await ethers.provider.waitForTransaction(updateTx.hash, 2)
+      }
+    }
+  } catch (error) {
+    console.log("Cannot update proxy implementation.")
+  }
 }
 
 main.dependencies = ['preDeploy', 'HoprStake']

--- a/packages/ethereum/deploy/17_HoprNetworkRegistry.ts
+++ b/packages/ethereum/deploy/17_HoprNetworkRegistry.ts
@@ -2,6 +2,9 @@ import type { DeployFunction } from 'hardhat-deploy/types'
 import type { HardhatRuntimeEnvironment } from 'hardhat/types'
 import type { HoprNetworkRegistry } from '../src/types'
 
+/**
+ * This Network Registry contract should not be redeployed, even when the proxy is deployed at a new address
+ */
 const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { ethers, deployments, getNamedAccounts, network, environment, maxFeePerGas, maxPriorityFeePerGas } = hre
   const { deployer } = await getNamedAccounts()
@@ -61,5 +64,6 @@ const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
 main.dependencies = ['preDeploy', 'HoprNetworkRegistryProxy']
 main.tags = ['HoprNetworkRegistry']
+main.skip = async (env: HardhatRuntimeEnvironment) => !!env.network.tags.production || !!env.network.tags.staging
 
 export default main

--- a/packages/ethereum/deploy/20_mintNetworkRegistryNfts.ts
+++ b/packages/ethereum/deploy/20_mintNetworkRegistryNfts.ts
@@ -130,24 +130,16 @@ const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
     console.log(`Admin ${admin} has ${await hoprBoost.balanceOf(admin)} Boost NFTs`)
   } else {
-    console.log(`Deployer is not minter. Skip minting NFTs.`)
+    console.log(`Deployer is not minter. Skip minting NFTs, although ${dummyNftTypesToBeMinted} need to be minted.`)
   }
 
-  // Add special NFTs in staging environment
-  if (network.tags.staging) {
-    // add special NFT types (dev NFTs) in network registry for staging envionment
+  // Add special NFTs in staging environment (for both staging and production environments)
+  if (network.tags.staging || network.tags.production) {
+    // add special NFT types (dev NFTs) in network registry for both staging and production envionment
     const registryProxy = (await ethers.getContractFactory('HoprStakingProxyForNetworkRegistry')).attach(
       registryProxyDeployment.address
     ) as HoprStakingProxyForNetworkRegistry
 
-    await awaitTxConfirmation(
-      registryProxy.ownerBatchAddNftTypeAndRank(
-        [NR_NFT_TYPE_INDEX, NR_NFT_TYPE_INDEX],
-        [NR_NFT_RANK_TECH, NR_NFT_RANK_COM]
-      ),
-      environment,
-      ethers
-    )
     await awaitTxConfirmation(
       registryProxy.ownerBatchAddSpecialNftTypeAndRank(
         [NR_NFT_TYPE_INDEX, NR_NFT_TYPE_INDEX],
@@ -162,6 +154,14 @@ const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     )
 
     // // currently we don't use funds, only NFTs
+    // await awaitTxConfirmation(
+    //   registryProxy.ownerBatchAddNftTypeAndRank(
+    //     [NR_NFT_TYPE_INDEX, NR_NFT_TYPE_INDEX],
+    //     [NR_NFT_RANK_TECH, NR_NFT_RANK_COM]
+    //   ),
+    //   environment,
+    //   ethers
+    // )
     // try {
     //   // mint minimum stake to addresses that will stake and are binded to nodes in NR
     //   const tokenContract = await deployments.get('xHoprToken')
@@ -200,6 +200,5 @@ const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
 main.dependencies = ['preDeploy', 'HoprNetworkRegistry', 'HoprBoost', 'HoprStake']
 main.tags = ['MintNetworkRegistryNfts']
-main.skip = async (env: HardhatRuntimeEnvironment) => !!env.network.tags.production
 
 export default main


### PR DESCRIPTION
Fix https://github.com/hoprnet/hoprnet/issues/4109

- Fix bug in SC that does not update `maxRegistrationsPerSpecialNft` when adding a special NFT
- Fix script that skip adding special NFTs in production environment
- Skip HoprToken deployment in staging and prod. 
- Allow proxy to be updated when a NR contract is in place. (Note: This will always update the proxy implementation in the last NetworkRegistry contract, even when a new NR contract will be deployed.)