### PR TITLE
fix shebang

### DIFF
--- a/packages/hoprd/Dockerfile
+++ b/packages/hoprd/Dockerfile
@@ -128,4 +128,4 @@ ENV HOPRD_DATA=/app/hoprd-db
 # finally set the non-root user so the process also run un-privilidged
 # USER node
 
-ENTRYPOINT ["/usr/bin/tini", "--", "yarn", "hoprd"]
+ENTRYPOINT ["/usr/bin/tini", "--", "node", "./lib/main.cjs"]

--- a/packages/hoprd/src/main.cts
+++ b/packages/hoprd/src/main.cts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env -S DEBUG=${DEBUG} NODE_OPTIONS=${NODE_OPTIONS} node
 
 // File must be a CommonJS script to make sure it does not include any ESM syntax,
 // such as `export` or `import`, which causes incomprensive syntax errors when


### PR DESCRIPTION
- Changes the shebang to forward specific environment variables, namely `NODE_OPTIONS` and `DEBUG`
- Directly use `node` process to start `horpd` client. This is possible because we're not using *pnp* and / or *zero-installs*

# Out of scope

This is a temporary fix! Forwarding additional environment variablesor fixing that properly is out of scope, will be fixed by https://github.com/hoprnet/hoprnet/pull/4320