### PR TITLE
Increase GCloud build timeouts

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,7 +18,7 @@ steps:
       - --cache-ttl=96h
       - --build-arg=PACKAGE_VERSION=${_PACKAGE_VERSION}
       - --build-arg=HOPRD_RELEASE=${_IMAGE_VERSION}
-    timeout: 600s
+    timeout: 1200s
     waitFor:
       - buildHoprd
   - name: 'gcr.io/kaniko-project/executor:latest'
@@ -29,7 +29,7 @@ steps:
       - --cache=true
       - --cache-ttl=96h
       - --build-arg=PACKAGE_VERSION=${_PACKAGE_VERSION}
-    timeout: 600s
+    timeout: 1200s
     waitFor: ['-']
   - name: 'gcr.io/kaniko-project/executor:latest'
     id: buildHardhat
@@ -38,7 +38,7 @@ steps:
       - --destination=gcr.io/${PROJECT_ID}/hopr-hardhat:${_IMAGE_VERSION}
       - --cache=true
       - --cache-ttl=96h
-    timeout: 600s
+    timeout: 1200s
     waitFor: ['-']
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     id: testImages
@@ -51,7 +51,7 @@ steps:
     env:
       - 'PACKAGE_VERSION=$_PACKAGE_VERSION'
       - 'IMAGE_VERSION=$_IMAGE_VERSION'
-    timeout: 600s
+    timeout: 1200s
     waitFor:
       - buildHoprd
       - buildHoprdNat


### PR DESCRIPTION
Increases timeouts in `cloudbuild.yaml` to 20 minutes to make sure the build does not fail with errors like:

````
Finished Step #3 - "buildHardhat"
ERROR
ERROR: build step 3 "gcr.io/kaniko-project/executor:latest" failed: context deadline exceeded
````