### PR TITLE
Prevent bypassing pre-merge checks by not pushing commits to the PR

### DIFF
--- a/.github/workflows/pr_checks.yaml
+++ b/.github/workflows/pr_checks.yaml
@@ -6,7 +6,7 @@ env:
 
 on:
   pull_request:
-    types: [ synchronize ]
+    types: [ synchronize, opened ]
 
 jobs:
   deployment_check:


### PR DESCRIPTION
Deployment flag pre-merge check was not triggered when no commits were pushed to the PR.