### PR TITLE
Use pre-increment addition to prevent wrong exit code

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'macos-latest']
+        os: ['ubuntu-latest']
 
     steps:
       - uses: actions/checkout@v3
@@ -78,15 +78,6 @@ jobs:
           path: |
             /tmp/hopr-source-node-*.log
             /tmp/hopr-source-hardhat-rpc.log
-
-      - name: Upload node logs (macOS)
-        uses: actions/upload-artifact@v3
-        if: ${{ always() && runner.os == 'macOS' }}
-        with:
-          name: hopr-macOS-e2e-source-node-logs
-          path: |
-            /var/tmp/hopr-source-node-*.log
-            /var/tmp/hopr-source-hardhat-rpc.log
 
       - name: Send notification if anything failed on master or release branches
         if: ${{ failure() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && !env.ACT }}

--- a/scripts/api.sh
+++ b/scripts/api.sh
@@ -74,7 +74,7 @@ api_call(){
       sleep ${step_time}
 
       now=$(node -e "console.log(process.hrtime.bigint().toString());")
-      (( attempt++ ))
+      (( ++attempt ))
     fi
   done
 


### PR DESCRIPTION
From the bash manual:

Each arg is an arithmetic expression to be evaluated (see ARITHMETIC EVALUATION). If the last arg evaluates to 0, let returns 1; 0 is returned otherwise.

Fixes #4481 