### PR TITLE
wasm-pack workspaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ deps: ## install dependencies
 	# only use corepack on non-nix systems
 	[ -n "${NIX_PATH}" ] || corepack enable
 	yarn
-	command -v rustup && rustup update || echo "No rustup installed, ignoring"
+#	command -v rustup && rustup update || echo "No rustup installed, ignoring"
 	command -v wasm-pack || cargo install wasm-pack
 
 .PHONY: build

--- a/Makefile
+++ b/Makefile
@@ -10,11 +10,12 @@ all: help
 
 .PHONY: $(CRATES) ## builds all Rust crates
 $(CRATES):
-	wasm-pack build --target=bundler --out-dir $@pkg $@
+# --out-dir is relative to working directory
+	wasm-pack build --target=bundler --out-dir ./pkg $@
 
 .PHONY: $(WORKSPACES_WITH_RUST_MODULES) ## builds all WebAssembly modules
 $(WORKSPACES_WITH_RUST_MODULES):
-	# $(MAKE) -j 1 -C $@ install
+	$(MAKE) -C $@ install
 
 .PHONY: deps
 deps: ## install dependencies

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,8 @@ test: ## run unit tests for all packages, or a single package if package= is set
 ifeq ($(package),)
 	yarn workspaces foreach -pv run test
 else
+# Prebuild Rust unit tests
+	cargo build --tests
 	yarn workspace @hoprnet/${package} run test
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ deps: ## install dependencies
 	# only use corepack on non-nix systems
 	[ -n "${NIX_PATH}" ] || corepack enable
 	yarn
-#	command -v rustup && rustup update || echo "No rustup installed, ignoring"
+	command -v rustup && rustup update || echo "No rustup installed, ignoring"
 	command -v wasm-pack || cargo install wasm-pack
 
 .PHONY: build
@@ -49,7 +49,7 @@ build-yarn-watch: build-solidity-types build-cargo
 .PHONY: build-cargo
 build-cargo: ## build cargo packages and create boilerplate JS code
 # First compile Rust crates and create bindings
-	$(MAKE) $(CRATES)
+	$(MAKE) -j 1 $(CRATES)
 # Copy bindings to their destination
 	$(MAKE) ${WORKSPACES_WITH_RUST_MODULES}
 


### PR DESCRIPTION
# Context

Compiling Rust code is pretty slow, hence it is advisable to compile it not more than once.

Currently, when building `hoprnet` monorepo, packages with Rust crates are compiled individually and do not use caching done by `cargo`.

# Changes

This PR changes the build process such that `wasm-pack` builds are initiated from top-level, so `cargo` can make use of its cache.

To keep compilation of individual crates convenient, this PR does not remove `make` target of individual crates.