### PR TITLE
core-ethereum: Fix bug in on-chain tx listener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Improve error messages passed to the User ([#4375](https://github.com/hoprnet/hoprnet/pull/4375))
 - Fix channel metrics, add channel balances metrics ([#4374](https://github.com/hoprnet/hoprnet/pull/4374))
 - Fix ticket redemption ([#4382](https://github.com/hoprnet/hoprnet/pull/4382))
+- Increase wait timeout for on-chain transactions to 60 seconds
+- Fix bug in waiting logic for on-chain transactions
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@
 - Improve error messages passed to the User ([#4375](https://github.com/hoprnet/hoprnet/pull/4375))
 - Fix channel metrics, add channel balances metrics ([#4374](https://github.com/hoprnet/hoprnet/pull/4374))
 - Fix ticket redemption ([#4382](https://github.com/hoprnet/hoprnet/pull/4382))
-- Increase wait timeout for on-chain transactions to 60 seconds
-- Fix bug in waiting logic for on-chain transactions
+- Increase wait timeout for on-chain transactions to 60 seconds ([#4425](https://github.com/hoprnet/hoprnet/pull/4425))
+- Fix bug in waiting logic for on-chain transactions ([#4425](https://github.com/hoprnet/hoprnet/pull/4425))
 
 ---
 

--- a/packages/core-ethereum/src/constants.ts
+++ b/packages/core-ethereum/src/constants.ts
@@ -4,7 +4,7 @@
  */
 export const PROVIDER_CACHE_TTL = 30e3 // 30 seconds
 export const CONFIRMATIONS = 8
-export const TX_CONFIRMATION_WAIT = 30e3 // 30 seconds
+export const TX_CONFIRMATION_WAIT = 60e3 // 30 seconds
 export const INDEXER_BLOCK_RANGE = 2000
 export const INDEXER_TIMEOUT = 900000 // 15 minutes
 export const MAX_TRANSACTION_BACKOFF = 1800000 // 30 minutes

--- a/packages/core-ethereum/src/constants.ts
+++ b/packages/core-ethereum/src/constants.ts
@@ -4,7 +4,7 @@
  */
 export const PROVIDER_CACHE_TTL = 30e3 // 30 seconds
 export const CONFIRMATIONS = 8
-export const TX_CONFIRMATION_WAIT = 60e3 // 30 seconds
+export const TX_CONFIRMATION_WAIT = 60e3 // 60 seconds
 export const INDEXER_BLOCK_RANGE = 2000
 export const INDEXER_TIMEOUT = 900000 // 15 minutes
 export const MAX_TRANSACTION_BACKOFF = 1800000 // 30 minutes

--- a/packages/core-ethereum/src/ethereum.ts
+++ b/packages/core-ethereum/src/ethereum.ts
@@ -215,7 +215,9 @@ export async function createChainWrapper(
         done = true
         timer?.clear()
 
-        provider.off(txHash, onTransaction)
+        // delete all listeners for this particular tx
+        provider.off(txHash)
+
         // Give other tasks time to get scheduled before
         // processing the result
         if (err) {
@@ -235,13 +237,16 @@ export async function createChainWrapper(
         if (receipt.confirmations >= 1) {
           transactions.moveFromPendingToMined(receipt.transactionHash)
           cleanUp()
+        } else {
+          log(`Received tx receipt for ${txHash} with 0 confirmations, continue listening`)
         }
       }
-      timer = retimer(cleanUp, txTimeout, `Timeout while waiting for transaction ${txHash}`)
 
-      // Immediately stops polling once the transaction hash appeared
-      // in the mempool
-      provider.once(txHash, onTransaction)
+      // Subscribe to all tx events, unsubscription is handled in cleanup
+      provider.on(txHash, onTransaction)
+
+      // Schedule clean up if the timeout is reached
+      timer = retimer(cleanUp, txTimeout, `Timed out after waiting ${txTimeout}ms for transaction ${txHash}`)
     })
   }
 


### PR DESCRIPTION
Refs #4422 

This fixes the un-subscription which would previously fail due to the listener parameter being undefined. Moreover, the timeout for waiting for a tx to appear on-chain is increased to 60seconds to make room for delays.

Also if confirmations is 0 we log some information and keep the listener alive.