### PR TITLE
enhance tcp socket teardowns

### DIFF
--- a/packages/connect/src/base/entry.ts
+++ b/packages/connect/src/base/entry.ts
@@ -1,11 +1,13 @@
-import type { HoprConnectOptions, PeerStoreType } from '../types.js'
+import type { HoprConnectOptions, PeerStoreType, StreamType } from '../types.js'
 import type { Connection, ProtocolStream } from '@libp2p/interface-connection'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import type { Initializable, Components } from '@libp2p/interfaces/components'
 import type { Startable } from '@libp2p/interfaces/startable'
 import { Multiaddr } from '@multiformats/multiaddr'
+import { peerIdFromString } from '@libp2p/peer-id'
+import { handshake } from 'it-handshake'
+
 import type { HoprConnect } from '../index.js'
-import { peerIdFromBytes, peerIdFromString } from '@libp2p/peer-id'
 
 import errCode from 'err-code'
 import { EventEmitter } from 'events'
@@ -40,7 +42,6 @@ import { attemptClose, relayFromRelayAddress } from '../utils/index.js'
 const DEBUG_PREFIX = 'hopr-connect:entry'
 const log = Debug(DEBUG_PREFIX)
 const error = Debug(DEBUG_PREFIX.concat(':error'))
-const verbose = Debug(DEBUG_PREFIX.concat(':verbose'))
 
 const ENTRY_NODE_CONTACT_TIMEOUT = 5e3
 const ENTRY_NODES_MAX_PARALLEL_DIALS = 14
@@ -279,7 +280,8 @@ export class EntryNodes extends EventEmitter implements Initializable, Startable
   private _onNewRelay: ((peer: PeerStoreType) => void) | undefined
   private _onRemoveRelay: ((peer: PeerId) => void) | undefined
   private _connectToRelay: EntryNodes['connectToRelay'] | undefined
-  public _onEntryNodeDisconnect: EntryNodes['onEntryDisconnect'] | undefined
+
+  private disconnectListener: ((conn: CustomEvent<Connection>) => void) | undefined
 
   private addToUpdateQueue: ReturnType<typeof oneAtATime>
 
