### PR TITLE
Use proper upstream version tag for Avado on `master`

### DIFF
--- a/packages/avado/docker-compose.yml
+++ b/packages/avado/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     build:
       context: ./build
       args:
-        UPSTREAM_VERSION: '%AVADO_VERSION%'
+        UPSTREAM_VERSION: '%UPSTREAM_VERSION%'
     network_mode: host
     # Lines between *_JSON_EXPORT are intentionally also a valid JSON
     # Info: a hoprd node should never consume more than 1GByte of memory

--- a/scripts/build_avado.sh
+++ b/scripts/build_avado.sh
@@ -74,6 +74,12 @@ function cleanup {
   exit $EC
 }
 
+# For master builds, we need to use special upstream version, since we do not publish 0.100.0 Docker tag
+declare upstream_version="${avado_version}"
+if [[ "${avado_version}" = "0.100.0" && "${release_id}" = "master-goerli" ]]; then
+  upstream_version="master-goerli"
+fi
+
 msg "Building Avado v. ${avado_version} for release ${release_id} using environment ${environment_id} with default provider ${provider_url}"
 
 # Create backups
@@ -84,7 +90,7 @@ cp ./build/Dockerfile ./build/Dockerfile.bak
 trap cleanup SIGINT SIGTERM ERR EXIT
 
 ### Update docker-compose.yaml
-sed -E "s/%AVADO_VERSION%/${avado_version}/g ; s/%TOKEN%/${api_token}/g ; \
+sed -E "s/%AVADO_VERSION%/${avado_version}/g ; s/%TOKEN%/${api_token}/g ; s/%UPSTREAM_VERSION%/${upstream_version}/g ; \
  s/%ENV_ID%/${environment_id}/g ; s|%PROVIDER_URL%|${provider_url}|g" ./docker-compose.yml \
   > ./docker-compose.yml.tmp && mv ./docker-compose.yml.tmp ./docker-compose.yml
 

--- a/scripts/build_avado.sh
+++ b/scripts/build_avado.sh
@@ -80,7 +80,7 @@ if [[ "${avado_version}" = "0.100.0" && "${release_id}" = "master-goerli" ]]; th
   upstream_version="master-goerli"
 fi
 
-msg "Building Avado v. ${avado_version} for release ${release_id} using environment ${environment_id} with default provider ${provider_url}"
+msg "Building Avado v. ${avado_version} for release ${release_id} (upstream v. ${upstream_version}) using environment ${environment_id} with default provider ${provider_url}"
 
 # Create backups
 cp ./docker-compose.yml ./docker-compose.bak


### PR DESCRIPTION
The `0.100.0` Docker tag is not published for Avado to grab.