### PR TITLE
Allow `info` command before node has finished startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Reuse existing connections to connections to entry nodes ([#4250](https://github.com/hoprnet/hoprnet/pull/4250))
 - Remove recurring DHT ping queue cleanup and turn all public relay nodes into DHT servers ([#4247](https://github.com/hoprnet/hoprnet/pull/4247))
 - Various enhancements regarding memory consumption and overall efficiency, spread over multiple PRs
+- Allow `info` command before node startup has finished ([#4273](https://github.com/hoprnet/hoprnet/pull/4273))
 
 ---
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -754,6 +754,10 @@ class Hopr extends EventEmitter {
    * List the addresses on which the node is listening
    */
   public getListeningAddresses(): Multiaddr[] {
+    if (this.status !== 'RUNNING') {
+      // Not listening to any address unless `hopr` is running
+      return []
+    }
     // @TODO find a better way to do this
     // @ts-ignore undocumented method
     return this.libp2pComponents.getAddressManager().getListenAddrs()


### PR DESCRIPTION
Users can use the `info` command to get meaningful information before the node has finished startup