### PR TITLE
non-blocking mixer & proper acknowledgement queueing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 - Remove charset complexity validation on API token ([#4210](https://github.com/hoprnet/hoprnet/pull/4210))
 - Properly encode API token passed from the Admin UI ([#4210](https://github.com/hoprnet/hoprnet/pull/4210))
 - Refactor timeouts for more throughput and increase usage of iterables ([#4238](https://github.com/hoprnet/hoprnet/pull/4238))
+- Refactor packet forward interaction for less locking ([#4232](https://github.com/hoprnet/hoprnet/pull/4243))
+- Refactor mixer to migitate backpressure ([#4232](https://github.com/hoprnet/hoprnet/pull/4243))
 
 ---
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -51,6 +51,7 @@
     "debug": "4.3.4",
     "err-code": "3.0.1",
     "heap-js": "2.2.0",
+    "it-pushable": "3.0.0",
     "leveldown": "6.1.1",
     "levelup": "5.1.1",
     "libp2p": "0.37.3",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -706,7 +706,8 @@ class Hopr extends EventEmitter {
       throw Error(`Hopr instance already destroyed.`)
     }
     this.status = 'DESTROYED'
-    this.forward.stop()
+    this.forward?.stop()
+    this.acknowledgements?.stop()
     verbose('Stopping checking timeout')
     this.stopPeriodicCheck?.()
     verbose('Stopping heartbeat & indexer')

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -722,6 +722,7 @@ class Hopr extends EventEmitter {
       throw Error(`Hopr instance already destroyed.`)
     }
     this.status = 'DESTROYED'
+    this.forward.stop()
     verbose('Stopping checking timeout')
     this.stopPeriodicCheck?.()
     verbose('Stopping heartbeat & indexer')

--- a/packages/core/src/interactions/packet/acknowledgement.ts
+++ b/packages/core/src/interactions/packet/acknowledgement.ts
@@ -73,6 +73,12 @@ export class AcknowledgementInteraction {
     this.startSendAcknowledgements()
   }
 
+  stop() {
+    // End the streams to avoid handing promises
+    this.incomingAcks.end()
+    this.outgoingAcks.end()
+  }
+
   async startHandleIncoming() {
     for await (const incomingAck of this.incomingAcks) {
       await this.handleAcknowledgement(incomingAck[0], incomingAck[1])

--- a/packages/core/src/interactions/packet/acknowledgement.ts
+++ b/packages/core/src/interactions/packet/acknowledgement.ts
@@ -1,152 +1,188 @@
-import { oneAtATime, debug, AcknowledgedTicket, HoprDB } from '@hoprnet/hopr-utils'
-import type { PendingAckowledgement, HalfKeyChallenge, Hash } from '@hoprnet/hopr-utils'
+import {
+  debug,
+  pickVersion,
+  AcknowledgedTicket,
+  type HoprDB,
+  type PendingAckowledgement,
+  type HalfKeyChallenge,
+  type Hash
+} from '@hoprnet/hopr-utils'
 import { findCommitmentPreImage, bumpCommitment } from '@hoprnet/hopr-core-ethereum'
 import type { SendMessage, Subscribe } from '../../index.js'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import { ACKNOWLEDGEMENT_TIMEOUT } from '../../constants.js'
 import { Acknowledgement, Packet } from '../../messages/index.js'
+import { Pushable, pushable } from 'it-pushable'
+import type { ResolvedEnvironment } from '../../environment.js'
 const log = debug('hopr-core:acknowledgement')
 
 type OnAcknowledgement = (halfKey: HalfKeyChallenge) => void
 type OnWinningTicket = (ackMessage: AcknowledgedTicket) => void
 type OnOutOfCommitments = (channelId: Hash) => void
 
-/**
- * Reserve a preImage for the given ticket if it is a winning ticket.
- */
-async function handleAcknowledgement(
-  msg: Uint8Array,
-  remotePeer: PeerId,
-  pubKey: PeerId,
-  db: HoprDB,
-  onAcknowledgement: OnAcknowledgement,
-  onWinningTicket: OnWinningTicket,
-  onOutOfCommitments: OnOutOfCommitments
-): Promise<void> {
-  const acknowledgement = Acknowledgement.deserialize(msg, pubKey, remotePeer)
+type Incoming = [msg: Uint8Array, remotePeer: PeerId]
+type Outgoing = [ack: Uint8Array, destination: PeerId]
 
-  // There are three cases:
-  // 1. There is an unacknowledged ticket and we are
-  //    awaiting a half key.
-  // 2. We were the creator of the packet, hence we
-  //    do not wait for any half key
-  // 3. The acknowledgement is unexpected and stems from
-  //    a protocol bug or an attacker
-  let pending: PendingAckowledgement
-  try {
-    pending = await db.getPendingAcknowledgement(acknowledgement.ackChallenge)
-  } catch (err) {
-    // Protocol bug?
-    if (err.notFound) {
-      log(
-        `Received unexpected acknowledgement for half key challenge ${acknowledgement.ackChallenge.toHex()} - half key ${acknowledgement.ackKeyShare.toHex()}`
-      )
+// Do not type-check JSON files
+// @ts-ignore
+import pkg from '../../../package.json' assert { type: 'json' }
+
+const NORMALIZED_VERSION = pickVersion(pkg.version)
+
+export class AcknowledgementInteraction {
+  private incomingAcks: Pushable<Incoming>
+  private outgoingAcks: Pushable<Outgoing>
+
+  public readonly protocols: string | string[]
+
+  constructor(
+    private sendMessage: SendMessage,
+    private subscribe: Subscribe,
+    private privKey: PeerId,
+    private db: HoprDB,
+    private onAcknowledgement: OnAcknowledgement,
+    private onWinningTicket: OnWinningTicket,
+    private onOutOfCommitments: OnOutOfCommitments,
+    private environment: ResolvedEnvironment
+  ) {
+    this.incomingAcks = pushable<Incoming>({ objectMode: true })
+    this.outgoingAcks = pushable<Outgoing>({ objectMode: true })
+
+    this.protocols = [
+      // current
+      `/hopr/${this.environment.id}/ack/${NORMALIZED_VERSION}`,
+      // deprecated
+      `/hopr/${this.environment.id}/ack`
+    ]
+
+    this.handleAcknowledgement = this.handleAcknowledgement.bind(this)
+  }
+  async start() {
+    await this.subscribe(
+      this.protocols,
+      (msg: Uint8Array, remotePeer: PeerId) => {
+        this.incomingAcks.push([msg, remotePeer])
+      },
+      false,
+      (err: any) => {
+        log(`Error while receiving acknowledgement`, err)
+      }
+    )
+
+    this.startHandleIncoming()
+    this.startSendAcknowledgements()
+  }
+
+  async startHandleIncoming() {
+    for await (const incomingAck of this.incomingAcks) {
+      await this.handleAcknowledgement(incomingAck[0], incomingAck[1])
     }
-    throw err
   }
 
-  // No pending ticket, nothing to do.
-  if (pending.isMessageSender == true) {
-    log(`Received acknowledgement as sender. First relayer has processed the packet.`)
-    // Resolves `sendMessage()` promise
-    onAcknowledgement(acknowledgement.ackChallenge)
-    // nothing else to do
-    return
-  }
-
-  // Try to unlock our incentive
-  const unacknowledged = pending.ticket
-
-  if (!unacknowledged.verifyChallenge(acknowledgement.ackKeyShare)) {
-    throw Error(`The acknowledgement is not sufficient to solve the embedded challenge.`)
-  }
-
-  let channelId: Hash
-  try {
-    channelId = (await db.getChannelFrom(unacknowledged.signer)).getId()
-  } catch (e) {
-    // We are acknowledging a ticket for a channel we do not think exists?
-    // Also we know about the unacknowledged ticket? This should never happen.
-    // Something clearly screwy here. This is bad enough to be a fatal error
-    // we should kill the node and debug.
-    log('Error, acknowledgement received for channel that does not exist')
-    throw e
-  }
-  const response = unacknowledged.getResponse(acknowledgement.ackKeyShare)
-  const ticket = unacknowledged.ticket
-  let opening: Hash
-  try {
-    opening = await findCommitmentPreImage(db, channelId)
-  } catch (err) {
-    log(`Channel ${channelId.toHex()} is out of commitments`)
-    onOutOfCommitments(channelId)
-    // TODO: How should we handle this ticket?
-    return
-  }
-
-  if (!ticket.isWinningTicket(opening, response, ticket.winProb)) {
-    log(`Got a ticket that is not a win. Dropping ticket.`)
-    await db.markLosing(unacknowledged)
-    return
-  }
-
-  // Ticket is a win, let's store it
-  const ack = new AcknowledgedTicket(ticket, response, opening, unacknowledged.signer)
-  log(`Acknowledging ticket. Using opening ${opening.toHex()} and response ${response.toHex()}`)
-
-  try {
-    await db.replaceUnAckWithAck(acknowledgement.ackChallenge, ack)
-    log(`Stored winning ticket`)
-  } catch (err) {
-    log(`ERROR: commitment could not be bumped, thus dropping ticket`, err)
-  }
-
-  // store commitment in db
-  await bumpCommitment(db, channelId, opening)
-
-  onWinningTicket(ack)
-}
-
-export async function subscribeToAcknowledgements(
-  subscribe: Subscribe,
-  db: HoprDB,
-  pubKey: PeerId,
-  onAcknowledgement: OnAcknowledgement,
-  onWinningTicket: OnWinningTicket,
-  onOutOfCommitments: OnOutOfCommitments,
-  protocolAck: string | string[]
-) {
-  const limitConcurrency = oneAtATime<void>()
-  await subscribe(
-    protocolAck,
-    (msg: Uint8Array, remotePeer: PeerId) =>
-      limitConcurrency(
-        (): Promise<void> =>
-          handleAcknowledgement(msg, remotePeer, pubKey, db, onAcknowledgement, onWinningTicket, onOutOfCommitments)
-      ),
-    false,
-    (err: any) => {
-      log(`Error while receiving acknowledgement`, err)
+  async startSendAcknowledgements() {
+    for await (const outgoingAck of this.outgoingAcks) {
+      try {
+        await this.sendMessage(outgoingAck[1], this.protocols, outgoingAck[0], false, {
+          timeout: ACKNOWLEDGEMENT_TIMEOUT
+        })
+      } catch (err) {
+        // Currently unclear how to proceed if sending acknowledgements
+        // fails
+        log(`Error: could not send acknowledgement`, err)
+      }
     }
-  )
-}
+  }
+  sendAcknowledgement(packet: Packet, destination: PeerId): void {
+    const ack = packet.createAcknowledgement(this.privKey)
 
-export async function sendAcknowledgement(
-  packet: Packet,
-  destination: PeerId,
-  sendMessage: SendMessage,
-  privKey: PeerId,
-  protocolAck: string | string[]
-): Promise<void> {
-  const ack = packet.createAcknowledgement(privKey)
+    this.outgoingAcks.push([ack.serialize(), destination])
+  }
 
-  try {
-    await sendMessage(destination, protocolAck, ack.serialize(), false, {
-      timeout: ACKNOWLEDGEMENT_TIMEOUT
-    })
-  } catch (err) {
-    // Currently unclear how to proceed if sending acknowledgements
-    // fails
-    log(`Error: could not send acknowledgement`, err)
+  /**
+   * Reserve a preImage for the given ticket if it is a winning ticket.
+   */
+  async handleAcknowledgement(msg: Uint8Array, remotePeer: PeerId): Promise<void> {
+    const acknowledgement = Acknowledgement.deserialize(msg, this.privKey, remotePeer)
+
+    // There are three cases:
+    // 1. There is an unacknowledged ticket and we are
+    //    awaiting a half key.
+    // 2. We were the creator of the packet, hence we
+    //    do not wait for any half key
+    // 3. The acknowledgement is unexpected and stems from
+    //    a protocol bug or an attacker
+    let pending: PendingAckowledgement
+    try {
+      pending = await this.db.getPendingAcknowledgement(acknowledgement.ackChallenge)
+    } catch (err) {
+      // Protocol bug?
+      if (err.notFound) {
+        log(
+          `Received unexpected acknowledgement for half key challenge ${acknowledgement.ackChallenge.toHex()} - half key ${acknowledgement.ackKeyShare.toHex()}`
+        )
+      }
+      throw err
+    }
+
+    // No pending ticket, nothing to do.
+    if (pending.isMessageSender == true) {
+      log(`Received acknowledgement as sender. First relayer has processed the packet.`)
+      // Resolves `sendMessage()` promise
+      this.onAcknowledgement(acknowledgement.ackChallenge)
+      // nothing else to do
+      return
+    }
+
+    // Try to unlock our incentive
+    const unacknowledged = pending.ticket
+
+    if (!unacknowledged.verifyChallenge(acknowledgement.ackKeyShare)) {
+      throw Error(`The acknowledgement is not sufficient to solve the embedded challenge.`)
+    }
+
+    let channelId: Hash
+    try {
+      channelId = (await this.db.getChannelFrom(unacknowledged.signer)).getId()
+    } catch (e) {
+      // We are acknowledging a ticket for a channel we do not think exists?
+      // Also we know about the unacknowledged ticket? This should never happen.
+      // Something clearly screwy here. This is bad enough to be a fatal error
+      // we should kill the node and debug.
+      log('Error, acknowledgement received for channel that does not exist')
+      throw e
+    }
+    const response = unacknowledged.getResponse(acknowledgement.ackKeyShare)
+    const ticket = unacknowledged.ticket
+    let opening: Hash
+    try {
+      opening = await findCommitmentPreImage(this.db, channelId)
+    } catch (err) {
+      log(`Channel ${channelId.toHex()} is out of commitments`)
+      this.onOutOfCommitments(channelId)
+      // TODO: How should we handle this ticket?
+      return
+    }
+
+    if (!ticket.isWinningTicket(opening, response, ticket.winProb)) {
+      log(`Got a ticket that is not a win. Dropping ticket.`)
+      await this.db.markLosing(unacknowledged)
+      return
+    }
+
+    // Ticket is a win, let's store it
+    const ack = new AcknowledgedTicket(ticket, response, opening, unacknowledged.signer)
+    log(`Acknowledging ticket. Using opening ${opening.toHex()} and response ${response.toHex()}`)
+
+    try {
+      await this.db.replaceUnAckWithAck(acknowledgement.ackChallenge, ack)
+      log(`Stored winning ticket`)
+    } catch (err) {
+      log(`ERROR: commitment could not be bumped, thus dropping ticket`, err)
+    }
+
+    // store commitment in db
+    await bumpCommitment(this.db, channelId, opening)
+
+    this.onWinningTicket(ack)
   }
 }

--- a/packages/core/src/interactions/packet/index.spec.ts
+++ b/packages/core/src/interactions/packet/index.spec.ts
@@ -3,7 +3,7 @@ import { randomBytes } from 'crypto'
 import { EventEmitter } from 'events'
 import BN from 'bn.js'
 
-import { subscribeToAcknowledgements, sendAcknowledgement } from './acknowledgement.js'
+import { AcknowledgementInteraction } from './acknowledgement.js'
 import {
   Balance,
   defer,
@@ -27,6 +27,7 @@ import { AcknowledgementChallenge, Packet, Acknowledgement } from '../../message
 import { PacketForwardInteraction } from './forward.js'
 import { initializeCommitment } from '@hoprnet/hopr-core-ethereum'
 import { ChannelCommitmentInfo } from '@hoprnet/hopr-core-ethereum'
+import type { ResolvedEnvironment } from '../../environment.js'
 
 const SECRET_LENGTH = 32
 
@@ -54,15 +55,44 @@ const TestingSnapshot = new Snapshot(new BN(0), new BN(0), new BN(0))
  * @param self our own identity to know which messages are destined for us
  */
 function createFakeSendReceive(events: EventEmitter, self: PeerId) {
-  const send = (destination: PeerId, protocol: any, msg: Uint8Array) => {
+  const send = (destination: PeerId, protocol: string | string[], msg: Uint8Array) => {
     events.emit('msg', msg, self, destination, protocol)
   }
 
-  const subscribe = async (protocol: string, onPacket: (msg: Uint8Array, sender: PeerId) => any) => {
-    events.on('msg', (msg: Uint8Array, sender: PeerId, destination: PeerId, protocolSubscription: string) => {
-      if (self.equals(destination) && protocol === protocolSubscription) {
-        onPacket(msg, sender)
+  const subscribe = async (
+    subscribedProtocols: string | string[],
+    onPacket: (msg: Uint8Array, sender: PeerId) => any
+  ) => {
+    if (!Array.isArray(subscribedProtocols)) {
+      subscribedProtocols = [subscribedProtocols]
+    }
+    subscribedProtocols.sort()
+
+    events.on('msg', (msg: Uint8Array, sender: PeerId, destination: PeerId, incomingProtocols: string | string[]) => {
+      if (!self.equals(destination)) {
+        return
       }
+
+      if (!Array.isArray(incomingProtocols)) {
+        incomingProtocols = [incomingProtocols]
+      }
+
+      incomingProtocols.sort()
+
+      let found = false
+      for (const subscribedProtocol of subscribedProtocols) {
+        for (const incomingProtocol of incomingProtocols) {
+          if (incomingProtocol === subscribedProtocol) {
+            found = true
+          }
+        }
+      }
+
+      if (!found) {
+        return
+      }
+
+      onPacket(msg, sender)
     })
   }
 
@@ -142,20 +172,6 @@ async function createMinimalChannelTopology(dbs: HoprDB[], nodes: PeerId[]): Pro
   }
 }
 
-class TestingForwardInteraction extends PacketForwardInteraction {
-  /**
-   * Disable probablistic mixing
-   */
-  useMockMixer() {
-    const push = (p: Packet) => {
-      this.handleMixedPacket(p)
-    }
-    this.mixer = {
-      push
-    } as any
-  }
-}
-
 // Tests two different packet acknowledgement settings
 // - Acknowledgement for packet sender
 // - Acknowledgement for relayer, unlocking a ticket
@@ -195,10 +211,11 @@ describe('packet acknowledgement', function () {
 
     await dbs[0].storePendingAcknowledgement(ackChallenge, true)
 
-    await subscribeToAcknowledgements(
+    const ackInteration = new AcknowledgementInteraction(
+      libp2pSelf.send as any,
       libp2pSelf.subscribe,
-      dbs[0],
       SELF,
+      dbs[0],
       (receivedAckChallenge: HalfKeyChallenge) => {
         if (receivedAckChallenge.eq(ackChallenge)) {
           ackReceived.resolve()
@@ -206,8 +223,26 @@ describe('packet acknowledgement', function () {
       },
       () => {},
       () => {},
-      'protocolAck'
+      {
+        id: 'testing'
+      } as ResolvedEnvironment
     )
+
+    const ackInterationCounterparty = new AcknowledgementInteraction(
+      libp2pCounterparty.send as any,
+      libp2pCounterparty.subscribe,
+      COUNTERPARTY,
+      dbs[1],
+      () => {},
+      () => {},
+      () => {},
+      {
+        id: 'testing'
+      } as ResolvedEnvironment
+    )
+
+    await ackInteration.start()
+    await ackInterationCounterparty.start()
 
     const ackKey = deriveAckKeyShare(secrets[0])
     const ackMessage = AcknowledgementChallenge.create(ackChallenge, SELF)
@@ -217,16 +252,13 @@ describe('packet acknowledgement', function () {
       `acknowledgement key must be sufficient to solve acknowledgement challenge`
     )
 
-    await sendAcknowledgement(
+    ackInterationCounterparty.sendAcknowledgement(
       {
         createAcknowledgement: (privKey: PeerId) => {
           return Acknowledgement.create(ackMessage, ackKey, privKey)
         }
       } as any,
-      SELF,
-      libp2pCounterparty.send as any,
-      COUNTERPARTY,
-      'protocolAck'
+      SELF
     )
 
     await ackReceived.promise
@@ -244,22 +276,42 @@ describe('packet acknowledgement', function () {
     const packet = await Packet.create(TEST_MESSAGE, nodes, SELF, dbs[0])
 
     const libp2pRelay0 = createFakeSendReceive(events, RELAY0)
+    const libp2pCounterparty = createFakeSendReceive(events, COUNTERPARTY)
 
     const ackReceived = defer<void>()
 
-    await subscribeToAcknowledgements(
+    const ackRelay0Interaction = new AcknowledgementInteraction(
+      libp2pRelay0.send as any,
       libp2pRelay0.subscribe,
-      dbs[1],
       RELAY0,
+      dbs[1],
       () => {},
       () => {
         ackReceived.resolve()
       },
       () => {},
-      'protocolAck'
+      {
+        id: 'testing'
+      } as ResolvedEnvironment
     )
 
-    const interaction = new TestingForwardInteraction(
+    const ackCounterpartyInteraction = new AcknowledgementInteraction(
+      libp2pCounterparty.send as any,
+      libp2pCounterparty.subscribe,
+      COUNTERPARTY,
+      dbs[2],
+      () => {},
+      () => {},
+      () => {},
+      {
+        id: 'testing'
+      } as ResolvedEnvironment
+    )
+
+    await ackCounterpartyInteraction.start()
+    await ackRelay0Interaction.start()
+
+    const interaction = new PacketForwardInteraction(
       libp2pRelay0.subscribe,
       libp2pRelay0.send as any,
       RELAY0,
@@ -267,22 +319,16 @@ describe('packet acknowledgement', function () {
         throw Error(`Node is not supposed to receive message`)
       },
       dbs[1],
-      'protocolMsg',
-      'protocolAck'
+      {
+        id: 'testing'
+      } as ResolvedEnvironment,
+      ackRelay0Interaction,
+      () => 1
     )
+    await interaction.start()
 
-    interaction.useMockMixer()
-
-    const libp2pCounterparty = createFakeSendReceive(events, COUNTERPARTY)
-
-    await libp2pCounterparty.subscribe('protocolMsg', async (msg: Uint8Array) => {
-      await sendAcknowledgement(
-        Packet.deserialize(msg, COUNTERPARTY, RELAY0),
-        RELAY0,
-        libp2pCounterparty.send as any,
-        COUNTERPARTY,
-        'protocolAck'
-      )
+    await libp2pCounterparty.subscribe(interaction.protocols, async (msg: Uint8Array) => {
+      ackCounterpartyInteraction.sendAcknowledgement(Packet.deserialize(msg, COUNTERPARTY, RELAY0), RELAY0)
     })
 
     await interaction.handleMixedPacket(Packet.deserialize(packet.serialize(), RELAY0, SELF))
@@ -317,7 +363,7 @@ describe('packet relaying interaction', function () {
     const msgDefer = defer<void>()
     const nodes: PeerId[] = [RELAY0, RELAY1, RELAY2, COUNTERPARTY]
     const allNodes: PeerId[] = [SELF].concat(nodes)
-    let senderInteraction: TestingForwardInteraction
+    let senderInteraction: PacketForwardInteraction
 
     const packet = await Packet.create(TEST_MESSAGE, nodes, SELF, dbs[0])
     await packet.storePendingAcknowledgement(dbs[0])
@@ -337,16 +383,31 @@ describe('packet relaying interaction', function () {
         }
       }
 
-      const interaction = new TestingForwardInteraction(
+      const acknowledgementInteraction = new AcknowledgementInteraction(
+        send as any,
+        subscribe,
+        pId,
+        dbs[index],
+        () => {},
+        () => {},
+        () => {},
+        {
+          id: 'testing'
+        } as ResolvedEnvironment
+      )
+
+      const interaction = new PacketForwardInteraction(
         subscribe,
         send as any,
         pId,
         receiveHandler,
         dbs[index],
-        'protocolMsg',
-        'protocolAck'
+        {
+          id: 'testing'
+        } as ResolvedEnvironment,
+        acknowledgementInteraction,
+        () => 1
       )
-      interaction.useMockMixer()
       await interaction.start()
 
       if (pId.equals(SELF)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3102,6 +3102,7 @@ __metadata:
     debug: 4.3.4
     err-code: 3.0.1
     heap-js: 2.2.0
+    it-pushable: 3.0.0
     leveldown: 6.1.1
     levelup: 5.1.1
     libp2p: 0.37.3


### PR DESCRIPTION
This PR improves scheduling and reduces locking

### Changes

Reimplement mixer as async interable, which

- allows removal of `await setImmediate()` in `ForwardInteraction`
- limits backpressure for relaying mixnet packets

Reimplement acknowledgement workflow to:

- have a queue for `outgoing` acknowledgements (send queue)
- have a queue for `incoming` acknowledgements (receive queue)
- allow removal of `await setImmediate()`

### Out of scope

Individual packet send queues for individual recipients