@@ -330,7 +332,6 @@ export class EntryNodes extends EventEmitter implements Initializable, Startable
    */
   public start() {
     this._connectToRelay = this.connectToRelay.bind(this)
-    this._onEntryNodeDisconnect = this.onEntryDisconnect.bind(this)
 
     if (this.options.publicNodes != undefined) {
       this._onNewRelay = (peer: PeerStoreType) => {
@@ -413,16 +414,25 @@ export class EntryNodes extends EventEmitter implements Initializable, Startable
   }
 
   /**
-   * Called once connection to an entry node gets closed.
-   * @param ma disconnected Multiaddr
+   * Used to track once a connection to a selected entry node got closed.
    */
-  // @TODO add this call to "global" queue
-  private async onEntryDisconnect(ma: Multiaddr) {
-    const tuples = ma.tuples() as [code: number, addr: Uint8Array][]
-    const peer = peerIdFromBytes(tuples[2][1].slice(1))
+  private trackEntryNodeConnections(): void {
+    const usedRelays = new Set(this.getUsedRelayPeerIds().map((p: PeerId) => p.toString()))
 
-    log(`Disconnected from entry node ${peer.toString()}, trying to reconnect ...`)
-    this.addToUpdateQueue(() => this.reconnectToEntryNode(peer))
+    if (this.disconnectListener != undefined) {
+      this.getComponents().getConnectionManager().removeEventListener('peer:disconnect', this.disconnectListener)
+    }
+    this.disconnectListener = (event: CustomEvent<Connection>) => {
+      const remotePeer = event.detail.remotePeer
+      console.log(`disconnected`)
+
+      if (usedRelays.has(remotePeer.toString())) {
+        log(`Disconnected from entry node ${remotePeer.toString()}, trying to reconnect ...`)
+        this.addToUpdateQueue(() => this.reconnectToEntryNode(remotePeer))
+      }
+    }
+
+    this.getComponents().getConnectionManager().addEventListener('peer:disconnect', this.disconnectListener)
   }
 
   private async reconnectToEntryNode(peer: PeerId) {
@@ -719,6 +729,7 @@ export class EntryNodes extends EventEmitter implements Initializable, Startable
         await this.updatePublicNodes()
       } else {
         this.updateUsedRelays([[peer.toString(), [undefined]]])
+        this.trackEntryNodeConnections()
         this.emit(RELAY_CHANGED_EVENT)
       }
     }
@@ -959,6 +970,7 @@ export class EntryNodes extends EventEmitter implements Initializable, Startable
     if (isDifferent) {
       log(printListOfUsedRelays(this.usedRelays, `Updated list of entry nodes:`))
 
+      this.trackEntryNodeConnections()
       this.emit(RELAY_CHANGED_EVENT)
     }
   }
@@ -969,14 +981,12 @@ export class EntryNodes extends EventEmitter implements Initializable, Startable
    * @param destination peer to connect to
    * @param destinationAddress address to use for connect attempt
    * @param timeout when to timeout
-   * @param onDisconnect called once connection gets closed
    * @returns either a connection result or nothing, if there was an error
    */
   private async establishNewConnection(
     destination: PeerId,
     destinationAddress: Multiaddr,
-    timeout: number,
-    onDisconnect: (ma: Multiaddr) => void
+    timeout: number
   ): Promise<ConnResult | void> {
     const abort = new AbortController()
     let done = false
@@ -993,8 +1003,7 @@ export class EntryNodes extends EventEmitter implements Initializable, Startable
       conn = await this.dialDirectly(destinationAddress, {
         signal: abort.signal,
         // libp2p interface type clash
-        upgrader: this.getComponents().getUpgrader() as any,
-        onDisconnect
+        upgrader: this.getComponents().getUpgrader() as any
       })
     } catch (err: any) {
       error(`error while contacting entry node ${destination.toString()}.`, err?.message)
@@ -1046,12 +1055,7 @@ export class EntryNodes extends EventEmitter implements Initializable, Startable
     let conn = await tryExistingConnections(this.getComponents(), id, protocolsCanRelay)
 
     if (conn == null) {
-      conn = await this.establishNewConnection(
-        id,
-        relay,
-        timeout,
-        this._onEntryNodeDisconnect as EntryNodes['onEntryDisconnect']
-      )
+      conn = await this.establishNewConnection(id, relay, timeout)
     }
 
     if (conn == null) {
@@ -1064,42 +1068,39 @@ export class EntryNodes extends EventEmitter implements Initializable, Startable
       }
     }
 
-    let done = false
+    // Only reads from socket once but keeps socket open
+    // to eventually use it to exchange signalling information
+    const shaker = handshake(conn.stream)
 
-    // calls the iterator, thereby starts the stream and
-    // consumes the first messages, afterwards closes the stream
-    for await (const msg of conn.stream.source as AsyncIterable<Uint8Array>) {
-      verbose(`can relay received ${new TextDecoder().decode(msg.subarray())} from ${id.toString()}`)
-      if (u8aEquals(msg.subarray(), OK)) {
-        done = true
-      }
-      // End receive stream after first message
-      break
-    }
-
+    let chunk: StreamType | undefined
     try {
-      // End the send stream by sending nothing
-      conn.stream.sink((async function* () {})()).catch(error)
+      chunk = await shaker.read()
     } catch (err) {
       error(err)
-    }
-
-    if (done) {
-      return {
-        conn: conn.conn,
-        entry: {
-          id,
-          multiaddrs: [relay],
-          latency: Date.now() - start
-        }
-      }
-    } else {
       return {
         entry: {
           id,
           multiaddrs: [relay],
           latency: -1
         }
+      }
+    }
+
+    if (chunk == undefined || !u8aEquals(chunk.subarray(), OK)) {
+      return {
+        entry: {
+          id,
+          multiaddrs: [relay],
+          latency: -1
+        }
+      }
+    }
+
+    return {
+      entry: {
+        id,
+        multiaddrs: [relay],
+        latency: Date.now() - start
       }
     }
   }

