### PR TITLE
Indicator of a broken deployment in pre-merge check

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -275,10 +275,10 @@ jobs:
           project_id: ${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}
           install_components: beta
 
-      - name: Unset flag for deployment
+      - name: Set deployment failure flag
         if: ${{ !env.ACT }}
         run: |
-          ./scripts/deployment-status.sh deactivate
+          ./scripts/deployment-gater.sh set
 
   deploy_public_instances:
     name: 'Continuous Deployment: Deploy public instances'
@@ -465,7 +465,7 @@ jobs:
           project_id: ${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}
           install_components: beta
 
-      - name: Set flag for deployment
+      - name: Unset deployment failure flag
         if: ${{ !env.ACT }}
         run: |
-          ./scripts/deployment-status.sh activate
+          ./scripts/deployment-gater.sh unset

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -255,6 +255,20 @@ jobs:
           ./scripts/notify-matrix-github-workflow-failure.sh "${MATRIX_ROOM}" "${{ github.repository }}" \
             "${{ github.workflow }}" "${{ github.run_id }}"
 
+  deactivate_deployment:
+    name: 'Unset active deployment flag'
+    runs-on: ubuntu-latest
+    needs: [ build_docker ]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Unset flag for deployment
+        if: ${{ !env.ACT }}
+        run: |
+          ./scripts/deployment-status.sh deactivate
+
   deploy_public_instances:
     name: 'Continuous Deployment: Deploy public instances'
     strategy:
@@ -263,7 +277,7 @@ jobs:
         os: ['ubuntu-latest']
         rust: ['stable']
     runs-on: ${{ matrix.os }}
-    needs: [build_docker]
+    needs: [deactivate_deployment]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -419,3 +433,17 @@ jobs:
         run: |
           ./scripts/notify-matrix-github-workflow-failure.sh "${MATRIX_ROOM}" "${{ github.repository }}" \
             "${{ github.workflow }}" "${{ github.run_id }}"
+
+  activate_deployment:
+    name: 'Set active deployment flag'
+    runs-on: ubuntu-latest
+    needs: [avado,deploy_public_instances,deploy_nat_instances]
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Set flag for deployment
+        if: ${{ !env.ACT }}
+        run: |
+          ./scripts/deployment-status.sh activate

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -255,8 +255,8 @@ jobs:
           ./scripts/notify-matrix-github-workflow-failure.sh "${MATRIX_ROOM}" "${{ github.repository }}" \
             "${{ github.workflow }}" "${{ github.run_id }}"
 
-  deactivate_deployment:
-    name: 'Unset active deployment flag'
+  set_failed_deployment_flag:
+    name: 'Set failed deployment flag'
     runs-on: ubuntu-latest
     needs: [ build_docker ]
     steps:
@@ -288,7 +288,7 @@ jobs:
         os: ['ubuntu-latest']
         rust: ['stable']
     runs-on: ${{ matrix.os }}
-    needs: [deactivate_deployment]
+    needs: [ set_failed_deployment_flag ]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -371,7 +371,7 @@ jobs:
         rust: ['stable']
 
     runs-on: ${{ matrix.os }}
-    needs: [deploy_public_instances] # Public nodes need to be deployed first
+    needs: [ deploy_public_instances ] # Public nodes need to be deployed first
     steps:
       - uses: actions/checkout@v3
         with:
@@ -445,10 +445,10 @@ jobs:
           ./scripts/notify-matrix-github-workflow-failure.sh "${MATRIX_ROOM}" "${{ github.repository }}" \
             "${{ github.workflow }}" "${{ github.run_id }}"
 
-  activate_deployment:
-    name: 'Set active deployment flag'
+  unset_failed_deployment_flag:
+    name: 'Unset failed deployment flag'
     runs-on: ubuntu-latest
-    needs: [avado,deploy_public_instances,deploy_nat_instances]
+    needs: [ avado, deploy_public_instances, deploy_nat_instances ]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -264,6 +264,17 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Google Cloud Credentials
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
+        with:
+          project_id: ${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}
+          install_components: beta
+
       - name: Unset flag for deployment
         if: ${{ !env.ACT }}
         run: |
