### PR TITLE
fix empty ping response

### DIFF
--- a/packages/core/src/network/heartbeat.ts
+++ b/packages/core/src/network/heartbeat.ts
@@ -182,8 +182,12 @@ export default class Heartbeat {
       } else if (pingResponse == null || pingResponse.length == 1) {
         const expectedResponse = Heartbeat.calculatePingResponse(challenge)
 
-        if (!u8aEquals(expectedResponse, pingResponse[0])) {
-          log(`Mismatched challenge. Got ${u8aToHex(pingResponse[0])} but expected ${u8aToHex(expectedResponse)}`)
+        if (pingResponse == null || !u8aEquals(expectedResponse, pingResponse[0])) {
+          log(
+            `Mismatched challenge. Got ${
+              pingResponse == null ? '<empty>' : u8aToHex(pingResponse[0])
+            } but expected ${u8aToHex(expectedResponse)}`
+          )
         }
 
         // Eventually close the connections, all errors are handled


### PR DESCRIPTION
Fixes an incorrect if-clause that could lead to errors if `sendMessage` returns an empty response, which is unexpected in this case.