### PR TITLE
Allow `disableApiAuthentication` and `apiToken` CLI args together

### DIFF
--- a/packages/hoprd/src/api/v2.ts
+++ b/packages/hoprd/src/api/v2.ts
@@ -121,11 +121,7 @@ export async function setupRestApi(
         // Applying multiple URI encoding is an identity
         let apiTokenFromUser = encodeURIComponent(req.get('x-auth-token') || '')
 
-        if (
-          !this.options.disableApiAuthentication &&
-          this.options.apiToken !== undefined &&
-          apiTokenFromUser !== encodedApiToken
-        ) {
+        if (this.options.apiToken !== undefined && apiTokenFromUser !== encodedApiToken) {
           // because this is not the last auth check, we just indicate that
           // the authentication failed so the auth chain can continue
           return false
@@ -142,11 +138,7 @@ export async function setupRestApi(
         // We only expect a single value here, instead of the usual user:password, so we take the user part as token
         let apiTokenFromUser = encodeURIComponent(Buffer.from(authEncoded, 'base64').toString('binary').split(':')[0])
 
-        if (
-          !this.options.disableApiAuthentication &&
-          this.options.apiToken !== undefined &&
-          apiTokenFromUser !== encodedApiToken
-        ) {
+        if (this.options.apiToken !== undefined && apiTokenFromUser !== encodedApiToken) {
           // because this is the last auth check, we must throw the appropriate
           // error to be sent back to the user
           throw {

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -123,8 +123,7 @@ const argv = yargsInstance
   .option('apiToken', {
     string: true,
     describe: 'A REST API token and for user authentication [env: HOPRD_API_TOKEN]',
-    default: undefined,
-    conflicts: 'disableApiAuthentication'
+    default: undefined
   })
   .option('healthCheck', {
     boolean: true,


### PR DESCRIPTION
Allow `--disableApiAuthentication` and `--apiToken` CLI arguments to be specified at the same time.

However, the usage of `--disableApiAuthentication` will reset whatever is set by `--apiToken` (as expected).

This behaviour is required by e.g. Avado, which will always pass both arguments, no matter their values.