### PR TITLE
Make all tests run during Rust crates testing + minor metric fix

### DIFF
--- a/packages/connect/crates/Makefile
+++ b/packages/connect/crates/Makefile
@@ -10,7 +10,7 @@ JS_FILES = $(foreach package,$(PACKAGES),$(package)/pkg/$(subst -,_,$(package)).
 all: $(JS_FILES)
 
 test: $(JS_FILES)
-	$(foreach pkg,$(PACKAGES),npx wasm-pack test --node `pwd`/$(pkg) && ) true
+	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && npx wasm-pack test --node `pwd`/$(pkg) && ) true
 
 $(JS_FILES):
 	mkdir -p $(@D)

--- a/packages/core-ethereum/crates/Makefile
+++ b/packages/core-ethereum/crates/Makefile
@@ -10,7 +10,7 @@ JS_FILES = $(foreach package,$(PACKAGES),$(package)/pkg/$(subst -,_,$(package)).
 all: $(JS_FILES)
 
 test: $(JS_FILES)
-	$(foreach pkg,$(PACKAGES),npx wasm-pack test --node `pwd`/$(pkg) && ) true
+	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && npx wasm-pack test --node `pwd`/$(pkg) && ) true
 
 $(JS_FILES):
 	mkdir -p $(@D)

--- a/packages/core/crates/Makefile
+++ b/packages/core/crates/Makefile
@@ -10,7 +10,7 @@ JS_FILES = $(foreach package,$(PACKAGES),$(package)/pkg/$(subst -,_,$(package)).
 all: $(JS_FILES)
 
 test: $(JS_FILES)
-	$(foreach pkg,$(PACKAGES),npx wasm-pack test --node `pwd`/$(pkg) && ) true
+	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && npx wasm-pack test --node `pwd`/$(pkg) && ) true
 
 $(JS_FILES):
 	mkdir -p $(@D)

--- a/packages/core/src/network/heartbeat.ts
+++ b/packages/core/src/network/heartbeat.ts
@@ -306,8 +306,6 @@ export default class Heartbeat {
     // Will handle timeouts automatically
     const pingResults = await nAtATime(this.pingNode, pingWork, this.config.maxParallelHeartbeats)
 
-    metric_timeToHeartbeat.record_measure(metric_timer)
-
     for (const [resultIndex, pingResult] of pingResults.entries()) {
       if (pingResult instanceof Error) {
         // we need to get the destination so we can map a ping error properly
@@ -321,6 +319,8 @@ export default class Heartbeat {
         this.networkPeers.updateRecord(pingResult)
       }
     }
+
+    metric_timeToHeartbeat.record_measure(metric_timer)
 
     // Recalculate the network health indicator state after checking nodes
     this.recalculateNetworkHealth()

--- a/packages/cover-traffic-daemon/crates/Makefile
+++ b/packages/cover-traffic-daemon/crates/Makefile
@@ -10,7 +10,7 @@ JS_FILES = $(foreach package,$(PACKAGES),$(package)/pkg/$(subst -,_,$(package)).
 all: $(JS_FILES)
 
 test: $(JS_FILES)
-	$(foreach pkg,$(PACKAGES),npx wasm-pack test --node `pwd`/$(pkg) && ) true
+	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && npx wasm-pack test --node `pwd`/$(pkg) && ) true
 
 $(JS_FILES):
 	mkdir -p $(@D)

--- a/packages/ethereum/crates/Makefile
+++ b/packages/ethereum/crates/Makefile
@@ -10,7 +10,7 @@ JS_FILES = $(foreach package,$(PACKAGES),$(package)/pkg/$(subst -,_,$(package)).
 all: $(JS_FILES)
 
 test: $(JS_FILES)
-	$(foreach pkg,$(PACKAGES),npx wasm-pack test --node `pwd`/$(pkg) && ) true
+	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && npx wasm-pack test --node `pwd`/$(pkg) && ) true
 
 $(JS_FILES):
 	mkdir -p $(@D)

--- a/packages/hoprd/crates/Makefile
+++ b/packages/hoprd/crates/Makefile
@@ -10,7 +10,7 @@ JS_FILES = $(foreach package,$(PACKAGES),$(package)/pkg/$(subst -,_,$(package)).
 all: $(JS_FILES)
 
 test: $(JS_FILES)
-	$(foreach pkg,$(PACKAGES),npx wasm-pack test --node `pwd`/$(pkg) && ) true
+	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && npx wasm-pack test --node `pwd`/$(pkg) && ) true
 
 $(JS_FILES):
 	mkdir -p $(@D)

--- a/packages/real/crates/Makefile
+++ b/packages/real/crates/Makefile
@@ -10,7 +10,7 @@ JS_FILES = $(foreach package,$(PACKAGES),$(package)/pkg/$(subst -,_,$(package)).
 all: $(JS_FILES)
 
 test: $(JS_FILES)
-	$(foreach pkg,$(PACKAGES),npx wasm-pack test --node `pwd`/$(pkg) && ) true
+	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && npx wasm-pack test --node `pwd`/$(pkg) && ) true
 
 $(JS_FILES):
 	mkdir -p $(@D)

--- a/packages/utils/crates/Makefile
+++ b/packages/utils/crates/Makefile
@@ -10,7 +10,7 @@ JS_FILES = $(foreach package,$(PACKAGES),$(package)/pkg/$(subst -,_,$(package)).
 all: $(JS_FILES)
 
 test: $(JS_FILES)
-	$(foreach pkg,$(PACKAGES),npx wasm-pack test --node `pwd`/$(pkg) && ) true
+	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && npx wasm-pack test --node `pwd`/$(pkg) && ) true
 
 $(JS_FILES):
 	mkdir -p $(@D)


### PR DESCRIPTION
A leftover bug introduced during the Rust improvements PR - only WASM tests were running. After this fix `cargo test` and `npx wasm-pack test` should run both.

Bonus fix: proper heartbeat time measurement