### PR TITLE
pluto: Use npx instead of yarn to start hoprd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ## [1.90](https://github.com/hoprnet/hoprnet/compare/release/paleochora...hoprnet:release/valencia)
 
 - Improve Network Registry smart contract to allow 1-to-many node registration, add enable/disable make targets ([#4008](https://github.com/hoprnet/hoprnet/pull/4091))
+- Replace `yarn` with `npx` in `pluto` Docker image to run `hoprd` to fix binary discoverability issue
 
 ---
 

--- a/scripts/pluto/Dockerfile
+++ b/scripts/pluto/Dockerfile
@@ -53,4 +53,4 @@ EXPOSE 19505
 ARG HOPRD_API_TOKEN
 ENV HOPRD_API_TOKEN=${HOPRD_API_TOKEN:-%th1s-IS-a-S3CR3T-ap1-PUSHING-b1ts-TO-you%}
 
-ENTRYPOINT /hardhat/scripts/setup-local-cluster.sh -p -t "${HOPRD_API_TOKEN}" -i /hardhat/scripts/topologies/full_interconnected_cluster.sh --hoprd-command "yarn hoprd" --hardhat-basedir "/hardhat" -l "0.0.0.0"
+ENTRYPOINT /hardhat/scripts/setup-local-cluster.sh -p -t "${HOPRD_API_TOKEN}" -i /hardhat/scripts/topologies/full_interconnected_cluster.sh --hoprd-command "npx hoprd" --hardhat-basedir "/hardhat" -l "0.0.0.0"


### PR DESCRIPTION
Replace `yarn` with `npx` in `pluto` Docker image to run `hoprd` to fix binary discoverability issue