### PR TITLE
Update wallets.md & add Dappnode Public repo release guide

### DIFF
--- a/.processes/wallets.md
+++ b/.processes/wallets.md
@@ -28,6 +28,7 @@ The purpose of this process is to document how crypto wallets are created and st
 | `0xD9a00176Cf49dFB9cA3Ef61805a2850F45Cb1D05` | HOPR Commercial team Gnosis Safe Gnosis Chain | HOPR commercial team Gnosis Safe wallet on Gnosis Chain (aka xDai)                |
 | `0x217a6d29ABbacEAfB36207b4cB25ACc148E1fc65` | HOPR Commercial team Gnosis Safe Mainnet      | HOPR commercial team Gnosis Safe wallet on Mainnet                                |
 | `0x8C9877a1279192448cAbeC9e8C4697b159cF645e` | CI/CD funding                                 | Used in our CI/CD pipelines to fund nodes automatically for testing.              |
+| `0x7305356ad936A06c4ea5DF45AD5E5C3ff9Db818E` | Dappnode HOPR Repository Owner Mainnet	       | Used to sign & publish releases in the Dappnode Public repository                 |
 
 There are some additional wallets used for testing, that had been label `[ Unknown ]`. They will be handled in https://github.com/hoprnet/hoprnet/issues/2893.
 

--- a/DAPPNODE_PUBLISH.md
+++ b/DAPPNODE_PUBLISH.md
@@ -14,7 +14,7 @@ The current process is as follows when a new version needs to be published:
 6. On GH page of the `DAppNodePackage-Hopr`, go to the newly created release and click the link that takes you to the pre-filled release signing form.
 8. In Site setting for this page make sure you allow Insecure content (it usually does an HTTP request to your Dappnode while itself being behind HTTPS).
 7. Make sure the developer address in the form corresponds to the `Dappnode HOPR Repository Owner`, change it if not.
-8. In MetaMask, load the `Dappnode HOPR Repository Owner` wallet on Mainnet.
+8. In MetaMask, load the `Dappnode HOPR Repository Owner` wallet on Mainnet and click `Connect MetaMask` in the form.
 9. Click `Sign release` to sign the release (confirm in MM). New IPFS hash is created with the signed release, changes automatically in the Release hash field in the form.
 10. Click `Publish release` to publish the signed release (confirm transaction in MM).
 

--- a/DAPPNODE_PUBLISH.md
+++ b/DAPPNODE_PUBLISH.md
@@ -1,0 +1,20 @@
+This guide aim to explain the process of publishing a new HOPR package in the Dappnode public repository:
+
+The Dappnode package is versioned differently in it's own repository: https://github.com/dappnode/DAppNodePackage-Hopr
+Each Dappnode package version is tied to a certain upstream version in our Monorepo (As of now: 1.0.0 -> 1.90.12)
+
+The current process is as follows when a new version needs to be published:
+
+1. Clone the HOPR Dappnode repo from https://github.com/dappnode/DAppNodePackage-Hopr
+2. Connect to your Dappnode VPN.
+3. Make changes to `dappnode_package.json`: bump the `version` and change to the desired `upstreamVersion`.
+3. Do a Dappnode build using: `dapnnodesdk build` This will build a new unsigned Dappnode package and push it to your IPFS node.  
+4. Commit all the changes in a new branch (e.g. `bump-upstream-1.90.x`) and create a new PR in the `DAppNodePackage-Hopr` repo.
+5. Wait until the PR is approved and merged.
+6. On GH page of the `DAppNodePackage-Hopr`, go to the newly created release and click the link that takes you to the pre-filled release signing form.
+8. In Site setting for this page make sure you allow Insecure content (it usually does an HTTP request to your Dappnode while itself being behind HTTPS).
+7. Make sure the developer address in the form corresponds to the `Dappnode HOPR Repository Owner`, change it if not.
+8. In MetaMask, load the `Dappnode HOPR Repository Owner` wallet on Mainnet.
+9. Click `Sign release` to sign the release (confirm in MM). New IPFS hash is created with the signed release, changes automatically in the Release hash field in the form.
+10. Click `Publish release` to publish the signed release (confirm transaction in MM).
+

--- a/DAPPNODE_PUBLISH.md
+++ b/DAPPNODE_PUBLISH.md
@@ -13,8 +13,7 @@ The current process is as follows when a new version needs to be published:
 6. Wait until the PR is approved and merged.
 7. On GH page of the `DAppNodePackage-Hopr`, go to the newly created release and click the link that takes you to the pre-filled release signing form.
 8. In Site setting for this page make sure you allow Insecure content (it usually does an HTTP request to your Dappnode while itself being behind HTTPS).
-7. Make sure the developer address in the form corresponds to the `Dappnode HOPR Repository Owner`, change it if not.
-8. In MetaMask, load the `Dappnode HOPR Repository Owner` wallet on Mainnet and click `Connect MetaMask` in the form.
-9. Click `Sign release` to sign the release (confirm in MM). New IPFS hash is created with the signed release, changes automatically in the Release hash field in the form.
-10. Click `Publish release` to publish the signed release (confirm transaction in MM).
-
+9. Make sure the developer address in the form corresponds to the `Dappnode HOPR Repository Owner`, change it if not.
+10. In MetaMask, load the `Dappnode HOPR Repository Owner` wallet on Mainnet and click `Connect MetaMask` in the form.
+11. Click `Sign release` to sign the release (confirm in MM). New IPFS hash is created with the signed release, changes automatically in the Release hash field in the form.
+12. Click `Publish release` to publish the signed release (confirm transaction in MM).


### PR DESCRIPTION
- updates `wallets.md` with the Dappnode HOPR Repo Owner wallet
- adds `DAPPNODE_PUBLISH.md` with a guide on how to publish a version to Dappnode Public repo.