### PR TITLE
Fix the `get-default-environment` script

### DIFF
--- a/scripts/get-default-environment.sh
+++ b/scripts/get-default-environment.sh
@@ -20,10 +20,10 @@ declare branch=$(git rev-parse --abbrev-ref HEAD)
 declare environment_id
 for git_ref in $(cat "${mydir}/../packages/hoprd/releases.json" | jq -r "to_entries[] | .value.git_ref" | uniq); do
   if [[ "${branch}" =~ ${git_ref} ]]; then
-    environment_id=$(cat "${mydir}/../packages/hoprd/releases.json" | jq -r "to_entries[] | select(.value.git_ref==\"${git_ref}\" and .value.default==true) | .key")
+    environment_id=$(cat "${mydir}/../packages/hoprd/releases.json" | jq -r "to_entries[] | select(.value.git_ref==\"${git_ref}\" and .value.default==true) | .value.environment_id")
     # if no default is set we take the first entry
     if [ -z "${environment_id}" ]; then
-      environment_id=$(cat "${mydir}/../packages/hoprd/releases.json" | jq -r "to_entries[] | select(.value.git_ref==\"${git_ref}\") | .key" | sed q)
+      environment_id=$(cat "${mydir}/../packages/hoprd/releases.json" | jq -r "to_entries[] | select(.value.git_ref==\"${git_ref}\") | .value.environment_id" | sed q)
     fi
     break
   fi


### PR DESCRIPTION
Script should output the actual environment_id from releases.json