### PR TITLE
Avado: limit Docker container memory to maximum 1GB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Improve Network Registry smart contract to allow 1-to-many node registration, add enable/disable make targets ([#4008](https://github.com/hoprnet/hoprnet/pull/4091))
 - Replace `yarn` with `npx` in `pluto` Docker image to run `hoprd` to fix binary discoverability issue
 - Add support for communication between different releases within the same environment
+- Avado: limit Docker container memory to maximum 1GB
 
 ---
 

--- a/packages/avado/docker-compose.yml
+++ b/packages/avado/docker-compose.yml
@@ -40,14 +40,8 @@ services:
         'HOPRD_PROVIDER=%PROVIDER_URL%'
       ]
     'ports': ['3000:3000/tcp', '3001:3001/tcp', '8080:8080/tcp', '9091:9091/tcp', '9091:9091/udp']
-    'restart': 'always',
-    'deploy': {
-      'resources': {
-        'limits': {
-          'memory': '1G'
-        }
-      }
-    }
+    'restart': 'always'
+    'deploy': { 'resources': { 'limits': { 'memory': '1G' } } }
     #}
     # END_JSON_EXPORT
 volumes:

--- a/packages/avado/docker-compose.yml
+++ b/packages/avado/docker-compose.yml
@@ -11,6 +11,7 @@ services:
         UPSTREAM_VERSION: '%AVADO_VERSION%'
     network_mode: host
     # Lines between *_JSON_EXPORT are intentionally also a valid JSON
+    # Info: a hoprd node should never consume more than 1GByte of memory
     # DO NOT REMOVE
     # BEGIN_JSON_EXPORT
     #{
@@ -39,7 +40,14 @@ services:
         'HOPRD_PROVIDER=%PROVIDER_URL%'
       ]
     'ports': ['3000:3000/tcp', '3001:3001/tcp', '8080:8080/tcp', '9091:9091/tcp', '9091:9091/udp']
-    'restart': 'always'
+    'restart': 'always',
+    'deploy': {
+      'resources': {
+        'limits': {
+          'memory': '1G'
+        }
+      }
+    }
     #}
     # END_JSON_EXPORT
 volumes:


### PR DESCRIPTION
The companion change for dappnode is https://github.com/hoprnet/DAppNodePackage-Hopr/pull/3