### PR TITLE
Fix hoprd/ctd engine spec to allow more recent NodeJS versions

### DIFF
--- a/packages/cover-traffic-daemon/package.json
+++ b/packages/cover-traffic-daemon/package.json
@@ -23,7 +23,7 @@
     "docs:watch": "yarn typedoc --watch"
   },
   "engines": {
-    "node": "16.15"
+    "node": ">=16.15"
   },
   "files": [
     "lib",

--- a/packages/hoprd/package.json
+++ b/packages/hoprd/package.json
@@ -19,7 +19,7 @@
     "rest-api-v2-spec.yaml"
   ],
   "engines": {
-    "node": "16.15"
+    "node": ">=16.15"
   },
   "scripts": {
     "clean:wasm": "make -C crates clean",


### PR DESCRIPTION
Fixes build issues in Docker, see https://github.com/hoprnet/hoprnet/actions/runs/3297241630/jobs/5437981744