### PR TITLE
Backported hotfixes to unblock CI Docker & Avado builds

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -161,7 +161,7 @@ jobs:
 
   build_docker:
     name: Build Docker Images
-    timeout-minutes: 60
+    timeout-minutes: 30
     runs-on: ubuntu-latest
     needs: [build_deploy_sc_npm]
     steps:

--- a/Dockerfile.hardhat
+++ b/Dockerfile.hardhat
@@ -62,6 +62,12 @@ RUN make -j build \
 # use alpine version of node for smallest image sizes
 FROM node:16-alpine as runtime
 
+# install tools required within our scripts
+RUN apk add --no-cache libc6-compat
+
+# symlink to ensure any files relying on the presence of the library keep working
+RUN ln -s /lib/libc.musl-x86_64.so.1 /lib/ld-linux-x86-64.so.2
+
 RUN mkdir /core
 
 WORKDIR /hardhat

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
-  - name: 'gcr.io/kaniko-project/executor:latest'
+  - name: 'gcr.io/kaniko-project/executor:v1.9.1'
     id: buildHoprd
     args:
       - --context=dir://packages/hoprd
@@ -9,7 +9,7 @@ steps:
       - --build-arg=PACKAGE_VERSION=${_PACKAGE_VERSION}
     timeout: 1200s
     waitFor: ['-']
-  - name: 'gcr.io/kaniko-project/executor:latest'
+  - name: 'gcr.io/kaniko-project/executor:v1.9.1'
     id: buildHoprdNat
     args:
       - --context=dir://scripts/nat
@@ -21,7 +21,7 @@ steps:
     timeout: 600s
     waitFor:
       - buildHoprd
-  - name: 'gcr.io/kaniko-project/executor:latest'
+  - name: 'gcr.io/kaniko-project/executor:v1.9.1'
     id: buildCoverTrafficDaemon
     args:
       - --context=dir://packages/cover-traffic-daemon
@@ -31,14 +31,14 @@ steps:
       - --build-arg=PACKAGE_VERSION=${_PACKAGE_VERSION}
     timeout: 600s
     waitFor: ['-']
-  - name: 'gcr.io/kaniko-project/executor@sha256:1f982af0b54be748221d9a35dcfa608660ab3d51229aa56bde5416f75aff7561'
+  - name: 'gcr.io/kaniko-project/executor:v1.9.1'
     id: buildHardhat
     args:
       - --dockerfile=Dockerfile.hardhat
       - --destination=gcr.io/${PROJECT_ID}/hopr-hardhat:${_IMAGE_VERSION}
-      - --cache=false
+      - --cache=true
       - --cache-ttl=96h
-    timeout: 3600s
+    timeout: 1200s
     waitFor: ['-']
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     id: testImages
@@ -57,7 +57,7 @@ steps:
       - buildHoprdNat
       - buildCoverTrafficDaemon
       - buildHardhat
-  - name: 'gcr.io/kaniko-project/executor:latest'
+  - name: 'gcr.io/kaniko-project/executor:v1.9.1'
     id: buildPluto
     args:
       - --context=dir://scripts/pluto
@@ -97,4 +97,4 @@ options:
   logStreamingOption: STREAM_ON
   substitutionOption: MUST_MATCH
   machineType: N1_HIGHCPU_32
-timeout: 3600s
+timeout: 1800s

--- a/packages/avado/docker-compose.yml
+++ b/packages/avado/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     build:
       context: ./build
       args:
-        UPSTREAM_VERSION: '%AVADO_VERSION%'
+        UPSTREAM_VERSION: '%UPSTREAM_VERSION%'
     network_mode: host
     # Lines between *_JSON_EXPORT are intentionally also a valid JSON
     # Info: a hoprd node should never consume more than 1GByte of memory

--- a/packages/cover-traffic-daemon/Dockerfile
+++ b/packages/cover-traffic-daemon/Dockerfile
@@ -34,7 +34,7 @@ FROM node:16-bullseye-slim@sha256:95d4fdef5e12916a89f7d56dca6d8099de61df875c3c61
 # making sure some standard environment variables are set for production use
 ENV NODE_ENV production
 ENV DEBUG 'hopr*'
-ENV NODE_OPTIONS=--max_old_space_size=4096
+ENV NODE_OPTIONS="--max_old_space_size=4096 --experimental-wasm-modules"
 
 # p2p
 EXPOSE 9091

