### PR TITLE
Properly use `encodeURIComponent` instead of `encodeURI`

### DIFF
--- a/packages/hoprd/src/api/v2.ts
+++ b/packages/hoprd/src/api/v2.ts
@@ -120,7 +120,7 @@ export async function setupRestApi(
         if (this.options.testNoAuthentication) return true
 
         // Applying multiple URI encoding is an identity
-        let apiTokenFromUser = encodeURI(req.get('x-auth-token') || '')
+        let apiTokenFromUser = encodeURIComponent(req.get('x-auth-token') || '')
 
         if (
           !this.options.testNoAuthentication &&
@@ -141,7 +141,7 @@ export async function setupRestApi(
 
         const authEncoded = (req.get('authorization') || '').replace('Basic ', '')
         // We only expect a single value here, instead of the usual user:password, so we take the user part as token
-        let apiTokenFromUser = encodeURI(Buffer.from(authEncoded, 'base64').toString('binary')).split(':')[0] // The colon ':' does not get encoded by encodeURI
+        let apiTokenFromUser = encodeURIComponent(Buffer.from(authEncoded, 'base64').toString('binary')).split(':')[0] // The colon ':' does not get encoded by encodeURI
 
         if (
           !this.options.testNoAuthentication &&


### PR DESCRIPTION
A followup PR after #4210 

Fixes #4217 
Refs #4181 