### PR TITLE
Fix `setup-local-cluster` script to use correct WS URL (backport #4321)

### DIFF
--- a/scripts/setup-local-cluster.sh
+++ b/scripts/setup-local-cluster.sh
@@ -339,45 +339,45 @@ log "\t\tPeer Id:\t${peers[0]}"
 log "\t\tRest API:\thttp://localhost:13301/api/v2/_swagger"
 log "\t\tAdmin UI:\thttp://localhost:19501/?apiEndpoint=http://localhost:13301&apiToken=${api_token}"
 log "\t\tHealthcheck:\thttp://localhost:18081/"
-log "\t\tWebSocket:\tws://localhost:19501/"
+log "\t\tWebSocket:\tws://localhost:13301/api/v2/messages/websocket?apiToken=${api_token}"
 log "\t\tMyne Chat:\t${myne_chat_url}/?apiEndpoint=http://localhost:13301&apiToken=${api_token}"
 log "\tnode2"
 log "\t\tPeer Id:\t${peers[1]}"
 log "\t\tRest API:\thttp://localhost:13302/api/v2/_swagger"
 log "\t\tAdmin UI:\thttp://localhost:19502/?apiEndpoint=http://localhost:13302&apiToken=${api_token}"
 log "\t\tHealthcheck:\thttp://localhost:18082/"
-log "\t\tWebSocket:\tws://localhost:19502/"
+log "\t\tWebSocket:\tws://localhost:13302/api/v2/messages/websocket?apiToken=${api_token}"
 log "\t\tMyne Chat:\t${myne_chat_url}/?apiEndpoint=http://localhost:13302&apiToken=${api_token}"
 log "\tnode3"
 log "\t\tPeer Id:\t${peers[2]}"
 log "\t\tRest API:\thttp://localhost:13303/api/v2/_swagger"
 log "\t\tAdmin UI:\thttp://localhost:19503/?apiEndpoint=http://localhost:13303&apiToken=${api_token}"
 log "\t\tHealthcheck:\thttp://localhost:18083/"
-log "\t\tWebSocket:\tws://localhost:19503/"
+log "\t\tWebSocket:\tws://localhost:13303/api/v2/messages/websocket?apiToken=${api_token}"
 log "\t\tMyne Chat:\t${myne_chat_url}/?apiEndpoint=http://localhost:13303&apiToken=${api_token}"
 log "\tnode4"
 log "\t\tPeer Id:\t${peers[3]}"
 log "\t\tRest API:\thttp://localhost:13304/api/v2/_swagger"
 log "\t\tAdmin UI:\thttp://localhost:19504/?apiEndpoint=http://localhost:13304&apiToken=${api_token}"
 log "\t\tHealthcheck:\thttp://localhost:18084/"
-log "\t\tWebSocket:\tws://localhost:19504/"
+log "\t\tWebSocket:\tws://localhost:13304/api/v2/messages/websocket?apiToken=${api_token}"
 log "\t\tMyne Chat:\t${myne_chat_url}/?apiEndpoint=http://localhost:13304&apiToken=${api_token}"
 log "\tnode5"
 log "\t\tPeer Id:\t${peers[4]}"
 log "\t\tRest API:\thttp://localhost:13305/api/v2/_swagger"
 log "\t\tAdmin UI:\thttp://localhost:19505/?apiEndpoint=http://localhost:13305&apiToken=${api_token}"
 log "\t\tHealthcheck:\thttp://localhost:18085/"
-log "\t\tWebSocket:\tws://localhost:19505/"
+log "\t\tWebSocket:\tws://localhost:13305/api/v2/messages/websocket?apiToken=${api_token}"
 log "\t\tMyne Chat:\t${myne_chat_url}/?apiEndpoint=http://localhost:13305&apiToken=${api_token}"
 
 cat <<EOF > ${env_file}
 #!/usr/bin/env bash
 export apiToken="${api_token}"
-export HOPR_NODE_1_ADDR=${peers[0]} HOPR_NODE_1_HTTP_URL=http://127.0.0.1:13301 HOPR_NODE_1_WS_URL=ws://127.0.0.1:19501
-export HOPR_NODE_2_ADDR=${peers[1]} HOPR_NODE_2_HTTP_URL=http://127.0.0.1:13302 HOPR_NODE_2_WS_URL=ws://127.0.0.1:19502
-export HOPR_NODE_3_ADDR=${peers[2]} HOPR_NODE_3_HTTP_URL=http://127.0.0.1:13303 HOPR_NODE_3_WS_URL=ws://127.0.0.1:19503
-export HOPR_NODE_4_ADDR=${peers[3]} HOPR_NODE_4_HTTP_URL=http://127.0.0.1:13304 HOPR_NODE_4_WS_URL=ws://127.0.0.1:19504
-export HOPR_NODE_5_ADDR=${peers[4]} HOPR_NODE_5_HTTP_URL=http://127.0.0.1:13305 HOPR_NODE_5_WS_URL=ws://127.0.0.1:19505
+export HOPR_NODE_1_ADDR=${peers[0]} HOPR_NODE_1_HTTP_URL=http://127.0.0.1:13301 HOPR_NODE_1_WS_URL=ws://127.0.0.1:13301/api/v2/messages/websocket
+export HOPR_NODE_2_ADDR=${peers[1]} HOPR_NODE_2_HTTP_URL=http://127.0.0.1:13302 HOPR_NODE_2_WS_URL=ws://127.0.0.1:13302/api/v2/messages/websocket
+export HOPR_NODE_3_ADDR=${peers[2]} HOPR_NODE_3_HTTP_URL=http://127.0.0.1:13303 HOPR_NODE_3_WS_URL=ws://127.0.0.1:13303/api/v2/messages/websocket
+export HOPR_NODE_4_ADDR=${peers[3]} HOPR_NODE_4_HTTP_URL=http://127.0.0.1:13304 HOPR_NODE_4_WS_URL=ws://127.0.0.1:13304/api/v2/messages/websocket
+export HOPR_NODE_5_ADDR=${peers[4]} HOPR_NODE_5_HTTP_URL=http://127.0.0.1:13305 HOPR_NODE_5_WS_URL=ws://127.0.0.1:13305/api/v2/messages/websocket
 echo -e "\n"
 echo "🌐 Node 1 REST API URL:  \$HOPR_NODE_1_HTTP_URL"
 echo "🔌 Node 1 WebSocket URL: \$HOPR_NODE_1_WS_URL"


### PR DESCRIPTION
Fixes what gets printed out by the setup-local-cluster scripts, so users use the correct WebSocket URL.

Cherry picked from commit 9b1602c19b249fc6e7ac24e4e6f699e8e1a1906a as hotfix for release Bogota 

See #4321 