### PR TITLE
Fixed incorrect handling of acknowledged tickets by the DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fix ticket redemption ([#4382](https://github.com/hoprnet/hoprnet/pull/4382))
 - Increase wait timeout for on-chain transactions to 60 seconds ([#4425](https://github.com/hoprnet/hoprnet/pull/4425))
 - Fix bug in waiting logic for on-chain transactions ([#4425](https://github.com/hoprnet/hoprnet/pull/4425))
+- Fixed incorrect acknowledged tickets handling in the DB
 
 ---
 

--- a/packages/utils/src/db/db.ts
+++ b/packages/utils/src/db/db.ts
@@ -538,7 +538,7 @@ export class HoprDB {
       .batch()
       .del(Buffer.from(unAcknowledgedDbKey.buffer, unAcknowledgedDbKey.byteOffset, unAcknowledgedDbKey.byteLength))
       .put(
-        Buffer.from(acknowledgedDbKey.buffer, unAcknowledgedDbKey.byteOffset, unAcknowledgedDbKey.byteLength),
+        Buffer.from(acknowledgedDbKey.buffer, acknowledgedDbKey.byteOffset, acknowledgedDbKey.byteLength),
         Buffer.from(serializedTicket.buffer, serializedTicket.byteOffset, serializedTicket.byteLength)
       )
       .write()


### PR DESCRIPTION
A copy-paste error introduced a bug which caused acknowledged tickets not to get properly erased from the DB after redeeming.

Fixes https://github.com/hoprnet/hoprnet/issues/4421
Fixes https://github.com/hoprnet/hoprnet/issues/4421
Fixes https://github.com/hoprnet/hoprnet/issues/4398