### PR TITLE
Use correct image tags for staging images

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -364,7 +364,7 @@ jobs:
       - name: Run deploy script for public nodes (staging-only)
         if: ${{ startsWith(github.ref, 'refs/heads/staging/') && !env.ACT }}
         run: |
-          HOPRD_SKIP_UNSTAKED=true ./scripts/deploy.sh "gcr.io/hoprassociation/hoprd" 1 "-staging"
+          HOPRD_SKIP_UNSTAKED=true ./scripts/deploy.sh "gcr.io/hoprassociation/hoprd" 1
         env:
           DEPLOYER_WALLET_PRIVATE_KEY: ${{ secrets.DEPLOYER_WALLET_PRIVATE_KEY }}
           HOPRD_PASSWORD: ${{ secrets.BS_PASSWORD }}
@@ -458,7 +458,7 @@ jobs:
       - name: Run deploy script for nodes behind NAT (staging-only)
         if: ${{ startsWith(github.ref, 'refs/heads/staging/') && !env.ACT }}
         run: |
-          HOPRD_SKIP_UNSTAKED=true ./scripts/deploy.sh "gcr.io/hoprassociation/hoprd" 1 "-staging-nat"
+          HOPRD_SKIP_UNSTAKED=true ./scripts/deploy.sh "gcr.io/hoprassociation/hoprd" 1 "-nat"
         env:
           DEPLOYER_WALLET_PRIVATE_KEY: ${{ secrets.DEPLOYER_WALLET_PRIVATE_KEY }}
           HOPRD_PASSWORD: ${{ secrets.BS_PASSWORD }}

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -126,6 +126,10 @@ for git_ref in $(jq -r "to_entries[] | .value.git_ref" < "${mydir}/../packages/h
   if [[ "${branch}" =~ ${git_ref} ]]; then
     declare additional_releases
     additional_releases="$(jq -r "to_entries[] | select(.value.git_ref==\"${git_ref}\") | .key" < "${mydir}/../packages/hoprd/releases.json")"
+    # Prepend "staging-" tag prefix, if this is a staging branch
+    if [[ "${branch}" =~ staging/.* ]]; then
+      additional_releases="staging-${additional_releases//[[:space:]]/" staging-"}"
+    fi
     releases="${releases} ${additional_releases}"
   fi
 done

--- a/scripts/build_avado.sh
+++ b/scripts/build_avado.sh
@@ -80,6 +80,11 @@ if [[ "${avado_version}" = "0.100.0" && "${release_id}" = "master-goerli" ]]; th
   upstream_version="master-goerli"
 fi
 
+# For staging releases, we need to prepend a prefix
+if [[ "${avado_version}" = "0.200.0" ]]; then
+  upstream_version="staging-${release_id}"
+fi
+
 msg "Building Avado v. ${avado_version} for release ${release_id} (upstream v. ${upstream_version}) using environment ${environment_id} with default provider ${provider_url}"
 
 # Create backups

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -51,7 +51,11 @@ for git_ref in $(cat "${mydir}/../packages/hoprd/releases.json" | jq -r "to_entr
 
       if [ "${docker_image_version}" != "null" ]; then 
         docker_image_full="${docker_image}:${docker_image_version}"
-      else 
+      elif [[ "${branch}" =~ staging/.* ]]; then
+        # Prepend "staging-" tag prefix, if this is a staging branch
+        docker_image_full="${docker_image}:staging-${release_id}"
+        cluster_tag="staging-${cluster_tag}"
+      else
         docker_image_full="${docker_image}:${release_id}"
       fi
       


### PR DESCRIPTION
The `staging` build was building incorrectly tagged images.

Images built in the Staging pipeline will be tagged with the `staging-` prefix, e.g.:

`gcr.io/hoprassociation/hoprd:staging-bogota` for release Bogota.