### PR TITLE
connect: Add support for handling multiple protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,12 @@
 # Changelog
 
-<a name="1.91"></a>
-
----
-
 <a name="1.90"></a>
 
 ## [1.90](https://github.com/hoprnet/hoprnet/compare/release/paleochora...hoprnet:release/valencia)
 
 - Improve Network Registry smart contract to allow 1-to-many node registration, add enable/disable make targets ([#4008](https://github.com/hoprnet/hoprnet/pull/4091))
 - Replace `yarn` with `npx` in `pluto` Docker image to run `hoprd` to fix binary discoverability issue
+- Add support for communication between different releases within the same environment
 
 ---
 

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,11 @@ build-yarn: ## build yarn packages
 build-yarn: build-solidity-types build-cargo
 	npx tsc --build tsconfig.build.json
 
+.PHONY: build-yarn-watch
+build-yarn-watch: ## build yarn packages (in watch mode)
+build-yarn-watch: build-solidity-types build-cargo
+	npx tsc --build tsconfig.build.json -w
+
 .PHONY: build-cargo
 build-cargo: ## build cargo packages and create boilerplate JS code
 	cargo build --release --target wasm32-unknown-unknown

--- a/packages/connect/src/relay/handshake.ts
+++ b/packages/connect/src/relay/handshake.ts
@@ -12,7 +12,7 @@ import { RelayState } from './state.js'
 import type { Relay } from './index.js'
 
 import debug from 'debug'
-import { DELIVERY_PROTOCOL } from '../constants.js'
+import { DELIVERY_PROTOCOLS } from '../constants.js'
 import { Components } from '@libp2p/interfaces/components'
 
 export enum RelayHandshakeMessage {
@@ -239,7 +239,8 @@ class RelayHandshake {
 
     let toDestinationStruct: Awaited<ReturnType<typeof getStreamToCounterparty>>
     try {
-      toDestinationStruct = await getStreamToCounterparty(destination, DELIVERY_PROTOCOL(this.options.environment), {
+      const protocolsDelivery = DELIVERY_PROTOCOLS(this.options.environment, this.options.supportedEnvironments)
+      toDestinationStruct = await getStreamToCounterparty(destination, protocolsDelivery, {
         upgrader
       })
     } catch (err) {

--- a/packages/connect/src/types.ts
+++ b/packages/connect/src/types.ts
@@ -55,6 +55,11 @@ export type Stream<T = StreamType> = {
 
 export type StreamResult = IteratorResult<StreamType, any>
 
+export type Environment = {
+  id: string
+  versionRange: string
+}
+
 export type HoprConnectOptions = {
   publicNodes?: PublicNodesEmitter
   allowLocalConnections?: boolean
@@ -63,6 +68,7 @@ export type HoprConnectOptions = {
   interface?: string
   maxRelayedConnections?: number
   environment?: string
+  supportedEnvironments?: Environment[]
   relayFreeTimeout?: number
   dhtRenewalTimeout?: number
   entryNodeReconnectBaseTimeout?: number

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -144,13 +144,13 @@ export type HoprOptions = {
 export type NodeStatus = 'UNINITIALIZED' | 'INITIALIZING' | 'RUNNING' | 'DESTROYED'
 
 export type Subscribe = ((
-  protocol: string,
+  protocols: string | string[],
   handler: LibP2PHandlerFunction<Promise<void> | void>,
   includeReply: false,
   errHandler: (err: any) => void
 ) => void) &
   ((
-    protocol: string,
+    protocols: string | string[],
     handler: LibP2PHandlerFunction<Promise<Uint8Array>>,
     includeReply: true,
     errHandler: (err: any) => void
@@ -158,12 +158,18 @@ export type Subscribe = ((
 
 export type SendMessage = ((
   dest: PeerId,
-  protocol: string,
+  protocols: string | string[],
   msg: Uint8Array,
   includeReply: false,
   opts: DialOpts
 ) => Promise<void>) &
-  ((dest: PeerId, protocol: string, msg: Uint8Array, includeReply: true, opts: DialOpts) => Promise<Uint8Array[]>)
+  ((
+    dest: PeerId,
+    protocols: string | string[],
+    msg: Uint8Array,
+    includeReply: true,
+    opts: DialOpts
+  ) => Promise<Uint8Array[]>)
 
 class Hopr extends EventEmitter {
   public status: NodeStatus = 'UNINITIALIZED'
@@ -283,14 +289,19 @@ class Hopr extends EventEmitter {
     this.libp2pComponents = libp2p.components
     // Subscribe to p2p events from libp2p. Wraps our instance of libp2p.
     const subscribe = ((
-      protocol: string,
+      protocols: string | string[],
       handler: LibP2PHandlerFunction<Promise<void | Uint8Array>>,
       includeReply: boolean,
       errHandler: (err: any) => void
-    ) => libp2pSubscribe(this.libp2pComponents, protocol, handler, errHandler, includeReply)) as Subscribe
+    ) => libp2pSubscribe(this.libp2pComponents, protocols, handler, errHandler, includeReply)) as Subscribe
 
-    const sendMessage = ((dest: PeerId, protocol: string, msg: Uint8Array, includeReply: boolean, opts: DialOpts) =>
-      libp2pSendMessage(this.libp2pComponents, dest, protocol, msg, includeReply, opts)) as SendMessage
+    const sendMessage = ((
+      dest: PeerId,
+      protocols: string | string[],
+      msg: Uint8Array,
+      includeReply: boolean,
+      opts: DialOpts
+    ) => libp2pSendMessage(this.libp2pComponents, dest, protocols, msg, includeReply, opts)) as SendMessage
 
     // Attach network health measurement functionality
     const peers: Peer[] = await this.libp2pComponents.getPeerStore().all()

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -20,6 +20,7 @@ import { getAddrs } from './identity.js'
 import type AccessControl from './network/access-control.js'
 import { createLibp2pMock } from './libp2p.mock.js'
 import { NetworkPeersOrigin } from './network/network-peers.js'
+import { supportedEnvironments } from './environment.js'
 
 const log = debug(`hopr-core:create-hopr`)
 
@@ -74,6 +75,12 @@ export async function createLibp2pInstance(
     // Make libp2p aware of environments
     const protocolPrefix = `/hopr/${options.environment.id}`
 
+    // Collect supported environments and versions to be passed to HoprConnect
+    // because hopr-connect doesn't have access to the protocol config file
+    const supportedEnvironmentsInfo = supportedEnvironments().map((env) => {
+      return { id: env.id, versionRange: env.version_range }
+    })
+
     libp2p = await createLibp2p({
       peerId,
       addresses: { listen: getAddrs(peerId, options).map((x: Multiaddr) => x.toString()) },
@@ -84,6 +91,7 @@ export async function createLibp2pInstance(
             initialNodes,
             publicNodes,
             environment: options.environment.id,
+            supportedEnvironments: supportedEnvironmentsInfo,
             allowLocalConnections: options.allowLocalConnections,
             allowPrivateConnections: options.allowPrivateConnections,
             // Amount of nodes for which we are willing to act as a relay

--- a/packages/utils/src/libp2p/dialHelper.spec.ts
+++ b/packages/utils/src/libp2p/dialHelper.spec.ts
@@ -61,7 +61,7 @@ async function getNode(id: PeerId, withDht = false, maDestination?: Multiaddr): 
     return dial(maDestination, options)
   }) as any
 
-  node.handle(TEST_PROTOCOL, async ({ stream }) => {
+  node.handle([TEST_PROTOCOL], async ({ stream }) => {
     await pipe(stream.source, stream.sink)
   })
 
@@ -117,7 +117,7 @@ describe('test dialHelper', function () {
     const peerA = await getNode(Alice)
 
     // components not part of interface
-    const result = await dialHelper((peerA as any).components, Bob, TEST_PROTOCOL)
+    const result = await dialHelper((peerA as any).components, Bob, [TEST_PROTOCOL])
 
     assert(result.status === DialStatus.NO_DHT)
 
@@ -132,7 +132,7 @@ describe('test dialHelper', function () {
     await peerA.peerStore.addressBook.add(peerB.peerId, peerB.getMultiaddrs())
 
     // components not part of interface
-    const result = await dialHelper((peerA as any).components, Bob, TEST_PROTOCOL)
+    const result = await dialHelper((peerA as any).components, Bob, [TEST_PROTOCOL])
 
     assert(result.status === DialStatus.SUCCESS)
 
@@ -150,7 +150,7 @@ describe('test dialHelper', function () {
     const peerA = await getNode(Alice, true)
 
     // components not part of interface
-    const result = await dialHelper((peerA as any).components, Bob, TEST_PROTOCOL)
+    const result = await dialHelper((peerA as any).components, Bob, [TEST_PROTOCOL])
 
     assert(result.status === DialStatus.DHT_ERROR, `Must return dht error`)
 
@@ -189,7 +189,7 @@ describe('test dialHelper', function () {
     await new Promise((resolve) => setTimeout(resolve, 200))
 
     // components not part of interface
-    let result = await dialHelper((peerA as any).components, Chris, TEST_PROTOCOL)
+    let result = await dialHelper((peerA as any).components, Chris, [TEST_PROTOCOL])
 
     assert(result.status === DialStatus.SUCCESS, `Dial must be successful`)
 
@@ -221,7 +221,7 @@ describe('test dialHelper', function () {
     }
 
     // Try to call Bob but does not exist
-    const result = await dialHelper(peerAComponents as any, Bob, TEST_PROTOCOL)
+    const result = await dialHelper(peerAComponents as any, Bob, [TEST_PROTOCOL])
 
     // Must fail with a DHT error because we obviously can't find
     // Bob's relay address in the DHT
@@ -248,7 +248,7 @@ describe('test dialHelper', function () {
       getPeerStore
     }
 
-    const result = await dialHelper(peerAComponents as any, Bob, TEST_PROTOCOL)
+    const result = await dialHelper(peerAComponents as any, Bob, [TEST_PROTOCOL])
 
     assert(result.status === DialStatus.DHT_ERROR)
   })

--- a/packages/utils/src/libp2p/index.spec.ts
+++ b/packages/utils/src/libp2p/index.spec.ts
@@ -167,7 +167,7 @@ describe(`test libp2pSendMessage`, function () {
       }
     )
 
-    await libp2pSendMessage(libp2pComponents, destination, 'demo protocol', msgToReceive, false, {
+    await libp2pSendMessage(libp2pComponents, destination, ['demo protocol'], msgToReceive, false, {
       timeout: 5000
     })
 
@@ -199,7 +199,7 @@ describe(`test libp2pSendMessage with response`, function () {
 
     const results = await Promise.all([
       msgReceived.promise,
-      libp2pSendMessage(libp2pComponents, destination, 'demo protocol', msgToReceive, true, {
+      libp2pSendMessage(libp2pComponents, destination, ['demo protocol'], msgToReceive, true, {
         timeout: 5000
       })
     ])
@@ -259,7 +259,7 @@ describe(`test libp2pSubscribe`, async function () {
       }
     } as Components
 
-    libp2pSubscribe(libp2pComponents, 'demo protocol', fakeOnMessage, () => {}, true)
+    libp2pSubscribe(libp2pComponents, ['demo protocol'], fakeOnMessage, () => {}, true)
 
     await Promise.all([msgReceived.promise, msgReplied.promise])
   })
@@ -301,7 +301,7 @@ describe(`test libp2pSubscribe`, async function () {
       }
     } as Components
 
-    libp2pSubscribe(libp2pComponents, 'demo protocol', fakeOnMessage, () => {}, false)
+    libp2pSubscribe(libp2pComponents, ['demo protocol'], fakeOnMessage, () => {}, false)
 
     await msgReceived.promise
   })

--- a/packages/utils/src/libp2p/index.ts
+++ b/packages/utils/src/libp2p/index.ts
@@ -96,7 +96,7 @@ const logError = debug(`hopr-core:libp2p:error`)
  * send message. If `includeReply` is set, wait for a response
  * @param libp2p libp2p instance
  * @param destination peer to connect to
- * @param protocol protocol to speak
+ * @param protocols protocols to speak
  * @param message message to send
  * @param includeReply try to receive a reply
  * @param opts [optional] timeout
@@ -105,7 +105,7 @@ const logError = debug(`hopr-core:libp2p:error`)
 export type libp2pSendMessage = ((
   components: Components,
   destination: PeerId,
-  protocol: string,
+  protocols: string | string[],
   message: Uint8Array,
   includeReply: false,
   opts?: DialOpts
@@ -113,7 +113,7 @@ export type libp2pSendMessage = ((
   ((
     components: Components,
     destination: PeerId,
-    protocol: string,
+    protocols: string | string[],
     message: Uint8Array,
     includeReply: true,
     opts?: DialOpts
@@ -122,13 +122,13 @@ export type libp2pSendMessage = ((
 export async function libp2pSendMessage(
   components: Components,
   destination: PeerId,
-  protocol: string,
+  protocols: string | string[],
   message: Uint8Array,
   includeReply: boolean,
   opts?: DialOpts
 ): Promise<void | Uint8Array[]> {
   // Components is not part of interface
-  const r = await dial(components, destination, protocol, opts)
+  const r = await dial(components, destination, protocols, opts)
 
   if (r.status !== 'SUCCESS') {
     logError(r)
@@ -237,7 +237,7 @@ function generateHandler(
  * Generates a handler that pulls messages out of a stream
  * and feeds them to the given handler.
  * @param libp2p libp2p instance
- * @param protocol protocol to dial
+ * @param protocols protocol to dial
  * @param handler called once another node requests that protocol
  * @param errHandler handle stream pipeline errors
  * @param includeReply try to receive a reply
@@ -245,14 +245,14 @@ function generateHandler(
 
 export type libp2pSubscribe = ((
   components: Components,
-  protocol: string,
+  protocols: string | string[],
   handler: LibP2PHandlerFunction<Promise<void> | void>,
   errHandler: ErrHandler,
   includeReply: false
 ) => void) &
   ((
     components: Components,
-    protocol: string,
+    protocols: string | string[],
     handler: LibP2PHandlerFunction<Promise<Uint8Array>>,
     errHandler: ErrHandler,
     includeReply: true
@@ -260,10 +260,10 @@ export type libp2pSubscribe = ((
 
 export async function libp2pSubscribe(
   components: Components,
-  protocol: string,
+  protocols: string | string[],
   handler: LibP2PHandlerFunction<Promise<void | Uint8Array> | void>,
   errHandler: ErrHandler,
   includeReply = false
 ): Promise<void> {
-  await components.getRegistrar().handle([protocol], generateHandler(handler, errHandler, includeReply))
+  await components.getRegistrar().handle(protocols, generateHandler(handler, errHandler, includeReply))
 }


### PR DESCRIPTION
Refs #4037 

Must be back-ported to #3803 in order to make https://github.com/hoprnet/hoprnet/pull/4167 work.

---

We previously called all libp2p connection handlers with a single
specified and supported protocol-prefix which was tied to the version
the node is running. This prevented nodes with different versions
communicating within the same environment even though they might be
supporting that as per the protocol config.

This change adds support for providing multiple supported protocols to
libp2p, which will handle the negotiation and pick the right protocol.

The supported protocols are determined based on the environments from the
protocol config.