### PR TITLE
CI register VM instances with `selfRegister`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,12 +158,17 @@ endif
 .PHONY: stake-nrnft
 stake-nrnft: ensure-environment-is-set
 stake-nrnft: ## stake Network_registry NFTs (idempotent operation)
-ifeq ($(origin PRIVATE_KEY),undefined)
-	echo "<PRIVATE_KEY> environment variable missing" >&2 && exit 1
-endif
 ifeq ($(nftrank),)
 	echo "parameter <nftrank> missing, it can be either 'developer' or 'community'" >&2 && exit 1
 endif
+ifeq ($(origin PRIVATE_KEY),undefined)
+	@TS_NODE_PROJECT=./tsconfig.hardhat.json \
+	HOPR_ENVIRONMENT_ID="$(environment)" \
+		yarn workspace @hoprnet/hopr-ethereum run hardhat stake \
+		--network $(network) \
+		--type nrnft \
+		--nftrank $(nftrank) \
+else
 	@TS_NODE_PROJECT=./tsconfig.hardhat.json \
 	HOPR_ENVIRONMENT_ID="$(environment)" \
 		yarn workspace @hoprnet/hopr-ethereum run hardhat stake \
@@ -171,6 +176,7 @@ endif
 		--type nrnft \
 		--nftrank $(nftrank) \
 		--privatekey "$(PRIVATE_KEY)"
+endif
 
 enable-network-registry: ensure-environment-is-set
 enable-network-registry: ## owner enables network registry (smart contract) globally
@@ -262,8 +268,13 @@ ifeq ($(peer_ids),)
 	echo "parameter <peer_ids> missing" >&2 && exit 1
 endif
 ifeq ($(origin PRIVATE_KEY),undefined)
-	echo "<PRIVATE_KEY> environment variable missing" >&2 && exit 1
-endif
+	TS_NODE_PROJECT=./tsconfig.hardhat.json \
+	HOPR_ENVIRONMENT_ID="$(environment)" \
+	  yarn workspace @hoprnet/hopr-ethereum run hardhat register:self \
+   --network $(network) \
+   --task add \
+   --peer-ids "$(peer_ids)" \
+else
 	TS_NODE_PROJECT=./tsconfig.hardhat.json \
 	HOPR_ENVIRONMENT_ID="$(environment)" \
 	  yarn workspace @hoprnet/hopr-ethereum run hardhat register:self \
@@ -271,6 +282,8 @@ endif
    --task add \
    --peer-ids "$(peer_ids)" \
    --privatekey "$(PRIVATE_KEY)"
+endif
+
 
 .PHONY: self-deregister-node
 self-deregister-node: ensure-environment-is-set

--- a/Makefile
+++ b/Makefile
@@ -167,7 +167,7 @@ ifeq ($(origin PRIVATE_KEY),undefined)
 		yarn workspace @hoprnet/hopr-ethereum run hardhat stake \
 		--network $(network) \
 		--type nrnft \
-		--nftrank $(nftrank) \
+		--nftrank $(nftrank)
 else
 	@TS_NODE_PROJECT=./tsconfig.hardhat.json \
 	HOPR_ENVIRONMENT_ID="$(environment)" \

--- a/NETWORK_REGISTRY.md
+++ b/NETWORK_REGISTRY.md
@@ -42,7 +42,7 @@ If there's not enough xHOPR token, please use "Dev Bank" account to transfer som
 
 #### Stake Network_registry NFT in staging environment
 
-<mark>When not in production</mark>, CI/CD will mint "Network_registry" NFTs to `CLUSTER_NETWORK_REGISTERY_LINKED_ADDRESSES[1]` and `CLUSTER_NETWORK_REGISTERY_LINKED_ADDRESSES[3]` on deployment.
+<mark>When not in production</mark>, CI/CD will mint "Network_registry" NFTs to its own wallet on deployment.
 
 There are 6 "Network_registry" NFTs (3 "developer" rank and 3 of "community" rank) being minted to the "Dev Bank" account per deployment, where you can transfer some tokens from.
 

