### PR TITLE
mono dht, disable dual dht

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Remove recurring DHT ping queue cleanup and turn all public relay nodes into DHT servers ([#4247](https://github.com/hoprnet/hoprnet/pull/4247))
 - Various enhancements regarding memory consumption and overall efficiency, spread over multiple PRs
 - Allow `info` command before node startup has finished ([#4273](https://github.com/hoprnet/hoprnet/pull/4273))
+- Turn libp2p dual DHT into single DHT by forking DHT package in order to avoid a memory leak https://github.com/hoprnet/hoprnet/pull/4288
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "resolutions": {
     "@ethersproject/providers": "https://github.com/hoprnet/ethers-js-provider/archive/refs/tags/v5.7.0-fixed-memory-leak.tar.gz",
     "@overnightjs/logger": "1.2.1",
+    "@libp2p/kad-dht": "https://github.com/hoprnet/js-libp2p-kad-dht/archive/refs/tags/v1.0.17.tar.gz",
     "colors": "1.4.0"
   },
   "prettier": {

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -126,8 +126,12 @@ export async function createLibp2pInstance(
         // Make entry nodes Kad-DHT servers
         // A network requires at least on Kad-DHT server otherwise nodes
         // will flood each other forever with Kad-DHT ping attempts
-        clientMode: !options.announce
+        clientMode: !options.announce,
         // Limit size of ping queue by using smaller timeouts
+        pingTimeout: 2e3,
+        // Only for e2e testing, use DHT `lan` mode to accept connections
+        // to nodes on the same machine
+        lan: options.testing?.announceLocalAddresses ?? false
       }),
       connectionManager: {
         autoDial: true,

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -117,6 +117,7 @@ export async function createLibp2pInstance(
       ],
       streamMuxers: [new Mplex()],
       connectionEncryption: [new Noise()],
+      // @ts-ignore forked DHT
       dht: new KadDHT({
         // Protocol prefixes require a trailing slash
         // @TODO disabled for compatibility reasons

--- a/packages/utils/src/libp2p/dialHelper.spec.ts
+++ b/packages/utils/src/libp2p/dialHelper.spec.ts
@@ -70,7 +70,7 @@ async function getNode(id: PeerId, withDht = false, oracle?: Map<string, Compone
     streamMuxers: [new Mplex()],
     connectionEncryption: [new Noise()],
     // @ts-ignore
-    dht: withDht ? new KadDHT({ protocolPrefix: '/hopr', clientMode: false }) : undefined,
+    dht: withDht ? new KadDHT({ protocolPrefix: '/hopr', clientMode: false, pingTimeout: 1e3, lan: true }) : undefined,
     metrics: {
       enabled: false
     },

--- a/packages/utils/src/libp2p/dialHelper.spec.ts
+++ b/packages/utils/src/libp2p/dialHelper.spec.ts
@@ -69,6 +69,7 @@ async function getNode(id: PeerId, withDht = false, oracle?: Map<string, Compone
     transports: [new MyTCP(oracle)],
     streamMuxers: [new Mplex()],
     connectionEncryption: [new Noise()],
+    // @ts-ignore
     dht: withDht ? new KadDHT({ protocolPrefix: '/hopr', clientMode: false }) : undefined,
     metrics: {
       enabled: false

--- a/packages/utils/src/libp2p/relayCode.spec.ts
+++ b/packages/utils/src/libp2p/relayCode.spec.ts
@@ -28,6 +28,7 @@ async function getNode(id: PeerId): Promise<Libp2p> {
     transports: [new TCP()],
     streamMuxers: [new Mplex()],
     connectionEncryption: [new Noise()],
+    // @ts-ignore
     dht: new KadDHT({ clientMode: false, protocolPrefix: '/hopr' }),
     metrics: {
       enabled: false

--- a/packages/utils/src/libp2p/relayCode.spec.ts
+++ b/packages/utils/src/libp2p/relayCode.spec.ts
@@ -29,7 +29,7 @@ async function getNode(id: PeerId): Promise<Libp2p> {
     streamMuxers: [new Mplex()],
     connectionEncryption: [new Noise()],
     // @ts-ignore
-    dht: new KadDHT({ clientMode: false, protocolPrefix: '/hopr' }),
+    dht: new KadDHT({ clientMode: false, protocolPrefix: '/hopr', lan: true, pingTimeout: 1e3 }),
     metrics: {
       enabled: false
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3636,9 +3636,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@libp2p/kad-dht@npm:1.0.16":
+"@libp2p/kad-dht@https://github.com/hoprnet/js-libp2p-kad-dht/archive/refs/tags/v1.0.17.tar.gz":
   version: 1.0.16
-  resolution: "@libp2p/kad-dht@npm:1.0.16"
+  resolution: "@libp2p/kad-dht@https://github.com/hoprnet/js-libp2p-kad-dht/archive/refs/tags/v1.0.17.tar.gz"
   dependencies:
     "@libp2p/crypto": ^0.22.12
     "@libp2p/interfaces": ^2.0.2
@@ -3673,7 +3673,7 @@ __metadata:
     timeout-abort-controller: ^3.0.0
     uint8arrays: ^3.0.0
     varint: ^6.0.0
-  checksum: 1f2a4f28894528236361fe632aa854ca7dcb44ded10bef55a1353396e04dca473d9262bb61bf774e0e4119b5988e61e0dd7195cabd51ccc35cc17ec969b4424f
+  checksum: 24146db665dd796efd72aa0e005dc81afc7dec5355f7c64cb26d757fac96b3bc7b7191971a8562a4d2dc0bdcd9d9892e7fadf6f94be42b69eefb74a2673f97bf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
TLDR; replaces DHT package by a fork to disable `lan` DHT in order to use less memory

### Context

Libp2p uses a DHT that consists of a DHT meant for nodes living in different subnets and those who live in the same subnet. The former one is known as `wan` DHT and the latter as `lan` DHT.

Entries in the DHT are organized within `kBuckets`. Once an entry reaches its full capacity, it need to get split into smaller buckets - which is done by those nodes who run the DHT in *server*-mode.

If a node detects that a bucket need to get split, it starts to *find* another node which runs the DHT in *server*-mode.

By default, both DHTs, `lan` and `wan` are running in *client*-mode, which means they depend on others to split the DHT buckets. For `wan` DHT, the value can be configured, i.e. all `hoprd` entry nodes are running the DHT in *server*-mode whereas all other nodes are running the DHT in *client*-mode.

Unfortunately, this option, does not exist for `lan`-DHT, so nodes will search *forever* for a "master node" to get their buckets split, leading to enormous ping queues which turn into severe memory drain.

### Changes in this PR

Since `lan`-DHT cannot be run in *server*-mode without code changes, this PR replaces the DHT package by a package that starts only *one* DHT, namely the `wan`-DHT, avoiding any `lan`-DHT ping queue(s).

Relevant commit in fork https://github.com/hoprnet/js-libp2p-kad-dht/commit/a8e1c1236274da9ec1a28f4d0c79041695d4031f

Changing in `src/index.ts` from
```ts
export class KadDHT extends DualKadDHT {
  constructor (init?: KadDHTInit) {
    super(new SingleKadDHT({
      protocolPrefix: '/ipfs',
      ...init,
      lan: false
    }),
    new SingleKadDHT({
      protocolPrefix: '/ipfs',
      ...init,
      clientMode: false,
      lan: true
    }))
  }
}
````
to
```ts
export { SingleKadDHT as KadDHT }
```