### PR TITLE
Fix regression that led to flat ping rate

### DIFF
--- a/packages/connect/src/base/entry.ts
+++ b/packages/connect/src/base/entry.ts
@@ -608,7 +608,8 @@ export class EntryNodes extends EventEmitter implements Initializable, Startable
         }
 
         return (initialDelay *= 1.5)
-      }
+      },
+      true
     )
   }
   /**

--- a/packages/connect/src/base/entry.ts
+++ b/packages/connect/src/base/entry.ts
@@ -571,7 +571,8 @@ export class EntryNodes extends EventEmitter implements Initializable, Startable
         // has finished
         return entriesRenewed.promise
       },
-      () => this.dhtRenewalInterval
+      () => this.dhtRenewalInterval,
+      true
     )
   }
 

--- a/packages/utils/src/process/retimer.ts
+++ b/packages/utils/src/process/retimer.ts
@@ -3,11 +3,15 @@
  * @param fn function to apply after every timeout
  * @param newTimeout function that returns the new timeout
  */
-export function retimer(fn: () => Promise<void> | void, newTimeout: () => number): () => void {
+export function retimer(fn: () => Promise<void> | void, newTimeout: () => number, awaitPromise?: boolean): () => void {
   let timeout: NodeJS.Timeout
 
   const again = async () => {
-    await fn()
+    if (awaitPromise == true) {
+      await fn()
+    } else {
+      fn()
+    }
     timeout = setTimeout(again, newTimeout()).unref()
   }
   timeout = setTimeout(again, newTimeout()).unref()


### PR DESCRIPTION
Closes #4489 

Fixes a regression that prevented heartbeat rounds from running through.

## Current situation

```ts
await heartbeatRound() // 99% complete, waiting forever for 1%
```

## New solution

```ts
heartbeatRound()
await setTimeout(1234)
heartbeatRound()
```