### PR TITLE
Fix ticket redemption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 - Show correct counterparty in the `channels` command output ([#4370](https://github.com/hoprnet/hoprnet/pull/4370))
 - Improve error messages passed to the User ([#4375](https://github.com/hoprnet/hoprnet/pull/4375))
 - Fix channel metrics, add channel balances metrics ([#4374](https://github.com/hoprnet/hoprnet/pull/4374))
-- Fix ticket redemption ([]())
+- Fix ticket redemption ([#4382](https://github.com/hoprnet/hoprnet/pull/4382))
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@
 - Add support for communication between different releases within the same environment
 - Avado: limit Docker container memory to maximum 1GB
 - Reduce memory copy operations by reusing underlying memory pages ([#4168](https://github.com/hoprnet/hoprnet/pull/4168))
-- Fix public node resolution for connectivity indicator ([#4205]https://github.com/hoprnet/hoprnet/pull/4205)
+- Fix public node resolution for connectivity indicator ([#4205](https://github.com/hoprnet/hoprnet/pull/4205))
 - Remove charset complexity validation on API token ([#4210](https://github.com/hoprnet/hoprnet/pull/4210))
 - Properly encode API token passed from the Admin UI ([#4210](https://github.com/hoprnet/hoprnet/pull/4210))
 - Refactor timeouts for more throughput and increase usage of iterables ([#4238](https://github.com/hoprnet/hoprnet/pull/4238))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Show correct counterparty in the `channels` command output ([#4370](https://github.com/hoprnet/hoprnet/pull/4370))
 - Improve error messages passed to the User ([#4375](https://github.com/hoprnet/hoprnet/pull/4375))
 - Fix channel metrics, add channel balances metrics ([#4374](https://github.com/hoprnet/hoprnet/pull/4374))
+- Fix ticket redemption ([]())
 
 ---
 


### PR DESCRIPTION
The ticket redemption was broken since 1.90.41. This PR fixes the ticket redemption logic in `core-ethereum`.

Fixes #4365 