### PR TITLE
Fix typo in the public node cache

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -361,7 +361,7 @@ class Hopr extends EventEmitter {
             .flatMap((c) => c.tags ?? [])
             .includes(PeerConnectionType.DIRECT)
         ) {
-          this.knownPublicNodesCache.add(peerId)
+          this.knownPublicNodesCache.add(peerId.toString())
           return true
         }
 


### PR DESCRIPTION
A typo caused that PeerIds of public nodes were not added properly to the cache.