### PR TITLE
Allow connectivity indicator to be GREEN on public nodes too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - Various optimizations of Rust crates ([#4221](https://github.com/hoprnet/hoprnet/pull/4260))
 - Add Metrics API for Prometheus, `metrics` API endpoint and collection of various metrics ([#4233](https://github.com/hoprnet/hoprnet/pull/4233))
 - Improve pre-merge check to prevent PR from merging when the upstream deployment is in the failed state ([#4294](https://github.com/hoprnet/hoprnet/pull/4294))
+- Add Health Status Indicator in the Admin UI ([#4197](https://github.com/hoprnet/hoprnet/pull/4197))
+- Allow connectivity indicator to be GREEN on public nodes too ([#4314](https://github.com/hoprnet/hoprnet/pull/4314))
 
 ---
 
@@ -15,7 +17,6 @@
 
 ## [1.90](https://github.com/hoprnet/hoprnet/compare/release/paleochora...hoprnet:release/valencia)
 
-- Add Health Status Indicator in the Admin UI ([#4197](https://github.com/hoprnet/hoprnet/pull/4197))
 - Improve Network Registry smart contract to allow 1-to-many node registration, add enable/disable make targets ([#4008](https://github.com/hoprnet/hoprnet/pull/4091))
 - Replace `yarn` with `npx` in `pluto` Docker image to run `hoprd` to fix binary discoverability issue
 - Add support for communication between different releases within the same environment

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -275,7 +275,9 @@ class Hopr extends EventEmitter {
     verbose('Started HoprEthereum. Waiting for indexer to find connected nodes.')
 
     // Add us as public node if announced
-    if (this.options.announce) this.knownPublicNodesCache.add(this.id.toString())
+    if (this.options.announce) {
+      this.knownPublicNodesCache.add(this.id.toString())
+    }
 
     // Fetch previous announcements from database
     const initialNodes = await this.connector.waitForPublicNodes()

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -274,6 +274,10 @@ class Hopr extends EventEmitter {
     await this.connector.start()
     verbose('Started HoprEthereum. Waiting for indexer to find connected nodes.')
 
+    // Add us as public node if announced
+    if (this.options.announce)
+      this.knownPublicNodesCache.add(this.id.toString())
+
     // Fetch previous announcements from database
     const initialNodes = await this.connector.waitForPublicNodes()
 
@@ -357,6 +361,7 @@ class Hopr extends EventEmitter {
     peers.forEach((peer) => log(`peer store: loaded peer ${peer.id.toString()}`))
 
     this.heartbeat = new Heartbeat(
+      this.id,
       this.networkPeers,
       subscribe,
       sendMessage,

--- a/packages/core/src/network/heartbeat.spec.ts
+++ b/packages/core/src/network/heartbeat.spec.ts
@@ -146,7 +146,7 @@ async function getPeer(
     }) as any,
     () => Promise.resolve(true),
     netStatEvents,
-    (peerId) => !peerId.equals(Charly),
+    (peerId) => !peerId.equals(Charly) && !peerId.equals(Me),
     TESTING_ENVIRONMENT,
     {
       ...SHORT_TIMEOUTS,

--- a/packages/core/src/network/heartbeat.spec.ts
+++ b/packages/core/src/network/heartbeat.spec.ts
@@ -25,6 +25,7 @@ class NetworkHealth extends EventEmitter {
   }
 }
 
+const Me = privKeyToPeerId('0x9135f358f94b59e8cdee5545eb9ecc8ff32bc3a79227a09ee2bb6b50f1ad8159')
 const Alice = privKeyToPeerId('0x427ff36aacbac09f6da4072161a6a338308c53cfb6e50ca56aa70b1a38602a9f')
 const Bob = privKeyToPeerId('0xf9bfbad938482b29076932b080fb6ac1e14616ee621fb3f77739784bcf1ee8cf')
 const Charly = privKeyToPeerId('0xfab2610822e8c973bec74c811e2f44b6b4b501e922b1d67f5367a26ce46088ea')
@@ -135,7 +136,7 @@ async function getPeer(
 ): Promise<{ heartbeat: TestingHeartbeat; peers: NetworkPeers }> {
   const peers = new NetworkPeers([], [self], 0.3)
 
-  const heartbeat = new TestingHeartbeat(
+  const heartbeat = new TestingHeartbeat(Me,
     peers,
     (protocols: string | string[], handler: LibP2PHandlerFunction<any>) => network.subscribe(self, protocols, handler),
     ((dest: PeerId, protocols: string | string[], msg: Uint8Array) =>
@@ -163,7 +164,7 @@ async function getPeer(
 describe('unit test heartbeat', async () => {
   it('check nodes is noop with empty store & health indicator is red', async () => {
     let netHealth = new NetworkHealth()
-    const heartbeat = new TestingHeartbeat(
+    const heartbeat = new TestingHeartbeat(Me,
       new NetworkPeers([], [Alice], 0.3),
       (() => {}) as any,
       (async () => {

--- a/packages/core/src/network/heartbeat.ts
+++ b/packages/core/src/network/heartbeat.ts
@@ -90,12 +90,13 @@ export default class Heartbeat {
   private stopHeartbeatInterval: (() => void) | undefined
   private protocolHeartbeat: string | string[]
 
-  // Initial network health is always RED
+  // Initial network health is UNKNOWN
   private currentHealth: NetworkHealthIndicator = NetworkHealthIndicator.UNKNOWN
 
   private config: HeartbeatConfig
 
   constructor(
+    private me: PeerId,
     private networkPeers: NetworkPeers,
     private subscribe: Subscribe,
     protected sendMessage: SendMessage,
@@ -244,8 +245,8 @@ export default class Heartbeat {
     // YELLOW = high-quality connection to a public node
     if (highQualityPublic > 0) newHealthValue = NetworkHealthIndicator.YELLOW
 
-    // GREEN = hiqh-quality connection to a public and a non-public node
-    if (highQualityPublic > 0 && highQualityNonPublic > 0) newHealthValue = NetworkHealthIndicator.GREEN
+    // GREEN = hiqh-quality connection to a public and a non-public node OR we're public node
+    if (highQualityPublic > 0 && (this.isPublicNode(this.me) || highQualityNonPublic > 0)) newHealthValue = NetworkHealthIndicator.GREEN
 
     log(
       `network health details: ${lowQualityPublic} LQ public, ${lowQualityNonPublic} LQ non-public, ${highQualityPublic} HQ public, ${highQualityNonPublic} HQ non-public`


### PR DESCRIPTION
This PR modifies the criteria for the GREEN state of the Connectivity Indicator, refs #3758

Connectivity indicator is GREEN if:

at least 1 HQ connection to a public node AND
at least 1 HQ connection to a NAT-node OR being a public relay (= used the --announce CLI flag)

Closes #4313 