### PR TITLE
fix empty Multiaddr

### DIFF
--- a/packages/connect/src/utils/addrs.spec.ts
+++ b/packages/connect/src/utils/addrs.spec.ts
@@ -21,6 +21,8 @@ describe('test address parsing', function () {
   })
 
   it('bad examples', function () {
+    assert(parseAddress(new Multiaddr()).valid === false)
+
     assert(parseAddress(new Multiaddr('/tcp/0')).valid === false)
 
     assert(parseAddress(new Multiaddr('/ip4/127.0.0.1/udp/0')).valid === false)

--- a/packages/connect/src/utils/addrs.ts
+++ b/packages/connect/src/utils/addrs.ts
@@ -146,6 +146,9 @@ function parseDirectAddress(maTuples: [code: number, addr: Uint8Array][]): Parse
 export function parseAddress(ma: Multiaddr): ParseResult<ValidAddress> {
   const tuples = ma.tuples() as [code: number, addr: Uint8Array][]
 
+  if (tuples.length == 0) {
+    return { valid: false }
+  }
   switch (tuples[0][0]) {
     case CODE_IP4:
     case CODE_IP6:


### PR DESCRIPTION
Fix parsing empty Multiaddr to prevent from error such as 
```
hopr-connect Dialing /p2p/16Uiu2HAmBUw1fj7xAQfAE4cmjm6M9BP7GMNCS4Y3cVsK3dvxKkW7/p2p-circuit/p2p/16Uiu2HAmRCt37o7znb9DNUwm5s1usYPGiAPGk7zoAJcezWfVd4hx +187ms
  hopr-connect:relay:error TypeError: Cannot read properties of undefined (reading '0')
  hopr-connect:relay:error     at parseAddress (file:///home/luc/repos/hopr/hoprnet/packages/connect/lib/utils/addrs.js:104:22)
  hopr-connect:relay:error     at Filter.filterDial (file:///home/luc/repos/hopr/hoprnet/packages/connect/lib/filter.js:93:24)
  hopr-connect:relay:error     at Filter.filter (file:///home/luc/repos/hopr/hoprnet/packages/connect/lib/filter.js:62:25)
  hopr-connect:relay:error     at Array.filter (<anonymous>)
  hopr-connect:relay:error     at HoprConnect.filter (file:///home/luc/repos/hopr/hoprnet/packages/connect/lib/index.js:191:72)
  hopr-connect:relay:error     at Relay.establishDirectConnection (file:///home/luc/repos/hopr/hoprnet/packages/connect/lib/relay/index.js:394:22)
  hopr-connect:relay:error     at async Relay.dialNodeDirectly (file:///home/luc/repos/hopr/hoprnet/packages/connect/lib/relay/index.js:375:26)
  hopr-connect:relay:error     at async Relay.connect (file:///home/luc/repos/hopr/hoprnet/packages/connect/lib/relay/index.js:154:32)
  hopr-connect:relay:error     at async HoprConnect.dialWithRelay (file:///home/luc/repos/hopr/hoprnet/packages/connect/lib/index.js:201:22)
  hopr-connect:relay:error     at async EventTarget.dial (file:///home/luc/repos/hopr/hoprnet/node_modules/libp2p/dist/src/transport-manager.js:78:20)
  hopr-connect:relay:error     at async DialRequest.dialAction (file:///home/luc/repos/hopr/hoprnet/node_modules/libp2p/dist/src/connection-manager/dialer/index.js:183:20)
  hopr-connect:relay:error     at async file:///home/luc/repos/hopr/hoprnet/node_modules/libp2p/dist/src/connection-manager/dialer/dial-request.js:67:28
  hopr-connect:relay:error     at async Promise.any (index 0)
  hopr-connect:relay:error     at async DialRequest.run (file:///home/luc/repos/hopr/hoprnet/node_modules/libp2p/dist/src/connection-manager/dialer/dial-request.js:53:20)
  hopr-connect:relay:error     at async Dialer.dial (file:///home/luc/repos/hopr/hoprnet/node_modules/libp2p/dist/src/connection-manager/dialer/index.js:100:32)
  hopr-connect:relay:error     at async EventTarget.openConnection (file:///home/luc/repos/hopr/hoprnet/node_modules/libp2p/dist/src/connection-manager/index.js:249:28) +181ms
  hopr-connect:relay:error Cannot establish a connection to 16Uiu2HAmRCt37o7znb9DNUwm5s1usYPGiAPGk7zoAJcezWfVd4hx because relay 16Uiu2HAmBUw1fj7xAQfAE4cmjm6M9BP7GMNCS4Y3cVsK3dvxKkW7 is not reachable +
```