### PR TITLE
free memory from DHT ping queues

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -431,6 +431,7 @@ class Hopr extends EventEmitter {
 
   /**
    * Total hack
+   Mannually wipes DHT's ping queues as they get unnecessarily populated
    */
   private freeMemory() {
     console.log(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -425,6 +425,33 @@ class Hopr extends EventEmitter {
     }
     await this.maybeLogProfilingToGCloud()
     this.heartbeat.recalculateNetworkHealth()
+
+    this.startMemoryFreeInterval()
+  }
+
+  /**
+   * Total hack
+   */
+  private freeMemory() {
+    console.log(
+      // @ts-ignore
+      `Freeing memory, size wan ${this.libp2pComponents.getDHT().wan.routingTable.pingQueue.size} lan ${
+        // @ts-ignore
+
+        this.libp2pComponents.getDHT().lan.routingTable.pingQueue.size
+      }`
+    )
+    // @ts-ignore
+    this.libp2pComponents.getDHT().wan.routingTable.pingQueue.clear()
+    // @ts-ignore
+    this.libp2pComponents.getDHT().lan.routingTable.pingQueue.clear()
+  }
+
+  /**
+   * Total hack
+   */
+  private startMemoryFreeInterval() {
+    retimer(this.freeMemory.bind(this), () => durations.minutes(1))
   }
 
   private async maybeLogProfilingToGCloud() {

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -109,7 +109,7 @@ export async function createLibp2pInstance(
       ],
       streamMuxers: [new Mplex()],
       connectionEncryption: [new Noise()],
-      dht: new KadDHT({ protocolPrefix }),
+      dht: new KadDHT({ protocolPrefix, pingTimeout: 2000 }),
       connectionManager: {
         autoDial: true,
         // Use custom sorting to prevent from problems with libp2p


### PR DESCRIPTION
# Context

Libp2p's DHT implementation provides its own availability measurement functionality. By default, `libp2p` runs two DHTs, one for WAN and one for LAN. This distinction is beneficial since routing works differently in a local network than in a global public network. In its current version, it seems that some ping attempts issued *by the DHT* never get done, so these queues grow without bounds and thus causes the process to consume way more memory than necessary.

See https://github.com/libp2p/js-libp2p-kad-dht/blob/a6129f39732f78217fe8cd6410c76b6332613353/src/routing-table/index.ts#L93

# Changes

- manually wipes both LAN and WAN ping queues every minute
- reduces the *DHT* ping timeout from 10s to 2s