--- a/packages/connect/src/base/listener.ts
+++ b/packages/connect/src/base/listener.ts
@@ -466,23 +466,6 @@ class Listener extends EventEmitter<ListenerEvents> implements InterfaceListener
       conn.tags = [PeerConnectionType.DIRECT]
     }
 
-    for (const peer of this.connectComponents.getEntryNodes().getUsedRelayPeerIds()) {
-      if (peer.equals(conn.remotePeer)) {
-        // Make sure that Multiaddr contains a PeerId
-        const maWithPeerId = maConn.remoteAddr
-          .decapsulateCode(CODE_P2P)
-          .encapsulate(`/p2p/${conn.remotePeer.toString()}`)
-
-        ;(maConn.conn as TCPSocket).on('close', () => {
-          if (maConn!.closed) {
-            return
-          }
-
-          this.connectComponents.getEntryNodes()._onEntryNodeDisconnect!(maWithPeerId)
-        })
-      }
-    }
-
     log('inbound connection %s upgraded', maConn.remoteAddr)
 
     socket.once('close', this.trackConn(conn))

--- a/packages/connect/src/base/tcp.spec.ts
+++ b/packages/connect/src/base/tcp.spec.ts
@@ -1,7 +1,7 @@
 import { createServer, type Socket, type AddressInfo } from 'net'
 import { setTimeout } from 'timers/promises'
 
-import { SOCKET_CLOSE_TIMEOUT, TCPConnection } from './tcp.js'
+import { TCPConnection } from './tcp.js'
 import { once } from 'events'
 import { Multiaddr } from '@multiformats/multiaddr'
 import { u8aEquals, defer } from '@hoprnet/hopr-utils'
