### PR TITLE
Use `cargo` to install `wasm-pack`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@ deps: ## install dependencies
 	[ -n "${NIX_PATH}" ] || corepack enable
 	yarn
 	command -v rustup && rustup update || echo "No rustup installed, ignoring"
+	cargo install wasm-pack
 
 .PHONY: build
 build: ## build all packages

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ deps: ## install dependencies
 	[ -n "${NIX_PATH}" ] || corepack enable
 	yarn
 	command -v rustup && rustup update || echo "No rustup installed, ignoring"
-	cargo install wasm-pack
+	command -v wasm-pack || cargo install wasm-pack
 
 .PHONY: build
 build: ## build all packages

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "prettier": "2.7.1",
     "ts-node": "10.8.1",
     "typescript": "4.7.4",
-    "wasm-pack": "0.10.3",
     "yargs": "17.5.1"
   },
   "resolutions": {

--- a/packages/connect/crates/Makefile
+++ b/packages/connect/crates/Makefile
@@ -10,11 +10,11 @@ JS_FILES = $(foreach package,$(PACKAGES),$(package)/pkg/$(subst -,_,$(package)).
 all: $(JS_FILES)
 
 test: $(JS_FILES)
-	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && npx wasm-pack test --node `pwd`/$(pkg) && ) true
+	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && wasm-pack test --node `pwd`/$(pkg) && ) true
 
 $(JS_FILES):
 	mkdir -p $(@D)
-	npx wasm-pack build --target=bundler `pwd`/$(@D)/..
+	wasm-pack build --target=bundler `pwd`/$(@D)/..
 
 install:
 ifneq ($(PACKAGES),)

--- a/packages/core-ethereum/crates/Makefile
+++ b/packages/core-ethereum/crates/Makefile
@@ -10,11 +10,11 @@ JS_FILES = $(foreach package,$(PACKAGES),$(package)/pkg/$(subst -,_,$(package)).
 all: $(JS_FILES)
 
 test: $(JS_FILES)
-	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && npx wasm-pack test --node `pwd`/$(pkg) && ) true
+	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && wasm-pack test --node `pwd`/$(pkg) && ) true
 
 $(JS_FILES):
 	mkdir -p $(@D)
-	npx wasm-pack build --target=bundler `pwd`/$(@D)/..
+	wasm-pack build --target=bundler `pwd`/$(@D)/..
 
 install:
 ifneq ($(PACKAGES),)

--- a/packages/core/crates/Makefile
+++ b/packages/core/crates/Makefile
@@ -10,11 +10,11 @@ JS_FILES = $(foreach package,$(PACKAGES),$(package)/pkg/$(subst -,_,$(package)).
 all: $(JS_FILES)
 
 test: $(JS_FILES)
-	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && npx wasm-pack test --node `pwd`/$(pkg) && ) true
+	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && wasm-pack test --node `pwd`/$(pkg) && ) true
 
 $(JS_FILES):
 	mkdir -p $(@D)
-	npx wasm-pack build --target=bundler `pwd`/$(@D)/..
+	wasm-pack build --target=bundler `pwd`/$(@D)/..
 
 install:
 ifneq ($(PACKAGES),)

--- a/packages/cover-traffic-daemon/crates/Makefile
+++ b/packages/cover-traffic-daemon/crates/Makefile
@@ -10,11 +10,11 @@ JS_FILES = $(foreach package,$(PACKAGES),$(package)/pkg/$(subst -,_,$(package)).
 all: $(JS_FILES)
 
 test: $(JS_FILES)
-	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && npx wasm-pack test --node `pwd`/$(pkg) && ) true
+	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && wasm-pack test --node `pwd`/$(pkg) && ) true
 
 $(JS_FILES):
 	mkdir -p $(@D)
-	npx wasm-pack build --target=bundler `pwd`/$(@D)/..
+	wasm-pack build --target=bundler `pwd`/$(@D)/..
 
 install:
 ifneq ($(PACKAGES),)

--- a/packages/ethereum/crates/Makefile
+++ b/packages/ethereum/crates/Makefile
@@ -10,11 +10,11 @@ JS_FILES = $(foreach package,$(PACKAGES),$(package)/pkg/$(subst -,_,$(package)).
 all: $(JS_FILES)
 
 test: $(JS_FILES)
-	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && npx wasm-pack test --node `pwd`/$(pkg) && ) true
+	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && wasm-pack test --node `pwd`/$(pkg) && ) true
 
 $(JS_FILES):
 	mkdir -p $(@D)
