### PR TITLE
ci: Handle npm execution error gracefully when publishing packages

### DIFF
--- a/scripts/get-npm-package-info.sh
+++ b/scripts/get-npm-package-info.sh
@@ -34,4 +34,6 @@ pkg_path="${mydir}/../packages/${pkg}/package.json"
 pkg_name=$(jq -r '.name' ${pkg_path})
 
 log "Get npm package info for ${pkg_name}@${pkg_vsn}"
-npm view "${pkg_name}@${pkg_vsn}" --json
+
+# handle errors in the npm execution gracefully
+npm view "${pkg_name}@${pkg_vsn}" --json || echo ""


### PR DESCRIPTION
Fixes issue seen in
https://github.com/hoprnet/hoprnet/actions/runs/3890447740/jobs/6639578776#step:12:2337