### PR TITLE
bump upload artifacts

### DIFF
--- a/.github/workflows/e2e-npm.yaml
+++ b/.github/workflows/e2e-npm.yaml
@@ -61,7 +61,7 @@ jobs:
         run: ./scripts/run-integration-tests-npm.sh
 
       - name: Upload node logs (Linux)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ always() && runner.os == 'Linux' }}
         with:
           name: hopr-linux-e2e-npm-node-logs
@@ -70,7 +70,7 @@ jobs:
             /tmp/hopr-npm-node*.log
 
       - name: Upload node logs (macOS)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ always() && runner.os == 'macOS' }}
         with:
           name: hopr-macOS-e2e-npm-node-logs

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -64,7 +64,7 @@ jobs:
         run: ./scripts/run-integration-tests-source.sh
 
       - name: Upload node logs (Linux)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ always() && runner.os == 'Linux' }}
         with:
           name: hopr-linux-e2e-source-node-logs
@@ -73,7 +73,7 @@ jobs:
             /tmp/hopr-source-hardhat-rpc.log
 
       - name: Upload node logs (macOS)
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: ${{ always() && runner.os == 'macOS' }}
         with:
           name: hopr-macOS-e2e-source-node-logs


### PR DESCRIPTION
Bumps `upload-artifacts` in GH actions to latest version to reduce errors such as https://github.com/hoprnet/hoprnet/actions/runs/3150122687/jobs/5122544786

See https://github.com/actions/upload-artifact/releases for changes