### PR TITLE
explicit extent

### DIFF
--- a/packages/connect/src/relay/connection.spec.ts
+++ b/packages/connect/src/relay/connection.spec.ts
@@ -125,7 +125,7 @@ describe('relay connection', function () {
       assert.fail(`Stream should be closed`)
     }
 
-    assert(alice.destroyed, `Stream must be destroyed`)
+    assert(alice.state.destroyed, `Stream must be destroyed`)
 
     assert(
       alice.timeline.close != undefined && Date.now() >= alice.timeline.close,
@@ -169,7 +169,7 @@ describe('relay connection', function () {
       assert.fail(`Stream must have ended`)
     }
 
-    assert(alice.destroyed, `Stream must be destroyed`)
+    assert(alice.state.destroyed, `Stream must be destroyed`)
 
     assert(
       alice.timeline.close != undefined && Date.now() >= alice.timeline.close,

--- a/packages/connect/src/relay/connection.spec.ts
+++ b/packages/connect/src/relay/connection.spec.ts
@@ -12,6 +12,14 @@ import type { StreamType } from '../types.js'
 import { createPeerId } from '../base/utils.spec.js'
 import type { ConnectComponents } from '../components.js'
 
+class WebRTC extends EventEmitter {
+  signal(args: any) {
+    this.emit('incoming msg', args)
+  }
+
+  destroy() {}
+}
+
 describe('test status message sorting', function () {
   it('sort status messages', function () {
     const arr = [
@@ -309,12 +317,6 @@ describe('relay connection', function () {
   })
 
   it('forward and prefix WebRTC messages', async function () {
-    class WebRTC extends EventEmitter {
-      signal(args: any) {
-        this.emit('incoming msg', args)
-      }
-    }
-
     const webRTC = new WebRTC()
 
     const [AliceRelay, RelayAlice] = duplexPair<StreamType>()
@@ -372,12 +374,6 @@ describe('relay connection', function () {
   })
 
   it('forward and prefix WebRTC messages after reconnect', async function () {
-    class WebRTC extends EventEmitter {
-      signal(args: any) {
-        this.emit('incoming msg', args)
-      }
-    }
-
     const webRTC = new WebRTC()
 
     const [AliceRelay, RelayAlice] = duplexPair<StreamType>()

--- a/packages/connect/src/relay/connection.ts
+++ b/packages/connect/src/relay/connection.ts
@@ -616,9 +616,9 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
       this: Pick<
         RelayConnection,
         | 'state'
-        | 'queueStatusMessage'
-        | 'unqueueStatusMessage'
-        | 'setClosed'
+        | '_queueStatusMessage'
+        | '_unqueueStatusMessage'
+        | '_setClosed'
         | '_attachWebRTCListeners'
         | 'testingOptions'
         | '_onReconnect'
@@ -731,7 +731,7 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
                     this.logging.log(`STOP received. Ending stream ...`)
                     this.state.destroyed = true
                     this.state._destroyedPromise.resolve()
-                    this.setClosed()
+                    this._setClosed()
                     leave = true
                     break
                   // A reconnect at the other of the relay happened,
@@ -771,14 +771,14 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
                 switch (SUFFIX[0]) {
                   case StatusMessages.PING:
                     this.logging.verbose(`PING received`)
-                    this.queueStatusMessage(Uint8Array.of(RelayPrefix.STATUS_MESSAGE, StatusMessages.PONG))
+                    this._queueStatusMessage(Uint8Array.of(RelayPrefix.STATUS_MESSAGE, StatusMessages.PONG))
                     break
                   case StatusMessages.PONG:
                     // noop, left for future usage
                     break
                   default:
                     this.logging.error(
-                      `Received invalid status message ${u8aToHex(SUFFIX || new Uint8Array([]))}. Dropping message.`
+                      `Received invalid status message ${u8aToHex(SUFFIX ?? new Uint8Array([]))}. Dropping message.`
                     )
                     break
                 }
@@ -828,9 +828,9 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
     }.call(
       {
         state: this.state,
-        queueStatusMessage: this._queueStatusMessage,
-        unqueueStatusMessage: this._unqueueStatusMessage,
-        setClosed: this._setClosed,
+        _queueStatusMessage: this._queueStatusMessage,
+        _unqueueStatusMessage: this._unqueueStatusMessage,
+        _setClosed: this._setClosed,
         _attachWebRTCListeners: this._attachWebRTCListeners,
         _switch: this._switch,
         _onReconnect: this._onReconnect,
@@ -893,7 +893,7 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
    * Removes the most recent status message from the queue
    * @returns most recent status message
    */
-  public unqueueStatusMessage(): Uint8Array {
+  public unqueueStatusMessage(this: Pick<RelayConnection, 'state'>): Uint8Array {
     switch (this.state.statusMessages.length) {
       case 0:
         throw Error(`No status messages available`)

--- a/packages/connect/src/relay/index.ts
+++ b/packages/connect/src/relay/index.ts
@@ -43,8 +43,9 @@ function printUsedRelays(peers: PeerId[], prefix = '') {
 
   for (const peer of peers) {
     if (out.length > prefix.length + 1) {
-      out += `  - ${peer.toString()}`
+      out += `\n`
     }
+    out += `  - ${peer.toString()}`
   }
 
   return out

--- a/packages/connect/src/webrtc/connection.spec.ts
+++ b/packages/connect/src/webrtc/connection.spec.ts
@@ -34,7 +34,9 @@ describe('test webrtc connection', function () {
         source: BobAlice.source,
         sink: AliceBob.sink,
         sendUpgraded: () => {},
-        getWebRTCInstance: () => fakedWebRTCInstance
+        state: {
+          channel: fakedWebRTCInstance
+        }
       } as RelayConnection,
       {}
     )
@@ -79,7 +81,9 @@ describe('test webrtc connection', function () {
         sendUpgraded: () => {
           upgradeCalls++
         },
-        getWebRTCInstance: () => webRTCInstance
+        state: {
+          channel: webRTCInstance
+        }
       } as RelayConnection,
       {}
     )
@@ -107,7 +111,9 @@ describe('test webrtc connection', function () {
         source: BobAlice.source,
         sink: AliceBob.sink,
         sendUpgraded: () => {},
-        getWebRTCInstance: () => webRTCInstance
+        state: {
+          channel: webRTCInstance
+        }
       } as RelayConnection,
       {}
     )
@@ -136,7 +142,9 @@ describe('test webrtc connection', function () {
       {
         source: BobAlice.source,
         sink: AliceBob.sink,
-        getWebRTCInstance: () => webRTCInstance
+        state: {
+          channel: webRTCInstance
+        }
       } as RelayConnection,
       {}
     )
@@ -177,7 +185,9 @@ describe('test webrtc connection', function () {
       {
         ...AliceBob,
         sendUpgraded: () => {},
-        getWebRTCInstance: () => webRTCInstance
+        state: {
+          channel: webRTCInstance
+        }
       } as RelayConnection,
       {}
     )
@@ -236,7 +246,9 @@ describe('test webrtc connection', function () {
         ...AliceBob,
         remoteAddr: new Multiaddr(`/p2p/${Bob.toString()}`),
         sendUpgraded: () => {},
-        getWebRTCInstance: () => webRTCInstance
+        state: {
+          channel: webRTCInstance
+        }
       } as RelayConnection,
       {}
     )
@@ -296,7 +308,9 @@ describe('test webrtc connection', function () {
     const conn = new WebRTCConnection(
       {
         ...AliceBob,
-        getWebRTCInstance: () => webRTCInstance
+        state: {
+          channel: webRTCInstance
+        }
       } as RelayConnection,
       {},
       {
@@ -336,7 +350,9 @@ describe('webrtc connection - stream error propagation', function () {
         source: BobAlice.source,
         sink: (_source: AsyncIterable<Uint8Array>) => waitForSinkAttach.promise,
         sendUpgraded: () => {},
-        getWebRTCInstance: () => fakedWebRTCInstance
+        state: {
+          channel: fakedWebRTCInstance
+        }
       } as RelayConnection,
       {}
     )
@@ -373,7 +389,9 @@ describe('webrtc connection - stream error propagation', function () {
           return Promise.reject(Error(falsySinkError))
         },
         sendUpgraded: () => {},
-        getWebRTCInstance: () => fakedWebRTCInstance
+        state: {
+          channel: fakedWebRTCInstance
+        }
       } as RelayConnection,
       {}
     )
@@ -396,7 +414,9 @@ describe('webrtc connection - stream error propagation', function () {
       {
         ...AliceBob,
         sendUpgraded: () => {},
-        getWebRTCInstance: () => fakedWebRTCInstance
+        state: {
+          channel: fakedWebRTCInstance
+        }
       } as RelayConnection,
       {}
     )
@@ -428,7 +448,9 @@ describe('webrtc connection - stream error propagation', function () {
         })() as AsyncIterable<Uint8Array>,
         sink: AliceBob.sink,
         sendUpgraded: () => {},
-        getWebRTCInstance: () => fakedWebRTCInstance
+        state: {
+          channel: fakedWebRTCInstance
+        }
       } as RelayConnection,
       {}
     )

--- a/packages/connect/src/webrtc/connection.ts
+++ b/packages/connect/src/webrtc/connection.ts
@@ -407,7 +407,7 @@ class WebRTCConnection implements MultiaddrConnection {
                 }
 
                 if (toYield != undefined) {
-                  //this.log(`sinking ${toYield.length} bytes into relayed connection`)
+                  // this.log(`sinking ${toYield.length} bytes into relayed connection`)
                   yield toYield
                 }
               }
@@ -474,11 +474,11 @@ class WebRTCConnection implements MultiaddrConnection {
                     break
                   }
 
-                  /*this.log(
-                    `sinking ${received.value.slice().length} bytes into webrtc[${
-                      (this.relayConn.getWebRTCInstance() as any)._id
-                    }]`
-                  )*/
+                  // this.log(
+                  //   `sinking ${received.value.slice().length} bytes into webrtc[${
+                  //     (this.relayConn.state.channel as any)._id
+                  //   }]`
+                  // )
 
                   // WebRTC tends to send multiple messages in one chunk, so add a
                   // length prefix to split messages when receiving them
@@ -525,7 +525,7 @@ class WebRTCConnection implements MultiaddrConnection {
           migrated = true
           break
         case MigrationStatus.NOT_DONE:
-          this.log(`getting ${payload.length} bytes from relayed connection`)
+          // this.log(`getting ${payload.length} bytes from relayed connection`)
           yield payload
           break
         default:
@@ -577,7 +577,7 @@ class WebRTCConnection implements MultiaddrConnection {
               break
             }
 
-            this.log(`Getting NOT_DONE from WebRTC - ${msg.length} bytes`)
+            // this.log(`Getting NOT_DONE from WebRTC - ${msg.length} bytes`)
             yield payload
           }
 

--- a/packages/connect/src/webrtc/connection.ts
+++ b/packages/connect/src/webrtc/connection.ts
@@ -155,12 +155,13 @@ class WebRTCConnection implements MultiaddrConnection {
     // Give each WebRTC connection instance a unique identifier
     this._id = u8aToHex(randomBytes(4), false)
 
-    this.relayConn.getWebRTCInstance().on(
+    // @TODO fail if now WebRTC
+    this.relayConn.state.channel?.on(
       'error',
       // not supposed to produce any errors
       this.onWebRTCError.bind(this)
     )
-    this.relayConn.getWebRTCInstance().once(
+    this.relayConn.state.channel?.once(
       'connect',
       // not supposed to produce any errors
       this.onWebRTCConnect.bind(this)
@@ -170,7 +171,7 @@ class WebRTCConnection implements MultiaddrConnection {
     // and remove stale connection from internal libp2p state
     // once there is a disconnect, set magic *close* property in
     // timeline object
-    this.relayConn.getWebRTCInstance().on('iceStateChange', (iceConnectionState: string, iceGatheringState: string) => {
+    this.relayConn.state.channel?.on('iceStateChange', (iceConnectionState: string, iceGatheringState: string) => {
       if (iceConnectionState === 'disconnected' && iceGatheringState === 'complete') {
         this.destroyed = true
         this.timeline.close = this.timeline.close ?? Date.now()
@@ -268,7 +269,10 @@ class WebRTCConnection implements MultiaddrConnection {
       value: WebRTCResult.UNAVAILABLE
     })
 
-    setImmediate(this.relayConn.getWebRTCInstance().destroy.bind(this.relayConn.getWebRTCInstance()))
+    // @TODO fail if no WebRTC instance
+    if (this.relayConn.state.channel) {
+      setImmediate(this.relayConn.state.channel.destroy.bind(this.relayConn.state.channel))
+    }
   }
 
   /**
@@ -430,9 +434,9 @@ class WebRTCConnection implements MultiaddrConnection {
         this._sinkMigrated = true
         if (this._sourceMigrated) {
           // Update state object once source *and* sink are migrated
-          this.conn = this.relayConn.getWebRTCInstance()
+          this.conn = this.relayConn.state.channel as SimplePeer
         }
-        await toIterable.sink(this.relayConn.getWebRTCInstance())(
+        await toIterable.sink(this.relayConn.state.channel as SimplePeer)(
           async function* (this: WebRTCConnection): StreamSource {
             let webRTCresult: PayloadEvent | SinkSourceAttachedEvent
             let toYield: Uint8Array | undefined
@@ -462,7 +466,7 @@ class WebRTCConnection implements MultiaddrConnection {
                   const received = webRTCresult.value
 
                   // Anything can happen
-                  if (received.done || this.destroyed || this.relayConn.getWebRTCInstance().destroyed) {
+                  if (received.done || this.destroyed || this.relayConn.state.channel?.destroyed) {
                     leave = true
 
                     // WebRTC uses UDP, so we need to explicitly end the connection
@@ -551,13 +555,13 @@ class WebRTCConnection implements MultiaddrConnection {
 
         if (this._sinkMigrated) {
           // Update state object once sink *and* source are migrated
-          this.conn = this.relayConn.getWebRTCInstance()
+          this.conn = this.relayConn.state.channel as SimplePeer
         }
 
         this.log(`webRTC source handover done. Using direct connection to peer ${this.remoteAddr.getPeerId()}`)
 
         let done = false
-        for await (const msg of this.relayConn.getWebRTCInstance()) {
+        for await (const msg of this.relayConn.state.channel as SimplePeer) {
           // WebRTC tends to bundle multiple message into one chunk,
           // so we need to encode messages and decode them before passing
           // to libp2p
@@ -606,7 +610,8 @@ class WebRTCConnection implements MultiaddrConnection {
     this.destroyed = true
 
     try {
-      this.relayConn.getWebRTCInstance().destroy()
+      // @TODO check if already closed
+      this.relayConn.state.channel?.destroy()
     } catch (e) {
       this.error(`Error while destroying WebRTC instance to ${this.remoteAddr}: ${e}`)
     }

--- a/packages/connect/src/webrtc/connection.ts
+++ b/packages/connect/src/webrtc/connection.ts
@@ -525,7 +525,7 @@ class WebRTCConnection implements MultiaddrConnection {
           migrated = true
           break
         case MigrationStatus.NOT_DONE:
-          //this.log(`getting ${payload.length} bytes from relayed connection`)
+          this.log(`getting ${payload.length} bytes from relayed connection`)
           yield payload
           break
         default:
@@ -577,7 +577,7 @@ class WebRTCConnection implements MultiaddrConnection {
               break
             }
 
-            //this.log(`Getting NOT_DONE from WebRTC - ${msg.length} bytes`)
+            this.log(`Getting NOT_DONE from WebRTC - ${msg.length} bytes`)
             yield payload
           }
 


### PR DESCRIPTION
Refs https://github.com/hoprnet/hoprnet/issues/4042

## Context

Streams in `connect` are implemented using AsyncIterables, hence consuming a stream is done by

```ts
for await (const chunk of stream) {
  console.log(`stream msg`, msg)
}
```
whereas `stream` gets constructed by implementing the `[Symbol.asyncIterator]()` property of a class, or - as done in `connect` - using Generators, meaning
```ts
const stream = (async function * () {
  yield stringToU8a(`0xdeadbeef`)
})()
```
Note that the Generator is functionable *once* it has been called. In contrast to "normal" functions, Generator *always* run in *their own* scope, so if the body needs to access properties such as `this`, it needs to be explicitly passed to the object, meaning.

```ts
const stream = async function * () {
  this.doSthFancy()
  yield stringToU8a(`0xdeadbeef`)
}.call({ doSthFancy })
```

Due to its nature, Generators run in a special context, which means that the interpreter caches more object properties than necessary, hence

```ts
const stream = async function * () {
  // some code
}.call({ this })
```

results in creating snapshots of the object - which cannot get garbage-collected in time and thus blows up memory consumption

## Main changes

(Within `connect/relay/connection.ts`)

- Bind functions to their minimal context and pass the function pointer to the Generator.
- Separate *methods* from *state* and encapsulate *state* into a single object that can be passed *by reference* to the Generator.

## Additional changes

- fix formatting in debug log function
- slight change in API between `RelayConnection` and `WebRTCConnection` objects
- some unit test refactoring