### PR TITLE
fix protocol identifiers

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -158,7 +158,7 @@ export type Subscribe = ((
   errHandler: (err: any) => void
 ) => void) &
   ((
-    protocol: string,
+    protocol: string | string[],
     handler: LibP2PHandlerFunction<Promise<void> | void>,
     includeReply: false,
     errHandler: (err: any) => void
@@ -375,8 +375,19 @@ class Hopr extends EventEmitter {
       this.networkPeers.register(event.detail.remotePeer, NetworkPeersOrigin.INCOMING_CONNECTION)
     })
 
-    const protocolMsg = `/hopr/${this.environment.id}/msg/${NORMALIZED_VERSION}`
-    const protocolAck = `/hopr/${this.environment.id}/ack/${NORMALIZED_VERSION}`
+    const protocolMsg = [
+      // current
+      `/hopr/${this.environment.id}/msg/${NORMALIZED_VERSION}`,
+      // deprecated
+      `/hopr/${this.environment.id}/msg`
+    ]
+
+    const protocolAck = [
+      // current
+      `/hopr/${this.environment.id}/ack/${NORMALIZED_VERSION}`,
+      // deprecated
+      `/hopr/${this.environment.id}/ack`
+    ]
 
     // Attach mixnet functionality
     await subscribeToAcknowledgements(

--- a/packages/core/src/interactions/packet/acknowledgement.ts
+++ b/packages/core/src/interactions/packet/acknowledgement.ts
@@ -114,7 +114,7 @@ export async function subscribeToAcknowledgements(
   onAcknowledgement: OnAcknowledgement,
   onWinningTicket: OnWinningTicket,
   onOutOfCommitments: OnOutOfCommitments,
-  protocolAck: string
+  protocolAck: string | string[]
 ) {
   const limitConcurrency = oneAtATime<void>()
   await subscribe(
@@ -136,7 +136,7 @@ export async function sendAcknowledgement(
   destination: PeerId,
   sendMessage: SendMessage,
   privKey: PeerId,
-  protocolAck: string
+  protocolAck: string | string[]
 ): Promise<void> {
   const ack = packet.createAcknowledgement(privKey)
 

--- a/packages/core/src/interactions/packet/forward.ts
+++ b/packages/core/src/interactions/packet/forward.ts
@@ -24,8 +24,8 @@ export class PacketForwardInteraction {
     private privKey: PeerId,
     private emitMessage: (msg: Uint8Array) => void,
     private db: HoprDB,
-    private protocolMsg: string,
-    private protocolAck: string
+    private protocolMsg: string | string[],
+    private protocolAck: string | string[]
   ) {
     this.mixer = new Mixer(this.handleMixedPacket.bind(this))
   }

--- a/packages/core/src/network/heartbeat.spec.ts
+++ b/packages/core/src/network/heartbeat.spec.ts
@@ -75,11 +75,11 @@ function createFakeNetwork() {
     protocols: string | string[],
     handler: (msg: Uint8Array, remotePeer: PeerId) => Promise<Uint8Array>
   ) => {
-    let protocol
-    if (typeof protocols === 'string') {
-      protocol = protocols
+    let protocol: string
+    if (Array.isArray(protocols)) {
+      protocol = protocols[0]
     } else {
-      protocol = protocol[0]
+      protocol = protocols
     }
 
     network.on(reqEventName(self, protocol), async (from: PeerId, request: Uint8Array) => {
@@ -93,11 +93,11 @@ function createFakeNetwork() {
 
   // mocks libp2p.dialProtocol
   const sendMessage = async (self: PeerId, dest: PeerId, protocols: string | string[], msg: Uint8Array) => {
-    let protocol
-    if (typeof protocols === 'string') {
-      protocol = protocols
+    let protocol: string
+    if (Array.isArray(protocols)) {
+      protocol = protocols[0]
     } else {
-      protocol = protocol[0]
+      protocol = protocols
     }
 
     if (network.listenerCount(reqEventName(dest, protocol)) > 0) {
@@ -162,7 +162,7 @@ async function getPeer(
   return { heartbeat, peers }
 }
 
-describe('unit test heartbeat', async () => {
+describe.only('unit test heartbeat', async () => {
   it('check nodes is noop with empty store & health indicator is red', async () => {
     let netHealth = new NetworkHealth()
     const heartbeat = new TestingHeartbeat(

--- a/packages/core/src/network/heartbeat.ts
+++ b/packages/core/src/network/heartbeat.ts
@@ -52,7 +52,7 @@ export enum NetworkHealthIndicator {
 
 export default class Heartbeat {
   private stopHeartbeatInterval: (() => void) | undefined
-  private protocolHeartbeat: string
+  private protocolHeartbeat: string | string[]
 
   private _pingNode: Heartbeat['pingNode'] | undefined
 
@@ -81,7 +81,12 @@ export default class Heartbeat {
       networkQualityThreshold: config?.networkQualityThreshold,
       maxParallelHeartbeats: config?.maxParallelHeartbeats ?? MAX_PARALLEL_HEARTBEATS
     }
-    this.protocolHeartbeat = `/hopr/${environmentId}/heartbeat/${NORMALIZED_VERSION}`
+    this.protocolHeartbeat = [
+      // current
+      `/hopr/${environmentId}/heartbeat/${NORMALIZED_VERSION}`,
+      // deprecated
+      `/hopr/${environmentId}/heartbeat`
+    ]
   }
 
   private errHandler(err: any) {


### PR DESCRIPTION
Recently, `hopr` switched from protocol identifiers, such as

```
/hopr/<ENVIRONMENT>/ack
```
to 
```
/hopr/<ENVIRONMENT>/ack/<VERSION>
```

Inbound connections with *old* protocol identifiers work on *new* nodes. Whereas outbound connection don't work.

This PR allows node to interact with *new* and *old* identifiers.