### PR TITLE
ci: Raise gas price for Goerli to 50gwei

### DIFF
--- a/packages/core/protocol-config.json
+++ b/packages/core/protocol-config.json
@@ -182,7 +182,7 @@
       "description": "Görli Testnet is the first proof-of-authority cross-client testnet, synching Parity Ethereum, Geth, Nethermind, Hyperledger Besu (formerly Pantheon), and EthereumJS",
       "chain_id": 5,
       "live": true,
-      "max_fee_per_gas": "20 gwei",
+      "max_fee_per_gas": "50 gwei",
       "max_priority_fee_per_gas": "2 gwei",
       "default_provider": "https://provider-proxy.hoprnet.workers.dev/eth_goerli",
       "etherscan_api_url": "http://api-goerli.etherscan.io/api",


### PR DESCRIPTION
Gas prices are up to 40 now. This change unblocks `master` deployment workflows.

See https://explorer.bitquery.io/goerli/gas?from=2022-10-01&till=2022-10-24