### PR TITLE
Split auth token then encode

### DIFF
--- a/packages/hoprd/src/api/v2.ts
+++ b/packages/hoprd/src/api/v2.ts
@@ -141,7 +141,7 @@ export async function setupRestApi(
 
         const authEncoded = (req.get('authorization') || '').replace('Basic ', '')
         // We only expect a single value here, instead of the usual user:password, so we take the user part as token
-        let apiTokenFromUser = encodeURIComponent(Buffer.from(authEncoded, 'base64').toString('binary')).split(':')[0] // The colon ':' does not get encoded by encodeURI
+        let apiTokenFromUser = encodeURIComponent(Buffer.from(authEncoded, 'base64').toString('binary').split(':')[0])
 
         if (
           !this.options.testNoAuthentication &&


### PR DESCRIPTION
The `:` character was not encoded using `encodeURI`, but since we switched to `encodeURIComponet`, a fix is needed to make `Authorization` header parsing work again.