-	npx wasm-pack build --target=bundler `pwd`/$(@D)/..
+	wasm-pack build --target=bundler `pwd`/$(@D)/..
 
 install:
 ifneq ($(PACKAGES),)

--- a/packages/hoprd/crates/Makefile
+++ b/packages/hoprd/crates/Makefile
@@ -10,11 +10,11 @@ JS_FILES = $(foreach package,$(PACKAGES),$(package)/pkg/$(subst -,_,$(package)).
 all: $(JS_FILES)
 
 test: $(JS_FILES)
-	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && npx wasm-pack test --node `pwd`/$(pkg) && ) true
+	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && wasm-pack test --node `pwd`/$(pkg) && ) true
 
 $(JS_FILES):
 	mkdir -p $(@D)
-	npx wasm-pack build --target=bundler `pwd`/$(@D)/..
+	wasm-pack build --target=bundler `pwd`/$(@D)/..
 
 install:
 ifneq ($(PACKAGES),)

--- a/packages/real/crates/Makefile
+++ b/packages/real/crates/Makefile
@@ -10,11 +10,11 @@ JS_FILES = $(foreach package,$(PACKAGES),$(package)/pkg/$(subst -,_,$(package)).
 all: $(JS_FILES)
 
 test: $(JS_FILES)
-	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && npx wasm-pack test --node `pwd`/$(pkg) && ) true
+	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && wasm-pack test --node `pwd`/$(pkg) && ) true
 
 $(JS_FILES):
 	mkdir -p $(@D)
-	npx wasm-pack build --target=bundler `pwd`/$(@D)/..
+	wasm-pack build --target=bundler `pwd`/$(@D)/..
 
 install:
 ifneq ($(PACKAGES),)

--- a/packages/utils/crates/Makefile
+++ b/packages/utils/crates/Makefile
@@ -10,11 +10,11 @@ JS_FILES = $(foreach package,$(PACKAGES),$(package)/pkg/$(subst -,_,$(package)).
 all: $(JS_FILES)
 
 test: $(JS_FILES)
-	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && npx wasm-pack test --node `pwd`/$(pkg) && ) true
+	$(foreach pkg,$(PACKAGES),cargo test -p $(pkg) && wasm-pack test --node `pwd`/$(pkg) && ) true
 
 $(JS_FILES):
 	mkdir -p $(@D)
-	npx wasm-pack build --target=bundler `pwd`/$(@D)/..
+	wasm-pack build --target=bundler `pwd`/$(@D)/..
 
 install:
 ifneq ($(PACKAGES),)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7314,17 +7314,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"binary-install@npm:^0.1.0":
-  version: 0.1.1
-  resolution: "binary-install@npm:0.1.1"
-  dependencies:
-    axios: ^0.21.1
-    rimraf: ^3.0.2
-    tar: ^6.1.0
-  checksum: a3df9c07a3ab81533cff610527263181c4c34a44efb115555be910b6011ac047bf875ad57469cc2259dfaba58e971c7ba2958038e9d222c546eef7b58b826ecc
-  languageName: node
-  linkType: hard
-
 "bindings@npm:^1.2.1":
   version: 1.5.0
   resolution: "bindings@npm:1.5.0"
@@ -12959,7 +12948,6 @@ __metadata:
     prettier: 2.7.1
     ts-node: 10.8.1
     typescript: 4.7.4
-    wasm-pack: 0.10.3
     yargs: 17.5.1
   languageName: unknown
   linkType: soft
@@ -22074,7 +22062,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^6.1.0, tar@npm:^6.1.11, tar@npm:^6.1.2":
+"tar@npm:^6.1.11, tar@npm:^6.1.2":
   version: 6.1.11
   resolution: "tar@npm:6.1.11"
   dependencies:
@@ -23544,17 +23532,6 @@ __metadata:
   bin:
     wait-on: bin/wait-on
   checksum: e4d62aa4145d99fe34747ccf7506d4b4d6e60dd677c0eb18a51e316d38116ace2d194e4b22a9eb7b767b0282f39878ddcc4ae9440dcb0c005c9150668747cf5b
-  languageName: node
-  linkType: hard
-
-"wasm-pack@npm:0.10.3":
-  version: 0.10.3
-  resolution: "wasm-pack@npm:0.10.3"
-  dependencies:
-    binary-install: ^0.1.0
-  bin:
-    wasm-pack: run.js
-  checksum: b980b33fc8adcd208556a1f5c4656b02d1ae584792259874f09ab5647dd52d0cdd3179d970ba99eed72ac1a422445c3c81122a3e9d7c05ebb2a3ff83bd7ec7db
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Install `wasm-pack` using `cargo` to make sure the correct version is used according to the platform.

Closes #4317 