@@ -47,9 +47,9 @@ describe('test TCP connection', function () {
 
     conn.close()
 
-    await once(conn.conn as EventEmitter, 'close')
+    await once(conn.socket as EventEmitter, 'close')
 
-    assert(conn.conn.destroyed)
+    assert(conn.socket.destroyed)
 
     assert(
       conn.timeline.close != undefined &&
@@ -62,50 +62,73 @@ describe('test TCP connection', function () {
   })
 
   it('trigger a socket close timeout', async function () {
+    const SOCKET_CLOSE_TIMEOUT = 1000
+
     this.timeout(SOCKET_CLOSE_TIMEOUT + 2e3)
 
-    const testMessage = new TextEncoder().encode('test')
+    // test server with tweaked behavior
+    const testServer = createServer()
+    const testMessage = new TextEncoder().encode('test message')
 
-    const server = createServer()
-
-    server.on('close', console.log)
-    server.on('error', console.log)
     const sockets: Socket[] = []
-    server.on('connection', sockets.push.bind(sockets))
+    testServer.on('connection', (socket: Socket) => {
+      // Handle incoming data
+      socket.on('data', (data) => {
+        assert(u8aEquals(data, testMessage))
+      })
+      sockets.push(socket)
+    })
 
-    await waitUntilListening(server, undefined)
+    // make testServer listen at a random port
+    await waitUntilListening<Socket>(testServer, undefined as any)
 
-    const conn = await TCPConnection.create(
-      new Multiaddr(`/ip4/127.0.0.1/tcp/${(server.address() as AddressInfo).port}`)
-    )
+    const conn = (await TCPConnection.create(
+      new Multiaddr(`/ip4/127.0.0.1/tcp/${(testServer.address() as AddressInfo).port}`),
+      {
+        closeTimeout: 1000
+      }
+    )) as TCPConnection
 
-    await conn.sink(
+    conn.sink(
       (async function* () {
-        yield testMessage
+        while (true) {
+          yield testMessage
+          await setTimeout(10)
+        }
       })()
     )
 
-    const start = Date.now()
-    const closePromise = once(conn.conn, 'close')
-
-    // Overwrite end method to mimic half-open stream
-    Object.assign(conn.conn, {
-      end: () => {}
+    const destroy = conn.socket.destroy.bind(conn.socket)
+    Object.assign(conn.socket, {
+      destroy: () => {}
     })
+
+    const start = Date.now()
+    const closePromise = once(conn.socket, 'close')
 
     // @dev produces a half-open socket on the other side
     conn.close()
 
+    assert(conn.closed === true, `Connection must be marked closed`)
+
+    // Wait some time before restoring `destroy()` method
+    await setTimeout(SOCKET_CLOSE_TIMEOUT / 2)
+
+    Object.assign(conn.socket, {
+      destroy
+    })
+
+    // Now that `destroy()` method has been restored, await `close` event
     await closePromise
 
-    // Destroy half-open sockets.
+    // Destroy all sockets of testServer
     for (const socket of sockets) {
       socket.destroy()
     }
 
-    await stopNode(server)
+    await stopNode(testServer)
 
-    assert(Date.now() - start >= SOCKET_CLOSE_TIMEOUT)
+    assert(Date.now() - start >= SOCKET_CLOSE_TIMEOUT, `should not timeout earlier than configured timeout`)
 
     assert(
       conn.timeline.close != undefined &&
@@ -151,8 +174,7 @@ describe('test TCP connection', function () {
     const conn = await TCPConnection.create(
       new Multiaddr(`/ip4/127.0.0.1/tcp/${(server.address() as AddressInfo).port}`),
       {
-        signal: abort.signal,
-        upgrader: undefined as any
+        signal: abort.signal
       }
     )
 

--- a/packages/connect/src/base/tcp.ts
+++ b/packages/connect/src/base/tcp.ts
@@ -7,15 +7,19 @@ const log = Debug('hopr-connect:tcp')
 const error = Debug('hopr-connect:tcp:error')
 const verbose = Debug('hopr-connect:verbose:tcp')
 
-// Timeout to wait for socket close before destroying it
-export const SOCKET_CLOSE_TIMEOUT = 1000
+// Timeout to wait for socket close before manually destroying it
+const SOCKET_CLOSE_TIMEOUT = 2000
 
 import type { MultiaddrConnection } from '@libp2p/interface-connection'
 
 import type { Multiaddr } from '@multiformats/multiaddr'
 import toIterable from 'stream-to-it'
-import type { Stream, StreamSink, StreamSource, StreamSourceAsync } from '../types.js'
-import type { DialOptions } from '@libp2p/interface-transport'
+import type { Stream, StreamSource, StreamSourceAsync } from '../types.js'
+
+type SocketOptions = {
+  signal?: AbortSignal
+  closeTimeout?: number
+}
 
 /**
  * Class to encapsulate TCP sockets
@@ -23,46 +27,49 @@ import type { DialOptions } from '@libp2p/interface-transport'
 class TCPConnection implements MultiaddrConnection {
   public localAddr: Multiaddr
 
-  // @ts-ignore
-  public sink: StreamSink
   public source: StreamSourceAsync
   public closed: boolean
 
   private _signal?: AbortSignal
+
+  private closeTimeout: number
 
   public timeline: {
     open: number
     close?: number
   }
 
-  constructor(public remoteAddr: Multiaddr, public conn: Socket, options?: DialOptions) {
-    this.localAddr = nodeToMultiaddr(this.conn.address() as AddressInfo)
+  constructor(public remoteAddr: Multiaddr, public socket: Socket, options?: SocketOptions) {
+    this.localAddr = nodeToMultiaddr(this.socket.address() as AddressInfo)
 
     this.closed = false
+    this._signal = options?.signal
+    this.closeTimeout = options?.closeTimeout ?? SOCKET_CLOSE_TIMEOUT
+
     this.timeline = {
       open: Date.now()
     }
 
-    this.conn.once('close', () => {
+    this.socket.once('close', () => {
       // Whenever the socket gets closed, mark the
       // connection closed to cleanup data structures in
       // ConnectionManager
       this.timeline.close ??= Date.now()
     })
 
-    this._signal = options?.signal
+    this.source = this.createSource(this.socket)
 
-    this.source = this.createSource(this.conn) as AsyncIterable<Uint8Array>
-    this.sink = this._sink.bind(this)
+    // Sink is passed as a function, so we need to explicitly bind it
+    this.sink = this.sink.bind(this)
   }
 
   public close(): Promise<void> {
-    if (this.conn.destroyed || this.closed) {
+    if (this.socket.destroyed || this.closed) {
       return Promise.resolve()
     }
     this.closed = true
 
-    return new Promise<void>((resolve) => {
+    return new Promise<void>((resolve, reject) => {
       let done = false
 
       const start = Date.now()
@@ -81,17 +88,17 @@ class TCPConnection implements MultiaddrConnection {
           Date.now() - start
         )
 
-        if (this.conn.destroyed) {
+        if (this.socket.destroyed) {
           log('%s:%s is already destroyed', cOptions.host, cOptions.port)
         } else {
           log(`destroying connection ${cOptions.host}:${cOptions.port}`)
-          this.conn.destroy()
+          this.socket.destroy()
         }
-      }, SOCKET_CLOSE_TIMEOUT)
+      }, this.closeTimeout).unref()
 
       // Resolve once closed
       // Could take place after timeout or as a result of `.end()` call
-      this.conn.once('close', () => {
+      this.socket.once('close', () => {
         if (done) {
           return
         }
@@ -100,14 +107,33 @@ class TCPConnection implements MultiaddrConnection {
         resolve()
       })
 
-      try {
-        this.conn.end(() => {
-          this.timeline.close ??= Date.now()
+      this.socket.once('error', (err: Error) => {
+        log('socket error', err)
+
+        // error closing socket
+        this.timeline.close ??= Date.now()
+
+        if (this.socket.destroyed) {
           done = true
+        }
+
+        reject(err)
+      })
+
+      // Send the FIN packet
+      this.socket.end()
+
+      if (this.socket.writableLength > 0) {
+        // there are outgoing bytes waiting to be sent
+        this.socket.once('drain', () => {
+          log('socket drained')
+
+          // all bytes have been sent we can destroy the socket (maybe) before the timeout
+          this.socket.destroy()
         })
-      } catch (err) {
-        // Anything can happen
-        this.conn.destroy()
+      } else {
+        // nothing to send, destroy immediately
+        this.socket.destroy()
       }
     })
   }
@@ -122,12 +148,12 @@ class TCPConnection implements MultiaddrConnection {
     }
   }
 
-  private async _sink(source: StreamSource): Promise<void> {
+  public async sink(source: StreamSource): Promise<void> {
     const u8aStream = toU8aStream(source)
 
     let iterableSink: Stream['sink']
     try {
-      iterableSink = toIterable.sink<Uint8Array>(this.conn)
+      iterableSink = toIterable.sink<Uint8Array>(this.socket)
 
       try {
         await iterableSink(
@@ -149,12 +175,13 @@ class TCPConnection implements MultiaddrConnection {
   }
 
   /**
-   * @param ma
-   * @param self
+   * Tries to establish a TCP connection to the given address.
+   *
+   * @param ma Multiaddr to connect to
    * @param options
-   * @returns Resolves a TCP Socket
+   * @returns Resolves to a TCP Socket, if successful
    */
-  public static create(ma: Multiaddr, options?: DialOptions): Promise<TCPConnection> {
+  public static create(ma: Multiaddr, options?: SocketOptions): Promise<TCPConnection> {
     return new Promise<TCPConnection>((resolve, reject) => {
       const start = Date.now()
       const cOpts = ma.toOptions()

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -296,21 +296,21 @@ class HoprConnect implements Transport, Initializable, Startable {
     // i.e. dialed node == desired destination
 
     // Set the SO_KEEPALIVE flag on socket to tell kernel to be more aggressive on keeping the connection up
-    maConn.conn.setKeepAlive(true, 1000)
+    maConn.socket.setKeepAlive(true, 1000)
 
-    maConn.conn.on('end', function () {
+    maConn.socket.on('end', function () {
       log(`SOCKET END on connection to ${maConn.remoteAddr.toString()}: other end of the socket sent a FIN packet`)
     })
 
-    maConn.conn.on('timeout', function () {
+    maConn.socket.on('timeout', function () {
       warn(`SOCKET TIMEOUT on connection to ${maConn.remoteAddr.toString()}`)
     })
 
-    maConn.conn.on('error', function (e) {
+    maConn.socket.on('error', function (e) {
       error(`SOCKET ERROR on connection to ${maConn.remoteAddr.toString()}: ' ${JSON.stringify(e)}`)
     })
 
-    maConn.conn.on('close', (had_error) => {
+    maConn.socket.on('close', (had_error) => {
       log(`SOCKET CLOSE on connection to ${maConn.remoteAddr.toString()}: error flag is ${had_error}`)
       // Don't call the disconnect handler if connection has been closed intentionally
       if (!maConn.closed && options && options.onDisconnect) {

--- a/packages/connect/src/webrtc/connection.ts
+++ b/packages/connect/src/webrtc/connection.ts
@@ -442,7 +442,7 @@ class WebRTCConnection implements MultiaddrConnection {
           // Update state object once source *and* sink are migrated
           this.conn = this.relayConn.state.channel as SimplePeer
           if (!this.tags.includes(PeerConnectionType.WEBRTC_DIRECT)) {
-            this.tags = [PeerConnectionType.WEBRTC_DIRECT]
+            this.tags.push(PeerConnectionType.WEBRTC_DIRECT)
           }
         }
         await toIterable.sink(this.relayConn.state.channel as SimplePeer)(
@@ -566,7 +566,7 @@ class WebRTCConnection implements MultiaddrConnection {
           // Update state object once sink *and* source are migrated
           this.conn = this.relayConn.state.channel as SimplePeer
           if (!this.tags.includes(PeerConnectionType.WEBRTC_DIRECT)) {
-            this.tags = [PeerConnectionType.WEBRTC_DIRECT]
+            this.tags.push(PeerConnectionType.WEBRTC_DIRECT)
           }
         }
 

--- a/packages/utils/src/process/promiseRejectionFilter.ts
+++ b/packages/utils/src/process/promiseRejectionFilter.ts
@@ -19,7 +19,9 @@ export function setupPromiseRejectionFilter() {
         msgString.match(/write ECONNRESET/) ||
         msgString.match(/write EPIPE/) ||
         // Requires changes in libp2p, tbd in upstream PRs to libp2p
-        msgString.match(/The operation was aborted/)
+        msgString.match(/The operation was aborted/) ||
+        // issues with WebRTC socket and `stream-to-it`
+        msgString.match(/ERR_DATA_CHANNEL/)
       ) {
         console.error('Unhandled promise rejection silenced')
         return


### PR DESCRIPTION
Second cherry-pick from #4171 

### TCP socket handling

After opening and writing to a socket, user-space code in the Node.js process needs to explicitly call `socket.end()` and afterwards `socket.destroy()`. Whereas, `socket.end()` makes the socket send a FIN packet to the other party and thus creates a *half-open* connection, `socket.destroy()` effectively closes the socket, no matter whether one of the parties has sent a FIN packet.

Thus, the *send* workflow is changed as follows from:
```ts
for await (const chunk of toSend) {
  socket.send(chunk)
}
```
to
```ts
for await (const chunk of toSend) {
  socket.send(chunk)
}
// added by the PR
socket.end()
```

### Holding the NAT-hole punch connection

Once a NATed node connects to a public relay, this connection might eventually become one of the only connection through which other nodes can reach this node - by using the public relay to forward messages. This mechanism is then used to run through an ICE handshake and finally upgrade the relayed connection to a direct one.

This PR changes the behavior of these specific connection, from NATed node to a public relay to stay open as long as either the NATed node or the public relay explicitly close this connection, which can also happen because one of them got restarted.

Instead of #4171 , this PR does not use any meta programming to extend the socket object. It rather changes the "user-space" code to hold the connection.

### Other changes

- minor testing enhancements