--- a/packages/ethereum/package.hardhat.json
+++ b/packages/ethereum/package.hardhat.json
@@ -30,7 +30,7 @@
     "chai": "4.3.6",
     "dotenv": "10.0.0",
     "ethers": "5.7.0",
-    "hardhat": "2.11.2",
+    "hardhat": "2.12.2",
     "hardhat-deploy": "^0.11.5",
     "hardhat-gas-reporter": "1.0.8",
     "solidity-coverage": "0.8.2",

--- a/packages/ethereum/package.json
+++ b/packages/ethereum/package.json
@@ -54,7 +54,7 @@
     "chai": "4.3.6",
     "dotenv": "10.0.0",
     "ethers": "5.7.0",
-    "hardhat": "2.11.2",
+    "hardhat": "2.12.2",
     "hardhat-deploy": "^0.11.5",
     "hardhat-gas-reporter": "1.0.8",
     "solidity-coverage": "0.8.2",

--- a/scripts/build_avado.sh
+++ b/scripts/build_avado.sh
@@ -74,7 +74,13 @@ function cleanup {
   exit $EC
 }
 
-msg "Building Avado v. ${avado_version} for release ${release_id} using environment ${environment_id} with default provider ${provider_url}"
+# For master builds, we need to use special upstream version, since we do not publish 0.100.0 Docker tag
+declare upstream_version="${avado_version}"
+if [[ "${avado_version}" = "0.100.0" && "${release_id}" = "master-goerli" ]]; then
+  upstream_version="master-goerli"
+fi
+
+msg "Building Avado v. ${avado_version} for release ${release_id} (upstream v. ${upstream_version}) using environment ${environment_id} with default provider ${provider_url}"
 
 # Create backups
 cp ./docker-compose.yml ./docker-compose.bak
@@ -84,7 +90,7 @@ cp ./build/Dockerfile ./build/Dockerfile.bak
 trap cleanup SIGINT SIGTERM ERR EXIT
 
 ### Update docker-compose.yaml
-sed -E "s/%AVADO_VERSION%/${avado_version}/g ; s/%TOKEN%/${api_token}/g ; \
+sed -E "s/%AVADO_VERSION%/${avado_version}/g ; s/%TOKEN%/${api_token}/g ; s/%UPSTREAM_VERSION%/${upstream_version}/g ; \
  s/%ENV_ID%/${environment_id}/g ; s|%PROVIDER_URL%|${provider_url}|g" ./docker-compose.yml \
   > ./docker-compose.yml.tmp && mv ./docker-compose.yml.tmp ./docker-compose.yml
 

--- a/scripts/deployment-gater.sh
+++ b/scripts/deployment-gater.sh
@@ -55,7 +55,7 @@ check() {
   return ${ec}
 }
 
