### PR TITLE
Change Docker memory limit to 2GB in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ docker pull gcr.io/hoprassociation/hoprd:valencia
 For ease of use you can set up a shell alias to run the latest release as a docker container:
 
 ```sh
-alias hoprd='docker run --pull always -ti -v ${HOPRD_DATA_DIR:-$HOME/.hoprd-db}:/app/db -p 9091:9091 -p 3000:3000 -p 3001:3001 gcr.io/hoprassociation/hoprd:valencia'
+alias hoprd='docker run --pull always -m 2g -ti -v ${HOPRD_DATA_DIR:-$HOME/.hoprd-db}:/app/db -p 9091:9091 -p 3000:3000 -p 3001:3001 gcr.io/hoprassociation/hoprd:valencia'
 ```
 
 **IMPORTANT:** Using the above command will map the database folder used by hoprd to a local folder called `.hoprd-db` in your home directory. You can customize the location of that folder further by executing the following command:


### PR DESCRIPTION
We agreed to change the memory limit of the running Docker container to 2GB.

This PR reflects that change in the docs.

Closes #4271 