### PR TITLE
Fix source/destination print out for channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Restore STUN functionality ([#4312](https://github.com/hoprnet/hoprnet/pull/4312))
 - Add Health Status Indicator in the Admin UI ([#4197](https://github.com/hoprnet/hoprnet/pull/4197))
 - Allow connectivity indicator to be GREEN on public nodes too ([#4314](https://github.com/hoprnet/hoprnet/pull/4314))
+- Show correct counterparty in the `channels` command output ([#4370](https://github.com/hoprnet/hoprnet/pull/4370))
 
 ---
 

--- a/packages/hoprd/src/api/v2/paths/channels/index.ts
+++ b/packages/hoprd/src/api/v2/paths/channels/index.ts
@@ -26,7 +26,7 @@ export const formatOutgoingChannel = (channel: ChannelEntry): ChannelInfo => {
   return {
     type: 'outgoing',
     channelId: channel.getId().toHex(),
-    peerId: channel.source.toPeerId().toString(),
+    peerId: channel.destination.toPeerId().toString(),
     status: channelStatusToString(channel.status),
     balance: channel.balance.toBN().toString()
   }
@@ -36,7 +36,7 @@ export const formatIncomingChannel = (channel: ChannelEntry): ChannelInfo => {
   return {
     type: 'incoming',
     channelId: channel.getId().toHex(),
-    peerId: channel.destination.toPeerId().toString(),
+    peerId: channel.source.toPeerId().toString(),
     status: channelStatusToString(channel.status),
     balance: channel.balance.toBN().toString()
   }


### PR DESCRIPTION
Print proper source/destination in the `channels` Admin UI command.

Closes #4364 