@@ -442,6 +453,17 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
+      - name: Set up Google Cloud Credentials
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
+        with:
+          project_id: ${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}
+          install_components: beta
 
       - name: Set flag for deployment
         if: ${{ !env.ACT }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,6 +2,7 @@ name: HOPR Lint fix
 
 env:
   HOPR_GITHUB_REF: ${{ github.ref }}
+  HOPR_GITHUB_BASE_REF: ${{ github.base_ref }}
 
 on:
   push:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,7 +2,6 @@ name: HOPR Lint fix
 
 env:
   HOPR_GITHUB_REF: ${{ github.ref }}
-  HOPR_GITHUB_BASE_REF: ${{ github.base_ref }}
 
 on:
   push:
@@ -13,7 +12,7 @@ on:
 
 jobs:
   lint:
-    name: Lint & additional pre-merge checks
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -47,15 +46,3 @@ jobs:
         continue-on-error: true
         run:
           shellcheck -a --norc -s bash -x scripts/*.sh
-
-  deployment_check:
-    name: Upstream deployment status check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-
-      - name: Check deployment status of the upstream branch
-        if: ${{ (github.base_ref == 'refs/heads/master' || startsWith(github.base_ref, 'refs/heads/debug-deploy/') || startsWith(github.base_ref, 'refs/heads/release/')) && !env.ACT }}
-        run:
-          ./scripts/deployment-status.sh check ${{ github.ref_name }}
-

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -47,3 +47,14 @@ jobs:
         run:
           shellcheck -a --norc -s bash -x scripts/*.sh
 
+  deployment_check:
+    name: Upstream deployment status check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check deployment status of the upstream branch
+        if: ${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/debug-deploy/') || startsWith(github.ref, 'refs/heads/release/')) && !env.ACT }}
+        run:
+          ./scripts/deployment-status.sh check ${{ github.ref_name }}
+

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   lint:
-    name: Lint
+    name: Lint & additional pre-merge checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Check deployment status of the upstream branch
-        if: ${{ (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/debug-deploy/') || startsWith(github.ref, 'refs/heads/release/')) && !env.ACT }}
+        if: ${{ (github.base_ref == 'refs/heads/master' || startsWith(github.base_ref, 'refs/heads/debug-deploy/') || startsWith(github.base_ref, 'refs/heads/release/')) && !env.ACT }}
         run:
           ./scripts/deployment-status.sh check ${{ github.ref_name }}
 

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -18,4 +18,4 @@ jobs:
       - name: Check deployment status of the upstream branch
         if: ${{ (github.base_ref == 'master' || startsWith(github.base_ref, 'debug-deploy/') || startsWith(github.base_ref, 'release/')) && !env.ACT }}
         run:
-          ./scripts/deployment-status.sh check ${{ github.ref_name }}
+          ./scripts/deployment-status.sh check ${{ github.base_ref }}

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -1,0 +1,21 @@
+name: HOPR Pre-merge Checks
+
+env:
+  HOPR_GITHUB_REF: ${{ github.ref }}
+  HOPR_GITHUB_BASE_REF: ${{ github.base_ref }}
+
+on:
+  pull_request:
+    types: [ synchronize ]
+
+jobs:
+  deployment_check:
+    name: Upstream deployment status check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Check deployment status of the upstream branch
+        if: ${{ (github.base_ref == 'refs/heads/master' || startsWith(github.base_ref, 'refs/heads/debug-deploy/') || startsWith(github.base_ref, 'refs/heads/release/')) && !env.ACT }}
+        run:
+          ./scripts/deployment-status.sh check ${{ github.ref_name }}

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -1,4 +1,4 @@
-name: HOPR Pre-merge Checks
+name: HOPR Pre-merge checks
 
 env:
   HOPR_GITHUB_REF: ${{ github.ref }}
@@ -10,7 +10,7 @@ on:
 
 jobs:
   deployment_check:
-    name: Check upstream deployment status
+    name: Upstream deployment status
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -29,4 +29,4 @@ jobs:
       - name: Check deployment status of the upstream branch
         if: ${{ (github.base_ref == 'master' || startsWith(github.base_ref, 'debug-deploy/') || startsWith(github.base_ref, 'release/')) && !env.ACT }}
         run:
-          ./scripts/deployment-status.sh check ${{ github.base_ref }}
+          ./scripts/deployment-gater.sh check ${{ github.base_ref }}

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -10,10 +10,21 @@ on:
 
 jobs:
   deployment_check:
-    name: Upstream deployment status check
+    name: Check upstream deployment status
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
+      - name: Set up Google Cloud Credentials
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v0
+        with:
+          project_id: ${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}
+          install_components: beta
 
       - name: Check deployment status of the upstream branch
         if: ${{ (github.base_ref == 'master' || startsWith(github.base_ref, 'debug-deploy/') || startsWith(github.base_ref, 'release/')) && !env.ACT }}

--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Check deployment status of the upstream branch
-        if: ${{ (github.base_ref == 'refs/heads/master' || startsWith(github.base_ref, 'refs/heads/debug-deploy/') || startsWith(github.base_ref, 'refs/heads/release/')) && !env.ACT }}
+        if: ${{ (github.base_ref == 'master' || startsWith(github.base_ref, 'debug-deploy/') || startsWith(github.base_ref, 'release/')) && !env.ACT }}
         run:
           ./scripts/deployment-status.sh check ${{ github.ref_name }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Include HOPR Staking Season 5 smart contracts ([#4221](https://github.com/hoprnet/hoprnet/pull/4221))
 - Various optimizations of Rust crates ([#4221](https://github.com/hoprnet/hoprnet/pull/4260))
 - Add Metrics API for Prometheus, `metrics` API endpoint and collection of various metrics ([#4233](https://github.com/hoprnet/hoprnet/pull/4233))
+- Improve pre-merge check to prevent PR from merging when the upstream deployment is in the failed state
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Include HOPR Staking Season 5 smart contracts ([#4221](https://github.com/hoprnet/hoprnet/pull/4221))
 - Various optimizations of Rust crates ([#4221](https://github.com/hoprnet/hoprnet/pull/4260))
 - Add Metrics API for Prometheus, `metrics` API endpoint and collection of various metrics ([#4233](https://github.com/hoprnet/hoprnet/pull/4233))
-- Improve pre-merge check to prevent PR from merging when the upstream deployment is in the failed state
+- Improve pre-merge check to prevent PR from merging when the upstream deployment is in the failed state ([#4294](https://github.com/hoprnet/hoprnet/pull/4294))
 
 ---
 

--- a/scripts/deployment-status.sh
+++ b/scripts/deployment-status.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# prevent sourcing of this script, only allow execution
+$(return >/dev/null 2>&1)
+test "$?" -eq "0" && { echo "This script should only be executed." >&2; exit 1; }
+
+# exit on errors, undefined variables, ensure errors in pipes are not hidden
+set -Eeuo pipefail
+
+# set log id and use shared log function for readable logs
+declare mydir
+mydir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+declare -x HOPR_LOG_ID="deployment-status"
+source "${mydir}/gcloud.sh"
+
+readonly flag_prefix="DEPLOYMENT_ACTIVE"
+
+# Use current branch if not specified as argument
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+used_branch=${2:-$current_branch}
+current_deployment=$(echo "${used_branch}" | sed 's|/|_|g' | tr '[:lower:]' '[:upper:]')
+
+msg "Deployment flag name for the branch \"${used_branch}\": ${current_deployment}"
+
+usage() {
+   msg
+   msg "Usage: $0 [-h|--help] [-a|--activate] [-d|--deactivate] [-c|--check] [branch]"
+   msg
+   msg "This script can check or manipulate the status flag of the Google Cloud nodes deployment"
+   msg "from the current Git branch. When the flag is set, the deployment is considered active."
+}
+
+activate() {
+  local ts="$(date +%s)"
+  gcloud_set_project_flag "${flag_prefix}_${current_deployment}" "${ts}"
+  msg "Set active deployment flag ${current_deployment}"
+}
+
+deactivate() {
+  gcloud_unset_project_flag "${flag_prefix}_${current_deployment}"
+  msg "Removed active deployment flag ${current_deployment}"
+}
+
+check() {
+  local is_set="$(gcloud_isset_project_flag "${flag_prefix}_${current_deployment}")"
+  local ec=0
+  if [ "${is_set,,}" = "true" ]; then
+    msg "✅ Active deployment flag ${current_deployment} IS set"
+  else
+    msg "❌ Active deployment flag ${current_deployment} IS NOT set"
+    ec=1
+  fi
+
+  return ${ec}
+}
+
+if [ $# -le 1 ]; then
+  usage
+  exit 1
+fi
+
+if [ "${1}" = "activate" ]; then
+  activate
+fi
+
+if [ "${1}" = "deactivate" ]; then
+  deactivate
+fi
+
+if [ "${1}" = "check" ]; then
+  check
+  exit $?
+fi
+

--- a/scripts/deployment-status.sh
+++ b/scripts/deployment-status.sh
@@ -24,10 +24,11 @@ msg "Deployment flag name for the branch \"${used_branch}\": ${current_deploymen
 
 usage() {
    msg
-   msg "Usage: $0 [-h|--help] [-a|--activate] [-d|--deactivate] [-c|--check] [branch]"
+   msg "Usage: $0 <activate|deactivate|check> [branch]"
    msg
    msg "This script can check or manipulate the status flag of the Google Cloud nodes deployment"
-   msg "from the current Git branch. When the flag is set, the deployment is considered active."
+   msg "from the given Git branch. When the flag is set, the deployment is considered active."
+   msg "If no branch argument is given, the current active branch is used."
 }
 
 activate() {

--- a/scripts/gcloud.sh
+++ b/scripts/gcloud.sh
@@ -362,3 +362,19 @@ gcloud_execute_command_instance() {
 
   ${gssh} "${name}" --command "${command}"
 }
+
+# $1=flag name
+gcloud_isset_project_flag() {
+  gcloud compute project-info describe --format=json | jq "any(.commonInstanceMetadata.items[]; .key ==\"${1}\")"
+}
+
+# $1=flag name
+# $2=flag value
+gcloud_set_project_flag() {
+  gcloud compute project-info add-metadata --metadata="${1}=${2}" 2> /dev/null
+}
+
+# $1=flag name
+gcloud_unset_project_flag() {
+  gcloud compute project-info remove-metadata --keys="${1}" 2> /dev/null
+}


### PR DESCRIPTION
This PR adds Failure Flags into project-wide GCP metadata.

- Failure Flags are specific per branch that is supposed to have an active GCP deployment (e.g. `master`, `release/**`, `debug-deploy/**`).
- the Failure Flag is set before a deployment to GCP is triggered via GH Action on  branch
- as soon as the GCP deployment via GH Action has *successfully* finished (public nodes up, NAT nodes up and Avado build succeded), the Failure Flag for that deployment is unset.
- when a commit is made to a PR with a target to a branch that is supposed to have an active deployment, a pre-merge check is made to find out if there's a Failure Flag set (a set flag indicates last deployment via GH action did not succeed or hasn't finished yet)
- PR pre-merge check will also fail when deployment on the target branch deployment is still in progress

It contains a new utility script `deployment-gater`  that can be used to check, set or unset the Failure Flag for the GCP deployment
- `./scripts/deployment-gater.sh check master`
- `./scripts/deployment-gater.sh check release/valencia`
- `./scripts/deployment-gater.sh set release/valencia`
- `./scripts/deployment-gater.sh unset release/valencia`

**Manual override:** the `unset` action can be used to manually unset the failure flag for a fixed deployment to unblock merging PRs.

Closes #4270 