### PR TITLE
Add 1.91 version range as supported in `monte_rosa` environment

### DIFF
--- a/packages/core/protocol-config.json
+++ b/packages/core/protocol-config.json
@@ -145,7 +145,7 @@
     "monte_rosa": {
       "network_id": "xdai",
       "environment_type": "production",
-      "version_range": "1.89||1.90",
+      "version_range": "1.89||1.90||1.91",
       "channel_contract_deploy_block": 0,
       "token_contract_address": "0x66225dE86Cac02b32f34992eb3410F59DE416698",
       "channels_contract_address": "0xFaBeE463f31E39eC8952bBfB4490C41103bf573e",


### PR DESCRIPTION
Version 1.91 will be supported in `monte_rosa` environment.