### PR TITLE
filter multiaddrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Refactor timeouts for more throughput and increase usage of iterables ([#4238](https://github.com/hoprnet/hoprnet/pull/4238))
 - Refactor packet forward interaction for less locking ([#4232](https://github.com/hoprnet/hoprnet/pull/4243))
 - Refactor mixer to migitate backpressure ([#4232](https://github.com/hoprnet/hoprnet/pull/4243))
+- Filter addresses before adding them to libp2p's PeerStore ([#4246](https://github.com/hoprnet/hoprnet/pull/4246))
 
 ---
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -74,6 +74,8 @@ import { createLibp2pInstance } from './main.js'
 import type { EventEmitter as Libp2pEmitter } from '@libp2p/interfaces/events'
 import { PeerConnectionType } from '@hoprnet/hopr-connect'
 
+const CODE_P2P = protocols('p2p').code
+
 const DEBUG_PREFIX = `hopr-core`
 const log = debug(DEBUG_PREFIX)
 const verbose = debug(DEBUG_PREFIX.concat(`:verbose`))
@@ -555,10 +557,19 @@ class Hopr extends EventEmitter {
       return
     }
 
-    const dialables = peer.multiaddrs.filter((ma: Multiaddr) => {
-      const tuples = ma.tuples()
-      return tuples.length > 1 && tuples[0][0] != protocols('p2p').code
-    })
+    const addrsToAdd: Multiaddr[] = []
+    for (const addr of peer.multiaddrs) {
+      const tuples = addr.tuples()
+
+      if (tuples.length <= 1 && tuples[0][0] == CODE_P2P) {
+        // No routable address
+        continue
+      }
+
+      // Remove /p2p/<PEER_ID> from Multiaddr to prevent from duplicates
+      // in peer store
+      addrsToAdd.push(addr.decapsulateCode(CODE_P2P))
+    }
 
     const pubKey = convertPubKeyFromPeerId(peer.id)
     try {
@@ -567,11 +578,11 @@ class Hopr extends EventEmitter {
       log(`Failed to update key peer-store with new peer ${peer.id.toString()} info`, err)
     }
 
-    if (dialables.length > 0) {
-      this.publicNodesEmitter.emit('addPublicNode', { id: peer.id, multiaddrs: dialables })
+    if (addrsToAdd.length > 0) {
+      this.publicNodesEmitter.emit('addPublicNode', { id: peer.id, multiaddrs: addrsToAdd })
 
       try {
-        await this.libp2pComponents.getPeerStore().addressBook.add(peer.id, dialables)
+        await this.libp2pComponents.getPeerStore().addressBook.add(peer.id, addrsToAdd)
       } catch (err) {
         log(`Failed to update address peer-store with new peer ${peer.id.toString()} info`, err)
       }

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -12,7 +12,7 @@ import { keysPBM } from '@libp2p/crypto/keys'
 import type { AddressSorter, Address } from '@libp2p/interfaces/peer-store'
 
 import { HoprConnect, compareAddressesLocalMode, type PublicNodesEmitter } from '@hoprnet/hopr-connect'
-import { HoprDB, PublicKey, debug } from '@hoprnet/hopr-utils'
+import { HoprDB, PublicKey, debug, isAddressWithPeerId } from '@hoprnet/hopr-utils'
 import HoprCoreEthereum from '@hoprnet/hopr-core-ethereum'
 
 import Hopr, { type HoprOptions } from './index.js'
@@ -162,6 +162,15 @@ export async function createLibp2pInstance(
       },
       identify: {
         protocolPrefix
+      },
+      peerStore: {
+        // Prevents peer-store from storing addresses twice, e.g.
+        // /ip4/1.2.3.4/tcp/23/p2p/16Uiu2HAmQBZA4TzjKjU5fpCSprGuM2y8mpepNwMS6ZKFATiKg68h
+        // /ip4/1.2.3.4/tcp/23
+        // same for
+        // /p2p/16Uiu2HAkzEnkW3xGJbvpXSXmvVR177LcR4Sw7z5S1ijuBcnbVFsV/p2p-circuit
+        // /p2p/16Uiu2HAkzEnkW3xGJbvpXSXmvVR177LcR4Sw7z5S1ijuBcnbVFsV/p2p-circuit/p2p/16Uiu2HAmQBZA4TzjKjU5fpCSprGuM2y8mpepNwMS6ZKFATiKg68h
+        addressFilter: async (_peerId: PeerId, multiaddr: Multiaddr) => !isAddressWithPeerId(multiaddr)
       },
       datastore
     })

--- a/packages/utils/src/network/addrs.spec.ts
+++ b/packages/utils/src/network/addrs.spec.ts
@@ -12,7 +12,8 @@ import {
   getPublicAddresses,
   prefixLength,
   u8aAddressToCIDR,
-  createCircuitAddress
+  createCircuitAddress,
+  isAddressWithPeerId
 } from './addrs.js'
 import { type Network, PRIVATE_V4_CLASS_B, PRIVATE_V4_CLASS_C } from './constants.js'
 import { u8aEquals, u8aToHex } from '../u8a/index.js'
@@ -229,5 +230,28 @@ describe('test utils', function () {
     const ma = new Multiaddr(`/p2p/16Uiu2HAmQBZA4TzjKjU5fpCSprGuM2y8mpepNwMS6ZKFATiKg68h/p2p-circuit`)
 
     assert(u8aEquals(createCircuitAddress(peerIdFromString(peerId)).bytes, ma.bytes))
+  })
+
+  it('should filter p2p addrs', function () {
+    assert(
+      isAddressWithPeerId(new Multiaddr(`/p2p/16Uiu2HAmQBZA4TzjKjU5fpCSprGuM2y8mpepNwMS6ZKFATiKg68h/p2p-circuit`)) ===
+        false
+    )
+
+    assert(
+      isAddressWithPeerId(
+        new Multiaddr(
+          `/p2p/16Uiu2HAmQBZA4TzjKjU5fpCSprGuM2y8mpepNwMS6ZKFATiKg68h/p2p-circuit/p2p/16Uiu2HAmQBZA4TzjKjU5fpCSprGuM2y8mpepNwMS6ZKFATiKg68h`
+        )
+      ) === true
+    )
+
+    assert(isAddressWithPeerId(new Multiaddr(`/ip4/1.2.3.4/tcp/23`)) === false)
+
+    assert(
+      isAddressWithPeerId(
+        new Multiaddr(`/ip4/1.2.3.4/tcp/23/p2p/16Uiu2HAmQBZA4TzjKjU5fpCSprGuM2y8mpepNwMS6ZKFATiKg68h`)
+      ) === true
+    )
   })
 })

--- a/packages/utils/src/network/addrs.ts
+++ b/packages/utils/src/network/addrs.ts
@@ -332,12 +332,10 @@ export function isAddressWithPeerId(ma: Multiaddr) {
       switch (tuples[1][0]) {
         case CODE_TCP:
         case CODE_CIRCUIT:
-          if (tuples.length == 3 && tuples[2][0] == CODE_P2P) {
-            return true
-          }
+          return tuples.length == 3 && tuples[2][0] == CODE_P2P
       }
 
     default:
-      return ma.getPeerId() == undefined
+      return ma.getPeerId() != undefined
   }
 }

--- a/packages/utils/src/network/addrs.ts
+++ b/packages/utils/src/network/addrs.ts
@@ -10,8 +10,15 @@ import {
 
 import { networkInterfaces, type NetworkInterfaceInfo } from 'os'
 import type { PeerId } from '@libp2p/interface-peer-id'
-import { Multiaddr } from '@multiformats/multiaddr'
+import { Multiaddr, protocols } from '@multiformats/multiaddr'
 
+const CODE_P2P = protocols('p2p').code
+const CODE_IP4 = protocols('ip4').code
+const CODE_IP6 = protocols('ip6').code
+const CODE_DNS4 = protocols('dns4').code
+const CODE_DNS6 = protocols('dns6').code
+const CODE_CIRCUIT = protocols('p2p-circuit').code
+const CODE_TCP = protocols('tcp').code
 /**
  * Checks if given address is any address
  * @param address ip address to check
@@ -301,4 +308,36 @@ export function getLocalHosts(_iface?: string): Network[] {
 export function createCircuitAddress(relay: PeerId): Multiaddr {
   // equivalent to `return new Multiaddr(`/p2p/${relay.toString()}/p2p-circuit`)`
   return new Multiaddr(Uint8Array.from([165, 3, 39, ...relay.toBytes(), 162, 2]))
+}
+
+/**
+ * Checks known direct and circuit addresses if they end with `/p2p/<PEER_ID>`
+ *
+ * If not a known address, use generic but expensive Multiaddr function
+ *
+ * Used to filter addresses that get stored into libp2p's peer-store
+ *
+ * @param ma Multiaddr to check
+ * @returns
+ */
+export function isAddressWithPeerId(ma: Multiaddr) {
+  const tuples = ma.tuples()
+
+  switch (tuples[0][0]) {
+    case CODE_IP4:
+    case CODE_IP6:
+    case CODE_DNS4:
+    case CODE_DNS6:
+    case CODE_P2P:
+      switch (tuples[1][0]) {
+        case CODE_TCP:
+        case CODE_CIRCUIT:
+          if (tuples.length == 3 && tuples[2][0] == CODE_P2P) {
+            return true
+          }
+      }
+
+    default:
+      return ma.getPeerId() == undefined
+  }
 }


### PR DESCRIPTION
Filter multiaddrs that are stored in libp2p's peer-store.

Current behavior: addresses appear twice, namely

```
/ip4/1.2.3.4/tcp/23/p2p/16Uiu2HAmQBZA4TzjKjU5fpCSprGuM2y8mpepNwMS6ZKFATiKg68h
/ip4/1.2.3.4/tcp/23
/p2p/16Uiu2HAkzEnkW3xGJbvpXSXmvVR177LcR4Sw7z5S1ijuBcnbVFsV/p2p-circuit
/p2p/16Uiu2HAkzEnkW3xGJbvpXSXmvVR177LcR4Sw7z5S1ijuBcnbVFsV/p2p-circuit/p2p/16Uiu2HAmQBZA4TzjKjU5fpCSprGuM2y8mpepNwMS6ZKFATiKg68h
```
... which causes libp2p to interpret them as multiple addresses for the same peer, and thus try to dial the same address more than once

New behavior: addresses get filtered before they are added to the peer-store, leading to

```
/ip4/1.2.3.4/tcp/23
/p2p/16Uiu2HAkzEnkW3xGJbvpXSXmvVR177LcR4Sw7z5S1ijuBcnbVFsV/p2p-circuit
```