### PR TITLE
streamline promise rejection filter

### DIFF
--- a/packages/cover-traffic-daemon/src/index.ts
+++ b/packages/cover-traffic-daemon/src/index.ts
@@ -21,7 +21,8 @@ import {
   PublicKey,
   debug,
   loadJson,
-  get_package_version
+  get_package_version,
+  setupPromiseRejectionFilter
 } from '@hoprnet/hopr-utils'
 
 import { PersistedState } from './state.js'
@@ -232,6 +233,10 @@ if (import.meta.url === `file://${process.argv[1]}`) {
   process.once('exit', stopGracefully)
   process.on('SIGINT', stopGracefully)
   process.on('SIGTERM', stopGracefully)
+
+  // Filter specific known promise rejection that cannot be handled for
+  // one reason or the other
+  setupPromiseRejectionFilter()
 
   process.on('uncaughtExceptionMonitor', (err, origin) => {
     // Make sure we get a log.

--- a/packages/utils/src/process/index.ts
+++ b/packages/utils/src/process/index.ts
@@ -1,3 +1,4 @@
 export * from './debug.js'
+export * from './promiseRejectionFilter.js'
 export * from './resourceLogger.js'
 export * from './retimer.js'

--- a/packages/utils/src/process/promiseRejectionFilter.ts
+++ b/packages/utils/src/process/promiseRejectionFilter.ts
@@ -1,0 +1,33 @@
+/**
+ * Sets a custom promise rejection handler to filter out known promise rejections
+ * that are harmless but couldn't be handled for some reason.
+ */
+export function setupPromiseRejectionFilter() {
+  // See https://github.com/hoprnet/hoprnet/issues/3755
+  process.on('unhandledRejection', (reason: any, _promise: Promise<any>) => {
+    if (reason && reason.message && reason.message.toString) {
+      const msgString = reason.toString()
+
+      // Only silence very specific errors
+      if (
+        // HOPR uses the `stream-to-it` library to convert streams from Node.js sockets
+        // to async iterables. This library has shown to have issues with runtime errors,
+        // mainly ECONNRESET and EPIPE
+        msgString.match(/read ETIMEDOUT/) ||
+        msgString.match(/read ECONNRESET/) ||
+        msgString.match(/write ETIMEDOUT/) ||
+        msgString.match(/write ECONNRESET/) ||
+        msgString.match(/write EPIPE/) ||
+        // Requires changes in libp2p, tbd in upstream PRs to libp2p
+        msgString.match(/The operation was aborted/)
+      ) {
+        console.error('Unhandled promise rejection silenced')
+        return
+      }
+    }
+
+    console.warn('UnhandledPromiseRejectionWarning')
+    console.log(reason)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
Streamlines the promise rejection filter to be usable in both leaf packages, `ctd` and `hoprd`.

Promises originating from socket errors that cannot be caught for some reason are now silenced for all packages that import that function.