### PR TITLE
timeout refactor & more iterables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fix public node resolution for connectivity indicator ([#4205]https://github.com/hoprnet/hoprnet/pull/4205)
 - Remove charset complexity validation on API token ([#4210](https://github.com/hoprnet/hoprnet/pull/4210))
 - Properly encode API token passed from the Admin UI ([#4210](https://github.com/hoprnet/hoprnet/pull/4210))
+- Refactor timeouts for more throughput and increase usage of iterables ([#4238](https://github.com/hoprnet/hoprnet/pull/4238))
 
 ---
 

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -44,6 +44,7 @@
     "it-handshake": "4.0.0",
     "multiformats": "9.6.5",
     "nat-api": "0.3.1",
+    "retimer": "3.0.0",
     "simple-peer": "9.11.1",
     "stream-to-it": "0.2.4",
     "webrtc-stun": "3.0.0",

--- a/packages/connect/src/base/entry.ts
+++ b/packages/connect/src/base/entry.ts
@@ -424,7 +424,6 @@ export class EntryNodes extends EventEmitter implements Initializable, Startable
     }
     this.disconnectListener = (event: CustomEvent<Connection>) => {
       const remotePeer = event.detail.remotePeer
-      console.log(`disconnected`)
 
       if (usedRelays.has(remotePeer.toString())) {
         log(`Disconnected from entry node ${remotePeer.toString()}, trying to reconnect ...`)

--- a/packages/connect/src/base/listener.ts
+++ b/packages/connect/src/base/listener.ts
@@ -105,9 +105,7 @@ class Listener extends EventEmitter<ListenerEvents> implements InterfaceListener
       // hopr-connect does not enable IPv6 connections right now, therefore we can set `listeningAddrs` statically
       // to `/ip4/0.0.0.0/tcp/0`, meaning listening on IPv4 using a canonical port
       // TODO check IPv6
-      this.connectComponents
-        .getAddressFilter()
-        .setAddrs(this.getAddrs(), [new Multiaddr(`/ip4/0.0.0.0/tcp/0/p2p/${this.components.getPeerId().toString()}`)])
+      this.connectComponents.getAddressFilter().setAddrs(this.getAddrs(), [new Multiaddr(`/ip4/0.0.0.0/tcp/0`)])
 
       const usedRelays = this.connectComponents.getEntryNodes().getUsedRelayAddresses()
 
@@ -337,7 +335,7 @@ class Listener extends EventEmitter<ListenerEvents> implements InterfaceListener
       ]
     }
 
-    this.addrs.interface = internalInterfaces.map((internalInterface) => nodeToMultiaddr(internalInterface))
+    this.addrs.interface = internalInterfaces.map(nodeToMultiaddr)
 
     this.attachSocketHandlers()
 
@@ -473,7 +471,7 @@ class Listener extends EventEmitter<ListenerEvents> implements InterfaceListener
           .decapsulateCode(CODE_P2P)
           .encapsulate(`/p2p/${conn.remotePeer.toString()}`)
 
-        ;(maConn.conn as TCPSocket).on('close', () => {
+        ;(maConn.socket as TCPSocket).on('close', () => {
           if (maConn!.closed) {
             return
           }

--- a/packages/connect/src/base/stun.ts
+++ b/packages/connect/src/base/stun.ts
@@ -5,6 +5,8 @@ import { Multiaddr } from '@multiformats/multiaddr'
 import debug from 'debug'
 import { randomSubset, ipToU8aAddress, isLocalhost, isPrivateAddress } from '@hoprnet/hopr-utils'
 import { CODE_IP4, CODE_IP6, CODE_DNS4, CODE_DNS6 } from '../constants.js'
+// @ts-ignore untyped module
+import retimer from 'retimer'
 
 const log = debug('hopr-connect:stun:error')
 const error = debug('hopr-connect:stun:error')
@@ -233,19 +235,19 @@ function decodeIncomingSTUNResponses(addrs: Request[], socket: Socket, ms: numbe
 
       socket.removeListener('message', listener)
 
-      clearTimeout(timeout)
+      timer.clear()
 
       resolve(addrs)
     }
 
-    const timeout = setTimeout(() => {
+    const timer = retimer(() => {
       log(
         `STUN timeout. ${addrs.filter((addr) => addr.response).length} of ${
           addrs.length
         } selected STUN servers replied.`
       )
       done()
-    }, ms).unref()
+    }, ms)
 
     // Receiving a Buffer, not a Uint8Array
     listener = (msg: Buffer) => {

--- a/packages/connect/src/base/tcp.spec.ts
+++ b/packages/connect/src/base/tcp.spec.ts
@@ -1,7 +1,7 @@
 import { createServer, type Socket, type AddressInfo } from 'net'
 import { setTimeout } from 'timers/promises'
 
-import { SOCKET_CLOSE_TIMEOUT, TCPConnection } from './tcp.js'
+import { TCPConnection } from './tcp.js'
 import { once } from 'events'
 import { Multiaddr } from '@multiformats/multiaddr'
 import { u8aEquals, defer } from '@hoprnet/hopr-utils'
@@ -47,9 +47,9 @@ describe('test TCP connection', function () {
 
     conn.close()
 
-    await once(conn.conn as EventEmitter, 'close')
+    await once(conn.socket as EventEmitter, 'close')
 
-    assert(conn.conn.destroyed)
+    assert(conn.socket.destroyed)
 
     assert(
       conn.timeline.close != undefined &&
@@ -62,50 +62,73 @@ describe('test TCP connection', function () {
   })
 
   it('trigger a socket close timeout', async function () {
+    const SOCKET_CLOSE_TIMEOUT = 1000
+
     this.timeout(SOCKET_CLOSE_TIMEOUT + 2e3)
 
-    const testMessage = new TextEncoder().encode('test')
+    // test server with tweaked behavior
+    const testServer = createServer()
+    const testMessage = new TextEncoder().encode('test message')
 
-    const server = createServer()
-
-    server.on('close', console.log)
-    server.on('error', console.log)
     const sockets: Socket[] = []
-    server.on('connection', sockets.push.bind(sockets))
+    testServer.on('connection', (socket: Socket) => {
+      // Handle incoming data
+      socket.on('data', (data) => {
+        assert(u8aEquals(data, testMessage))
+      })
+      sockets.push(socket)
+    })
 
-    await waitUntilListening(server, undefined)
+    // make testServer listen at a random port
+    await waitUntilListening<Socket>(testServer, undefined as any)
 
     const conn = await TCPConnection.create(
-      new Multiaddr(`/ip4/127.0.0.1/tcp/${(server.address() as AddressInfo).port}`)
+      new Multiaddr(`/ip4/127.0.0.1/tcp/${(testServer.address() as AddressInfo).port}`),
+      {
+        closeTimeout: 1000
+      }
     )
 
-    await conn.sink(
+    conn.sink(
       (async function* () {
-        yield testMessage
+        while (true) {
+          yield testMessage
+          await setTimeout(10)
+        }
       })()
     )
 
-    const start = Date.now()
-    const closePromise = once(conn.conn, 'close')
-
-    // Overwrite end method to mimic half-open stream
-    Object.assign(conn.conn, {
-      end: () => {}
+    const destroy = conn.socket.destroy.bind(conn.socket)
+    Object.assign(conn.socket, {
+      destroy: () => {}
     })
+
+    const start = Date.now()
+    const closePromise = once(conn.socket, 'close')
 
     // @dev produces a half-open socket on the other side
     conn.close()
 
+    assert(conn.closed === true, `Connection must be marked closed`)
+
+    // Wait some time before restoring `destroy()` method
+    await setTimeout(SOCKET_CLOSE_TIMEOUT / 2)
+
+    Object.assign(conn.socket, {
+      destroy
+    })
+
+    // Now that `destroy()` method has been restored, await `close` event
     await closePromise
 
-    // Destroy half-open sockets.
+    // Destroy all sockets of testServer
     for (const socket of sockets) {
       socket.destroy()
     }
 
-    await stopNode(server)
+    await stopNode(testServer)
 
-    assert(Date.now() - start >= SOCKET_CLOSE_TIMEOUT)
+    assert(Date.now() - start >= SOCKET_CLOSE_TIMEOUT, `should not timeout earlier than configured timeout`)
 
     assert(
       conn.timeline.close != undefined &&
@@ -151,8 +174,7 @@ describe('test TCP connection', function () {
     const conn = await TCPConnection.create(
       new Multiaddr(`/ip4/127.0.0.1/tcp/${(server.address() as AddressInfo).port}`),
       {
-        signal: abort.signal,
-        upgrader: undefined as any
+        signal: abort.signal
       }
     )
 

--- a/packages/connect/src/base/tcp.ts
+++ b/packages/connect/src/base/tcp.ts
@@ -2,20 +2,26 @@ import net, { type Socket, type AddressInfo } from 'net'
 import { abortableSource } from 'abortable-iterator'
 import Debug from 'debug'
 import { nodeToMultiaddr, toU8aStream } from '../utils/index.js'
+// @ts-ignore untyped module
+import retimer from 'retimer'
 
 const log = Debug('hopr-connect:tcp')
 const error = Debug('hopr-connect:tcp:error')
 const verbose = Debug('hopr-connect:verbose:tcp')
 
-// Timeout to wait for socket close before destroying it
-export const SOCKET_CLOSE_TIMEOUT = 1000
+// Timeout to wait for socket close before manually destroying it
+const SOCKET_CLOSE_TIMEOUT = 2000
 
 import type { MultiaddrConnection } from '@libp2p/interface-connection'
 
 import type { Multiaddr } from '@multiformats/multiaddr'
 import toIterable from 'stream-to-it'
-import type { Stream, StreamSink, StreamSource, StreamSourceAsync } from '../types.js'
-import type { DialOptions } from '@libp2p/interface-transport'
+import type { Stream, StreamSource, StreamSourceAsync } from '../types.js'
+
+type SocketOptions = {
+  signal?: AbortSignal
+  closeTimeout?: number
+}
 
 /**
  * Class to encapsulate TCP sockets
@@ -23,51 +29,54 @@ import type { DialOptions } from '@libp2p/interface-transport'
 class TCPConnection implements MultiaddrConnection {
   public localAddr: Multiaddr
 
-  // @ts-ignore
-  public sink: StreamSink
   public source: StreamSourceAsync
   public closed: boolean
 
   private _signal?: AbortSignal
+
+  private closeTimeout: number
 
   public timeline: {
     open: number
     close?: number
   }
 
-  constructor(public remoteAddr: Multiaddr, public conn: Socket, options?: DialOptions) {
-    this.localAddr = nodeToMultiaddr(this.conn.address() as AddressInfo)
+  constructor(public remoteAddr: Multiaddr, public socket: Socket, options?: SocketOptions) {
+    this.localAddr = nodeToMultiaddr(this.socket.address() as AddressInfo)
 
     this.closed = false
+    this._signal = options?.signal
+    this.closeTimeout = options?.closeTimeout ?? SOCKET_CLOSE_TIMEOUT
+
     this.timeline = {
       open: Date.now()
     }
 
-    this.conn.once('close', () => {
+    this.socket.once('close', () => {
       // Whenever the socket gets closed, mark the
       // connection closed to cleanup data structures in
       // ConnectionManager
       this.timeline.close ??= Date.now()
     })
 
-    this._signal = options?.signal
+    this.source = this.createSource(this.socket)
 
-    this.source = this.createSource(this.conn) as AsyncIterable<Uint8Array>
-    this.sink = this._sink.bind(this)
+    // Sink is passed as a function, so we need to explicitly bind it
+    this.sink = this.sink.bind(this)
   }
 
   public close(): Promise<void> {
-    if (this.conn.destroyed || this.closed) {
+    if (this.socket.destroyed || this.closed) {
       return Promise.resolve()
     }
     this.closed = true
 
-    return new Promise<void>((resolve) => {
+    return new Promise<void>((resolve, reject) => {
       let done = false
 
       const start = Date.now()
 
-      setTimeout(() => {
+      const timer = retimer(() => {
         if (done) {
           return
         }
@@ -81,33 +90,54 @@ class TCPConnection implements MultiaddrConnection {
           Date.now() - start
         )
 
-        if (this.conn.destroyed) {
+        if (this.socket.destroyed) {
           log('%s:%s is already destroyed', cOptions.host, cOptions.port)
         } else {
           log(`destroying connection ${cOptions.host}:${cOptions.port}`)
-          this.conn.destroy()
+          this.socket.destroy()
         }
-      }, SOCKET_CLOSE_TIMEOUT)
+      }, this.closeTimeout)
 
       // Resolve once closed
       // Could take place after timeout or as a result of `.end()` call
-      this.conn.once('close', () => {
+      this.socket.once('close', () => {
         if (done) {
           return
         }
         done = true
+        timer.clear()
 
         resolve()
       })
 
-      try {
-        this.conn.end(() => {
-          this.timeline.close ??= Date.now()
+      this.socket.once('error', (err: Error) => {
+        log('socket error', err)
+
+        // error closing socket
+        this.timeline.close ??= Date.now()
+
+        if (this.socket.destroyed) {
           done = true
+          timer.clear()
+        }
+
+        reject(err)
+      })
+
+      // Send the FIN packet
+      this.socket.end()
+
+      if (this.socket.writableLength > 0) {
+        // there are outgoing bytes waiting to be sent
+        this.socket.once('drain', () => {
+          log('socket drained')
+
+          // all bytes have been sent we can destroy the socket (maybe) before the timeout
+          this.socket.destroy()
         })
-      } catch (err) {
-        // Anything can happen
-        this.conn.destroy()
+      } else {
+        // nothing to send, destroy immediately
+        this.socket.destroy()
       }
     })
   }
@@ -122,12 +152,12 @@ class TCPConnection implements MultiaddrConnection {
     }
   }
 
-  private async _sink(source: StreamSource): Promise<void> {
+  public async sink(source: StreamSource): Promise<void> {
     const u8aStream = toU8aStream(source)
 
     let iterableSink: Stream['sink']
     try {
-      iterableSink = toIterable.sink<Uint8Array>(this.conn)
+      iterableSink = toIterable.sink<Uint8Array>(this.socket)
 
       try {
         await iterableSink(
@@ -146,15 +176,19 @@ class TCPConnection implements MultiaddrConnection {
       error(`TCP sink error`, err)
       return
     }
+
+    // End the socket (= send FIN packet) unless otherwise requested
+    this.socket.end()
   }
 
   /**
-   * @param ma
-   * @param self
+   * Tries to establish a TCP connection to the given address.
+   *
+   * @param ma Multiaddr to connect to
    * @param options
-   * @returns Resolves a TCP Socket
+   * @returns Resolves to a TCP Socket, if successful
    */
-  public static create(ma: Multiaddr, options?: DialOptions): Promise<TCPConnection> {
+  public static create(ma: Multiaddr, options?: SocketOptions): Promise<TCPConnection> {
     return new Promise<TCPConnection>((resolve, reject) => {
       const start = Date.now()
       const cOpts = ma.toOptions()

--- a/packages/connect/src/relay/state.ts
+++ b/packages/connect/src/relay/state.ts
@@ -99,13 +99,26 @@ class RelayState {
   }
 
   /**
+   * Returns an iterator over all stored relayed connections
+   */
+  *[Symbol.iterator]() {
+    const it = this.relayedConnections.values()
+
+    let chunk = it.next()
+
+    for (; !chunk.done; chunk = it.next()) {
+      yield* Object.entries(chunk.value)
+    }
+  }
+
+  /**
    * Performs an operation for each relay context in the current set.
    * @param action
    */
   async forEach(action: (dst: string, ctx: RelayContext) => Promise<void>) {
     await nAtATime(
-      (objEntries) => action(objEntries[0], objEntries[1]),
-      Array.from(this.relayedConnections.values()).map((s) => Object.entries(s)),
+      action,
+      this,
       10 // TODO: Make this configurable or use an existing constant
     )
   }

--- a/packages/connect/src/webrtc/connection.ts
+++ b/packages/connect/src/webrtc/connection.ts
@@ -134,7 +134,7 @@ class WebRTCConnection implements MultiaddrConnection {
   // @dev this is done using meta programming in libp2p
   public timeline: MultiaddrConnection['timeline']
 
-  private webRTCTimeout: any // untyped library
+  private webRTCTimeout: any | undefined // untyped library
 
   constructor(
     private relayConn: RelayConnection,
@@ -272,7 +272,7 @@ class WebRTCConnection implements MultiaddrConnection {
       // Already handled, so nothing to do
       return
     }
-    this.webRTCTimeout.clear()
+    this.webRTCTimeout?.clear()
     this._webRTCHandshakeFinished = true
 
     if (err) {
@@ -298,7 +298,7 @@ class WebRTCConnection implements MultiaddrConnection {
       // Already handled, so nothing to do
       return
     }
-    this.webRTCTimeout.clear()
+    this.webRTCTimeout?.clear()
     this._webRTCHandshakeFinished = true
 
     // For testing, disable WebRTC upgrade

--- a/packages/connect/src/webrtc/connection.ts
+++ b/packages/connect/src/webrtc/connection.ts
@@ -9,7 +9,6 @@ import { randomBytes } from 'crypto'
 import { toU8aStream, encodeWithLengthPrefix, decodeWithLengthPrefix, eagerIterator } from '../utils/index.js'
 import { abortableSource } from 'abortable-iterator'
 import {
-  type StreamSink,
   type StreamResult,
   type StreamType,
   type StreamSource,
@@ -19,6 +18,9 @@ import {
 } from '../types.js'
 import assert from 'assert'
 import type { DialOptions } from '@libp2p/interface-transport'
+
+// @ts-ignore untyped library
+import retimer from 'retimer'
 
 const DEBUG_PREFIX = `hopr-connect`
 
@@ -116,7 +118,6 @@ class WebRTCConnection implements MultiaddrConnection {
   private sinkCreator: Promise<void>
 
   // Endpoint for libp2p
-  public sink: StreamSink
   public source: StreamSourceAsync
 
   // Underlying connection. Always points the connection that
@@ -132,6 +133,8 @@ class WebRTCConnection implements MultiaddrConnection {
   // Set magic *close* property to end connection
   // @dev this is done using meta programming in libp2p
   public timeline: MultiaddrConnection['timeline']
+
+  private webRTCTimeout: any // untyped library
 
   constructor(
     private relayConn: RelayConnection,
@@ -149,7 +152,7 @@ class WebRTCConnection implements MultiaddrConnection {
     this._sourceMigrated = false
     this._sinkMigrated = false
 
-    this.remoteAddr = this.conn.remoteAddr
+    this.remoteAddr = this.relayConn.remoteAddr
 
     this.timeline = {
       open: Date.now()
@@ -173,6 +176,11 @@ class WebRTCConnection implements MultiaddrConnection {
       this.onWebRTCConnect.bind(this)
     )
 
+    this.relayConn.state.channel?.once('close', () => {
+      this.destroyed = true
+      this.timeline.close ??= Date.now()
+    })
+
     // Attach a listener to WebRTC to cleanup state
     // and remove stale connection from internal libp2p state
     // once there is a disconnect, set magic *close* property in
@@ -180,7 +188,7 @@ class WebRTCConnection implements MultiaddrConnection {
     this.relayConn.state.channel?.on('iceStateChange', (iceConnectionState: string, iceGatheringState: string) => {
       if (iceConnectionState === 'disconnected' && iceGatheringState === 'complete') {
         this.destroyed = true
-        this.timeline.close = this.timeline.close ?? Date.now()
+        this.timeline.close ??= Date.now()
       }
     })
 
@@ -193,7 +201,7 @@ class WebRTCConnection implements MultiaddrConnection {
 
     // Sink is passed as function handle, so we need to explicitly bind
     // an environment to it.
-    this.sink = this._sink.bind(this)
+    this.sink = this.sink.bind(this)
   }
 
   /**
@@ -203,8 +211,8 @@ class WebRTCConnection implements MultiaddrConnection {
    * @param source stream with messages to be sent to counterparty
    * @returns
    */
-  public _sink(source: StreamSource) {
-    setTimeout(this.onWebRTCError.bind(this), WEBRTC_UPGRADE_TIMEOUT).unref()
+  public sink(source: StreamSource) {
+    this.webRTCTimeout = retimer(this.onWebRTCError.bind(this), WEBRTC_UPGRADE_TIMEOUT)
 
     let deferred = defer<void>()
     this.sinkCreator.catch(deferred.reject)
@@ -264,6 +272,7 @@ class WebRTCConnection implements MultiaddrConnection {
       // Already handled, so nothing to do
       return
     }
+    this.webRTCTimeout.clear()
     this._webRTCHandshakeFinished = true
 
     if (err) {
@@ -289,6 +298,7 @@ class WebRTCConnection implements MultiaddrConnection {
       // Already handled, so nothing to do
       return
     }
+    this.webRTCTimeout.clear()
     this._webRTCHandshakeFinished = true
 
     // For testing, disable WebRTC upgrade
@@ -442,72 +452,82 @@ class WebRTCConnection implements MultiaddrConnection {
           // Update state object once source *and* sink are migrated
           this.conn = this.relayConn.state.channel as SimplePeer
           if (!this.tags.includes(PeerConnectionType.WEBRTC_DIRECT)) {
-            this.tags = [PeerConnectionType.WEBRTC_DIRECT]
+            this.tags.push(PeerConnectionType.WEBRTC_DIRECT)
           }
         }
-        await toIterable.sink(this.relayConn.state.channel as SimplePeer)(
-          async function* (this: WebRTCConnection): StreamSource {
-            let webRTCresult: PayloadEvent | SinkSourceAttachedEvent
-            let toYield: Uint8Array | undefined
-            let leave = false
+        try {
+          await toIterable.sink(this.relayConn.state.channel as SimplePeer)(
+            async function* (this: WebRTCConnection): StreamSource {
+              let webRTCresult: PayloadEvent | SinkSourceAttachedEvent
+              let toYield: Uint8Array | undefined
+              let leave = false
 
-            while (!leave) {
-              // If no source attached, wait until there is one,
-              // otherwise wait for messages
-              if (source == undefined) {
-                webRTCresult = await this._sinkSourceAttachedPromise.promise
-              } else {
-                if (sourcePromise == undefined) {
-                  advanceIterator()
-                }
-                webRTCresult = await (sourcePromise as Promise<PayloadEvent>)
-              }
-
-              switch (webRTCresult.type) {
-                case ConnectionEventTypes.SINK_SOURCE_ATTACHED:
-                  // Libp2p has started to send messages through this connection,
-                  // so forward these messages
-                  // @dev this can happen *before* or *after* WebRTC upgrade -
-                  //      or never!
-                  source = webRTCresult.value[Symbol.asyncIterator]()
-                  break
-                case ConnectionEventTypes.PAYLOAD:
-                  const received = webRTCresult.value
-
-                  // Anything can happen
-                  if (received.done || this.destroyed || this.relayConn.state.channel?.destroyed) {
-                    leave = true
-
-                    // WebRTC uses UDP, so we need to explicitly end the connection
-                    toYield = encodeWithLengthPrefix(Uint8Array.of(MigrationStatus.DONE))
-                    break
+              while (!leave) {
+                // If no source attached, wait until there is one,
+                // otherwise wait for messages
+                if (source == undefined) {
+                  webRTCresult = await this._sinkSourceAttachedPromise.promise
+                } else {
+                  if (sourcePromise == undefined) {
+                    advanceIterator()
                   }
+                  webRTCresult = await (sourcePromise as Promise<PayloadEvent>)
+                }
 
-                  // this.log(
-                  //   `sinking ${received.value.slice().length} bytes into webrtc[${
-                  //     (this.relayConn.state.channel as any)._id
-                  //   }]`
-                  // )
+                switch (webRTCresult.type) {
+                  case ConnectionEventTypes.SINK_SOURCE_ATTACHED:
+                    // Libp2p has started to send messages through this connection,
+                    // so forward these messages
+                    // @dev this can happen *before* or *after* WebRTC upgrade -
+                    //      or never!
+                    source = webRTCresult.value[Symbol.asyncIterator]()
+                    break
+                  case ConnectionEventTypes.PAYLOAD:
+                    const received = webRTCresult.value
 
-                  // WebRTC tends to send multiple messages in one chunk, so add a
-                  // length prefix to split messages when receiving them
-                  toYield = encodeWithLengthPrefix(
-                    Uint8Array.from([MigrationStatus.NOT_DONE, ...received.value.subarray()])
-                  )
+                    // Anything can happen
+                    if (received.done || this.destroyed || this.relayConn.state.channel?.destroyed) {
+                      leave = true
 
-                  advanceIterator()
+                      // WebRTC uses UDP, so we need to explicitly end the connection
+                      toYield = encodeWithLengthPrefix(Uint8Array.of(MigrationStatus.DONE))
+                      break
+                    }
 
-                  break
-                default:
-                  throw Error(`Received invalid result. Got ${JSON.stringify(result)}`)
+                    // this.log(
+                    //   `sinking ${received.value.slice().length} bytes into webrtc[${
+                    //     (this.relayConn.state.channel as any)._id
+                    //   }]`
+                    // )
+
+                    // WebRTC tends to send multiple messages in one chunk, so add a
+                    // length prefix to split messages when receiving them
+                    toYield = encodeWithLengthPrefix(
+                      Uint8Array.from([MigrationStatus.NOT_DONE, ...received.value.subarray()])
+                    )
+
+                    advanceIterator()
+
+                    break
+                  default:
+                    throw Error(`Received invalid result. Got ${JSON.stringify(result)}`)
+                }
+
+                if (toYield != undefined) {
+                  yield toYield
+                }
               }
+            }.call(this)
+          )
 
-              if (toYield != undefined) {
-                yield toYield
-              }
-            }
-          }.call(this)
-        )
+          // End the stream
+          this.relayConn.state.channel?.end()
+        } catch (err) {
+          this.error(`WebRTC sink err`, err)
+          // Initiates Connection object teardown
+          // by using meta programming
+          this.timeline.close ??= Date.now()
+        }
     }
   }
 
@@ -566,11 +586,13 @@ class WebRTCConnection implements MultiaddrConnection {
           // Update state object once sink *and* source are migrated
           this.conn = this.relayConn.state.channel as SimplePeer
           if (!this.tags.includes(PeerConnectionType.WEBRTC_DIRECT)) {
-            this.tags = [PeerConnectionType.WEBRTC_DIRECT]
+            this.tags.push(PeerConnectionType.WEBRTC_DIRECT)
           }
         }
 
-        this.log(`webRTC source handover done. Using direct connection to peer ${this.remoteAddr.getPeerId()}`)
+        this.log(
+          `webRTC source handover done. Using direct connection to peer ${this.relayConn._counterparty.toString()}`
+        )
 
         let done = false
         for await (const msg of this.relayConn.state.channel as SimplePeer) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -72,8 +72,8 @@
     "memdown": "6.1.1",
     "mocha": "9.2.2",
     "nyc": "15.1.0",
-    "sinon": "12.0.1",
     "retimer": "3.0.0",
+    "sinon": "12.0.1",
     "typedoc": "0.23.2",
     "typedoc-plugin-markdown": "3.13.1",
     "typescript": "4.7.4"

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -73,6 +73,7 @@
     "mocha": "9.2.2",
     "nyc": "15.1.0",
     "sinon": "12.0.1",
+    "retimer": "3.0.0",
     "typedoc": "0.23.2",
     "typedoc-plugin-markdown": "3.13.1",
     "typescript": "4.7.4"

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -11,7 +11,6 @@ export const VERSION = pickVersion(pkg.version)
 
 // The timeout must include the time necessary to traverse
 // NATs which might include several round trips
-export const HEARTBEAT_TIMEOUT = 30000
 export const HEARTBEAT_INTERVAL = 60000
 export const HEARTBEAT_THRESHOLD = 60000
 export const HEARTBEAT_INTERVAL_VARIANCE = 2000

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -493,7 +493,7 @@ class Hopr extends EventEmitter {
    * Total hack
    */
   private startMemoryFreeInterval() {
-    retimer(this.freeMemory.bind(this), () => durations.minutes(1))
+    intervalTimer(this.freeMemory.bind(this), () => durations.minutes(1))
   }
 
   private async maybeLogProfilingToGCloud() {

--- a/packages/core/src/network/heartbeat.spec.ts
+++ b/packages/core/src/network/heartbeat.spec.ts
@@ -33,8 +33,6 @@ const TESTING_ENVIRONMENT = 'unit-testing'
 
 // Overwrite default timeouts with shorter ones for unit testing
 const SHORT_TIMEOUTS: Partial<HeartbeatConfig> = {
-  heartbeatDialTimeout: 50,
-  heartbeatRunTimeout: 100,
   heartbeatInterval: 200,
   heartbeatVariance: 1,
   networkQualityThreshold: 0.5
@@ -162,7 +160,7 @@ async function getPeer(
   return { heartbeat, peers }
 }
 
-describe.only('unit test heartbeat', async () => {
+describe('unit test heartbeat', async () => {
   it('check nodes is noop with empty store & health indicator is red', async () => {
     let netHealth = new NetworkHealth()
     const heartbeat = new TestingHeartbeat(

--- a/packages/hoprd/package.json
+++ b/packages/hoprd/package.json
@@ -59,7 +59,6 @@
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "rlp": "3.0.0",
-    "run-queue": "2.0.1",
     "semver": "7.3.7",
     "swagger-ui-express": "4.3.0",
     "tiny-hashes": "1.0.1",

--- a/packages/hoprd/src/admin.ts
+++ b/packages/hoprd/src/admin.ts
@@ -14,7 +14,8 @@ import {
   SUGGESTED_BALANCE,
   SUGGESTED_NATIVE_BALANCE,
   debug,
-  startResourceUsageLogger
+  startResourceUsageLogger,
+  retimer
 } from '@hoprnet/hopr-utils'
 import type { WebSocket } from 'ws'
 
@@ -156,8 +157,16 @@ export function showDisclaimer(logs: LogStream) {
 }
 
 export async function startConnectionReports(node: Hopr, logs: LogStream) {
-  logs.logConnectedPeers(node.getConnectedPeers().map((p) => p.toString()))
-  setInterval(() => {
-    logs.logConnectedPeers(node.getConnectedPeers().map((p) => p.toString()))
-  }, 60 * 1000)
+  const printConnectedPeers = () => {
+    const peers = node.getConnectedPeers()
+    logs.logConnectedPeers(
+      (function* () {
+        for (const peerId of peers) {
+          yield peerId.toString()
+        }
+      })()
+    )
+  }
+
+  retimer(printConnectedPeers, () => 60 * 1000)
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hoprnet/hopr-utils",
   "description": "HOPR-based utilities to process multiple data structures",
-  "version": "1.90.33",
+  "version": "1.90.39",
   "repository": "https://github.com/hoprnet/hoprnet.git",
   "homepage": "https://hoprnet.org",
   "license": "GPL-3.0",
@@ -31,7 +31,7 @@
     "@libp2p/crypto": "1.0.0",
     "@libp2p/peer-id": "1.1.13",
     "@multiformats/multiaddr": "10.3.3",
-    "abort-controller": "~3.0.0",
+    "abortable-iterator": "4.0.2",
     "bignumber.js": "9.0.2",
     "bn.js": "5.2.0",
     "chalk": "5.0.1",
@@ -45,7 +45,8 @@
     "levelup": "5.1.1",
     "memdown": "6.1.1",
     "multiformats": "9.6.5",
-    "secp256k1": "4.0.3"
+    "secp256k1": "4.0.3",
+    "timeout-abort-controller": "3.0.0"
   },
   "devDependencies": {
     "@chainsafe/libp2p-noise": "7.0.0",

--- a/packages/utils/src/async/timeout.spec.ts
+++ b/packages/utils/src/async/timeout.spec.ts
@@ -8,7 +8,7 @@ describe('testing timeoutAfter', () => {
   })
 
   it('reject with timeout', async () => {
-    await assert.rejects(async () => await timeout(100, () => new Promise<void>(() => {})))
+    await assert.rejects(async () => await timeout(100, () => new Promise<void>(() => {})), Error('Timeout'))
   })
 
   it('reject asynchronously', async () => {
@@ -20,7 +20,8 @@ describe('testing timeoutAfter', () => {
             new Promise((_, reject) => {
               setTimeout(reject, 50)
             })
-        )
+        ),
+      undefined
     )
   })
 
@@ -28,8 +29,9 @@ describe('testing timeoutAfter', () => {
     await assert.rejects(
       async () =>
         await timeout(100, () => {
-          throw Error()
-        })
+          throw Error('internal error')
+        }),
+      Error(`internal error`)
     )
   })
 })

--- a/packages/utils/src/async/timeout.ts
+++ b/packages/utils/src/async/timeout.ts
@@ -1,10 +1,13 @@
+// @ts-ignore untyped library
+import retimer from 'retimer'
+
 /**
  * Races a timeout against some work
- * @param timeout return after timeout in ms
+ * @param ms return after timeout in ms
  * @param work function that returns a Promise that resolves once the work is done
  * @returns a Promise that resolves once the timeout is due or the work is done
  */
-export function timeout<T>(timeout: number, work: () => Promise<T>): Promise<T> {
+export function timeout<T>(ms: number, work: () => Promise<T>): Promise<T> {
   let resolve: any
   let reject: any
 
@@ -15,11 +18,14 @@ export function timeout<T>(timeout: number, work: () => Promise<T>): Promise<T> 
     reject = rej
   })
 
+  let timeout: any // untyped library
+
   const onReject = (err?: any) => {
     if (done) {
       return
     }
     done = true
+    timeout.clear()
 
     reject(err)
   }
@@ -29,11 +35,12 @@ export function timeout<T>(timeout: number, work: () => Promise<T>): Promise<T> 
       return
     }
     done = true
+    timeout.clear()
 
     resolve(res)
   }
 
-  setTimeout(onReject, timeout)
+  timeout = retimer(onReject, ms, Error('Timeout'))
 
   try {
     work().then(onResolve, onReject)

--- a/packages/utils/src/libp2p/dialHelper.spec.ts
+++ b/packages/utils/src/libp2p/dialHelper.spec.ts
@@ -48,8 +48,6 @@ class MyTCP extends TCP {
           continue
         }
 
-        console.log(conn)
-
         if (conn != undefined) {
           return conn
         }

--- a/packages/utils/src/libp2p/dialHelper.spec.ts
+++ b/packages/utils/src/libp2p/dialHelper.spec.ts
@@ -1,13 +1,15 @@
 import { Noise } from '@chainsafe/libp2p-noise'
 import { Mplex } from '@libp2p/mplex'
 import { createLibp2p, type Libp2p } from 'libp2p'
-import { TCP } from '@libp2p/tcp'
 import { KadDHT } from '@libp2p/kad-dht'
 import { Multiaddr } from '@multiformats/multiaddr'
+import { TCP } from '@libp2p/tcp'
+import type { DialOptions } from '@libp2p/interfaces/transport'
 import type { Address, AddressBook, PeerStore } from '@libp2p/interface-peer-store'
 import type { Connection } from '@libp2p/interface-connection'
-import { isPeerId, type PeerId } from '@libp2p/interface-peer-id'
+import type { PeerId } from '@libp2p/interface-peer-id'
 import type { ConnectionManager } from '@libp2p/interface-connection-manager'
+import type { Components } from '@libp2p/interfaces/components'
 
 import assert from 'assert'
 import { pipe } from 'it-pipe'
@@ -24,13 +26,49 @@ const Alice = privKeyToPeerId(stringToU8a('0xcf0b158c5f9d83dabf81a43391cce6cced6
 const Bob = privKeyToPeerId(stringToU8a('0x801f499e287fa0e5ac546a86d7f1e3ca766249f62759e6a1f2c90de6090cc4c0'))
 const Chris = privKeyToPeerId(stringToU8a('0x1bbb9a915ddd6e19d0f533da6c0fbe8820541a370110728f647829cd2c91bc79'))
 
-async function getNode(id: PeerId, withDht = false, maDestination?: Multiaddr): Promise<Libp2p> {
+/**
+ * Annotates libp2p's TCP module to work similarly as `hopr-connect`
+ * by using an oracle that knows how to connect to hidden nodes
+ */
+class MyTCP extends TCP {
+  constructor(private oracle?: Map<string, Components>) {
+    super()
+  }
+
+  async dial(ma: Multiaddr, options: DialOptions): Promise<Connection> {
+    if (ma.toString().startsWith('/ip4')) {
+      return super.dial(ma, options)
+    } else if (this.oracle != undefined) {
+      const destination = ma.getPeerId() as string
+      for (const address of this.oracle.get(destination.toString())?.getTransportManager().getAddrs()) {
+        let conn: Connection
+        try {
+          conn = await super.dial(address, options)
+        } catch (err) {
+          continue
+        }
+
+        console.log(conn)
+
+        if (conn != undefined) {
+          return conn
+        }
+      }
+    }
+  }
+
+  filter(multiaddrs: Multiaddr[]): Multiaddr[] {
+    return multiaddrs
+  }
+}
+
+async function getNode(id: PeerId, withDht = false, oracle?: Map<string, Components>): Promise<Libp2p> {
   const node = await createLibp2p({
     addresses: {
       listen: [new Multiaddr(`/ip4/0.0.0.0/tcp/0/p2p/${id.toString()}`).toString()]
     },
     peerId: id,
-    transports: [new TCP()],
+    transports: [new MyTCP(oracle)],
     streamMuxers: [new Mplex()],
     connectionEncryption: [new Noise()],
     dht: withDht ? new KadDHT({ protocolPrefix: '/hopr', clientMode: false }) : undefined,
@@ -51,16 +89,7 @@ async function getNode(id: PeerId, withDht = false, maDestination?: Multiaddr): 
     }
   })
 
-  const dial = node.dial.bind(node)
-
-  // libp2p type clash
-  node.dial = (async (peer: PeerId | Multiaddr, options: any) => {
-    if (isPeerId(peer)) {
-      return dial(peer, options)
-    }
-    return dial(maDestination, options)
-  }) as any
-
+  // Loopback
   node.handle([TEST_PROTOCOL], async ({ stream }) => {
     await pipe(stream.source, stream.sink)
   })
@@ -152,7 +181,7 @@ describe('test dialHelper', function () {
     // components not part of interface
     const result = await dialHelper((peerA as any).components, Bob, [TEST_PROTOCOL])
 
-    assert(result.status === DialStatus.DHT_ERROR, `Must return dht error`)
+    assert(result.status === DialStatus.DIAL_ERROR, `Must return dht error`)
 
     // Shutdown node
     await peerA.stop()
@@ -161,12 +190,16 @@ describe('test dialHelper', function () {
   it('regular dial with DHT', async function () {
     this.timeout(5e3)
 
+    const oracle = new Map<string, Components>()
+
     const peerB = await getNode(Bob, true)
     const peerC = await getNode(Chris, true)
 
     // Secretly tell peerA the address of peerC
     // libp2p type clash
-    const peerA = await getNode(Alice, true, peerC.getMultiaddrs()[0] as any)
+    const peerA = await getNode(Alice, true, oracle)
+
+    oracle.set(Chris.toString(), (peerC as any).components)
 
     await peerB.peerStore.addressBook.add(peerA.peerId, peerA.getMultiaddrs())
     await peerA.peerStore.addressBook.add(peerB.peerId, peerB.getMultiaddrs())
@@ -225,7 +258,7 @@ describe('test dialHelper', function () {
 
     // Must fail with a DHT error because we obviously can't find
     // Bob's relay address in the DHT
-    assert(result.status === DialStatus.DHT_ERROR)
+    assert(result.status === DialStatus.DIAL_ERROR)
   })
 
   it('DHT throws an error', async function () {
@@ -250,6 +283,6 @@ describe('test dialHelper', function () {
 
     const result = await dialHelper(peerAComponents as any, Bob, [TEST_PROTOCOL])
 
-    assert(result.status === DialStatus.DHT_ERROR)
+    assert(result.status === DialStatus.DIAL_ERROR)
   })
 })

--- a/packages/utils/src/libp2p/dialHelper.ts
+++ b/packages/utils/src/libp2p/dialHelper.ts
@@ -1,16 +1,20 @@
 /*
  * Add a more usable API on top of LibP2P
  */
-import type { PeerId } from '@libp2p/interface-peer-id'
+import { type PeerId, isPeerId } from '@libp2p/interface-peer-id'
 import type { Connection, ProtocolStream } from '@libp2p/interface-connection'
+import type { ConnectionManager, Dialer } from '@libp2p/interface-connection-manager'
 import type { Components } from '@libp2p/interfaces/components'
 import { type Multiaddr, protocols as maProtocols } from '@multiformats/multiaddr'
 
-import { timeout, abortableTimeout, type TimeoutOpts } from '../async/index.js'
+import { type TimeoutOpts } from '../async/index.js'
 
 import { debug } from '../process/index.js'
 import { createRelayerKey } from './relayCode.js'
 import { createCircuitAddress } from '../network/index.js'
+import { peerIdFromString } from '@libp2p/peer-id'
+
+import { TimeoutController } from 'timeout-abort-controller'
 
 const DEBUG_PREFIX = `hopr-core:libp2p`
 
@@ -20,6 +24,9 @@ const log = debug(DEBUG_PREFIX)
 const error = debug(DEBUG_PREFIX.concat(`:error`))
 
 const DEFAULT_DHT_QUERY_TIMEOUT = 20000
+
+// Current types do not expose `dialer` property
+type MyConnectionManager = ConnectionManager & { dialer: Dialer }
 
 export enum DialStatus {
   SUCCESS = 'SUCCESS',
@@ -55,17 +62,40 @@ export type DialResponse =
       status: DialStatus.NO_DHT
     }
 
-async function printPeerStoreAddresses(msg: string, destination: PeerId, components: Components): Promise<void> {
-  error(msg)
-  error(`Known addresses:`)
+async function printPeerStoreAddresses(prefix: string, destination: PeerId, components: Components): Promise<string> {
+  const SUFFIX = 'Known addresses:\n'
+
+  let out = `${prefix}\n${SUFFIX}`
 
   for (const address of await components.getPeerStore().addressBook.get(destination)) {
-    error(address.multiaddr.toString())
+    if (out.length > prefix.length + 1 + SUFFIX.length) {
+      out += '  \n'
+    }
+    out += `  ${address.multiaddr.toString()}`
   }
+
+  if (out.length == prefix.length + 1 + SUFFIX.length) {
+    out += `  No addresses known for peer ${destination.toString()}`
+  }
+
+  return out
 }
 
-const PROTOCOL_SELECT_TIMEOUT = 10e3
+// Timeout protocol selection to prevent from irresponsive nodes
+const PROTOCOL_SELECTION_TIMEOUT = 10e3
 
+/**
+ * Tries to use existing connection to connect to the given peer.
+ * Closes all connection that could not be used to speak the desired
+ * protocols.
+ * @dev if used with unsupported protocol, this function might close
+ * connections unintendedly
+ *
+ * @param components libp2p components
+ * @param destination peer to connect to
+ * @param protocols desired protocol
+ * @returns
+ */
 export async function tryExistingConnections(
   components: Components,
   destination: PeerId,
@@ -88,9 +118,19 @@ export async function tryExistingConnections(
   const deadConnections: Connection[] = []
 
   for (const existingConnection of existingConnections) {
+    let timeoutController = new TimeoutController(PROTOCOL_SELECTION_TIMEOUT)
+
+    const options = {
+      signal: timeoutController.signal
+    }
+
     try {
-      stream = await timeout(PROTOCOL_SELECT_TIMEOUT, () => existingConnection.newStream(protocols))
-    } catch (err) {}
+      stream = await existingConnection.newStream(protocols, options)
+    } catch (err: any) {
+      error(`Could not open stream to ${destination.toString()} due to "${err?.message}".`)
+    } finally {
+      timeoutController.clear()
+    }
 
     if (stream == undefined) {
       deadConnections.push(existingConnection)
@@ -107,14 +147,17 @@ export async function tryExistingConnections(
     )
   }
 
-  for (const deadConnection of deadConnections) {
-    // @fixme does that work?
-    try {
-      await deadConnection.close()
-    } catch (err) {
-      error(`Error while closing dead connection`, err)
+  // Close dead connections later
+  ;(async function () {
+    for (const deadConnection of deadConnections) {
+      // @fixme does that work?
+      try {
+        await deadConnection.close()
+      } catch (err) {
+        error(`Error while closing dead connection`, err)
+      }
     }
-  }
+  })()
 
   if (stream != undefined && conn != undefined) {
     return { conn, ...stream }
@@ -123,68 +166,69 @@ export async function tryExistingConnections(
 
 /**
  * Performs a dial attempt and handles possible errors.
+ * Uses global connection timeout as defined in libp2p constructor call
+ * (see ConnectionManager config)
+ *
  * @param components Libp2p components
  * @param destination which peer to dial
- * @param protocols which protocols to use
- * @param opts timeout options
+ * @param protocols which protocol to use
  */
 async function establishNewConnection(
   components: Components,
-  destination: PeerId | Multiaddr,
+  destination: PeerId,
   protocols: string | string[],
-  opts: {
-    signal: AbortSignal
-  }
-) {
-  const start = Date.now()
-
-  let aborted = false
-
-  const onAbort = () => {
-    aborted = true
-  }
-
-  opts.signal?.addEventListener('abort', onAbort)
-
+  noRelay: boolean = false
+): Promise<
+  | void
+  | (ProtocolStream & {
+      conn: Connection
+    })
+> {
   log(`Trying to establish connection to ${destination.toString()}`)
 
   let conn: Connection | undefined
   try {
-    // @ts-ignore Dialer is not yet part of interface
-    conn = await components.getConnectionManager().dialer.dial(destination, opts)
-  } catch (err) {
+    conn = (await (components.getConnectionManager() as unknown as MyConnectionManager).dialer.dial(destination, {
+      // @ts-ignore extension to libp2p's DialOptions
+      noRelay
+    })) as any as Connection
+  } catch (err: any) {
     error(`Error while establishing connection to ${destination.toString()}.`)
-    if (err?.message) {
+    if (err?.message && (err?.code == undefined || err?.code !== 'ERR_NO_VALID_ADDRESSES')) {
       error(`Dial error:`, err)
     }
   }
 
   if (!conn) {
-    // Do not forget to remove event listener, to prevent leakage
-    opts.signal?.removeEventListener('abort', onAbort)
     return
   }
 
   log(`Connection ${destination.toString()} established !`)
 
-  const stream: ProtocolStream | undefined = await timeout(10000, () => (conn as Connection).newStream(protocols))
+  const timeoutController = new TimeoutController(PROTOCOL_SELECTION_TIMEOUT)
 
-  opts.signal?.removeEventListener('abort', onAbort)
+  const options = {
+    signal: timeoutController.signal
+  }
 
-  // Libp2p's return types tend to change every now and then
-  if (stream && stream != null && aborted) {
-    log(`ending obsolete write stream after ${Date.now() - start} ms`)
+  let stream: ProtocolStream | undefined
+  let errThrown = false
+  try {
+    // Timeout protocol selection to prevent from irresponsive nodes
+    stream = await conn.newStream(protocols, options)
+  } catch (err) {
+    error(`error while trying to establish protocol ${protocols} with ${destination.toString()}`, err)
+    errThrown = true
+  } finally {
+    timeoutController.clear()
+  }
+
+  if (stream == undefined || errThrown) {
     try {
-      stream.stream
-        .sink((async function* () {})())
-        .catch((err: any) => error(`Error while ending obsolete write stream`, err))
+      await conn.close()
     } catch (err) {
       error(`Error while ending obsolete write stream`, err)
     }
-    return
-  }
-
-  if (!stream) {
     return
   }
 
@@ -199,91 +243,73 @@ async function establishNewConnection(
  * @param components Libp2p components
  * @param destination which peer to look for
  */
-async function queryDHT(components: Components, destination: PeerId): Promise<PeerId[]> {
-  const relayers: PeerId[] = []
-
+async function* queryDHT(components: Components, destination: PeerId): AsyncIterable<PeerId> {
   const key = createRelayerKey(destination)
   log(`fetching relay keys for node ${destination.toString()} from DHT.`, key)
 
-  const abort = new AbortController()
+  const timeoutController = new TimeoutController(DEFAULT_DHT_QUERY_TIMEOUT)
 
-  let done = false
+  const options = {
+    signal: timeoutController.signal
+  }
 
-  setTimeout(() => {
-    if (done) {
-      return
-    }
-    done = true
-
-    abort.abort()
-  }, DEFAULT_DHT_QUERY_TIMEOUT).unref()
   try {
-    // libp2p type clash
-    for await (const relayer of components.getContentRouting().findProviders(key as any, { signal: abort.signal })) {
-      relayers.push(relayer.id)
+    for await (const dhtResult of components.getContentRouting().findProviders(key as any, options)) {
+      yield dhtResult.id
     }
-    done = true
   } catch (err) {
-    done = true
     error(`Error while querying the DHT for ${destination.toString()}.`)
     if (err?.message) {
       error(`DHT error: ${err.message}`)
     }
   }
-
-  if (relayers.length > 0) {
-    log(`found ${relayers.map((relayer) => relayer.toString()).join(' ,')} for node ${destination.toString()}.`)
-  } else {
-    log(`could not find any relayer for ${destination.toString()}`)
-  }
-
-  return relayers
+  timeoutController.clear()
 }
 
-/**
- * Runs through the dial strategy and handles possible errors
- *
- * 1. Use already known addresses
- * 2. Check the DHT (if available) for additional addresses
- * 3. Try new addresses
- *
- * @param components components of libp2p instance
- * @param destination which peer to connect to
- * @param protocols which protocols to use
- * @param opts timeout options
- * @returns
- */
-async function doDial(
+async function doDirectDial(
   components: Components,
-  destination: PeerId,
+  id: PeerId,
   protocols: string | string[],
-  opts: Required<TimeoutOpts>
+  noRelay: boolean = false
 ): Promise<DialResponse> {
   // First let's try already existing connections
-  let struct = await tryExistingConnections(components, destination, protocols)
+  let struct = await tryExistingConnections(components, id, protocols)
 
   if (struct) {
-    log(`Successfully reached ${destination.toString()} via existing connection !`)
+    log(`Successfully reached ${id.toString()} via existing connection !`)
     return { status: DialStatus.SUCCESS, resp: struct }
   }
 
   // Fetch known addresses for the given destination peer
-  const knownAddressesForPeer = await components.getPeerStore().addressBook.get(destination)
+  const knownAddressesForPeer = await components.getPeerStore().addressBook.get(id)
   if (knownAddressesForPeer.length > 0) {
     // Let's try using the known addresses by connecting directly
-    log(`There are ${knownAddressesForPeer.length} already known addresses for ${destination.toString()}:`)
+    log(
+      `There ${knownAddressesForPeer.length == 1 ? 'is' : 'are'} ${knownAddressesForPeer.length} already known address${
+        knownAddressesForPeer.length == 1 ? '' : 'es'
+      } for ${id.toString()}:`
+    )
     for (const address of knownAddressesForPeer) {
       log(`- ${address.multiaddr.toString()}`)
     }
-    struct = await establishNewConnection(components, destination, protocols, opts)
-    if (struct) {
-      log(`Successfully reached ${destination.toString()} via already known addresses !`)
-      return { status: DialStatus.SUCCESS, resp: struct }
-    }
+    struct = await establishNewConnection(components, id, protocols, noRelay)
   } else {
-    log(`No currently known addresses for peer ${destination.toString()}`)
+    log(`No currently known addresses for peer ${id.toString()}`)
   }
 
+  if (struct) {
+    log(`Successfully reached ${id.toString()} via already known addresses !`)
+    return { status: DialStatus.SUCCESS, resp: struct }
+  }
+
+  return { status: DialStatus.DIAL_ERROR, dhtContacted: false }
+}
+
+async function fetchCircuitAddressesAndDial(
+  components: Components,
+  destination: PeerId,
+  protocols: string | string[]
+): Promise<DialResponse> {
   let noDht = false
   try {
     components.getDHT()
@@ -295,59 +321,58 @@ async function doDial(
   // Check if DHT is available
   if (noDht || components.getDHT()[Symbol.toStringTag] === /* catchall package of libp2p */ '@libp2p/dummy-dht') {
     // Stop if there is no DHT available
-    await printPeerStoreAddresses(
-      `Could not establish a connection to ${destination.toString()} and libp2p was started without a DHT. Giving up`,
-      destination,
-      components
+    error(
+      await printPeerStoreAddresses(
+        `Could not establish a connection to ${destination.toString()} and libp2p was started without a DHT. Giving up`,
+        destination,
+        components
+      )
     )
     return { status: DialStatus.NO_DHT }
   }
 
+  const knownAddressesForPeer = await components.getPeerStore().addressBook.get(destination)
+
   // Try to get some fresh addresses from the DHT
   log(`Could not reach ${destination.toString()} using known addresses, querying DHT for more addresses...`)
-  const dhtResult = await queryDHT(components, destination)
 
-  if (dhtResult.length == 0) {
-    await printPeerStoreAddresses(
-      `Direct dial attempt to ${destination.toString()} failed and DHT query has not brought any new addresses. Giving up`,
-      destination,
-      components
-    )
-    return { status: DialStatus.DHT_ERROR, query: destination.toString() }
+  const knownCircuitAddressSet = new Set<string>()
+
+  for (const knownAddressForPeer of knownAddressesForPeer) {
+    const tuples = knownAddressForPeer.multiaddr.tuples()
+
+    if (tuples.length > 0 && tuples[0].length > 0 && tuples[0][0] == CODE_P2P) {
+      knownCircuitAddressSet.add(knownAddressForPeer.multiaddr.decapsulateCode(CODE_P2P).toString())
+    }
   }
 
   // Take all the known circuit addresses from the existing set of known addresses
-  const knownCircuitAddressSet = new Set(
-    knownAddressesForPeer
-      .map((address) => address.multiaddr)
-      .filter((address) => {
-        const tuples = address.tuples()
-        return tuples[0][0] == CODE_P2P
-      })
-      .map((address) => address.toString())
-  )
 
   let relayStruct:
+    | void
     | (ProtocolStream & {
         conn: Connection
       })
-    | undefined
 
-  // Filter out the circuit addresses that were tried using the previous attempt
-  const circuitsNotTriedYet = dhtResult
-    .map((relay) => createCircuitAddress(relay))
-    .filter((circuitAddr) => !knownCircuitAddressSet.has(circuitAddr.toString()))
+  for await (const relay of queryDHT(components, destination)) {
+    // Make sure we don't use self as relay
+    if (relay.equals(components.getPeerId())) {
+      continue
+    }
 
-  for (const circuitAddress of circuitsNotTriedYet) {
-    // Share new knowledge about peer with Libp2p's peerStore
+    const circuitAddress = createCircuitAddress(relay)
+
+    // Filter out the circuit addresses that were tried using the previous attempt
+    if (knownCircuitAddressSet.has(circuitAddress.toString())) {
+      continue
+    }
+
+    // Share new knowledge about peer with Libp2p's peerStore, dropping `/p2p/<DESTINATION>`
     await components.getPeerStore().addressBook.add(destination, [circuitAddress as any])
 
     log(`Trying to reach ${destination.toString()} via circuit ${circuitAddress}...`)
 
-    relayStruct = await establishNewConnection(components, circuitAddress, protocols, {
-      ...opts,
-      signal: undefined
-    })
+    relayStruct = await establishNewConnection(components, destination, protocols)
 
     // Return if we were successful
     if (relayStruct) {
@@ -360,29 +385,49 @@ async function doDial(
 }
 
 /**
- * Performs a dial strategy using libp2p.dialProtocol and libp2p.findPeer
- * to establish a connection.
- * Contains a baseline protection against dialing same addresses twice.
- * @param components components of a libp2p instance
- * @param destination PeerId of the destination
- * @param protocols protocols to use
- * @param opts
+ * Runs through the dial strategy and handles possible errors
+ *
+ * 1. Use already known addresses
+ * 2. Check the DHT (if available) for additional addresses
+ * 3. Try new addresses
+ *
+ * @param components components of libp2p instance
+ * @param destination which peer to connect to
+ * @param protocols which protocol to use
+ * @returns
  */
 export async function dial(
   components: Components,
-  destination: PeerId,
+  destination: PeerId | Multiaddr,
   protocols: string | string[],
-  opts?: TimeoutOpts
+  withDHT: boolean = true,
+  noRelay: boolean = false
 ): Promise<DialResponse> {
-  return abortableTimeout(
-    (timeoutOpts: Required<TimeoutOpts>) => doDial(components, destination, protocols, timeoutOpts),
-    { status: DialStatus.ABORTED },
-    { status: DialStatus.TIMEOUT },
-    {
-      timeout: opts?.timeout ?? DEFAULT_DHT_QUERY_TIMEOUT,
-      signal: opts?.signal
+  let id: PeerId
+  if (isPeerId(destination)) {
+    id = destination
+  } else {
+    const idStr = destination.getPeerId()
+
+    if (idStr == null) {
+      error(`Cannot determine PeerId from ${destination.toString()}`)
+      return {
+        status: DialStatus.DIAL_ERROR,
+        dhtContacted: false
+      }
     }
-  )
+    id = peerIdFromString(idStr)
+    await components.getPeerStore().addressBook.add(id, [destination.decapsulateCode(CODE_P2P)])
+  }
+
+  const res = await doDirectDial(components, id, protocols, noRelay)
+
+  if (noRelay == true || withDHT == false || (withDHT == true && res.status == DialStatus.SUCCESS)) {
+    // Take first result and don't do any further steps
+    return res
+  }
+
+  return await fetchCircuitAddressesAndDial(components, id, protocols)
 }
 
 export type { TimeoutOpts as DialOpts }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3023,6 +3023,7 @@ __metadata:
     mocha: 9.2.2
     multiformats: 9.6.5
     nat-api: 0.3.1
+    retimer: 3.0.0
     simple-peer: 9.11.1
     stream-to-it: 0.2.4
     typescript: 4.7.4
@@ -3107,6 +3108,7 @@ __metadata:
     memdown: 6.1.1
     mocha: 9.2.2
     nyc: 15.1.0
+    retimer: 3.0.0
     secp256k1: 4.0.3
     semver: 7.3.7
     sinon: 12.0.1
@@ -3211,7 +3213,7 @@ __metadata:
     "@multiformats/multiaddr": 10.3.3
     "@types/chai": 4.3.3
     "@types/mocha": 9.1.1
-    abort-controller: ~3.0.0
+    abortable-iterator: 4.0.2
     bignumber.js: 9.0.2
     bl: 5.0.0
     bn.js: 5.2.0
@@ -3232,6 +3234,7 @@ __metadata:
     rewiremock: 3.14.3
     secp256k1: 4.0.3
     sinon: 12.0.1
+    timeout-abort-controller: 3.0.0
     typedoc: 0.23.2
     typedoc-plugin-markdown: 3.13.1
     typescript: 4.7.4
@@ -3273,7 +3276,6 @@ __metadata:
     react: 17.0.2
     react-dom: 17.0.2
     rlp: 3.0.0
-    run-queue: 2.0.1
     semver: 7.3.7
     sinon: 12.0.1
     supertest: ^6.2.2
@@ -6183,7 +6185,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abort-controller@npm:3.0.0, abort-controller@npm:^3.0.0, abort-controller@npm:~3.0.0":
+"abort-controller@npm:3.0.0, abort-controller@npm:^3.0.0":
   version: 3.0.0
   resolution: "abort-controller@npm:3.0.0"
   dependencies:
@@ -6649,7 +6651,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aproba@npm:^1.0.3 || ^2.0.0, aproba@npm:^2.0.0":
+"aproba@npm:^1.0.3 || ^2.0.0":
   version: 2.0.0
   resolution: "aproba@npm:2.0.0"
   checksum: 5615cadcfb45289eea63f8afd064ab656006361020e1735112e346593856f87435e02d8dcc7ff0d11928bc7d425f27bc7c2a84f6c0b35ab0ff659c814c138a24
@@ -20509,7 +20511,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"retimer@npm:^3.0.0":
+"retimer@npm:3.0.0, retimer@npm:^3.0.0":
   version: 3.0.0
   resolution: "retimer@npm:3.0.0"
   checksum: f88309196e9d4f2d4be0c76eafc27a9f102c74b40b391ce730785b052c345d7bd59c3e4411a4c422f89f19a42b97b28034639e2f06c63133a06ec8958e9e7516
@@ -20676,15 +20678,6 @@ __metadata:
   dependencies:
     queue-microtask: ^1.2.2
   checksum: cb4f97ad25a75ebc11a8ef4e33bb962f8af8516bb2001082ceabd8902e15b98f4b84b4f8a9b222e5d57fc3bd1379c483886ed4619367a7680dad65316993021d
-  languageName: node
-  linkType: hard
-
-"run-queue@npm:2.0.1":
-  version: 2.0.1
-  resolution: "run-queue@npm:2.0.1"
-  dependencies:
-    aproba: ^2.0.0
-  checksum: ce79d8099629c215620c545060c6a7ba5cf9b0166e011a56c6173775d86e117349418dd2e55d35584d920d1670d51ec9961752831fa0fddeec8a745c60b89ba3
   languageName: node
   linkType: hard
 
@@ -22633,7 +22626,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"timeout-abort-controller@npm:^3.0.0":
+"timeout-abort-controller@npm:3.0.0, timeout-abort-controller@npm:^3.0.0":
   version: 3.0.0
   resolution: "timeout-abort-controller@npm:3.0.0"
   dependencies:


### PR DESCRIPTION
### Use `retimer` library

In general, timeouts Javascript are used as:

```ts
const timeout = setTimeout(() => console.log('never shown'), 500)
// do stuff
clearTimeout(timeout)
```
This works as long as there are a only a few timeout, but soon `clearTimeout` becomes an expensive operation.

`retimer` and `timeout-abort-controller` "reuse" timeouts to prevent the usage of `clearTimeout` to free timeouts.

This PR replaces several critical occurences by `retimer` / `timeout-abort-controller` to save memory and CPU time.

### New dial behavior - changed timeout behavior

Previously: many protocols set their own dial timeout, leading to undeterministic behavior when connecting to other nodes, plus created lots of listeners to AbortControllers.

New behavior: Dial attempts are split into two stages: 

- establishing a message stream and
- handling the specified protocol

All attempts to create a message stream use the same *timeout*, namely the one specified in libp2p's ConnectionManager. In addition, "user space" code can specify own timeouts for how long a specific protocol interaction is allowed to take.

### Use Iterables to relieve garbage collector

Having objects cleaned by the Garbage collect at some point takes unnecessarily time. Example:

```ts
const largerRepresentations = []
for (const obj of objects) {
  largerRepresentations.push(obj.expand())
}
// in a different function or context
let out = ''
for (const largeObject of largerRepresentations) {
  out += largeObject.toString()
}
```
In case `objects` contains lots of entries, this takes a lot of runtime memory and additional work, namely for the Garbage collector, whereas
```ts
 const largerRepresentationsIterator = (function *() {
   for (const obj of objects) {
     yield obj.expand()
   }
})()
// in a different context
let out = ''
for (const largeObject of largerRepresentations) {
  out += largeObject.toString()
}
```
creates `largeObjects` on demand, and thus requires the large representation only once.

### Other changes

- make heartbeat use less timeouts and less AbortController instances
- slight refactoring