--- a/packages/ethereum/deploy/20_mintNetworkRegistryNfts.ts
+++ b/packages/ethereum/deploy/20_mintNetworkRegistryNfts.ts
@@ -3,7 +3,6 @@ import type { DeployFunction } from 'hardhat-deploy/types'
 import type { HoprBoost } from '../src/types'
 import { type ContractTransaction, utils } from 'ethers'
 import {
-  CLUSTER_NETWORK_REGISTERY_LINKED_ADDRESSES,
   NR_NFT_BOOST,
   NR_NFT_RANK_COM,
   NR_NFT_RANK_TECH,
@@ -103,13 +102,13 @@ const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     if (!network.tags.staging) {
       for (const networkRegistryNftRank of [NR_NFT_RANK_TECH, NR_NFT_RANK_COM]) {
         console.log(
-          `... minting ${NUM_NR_NFT} ${NR_NFT_TYPE} NFTs type of index ${NR_NFT_TYPE_INDEX} to ${admin}\n...minting 1 ${NR_NFT_TYPE} NFTs to CLUSTER_NETWORK_REGISTERY_LINKED_ADDRESSES\n...minting 10 ${NR_NFT_TYPE} NFTs to dev bank ${DEV_BANK_ADDRESS}`
+          `... minting ${NUM_NR_NFT} ${NR_NFT_TYPE} NFTs type of index ${NR_NFT_TYPE_INDEX} to ${admin}\n...minting 1 ${NR_NFT_TYPE} NFTs to deployer ${deployer}\n...minting 10 ${NR_NFT_TYPE} NFTs to dev bank ${DEV_BANK_ADDRESS}`
         )
         await awaitTxConfirmation(
           hoprBoost.batchMint(
             [
               ...new Array(NUM_NR_NFT).fill(admin),
-              ...CLUSTER_NETWORK_REGISTERY_LINKED_ADDRESSES,
+              deployer,
               ...Array(10).fill(DEV_BANK_ADDRESS)
             ],
             NR_NFT_TYPE,

--- a/packages/ethereum/deploy/20_mintNetworkRegistryNfts.ts
+++ b/packages/ethereum/deploy/20_mintNetworkRegistryNfts.ts
@@ -2,13 +2,7 @@ import { HardhatRuntimeEnvironment } from 'hardhat/types'
 import type { DeployFunction } from 'hardhat-deploy/types'
 import type { HoprBoost } from '../src/types'
 import { type ContractTransaction, utils } from 'ethers'
-import {
-  NR_NFT_BOOST,
-  NR_NFT_RANK_COM,
-  NR_NFT_RANK_TECH,
-  NR_NFT_TYPE,
-  NR_NFT_TYPE_INDEX
-} from '../utils/constants'
+import { NR_NFT_BOOST, NR_NFT_RANK_COM, NR_NFT_RANK_TECH, NR_NFT_TYPE, NR_NFT_TYPE_INDEX } from '../utils/constants'
 
 const NUM_NR_NFT = 3
 const DUMMY_NFT_TYPE = 'Dummy'
@@ -106,11 +100,7 @@ const main: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
         )
         await awaitTxConfirmation(
           hoprBoost.batchMint(
-            [
-              ...new Array(NUM_NR_NFT).fill(admin),
-              deployer,
-              ...Array(10).fill(DEV_BANK_ADDRESS)
-            ],
+            [...new Array(NUM_NR_NFT).fill(admin), deployer, ...Array(10).fill(DEV_BANK_ADDRESS)],
             NR_NFT_TYPE,
             networkRegistryNftRank,
             NR_NFT_BOOST,

--- a/packages/ethereum/tasks/selfRegister.ts
+++ b/packages/ethereum/tasks/selfRegister.ts
@@ -5,7 +5,7 @@ import type { HoprNetworkRegistry } from '../src/types'
 export type SelfRegisterOpts = {
   task: 'add' | 'remove'
   peerIds: string
-  privatekey: string // private key of the caller
+  privatekey?: string // private key of the caller
 }
 
 /**

--- a/packages/ethereum/utils/constants.ts
+++ b/packages/ethereum/utils/constants.ts
@@ -26,10 +26,3 @@ export const NR_NFT_RANK_COM = 'community'
 export const NR_NFT_MAX_REGISTRATION_TECH = constants.MaxUint256
 export const NR_NFT_MAX_REGISTRATION_COM = 1
 export type NetworkRegistryNftRank = typeof NR_NFT_RANK_TECH | typeof NR_NFT_RANK_COM
-
-export const CLUSTER_NETWORK_REGISTERY_LINKED_ADDRESSES = [
-  '0x6c150A63941c6d58a2f2687a23d5a8E0DbdE181C', // nat_with_stake
-  '0x0Fd4C32CC8C6237132284c1600ed94D06AC478C6', // nat_with_nft
-  '0xBA28EE6743d008ed6794D023B10D212bc4Eb7e75', // public_with_stake
-  '0xf84Ba32dd2f2EC2F355fB63F3fC3e048900aE3b2' // public_with_nft
-]

--- a/scripts/setup-gcloud-cluster.sh
+++ b/scripts/setup-gcloud-cluster.sh
@@ -60,10 +60,6 @@ usage() {
 
 # verify and set parameters
 : "${FAUCET_SECRET_API_KEY?"Missing environment variable FAUCET_SECRET_API_KEY"}"
-: "${STAKING_ACCOUNT_BA28?"Missing environment variable STAKING_ACCOUNT_BA28"}"
-: "${STAKING_ACCOUNT_F84B?"Missing environment variable STAKING_ACCOUNT_F84B"}"
-: "${STAKING_ACCOUNT_0FD4?"Missing environment variable STAKING_ACCOUNT_0FD4"}"
-: "${STAKING_ACCOUNT_6C15?"Missing environment variable STAKING_ACCOUNT_6C15"}"
 
 declare environment="${1?"missing parameter <environment>"}"
 declare init_script=${2:-}
@@ -137,27 +133,6 @@ gcloud_create_or_update_managed_instance_group  \
   "${cluster_size}" \
   "${instance_template_name}"
 
-# This maps "staking account address" => "private key"
-declare -A staking_addrs_dict
-
-# NOTE: the addresses are sorted alphabetically here, to see the actual order the keys will
-# have after sorting. As usual, dictionaries do not keep the insertion order of the keys.
-
-# May be supplied differently in future to accommodate with bigger GCP cluster sizes.
-if [[  "${docker_image}" != *-nat:* ]]; then
-  # Staking addresses for public nodes
-  staking_addrs_dict=(
-    [0xBA28EE6743d008ed6794D023B10D212bc4Eb7e75]="${STAKING_ACCOUNT_BA28}"
-    [0xf84Ba32dd2f2EC2F355fB63F3fC3e048900aE3b2]="${STAKING_ACCOUNT_F84B}"
-  )
-else
-  # Staking addresses for NAT nodes
-  staking_addrs_dict=(
-    [0x0Fd4C32CC8C6237132284c1600ed94D06AC478C6]="${STAKING_ACCOUNT_0FD4}"
-    [0x6c150A63941c6d58a2f2687a23d5a8E0DbdE181C]="${STAKING_ACCOUNT_6C15}"
-  )
-fi
-
 declare network_id
 network_id="$(get_network "${environment}")"
 
@@ -167,11 +142,8 @@ network_id="$(get_network "${environment}")"
 # FIXME: Correctly format the condition (in line with *meta* environment), so that the following lines are skipped for most of the time, and only be executed when:
 # - the CI nodes wants to perform `selfRegister`
 # This can be called always, because the "stake" task is idempotent given the same arguments
-for staking_addr in "${!staking_addrs_dict[@]}" ; do
-  fund_if_empty "${staking_addr}" "${environment}"
-  # we only stake NFT for valencia release
-  PRIVATE_KEY="${staking_addrs_dict[${staking_addr}]}" make -C "${mydir}/.." stake-nrnft environment="${environment}" nftrank=developer network="${network_id}"
-done
+# CI wallet stakes a developer NR NFT
+make -C "${mydir}/.." stake-nrnft environment="${environment}" nftrank=developer network="${network_id}"
 
 # Get names of all instances in this cluster
 # TODO: now `native-addresses` (a.k.a. `hopr_addrs`) doesn't need to contain unique values. The array can contain repetitive addresses
@@ -180,15 +152,10 @@ instance_names="$(gcloud_get_managed_instance_group_instances_names "${cluster_i
 declare -a instance_names_arr
 IFS="," read -r -a instance_names_arr <<< "$(echo "${instance_names}" | jq -r '@csv' | tr -d '\"')"
 
-# Prepare sorted staking account addresses so we ensure a stable order of assignment
-declare staking_addresses_arr=( "${!staking_addrs_dict[@]}" )
-readarray -t staking_addresses_arr < <(for addr in "${!staking_addrs_dict[@]}"; do echo "$addr"; done | sort)
-
-# These arrays will hold IP addresses, peer IDs and staking addresses
+# These arrays will hold IP addresses and peer IDs
 # for instance VMs in the encounter order of the `instance_names` array
 declare -a ip_addrs
 declare -a hopr_addrs
-declare -a used_staking_addrs
 
 # Iterate through all VM instances
 # The loop should be parallelized in future to accommodate better with larger clusters
@@ -200,7 +167,7 @@ for instance_idx in "${!instance_names_arr[@]}" ; do
   wait_until_node_is_ready "${node_ip}"
 
   if [[ "${reset_metadata}" = "true" ]]; then
-    gcloud_remove_instance_metadata "${instance_name}" "HOPRD_PEER_ID,HOPRD_WALLET_ADDR,HOPRD_STAKING_ADDR"
+    gcloud_remove_instance_metadata "${instance_name}" "HOPRD_PEER_ID,HOPRD_WALLET_ADDR,HOPRD_STAKING_STATUS"
   fi
 
   # All VM instances in the deployed cluster will get a special metadata entries
@@ -208,37 +175,35 @@ for instance_idx in "${!instance_names_arr[@]}" ; do
   # These currently include:
   # - node wallet address
   # - node peer ID
-  # - associated staking account
+  # - staking status
   # This information is constant during the lifetime of the VM and
   # does not change during re-deployment once set.
   declare instance_metadata
   instance_metadata="$(gcloud_get_node_info_metadata "${instance_name}")"
 
   # known metadata keys
-  declare wallet_addr peer_id staking_addr
+  declare wallet_addr peer_id staking_status
   wallet_addr="$(echo "${instance_metadata}" | jq -r '."HOPRD_WALLET_ADDR" // empty')"
   peer_id="$(echo "${instance_metadata}" | jq -r '."HOPRD_PEER_ID" // empty')"
-  staking_addr="$(echo "${instance_metadata}" | jq -r '."HOPRD_STAKING_ADDR" // empty')"
+  staking_status="$(echo "${instance_metadata}" | jq -r '."HOPRD_STAKING_STATUS" // empty')"
 
   # data from the node's API for verification or initialization
   declare api_wallet_addr api_peer_id
   api_wallet_addr="$(get_native_address "${api_token}@${node_ip}:3001")"
   api_peer_id="$(get_hopr_address "${api_token}@${node_ip}:3001")"
 
-  if [[ -z "${staking_addr}" ]]; then
+  if [[ -z "${staking_status}" ]]; then
     # If the instance does not have metadata yet, we set it once
 
     # NOTE: We leave only the first public node unstaked
     if [[ ${instance_idx} -eq 0 && "${instance_template_name}" != *-nat* && "${skip_unstaked}" != "true" ]]; then
-      staking_addr="unstaked"
+      staking_status="unstaked"
     else
-      # Staking accounts are assigned round-robin
-      staking_addr_idx=$(( (instance_idx ) % ${#staking_addresses_arr[@]} ))
-      staking_addr="${staking_addresses_arr[staking_addr_idx]}"
+      staking_status="staked"
     fi
 
     # Save the metadata
-    declare new_metadata="HOPRD_WALLET_ADDR=${api_wallet_addr},HOPRD_PEER_ID=${api_peer_id},HOPRD_STAKING_ADDR=${staking_addr}"
+    declare new_metadata="HOPRD_WALLET_ADDR=${api_wallet_addr},HOPRD_PEER_ID=${api_peer_id},HOPRD_STAKING_STATUS=${staking_status}"
     gcloud_add_instance_metadata "${instance_name}" "${new_metadata}"
     gcloud_execute_command_instance "${instance_name}" 'sudo /opt/hoprd/startup-script.sh >> /tmp/startup-script-`date +%Y%m%d-%H%M%S`.log'
   else
@@ -254,10 +219,9 @@ for instance_idx in "${!instance_names_arr[@]}" ; do
 
   ip_addrs+=( "${node_ip}" )
 
-  # Do not include the unstaked nodes (= skipped during registration for NR)
+  # Build an array of hopr_addrs to be staked
   if [[ "${staking_addr}" != "unstaked" ]]; then
     hopr_addrs+=( "${api_peer_id}" )
-    used_staking_addrs+=( "${staking_addr}" )
   fi
 
   # Fund the node as well
@@ -266,14 +230,9 @@ done
 
 # Register all nodes in cluster
 IFS=','
-# If same order of parameters is given, the "register" task is idempotent
-make -C "${mydir}/.." register-nodes \
-  environment="${environment}" \
-  native_addresses="${used_staking_addrs[*]}" \
-  peer_ids="${hopr_addrs[*]}" \
-  network="${network_id}"
 
-make -C "${mydir}/.." sync-eligibility \
+# use CI wallet to register VM instances. This action may fail if nodes were previously linked to other staking accounts
+make -C "${mydir}/.." self-register-node \
   environment="${environment}" \
   peer_ids="${hopr_addrs[*]}" \
   network="${network_id}"


### PR DESCRIPTION
Close #4101 

## Description
CI used to use `ownerRegister` and register VM instances under 4 staking wallets (`CLUSTER_NETWORK_REGISTERY_LINKED_ADDRESSES`). Each staking wallet has to have one NR NFT staked in the ongoing staking season. This approach become obsolete as the NetworkRegistry allows staking account with "Network_registry/developer" to register multiple peers. 

This PR
- Removes `CLUSTER_NETWORK_REGISTERY_LINKED_ADDRESSES` in hardhat tasks as well as `STAKING_ACCOUNT_BA28`, `STAKING_ACCOUNT_F84B`, `STAKING_ACCOUNT_0FD4`, `STAKING_ACCOUNT_6C15` from `setup-gcloud-cluster.sh`.
- Makes the CI wallet the default associated staking account for all VM instances in the deployed cluster.
- Replaces "HOPRD_STAKING_ADDR" with "HOPRD_STAKING_STATUS" in `instance_metadata`.

## Related on-chain actions
Some on-chain actions have been done to support introduced changes:

### In Production environment:
1. Get all the peers (see Section "Affected PeerIds") that were linked to `CLUSTER_NETWORK_REGISTERY_LINKED_ADDRESSES` from [subgraph query](https://api.thegraph.com/subgraphs/name/hoprnet/hopr-channels/graphql?query=%0A++++%23%0A++++%23+Welcome+to+The+GraphiQL%0A++++%23%0A++++%23+GraphiQL+is+an+in-browser+tool+for+writing%2C+validating%2C+and%0A++++%23+testing+GraphQL+queries.%0A++++%23%0A++++%23+Type+queries+into+this+side+of+the+screen%2C+and+you+will+see+intelligent%0A++++%23+typeaheads+aware+of+the+current+GraphQL+type+schema+and+live+syntax+and%0A++++%23+validation+errors+highlighted+within+the+text.%0A++++%23%0A++++%23+GraphQL+queries+typically+start+with+a+%22%7B%22+character.+Lines+that+start%0A++++%23+with+a+%23+are+ignored.%0A++++%23%0A++++%23+An+example+GraphQL+query+might+look+like%3A%0A++++%23%0A++++%23+++++%7B%0A++++%23+++++++field%28arg%3A+%22value%22%29+%7B%0A++++%23+++++++++subField%0A++++%23+++++++%7D%0A++++%23+++++%7D%0A++++%23%0A++++%23+Keyboard+shortcuts%3A%0A++++%23%0A++++%23++Prettify+Query%3A++Shift-Ctrl-P+%28or+press+the+prettify+button+above%29%0A++++%23%0A++++%23+++++Merge+Query%3A++Shift-Ctrl-M+%28or+press+the+merge+button+above%29%0A++++%23%0A++++%23+++++++Run+Query%3A++Ctrl-Enter+%28or+press+the+play+button+above%29%0A++++%23%0A++++%23+++Auto+Complete%3A++Ctrl-Space+%28or+just+start+typing%29%0A++++%23%0A++++%0A%7B%0A++networkRegistries%28where%3A+%7Bid_in%3A+%5B%220x6c150a63941c6d58a2f2687a23d5a8e0dbde181c%22%2C%220x0fd4c32cc8c6237132284c1600ed94d06ac478c6%22%2C%220xba28ee6743d008ed6794d023b10d212bc4eb7e75%22%2C%220xf84ba32dd2f2ec2f355fb63f3fc3e048900ae3b2%22%5D%7D%29+%7B%0A++++registeredPeers%0A++++eligibility%0A++%7D%0A%7D) and call `ownerRegister` to link all the peers returned in the aforementioned query to CI wallet.  
2. Ensure CI wallet has a "Network_registery/developer" NFT and it's staked in season 5 contract.

### In Staging envirionment:
1. Ensure CI wallet developer has at least one "Network_registery/developer" NFT
2. CI wallet stakes one developer NFT to staking contract

## Note for next transition of staking seasons
When a new season arrives, ensure one of the two actions gets done before `sync` was called on the NetworkRegistry contract.
a. `unlockFor` CI wallet (`0x4fF4e61052a4DFb1bE72866aB711AE08DD861976`) and Dev Bank (`0x2402da10A6172ED018AEEa22CA60EDe1F766655C`). Re-stake tokens of id "15150" and "15082" respectively into the new staking season. Or
b. Let CI wallet (`0x4fF4e61052a4DFb1bE72866aB711AE08DD861976`) and Dev Bank (`0x2402da10A6172ED018AEEa22CA60EDe1F766655C`) stake a new developer NFT respectively in the new season.

## List of affected Peer IDs
```json
[
    "16Uiu2HAkuSJGhMngaMAt4XYbqvyQ2TstxaHRMV77CeeojK8iiC1E",
    "16Uiu2HAkubreboTdxq9JPHGguAiH153KdPRXDPvYgAeun3g4QkNC",
    "16Uiu2HAkuigoZBPyKc47U99GxFwLq7qR9ocxfAd7S8AnRkDv3gD2",
    "16Uiu2HAkuvj3ymMu1FeYFcdVhrzkJLqzj4tgfsx6bt4HLcRCASKz",
    "16Uiu2HAkuwRXFsVsAmpdQxkCJZXH2xALJG5GXC6szUg2nxSz1hBk",
    "16Uiu2HAkv8gtMkETpqxUwjZ7fYyGJDNe9JhXZDSmtNuAwjYuaDLL",
    "16Uiu2HAkvS37pnLvhA3nXCnwGmnW5L4gipthgKMM5PfyERndJgBF",
    "16Uiu2HAkvku8Ff7eV9LHMeWbq9FNFHWGnxD1QgndWmLaTHL2vXJk",
    "16Uiu2HAkvpRiMsFLDH2cHCvsXBzv71NWJcX8Jx7wDshzPTUtyuvA",
    "16Uiu2HAkvxL6jfgu9V8TFhSAwGgLGdr3UKLfMTVMVqyxHzzTHBG5",
    "16Uiu2HAkw6Kv7prypc7mt1VkxeRYUHEBMaA6ndNxPBCSitxU7G5n",
    "16Uiu2HAkw7AWMK7DWfE4baPLH4rLR35fTkUFktDymgh8714E9pJ9",
    "16Uiu2HAkwQa9SPh3ksjPn8Qmj9FB6JKtSfG1UY8naDZAZnJCGFCZ",
    "16Uiu2HAkwt2BFSWmmUNXb7FmLsM8tdnLLzKt31xMz5HVpp63sJR5",
    "16Uiu2HAkx616VAg18co7gKc6j7cDdwohA6mLq6kp2QVhqSExexPz",
    "16Uiu2HAkxShHQ6M35vgZZKyUEMxpcBwq5UVVMQ2BWQp8rwmNuyJH",
    "16Uiu2HAkxbKknPSLQYNUCS15howxTdZuVpTDNMwbfQkx5CXiEDtg",
    "16Uiu2HAkxe4myTySSxr6XhgRVXvnRK3rMi6v34s59jcM7Zjdttja",
    "16Uiu2HAkxyqsADhqiVeaLRHyXetcjgFrLdsRnR9WrAyucD7V7GKr",
    "16Uiu2HAky1FmbdyrY4EC2ZmKVH5t1XTqZqkutnqNf5BpSjHuD9nF",
    "16Uiu2HAkyBZUaRwZVJVvujjJf5StUpJEUe37gsuXjein3jZwd3pJ",
    "16Uiu2HAkyQZUfr88HvzrVeGji8a6Kfqt8fPueWbSNLksiqK8bT16",
    "16Uiu2HAkzxFL35QwHtgEt6eXs3UhkRqAkB3UqWRXb7heZSeVkN2j",
    "16Uiu2HAm1a6xeXNShmYyCaaSYZL1rcRbdVz2hbzB5HainJffRFHE",
    "16Uiu2HAm1k9qqLg2wjLchpbjpBMbNemPuQfWNsWdg3Ld25tPxJ44",
    "16Uiu2HAm2TxCPtUFzwYYNHEv3ZrSM3WqRLEh16fu53C37bYZzcr2",
    "16Uiu2HAm2sg49MxmS7sKFVgbihr5aCtPwjpcd1QsRfiP5nbfRx4N",
    "16Uiu2HAm36oyGWjAs1iaFvDmYbUZiZ5SGFwAv1hJFUU55AAqYYFy",
    "16Uiu2HAm3dDRPSfPBBF2fC6PxjSeXiepuJzD9DP9UNNqpjaZahTo",
    "16Uiu2HAm3h1kuHHmgmpt4yktaZKAmxNsjg6wVw7hbFF245pKPyCw",
    "16Uiu2HAm3kHdkbiHGVPhzzcYxJ6bAHSKDYHsJuVc5FNsWYJAug8J",
    "16Uiu2HAm5A49sQ9ivpXqw3NQEQQYoAeWPnEXWJks5CufTEHpui5f",
    "16Uiu2HAm5ZsbRvQreNFMuDtgro1CoacjSwNQCixGrDFsoWJ5Cfq2",
    "16Uiu2HAm5yRzZBUYbx9Biyi3TnHuKZPJ9gqXgP3VipiUX5JuH9b8",
    "16Uiu2HAm5yvoDSiXN2QcXMcoWZUjpN4akUsRdXdTaPUyDuHRw6PE",
    "16Uiu2HAm64MRfbKGNcHcNs7XV96f4fhNNrdrGHMJHdBKY3496QDB",
    "16Uiu2HAm6od2tqkC9xUUXqQARXHAAj93uaQCVL4z6wJGe8RtawzW",
    "16Uiu2HAm7B6dNcYc7voep4zoGB68DMcKrwg8hDXkieZp5tZ4Ggsg",
    "16Uiu2HAm7eAFmHkjhwM9aka9TPeUV6uqauXvRSjQjLjFHUub1wPW",
    "16Uiu2HAm86XRufcPR7Njkc7gc7AM2DusFBgtk5WndHPu4MRVKmku",
    "16Uiu2HAm8oU3cpMJs2eFQwi3JHoSPhJ7A4CK8RV2p52GE6gqYD3x",
    "16Uiu2HAm94GYjLa3fgm7fS4nB7mwba7srn8mu9BH2WbviE5n9Lrk",
    "16Uiu2HAm9gB9CBbVZF5vVPmyYBqTxKHLAKaWr1oXc31Guv3Sb38W",
    "16Uiu2HAmA9Ppk3ucCgNuFRhMqhVnu2bFocSHE931BSTci6Xh4Dic",
    "16Uiu2HAmAk456tVrS5LYt4VTaZPAJUGqHCeE8h77JHHQFu9xY1zM",
    "16Uiu2HAmAmXnq8FtFsBAnSyfujaXbU3B5wdVRPYGfN8S99E5azdH",
    "16Uiu2HAmAw4ocaQ2AYjwaj9Vdwmg3G7fjCEQvxvQXBBGLSeVgUfE",
    "16Uiu2HAmAwh4E79FUN5GcGpEvgxLhSoZvNQZtGk6HbkfMqqaEwbp",
    "16Uiu2HAmAwqXyeb5wqJpnKigJRP8WbBP42PdKiPMQfkdxpbXUPTi",
    "16Uiu2HAmBbbGAQsGLQP9V7aYVoaMcf49K4Zyx8EwJXMKMh3YtTYz",
    "16Uiu2HAmCDKM2o3hdURuSkV4ip5UkSaCt3vjNnuvdrEWsqfq4KYM",
    "16Uiu2HAmDSuT6amkr6ELzbQn2odWW7o7UuMEb6yPYBKbGiihWtSX",
    "16Uiu2HAmE5Ec628GSseSbAVrHj33VDhNjZ4NX5FocNBPJoCocMQZ",
    "16Uiu2HAmEiF23LoLoHpMbH8Y5dM4iamhQgghxy9trPWv6i6jU4hh",
    "16Uiu2HAmFBaADdcP2bAyDZzoQk54yPMZUz18BHggCeGaEuijn7cW",
    "16Uiu2HAmFyP8nV7c2RXu9ej1NRiBaJcfATrKarRLWi4kVch3kpKU",
    "16Uiu2HAmGHGMR2pJjJtkRqdKmSVBsKYbf7n1mxNrFky7KjGWh56L",
    "16Uiu2HAmHMEuxrbp2CBJf7XoXXSvSEhLQDzPMJjuWH23Q8xHueqT",
    "16Uiu2HAmHXLU5U5iETFvHihdzAEV7K9vk5rTEASsT5GRubkr7Fe6",
    "16Uiu2HAmHgmp1HY23tWTFaTnrUn11Dfy8J2TzWgtGh41kJvWJE7V",
    "16Uiu2HAmHx3Mrnf6NE9rZnCoC7da2wAvSSu6G8MEiGixccmAHr2T",
    "16Uiu2HAmJ4VcSfmYKAyfVxK2J5cgxUP8oGoEgLX4ZG2c2U3BJV9t",
    "16Uiu2HAmJJGw8s2e597A6Df4WQhMy52evNBsLRjqqQFAunCkJwii",
    "16Uiu2HAmJQh2qE7wqeP4pkj81a8KBWsJoj732hsHwKJnW7hBNYEq",
    "16Uiu2HAmJcNGdgnWuGs8EtVdAZJAJHjKE96LE8DP6z3U2a4fAutx",
    "16Uiu2HAmK5ujjMKamTFNpUfyyV64nRgNXuMHgTV41xE5mc9KKtBo",
    "16Uiu2HAmK7aHvXFfpcCYuwU5tK4VpzP6FjzjTTwmnJxAqSu2Ez69",
    "16Uiu2HAmKAKiRoyWCXQoEZoyEgWKFWJmi8399oZerh2HU7sFDiz6",
    "16Uiu2HAmLG2FCeWqgGgh4FUeXd82D45XXKTQgcCQ7vvdkBrRZbNX",
    "16Uiu2HAmLrp8985u5SPyBWiPM6HoTvNz9V6xEcJXd4hzcDFGXdb6",
    "16Uiu2HAmM2W4y3ot34jNrNp8i7Wvv61nVbjsE6PQCLMBqycMutR7",
    "16Uiu2HAmMMByDwmKUg9bBWBVsj7n5Y4hrJb8oKo1yeF15ZSabQCh",
    "16Uiu2HAmMQTxX1NXNqp17zdEc7WUG2BFDsFQQ31U4Q1Fd6TcAQ6N",
    "16Uiu2HAmMy15anqPqPUAHMwd8MgsJo9bhPgj2oQ5KgjYcKX1bbAT",
    "16Uiu2HAmN4rp58a4MjgzBjZ91LoRw9rXA94Yy2aNrL72dHZ7bDVF",
    "16Uiu2HAmNFRoAKBCs7tMXDzpkT1fFtzi5mAFnriJY5dYXki14KTn",
    "16Uiu2HAmPswTj7gRYiB6XGNzu6wr5bvtPf32WHg2aQdtKNUeKKsR",
    "16Uiu2HAmPu4D6ZcgCYo76zCmCBoyeBBnsqHZS2uU7hWiqKgnyM4P",
    "16Uiu2HAmQYRnuHfDieSTM54Y8D231h7ixy3Miyzm8gVVRkiw9xWn",
    "16Uiu2HAmQaTZkW2XYMmbRC2NHvHZppnTGWEjTwCGrMYkWJqJAsL9",
    "16Uiu2HAmQg6VYWrZXdUV4S2xYj5u4ye11a2FLLo91U1y2XpvZCWK",
    "16Uiu2HAmQpwTDxFaoT3NUvWK6V4D8GNLzxGsPUrvuEFc1kvVDgHe",
    "16Uiu2HAmR6jUW8or13AjHLvL6VmRyFgLFetRHgLEMRGF22tHxz1A",
    "16Uiu2HAmRUPrpq5eEN4khYXdJZwxKf3TDbCPFqThpvYongJx6iBy",
    "16Uiu2HAmRy6D9cpiqmbMmHf9SUPvJsHVeMfHDqxtmxa2x7UTsGtW",
    "16Uiu2HAmSwFbqwg2NZzJdwV8DeddVYjF41YsPz59NvJBHQEnWRR7",
    "16Uiu2HAmTEhFRShLdTJSG2hyY5n3hoVXGcpoiRHQSNiu4qhuSHnq",
    "16Uiu2HAmTRG8njiMNUMeLHFTkvek4ezRxQ6j8iQzVSSCCdkwD8VT",
    "16Uiu2HAmUF8aqMfsxTSNSR3Z5phzLs9s4DhPpykaAM2ynvj9Fzof",
    "16Uiu2HAmUSBXkSBg6b3GGL8tnzjr1W87aEubVjMg3ezhGq83P3px",
    "16Uiu2HAmV9cqUw2ikjJSZqgJP6apcR2SNiE8zdKxboTEmsSBFhrR",
    "16Uiu2HAmVHKydCJtyGuXxFvvyRyA4oK6eMurvi6innDqmJVzRvqk",
    "16Uiu2HAmVccEacoXVHmz1RrM4rCRkpsWufiaXAgvXhReC7eNCbYP"
]
```