### PR TITLE
More indicators

### DIFF
--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -17,7 +17,12 @@ import { TCPConnection, Listener } from './base/index.js'
 // @ts-ignore
 import pkg from '../package.json' assert { type: 'json' }
 
-import type { PublicNodesEmitter, HoprConnectOptions, HoprConnectTestingOptions } from './types.js'
+import {
+  type PublicNodesEmitter,
+  type HoprConnectOptions,
+  type HoprConnectTestingOptions,
+  PeerConnectionType
+} from './types.js'
 
 import { Relay } from './relay/index.js'
 import { Filter } from './filter.js'
@@ -251,6 +256,7 @@ class HoprConnect implements Transport, Initializable, Startable {
       // want to log it for debugging purposes
       throw err
     }
+
     const _tags = conn.tags ?? []
     conn.tags = new Proxy(_tags, {
       get: (target) => {
@@ -260,7 +266,6 @@ class HoprConnect implements Transport, Initializable, Startable {
     })
 
     verbose(`Relayed connection to ${maConn.remoteAddr.toString()} has been established successfully!`)
-
     return conn
   }
 
@@ -311,9 +316,9 @@ class HoprConnect implements Transport, Initializable, Startable {
 
     verbose(`Direct connection to ${maConn.remoteAddr.toString()} has been established successfully!`)
     if (conn.tags) {
-      conn.tags = ['DIRECT', ...conn.tags]
+      conn.tags = [PeerConnectionType.DIRECT, ...conn.tags]
     } else {
-      conn.tags = ['DIRECT']
+      conn.tags = [PeerConnectionType.DIRECT]
     }
 
     return conn
@@ -323,4 +328,4 @@ class HoprConnect implements Transport, Initializable, Startable {
 export type { PublicNodesEmitter, HoprConnectConfig }
 export { compareAddressesLocalMode, compareAddressesPublicMode } from './utils/index.js'
 
-export { HoprConnect }
+export { HoprConnect, PeerConnectionType }

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -251,13 +251,16 @@ class HoprConnect implements Transport, Initializable, Startable {
       // want to log it for debugging purposes
       throw err
     }
+    const _tags = conn.tags ?? []
+    conn.tags = new Proxy(_tags, {
+      get: (target) => {
+        // Always get *latest* tags from maConn object
+        return [...target, ...((maConn as any).tags ?? [])]
+      }
+    })
 
     verbose(`Relayed connection to ${maConn.remoteAddr.toString()} has been established successfully!`)
-    if (conn.tags) {
-      conn.tags = ['RELAYED', ...conn.tags]
-    } else {
-      conn.tags = ['RELAYED']
-    }
+
     return conn
   }
 

--- a/packages/connect/src/relay/connection.ts
+++ b/packages/connect/src/relay/connection.ts
@@ -1,12 +1,13 @@
 import type { MultiaddrConnection } from '@libp2p/interface-connection'
-import type {
-  Stream,
-  StreamSink,
-  StreamSource,
-  StreamSourceAsync,
-  StreamResult,
-  StreamType,
-  HoprConnectTestingOptions
+import {
+  type Stream,
+  type StreamSink,
+  type StreamSource,
+  type StreamSourceAsync,
+  type StreamResult,
+  type StreamType,
+  type HoprConnectTestingOptions,
+  ConnectionTags
 } from '../types.js'
 import { randomBytes } from 'crypto'
 import { RelayPrefix, ConnectionStatusMessages, StatusMessages } from '../constants.js'
@@ -198,6 +199,8 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
 
   public readonly timeline: MultiaddrConnection['timeline']
 
+  public tags: ConnectionTags[]
+
   constructor(
     private _stream: Stream,
     relay: PeerId,
@@ -234,6 +237,8 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
 
     // Pre-generate object to attach to function pointers
     this.state = {} as RelayConnection['state']
+
+    this.tags = [ConnectionTags.RELAYED]
 
     this._queueStatusMessage = this.queueStatusMessage.bind({
       state: this.state

--- a/packages/connect/src/relay/connection.ts
+++ b/packages/connect/src/relay/connection.ts
@@ -7,7 +7,7 @@ import {
   type StreamResult,
   type StreamType,
   type HoprConnectTestingOptions,
-  ConnectionTags
+  PeerConnectionType
 } from '../types.js'
 import { randomBytes } from 'crypto'
 import { RelayPrefix, ConnectionStatusMessages, StatusMessages } from '../constants.js'
@@ -199,7 +199,7 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
 
   public readonly timeline: MultiaddrConnection['timeline']
 
-  public tags: ConnectionTags[]
+  public tags: PeerConnectionType[]
 
   constructor(
     private _stream: Stream,
@@ -238,7 +238,7 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
     // Pre-generate object to attach to function pointers
     this.state = {} as RelayConnection['state']
 
-    this.tags = [ConnectionTags.RELAYED]
+    this.tags = [PeerConnectionType.RELAYED]
 
     this._queueStatusMessage = this.queueStatusMessage.bind({
       state: this.state

--- a/packages/connect/src/types.ts
+++ b/packages/connect/src/types.ts
@@ -60,6 +60,15 @@ export type Environment = {
   versionRange: string
 }
 
+export enum ConnectionTags {
+  DIRECT = 'DIRECT',
+  // @TODO to be implemented in https://github.com/hoprnet/hoprnet/pull/4171
+  DIRECT_TO_ENTRY = 'DIRECT_TO_ENTRY',
+  RELAYED = 'RELAYED',
+  WEBRTC_RELAYED = 'WEBRTC_RELAYED',
+  WEBRTC_DIRECT = 'WEBRTC_DIRECT'
+}
+
 export type HoprConnectOptions = {
   publicNodes?: PublicNodesEmitter
   allowLocalConnections?: boolean

--- a/packages/connect/src/types.ts
+++ b/packages/connect/src/types.ts
@@ -60,7 +60,7 @@ export type Environment = {
   versionRange: string
 }
 
-export enum ConnectionTags {
+export enum PeerConnectionType {
   DIRECT = 'DIRECT',
   // @TODO to be implemented in https://github.com/hoprnet/hoprnet/pull/4171
   DIRECT_TO_ENTRY = 'DIRECT_TO_ENTRY',

--- a/packages/connect/src/webrtc/connection.ts
+++ b/packages/connect/src/webrtc/connection.ts
@@ -8,13 +8,14 @@ import type { RelayConnection } from '../relay/connection.js'
 import { randomBytes } from 'crypto'
 import { toU8aStream, encodeWithLengthPrefix, decodeWithLengthPrefix, eagerIterator } from '../utils/index.js'
 import { abortableSource } from 'abortable-iterator'
-import type {
-  StreamSink,
-  StreamResult,
-  StreamType,
-  StreamSource,
-  StreamSourceAsync,
-  HoprConnectTestingOptions
+import {
+  type StreamSink,
+  type StreamResult,
+  type StreamType,
+  type StreamSource,
+  type StreamSourceAsync,
+  type HoprConnectTestingOptions,
+  ConnectionTags
 } from '../types.js'
 import assert from 'assert'
 import type { DialOptions } from '@libp2p/interface-transport'
@@ -126,6 +127,8 @@ class WebRTCConnection implements MultiaddrConnection {
 
   private _id: string
 
+  public tags: ConnectionTags[]
+
   // Set magic *close* property to end connection
   // @dev this is done using meta programming in libp2p
   public timeline: MultiaddrConnection['timeline']
@@ -151,6 +154,8 @@ class WebRTCConnection implements MultiaddrConnection {
     this.timeline = {
       open: Date.now()
     }
+
+    this.tags = [ConnectionTags.WEBRTC_RELAYED]
 
     // Give each WebRTC connection instance a unique identifier
     this._id = u8aToHex(randomBytes(4), false)
@@ -435,6 +440,9 @@ class WebRTCConnection implements MultiaddrConnection {
         if (this._sourceMigrated) {
           // Update state object once source *and* sink are migrated
           this.conn = this.relayConn.state.channel as SimplePeer
+          if (!this.tags.includes(ConnectionTags.WEBRTC_DIRECT)) {
+            this.tags = [ConnectionTags.WEBRTC_DIRECT]
+          }
         }
         await toIterable.sink(this.relayConn.state.channel as SimplePeer)(
           async function* (this: WebRTCConnection): StreamSource {
@@ -556,6 +564,9 @@ class WebRTCConnection implements MultiaddrConnection {
         if (this._sinkMigrated) {
           // Update state object once sink *and* source are migrated
           this.conn = this.relayConn.state.channel as SimplePeer
+          if (!this.tags.includes(ConnectionTags.WEBRTC_DIRECT)) {
+            this.tags = [ConnectionTags.WEBRTC_DIRECT]
+          }
         }
 
         this.log(`webRTC source handover done. Using direct connection to peer ${this.remoteAddr.getPeerId()}`)

--- a/packages/connect/src/webrtc/connection.ts
+++ b/packages/connect/src/webrtc/connection.ts
@@ -15,7 +15,7 @@ import {
   type StreamSource,
   type StreamSourceAsync,
   type HoprConnectTestingOptions,
-  ConnectionTags
+  PeerConnectionType
 } from '../types.js'
 import assert from 'assert'
 import type { DialOptions } from '@libp2p/interface-transport'
@@ -127,7 +127,7 @@ class WebRTCConnection implements MultiaddrConnection {
 
   private _id: string
 
-  public tags: ConnectionTags[]
+  public tags: PeerConnectionType[]
 
   // Set magic *close* property to end connection
   // @dev this is done using meta programming in libp2p
@@ -155,7 +155,8 @@ class WebRTCConnection implements MultiaddrConnection {
       open: Date.now()
     }
 
-    this.tags = [ConnectionTags.WEBRTC_RELAYED]
+    // Initial state + fallback if WebRTC failed
+    this.tags = [PeerConnectionType.WEBRTC_RELAYED]
 
     // Give each WebRTC connection instance a unique identifier
     this._id = u8aToHex(randomBytes(4), false)
@@ -440,8 +441,8 @@ class WebRTCConnection implements MultiaddrConnection {
         if (this._sourceMigrated) {
           // Update state object once source *and* sink are migrated
           this.conn = this.relayConn.state.channel as SimplePeer
-          if (!this.tags.includes(ConnectionTags.WEBRTC_DIRECT)) {
-            this.tags = [ConnectionTags.WEBRTC_DIRECT]
+          if (!this.tags.includes(PeerConnectionType.WEBRTC_DIRECT)) {
+            this.tags = [PeerConnectionType.WEBRTC_DIRECT]
           }
         }
         await toIterable.sink(this.relayConn.state.channel as SimplePeer)(
@@ -564,8 +565,8 @@ class WebRTCConnection implements MultiaddrConnection {
         if (this._sinkMigrated) {
           // Update state object once sink *and* source are migrated
           this.conn = this.relayConn.state.channel as SimplePeer
-          if (!this.tags.includes(ConnectionTags.WEBRTC_DIRECT)) {
-            this.tags = [ConnectionTags.WEBRTC_DIRECT]
+          if (!this.tags.includes(PeerConnectionType.WEBRTC_DIRECT)) {
+            this.tags = [PeerConnectionType.WEBRTC_DIRECT]
           }
         }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,6 +69,7 @@ import { Packet } from './messages/index.js'
 import type { ResolvedEnvironment } from './environment.js'
 import { createLibp2pInstance } from './main.js'
 import type { EventEmitter as Libp2pEmitter } from '@libp2p/interfaces/events'
+import { PeerConnectionType } from '@hoprnet/hopr-connect'
 
 const DEBUG_PREFIX = `hopr-core`
 const log = debug(DEBUG_PREFIX)
@@ -350,8 +351,8 @@ class Hopr extends EventEmitter {
         if (
           libp2p.connectionManager
             .getConnections(peerId)
-            .flatMap((c) => c.tags)
-            .includes('DIRECT')
+            .flatMap((c) => c.tags ?? [])
+            .includes(PeerConnectionType.DIRECT)
         ) {
           this.knownPublicNodesCache.add(peerId)
           return true


### PR DESCRIPTION
Adds better distinction between multiple types of relayed connection, including

- `WEBRTC_DIRECT` -> WebRTC was successful, now using a direct connection
- `WEBRTC_RELAYED` -> initial state and fallback if WebRTC upgrade failed, i.e. due to bidirectional NAT
- `RELAYED` - configuration permits WebRTC upgrades, used for testing