### PR TITLE
mitigate duplicate entry connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@
 - Refactor timeouts for more throughput and increase usage of iterables ([#4238](https://github.com/hoprnet/hoprnet/pull/4238))
 - Refactor packet forward interaction for less locking ([#4232](https://github.com/hoprnet/hoprnet/pull/4243))
 - Refactor mixer to migitate backpressure ([#4232](https://github.com/hoprnet/hoprnet/pull/4243))
-- Reuse existing connections to establish relayed connections over public relay ([#2545](https://github.com/hoprnet/hoprnet/pull/4245))
+- Reuse existing connections to establish relayed connections over public relay ([#4245](https://github.com/hoprnet/hoprnet/pull/4245))
+- Reuse existing connections to connections to entry nodes ([#4250](https://github.com/hoprnet/hoprnet/pull/4250))
 
 ---
 

--- a/packages/connect/src/base/entry.ts
+++ b/packages/connect/src/base/entry.ts
@@ -844,9 +844,27 @@ export class EntryNodes extends EventEmitter implements Initializable, Startable
    */
   protected updateRecords(groupedResults: Iterable<Grouped>) {
     // @TODO replace this by a more efficient data structure
-    const availableOnes = new Set<string>(this.availableEntryNodes.map((nodeData) => nodeData.id.toString()))
-    const uncheckedOnes = new Set<string>(this.uncheckedEntryNodes.map((nodeData) => nodeData.id.toString()))
-    const offlineOnes = new Set<string>(this.offlineEntryNodes.map((nodeData) => nodeData.id.toString()))
+    const availableOnes = new Set<string>(
+      function* (this: EntryNodes) {
+        for (const nodeData of this.availableEntryNodes) {
+          yield nodeData.id.toString()
+        }
+      }.call(this)
+    )
+    const uncheckedOnes = new Set<string>(
+      function* (this: EntryNodes) {
+        for (const nodeData of this.uncheckedEntryNodes) {
+          yield nodeData.id.toString()
+        }
+      }.call(this)
+    )
+    const offlineOnes = new Set<string>(
+      function* (this: EntryNodes) {
+        for (const nodeData of this.offlineEntryNodes) {
+          yield nodeData.id.toString()
+        }
+      }.call(this)
+    )
 
     for (const [id, results] of groupedResults) {
       if (results.every((result) => result == undefined)) {

--- a/packages/connect/src/base/entry.ts
+++ b/packages/connect/src/base/entry.ts
@@ -326,9 +326,11 @@ export class EntryNodes extends EventEmitter implements Initializable, Startable
   }
 
   /**
-   * Enables entry node functionality. Called by listener once
-   * it determines that node *does not* have a publicly available
-   * address.
+   * Enables monitoring of entry nodes. Called by Listener
+   * once it is clear that nodes requires relayed connections.
+   *
+   * If not called, node won't contact any entry nodes or
+   * monitor their availability.
    */
   public enable() {
     this.enabled = true
@@ -795,6 +797,8 @@ export class EntryNodes extends EventEmitter implements Initializable, Startable
           if (result == undefined || result instanceof Error) {
             break
           }
+          // Includes a catch-all block and swallows, but
+          // logs all exceptions
           attemptClose((result as ConnectionResult).conn, error)
         }
 

--- a/packages/connect/src/base/listener.ts
+++ b/packages/connect/src/base/listener.ts
@@ -350,11 +350,9 @@ class Listener extends EventEmitter<ListenerEvents> implements InterfaceListener
     if (this.testingOptions.__runningLocally || natSituation.bidirectionalNAT || !natSituation.isExposed) {
       this.connectComponents.getEntryNodes().on(RELAY_CHANGED_EVENT, this._emitListening)
 
-      // Finish startup
-      this.connectComponents.getEntryNodes().start()
-
-      // Initiate update but don't await its result
-      this.connectComponents.getEntryNodes().updatePublicNodes()
+      // Instructs entry node manager to assign to available
+      // entry once startup has finished
+      this.connectComponents.getEntryNodes().enable()
     }
 
     this.state = ListenerState.LISTENING

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -86,11 +86,9 @@ class HoprConnect implements Transport, Initializable, Startable {
   public init(components: Components) {
     this.components = components
 
-    const dialDirectly = this.dialDirectly.bind(this)
-
     this.connectComponents = new ConnectComponents({
       addressFilter: new Filter(this.options),
-      entryNodes: new EntryNodes(dialDirectly, this.options),
+      entryNodes: new EntryNodes(this.options),
       relay: new Relay(this.options, this.testingOptions),
       upnpManager: new UpnpManager(),
       webRTCUpgrader: new WebRTCUpgrader(this.options)


### PR DESCRIPTION
cherry-pick from #4171 

### Prevent from duplicate connections to entry nodes

**Current behavior**: Whenever `connect` connects to an entry node, e.g. to reserve a relay slot, it creates a new connection to the entry nodes, no matter whether there was already a connection.

**New behavior**: Reuse existing connections and use same dial method as rest of the code.