### PR TITLE
Fix internal container addresses on AVADO / Dappnode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix bug in waiting logic for on-chain transactions ([#4425](https://github.com/hoprnet/hoprnet/pull/4425))
 - Fixed incorrect acknowledged tickets handling in the DB
 - Fix STUN functionality, enhance it to check if host is exposed and a keep-alive mechanism to keep NAT port mapping ([#4401](https://github.com/hoprnet/hoprnet/pull/4401))
+- Fix DAppnode / AVADO announcing internal container addresses ([#4467](https://github.com/hoprnet/hoprnet/pull/4467))
 
 ---
 

--- a/packages/connect/src/base/addrs.ts
+++ b/packages/connect/src/base/addrs.ts
@@ -1,5 +1,11 @@
 import { networkInterfaces, type NetworkInterfaceInfo } from 'os'
-import { isLocalhost, ipToU8aAddress, isPrivateAddress, isLinkLocaleAddress } from '@hoprnet/hopr-utils'
+import {
+  isLocalhost,
+  ipToU8aAddress,
+  isPrivateAddress,
+  isLinkLocaleAddress,
+  isAvadoPrivateNetwork
+} from '@hoprnet/hopr-utils'
 
 import Debug from 'debug'
 const log = Debug('hopr-connect')
@@ -90,6 +96,11 @@ export function getAddrs(
 
     for (const address of iface) {
       const u8aAddr = ipToU8aAddress(address.address, address.family)
+
+      if ((process.env.AVADO ?? 'false').toLowerCase() === 'true' && isAvadoPrivateNetwork(u8aAddr, address.family)) {
+        // Never expose internal container addresses of DAppnode or AVADO machines
+        continue
+      }
 
       if (isLinkLocaleAddress(u8aAddr, address.family)) {
         continue

--- a/packages/connect/src/base/stun/udp/client.ts
+++ b/packages/connect/src/base/stun/udp/client.ts
@@ -8,7 +8,7 @@ import { isStun } from '../../../utils/index.js'
 // @ts-ignore untyped module
 import retimer from 'retimer'
 
-import { u8aToHex, ipToU8aAddress, isPrivateAddress, isLocalhost } from '@hoprnet/hopr-utils'
+import { u8aToHex, ipToU8aAddress, isAvadoPrivateNetwork, isPrivateAddress, isLocalhost } from '@hoprnet/hopr-utils'
 
 import {
   isStunErrorResponse,
@@ -214,6 +214,12 @@ function isUsableResult(result: Interface, runningLocally = false): boolean {
           return true
         }
         break
+      }
+
+      if ((process.env.AVADO ?? 'false').toLowerCase() === 'true' && isAvadoPrivateNetwork(u8aAddr, 'IPv4')) {
+        // Even if we find a STUN server within our DAppnode or AVADO network,
+        // the perceived internal container address is not public despite it looks like that
+        return false
       }
 
       // Only take public addresses

--- a/packages/connect/src/filter.ts
+++ b/packages/connect/src/filter.ts
@@ -5,6 +5,7 @@ import type { Initializable, Components } from '@libp2p/interfaces/components'
 import {
   u8aEquals,
   checkNetworks,
+  isAvadoPrivateNetwork,
   isPrivateAddress,
   isLinkLocaleAddress,
   isReservedAddress,
@@ -167,6 +168,14 @@ export class Filter implements Initializable {
    * @returns
    */
   private filterDirectDial(address: DirectAddress, ma: Multiaddr): boolean {
+    if (
+      (process.env.AVADO ?? 'false').toLowerCase() === 'true' &&
+      isAvadoPrivateNetwork(address.address, address.type)
+    ) {
+      // Never attempt to dial internal container addresses of DAppnode or AVADO machines
+      return false
+    }
+
     if (!this.listeningFamilies!.includes(address.type)) {
       // Prevent dialing IPv6 addresses when only listening to IPv4 and vice versa
       log(`Tried to dial ${address.type} address but listening to ${this.listeningFamilies!.join(', ')}`)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -834,7 +834,7 @@ class Hopr extends EventEmitter {
 
       if (ticketIssuer.eq(ticketReceiver)) log(`WARNING: duplicated adjacent path entries.`)
 
-      let channel
+      let channel: ChannelEntry
       try {
         channel = await this.db.getChannelX(ticketIssuer, ticketReceiver)
       } catch (err) {

--- a/packages/utils/src/network/addrs.ts
+++ b/packages/utils/src/network/addrs.ts
@@ -52,12 +52,18 @@ export function isLocalhost(address: Uint8Array, family: NetworkInterfaceInfo['f
  * @returns true if private address
  */
 export function isPrivateAddress(address: Uint8Array, family: NetworkInterfaceInfo['family']): boolean {
-  // DAppnode/Avado consider 172.33.0.0/16 a private network
-  let priv_networks = PRIVATE_NETWORKS
-  if ((process.env.AVADO ?? 'false').toLowerCase() === 'true')
-    priv_networks = [...PRIVATE_NETWORKS, PRIVATE_V4_CLASS_AVADO]
+  return checkNetworks(PRIVATE_NETWORKS, address, family)
+}
 
-  return checkNetworks(priv_networks, address, family)
+/**
+ * Checks if given address is in internally network of
+ * Dappnode or AVADO based nodes.
+ * @param address
+ * @param family
+ * @returns
+ */
+export function isAvadoPrivateNetwork(address: Uint8Array, family: NetworkInterfaceInfo['family']): boolean {
+  return checkNetworks([PRIVATE_V4_CLASS_AVADO], address, family)
 }
 
 /**


### PR DESCRIPTION
### TLDR

Fixes an issue with private addresses considered public when running on DAppnode / AVADO machines.

### Detailed description

**Current situation**

`connect` detects that it is running on a DAppnode machine and therefore considers the address private - and publishes it as their private address. To make sure that nodes in the same network can connect to each other.

Whereas other nodes - which are not running on a DAppnode / AVADO - consider this address public and thus try to connect to it.

**New behavior**

`connect` detects that it is running on a DAppnode / AVADO machine and ignores that internal container address. As it is not expected to have multiple nodes running on the same DAppnode / AVADO machine, clients running on DAppnode / AVADO machines don't try to dial internal container addresses.