### PR TITLE
Use webrtc release build

### DIFF
--- a/packages/hoprd/Dockerfile
+++ b/packages/hoprd/Dockerfile
@@ -101,8 +101,8 @@ COPY --from=build /app/hoprnet .
 # As we are on Debian, use hardlinks in node_modules to save space
 RUN yarn config set nmMode hardlinks-local
 
-# Install without devDependencies
-RUN CI=true yarn workspaces focus --production @hoprnet/hoprd
+# Install without devDependencies, and using WebRTC Release builds (`DEBUG=`)
+RUN DEBUG= CI=true yarn workspaces focus --production @hoprnet/hoprd
 
 # Remove yarn cache globally
 RUN yarn cache clean --all

--- a/packages/hoprd/Dockerfile
+++ b/packages/hoprd/Dockerfile
@@ -102,6 +102,7 @@ COPY --from=build /app/hoprnet .
 RUN yarn config set nmMode hardlinks-local
 
 # Install without devDependencies, and using WebRTC Release builds (`DEBUG=`)
+# see https://github.com/node-webrtc/node-webrtc/blob/685aa433623b9bf98e8c7c0124e7864e01b883e6/scripts/download-prebuilt.js#L11
 RUN DEBUG= CI=true yarn workspaces focus --production @hoprnet/hoprd
 
 # Remove yarn cache globally


### PR DESCRIPTION
`node-webrtc` supports two builds - a Release build and a Debug build, including debug symbols

# Changes

- when installing node packages within production `hoprd` Docker image, use Release build instead of Debug build, see https://github.com/node-webrtc/node-webrtc/blob/685aa433623b9bf98e8c7c0124e7864e01b883e6/scripts/download-prebuilt.js#L11