### PR TITLE
Restore STUN functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Various optimizations of Rust crates ([#4221](https://github.com/hoprnet/hoprnet/pull/4260))
 - Add Metrics API for Prometheus, `metrics` API endpoint and collection of various metrics ([#4233](https://github.com/hoprnet/hoprnet/pull/4233))
 - Improve pre-merge check to prevent PR from merging when the upstream deployment is in the failed state ([#4294](https://github.com/hoprnet/hoprnet/pull/4294))
+- Restore STUN functionality ([#4312](https://github.com/hoprnet/hoprnet/pull/4312))
 
 ---
 

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -42,13 +42,14 @@
     "debug": "4.3.4",
     "err-code": "3.0.1",
     "heap-js": "2.2.0",
+    "is-stun": "2.0.0",
     "it-handshake": "4.0.0",
     "multiformats": "9.6.5",
     "nat-api": "0.3.1",
     "retimer": "3.0.0",
     "simple-peer": "9.11.1",
     "stream-to-it": "0.2.4",
-    "webrtc-stun": "3.0.0",
+    "stun": "2.1.0",
     "wrtc": "0.4.7"
   },
   "devDependencies": {

--- a/packages/connect/src/base/listener.ts
+++ b/packages/connect/src/base/listener.ts
@@ -85,10 +85,7 @@ class Listener extends EventEmitter<ListenerEvents> implements InterfaceListener
 
     this.tcpSocket = createServer()
     this.udpSocket = createSocket({
-      // @TODO
-      // `udp6` does not seem to work in Node 12.x
-      // can receive IPv6 packet and IPv4 after reconnecting the socket
-      type: 'udp4',
+      type: 'udp6',
       // set to true to reuse port that is bound
       // to TCP socket
       reuseAddr: true
@@ -195,11 +192,8 @@ class Listener extends EventEmitter<ListenerEvents> implements InterfaceListener
       // bind the UDP socket and bind to same port
       await this.listenTCP().then((tcpPort) => this.listenUDP(tcpPort))
     } else {
-      await Promise.all([
-        // prettier-ignore
-        this.listenTCP(options),
-        this.listenUDP(options.port)
-      ])
+      await this.listenTCP(options)
+      await this.listenUDP(options.port)
     }
   }
 

--- a/packages/connect/src/base/listener.ts
+++ b/packages/connect/src/base/listener.ts
@@ -94,13 +94,18 @@ class Listener extends EventEmitter<ListenerEvents> implements InterfaceListener
       // We use IPv4 traffic on udp6 sockets, so DNS queries
       // must return the A record (IPv4) not the AAAA record (IPv6)
       // - unless we explicitly check for a IPv6 address
-      lookup: (...args: any[]) => {
-        if (isIPv6(args[0])) {
+      lookup: (...requestArgs: any[]) => {
+        if (isIPv6(requestArgs[0])) {
           // @ts-ignore
-          return lookup(...args)
+          return lookup(...requestArgs)
         }
-        return lookup(args[0], 4, (...innerArgs: any) => {
-          args[2](innerArgs[0], `::ffff:${innerArgs[1]}`, innerArgs[2])
+        return lookup(requestArgs[0], 4, (...responseArgs: any[]) => {
+          const callback = requestArgs.length == 3 ? requestArgs[2] : requestArgs[1]
+          // Error | null
+          if (responseArgs[0] != null) {
+            return callback(responseArgs[0])
+          }
+          callback(responseArgs[0], `::ffff:${responseArgs[1]}`, responseArgs[2])
         })
       }
     })

--- a/packages/connect/src/base/listener.ts
+++ b/packages/connect/src/base/listener.ts
@@ -87,10 +87,13 @@ class Listener extends EventEmitter<ListenerEvents> implements InterfaceListener
 
     this.tcpSocket = createServer()
     this.udpSocket = createSocket({
+      // `udp4` seems to have binding issues
       type: 'udp6',
-      // set to true to reuse port that is bound
-      // to TCP socket
+      // set to true to use same port for TCP and UDP
       reuseAddr: true,
+      // We use IPv4 traffic on udp6 sockets, so DNS queries
+      // must return the A record (IPv4) not the AAAA record (IPv6)
+      // - unless we explicitly check for a IPv6 address
       lookup: (...args: any[]) => {
         if (isIPv6(args[0])) {
           // @ts-ignore

--- a/packages/connect/src/base/stun.spec.ts
+++ b/packages/connect/src/base/stun.spec.ts
@@ -300,7 +300,7 @@ describe('test getExternalIp', function () {
 
     assert(result != undefined, `local-mode should lead to a valid external IP`)
 
-    await Promise.all(servers.concat(socket).map(stopNode))
+    await Promise.all([...servers, socket].map(stopNode))
   })
 
   it(`return no address in local-mode if results are ambiguous`, async function () {
@@ -319,7 +319,7 @@ describe('test getExternalIp', function () {
 
     assert(result == undefined, `ambiguos results in local-mode should not lead to an address`)
 
-    await Promise.all(servers.concat(socket).map(stopNode))
+    await Promise.all([...servers, socket].map(stopNode))
   })
 
   it(`return no address in local-mode if only one STUN server answers`, async function () {
@@ -340,7 +340,7 @@ describe('test getExternalIp', function () {
 
     assert(result == undefined, `ambiguos results in local-mode should not lead to an address`)
 
-    await Promise.all(servers.concat(socket).map(stopNode))
+    await Promise.all([...servers, socket].map(stopNode))
   })
 
   it(`get the external IP`, async function () {
@@ -352,6 +352,7 @@ describe('test getExternalIp', function () {
     if (results.length == 0) {
       console.log(`Node cannot reach more than one external STUN servers. Has the node access to the internet?`)
       // Cannot proceed without access to internet
+      await stopNode(socket)
       return
     }
 
@@ -359,6 +360,7 @@ describe('test getExternalIp', function () {
 
     if (interpreted.ambiguous) {
       console.log(`Node seems to run behind a bidirectional NAT. External IP address is ambigous`)
+      await stopNode(socket)
       return
     }
 

--- a/packages/connect/src/base/stun.ts
+++ b/packages/connect/src/base/stun.ts
@@ -231,13 +231,13 @@ function sendStunRequests(addrs: Request[], socket: Socket): void {
     switch (tuples[0][0]) {
       case CODE_DNS4:
       case CODE_DNS6:
-        address = new TextDecoder().decode(tuples[0][1]?.subarray(1) as Uint8Array)
+        address = new TextDecoder().decode(tuples[0][1] as Uint8Array)
         break
       case CODE_IP6:
-        address = u8aAddrToString(tuples[0][1]?.subarray(1) as Uint8Array, 'IPv6')
+        address = u8aAddrToString(tuples[0][1] as Uint8Array, 'IPv6')
         break
       case CODE_IP4:
-        address = `::ffff:${u8aAddrToString(tuples[0][1]?.subarray(1) as Uint8Array, 'IPv4')}`
+        address = `::ffff:${u8aAddrToString(tuples[0][1] as Uint8Array, 'IPv4')}`
         break
       default:
         throw Error(`Invalid address: ${addr.multiaddr.toString()}`)

--- a/packages/connect/src/base/utils.spec.ts
+++ b/packages/connect/src/base/utils.spec.ts
@@ -67,13 +67,18 @@ export function bindToUdpSocket(port?: number): Promise<Socket> {
     // We use IPv4 traffic on udp6 sockets, so DNS queries
     // must return the A record (IPv4) not the AAAA record (IPv6)
     // - unless we explicitly check for a IPv6 address
-    lookup: (...args: any[]) => {
-      if (isIPv6(args[0])) {
+    lookup: (...requestArgs: any[]) => {
+      if (isIPv6(requestArgs[0])) {
         // @ts-ignore
-        return lookup(...args)
+        return lookup(...requestArgs)
       }
-      return lookup(args[0], 4, (...innerArgs: any) => {
-        args[2](innerArgs[0], `::ffff:${innerArgs[1]}`, innerArgs[2])
+      return lookup(requestArgs[0], 4, (...responseArgs: any[]) => {
+        const callback = requestArgs.length == 3 ? requestArgs[2] : requestArgs[1]
+        // Error | null
+        if (responseArgs[0] != null) {
+          return callback(responseArgs[0])
+        }
+        callback(responseArgs[0], `::ffff:${responseArgs[1]}`, responseArgs[2])
       })
     }
   })

--- a/packages/connect/src/base/utils.spec.ts
+++ b/packages/connect/src/base/utils.spec.ts
@@ -62,7 +62,11 @@ export async function startStunServer(
  */
 export function bindToUdpSocket(port?: number): Promise<Socket> {
   const socket = createSocket({
+    // `udp4` seems to have binding issues
     type: 'udp6',
+    // We use IPv4 traffic on udp6 sockets, so DNS queries
+    // must return the A record (IPv4) not the AAAA record (IPv6)
+    // - unless we explicitly check for a IPv6 address
     lookup: (...args: any[]) => {
       if (isIPv6(args[0])) {
         // @ts-ignore

--- a/packages/connect/src/base/utils.spec.ts
+++ b/packages/connect/src/base/utils.spec.ts
@@ -59,7 +59,7 @@ export async function startStunServer(
  * @returns a bound socket
  */
 export function bindToUdpSocket(port?: number): Promise<Socket> {
-  const socket = createSocket('udp4')
+  const socket = createSocket('udp6')
 
   return new Promise<Socket>((resolve, reject) => {
     socket.once('error', (err: any) => {

--- a/packages/connect/src/relay/handshake.spec.ts
+++ b/packages/connect/src/relay/handshake.spec.ts
@@ -53,7 +53,6 @@ describe('test relay handshake', function () {
           async ({ stream }) => {
             stream.sink(
               (async function* () {
-                console.log(`sent`)
                 yield Uint8Array.from([RelayHandshakeMessage.OK])
               })()
             )

--- a/yarn.lock
+++ b/yarn.lock
@@ -2958,6 +2958,7 @@ __metadata:
     debug: 4.3.4
     err-code: 3.0.1
     heap-js: 2.2.0
+    is-stun: 2.0.0
     it-handshake: 4.0.0
     it-pair: 2.0.2
     it-pipe: 2.0.3
@@ -2969,9 +2970,9 @@ __metadata:
     retimer: 3.0.0
     simple-peer: 9.11.1
     stream-to-it: 0.2.4
+    stun: 2.1.0
     typescript: 4.7.4
     uint8arraylist: 2.3.2
-    webrtc-stun: 3.0.0
     wrtc: 0.4.7
     yargs: 17.5.1
   languageName: unknown
@@ -6827,6 +6828,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"array-find-index@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "array-find-index@npm:1.0.2"
+  checksum: aac128bf369e1ac6c06ff0bb330788371c0e256f71279fb92d745e26fb4b9db8920e485b4ec25e841c93146bf71a34dcdbcefa115e7e0f96927a214d237b7081
+  languageName: node
+  linkType: hard
+
 "array-flatten@npm:1.1.1":
   version: 1.1.1
   resolution: "array-flatten@npm:1.1.1"
@@ -6875,7 +6883,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"arrify@npm:^1.0.0":
+"arrify@npm:^1.0.0, arrify@npm:^1.0.1":
   version: 1.0.1
   resolution: "arrify@npm:1.0.1"
   checksum: 745075dd4a4624ff0225c331dacb99be501a515d39bcb7c84d24660314a6ec28e68131b137e6f7e16318170842ce97538cd298fc4cd6b2cc798e0b957f2747e7
@@ -7307,6 +7315,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"binary-data@npm:^0.6.0":
+  version: 0.6.0
+  resolution: "binary-data@npm:0.6.0"
+  dependencies:
+    generate-function: ^2.3.1
+    is-plain-object: ^2.0.3
+  checksum: e3ae5bc0ebd40336ac09e17eccc7b800dbdd2ae9ae0befb58ea3c034585a78afbfc5d660472144dea4457092867ff90cc858c2672c39466f8376193bdfbe2c86
+  languageName: node
+  linkType: hard
+
 "binary-extensions@npm:^2.0.0":
   version: 2.2.0
   resolution: "binary-extensions@npm:2.2.0"
@@ -7637,13 +7655,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"buffer-crc32@npm:^0.2.13":
-  version: 0.2.13
-  resolution: "buffer-crc32@npm:0.2.13"
-  checksum: 06252347ae6daca3453b94e4b2f1d3754a3b146a111d81c68924c22d91889a40623264e95e67955b1cb4a68cbedf317abeabb5140a9766ed248973096db5ce1c
-  languageName: node
-  linkType: hard
-
 "buffer-equal-constant-time@npm:1.0.1":
   version: 1.0.1
   resolution: "buffer-equal-constant-time@npm:1.0.1"
@@ -7669,6 +7680,15 @@ __metadata:
   version: 1.0.3
   resolution: "buffer-xor@npm:1.0.3"
   checksum: 10c520df29d62fa6e785e2800e586a20fc4f6dfad84bcdbd12e1e8a83856de1cb75c7ebd7abe6d036bbfab738a6cf18a3ae9c8e5a2e2eb3167ca7399ce65373a
+  languageName: node
+  linkType: hard
+
+"buffer-xor@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "buffer-xor@npm:2.0.2"
+  dependencies:
+    safe-buffer: ^5.1.1
+  checksum: 78226fcae9f4a0b4adec69dffc049f26f6bab240dfdd1b3f6fe07c4eb6b90da202ea5c363f98af676156ee39450a06405fddd9e8965f68a5327edcc89dcbe5d0
   languageName: node
   linkType: hard
 
@@ -7891,6 +7911,17 @@ __metadata:
   version: 2.0.1
   resolution: "camelcase-css@npm:2.0.1"
   checksum: 1cec2b3b3dcb5026688a470b00299a8db7d904c4802845c353dbd12d9d248d3346949a814d83bfd988d4d2e5b9904c07efe76fecd195a1d4f05b543e7c0b56b1
+  languageName: node
+  linkType: hard
+
+"camelcase-keys@npm:^4.0.0":
+  version: 4.2.0
+  resolution: "camelcase-keys@npm:4.2.0"
+  dependencies:
+    camelcase: ^4.1.0
+    map-obj: ^2.0.0
+    quick-lru: ^1.0.0
+  checksum: 8cb52633f2d335bf7efd9ec4169df3174047dbeadbe9b7604fb4a24cbc53a976bc26bb8557f6e9da5feff139bf94e36f40e2636b31225670f9524f586070c3ec
   languageName: node
   linkType: hard
 
@@ -9349,6 +9380,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"currently-unhandled@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "currently-unhandled@npm:0.4.1"
+  dependencies:
+    array-find-index: ^1.0.1
+  checksum: 1f59fe10b5339b54b1a1eee110022f663f3495cf7cf2f480686e89edc7fa8bfe42dbab4b54f85034bc8b092a76cc7becbc2dad4f9adad332ab5831bec39ad540
+  languageName: node
+  linkType: hard
+
 "d@npm:1, d@npm:^1.0.1":
   version: 1.0.1
   resolution: "d@npm:1.0.1"
@@ -9467,7 +9507,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"decamelize@npm:^1.1.1, decamelize@npm:^1.2.0":
+"decamelize-keys@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "decamelize-keys@npm:1.1.0"
+  dependencies:
+    decamelize: ^1.1.0
+    map-obj: ^1.0.0
+  checksum: 8bc5d32e035a072f5dffc1f1f3d26ca7ab1fb44a9cade34c97ab6cd1e62c81a87e718101e96de07d78cecda20a3fdb955df958e46671ccad01bb8dcf0de2e298
+  languageName: node
+  linkType: hard
+
+"decamelize@npm:^1.1.0, decamelize@npm:^1.1.1, decamelize@npm:^1.2.0":
   version: 1.2.0
   resolution: "decamelize@npm:1.2.0"
   checksum: ad8c51a7e7e0720c70ec2eeb1163b66da03e7616d7b98c9ef43cce2416395e84c1e9548dd94f5f6ffecfee9f8b94251fc57121a8b021f2ff2469b2bae247b8aa
@@ -11294,6 +11344,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"filter-obj@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "filter-obj@npm:1.1.0"
+  checksum: cf2104a7c45ff48e7f505b78a3991c8f7f30f28bd8106ef582721f321f1c6277f7751aacd5d83026cb079d9d5091082f588d14a72e7c5d720ece79118fa61e10
+  languageName: node
+  linkType: hard
+
 "finalhandler@npm:1.2.0":
   version: 1.2.0
   resolution: "finalhandler@npm:1.2.0"
@@ -11373,7 +11430,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"find-up@npm:^2.1.0":
+"find-up@npm:^2.0.0, find-up@npm:^2.1.0":
   version: 2.1.0
   resolution: "find-up@npm:2.1.0"
   dependencies:
@@ -11904,6 +11961,15 @@ __metadata:
     gaxios: ^4.0.0
     json-bigint: ^1.0.0
   checksum: b0b1b85ea2efee1d640a1d4ead0937fdcceffd43ab4cacfdd66fd086fcfe5c3d09ad850ee14f43f2dc73244b2617b166adfa09a2a85e0652a8c56bed194f01fe
+  languageName: node
+  linkType: hard
+
+"generate-function@npm:^2.3.1":
+  version: 2.3.1
+  resolution: "generate-function@npm:2.3.1"
+  dependencies:
+    is-property: ^1.0.2
+  checksum: 652f083de206ead2bae4caf9c7eeb465e8d98c0b8ed2a29c6afc538cef0785b5c6eea10548f1e13cc586d3afd796c13c830c2cb3dc612ec2457b2aadda5f57c9
   languageName: node
   linkType: hard
 
@@ -13387,6 +13453,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"indent-string@npm:^3.0.0":
+  version: 3.2.0
+  resolution: "indent-string@npm:3.2.0"
+  checksum: a0b72603bba6c985d367fda3a25aad16423d2056b22a7e83ee2dd9ce0ce3d03d1e078644b679087aa7edf1cfb457f0d96d9eeadc0b12f38582088cc00e995d2f
+  languageName: node
+  linkType: hard
+
 "indent-string@npm:^4.0.0":
   version: 4.0.0
   resolution: "indent-string@npm:4.0.0"
@@ -13553,6 +13626,13 @@ __metadata:
   version: 5.0.0
   resolution: "ip-regex@npm:5.0.0"
   checksum: 4098b2df89c015f1484a5946e733ec126af8c1828719d90e09f04af23ce487e1a852670e4d3f51b0dc6dfbaf7d8bfab23fd7893ca60e69833da99b7b1ee3623b
+  languageName: node
+  linkType: hard
+
+"ip2buf@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "ip2buf@npm:2.0.0"
+  checksum: a87fb2aaae4bb5da5ddc04628823a61819f110ddbaa45773858ea3a8c48d8640f08995e4ac90a5da0d229f8a83f88d3668693a915540c1d817d8a1785fe85a9d
   languageName: node
   linkType: hard
 
@@ -13949,12 +14029,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"is-plain-object@npm:^2.0.4":
+"is-plain-object@npm:^2.0.3, is-plain-object@npm:^2.0.4":
   version: 2.0.4
   resolution: "is-plain-object@npm:2.0.4"
   dependencies:
     isobject: ^3.0.1
   checksum: 2a401140cfd86cabe25214956ae2cfee6fbd8186809555cd0e84574f88de7b17abacb2e477a6a658fa54c6083ecbda1e6ae404c7720244cd198903848fca70ca
+  languageName: node
+  linkType: hard
+
+"is-property@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "is-property@npm:1.0.2"
+  checksum: 33b661a3690bcc88f7e47bb0a21b9e3187e76a317541ea7ec5e8096d954f441b77a46d8930c785f7fbf4ef8dfd624c25495221e026e50f74c9048fe501773be5
   languageName: node
   linkType: hard
 
@@ -14005,6 +14092,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-ssh@npm:^1.3.0":
+  version: 1.4.0
+  resolution: "is-ssh@npm:1.4.0"
+  dependencies:
+    protocols: ^2.0.1
+  checksum: 75eaa17b538bee24b661fbeb0f140226ac77e904a6039f787bea418431e2162f1f9c4c4ccad3bd169e036cd701cc631406e8c505d9fa7e20164e74b47f86f40f
+  languageName: node
+  linkType: hard
+
 "is-stream-ended@npm:^0.1.4":
   version: 0.1.4
   resolution: "is-stream-ended@npm:0.1.4"
@@ -14032,6 +14128,13 @@ __metadata:
   dependencies:
     has-tostringtag: ^1.0.0
   checksum: 323b3d04622f78d45077cf89aab783b2f49d24dc641aa89b5ad1a72114cfeff2585efc8c12ef42466dff32bde93d839ad321b26884cf75e5a7892a938b089989
+  languageName: node
+  linkType: hard
+
+"is-stun@npm:2.0.0, is-stun@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "is-stun@npm:2.0.0"
+  checksum: 177599f9931015c79db853b24151f66306e6fdac33110ca8eb1bc84612fd43b412996a4fa803efb9c85d766e67657b44a0f9b22e642ab1ac5cd154cd5a12d027
   languageName: node
   linkType: hard
 
@@ -15147,6 +15250,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"load-json-file@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "load-json-file@npm:4.0.0"
+  dependencies:
+    graceful-fs: ^4.1.2
+    parse-json: ^4.0.0
+    pify: ^3.0.0
+    strip-bom: ^3.0.0
+  checksum: 8f5d6d93ba64a9620445ee9bde4d98b1eac32cf6c8c2d20d44abfa41a6945e7969456ab5f1ca2fb06ee32e206c9769a20eec7002fe290de462e8c884b6b8b356
+  languageName: node
+  linkType: hard
+
 "loader-runner@npm:^4.2.0":
   version: 4.3.0
   resolution: "loader-runner@npm:4.3.0"
@@ -15409,6 +15524,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"loud-rejection@npm:^1.0.0":
+  version: 1.6.0
+  resolution: "loud-rejection@npm:1.6.0"
+  dependencies:
+    currently-unhandled: ^0.4.1
+    signal-exit: ^3.0.0
+  checksum: 750e12defde34e8cbf263c2bff16f028a89b56e022ad6b368aa7c39495b5ac33f2349a8d00665a9b6d25c030b376396524d8a31eb0dde98aaa97956d7324f927
+  languageName: node
+  linkType: hard
+
 "loupe@npm:^2.3.1":
   version: 2.3.4
   resolution: "loupe@npm:2.3.4"
@@ -15547,6 +15672,20 @@ __metadata:
     socks-proxy-agent: ^7.0.0
     ssri: ^9.0.0
   checksum: 2f6c294179972f56fab40fd8618f07841e06550692bb78f6da16e7afaa9dca78c345b08cf44a77a8907ef3948e4dc77e93eb7492b8381f1217d7ac057a7522f8
+  languageName: node
+  linkType: hard
+
+"map-obj@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "map-obj@npm:1.0.1"
+  checksum: 9949e7baec2a336e63b8d4dc71018c117c3ce6e39d2451ccbfd3b8350c547c4f6af331a4cbe1c83193d7c6b786082b6256bde843db90cb7da2a21e8fcc28afed
+  languageName: node
+  linkType: hard
+
+"map-obj@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "map-obj@npm:2.0.0"
+  checksum: 77d2b7b03398a71c84bd7df8ab7be2139e5459fc1e18dbb5f15055fe7284bec0fc37fe410185b5f8ca2e3c3e01fd0fd1f946c579607878adb26cad1cd75314aa
   languageName: node
   linkType: hard
 
@@ -15704,6 +15843,23 @@ __metadata:
   version: 0.3.1
   resolution: "memorystream@npm:0.3.1"
   checksum: f18b42440d24d09516d01466c06adf797df7873f0d40aa7db02e5fb9ed83074e5e65412d0720901d7069363465f82dc4f8bcb44f0cde271567a61426ce6ca2e9
+  languageName: node
+  linkType: hard
+
+"meow@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "meow@npm:5.0.0"
+  dependencies:
+    camelcase-keys: ^4.0.0
+    decamelize-keys: ^1.0.0
+    loud-rejection: ^1.0.0
+    minimist-options: ^3.0.1
+    normalize-package-data: ^2.3.4
+    read-pkg-up: ^3.0.0
+    redent: ^2.0.0
+    trim-newlines: ^2.0.0
+    yargs-parser: ^10.0.0
+  checksum: c00b6cdde2b1c1d8679eb0de46a51ed4eb1ee2c8785454d7383d09ddde1076e6928f17ef0d9111e28585d4d59cc15b4ba85668e274211b502f14bd1cf659fc46
   languageName: node
   linkType: hard
 
@@ -15940,6 +16096,16 @@ __metadata:
   dependencies:
     brace-expansion: ^2.0.1
   checksum: 15ce53d31a06361e8b7a629501b5c75491bc2b59712d53e802b1987121d91b433d73fcc5be92974fde66b2b51d8fb28d75a9ae900d249feb792bb1ba2a4f0a90
+  languageName: node
+  linkType: hard
+
+"minimist-options@npm:^3.0.1":
+  version: 3.0.2
+  resolution: "minimist-options@npm:3.0.2"
+  dependencies:
+    arrify: ^1.0.1
+    is-plain-obj: ^1.1.0
+  checksum: f111ff4a3371312f3827bc5a519d757bd5bd8406599193b6cd32b8137eeaee74dd8f1896b66778ac26069ecbaee0659dd0ca4b65c6ec9d0683b09a9573e4f389
   languageName: node
   linkType: hard
 
@@ -16909,7 +17075,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-package-data@npm:^2.3.2":
+"normalize-package-data@npm:^2.3.2, normalize-package-data@npm:^2.3.4":
   version: 2.5.0
   resolution: "normalize-package-data@npm:2.5.0"
   dependencies:
@@ -16942,7 +17108,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"normalize-url@npm:^6.0.1":
+"normalize-url@npm:^6.0.1, normalize-url@npm:^6.1.0":
   version: 6.1.0
   resolution: "normalize-url@npm:6.1.0"
   checksum: 4a4944631173e7d521d6b80e4c85ccaeceb2870f315584fa30121f505a6dfd86439c5e3fdd8cd9e0e291290c41d0c3599f0cb12ab356722ed242584c30348e50
@@ -17912,6 +18078,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse-path@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "parse-path@npm:4.0.4"
+  dependencies:
+    is-ssh: ^1.3.0
+    protocols: ^1.4.0
+    qs: ^6.9.4
+    query-string: ^6.13.8
+  checksum: 909e628c35baebeb3bdcaa376e2c5a21632a9094079ac55e04b3311db28219b15e517e10987dd49a13a904f2605b747b6368b0092130e0f2ff9bc5ffc40ceb63
+  languageName: node
+  linkType: hard
+
+"parse-url@npm:^5.0.1":
+  version: 5.0.8
+  resolution: "parse-url@npm:5.0.8"
+  dependencies:
+    is-ssh: ^1.3.0
+    normalize-url: ^6.1.0
+    parse-path: ^4.0.4
+    protocols: ^1.4.0
+  checksum: ef42cd11a66722e16b1479f6c948f09872bd830c7bda3ec60ec7e3491c902df3bc211749539520a2933008750ce4d78af10260afe29030d77215197ffd23fe6a
+  languageName: node
+  linkType: hard
+
 "parse5-htmlparser2-tree-adapter@npm:^7.0.0":
   version: 7.0.0
   resolution: "parse5-htmlparser2-tree-adapter@npm:7.0.0"
@@ -18097,6 +18287,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"path-type@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "path-type@npm:3.0.0"
+  dependencies:
+    pify: ^3.0.0
+  checksum: 735b35e256bad181f38fa021033b1c33cfbe62ead42bb2222b56c210e42938eecb272ae1949f3b6db4ac39597a61b44edd8384623ec4d79bfdc9a9c0f12537a6
+  languageName: node
+  linkType: hard
+
 "path-type@npm:^4.0.0":
   version: 4.0.0
   resolution: "path-type@npm:4.0.0"
@@ -18156,6 +18355,13 @@ __metadata:
   version: 2.3.0
   resolution: "pify@npm:2.3.0"
   checksum: 9503aaeaf4577acc58642ad1d25c45c6d90288596238fb68f82811c08104c800e5a7870398e9f015d82b44ecbcbef3dc3d4251a1cbb582f6e5959fe09884b2ba
+  languageName: node
+  linkType: hard
+
+"pify@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "pify@npm:3.0.0"
+  checksum: 6cdcbc3567d5c412450c53261a3f10991665d660961e06605decf4544a61a97a54fefe70a68d5c37080ff9d6f4cf51444c90198d1ba9f9309a6c0d6e9f5c4fde
   languageName: node
   linkType: hard
 
@@ -18949,6 +19155,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"protocols@npm:^1.4.0":
+  version: 1.4.8
+  resolution: "protocols@npm:1.4.8"
+  checksum: 2d555c013df0b05402970f67f7207c9955a92b1d13ffa503c814b5fe2f6dde7ac6a03320e0975c1f5832b0113327865e0b3b28bfcad023c25ddb54b53fab8684
+  languageName: node
+  linkType: hard
+
+"protocols@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "protocols@npm:2.0.1"
+  checksum: 4a9bef6aa0449a0245ded319ac3cbfd032c3e76ebb562777037a3a832c99253d0e8bc2847f7be350236df620a11f7d4fe683ea7f59a2cc14c69f746b6259eda4
+  languageName: node
+  linkType: hard
+
 "protons-runtime@npm:^1.0.2, protons-runtime@npm:^1.0.3, protons-runtime@npm:^1.0.4":
   version: 1.0.4
   resolution: "protons-runtime@npm:1.0.4"
@@ -19137,6 +19357,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"query-string@npm:^6.13.8":
+  version: 6.14.1
+  resolution: "query-string@npm:6.14.1"
+  dependencies:
+    decode-uri-component: ^0.2.0
+    filter-obj: ^1.1.0
+    split-on-first: ^1.0.0
+    strict-uri-encode: ^2.0.0
+  checksum: f2c7347578fa0f3fd4eaace506470cb4e9dc52d409a7ddbd613f614b9a594d750877e193b5d5e843c7477b3b295b857ec328903c943957adc41a3efb6c929449
+  languageName: node
+  linkType: hard
+
 "querystring-es3@npm:^0.2.0":
   version: 0.2.1
   resolution: "querystring-es3@npm:0.2.1"
@@ -19164,6 +19396,13 @@ __metadata:
   dependencies:
     inherits: ~2.0.3
   checksum: ebc23639248e4fe40a789f713c20548e513e053b3dc4924b6cb0ad741e3f264dcff948225c8737834dd4f9ec286dbc06a1a7c13858ea382d9379f4303bcc0916
+  languageName: node
+  linkType: hard
+
+"quick-lru@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "quick-lru@npm:1.1.0"
+  checksum: 7fd3fb3fb19dfc1d32bc0799c336f5867adc9ba3d9a662a50fdb463d2bb27d9c89b5e55b01a51fe09c3e251389ea858e1c38326bac8f550ff92dcebbf26665a3
   languageName: node
   linkType: hard
 
@@ -19476,6 +19715,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"read-pkg-up@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "read-pkg-up@npm:3.0.0"
+  dependencies:
+    find-up: ^2.0.0
+    read-pkg: ^3.0.0
+  checksum: 16175573f2914ab9788897bcbe2a62b5728d0075e62285b3680cebe97059e2911e0134a062cf6e51ebe3e3775312bc788ac2039ed6af38ec68d2c10c6f2b30fb
+  languageName: node
+  linkType: hard
+
 "read-pkg@npm:^1.0.0":
   version: 1.1.0
   resolution: "read-pkg@npm:1.1.0"
@@ -19484,6 +19733,17 @@ __metadata:
     normalize-package-data: ^2.3.2
     path-type: ^1.0.0
   checksum: a0f5d5e32227ec8e6a028dd5c5134eab229768dcb7a5d9a41a284ed28ad4b9284fecc47383dc1593b5694f4de603a7ffaee84b738956b9b77e0999567485a366
+  languageName: node
+  linkType: hard
+
+"read-pkg@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "read-pkg@npm:3.0.0"
+  dependencies:
+    load-json-file: ^4.0.0
+    normalize-package-data: ^2.3.2
+    path-type: ^3.0.0
+  checksum: 398903ebae6c7e9965419a1062924436cc0b6f516c42c4679a90290d2f87448ed8f977e7aa2dbba4aa1ac09248628c43e493ac25b2bc76640e946035200e34c6
   languageName: node
   linkType: hard
 
@@ -19574,6 +19834,16 @@ __metadata:
   dependencies:
     minimatch: 3.0.4
   checksum: a6b22994d76458443d4a27f5fd7147ac63ad31bba972666a291d511d4d819ee40ff71ba7524c14f6a565b8cfaf7f48b318f971804b913cf538d58f04e25d1fee
+  languageName: node
+  linkType: hard
+
+"redent@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "redent@npm:2.0.0"
+  dependencies:
+    indent-string: ^3.0.0
+    strip-indent: ^2.0.0
+  checksum: c3bcea97de01023efbe826cd72abf2e5948e096acd808a498b4de5dd25e64ad8df0cb4218403197b4ea050ce73f2264a318bf469a27f87ba8ca31543892011d4
   languageName: node
   linkType: hard
 
@@ -21332,6 +21602,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"split-on-first@npm:^1.0.0":
+  version: 1.1.0
+  resolution: "split-on-first@npm:1.1.0"
+  checksum: 16ff85b54ddcf17f9147210a4022529b343edbcbea4ce977c8f30e38408b8d6e0f25f92cd35b86a524d4797f455e29ab89eb8db787f3c10708e0b47ebf528d30
+  languageName: node
+  linkType: hard
+
 "split@npm:^1.0.1":
   version: 1.0.1
   resolution: "split@npm:1.0.1"
@@ -21495,6 +21772,13 @@ __metadata:
   version: 1.1.0
   resolution: "strict-uri-encode@npm:1.1.0"
   checksum: 9466d371f7b36768d43f7803f26137657559e4c8b0161fb9e320efb8edba3ae22f8e99d4b0d91da023b05a13f62ec5412c3f4f764b5788fac11d1fea93720bb3
+  languageName: node
+  linkType: hard
+
+"strict-uri-encode@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "strict-uri-encode@npm:2.0.0"
+  checksum: eaac4cf978b6fbd480f1092cab8b233c9b949bcabfc9b598dd79a758f7243c28765ef7639c876fa72940dac687181b35486ea01ff7df3e65ce3848c64822c581
   languageName: node
   linkType: hard
 
@@ -21733,6 +22017,26 @@ __metadata:
   version: 3.0.0
   resolution: "stubs@npm:3.0.0"
   checksum: dec7b82186e3743317616235c59bfb53284acc312cb9f4c3e97e2205c67a5c158b0ca89db5927e52351582e90a2672822eeaec9db396e23e56893d2a8676e024
+  languageName: node
+  linkType: hard
+
+"stun@npm:2.1.0":
+  version: 2.1.0
+  resolution: "stun@npm:2.1.0"
+  dependencies:
+    binary-data: ^0.6.0
+    buffer-xor: ^2.0.2
+    debug: ^4.1.1
+    ip: ^1.1.5
+    ip2buf: ^2.0.0
+    is-stun: ^2.0.0
+    meow: ^5.0.0
+    parse-url: ^5.0.1
+    turbo-crc32: ^1.0.0
+    universalify: ^0.1.2
+  bin:
+    stun: ./src/cli.js
+  checksum: d964760229ca5f6a2251e191c53d64b46361a75941e65b8165679006e4e3f90623dd542d6ded0d3e1db3d0a3c7fb0433bcac7058380fb86abde60dd686aa0619
   languageName: node
   linkType: hard
 
@@ -22351,6 +22655,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"trim-newlines@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "trim-newlines@npm:2.0.0"
+  checksum: 8a288a860f051f585bdda07ffb97e9e0791ca7c5c1c025b6af4badac185f2eed23ccedeb54da2a79e06ead69824d69b6c9c35c7a69c48e07ee56ac76f91c3096
+  languageName: node
+  linkType: hard
+
 "trim-trailing-lines@npm:^1.0.0":
   version: 1.1.4
   resolution: "trim-trailing-lines@npm:1.1.4"
@@ -22594,6 +22905,13 @@ __metadata:
   dependencies:
     safe-buffer: ^5.0.1
   checksum: 05f6510358f8afc62a057b8b692f05d70c1782b70db86d6a1e0d5e28a32389e52fa6e7707b6c5ecccacc031462e4bc35af85ecfe4bbc341767917b7cf6965711
+  languageName: node
+  linkType: hard
+
+"turbo-crc32@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "turbo-crc32@npm:1.0.1"
+  checksum: 623b376a0d8634d2b6c5df4581141fee188c6e9188e75baad29e5e07102da6ef8d8f3e31d1be0428457ea4080b36dbf1a2683bc50f1caa155940e5065e6b749f
   languageName: node
   linkType: hard
 
@@ -23092,7 +23410,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"universalify@npm:^0.1.0":
+"universalify@npm:^0.1.0, universalify@npm:^0.1.2":
   version: 0.1.2
   resolution: "universalify@npm:0.1.2"
   checksum: 40cdc60f6e61070fe658ca36016a8f4ec216b29bf04a55dce14e3710cc84c7448538ef4dad3728d0bfe29975ccd7bfb5f414c45e7b78883567fb31b246f02dff
@@ -24301,16 +24619,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webrtc-stun@npm:3.0.0":
-  version: 3.0.0
-  resolution: "webrtc-stun@npm:3.0.0"
-  dependencies:
-    buffer-crc32: ^0.2.13
-    ip: ^1.1.5
-  checksum: b0c0be933a35a3c15ce8d6f507a3a7bfe39bb982f20c21dfd5de73c70bf2ec29c9ce5b55d748e8e40e25a417b0a6aae510e018b248bc6b4c4b38ea6d0f469447
-  languageName: node
-  linkType: hard
-
 "websocket-driver@npm:>=0.5.1, websocket-driver@npm:^0.7.4":
   version: 0.7.4
   resolution: "websocket-driver@npm:0.7.4"
@@ -24877,6 +25185,15 @@ __metadata:
   version: 20.2.4
   resolution: "yargs-parser@npm:20.2.4"
   checksum: d251998a374b2743a20271c2fd752b9fbef24eb881d53a3b99a7caa5e8227fcafd9abf1f345ac5de46435821be25ec12189a11030c12ee6481fef6863ed8b924
+  languageName: node
+  linkType: hard
+
+"yargs-parser@npm:^10.0.0":
+  version: 10.1.0
+  resolution: "yargs-parser@npm:10.1.0"
+  dependencies:
+    camelcase: ^4.1.0
+  checksum: 4cd46207839192785675893ae2d69ebc9acb31237f0f1a4016002fecdd92715656fd44facc27172e437ac503dbd5793f534cb2d412347e525b426ffcac727080
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
By default, *each* hopr node acts as a STUN server.

Due to updates to the ecosystem, the functionality got broken. This PR reenables the functionality by using new modules.

*Changes in detail*:

- Use `udp6` socket instead of `udp4` -> fixes general listening issue. IPv4 traffic using IPv4 addresses prefixed by `::ffff:`
- Replaces the *hacky* `webrtc-stun` library by `stun`, so `console.log` overwrites become obsolete
- Simplify STUN logic

Fixes https://github.com/hoprnet/hoprnet/issues/4303