### PR TITLE
Adapt prettier to Rust

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -26,6 +26,9 @@ packages/ethereum/hardhat
 packages/ethereum/src/types
 packages/ethereum/deployments
 
+# Compiled rust code
+target/
+
 # prettier breaks scss
 *.scss
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -26,8 +26,11 @@ packages/ethereum/hardhat
 packages/ethereum/src/types
 packages/ethereum/deployments
 
-# Compiled rust code
+# Compiled rust code cache
 target/
+
+# Ignore WebAssembly
+*.wasm
 
 # prettier breaks scss
 *.scss


### PR DESCRIPTION
Extend prettier-ignore to ignore:

- WASM files
- cached Rust artifacts