### PR TITLE
Handle exceptions thrown within Indexer

### DIFF
--- a/packages/core-ethereum/src/indexer/index.ts
+++ b/packages/core-ethereum/src/indexer/index.ts
@@ -535,8 +535,7 @@ class Indexer extends (EventEmitter as new () => IndexerEventEmitter) {
 
     try {
       await this.processUnconfirmedEvents(blockNumber, lastDatabaseSnapshot, blocking)
-    }
-    catch (err) {
+    } catch (err) {
       log(`error while processing unconfirmed events`, err)
     }
 

--- a/packages/core-ethereum/src/indexer/index.ts
+++ b/packages/core-ethereum/src/indexer/index.ts
@@ -798,13 +798,11 @@ class Indexer extends (EventEmitter as new () => IndexerEventEmitter) {
   }
 
   private async onChannelUpdated(event: Event<'ChannelUpdated'>, lastSnapshot: Snapshot): Promise<void> {
-
-    let channel: ChannelEntry;
+    let channel: ChannelEntry
     try {
       log('channel-updated for hash %s', event.transactionHash)
       channel = await ChannelEntry.fromSCEvent(event, this.getPublicKeyOf.bind(this))
-    }
-    catch (err) {
+    } catch (err) {
       log(`fatal error: failed to construct new ChannelEntry from the SC event`, err)
       return
     }

--- a/packages/core-ethereum/src/indexer/index.ts
+++ b/packages/core-ethereum/src/indexer/index.ts
@@ -123,7 +123,7 @@ class Indexer extends (EventEmitter as new () => IndexerEventEmitter) {
     // and feeds them to the event listener
     ;(async function (this: Indexer) {
       for await (const block of orderedBlocks.iterator()) {
-        await this.onNewBlock(block.value, true, true) // exceptions are handled
+        await this.onNewBlock(block.value, true, true) // exceptions are handled (for real)
       }
     }.call(this))
 
@@ -533,7 +533,12 @@ class Indexer extends (EventEmitter as new () => IndexerEventEmitter) {
       }
     }
 
-    await this.processUnconfirmedEvents(blockNumber, lastDatabaseSnapshot, blocking)
+    try {
+      await this.processUnconfirmedEvents(blockNumber, lastDatabaseSnapshot, blocking)
+    }
+    catch (err) {
+      log(`error while processing unconfirmed events`, err)
+    }
 
     // resend queuing transactions, when there are transactions (in queue) that haven't been accepted by the RPC
     // and resend transactions if the current balance is sufficient.

--- a/packages/core-ethereum/src/indexer/index.ts
+++ b/packages/core-ethereum/src/indexer/index.ts
@@ -798,8 +798,16 @@ class Indexer extends (EventEmitter as new () => IndexerEventEmitter) {
   }
 
   private async onChannelUpdated(event: Event<'ChannelUpdated'>, lastSnapshot: Snapshot): Promise<void> {
-    log('channel-updated for hash %s', event.transactionHash)
-    const channel = await ChannelEntry.fromSCEvent(event, this.getPublicKeyOf.bind(this))
+
+    let channel: ChannelEntry;
+    try {
+      log('channel-updated for hash %s', event.transactionHash)
+      channel = await ChannelEntry.fromSCEvent(event, this.getPublicKeyOf.bind(this))
+    }
+    catch (err) {
+      log(`fatal error: failed to construct new ChannelEntry from the SC event`, err)
+      return
+    }
 
     let prevState: ChannelEntry
     try {


### PR DESCRIPTION
Handle some additional code path that can throw an exception:

````
 hopr-core-ethereum:indexer channel-updated for hash 0x365d48786495f92d5f001f6d386dd5fbd8d5f9c2e6c7e0a7c36e580a5fdaf528 +0ms
(node:196996) UnhandledPromiseRejectionWarning
Error: Could not find public key for address - have they announced? -0xea021b6A4b2AdD6C04a5174913D63873aEc0dA0D
    at Indexer.getPublicKeyOf (file:///home/luc/repos/hopr/hoprnet/packages/core-ethereum/lib/indexer/index.js:720:15)
    at async Function.fromSCEvent (file:///home/luc/repos/hopr/hoprnet/packages/utils/lib/types/channelEntry.js:90:33)
    at async Indexer.onChannelUpdated (file:///home/luc/repos/hopr/hoprnet/packages/core-ethereum/lib/indexer/index.js:595:25)
    at async Indexer.processUnconfirmedEvents (file:///home/luc/repos/hopr/hoprnet/packages/core-ethereum/lib/indexer/index.js:525:21)
    at async Indexer.onNewBlock (file:///home/luc/repos/hopr/hoprnet/packages/core-ethereum/lib/indexer/index.js:395:9)
    at async Indexer.<anonymous> (file:///home/luc/repos/hopr/hoprnet/packages/core-ethereum/lib/indexer/index.js:63:17)
UnhandledPromiseRejectionWarning
Error: Could not find public key for address - have they announced? -0xea021b6A4b2AdD6C04a5174913D63873aEc0dA0D
    at Indexer.getPublicKeyOf (file:///home/luc/repos/hopr/hoprnet/packages/core-ethereum/lib/indexer/index.js:720:15)
    at async Function.fromSCEvent (file:///home/luc/repos/hopr/hoprnet/packages/utils/lib/types/channelEntry.js:90:33)
    at async Indexer.onChannelUpdated (file:///home/luc/repos/hopr/hoprnet/packages/core-ethereum/lib/indexer/index.js:595:25)
    at async Indexer.processUnconfirmedEvents (file:///home/luc/repos/hopr/hoprnet/packages/core-ethereum/lib/indexer/index.js:525:21)
    at async Indexer.onNewBlock (file:///home/luc/repos/hopr/hoprnet/packages/core-ethereum/lib/indexer/index.js:395:9)
    at async Indexer.<anonymous> (file:///home/luc/repos/hopr/hoprnet/packages/core-ethereum/lib/indexer/index.js:63:17)
  hoprd { type: 'log', msg: 'Process exiting with signal 1', ts: '2022-10-08T02:25:43.154Z' } +0ms

````