### PR TITLE
mitigate duplicate relay connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Refactor timeouts for more throughput and increase usage of iterables ([#4238](https://github.com/hoprnet/hoprnet/pull/4238))
 - Refactor packet forward interaction for less locking ([#4232](https://github.com/hoprnet/hoprnet/pull/4243))
 - Refactor mixer to migitate backpressure ([#4232](https://github.com/hoprnet/hoprnet/pull/4243))
+- Reuse existing connections to establish relayed connections over public relay ([#2545](https://github.com/hoprnet/hoprnet/pull/4245))
 
 ---
 

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -87,12 +87,11 @@ class HoprConnect implements Transport, Initializable, Startable {
     this.components = components
 
     const dialDirectly = this.dialDirectly.bind(this)
-    const filter = this.filter.bind(this)
 
     this.connectComponents = new ConnectComponents({
       addressFilter: new Filter(this.options),
       entryNodes: new EntryNodes(dialDirectly, this.options),
-      relay: new Relay(dialDirectly, filter, this.options, this.testingOptions),
+      relay: new Relay(this.options, this.testingOptions),
       upnpManager: new UpnpManager(),
       webRTCUpgrader: new WebRTCUpgrader(this.options)
     })
@@ -127,27 +126,25 @@ class HoprConnect implements Transport, Initializable, Startable {
   // we populate the address mapping of the router.
   // Or, if we get contacted by a relay to which we already have an *outgoing*
   // connection that gets reused.
-  // @TODO
   private setupSimulatedNAT(): void {
     // Simulated NAT using connection gater
     const denyInboundConnection = this.getComponents().getConnectionGater().denyInboundConnection
     this.getComponents().getConnectionGater().denyInboundConnection = async (maConn: MultiaddrConnection) => {
-      log(`New connection:`)
-      log(`remoteAddr: ${maConn.remoteAddr.toString()}`)
+      if (await denyInboundConnection(maConn)) {
+        // Blocked by e.g. Network Registry
+        return true
+      }
+
+      if (maConn.remoteAddr.toString().startsWith(`/p2p/`)) {
+        return false
+      }
+
+      log(`closing due to simulated NAT`)
       // log(`remotePeer ${maConn.remotePeer.toB58String()}`)
       // log(`localAddr: ${conn.localAddr?.toString()}`)
       // log(`remotePeer ${conn.localPeer.toB58String()}`)
-      if (await denyInboundConnection(maConn)) {
-        log(`closing due to simulated NAT`)
-        return true
-      } else if (maConn.remoteAddr.toString().startsWith(`/p2p/`)) {
-        return false
-      }
-      log(`closing due to simulated NAT`)
       return true
     }
-    // @TODO only allow connections to entry nodes
-    // this.getComponents().getConnectionGater().denyDialMultiaddr
   }
 
   public async beforeStart() {
@@ -196,6 +193,9 @@ class HoprConnect implements Transport, Initializable, Startable {
       case CODE_IP6:
         return this.dialDirectly(ma, options)
       case CODE_P2P:
+        if ((options as any).noRelay === true) {
+          throw new Error(`Cannot extend already relayed connections`)
+        }
         const relay = peerIdFromBytes((maTuples[0][1] as Uint8Array).slice(1))
 
         return this.dialWithRelay(relay, destination, options)

--- a/packages/connect/src/relay/connection.ts
+++ b/packages/connect/src/relay/connection.ts
@@ -11,7 +11,7 @@ import {
 } from '../types.js'
 import { randomBytes } from 'crypto'
 import { RelayPrefix, ConnectionStatusMessages, StatusMessages, CODE_P2P } from '../constants.js'
-import { u8aEquals, u8aToHex, defer, createCircuitAddress, type DeferType } from '@hoprnet/hopr-utils'
+import { u8aEquals, u8aToHex, defer, createCircuitAddress, type DeferType, timeout } from '@hoprnet/hopr-utils'
 import HeapPkg, { type Heap as HeapType } from 'heap-js'
 
 import SimplePeer from 'simple-peer'
@@ -392,7 +392,7 @@ class RelayConnection extends EventEmitter implements MultiaddrConnection {
 
     this.flow(`FLOW: awaiting destroyed promise / timeout`)
     // @TODO remove timeout once issue with destroyPromise is solved
-    await Promise.race([new Promise((resolve) => setTimeout(resolve, 100)), this.state._destroyedPromise.promise])
+    await timeout(100, () => this.state._destroyedPromise.promise)
     this.flow(`FLOW: close complete, finish`)
   }
 

--- a/packages/connect/src/relay/index.spec.ts
+++ b/packages/connect/src/relay/index.spec.ts
@@ -1,12 +1,6 @@
-import type { HoprConnectTestingOptions, StreamType } from '../types.js'
-import type { StreamHandler } from '@libp2p/interfaces/registrar'
-import type { Connection } from '@libp2p/interface-connection'
-import type { Address } from '@libp2p/interface-peer-store'
-import type { Components } from '@libp2p/interfaces/components'
+import type { HoprConnectTestingOptions } from '../types.js'
 import type { PeerId } from '@libp2p/interface-peer-id'
 
-import { peerIdFromString } from '@libp2p/peer-id'
-import { pair } from 'it-pair'
 import { handshake } from 'it-handshake'
 import { Multiaddr } from '@multiformats/multiaddr'
 
@@ -15,8 +9,9 @@ import assert from 'assert'
 
 import { Relay } from './index.js'
 import { privKeyToPeerId, stringToU8a, u8aEquals } from '@hoprnet/hopr-utils'
-import type { RelayConnection } from './connection.js'
 import type { ConnectComponents } from '../components.js'
+import { createFakeComponents, createFakeNetwork } from '../utils/libp2p.mock.spec.js'
+import { Stream } from '../types.js'
 
 const initiator = privKeyToPeerId(stringToU8a('0xa889bad3e2a31cceff4faccdd374af67db485ac0e05e7e654530aff0da5199f7'))
 const relay = privKeyToPeerId(stringToU8a('0xcd1fb76053833d9bb5b3ff243b2d17b96dc5ad7cc09b33c4cf77ba83c297443f'))
@@ -26,101 +21,19 @@ function msgToEchoedMessage(message: string): Uint8Array {
   return new TextEncoder().encode(`Echo: <${message}>`)
 }
 
-function getPeerProtocol(peer: PeerId, protocol: string) {
-  return `${peer.toString()}${protocol}`
+async function onInboundStream(stream: Stream) {
+  const shaker = handshake(stream)
+  const message = new TextDecoder().decode(((await shaker.read()) as Uint8Array).slice())
+
+  shaker.write(msgToEchoedMessage(message))
 }
 
-function createFakeComponents(peerId: PeerId, network: EventEmitter): Components {
+/**
+ * Creates a minimum instance of ConnectComponents
+ * @returns mocked ConnectComponents
+ */
+function createFakeConnectComponents(): ConnectComponents {
   return {
-    getPeerId() {
-      return peerId
-    },
-    getRegistrar() {
-      return {
-        handle(protocol: string, handler: (conn: StreamHandler) => void) {
-          network.on(getPeerProtocol(peerId, protocol), handler)
-        }
-      } as Components['registrar']
-    },
-    getUpgrader() {
-      return {
-        upgradeInbound: (async (conn: RelayConnection) => {
-          const shaker = handshake(conn)
-
-          const message = new TextDecoder().decode(((await shaker.read()) as Uint8Array).slice())
-
-          shaker.write(msgToEchoedMessage(message))
-
-          shaker.rest()
-        }) as any,
-        upgradeOutbound: (conn: any) => conn
-      }
-    },
-    getPeerStore() {
-      return {
-        addressBook: {
-          get: async (peer: PeerId): Promise<Address[]> => {
-            return [
-              {
-                multiaddr: new Multiaddr(`/ip4/127.0.0.1/tcp/1/p2p/${peer.toString()}`),
-                isCertified: true
-              }
-            ]
-          }
-        }
-      }
-    },
-    getConnectionManager() {
-      return {
-        getConnections(_peerId: PeerId) {
-          return []
-        },
-        dialer: {} as any
-      } as Components['connectionManager']
-    }
-  } as Components
-}
-
-function getPeer(peerId: PeerId, network: EventEmitter, testingOptions?: HoprConnectTestingOptions) {
-  async function dialDirectly(ma: Multiaddr): Promise<Connection> {
-    const peerId = peerIdFromString(ma.getPeerId() as string)
-
-    return {
-      remotePeer: peerId,
-      newStream: async (protocol: string) => {
-        const AtoB = pair<StreamType>()
-        const BtoA = pair<StreamType>()
-
-        network.emit(getPeerProtocol(peerId, protocol), {
-          stream: {
-            sink: AtoB.sink,
-            source: BtoA.source
-          },
-          connection: {
-            remotePeer: peerId
-          }
-        })
-
-        return {
-          protocol,
-          stream: {
-            sink: BtoA.sink,
-            source: AtoB.source
-          }
-        }
-      }
-    } as any
-  }
-
-  const relay = new Relay(
-    dialDirectly,
-    (multiaddrs: Multiaddr[]) => multiaddrs,
-    { environment: `testingEnvironment` },
-    testingOptions ?? { __noWebRTCUpgrade: true }
-  )
-
-  relay.init(createFakeComponents(peerId, network))
-  relay.initConnect({
     getWebRTCUpgrader() {
       const webRTCInstance = new EventEmitter()
       return {
@@ -130,23 +43,47 @@ function getPeer(peerId: PeerId, network: EventEmitter, testingOptions?: HoprCon
         upgradeInbound() {
           return webRTCInstance
         }
-      }
+      } as NonNullable<ConnectComponents['webRTCUpgrader']>
     }
-  } as ConnectComponents)
+  } as ConnectComponents
+}
 
-  relay.start()
-  relay.afterStart()
+async function getPeer(
+  peerId: PeerId,
+  network: ReturnType<typeof createFakeNetwork>,
+  port: number,
+  testingOptions?: HoprConnectTestingOptions
+) {
+  const relay = new Relay({ environment: `testingEnvironment` }, testingOptions ?? { __noWebRTCUpgrade: true })
+
+  relay.init(
+    await createFakeComponents(peerId, network, {
+      listeningAddrs: [new Multiaddr(`/ip4/127.0.0.1/tcp/${port}`)],
+      onIncomingStream: onInboundStream
+    })
+  )
+  relay.initConnect(createFakeConnectComponents())
+
+  await relay.afterStart()
 
   return relay
 }
 
 describe('test relay', function () {
   it('connect to a relay, close the connection and reconnect', async function () {
-    const network = new EventEmitter()
+    const network = createFakeNetwork()
 
-    const Alice = getPeer(initiator, network)
-    const Bob = getPeer(relay, network)
-    const Charly = getPeer(counterparty, network)
+    const Alice = await getPeer(initiator, network, 1)
+    const Bob = await getPeer(relay, network, 2)
+    const Charly = await getPeer(counterparty, network, 3)
+
+    await Alice.getComponents()
+      .getPeerStore()
+      .addressBook.add(Bob.getComponents().getPeerId(), Bob.getComponents().getTransportManager().getAddrs())
+
+    await Bob.getComponents()
+      .getPeerStore()
+      .addressBook.add(Charly.getComponents().getPeerId(), Charly.getComponents().getTransportManager().getAddrs())
 
     for (let i = 0; i < 5; i++) {
       const conn = await Alice.connect(Bob.getComponents().getPeerId(), Charly.getComponents().getPeerId())
@@ -171,15 +108,23 @@ describe('test relay', function () {
     Bob.stop()
     Charly.stop()
 
-    network.removeAllListeners()
+    network.stop()
   })
 
   it('connect to a relay and reconnect', async function () {
-    const network = new EventEmitter()
+    const network = createFakeNetwork()
 
-    const Alice = getPeer(initiator, network)
-    const Bob = getPeer(relay, network)
-    const Charly = getPeer(counterparty, network)
+    const Alice = await getPeer(initiator, network, 1)
+    const Bob = await getPeer(relay, network, 2)
+    const Charly = await getPeer(counterparty, network, 3)
+
+    await Alice.getComponents()
+      .getPeerStore()
+      .addressBook.add(Bob.getComponents().getPeerId(), Bob.getComponents().getTransportManager().getAddrs())
+
+    await Bob.getComponents()
+      .getPeerStore()
+      .addressBook.add(Charly.getComponents().getPeerId(), Charly.getComponents().getTransportManager().getAddrs())
 
     for (let i = 0; i < 3; i++) {
       const conn = await Alice.connect(Bob.getComponents().getPeerId(), Charly.getComponents().getPeerId())
@@ -202,6 +147,6 @@ describe('test relay', function () {
     Bob.stop()
     Charly.stop()
 
-    network.removeAllListeners()
+    network.stop()
   })
 })

--- a/packages/connect/src/relay/index.ts
+++ b/packages/connect/src/relay/index.ts
@@ -1,32 +1,27 @@
 import type { PeerId } from '@libp2p/interface-peer-id'
-import type { Connection, ProtocolStream } from '@libp2p/interface-connection'
-import type { Multiaddr } from '@multiformats/multiaddr'
-import type { Address } from '@libp2p/interface-peer-store'
+import type { Connection } from '@libp2p/interface-connection'
 import type { IncomingStreamData } from '@libp2p/interfaces/registrar'
 import type { Initializable, Components } from '@libp2p/interfaces/components'
 import type { Startable } from '@libp2p/interfaces/startable'
 import type { DialOptions } from '@libp2p/interface-transport'
+import type { Stream, HoprConnectOptions, HoprConnectTestingOptions } from '../types.js'
+import type { ConnectComponents, ConnectInitializable } from '../components.js'
 
 import { peerIdFromString } from '@libp2p/peer-id'
-
-import type { HoprConnect } from '../index.js'
-
-import type { Stream, HoprConnectOptions, HoprConnectTestingOptions } from '../types.js'
 
 import errCode from 'err-code'
 import debug from 'debug'
 import chalk from 'chalk'
 
 import { WebRTCConnection } from '../webrtc/index.js'
-import { RELAY_PROTOCOLS, DELIVERY_PROTOCOLS, CODE_P2P, OK, CAN_RELAY_PROTOCOLS } from '../constants.js'
+import { RELAY_PROTOCOLS, DELIVERY_PROTOCOLS, OK, CAN_RELAY_PROTOCOLS } from '../constants.js'
 import { RelayConnection } from './connection.js'
 import { RelayHandshake, RelayHandshakeMessage } from './handshake.js'
 import { RelayState } from './state.js'
-import { createRelayerKey, randomInteger, retimer, tryExistingConnections } from '@hoprnet/hopr-utils'
+import { createRelayerKey, dial, DialStatus, randomInteger, retimer } from '@hoprnet/hopr-utils'
 import { handshake } from 'it-handshake'
 
 import { attemptClose } from '../utils/index.js'
-import { type ConnectComponents, ConnectInitializable } from '../components.js'
 
 const DEBUG_PREFIX = 'hopr-connect:relay'
 const DEFAULT_MAX_RELAYED_CONNECTIONS = 10
@@ -34,10 +29,6 @@ const DEFAULT_MAX_RELAYED_CONNECTIONS = 10
 const log = debug(DEBUG_PREFIX)
 const error = debug(DEBUG_PREFIX.concat(':error'))
 const verbose = debug(DEBUG_PREFIX.concat(':verbose'))
-
-type ConnResult = ProtocolStream & {
-  conn: Connection
-}
 
 function printUsedRelays(peers: PeerId[], prefix = '') {
   let out = `${prefix}\n`
@@ -67,12 +58,7 @@ class Relay implements Initializable, ConnectInitializable, Startable {
   private components: Components | undefined
   private connectComponents: ConnectComponents | undefined
 
-  constructor(
-    private dialDirectly: HoprConnect['dialDirectly'],
-    private filter: HoprConnect['filter'],
-    private options: HoprConnectOptions,
-    private testingOptions: HoprConnectTestingOptions
-  ) {
+  constructor(private options: HoprConnectOptions, private testingOptions: HoprConnectTestingOptions) {
     this._isStarted = false
 
     log(`relay testing options`, testingOptions)
@@ -91,7 +77,6 @@ class Relay implements Initializable, ConnectInitializable, Startable {
     this.onDelivery = this.onDelivery.bind(this)
     this.onRelay = this.onRelay.bind(this)
     this.onCanRelay = this.onCanRelay.bind(this)
-    this.dialNodeDirectly = this.dialNodeDirectly.bind(this)
   }
 
   public init(components: Components) {
@@ -207,14 +192,14 @@ class Relay implements Initializable, ConnectInitializable, Startable {
     destination: PeerId,
     options?: DialOptions
   ): Promise<RelayConnection | WebRTCConnection | undefined> {
-    const protocolsRelay = RELAY_PROTOCOLS(this.options.environment, this.options.supportedEnvironments)
-    const baseConnection = await this.dialNodeDirectly(relay, protocolsRelay, {
-      signal: options?.signal,
-      // libp2p interface type clash
-      upgrader: this.getComponents().getUpgrader() as any
-    }).catch(error)
+    const response = await dial(
+      this.getComponents(),
+      relay,
+      RELAY_PROTOCOLS(this.options.environment, this.options.supportedEnvironments),
+      false
+    )
 
-    if (baseConnection == undefined) {
+    if (response.status != DialStatus.SUCCESS) {
       error(
         `Cannot establish a connection to ${chalk.green(destination.toString())} because relay ${chalk.green(
           relay.toString()
@@ -223,7 +208,7 @@ class Relay implements Initializable, ConnectInitializable, Startable {
       return
     }
 
-    const shaker = new RelayHandshake(baseConnection.stream, this.options)
+    const shaker = new RelayHandshake(response.resp.stream, this.options)
 
     const handshakeResult = await shaker.initiate(relay, destination)
 
@@ -233,7 +218,7 @@ class Relay implements Initializable, ConnectInitializable, Startable {
       // for us.
       if (this.usedRelays.findIndex((usedRelay: PeerId) => usedRelay.equals(relay)) < 0) {
         try {
-          await baseConnection.conn.close()
+          await response.resp.conn.close()
         } catch (err) {
           error(`Error while closing unused connection to relay ${relay.toString()}`, err)
         }
@@ -269,8 +254,6 @@ class Relay implements Initializable, ConnectInitializable, Startable {
     if (!this.testingOptions.__noWebRTCUpgrade) {
       return new WebRTCConnection(conn, {
         __noWebRTCUpgrade: this.testingOptions.__noWebRTCUpgrade,
-        // libp2p interface type clash
-        upgrader: this.getComponents().getUpgrader() as any,
         ...opts
       })
     } else {
@@ -290,10 +273,7 @@ class Relay implements Initializable, ConnectInitializable, Startable {
     )
 
     if (!this.testingOptions.__noWebRTCUpgrade) {
-      return new WebRTCConnection(conn, this.testingOptions, {
-        // libp2p interface type clash
-        upgrader: this.getComponents().getUpgrader() as any
-      })
+      return new WebRTCConnection(conn, this.testingOptions)
     } else {
       return conn
     }
@@ -359,12 +339,7 @@ class Relay implements Initializable, ConnectInitializable, Startable {
       } else {
         // NOTE: This cannot be awaited, otherwise it stalls the relay loop. Therefore, promise rejections must
         // be handled downstream to avoid unhandled promise rejection crashes
-        shaker.negotiate(
-          conn.connection.remotePeer,
-          this.dialNodeDirectly,
-          this.relayState,
-          this.getComponents().getUpgrader()
-        )
+        await shaker.negotiate(conn.connection.remotePeer, this.getComponents(), this.relayState)
       }
     } catch (e) {
       error(`Error while processing relay request from ${conn.connection.remotePeer.toString()}: ${e}`)
@@ -433,7 +408,7 @@ class Relay implements Initializable, ConnectInitializable, Startable {
 
     let newConn: Connection
 
-    log(`Handling reconnection to ${counterparty.toString()}`)
+    log(`Handling reconnect attempt to ${counterparty.toString()}`)
 
     try {
       if (!this.testingOptions.__noWebRTCUpgrade) {
@@ -471,90 +446,6 @@ class Relay implements Initializable, ConnectInitializable, Startable {
         error(`Error while closing dead connection`, err)
       }
     }
-  }
-
-  /**
-   * Attempts to establish a direct connection to the destination
-   * @param destination peer to connect to
-   * @param protocols
-   * @param opts
-   * @returns a stream to the given peer
-   */
-  private async dialNodeDirectly(
-    destination: PeerId,
-    protocols: string[],
-    opts: DialOptions
-  ): Promise<ConnResult | void> {
-    let connResult = await tryExistingConnections(this.getComponents(), destination, protocols)
-
-    // Only establish a new connection if we don't have any.
-    // Don't establish a new direct connection to the recipient when using
-    // simulated NAT
-    if (connResult == undefined) {
-      connResult = await this.establishDirectConnection(destination, protocols, opts)
-    }
-
-    return connResult
-  }
-
-  /**
-   * Establishes a new connection to the given by using a direct
-   * TCP connection.
-   * @param destination peer to connect to
-   * @param protocols desired protocols
-   * @param opts additional options such as timeout
-   * @returns a stream to the given peer
-   */
-  private async establishDirectConnection(
-    destination: PeerId,
-    protocols: string[],
-    opts: DialOptions
-  ): Promise<ConnResult | undefined> {
-    const usableAddresses: Multiaddr[] = []
-
-    const knownAddresses: Address[] = await this.getComponents().getPeerStore().addressBook.get(destination)
-    for (const knownAddress of knownAddresses) {
-      // Check that the address:
-      // - matches the format (PeerStore might include addresses of other transport modules)
-      // - is a direct address (PeerStore might include relay addresses)
-      if (this.filter([knownAddress.multiaddr]).length > 0 && knownAddress.multiaddr.tuples()[0][0] != CODE_P2P) {
-        usableAddresses.push(knownAddress.multiaddr)
-      }
-    }
-
-    if (usableAddresses.length == 0) {
-      return
-    }
-
-    let stream: ProtocolStream | undefined
-    let conn: Connection | undefined
-
-    for (const usable of usableAddresses) {
-      try {
-        conn = await this.dialDirectly(usable, opts)
-      } catch (err) {
-        await attemptClose(conn, error)
-        continue
-      }
-
-      if (conn != undefined) {
-        try {
-          stream = await conn.newStream(protocols)
-        } catch (err) {
-          await attemptClose(conn, error)
-          continue
-        }
-
-        if (
-          stream == undefined &&
-          // Only close the connection if we are not using this peer as a relay
-          this.usedRelays.findIndex((usedRelay: PeerId) => usedRelay.equals(destination)) < 0
-        ) {
-          await attemptClose(conn, error)
-        }
-      }
-    }
-    return conn != undefined && stream != undefined ? { conn, ...stream } : undefined
   }
 }
 

--- a/packages/connect/src/utils/libp2p.mock.spec.ts
+++ b/packages/connect/src/utils/libp2p.mock.spec.ts
@@ -1,0 +1,405 @@
+import type { Connection } from '@libp2p/interface-connection'
+import type { Dialer, ConnectionManagerEvents } from '@libp2p/interface-connection-manager'
+import type { Components, Initializable } from '@libp2p/interfaces/components'
+import type { AbortOptions } from '@libp2p/interfaces'
+import { type PeerId, isPeerId } from '@libp2p/interface-peer-id'
+import { CustomEvent, EventEmitter as TypedEventEmitter } from '@libp2p/interfaces/events'
+import { peerIdFromString } from '@libp2p/peer-id'
+import type { PeerStore } from '@libp2p/interfaces/peer-store'
+import { duplexPair } from 'it-pair/duplex'
+
+import { EventEmitter } from 'events'
+import { Multiaddr } from '@multiformats/multiaddr'
+
+import type { Stream } from '../types.js'
+import { CODE_P2P } from '../constants.js'
+import { StreamHandler } from '@libp2p/interfaces/registrar'
+import { MultiaddrConnection } from '@libp2p/interfaces/transport'
+
+/**
+ * Minimal TransportManager, used for unit testing
+ */
+class MyTransportManager implements Initializable {
+  private components: Components | undefined
+
+  private addrs: Set<string>
+
+  constructor(private network: ReturnType<typeof createFakeNetwork>) {
+    this.addrs = new Set<string>()
+  }
+
+  public init(components: Components) {
+    this.components = components
+  }
+
+  public getComponents() {
+    if (this.components == undefined) {
+      throw Error(`Components not set`)
+    }
+    return this.components
+  }
+
+  public async listen(addrs: Multiaddr[]) {
+    for (const addr of addrs) {
+      addr.decapsulateCode(CODE_P2P)
+      if (!this.addrs.has(addr.toString())) {
+        this.addrs.add(addr.toString())
+      }
+      this.network.listen(addr, this.getComponents())
+    }
+  }
+
+  public getAddrs(): Multiaddr[] {
+    return [...this.addrs].map((str) => new Multiaddr(str))
+  }
+}
+
+/**
+ * Minimal Registrar, used for unit testing
+ */
+class MyRegistrar {
+  handlers: Map<string, StreamHandler>
+
+  constructor() {
+    this.handlers = new Map<string, StreamHandler>()
+  }
+
+  public async handle(protocols: string | string[], handler: StreamHandler): Promise<void> {
+    for (const protocol of Array.isArray(protocols) ? protocols : [protocols]) {
+      this.handlers.set(protocol, handler)
+    }
+  }
+
+  public getHandler(protocol: string): StreamHandler {
+    return this.handlers.get(protocol) as StreamHandler
+  }
+}
+
+/**
+ * Minimal ConnectionManager used for unit testing
+ */
+class MyConnectionManager extends TypedEventEmitter<ConnectionManagerEvents> implements Initializable {
+  dialer: Dialer
+
+  connections: Map<string, Connection[]>
+
+  components: Components | undefined
+
+  constructor(
+    peerStore: PeerStore,
+    network: ReturnType<typeof createFakeNetwork>,
+    connManagerOpts: {
+      outerDial?: ReturnType<typeof createFakeNetwork>['connect']
+      getStream?: (protocol?: string | string[]) => Stream
+    } = {}
+  ) {
+    super()
+
+    this.connections = new Map<string, Connection[]>()
+
+    this.dialer = {
+      dial: async (peer: PeerId | Multiaddr, _opts: Parameters<Dialer['dial']>[1]) => {
+        const dialMethod = connManagerOpts.outerDial ?? network.connect
+
+        let conn: Connection | undefined
+        let fullAddr: Multiaddr | undefined
+        let peerId: PeerId
+
+        if (isPeerId(peer)) {
+          // Connect using PeerId and known addresses
+          peerId = peer
+          const addrs = await peerStore.addressBook.get(peer)
+
+          if (addrs == null || addrs.length == 0) {
+            throw Error(`No addresses known`)
+          }
+
+          for (const addr of addrs) {
+            fullAddr = addr.multiaddr.decapsulateCode(CODE_P2P).encapsulate(`/p2p/${peer.toString()}`)
+            try {
+              conn = dialMethod(this.getComponents().getPeerId(), fullAddr) as any
+            } catch (err) {
+              // try next address
+              continue
+            }
+
+            if (conn != undefined) {
+              break
+            }
+          }
+
+          if (conn == undefined) {
+            throw Error(`Dial error: no valid addresses known`)
+          }
+        } else {
+          // Connect using given Multiaddr that contains a PeerId
+          peerId = peerIdFromString(peer.getPeerId() as string)
+          fullAddr = peer.decapsulateCode(CODE_P2P).encapsulate(`/p2p/${peer.toString()}`)
+
+          conn = dialMethod(this.getComponents().getPeerId(), fullAddr)
+        }
+
+        if (conn != undefined) {
+          this.connections.set(peer.toString(), (this.connections.get(peer.toString()) ?? []).concat([conn]))
+
+          network.events.once(disconnectEvent(fullAddr as Multiaddr), (emitEvent: boolean = true) =>
+            this.onClose(peerId, emitEvent)
+          )
+
+          return conn as any
+        }
+
+        throw Error(`not implemented within unit test`)
+      }
+    } as Dialer
+  }
+
+  public init(components: Components) {
+    this.components = components
+  }
+
+  public getConnections(peer: PeerId | undefined, _options?: AbortOptions): Connection[] {
+    if (peer == undefined) {
+      return [...this.connections.values()].flat(1)
+    } else {
+      return this.connections.get(peer.toString()) ?? []
+    }
+  }
+
+  public getComponents() {
+    if (this.components == undefined) {
+      throw Error(`Components not set`)
+    }
+    return this.components
+  }
+
+  private onClose(peer: PeerId, emitEvent: boolean = true) {
+    const existingConnections = this.connections.get(peer.toString())
+    if (existingConnections != undefined && existingConnections.length > 0) {
+      const toClose = existingConnections.shift()
+
+      this.connections.set(peer.toString(), existingConnections)
+
+      if (emitEvent && existingConnections.length == 0) {
+        this.dispatchEvent(
+          new CustomEvent<Connection>('peer:disconnect', {
+            detail: toClose
+          })
+        )
+      }
+    }
+  }
+}
+
+/**
+ * Implements a minimal, non-persistent PeerStore
+ * @returns mocked PeerStore
+ */
+function createFakePeerStore(): PeerStore {
+  const addrs = new Map<string, Multiaddr[]>()
+
+  return {
+    addressBook: {
+      async get(id: PeerId) {
+        return (addrs.get(id.toString()) ?? []).map((ma) => ({ multiaddr: ma, isCertified: true }))
+      },
+      async add(id: PeerId, multiaddrs: Multiaddr[]) {
+        addrs.set(
+          id.toString(),
+          [
+            ...new Set(
+              (addrs.get(id.toString()) ?? []).concat(multiaddrs).map((ma) => ma.decapsulateCode(CODE_P2P).toString())
+            )
+          ].map((str) => new Multiaddr(str))
+        )
+      }
+    }
+  } as PeerStore
+}
+
+/**
+ * Implements a minimal Upgrader, bypassing any protocol uprades
+ * @param onInboundStream reply to inbound stream
+ * @returns
+ */
+function createFakeUpgrader(onInboundStream?: (stream: Stream) => Promise<void>): NonNullable<Components['upgrader']> {
+  return {
+    async upgradeInbound(maConn: MultiaddrConnection) {
+      maConn.timeline.upgraded = Date.now()
+
+      // @TODO enhance this
+      onInboundStream?.(maConn)
+
+      return maConn
+    },
+    async upgradeOutbound(maConn: MultiaddrConnection) {
+      maConn.timeline.upgraded = Date.now()
+
+      return maConn
+    }
+  }
+}
+
+export function connectEvent(addr: Multiaddr): string {
+  return `connect:${addr.decapsulateCode(CODE_P2P).toString()}`
+}
+
+export function disconnectEvent(addr: Multiaddr) {
+  return `disconnect:${addr.decapsulateCode(CODE_P2P).toString()}`
+}
+
+/**
+ * Creates a connection that mimics libp2p's protocol selection
+ * @param self initiator of the connection
+ * @param remoteComponents libp2p instance of remote peer
+ * @param throwError if true, throw an error instead of returning a stream
+ * @returns
+ */
+function createConnection(self: PeerId, remoteComponents: Components, throwError: boolean = false): Connection {
+  const conn = {
+    remotePeer: remoteComponents.getPeerId(),
+    _closed: false,
+    close: async () => {
+      // @ts-ignore
+      conn._closed = true
+    },
+    stat: {
+      direction: 'outbound',
+      timeline: {
+        open: Date.now()
+      }
+    },
+    newStream: async (protocols: string[]) => {
+      if (throwError) {
+        throw Error(`boom - protocol error`)
+      }
+
+      for (const protocol of protocols) {
+        const streamHandler = remoteComponents.getRegistrar().getHandler(protocol)
+        if (streamHandler != undefined) {
+          const duplex = duplexPair<Uint8Array>()
+
+          streamHandler({
+            stream: {
+              sink: duplex[1].sink,
+              source: duplex[1].source
+            } as any,
+            protocol,
+            connection: {
+              remotePeer: self,
+              stat: {
+                direction: 'inbound',
+                timeline: {
+                  open: Date.now()
+                }
+              }
+            } as any
+          })
+          return {
+            protocol,
+            stream: {
+              sink: duplex[0].sink,
+              source: duplex[0].source
+            }
+          }
+        }
+      }
+
+      throw Error(`None of the given protocols '${protocols.join(', ')}' are spoken`)
+    }
+  } as unknown as Connection
+
+  return conn as Connection
+}
+
+/**
+ * Creates a network that behaves similarly to a socket-based network
+ * @returns Event-based network implementation
+ */
+export function createFakeNetwork() {
+  const network = new EventEmitter()
+
+  // Multiaddr (including PeerId) -> Components
+  let components: Map<string, Components> = new Map<string, Components>()
+
+  const listen = (addr: Multiaddr, nodeComponents: Components) => {
+    components.set(
+      addr.decapsulateCode(CODE_P2P).encapsulate(`/p2p/${nodeComponents.getPeerId().toString()}`).toString(),
+      nodeComponents
+    )
+  }
+
+  const connect = (self: PeerId, ma: Multiaddr, throwError: boolean = false) => {
+    const remoteComponents = components.get(ma.toString())
+
+    if (remoteComponents != undefined) {
+      return createConnection(self, remoteComponents, throwError)
+    }
+
+    throw Error(`Cannot connect. Maybe not listening?`)
+  }
+
+  const close = (ma: Multiaddr, emitEvent: boolean = true) => {
+    components.delete(ma.toString())
+    network.emit(disconnectEvent(ma), emitEvent)
+  }
+
+  return {
+    events: network,
+    listen,
+    connect,
+    close,
+    stop: network.removeAllListeners.bind(network)
+  }
+}
+
+/**
+ * Returns a minimal implementation of libp2p components
+ * @param peerId the components identity
+ * @param opts customizable dial behavior
+ * @returns
+ */
+export async function createFakeComponents(
+  peerId: PeerId,
+  network: ReturnType<typeof createFakeNetwork>,
+  opts: {
+    outerDial?: ReturnType<typeof createFakeNetwork>['connect']
+    protocols?: Iterable<[string | string[], StreamHandler]>
+    listeningAddrs?: Multiaddr[]
+    onIncomingStream?: (stream: Stream) => Promise<void>
+  } = {}
+) {
+  const peerStore = createFakePeerStore()
+
+  const registrar = new MyRegistrar() as NonNullable<Components['registrar']>
+
+  const transportManager = new MyTransportManager(network) as NonNullable<Components['transportManager']>
+
+  const connectionManager = new MyConnectionManager(peerStore, network, opts) as NonNullable<
+    Components['connectionManager']
+  >
+
+  const upgrader = createFakeUpgrader(opts.onIncomingStream)
+
+  const components = {
+    getConnectionManager: () => connectionManager,
+    getPeerId: () => peerId,
+    getPeerStore: () => peerStore,
+    getRegistrar: () => registrar,
+    getTransportManager: () => transportManager,
+    getUpgrader: () => upgrader
+  } as Components
+
+  connectionManager.init(components)
+  transportManager.init(components)
+
+  for (const protcolHandler of opts.protocols ?? []) {
+    await components.getRegistrar().handle(...protcolHandler)
+  }
+
+  if (opts.listeningAddrs) {
+    await components.getTransportManager().listen(opts.listeningAddrs)
+  }
+
+  return components
+}


### PR DESCRIPTION
Cherry-pick from #4171 

### Reuse existing connections for relayed connections

Current bevavior: `connect` ignores any existing connect when initiating a relayed connection over a public relay.

New behavior: Reuse existing connections by using same connection method as other sub-protocols

### Additional changes

Implements a minimal version of libp2p for testing that does not require any real sockets.