### PR TITLE
unset HOPRD_ environment variables

### DIFF
--- a/scripts/nat/start-nat-node.sh
+++ b/scripts/nat/start-nat-node.sh
@@ -11,7 +11,7 @@ if [ $(id -u) -ne 0 ] ; then
   exit 1
 fi
 
-if [ -z "$HOPRD_RELEASE" ]; then
+if [ -z "${HOPRD_RELEASE}" ]; then
   >&2 echo "ERROR: Must specify HOPRD_RELEASE environment variable"
   exit 1
 fi
@@ -22,7 +22,7 @@ if [ ! -S "/var/run/docker.sock" ]; then
 fi
 
 if [[ $# = 1 && "$1" = "--version" ]]; then
-  docker run --pull always --rm "gcr.io/hoprassociation/hoprd:$HOPRD_RELEASE" --version 2> /dev/null
+  docker run --pull always --rm "gcr.io/hoprassociation/hoprd:${HOPRD_RELEASE}" --version 2> /dev/null
   exit $?
 fi
 
@@ -45,9 +45,12 @@ fi
 # Stop & remove the Docker container if it was running already
 docker stop ${container_name} > /dev/null 2>&1 || true && docker rm ${container_name} > /dev/null 2>&1 || true
 
+# Unsets additional environment variables since HOPRD_ prefixed environment values are treated as CLI arguments
+declare internal_env=$(env -u HOPRD_RELEASE -u HOPRD_CONTAINER_NAME)
+
 # Fork here and pass all the environment variables down into the forked image
 docker run -d --pull always -v /var/hoprd/:/app/hoprd-db -p ${admin_port}:3000 -p ${api_port}:3001 -p ${healthcheck_port}:8080 \
  --name=${container_name} --restart=on-failure \
  --network=${network_name} \
- --env-file <(env) \
- "gcr.io/hoprassociation/hoprd:$HOPRD_RELEASE" "$@"
+ --env-file <(echo ${internal_env}) \
+ "gcr.io/hoprassociation/hoprd:${HOPRD_RELEASE}" "$@"


### PR DESCRIPTION
Environment variables that are prefixed by `HOPRD_` are treated as CLI arguments, hence copying an entire environment should unset all `HOPRD_` prefixed variables that are not meant to be passed to the `hoprd` process.

# Changes

- when building `hoprd-behind-nat` image, unset all irrelevant `HOPRD_` prefixed environment variables before passing them into the internal `hoprd` image.