### PR TITLE
Use non-deprecated `account/addresses` endpoint in the docs

### DIFF
--- a/docs/hopr-documentation/docs/developers/connecting-node.md
+++ b/docs/hopr-documentation/docs/developers/connecting-node.md
@@ -154,7 +154,7 @@ Using your node's `apiToken` and your `HOPR_NODE_1_HTTP_URL` from the ["Running 
 command. If you don’t have `jq` installed, just remove it from the end of the command.
 
 ```bash
-echo -n $apiToken | base64 | xargs -I {} curl -s -H "Authorization: Basic {}" $HOPR_NODE_1_HTTP_URL/api/v2/account/address | jq
+echo -n $apiToken | base64 | xargs -I {} curl -s -H "Authorization: Basic {}" $HOPR_NODE_1_HTTP_URL/api/v2/account/addresses | jq
 ```
 
 If successful, you should get a response similar to this one:

--- a/docs/hopr-documentation/docs/developers/tutorial-hello-world.md
+++ b/docs/hopr-documentation/docs/developers/tutorial-hello-world.md
@@ -113,7 +113,7 @@ Using `curl` or any other HTTP client, verify you can reach `node 1`'s API
 **Obtaining the address for `node 1` using `curl`**
 
 ```bash
-echo -n $apiToken | base64 | xargs -I {} curl -s -H "Authorization: Basic {}" $HOPR_NODE_1_HTTP_URL/api/v2/account/address | jq
+echo -n $apiToken | base64 | xargs -I {} curl -s -H "Authorization: Basic {}" $HOPR_NODE_1_HTTP_URL/api/v2/account/addresses | jq
 ```
 
 **Obtaining the address for `node 1` using [reqbin](https://reqbin.com/)**


### PR DESCRIPTION
Small improvements in the documentation.