-if [ $# -le 1 ]; then
+if [ $# -lt 1 ]; then
   usage
   exit 1
 fi

--- a/scripts/pluto/Dockerfile
+++ b/scripts/pluto/Dockerfile
@@ -9,10 +9,7 @@ FROM ${HARDHAT_IMAGE} as runtime
 LABEL description="Docker image running a HOPR-enabled hardhat network with 5 hoprd nodes using it and being fully interconnected."
 
 # install tools required within our scripts
-RUN apk add --no-cache bash libc6-compat lsof curl jq
-
-# symlink required to get WRTC to work
-RUN ln -s /lib/libc.musl-x86_64.so.1 /lib/ld-linux-x86-64.so.2
+RUN apk add --no-cache bash lsof curl jq
 
 WORKDIR /app
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3114,7 +3114,7 @@ __metadata:
     chai: 4.3.6
     dotenv: 10.0.0
     ethers: 5.7.0
-    hardhat: 2.11.2
+    hardhat: 2.12.2
     hardhat-deploy: ^0.11.5
     hardhat-gas-reporter: 1.0.8
     solidity-coverage: 0.8.2
@@ -4291,90 +4291,90 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@nomicfoundation/solidity-analyzer-darwin-arm64@npm:0.0.3":
-  version: 0.0.3
-  resolution: "@nomicfoundation/solidity-analyzer-darwin-arm64@npm:0.0.3"
+"@nomicfoundation/solidity-analyzer-darwin-arm64@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@nomicfoundation/solidity-analyzer-darwin-arm64@npm:0.1.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@nomicfoundation/solidity-analyzer-darwin-x64@npm:0.0.3":
-  version: 0.0.3
-  resolution: "@nomicfoundation/solidity-analyzer-darwin-x64@npm:0.0.3"
+"@nomicfoundation/solidity-analyzer-darwin-x64@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@nomicfoundation/solidity-analyzer-darwin-x64@npm:0.1.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@nomicfoundation/solidity-analyzer-freebsd-x64@npm:0.0.3":
-  version: 0.0.3
-  resolution: "@nomicfoundation/solidity-analyzer-freebsd-x64@npm:0.0.3"
+"@nomicfoundation/solidity-analyzer-freebsd-x64@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@nomicfoundation/solidity-analyzer-freebsd-x64@npm:0.1.0"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
 
-"@nomicfoundation/solidity-analyzer-linux-arm64-gnu@npm:0.0.3":
-  version: 0.0.3
-  resolution: "@nomicfoundation/solidity-analyzer-linux-arm64-gnu@npm:0.0.3"
+"@nomicfoundation/solidity-analyzer-linux-arm64-gnu@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@nomicfoundation/solidity-analyzer-linux-arm64-gnu@npm:0.1.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@nomicfoundation/solidity-analyzer-linux-arm64-musl@npm:0.0.3":
-  version: 0.0.3
-  resolution: "@nomicfoundation/solidity-analyzer-linux-arm64-musl@npm:0.0.3"
+"@nomicfoundation/solidity-analyzer-linux-arm64-musl@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@nomicfoundation/solidity-analyzer-linux-arm64-musl@npm:0.1.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@nomicfoundation/solidity-analyzer-linux-x64-gnu@npm:0.0.3":
-  version: 0.0.3
-  resolution: "@nomicfoundation/solidity-analyzer-linux-x64-gnu@npm:0.0.3"
+"@nomicfoundation/solidity-analyzer-linux-x64-gnu@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@nomicfoundation/solidity-analyzer-linux-x64-gnu@npm:0.1.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@nomicfoundation/solidity-analyzer-linux-x64-musl@npm:0.0.3":
-  version: 0.0.3
-  resolution: "@nomicfoundation/solidity-analyzer-linux-x64-musl@npm:0.0.3"
+"@nomicfoundation/solidity-analyzer-linux-x64-musl@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@nomicfoundation/solidity-analyzer-linux-x64-musl@npm:0.1.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@nomicfoundation/solidity-analyzer-win32-arm64-msvc@npm:0.0.3":
-  version: 0.0.3
-  resolution: "@nomicfoundation/solidity-analyzer-win32-arm64-msvc@npm:0.0.3"
+"@nomicfoundation/solidity-analyzer-win32-arm64-msvc@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@nomicfoundation/solidity-analyzer-win32-arm64-msvc@npm:0.1.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@nomicfoundation/solidity-analyzer-win32-ia32-msvc@npm:0.0.3":
-  version: 0.0.3
-  resolution: "@nomicfoundation/solidity-analyzer-win32-ia32-msvc@npm:0.0.3"
+"@nomicfoundation/solidity-analyzer-win32-ia32-msvc@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@nomicfoundation/solidity-analyzer-win32-ia32-msvc@npm:0.1.0"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@nomicfoundation/solidity-analyzer-win32-x64-msvc@npm:0.0.3":
-  version: 0.0.3
-  resolution: "@nomicfoundation/solidity-analyzer-win32-x64-msvc@npm:0.0.3"
+"@nomicfoundation/solidity-analyzer-win32-x64-msvc@npm:0.1.0":
+  version: 0.1.0
+  resolution: "@nomicfoundation/solidity-analyzer-win32-x64-msvc@npm:0.1.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@nomicfoundation/solidity-analyzer@npm:^0.0.3":
-  version: 0.0.3
-  resolution: "@nomicfoundation/solidity-analyzer@npm:0.0.3"
+"@nomicfoundation/solidity-analyzer@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "@nomicfoundation/solidity-analyzer@npm:0.1.0"
   dependencies:
-    "@nomicfoundation/solidity-analyzer-darwin-arm64": 0.0.3
-    "@nomicfoundation/solidity-analyzer-darwin-x64": 0.0.3
-    "@nomicfoundation/solidity-analyzer-freebsd-x64": 0.0.3
-    "@nomicfoundation/solidity-analyzer-linux-arm64-gnu": 0.0.3
-    "@nomicfoundation/solidity-analyzer-linux-arm64-musl": 0.0.3
-    "@nomicfoundation/solidity-analyzer-linux-x64-gnu": 0.0.3
-    "@nomicfoundation/solidity-analyzer-linux-x64-musl": 0.0.3
-    "@nomicfoundation/solidity-analyzer-win32-arm64-msvc": 0.0.3
-    "@nomicfoundation/solidity-analyzer-win32-ia32-msvc": 0.0.3
-    "@nomicfoundation/solidity-analyzer-win32-x64-msvc": 0.0.3
+    "@nomicfoundation/solidity-analyzer-darwin-arm64": 0.1.0
+    "@nomicfoundation/solidity-analyzer-darwin-x64": 0.1.0
+    "@nomicfoundation/solidity-analyzer-freebsd-x64": 0.1.0
+    "@nomicfoundation/solidity-analyzer-linux-arm64-gnu": 0.1.0
+    "@nomicfoundation/solidity-analyzer-linux-arm64-musl": 0.1.0
+    "@nomicfoundation/solidity-analyzer-linux-x64-gnu": 0.1.0
+    "@nomicfoundation/solidity-analyzer-linux-x64-musl": 0.1.0
+    "@nomicfoundation/solidity-analyzer-win32-arm64-msvc": 0.1.0
+    "@nomicfoundation/solidity-analyzer-win32-ia32-msvc": 0.1.0
+    "@nomicfoundation/solidity-analyzer-win32-x64-msvc": 0.1.0
   dependenciesMeta:
     "@nomicfoundation/solidity-analyzer-darwin-arm64":
       optional: true
@@ -4396,7 +4396,7 @@ __metadata:
       optional: true
     "@nomicfoundation/solidity-analyzer-win32-x64-msvc":
       optional: true
-  checksum: dd3e1e6aa75716eb22f256be06d6a4d808ef732f77c26b4489ae8f9508271799d555dff547cf037373b0974d892b4cc7f78bc4ea5027eee8561e4dd394fe61ac
+  checksum: 42dc5ba40e76bf14945fb6a423554bbbc6c99596675065d7d6f3c9a49ec39e37f3f77ecfedcf906fdb1bb33b033a5d92a90c645c886d6ff23334c8af8b14ff67
   languageName: node
   linkType: hard
 
@@ -12490,9 +12490,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hardhat@npm:2.11.2":
-  version: 2.11.2
-  resolution: "hardhat@npm:2.11.2"
+"hardhat@npm:2.12.2":
+  version: 2.12.2
+  resolution: "hardhat@npm:2.12.2"
   dependencies:
     "@ethersproject/abi": ^5.1.2
     "@metamask/eth-sig-util": ^4.0.0
@@ -12506,7 +12506,7 @@ __metadata:
     "@nomicfoundation/ethereumjs-tx": ^4.0.0
     "@nomicfoundation/ethereumjs-util": ^8.0.0
     "@nomicfoundation/ethereumjs-vm": ^6.0.0
-    "@nomicfoundation/solidity-analyzer": ^0.0.3
+    "@nomicfoundation/solidity-analyzer": ^0.1.0
     "@sentry/node": ^5.18.1
     "@types/bn.js": ^5.1.0
     "@types/lru-cache": ^5.1.0
@@ -12554,7 +12554,7 @@ __metadata:
       optional: true
   bin:
     hardhat: internal/cli/cli.js
-  checksum: 6fc289931c970a16fe09f7aa2b14f8b4f4a63304895be7e89112d4065cfdb15887d90cdd827d10f413fb5cc1ca09fb0b512b7ffc79dc6bc121368bda70dffb4a
+  checksum: cd45bf9d4f15d967bd2d8154cc5bc60e7d0d4bab80caea909d36e3660437fc9f6b4faf41736ed3b75b11ff15ac9a9b68828eebb1026ed9fa8d9eb87242f061d2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Backports of the following PRs to `release/bogota`. 

- #4331 
- #4330 
- #4329 
- #4327
- #4326 

This should unblock the Docker image build for Bogota.