### PR TITLE
Enhance option parsing

### DIFF
--- a/packages/hoprd/Dockerfile
+++ b/packages/hoprd/Dockerfile
@@ -120,6 +120,9 @@ RUN mkdir -p hoprd-db
 # set volume which can be mapped by users on the host system
 VOLUME ["/app/hoprd-db"]
 
+# set data directory to user-mountable directory
+ENV HOPRD_DATA=/app/hoprd-db
+
 # DISABLED temporarily until a migration path has been tested
 # finally set the non-root user so the process also run un-privilidged
 # USER node

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -195,7 +195,7 @@ const argv = yargsInstance
     hidden: true,
     boolean: true,
     describe: 'no remote authentication for easier testing [env: HOPRD_TEST_NO_AUTHENTICATION]',
-    default: false
+    default: undefined
   })
   .option('testNoDirectConnections', {
     hidden: true,

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -106,6 +106,12 @@ const argv = yargsInstance
     describe: 'Set host port to which the API server will bind. [env: HOPRD_API_PORT]',
     default: 3001
   })
+  .option('apiToken', {
+    string: true,
+    describe: 'A REST API token and admin panel password for user authentication [env: HOPRD_API_TOKEN]',
+    default: undefined,
+    conflicts: 'testNoAuthentication'
+  })
   .option('healthCheck', {
     boolean: true,
     describe: 'Run a health check end point on localhost:8080 [env: HOPRD_HEALTH_CHECK]',
@@ -126,16 +132,7 @@ const argv = yargsInstance
     describe: 'A password to encrypt your keys [env: HOPRD_PASSWORD]',
     default: ''
   })
-  .option('apiToken', {
-    string: true,
-    describe: 'A REST API token and admin panel password for user authentication [env: HOPRD_API_TOKEN]',
-    default: undefined
-  })
-  .option('privateKey', {
-    string: true,
-    describe: 'A private key to be used for the node [env: HOPRD_PRIVATE_KEY]',
-    default: undefined
-  })
+
   .option('provider', {
     string: true,
     describe: 'A custom RPC provider to be used for the node to connect to blockchain [env: HOPRD_PROVIDER]'
@@ -160,6 +157,12 @@ const argv = yargsInstance
     describe: "initialize a database if it doesn't already exist [env: HOPRD_INIT]",
     default: false
   })
+  .option('privateKey', {
+    hidden: true,
+    string: true,
+    describe: 'A private key to be used for the node [env: HOPRD_PRIVATE_KEY]',
+    default: undefined
+  })
   .option('allowLocalNodeConnections', {
     boolean: true,
     describe: 'Allow connections to other nodes running on localhost [env: HOPRD_ALLOW_LOCAL_NODE_CONNECTIONS]',
@@ -172,45 +175,49 @@ const argv = yargsInstance
     default: false
   })
   .option('testAnnounceLocalAddresses', {
+    hidden: true,
     boolean: true,
     describe: 'For testing local testnets. Announce local addresses [env: HOPRD_TEST_ANNOUNCE_LOCAL_ADDRESSES]',
     default: false
   })
   .option('testPreferLocalAddresses', {
+    hidden: true,
     boolean: true,
     describe: 'For testing local testnets. Prefer local peers to remote [env: HOPRD_TEST_PREFER_LOCAL_ADDRESSES]',
     default: false
   })
   .option('testUseWeakCrypto', {
+    hidden: true,
     boolean: true,
     describe: 'weaker crypto for faster node startup [env: HOPRD_TEST_USE_WEAK_CRYPTO]',
     default: false
   })
   .option('testNoAuthentication', {
+    hidden: true,
     boolean: true,
     describe: 'no remote authentication for easier testing [env: HOPRD_TEST_NO_AUTHENTICATION]',
     default: false
   })
   .option('testNoDirectConnections', {
+    hidden: true,
     boolean: true,
     describe:
       'NAT traversal testing: prevent nodes from establishing direct TCP connections [env: HOPRD_TEST_NO_DIRECT_CONNECTIONS]',
-    default: false,
-    hidden: true
+    default: false
   })
   .option('testNoWebRTCUpgrade', {
+    hidden: true,
     boolean: true,
     describe:
       'NAT traversal testing: prevent nodes from establishing direct TCP connections [env: HOPRD_TEST_NO_WEB_RTC_UPGRADE]',
-    default: false,
-    hidden: true
+    default: false
   })
   .option('testNoUPNP', {
+    hidden: true,
     boolean: true,
     describe:
       'NAT traversal testing: disable automatic detection of external IP address using UPNP [env: HOPRD_TEST_NO_UPNP]',
-    default: false,
-    hidden: true
+    default: false
   })
   .option('heartbeatInterval', {
     number: true,
@@ -239,7 +246,8 @@ const argv = yargsInstance
     describe: 'Number of confirmations required for on-chain transactions [env: HOPRD_ON_CHAIN_CONFIRMATIONS]',
     default: CONFIRMATIONS
   })
-
+  .showHidden('show-hidden', 'see all options, including development options')
+  .strict()
   .wrap(Math.min(120, yargsInstance.terminalWidth()))
   .parseSync()
 

