### PR TITLE
ethereum: add missing export of HoprStakeSeason5

### DIFF
--- a/packages/ethereum/src/index.ts
+++ b/packages/ethereum/src/index.ts
@@ -12,6 +12,7 @@ export type {
   HoprStake2,
   HoprStakeSeason3,
   HoprStakeSeason4,
+  HoprStakeSeason5,
   HoprWhitehat,
   // used by libraries that want to interact with xHOPR
   ERC677 as xHoprToken


### PR DESCRIPTION
Blocks deployment of staking website.