### PR TITLE
Silence trace unhandled

### DIFF
--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -25,7 +25,6 @@ import setupHealthcheck from './healthcheck.js'
 import { AdminServer } from './admin.js'
 import { LogStream } from './logs.js'
 import { getIdentity } from './identity.js'
-import { register as registerUnhandled, setLogger } from 'trace-unhandled'
 import { decodeMessage } from './api/utils.js'
 
 const DEFAULT_ID_PATH = path.join(process.env.HOME, '.hopr-identity')
@@ -297,11 +296,15 @@ function generateNodeOptions(environment: ResolvedEnvironment): HoprOptions {
   return options
 }
 
-function addUnhandledPromiseRejectionHandler() {
-  registerUnhandled()
-  setLogger((msg) => {
-    console.error(msg)
-  })
+async function addUnhandledPromiseRejectionHandler() {
+  if (process.env.NODE_ENV !== 'production') {
+    const { register: registerUnhandled, setLogger } = await import('trace-unhandled')
+
+    registerUnhandled()
+    setLogger((msg) => {
+      console.error(msg)
+    })
+  }
 
   // See https://github.com/hoprnet/hoprnet/issues/3755
   process.on('unhandledRejection', (reason: any, _promise: Promise<any>) => {

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -298,6 +298,9 @@ function generateNodeOptions(environment: ResolvedEnvironment): HoprOptions {
 
 async function addUnhandledPromiseRejectionHandler() {
   if (process.env.NODE_ENV !== 'production') {
+    console.log(
+      `Loading extended logger that enhances debugging of unhandled promise rejections. Disabled on production environments`
+    )
     const { register: registerUnhandled, setLogger } = await import('trace-unhandled')
 
     registerUnhandled()


### PR DESCRIPTION
`trace-unhandled` is used to decorate unhandled promise rejection in order to enhance debugging. This requires encapsulating each promise by a `TraceablePromise` which requires a lot of CPU time. 

# Changes

- do not load *or* register `trace-unhandled` if `NODE_ENV == production`