### PR TITLE
enhance debug log of dialHelper

### DIFF
--- a/packages/connect/src/base/entry.ts
+++ b/packages/connect/src/base/entry.ts
@@ -767,7 +767,12 @@ export class EntryNodes extends EventEmitter implements Initializable, Startable
     for (const nodeList of [this.uncheckedEntryNodes, this.availableEntryNodes, this.offlineEntryNodes]) {
       for (const node of nodeList) {
         // In case the addrs are not known to libp2p
-        await this.getComponents().getPeerStore().addressBook.add(node.id, node.multiaddrs)
+        await this.getComponents()
+          .getPeerStore()
+          .addressBook.add(
+            node.id,
+            node.multiaddrs.map((ma) => ma.decapsulateCode(CODE_P2P))
+          )
         for (const ma of node.multiaddrs) {
           args.push([node.id, ma])
         }

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -185,7 +185,12 @@ export async function createLibp2pInstance(
         // same for
         // /p2p/16Uiu2HAkzEnkW3xGJbvpXSXmvVR177LcR4Sw7z5S1ijuBcnbVFsV/p2p-circuit
         // /p2p/16Uiu2HAkzEnkW3xGJbvpXSXmvVR177LcR4Sw7z5S1ijuBcnbVFsV/p2p-circuit/p2p/16Uiu2HAmQBZA4TzjKjU5fpCSprGuM2y8mpepNwMS6ZKFATiKg68h
-        addressFilter: async (_peerId: PeerId, multiaddr: Multiaddr) => !isAddressWithPeerId(multiaddr)
+        addressFilter: async (_peerId: PeerId, multiaddr: Multiaddr) => {
+          const result = !isAddressWithPeerId(multiaddr)
+          log(`Address filter ${multiaddr.toString()}`, result)
+          console.trace()
+          return result
+        }
       },
       datastore
     })

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -185,12 +185,7 @@ export async function createLibp2pInstance(
         // same for
         // /p2p/16Uiu2HAkzEnkW3xGJbvpXSXmvVR177LcR4Sw7z5S1ijuBcnbVFsV/p2p-circuit
         // /p2p/16Uiu2HAkzEnkW3xGJbvpXSXmvVR177LcR4Sw7z5S1ijuBcnbVFsV/p2p-circuit/p2p/16Uiu2HAmQBZA4TzjKjU5fpCSprGuM2y8mpepNwMS6ZKFATiKg68h
-        addressFilter: async (_peerId: PeerId, multiaddr: Multiaddr) => {
-          const result = !isAddressWithPeerId(multiaddr)
-          log(`Address filter ${multiaddr.toString()}`, result)
-          console.trace()
-          return result
-        }
+        addressFilter: async (_peerId: PeerId, multiaddr: Multiaddr) => !isAddressWithPeerId(multiaddr)
       },
       datastore
     })


### PR DESCRIPTION
Fixes a bug where non-entry nodes, i.e. NATed nodes cannot connect to any relay node

This was caused by the address filter which takes care that addresses are not added twice (and thus dialed twice).