### PR TITLE
Add wasm feature to all crates

### DIFF
--- a/packages/core/crates/core-misc/Cargo.toml
+++ b/packages/core/crates/core-misc/Cargo.toml
@@ -11,6 +11,10 @@ license = "LGPL-3.0-only"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+default = ["console_error_panic_hook", "wasm"]
+wasm = []
+
 [dependencies]
 real-base = { path = "../../../real/crates/real-base" }
 serde = { version = "1.0", features = ["derive"] }

--- a/packages/core/crates/core-misc/src/environment.rs
+++ b/packages/core/crates/core-misc/src/environment.rs
@@ -246,6 +246,7 @@ impl ResolvedEnvironment {
     }
 }
 
+#[cfg(feature = "wasm")]
 pub mod wasm {
     use super::FromJsonFile;
     use wasm_bindgen::prelude::*;

--- a/packages/core/crates/core-misc/src/lib.rs
+++ b/packages/core/crates/core-misc/src/lib.rs
@@ -1,22 +1,25 @@
-use wasm_bindgen::prelude::wasm_bindgen;
-
 pub mod environment;
 
-#[allow(dead_code)]
-#[wasm_bindgen]
-pub fn core_misc_set_panic_hook() {
-    // When the `console_error_panic_hook` feature is enabled, we can call the
-    // `set_panic_hook` function at least once during initialization, and then
-    // we will get better error messages if our code ever panics.
-    //
-    // For more details see
-    // https://github.com/rustwasm/console_error_panic_hook#readme
-    #[cfg(feature = "console_error_panic_hook")]
-    console_error_panic_hook::set_once();
-}
+#[cfg(feature = "wasm")]
+pub mod wasm {
+    use wasm_bindgen::prelude::wasm_bindgen;
 
-// When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
-// allocator.
-// #[cfg(feature = "wee_alloc")]
-// #[global_allocator]
-// static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+    #[allow(dead_code)]
+    #[wasm_bindgen]
+    pub fn core_misc_set_panic_hook() {
+        // When the `console_error_panic_hook` feature is enabled, we can call the
+        // `set_panic_hook` function at least once during initialization, and then
+        // we will get better error messages if our code ever panics.
+        //
+        // For more details see
+        // https://github.com/rustwasm/console_error_panic_hook#readme
+        #[cfg(feature = "console_error_panic_hook")]
+        console_error_panic_hook::set_once();
+    }
+
+    // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
+    // allocator.
+    // #[cfg(feature = "wee_alloc")]
+    // #[global_allocator]
+    // static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+}

--- a/packages/hoprd/crates/hoprd-misc/Cargo.toml
+++ b/packages/hoprd/crates/hoprd-misc/Cargo.toml
@@ -11,6 +11,10 @@ license = "LGPL-3.0-only"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+default = ["console_error_panic_hook", "wasm"]
+wasm = []
+
 [dependencies]
 real-base = { path = "../../../real/crates/real-base" }
 wasm-bindgen = "0.2.83"

--- a/packages/hoprd/crates/hoprd-misc/src/lib.rs
+++ b/packages/hoprd/crates/hoprd-misc/src/lib.rs
@@ -1,20 +1,23 @@
-use wasm_bindgen::prelude::wasm_bindgen;
 
-#[allow(dead_code)]
-#[wasm_bindgen]
-pub fn set_panic_hook() {
-    // When the `console_error_panic_hook` feature is enabled, we can call the
-    // `set_panic_hook` function at least once during initialization, and then
-    // we will get better error messages if our code ever panics.
-    //
-    // For more details see
-    // https://github.com/rustwasm/console_error_panic_hook#readme
-    #[cfg(feature = "console_error_panic_hook")]
-    console_error_panic_hook::set_once();
+#[cfg(feature = "wasm")]
+pub mod wasm {
+    use wasm_bindgen::prelude::wasm_bindgen;
+
+    #[allow(dead_code)]
+    #[wasm_bindgen]
+    pub fn set_panic_hook() {
+        // When the `console_error_panic_hook` feature is enabled, we can call the
+        // `set_panic_hook` function at least once during initialization, and then
+        // we will get better error messages if our code ever panics.
+        //
+        // For more details see
+        // https://github.com/rustwasm/console_error_panic_hook#readme
+        #[cfg(feature = "console_error_panic_hook")]
+        console_error_panic_hook::set_once();
+    }
+
+    // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global allocator.
+    #[cfg(feature = "wee_alloc")]
+    #[global_allocator]
+    static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 }
-
-// When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
-// allocator.
-#[cfg(feature = "wee_alloc")]
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;

--- a/packages/utils/crates/utils-metrics/Cargo.toml
+++ b/packages/utils/crates/utils-metrics/Cargo.toml
@@ -12,7 +12,8 @@ license = "LGPL-3.0-only"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["console_error_panic_hook"]
+default = ["console_error_panic_hook", "wasm"]
+wasm = []
 
 [dependencies]
 prometheus = "0.13.2"

--- a/packages/utils/crates/utils-metrics/src/lib.rs
+++ b/packages/utils/crates/utils-metrics/src/lib.rs
@@ -1,22 +1,24 @@
-use wasm_bindgen::prelude::wasm_bindgen;
-
 pub mod metrics;
 
-// When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
-// allocator.
-#[cfg(feature = "wee_alloc")]
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+#[cfg(feature = "wasm")]
+pub mod wasm {
+    use wasm_bindgen::prelude::wasm_bindgen;
 
-#[allow(dead_code)]
-#[wasm_bindgen]
-pub fn set_panic_hook() {
-    // When the `console_error_panic_hook` feature is enabled, we can call the
-    // `set_panic_hook` function at least once during initialization, and then
-    // we will get better error messages if our code ever panics.
-    //
-    // For more details see
-    // https://github.com/rustwasm/console_error_panic_hook#readme
-    #[cfg(feature = "console_error_panic_hook")]
-    console_error_panic_hook::set_once();
+    // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global allocator.
+    #[cfg(feature = "wee_alloc")]
+    #[global_allocator]
+    static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+
+    #[allow(dead_code)]
+    #[wasm_bindgen]
+    pub fn set_panic_hook() {
+        // When the `console_error_panic_hook` feature is enabled, we can call the
+        // `set_panic_hook` function at least once during initialization, and then
+        // we will get better error messages if our code ever panics.
+        //
+        // For more details see
+        // https://github.com/rustwasm/console_error_panic_hook#readme
+        #[cfg(feature = "console_error_panic_hook")]
+        console_error_panic_hook::set_once();
+    }
 }

--- a/packages/utils/crates/utils-metrics/src/metrics.rs
+++ b/packages/utils/crates/utils-metrics/src/metrics.rs
@@ -522,6 +522,7 @@ mod tests {
 
 
 /// Bindings for JS/TS
+#[cfg(feature = "wasm")]
 pub mod wasm {
     use std::fmt::Display;
     use wasm_bindgen::prelude::*;

--- a/packages/utils/crates/utils-misc/Cargo.toml
+++ b/packages/utils/crates/utils-misc/Cargo.toml
@@ -11,6 +11,10 @@ license = "LGPL-3.0-only"
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+default = ["console_error_panic_hook", "wasm"]
+wasm = []
+
 [dependencies]
 real-base = { path = "../../../real/crates/real-base" }
 serde = { version = "1.0", features = ["derive"] }

--- a/packages/utils/crates/utils-misc/src/lib.rs
+++ b/packages/utils/crates/utils-misc/src/lib.rs
@@ -1,23 +1,25 @@
-use wasm_bindgen::prelude::*;
-
 pub mod utils;
 
-#[allow(dead_code)]
-#[wasm_bindgen]
-pub fn set_panic_hook() {
-    // When the `console_error_panic_hook` feature is enabled, we can call the
-    // `set_panic_hook` function at least once during initialization, and then
-    // we will get better error messages if our code ever panics.
-    //
-    // For more details see
-    // https://github.com/rustwasm/console_error_panic_hook#readme
-    #[cfg(feature = "console_error_panic_hook")]
-    console_error_panic_hook::set_once();
-}
+#[cfg(feature = "wasm")]
+pub mod wasm {
+    use wasm_bindgen::prelude::*;
 
-// When the `wee_alloc` feature is enabled, use `wee_alloc` as the global
-// allocator.
-#[cfg(feature = "wee_alloc")]
-#[global_allocator]
-static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+    #[allow(dead_code)]
+    #[wasm_bindgen]
+    pub fn set_panic_hook() {
+        // When the `console_error_panic_hook` feature is enabled, we can call the
+        // `set_panic_hook` function at least once during initialization, and then
+        // we will get better error messages if our code ever panics.
+        //
+        // For more details see
+        // https://github.com/rustwasm/console_error_panic_hook#readme
+        #[cfg(feature = "console_error_panic_hook")]
+        console_error_panic_hook::set_once();
+    }
+
+    // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global allocator.
+    #[cfg(feature = "wee_alloc")]
+    #[global_allocator]
+    static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+}
 

--- a/packages/utils/crates/utils-misc/src/utils.rs
+++ b/packages/utils/crates/utils-misc/src/utils.rs
@@ -19,6 +19,7 @@ pub fn get_package_version(package_file: &str) -> Result<String, RealError> {
     }
 }
 
+#[cfg(feature = "wasm")]
 pub mod wasm {
     use wasm_bindgen::prelude::*;
 


### PR DESCRIPTION
This adds a `wasm` feature (enabled by default) to all crates, so that the WASM modules within our crates are built only if this feature is turned on.