### PR TITLE
Add missing flag in the CTD

### DIFF
--- a/packages/cover-traffic-daemon/Dockerfile
+++ b/packages/cover-traffic-daemon/Dockerfile
@@ -34,7 +34,7 @@ FROM node:16-bullseye-slim@sha256:95d4fdef5e12916a89f7d56dca6d8099de61df875c3c61
 # making sure some standard environment variables are set for production use
 ENV NODE_ENV production
 ENV DEBUG 'hopr*'
-ENV NODE_OPTIONS=--max_old_space_size=4096
+ENV NODE_OPTIONS="--max_old_space_size=4096 --experimental-wasm-modules"
 
 # p2p
 EXPOSE 9091


### PR DESCRIPTION
The `--experimental-wasm-modules` flag was missing in the Cover Traffic Daemon.