--- a/scripts/run-integration-tests-source.sh
+++ b/scripts/run-integration-tests-source.sh
@@ -27,7 +27,7 @@ usage() {
 declare wait_delay=2
 declare wait_max_wait=1000
 declare skip_cleanup="false"
-declare api_token="e2e-API-token^^"
+declare default_api_token="e2e-API-token^^"
 
 while (( "$#" )); do
   case "$1" in
@@ -157,13 +157,14 @@ fi
 # $8 = OPTIONAL: additional args to hoprd
 function setup_node() {
   local api_port=${1}
-  local node_port=${2}
-  local admin_port=${3}
-  local dir=${4}
-  local log=${5}
-  local id=${6}
-  local private_key=${7}
-  local additional_args=${8:-""}
+  local api_token=${2}
+  local node_port=${3}
+  local admin_port=${4}
+  local dir=${5}
+  local log=${6}
+  local id=${7}
+  local private_key=${8}
+  local additional_args=${9:-""}
 
   log "Run node ${id} on API port ${api_port} -> ${log}"
 
@@ -171,10 +172,16 @@ function setup_node() {
     additional_args="--environment hardhat-localhost ${additional_args}"
   fi
 
-  log "Additional args: \"${additional_args}\""
+  if [[ -n "${api_token}" ]]; then
+    additional_args="--api-token='${api_token}' ${additional_args}"
+  else
+    additional_args="--testNoAuthentication ${additional_args}"
+  fi
 
   # Remove previous logs to make sure the regex does not match
   rm -f "${log}"
+
+  log "Additional args: \"${additional_args}\""
 
   # Set NODE_ENV=development to rebuild hopr-admin next files
   # at runtime. Necessary to start multiple instances of hoprd
@@ -333,15 +340,15 @@ cp -R \
 declare ct_node1_address="0xde913eeed23bce5274ead3de8c196a41176fbd49"
 
 #  --- Run nodes --- {{{
-setup_node 13301 19091 19501 "${node1_dir}" "${node1_log}" "${node1_id}" "${node1_privkey}" "--announce"
-setup_node 13302 19092 19502 "${node2_dir}" "${node2_log}" "${node2_id}" "${node2_privkey}" "--announce --testNoAuthentication"
-setup_node 13303 19093 19503 "${node3_dir}" "${node3_log}" "${node3_id}" "${node3_privkey}" "--announce"
-setup_node 13304 19094 19504 "${node4_dir}" "${node4_log}" "${node4_id}" "${node4_privkey}" "--testNoDirectConnections"
-setup_node 13305 19095 19505 "${node5_dir}" "${node5_log}" "${node5_id}" "${node5_privkey}" "--testNoDirectConnections"
+setup_node 13301 ${default_api_token} 19091 19501 "${node1_dir}" "${node1_log}" "${node1_id}" "${node1_privkey}" "--announce"
+setup_node 13302 "" 19092 19502 "${node2_dir}" "${node2_log}" "${node2_id}" "${node2_privkey}" "--announce"
+setup_node 13303 ${default_api_token} 19093 19503 "${node3_dir}" "${node3_log}" "${node3_id}" "${node3_privkey}" "--announce"
+setup_node 13304 ${default_api_token} 19094 19504 "${node4_dir}" "${node4_log}" "${node4_id}" "${node4_privkey}" "--testNoDirectConnections"
+setup_node 13305 ${default_api_token} 19095 19505 "${node5_dir}" "${node5_log}" "${node5_id}" "${node5_privkey}" "--testNoDirectConnections"
 # should not be able to talk to the rest
-setup_node 13306 19096 19506 "${node6_dir}" "${node6_log}" "${node6_id}" "${node6_privkey}" "--announce --environment hardhat-localhost2"
+setup_node 13306 ${default_api_token} 19096 19506 "${node6_dir}" "${node6_log}" "${node6_id}" "${node6_privkey}" "--announce --environment hardhat-localhost2"
 # node n8 will be the only one NOT registered
-setup_node 13307 19097 19507 "${node7_dir}" "${node7_log}" "${node7_id}" "${node7_privkey}" "--announce"
+setup_node 13307 ${default_api_token} 19097 19507 "${node7_dir}" "${node7_log}" "${node7_id}" "${node7_privkey}" "--announce"
 setup_ct_node "${ct_node1_log}" "0xa08666bca1363cb00b5402bbeb6d47f6b84296f3bba0f2f95b1081df5588a613" 20000 "${ct_node1_dir}"
 # }}}
 
@@ -389,13 +396,13 @@ log "All nodes came up online"
 
 # --- Run security tests --- {{{
 ${mydir}/../test/security-test.sh \
-  127.0.0.1 13301 13302 19501 19502 "${api_token}"
+  127.0.0.1 13301 13302 19501 19502 "${default_api_token}"
 # }}}
 
 # --- Run protocol test --- {{{
 ADDITIONAL_NODE_ADDRS="0xde913eeed23bce5274ead3de8c196a41176fbd49" \
 ADDITIONAL_NODE_PEERIDS="16Uiu2HAm2VD6owCxPEZwP6Moe1jzapqziVeaTXf1h7jVzu5dW1mk" \
-HOPRD_API_TOKEN="${api_token}" \
+HOPRD_API_TOKEN="${default_api_token}" \
 ${mydir}/../test/integration-test.sh \
   "localhost:13301" "localhost:13302" "localhost:13303" "localhost:13304" "localhost:13305" "localhost:13306" "localhost:13307"
 # }}}

--- a/scripts/run-integration-tests-source.sh
+++ b/scripts/run-integration-tests-source.sh
@@ -192,7 +192,6 @@ function setup_node() {
       --admin \
       --adminHost "127.0.0.1" \
       --adminPort ${admin_port} \
-      --api-token "${api_token}" \
       --data="${dir}" \
       --host="127.0.0.1:${node_port}" \
       --identity="${id}" \


### PR DESCRIPTION
Some bugfixes to enhance usability

# Changes

- set default `data` directory to user-mountable directory
-  make `--testNoAuthentication` conflict with `--apiToken`
- hide some debugging CLI arguments
- fail on unknown arguments, this *explicitly* includes typos such as `--testNoAuthenticatio`
- allow user to see hidden CLI arguments through `--show-hidden`