### PR TITLE
silence promise rejection

### DIFF
--- a/packages/utils/src/process/promiseRejectionFilter.ts
+++ b/packages/utils/src/process/promiseRejectionFilter.ts
@@ -21,7 +21,8 @@ export function setupPromiseRejectionFilter() {
         // Requires changes in libp2p, tbd in upstream PRs to libp2p
         msgString.match(/The operation was aborted/) ||
         // issues with WebRTC socket and `stream-to-it`
-        msgString.match(/ERR_DATA_CHANNEL/)
+        msgString.match(/ERR_DATA_CHANNEL/) ||
+        msgString.match(/ERR_ICE_CONNECTION_FAILURE/)
       ) {
         console.error('Unhandled promise rejection silenced')
         return


### PR DESCRIPTION
Closes #4057

The error is silenced because it can be safely ignored.