### PR TITLE
Make all docker images compatible with anvil/forge

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CRATES := $(foreach crate,${WORKSPACES_WITH_RUST_MODULES},$(dir $(wildcard $(cra
 FOUNDRY_TOOL_CRATE := ./packages/ethereum/foundry-tool
 
 # Set local foundry directory (for binaries) and versions
-FOUNDRY_DIR := ${CURDIR}/.foundry
+FOUNDRY_DIR ?= ${CURDIR}/.foundry
 FOUNDRY_VSN := be7084e
 
 # Set local cargo directory (for binaries)
@@ -52,6 +52,8 @@ all: help
 $(CRATES): ## builds all Rust crates with wasm-pack (except for foundry-tool)
 # --out-dir is relative to working directory
 	echo "use wasm-pack build"
+	which wasm-pack
+	wasm-pack --version
 	wasm-pack build --target=bundler --out-dir ./pkg $@
 
 .PHONY: $(FOUNDRY_TOOL_CRATE)
@@ -217,7 +219,11 @@ lint-fix: ## run linter in fix mode
 
 .PHONY: run-anvil
 run-anvil: ## spinup a local anvil instance (daemon) and deploy contracts
-	./script/run-local-anvil.sh
+	./scripts/run-local-anvil.sh
+
+.PHONY: run-anvil-foreground
+run-anvil-foreground: ## spinup a local anvil instance
+	./scripts/run-local-anvil.sh -f -s
 
 .PHONY: kill-anvil
 kill-anvil: ## kill process running at port 8545 (default port of anvil)

--- a/Makefile
+++ b/Makefile
@@ -52,8 +52,6 @@ all: help
 $(CRATES): ## builds all Rust crates with wasm-pack (except for foundry-tool)
 # --out-dir is relative to working directory
 	echo "use wasm-pack build"
-	which wasm-pack
-	wasm-pack --version
 	wasm-pack build --target=bundler --out-dir ./pkg $@
 
 .PHONY: $(FOUNDRY_TOOL_CRATE)

--- a/Makefile
+++ b/Makefile
@@ -233,9 +233,10 @@ run-local: ## run HOPRd from local repo
 		--testPreferLocalAddresses --disableApiAuthentication
 
 .PHONY: fund-local
+fund-local: id_dir=.
 fund-local: ## use faucet script to fund local identities
 	foundry-tool --environment-name anvil-localhost --environment-type development \
-		faucet --password local --use-local-identities --identity-directory "." \
+		faucet --password local --use-local-identities --identity-directory "${id_dir}" \
 		--private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
 		--make-root "./packages/ethereum/contracts"
 

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -46,8 +46,8 @@ steps:
     id: buildHardhat
     args:
       - --build-arg=HOPR_TOOLCHAIN_IMAGE=gcr.io/${PROJECT_ID}/hopr-toolchain:${_IMAGE_VERSION}
-      - --dockerfile=packages/ethereum/Dockerfile.hardhat
-      - --destination=gcr.io/${PROJECT_ID}/hopr-hardhat:${_IMAGE_VERSION}
+      - --dockerfile=packages/ethereum/Dockerfile.anvil
+      - --destination=gcr.io/${PROJECT_ID}/hopr-anvil:${_IMAGE_VERSION}
       - --cache=true
       - --cache-ttl=96h
     timeout: 1200s
@@ -77,7 +77,7 @@ steps:
       - --destination=gcr.io/${PROJECT_ID}/hopr-pluto:${_IMAGE_VERSION}
       - --cache=true
       - --cache-ttl=96h
-      - --build-arg=HARDHAT_IMAGE=gcr.io/${PROJECT_ID}/hopr-hardhat:${_IMAGE_VERSION}
+      - --build-arg=ANVIL_IMAGE=gcr.io/${PROJECT_ID}/hopr-anvil:${_IMAGE_VERSION}
       - --build-arg=HOPRD_IMAGE=gcr.io/${PROJECT_ID}/hoprd:${_IMAGE_VERSION}
     timeout: 1200s
     waitFor:
@@ -89,7 +89,7 @@ steps:
       #!/usr/bin/env bash
       set -Eeuo pipefail
       [ "${NO_TAGS}" = "true" ] && { exit 0; }
-      for image in hoprd hoprd-nat hopr-cover-traffic-daemon hopr-hardhat hopr-pluto; do
+      for image in hoprd hoprd-nat hopr-cover-traffic-daemon hopr-anvil hopr-pluto; do
         full_image="gcr.io/${PROJECT_ID}/${image}"
         gcloud container images add-tag ${full_image}:${IMAGE_VERSION} ${full_image}:${PACKAGE_VERSION}
         for release in ${RELEASES}; do

--- a/packages/cover-traffic-daemon/Dockerfile
+++ b/packages/cover-traffic-daemon/Dockerfile
@@ -19,7 +19,7 @@ RUN make deps-docker package=hopr-cover-traffic-daemon && \
     find ./packages -type f -name '*.spec.ts' -delete && \
     # Only build cover-traffic-daemon + dependencies
     NO_NEXT=true make -j build package=cover-traffic-daemon && \
-    # Remove all typescript files 
+    # Remove all typescript files
     find ./packages -type f -name '*.ts' -delete && \
     # No need for these packages
     rm -R packages/avado packages/hoprd && \
@@ -49,7 +49,7 @@ RUN apk add --no-cache tini libc6-compat bash curl tar jq xz libstdc++ && \
     apk del bash curl tar jq xz && \
     # Remove unused files and config
     rm -R scripts .nvmrc && \
-    # symlink required to get WRTC to work
+    # symlink required to get WRTC and other glibc-based tools to work
     ln -s /lib/libc.musl-x86_64.so.1 /lib/ld-linux-x86-64.so.2 && \
     # create directory which is later used for the database, so that it inherits
     # permissions when mapped to a volume

--- a/packages/ethereum/Dockerfile.anvil
+++ b/packages/ethereum/Dockerfile.anvil
@@ -1,0 +1,31 @@
+ARG HOPR_TOOLCHAIN_IMAGE=${HOPR_TOOLCHAIN_IMAGE:-hopr-toolchain:latest}
+
+# Creates a Docker container that encapsulates a local testnet with deployed smart contracts
+
+FROM ${HOPR_TOOLCHAIN_IMAGE} as build
+
+WORKDIR /app/hoprnet
+
+LABEL description="Launches an anvilnode running a local network with the HOPR contracts deployed and available." 
+
+COPY packages/ethereum/contracts .
+
+RUN cd contracts && make deploy-all
+
+# Alpine 3.16 x86_64 https://hub.docker.com/layers/library/alpine/3.16.3/images/sha256-3d426b0bfc361d6e8303f51459f17782b219dece42a1c7fe463b6014b189c86d
+FROM alpine:3.16@sha256:3d426b0bfc361d6e8303f51459f17782b219dece42a1c7fe463b6014b189c86d as runtime
+
+WORKDIR /app/anvil
+
+EXPOSE 8545
+
+RUN mkdir -p scripts/toolchain
+
+COPY Makefile .yarnrc.yml package.json yarn.lock tsconfig.json ./
+COPY scripts/toolchain/install-toolchain.sh ./scripts/toolchain
+
+COPY --from=build /app/hoprnet/.foundry .foundry/
+
+RUN make install-foundry
+
+ENTRYPOINT ["/sbin/tini", "--", "yarn", "run:network", "--network", "hardhat", "--show-stack-traces"]

--- a/packages/ethereum/Dockerfile.anvil
+++ b/packages/ethereum/Dockerfile.anvil
@@ -17,7 +17,10 @@ ENV FOUNDRY_DIR=/app/hoprnet-toolchain/.foundry
 # start anvil, deploy contracts, then terminate
 RUN make -f Makefile run-anvil \
  && sleep 2 \
- && make -f Makefile kill-anvil
+ && make -f Makefile kill-anvil \
+ && rm -rf packages/ethereum/contracts/broadcast/ \
+ && rm -f /tmp/*.log \
+ && rm -f .anvil.state.json
 
 # install missing process runner
 RUN apk add --no-cache tini

--- a/packages/ethereum/Dockerfile.anvil
+++ b/packages/ethereum/Dockerfile.anvil
@@ -6,26 +6,21 @@ FROM ${HOPR_TOOLCHAIN_IMAGE} as build
 
 WORKDIR /app/hoprnet
 
-LABEL description="Launches an anvilnode running a local network with the HOPR contracts deployed and available." 
+LABEL description="Launches an anvil node running a local network with the HOPR contracts deployed and available."
 
-COPY packages/ethereum/contracts .
+COPY packages/ethereum/contracts packages/ethereum/contracts
+COPY scripts/ scripts
+COPY Makefile .
 
-RUN cd contracts && make deploy-all
+ENV FOUNDRY_DIR=/app/hoprnet-toolchain/.foundry
 
-# Alpine 3.16 x86_64 https://hub.docker.com/layers/library/alpine/3.16.3/images/sha256-3d426b0bfc361d6e8303f51459f17782b219dece42a1c7fe463b6014b189c86d
-FROM alpine:3.16@sha256:3d426b0bfc361d6e8303f51459f17782b219dece42a1c7fe463b6014b189c86d as runtime
+# start anvil, deploy contracts, then terminate
+RUN make -f Makefile run-anvil \
+ && sleep 2 \
+ && make -f Makefile kill-anvil
 
-WORKDIR /app/anvil
+# install missing process runner
+RUN apk add --no-cache tini
 
-EXPOSE 8545
-
-RUN mkdir -p scripts/toolchain
-
-COPY Makefile .yarnrc.yml package.json yarn.lock tsconfig.json ./
-COPY scripts/toolchain/install-toolchain.sh ./scripts/toolchain
-
-COPY --from=build /app/hoprnet/.foundry .foundry/
-
-RUN make install-foundry
-
-ENTRYPOINT ["/sbin/tini", "--", "yarn", "run:network", "--network", "hardhat", "--show-stack-traces"]
+# start anvil in foreground, don't deploy contracts again
+ENTRYPOINT ["/sbin/tini", "--", "make", "run-anvil-foreground"]

--- a/packages/ethereum/contracts/Makefile
+++ b/packages/ethereum/contracts/Makefile
@@ -1,5 +1,5 @@
 # Use local foundry directory (for binaries)
-FOUNDRY_DIR := ${CURDIR}/../../../.foundry
+FOUNDRY_DIR ?= ${CURDIR}/../../../.foundry
 
 # add local Foundry install path (only once)
 PATH := $(subst :${FOUNDRY_DIR}/bin,,$(PATH)):${FOUNDRY_DIR}/bin

--- a/packages/ethereum/contracts/script/SingleAction.s.sol
+++ b/packages/ethereum/contracts/script/SingleAction.s.sol
@@ -280,7 +280,7 @@ contract SingleActionFromPrivateKeyScript is Test, EnvironmentConfig {
 
         vm.stopBroadcast();
     }
-    
+
     /**
      * @dev send some HOPR tokens to the recipient address
      */

--- a/packages/hoprd/Dockerfile
+++ b/packages/hoprd/Dockerfile
@@ -6,8 +6,10 @@ FROM ${HOPR_TOOLCHAIN_IMAGE} as build
 
 WORKDIR /app/hoprnet
 
-COPY .yarn/ .yarn/
-COPY .cargo .cargo/
+RUN mv /app/hoprnet-toolchain/.cargo . && \
+    mv /app/hoprnet-toolchain/.yarn .
+
+COPY .cargo/config.toml .cargo/
 COPY vendor vendor/
 COPY packages packages/
 COPY Makefile Cargo.toml Cargo.lock .yarnrc.yml yarn.lock package.json tsconfig.build.json tsconfig.json tsconfig.scripts.json yarn.lock rust-toolchain.toml ./
@@ -49,7 +51,7 @@ RUN apk add --no-cache tini libc6-compat bash curl tar jq xz libstdc++ && \
     apk del bash curl tar jq xz && \
     # Remove unused files and config
     rm -R scripts .nvmrc && \
-    # symlink required to get WRTC to work
+    # symlink required to get WRTC and other glibc-based tools to work
     ln -s /lib/libc.musl-x86_64.so.1 /lib/ld-linux-x86-64.so.2 && \
     # create directory which is later used for the database, so that it inherits
     # permissions when mapped to a volume

--- a/packages/hoprd/Dockerfile
+++ b/packages/hoprd/Dockerfile
@@ -26,13 +26,15 @@ RUN make deps-docker package=hoprd && \
     # No need for these packages
     rm -R packages/avado packages/cover-traffic-daemon && \
     # Everything that we don't need in ethereum package
-    rm -R packages/ethereum/contracts packages/ethereum/deploy packages/ethereum/hardhat packages/ethereum/tasks packages/ethereum/test && \
+    rm -R packages/ethereum/contracts packages/ethereum/deploy packages/ethereum/tasks packages/ethereum/test && \
     # Remove node_modules as they include devDependencies
     rm -R node_modules && \
     # As we are on *nix, use hardlinks in node_modules to save some space
     yarn config set nmMode hardlinks-local && \
     # Install without devDependencies
     PRODUCTION=true make deps-docker package=hoprd
+
+RUN find .cargo/bin
 
 # Alpine 3.16 x86_64 https://hub.docker.com/layers/library/alpine/3.16.3/images/sha256-3d426b0bfc361d6e8303f51459f17782b219dece42a1c7fe463b6014b189c86d
 FROM alpine:3.16@sha256:3d426b0bfc361d6e8303f51459f17782b219dece42a1c7fe463b6014b189c86d as runtime
@@ -59,6 +61,9 @@ RUN apk add --no-cache tini libc6-compat bash curl tar jq xz libstdc++ && \
 
 COPY --from=build /app/hoprnet/packages ./packages
 COPY --from=build /app/hoprnet/node_modules ./node_modules
+
+# we copy foundry-tool over since we might need it at some point as a binary
+COPY --from=build /app/hoprnet/.cargo/bin/foundry-tool .cargo/bin/
 
 # set volume which can be mapped by users on the host system
 VOLUME ["/app/hoprnet/hoprd-db"]

--- a/packages/hoprd/Dockerfile
+++ b/packages/hoprd/Dockerfile
@@ -34,8 +34,6 @@ RUN make deps-docker package=hoprd && \
     # Install without devDependencies
     PRODUCTION=true make deps-docker package=hoprd
 
-RUN find .cargo/bin
-
 # Alpine 3.16 x86_64 https://hub.docker.com/layers/library/alpine/3.16.3/images/sha256-3d426b0bfc361d6e8303f51459f17782b219dece42a1c7fe463b6014b189c86d
 FROM alpine:3.16@sha256:3d426b0bfc361d6e8303f51459f17782b219dece42a1c7fe463b6014b189c86d as runtime
 

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -29,7 +29,8 @@ usage() {
   msg
 }
 
-declare image_version package_version releases branch force no_tags local_build image_name
+declare image_version package_version releases branch force no_tags local_build
+declare image_name=""
 
 while (( "$#" )); do
   case "$1" in
@@ -114,7 +115,7 @@ build_and_tag_images() {
       docker build -q -t hopr-pluto-local \
         --build-arg=ANVIL_IMAGE="hopr-anvil-local" \
         --build-arg=HOPRD_IMAGE="hoprd-local" \
-        -f scripts/pluto/Dockerfile &
+        -f scripts/pluto/Dockerfile . &
     fi
 
     log "Waiting for Docker builds (part 2) to finish"

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -23,7 +23,7 @@ usage() {
   msg "Use -l to build the images locally instead and not publish them to a
   remote Docker repository. In addition -i can be used to build a single image locally instead of all images."
   msg "Supported values for -p are 'hoprd', 'hoprd-nat', 'cover-traffic-daemon',
-  'hardhat', 'pluto', 'pluto-complete'"
+  'anvil', 'pluto', 'pluto-complete'"
   msg
   msg "Use -f to force a Docker builds even though no environment can be found. This is useful for local testing. No additional docker tags will be applied though if no environment has been found which is in contrast to the normal execution of the script."
   msg
@@ -100,10 +100,10 @@ build_and_tag_images() {
         scripts/nat &
     fi
 
-    if [ -z "${image_name}" ] || [ "${image_name}" = "hardhat" ] || [ "${image_name}" = "pluto-complete" ]; then
-      log "Building Docker image hopr-hardhat-local"
-      docker build -t hopr-hardhat-local \
-        -f packages/ethereum/Dockerfile.hardhat . &
+    if [ -z "${image_name}" ] || [ "${image_name}" = "anvil" ] || [ "${image_name}" = "pluto-complete" ]; then
+      log "Building Docker image hopr-anvil-local"
+      docker build -t hopr-anvil-local \
+        -f packages/ethereum/Dockerfile.anvil . &
     fi
 
     log "Waiting for Docker builds (part 1) to finish"
@@ -112,7 +112,7 @@ build_and_tag_images() {
     if [ -z "${image_name}" ] || [ "${image_name}" = "pluto" ] || [ "${image_name}" = "pluto-complete" ]; then
       log "Building Docker image hopr-pluto-local"
       docker build -q -t hopr-pluto-local \
-        --build-arg=HARDHAT_IMAGE="hopr-hardhat-local" \
+        --build-arg=ANVIL_IMAGE="hopr-anvil-local" \
         --build-arg=HOPRD_IMAGE="hoprd-local" \
         -f scripts/pluto/Dockerfile &
     fi

--- a/scripts/nat/Dockerfile
+++ b/scripts/nat/Dockerfile
@@ -1,10 +1,15 @@
-FROM docker:20.10.14-alpine3.15@sha256:7dad83861f0b28bd6a0b281dc5f72144927b9f8173e388e461c8feba6be20bec
+# Alpine 3.16 x86_64 https://hub.docker.com/layers/library/alpine/3.16.3/images/sha256-3d426b0bfc361d6e8303f51459f17782b219dece42a1c7fe463b6014b189c86d
+FROM alpine:3.16@sha256:3d426b0bfc361d6e8303f51459f17782b219dece42a1c7fe463b6014b189c86d as runtime
 
 # This build arg is mandatory
 ARG HOPRD_RELEASE
+
 RUN test -n "$HOPRD_RELEASE"
 
 ENV HOPRD_RELEASE=${HOPRD_RELEASE}
-RUN apk add bash
+
+RUN apk add --no-cache bash
+
 COPY start-nat-node.sh start-nat-node.sh
+
 ENTRYPOINT ["./start-nat-node.sh"]

--- a/scripts/pluto/Dockerfile
+++ b/scripts/pluto/Dockerfile
@@ -1,12 +1,12 @@
 ARG HOPRD_IMAGE=${HOPRD_IMAGE:-hoprd-local:latest}
-ARG HARDHAT_IMAGE=${HARDHAT_IMAGE:-hopr-hardhat-local:latest}
+ARG ANVIL_IMAGE=${HARDHAT_IMAGE:-hopr-anvil-local:latest}
 
 # simply import hoprd image to copy in files later
 FROM ${HOPRD_IMAGE} as hoprd
 
-FROM ${HARDHAT_IMAGE} as runtime
+FROM ${ANVIL_IMAGE} as runtime
 
-LABEL description="Docker image running a HOPR-enabled hardhat network with 5 hoprd nodes using it and being fully interconnected."
+LABEL description="Docker image running a HOPR-enabled anvil network with 5 hoprd nodes using it and being fully interconnected."
 
 # install tools required within our scripts
 RUN apk add --no-cache bash lsof curl jq
@@ -15,13 +15,9 @@ WORKDIR /app
 
 COPY --from=hoprd /app/hoprnet ./hoprnet
 
-COPY scripts /app/hardhat/scripts
+COPY scripts /app/anvil/scripts
 
-# copy deployment files to make them available to hoprd as well
-RUN mkdir /app/hardhat/packages/ethereum/deployments/hardhat-localhost \
- && ln -s /app/hardhat/packages/ethereum/deployments/hardhat-localhost ./hoprnet/packages/ethereum/deployments/
-
-# hardhat RPC port
+# anvil RPC port
 EXPOSE 8545
 # hoprd Rest API ports
 EXPOSE 13301
@@ -52,4 +48,4 @@ EXPOSE 19505
 ARG HOPRD_API_TOKEN
 ENV HOPRD_API_TOKEN=${HOPRD_API_TOKEN:-%th1s-IS-a-S3CR3T-ap1-PUSHING-b1ts-TO-you%}
 
-ENTRYPOINT /app/hardhat/scripts/setup-local-cluster.sh -p -t "${HOPRD_API_TOKEN}" -i /app/hardhat/scripts/topologies/full_interconnected_cluster.sh --hoprd-command "node --experimental-wasm-modules hoprnet/packages/hoprd/lib/main.cjs" --hardhat-basedir "/app/hardhat/packages/ethereum" -l "0.0.0.0"
+ENTRYPOINT /app/anvil/scripts/setup-local-cluster.sh -p -t "${HOPRD_API_TOKEN}" -i /app/anvil/scripts/topologies/full_interconnected_cluster.sh --hoprd-command "node --experimental-wasm-modules hoprnet/packages/hoprd/lib/main.cjs" -l "0.0.0.0"

--- a/scripts/pluto/Dockerfile
+++ b/scripts/pluto/Dockerfile
@@ -15,7 +15,9 @@ WORKDIR /app
 
 COPY --from=hoprd /app/hoprnet ./hoprnet
 
-COPY scripts /app/anvil/scripts
+COPY packages/ethereum/contracts ./anvil/packages/ethereum/contracts
+COPY scripts/ ./anvil/scripts
+COPY Makefile ./anvil/
 
 # anvil RPC port
 EXPOSE 8545

--- a/scripts/pluto/Dockerfile
+++ b/scripts/pluto/Dockerfile
@@ -8,16 +8,19 @@ FROM ${ANVIL_IMAGE} as runtime
 
 LABEL description="Docker image running a HOPR-enabled anvil network with 5 hoprd nodes using it and being fully interconnected."
 
-# install tools required within our scripts
-RUN apk add --no-cache bash lsof curl jq
+# 1. install tools required within our scripts
+# 2. overwrite libc link under lib to make nodejs work alongside forge
+RUN apk add --no-cache bash lsof curl jq \
+ && ln -sf /lib/libc.musl-x86_64.so.1 /lib/ld-linux-x86-64.so.2
 
-WORKDIR /app
+WORKDIR /app/hoprnet
 
-COPY --from=hoprd /app/hoprnet ./hoprnet
+COPY --from=hoprd /app/hoprnet/ ./
+COPY --from=hoprd /app/hoprnet/.cargo/ ./.cargo/
 
-COPY packages/ethereum/contracts ./anvil/packages/ethereum/contracts
-COPY scripts/ ./anvil/scripts
-COPY Makefile ./anvil/
+COPY packages/ethereum/contracts/ ./packages/ethereum/contracts/
+COPY scripts/ ./scripts/
+COPY Makefile .
 
 # anvil RPC port
 EXPOSE 8545
@@ -50,4 +53,4 @@ EXPOSE 19505
 ARG HOPRD_API_TOKEN
 ENV HOPRD_API_TOKEN=${HOPRD_API_TOKEN:-%th1s-IS-a-S3CR3T-ap1-PUSHING-b1ts-TO-you%}
 
-ENTRYPOINT /app/anvil/scripts/setup-local-cluster.sh -p -t "${HOPRD_API_TOKEN}" -i /app/anvil/scripts/topologies/full_interconnected_cluster.sh --hoprd-command "node --experimental-wasm-modules hoprnet/packages/hoprd/lib/main.cjs" -l "0.0.0.0"
+ENTRYPOINT /app/hoprnet/scripts/setup-local-cluster.sh -p -t "${HOPRD_API_TOKEN}" -i /app/hoprnet/scripts/topologies/full_interconnected_cluster.sh --hoprd-command "node --experimental-wasm-modules packages/hoprd/lib/main.cjs" -l "0.0.0.0"

--- a/scripts/run-local-anvil.sh
+++ b/scripts/run-local-anvil.sh
@@ -97,7 +97,7 @@ function cleanup {
 trap cleanup SIGINT SIGTERM ERR
 
 # mine a block every 2 seconds
-declare flags="--block-time 2 --config-out ${cfg_file} --state ${state_file} -s 1"
+declare flags="--block-time 2 --config-out ${cfg_file}"
 
 if ! lsof -i ":8545" -s TCP:LISTEN; then
   log "Start local anvil network"

--- a/scripts/run-local-anvil.sh
+++ b/scripts/run-local-anvil.sh
@@ -17,21 +17,65 @@ usage() {
   msg
   msg "This script can be used to run a local Anvil instance at 127.0.0.1:8545"
   msg
-  msg "Usage: $0 [<log_file>] [<cfg_file>]"
+  msg "Usage: $0 [-h|--help] [-f] [-l <log_file>] [-c <cfg_file>] [-s]"
   msg
-  msg "Parameters:"
+  msg "Options:"
   msg
-  msg "log_file: (optional) log file name to be used by Anvil"
-  msg "cfg_file: (optional) cfg file name to be used by Anvil"
+  msg "-h|--help: Display help and exit"
+  msg "-s: Skip deployment of contracts"
+  msg "-f: Start anvil in foreground, blocking the script execution"
+  msg "-c <cfg_file>: Use particular anvil config file; default is ../.anvil.cfg"
+  msg "-l <log_file>: Use particular anvil log file; default is /tmp/anvil.log"
+  msg
 }
 
 # return early with help info when requested
 { [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; } && { usage; exit 0; }
 
 declare tmp="$(find_tmp_dir)"
-declare log_file="${1:-${tmp}/anvil.log}"
-declare cfg_file="${2:-${mydir}/../.anvil.cfg}"
+declare log_file="${tmp}/anvil.log"
+declare cfg_file="${mydir}/../.anvil.cfg"
 declare deployer_private_key=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
+declare foreground="false"
+declare skip_deploy="false"
+
+while (( "$#" )); do
+  case "$1" in
+    -h|--help)
+      # return early with help info when requested
+      usage
+      exit 0
+      ;;
+    -l)
+      log_file="$2"
+      shift
+      shift
+      ;;
+    -c)
+      cfg_file="$2"
+      shift
+      shift
+      ;;
+    -s)
+      skip_deploy="true"
+      shift
+      ;;
+    -f)
+      foreground="true"
+      shift
+      ;;
+    -*|--*=)
+      usage
+      exit 1
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+# derive location of the state file from the config file
+declare state_file="${cfg_file%.cfg}.state.json"
 
 function cleanup {
   local EXIT_CODE=$?
@@ -53,17 +97,23 @@ function cleanup {
 trap cleanup SIGINT SIGTERM ERR
 
 # mine a block every 2 seconds
-declare flags="--block-time 2 --config-out ${cfg_file}"
+declare flags="--block-time 2 --config-out ${cfg_file} --state ${state_file} -s 1"
 
 if ! lsof -i ":8545" -s TCP:LISTEN; then
   log "Start local anvil network"
-  ${mydir}/../.foundry/bin/anvil ${flags} > "${log_file}" 2>&1 &
+  anvil ${flags} > "${log_file}" 2>&1 &
   wait_for_regex ${log_file} "Listening on 127.0.0.1:8545"
   log "Anvil network started (127.0.0.1:8545)"
 else
   log "Anvil network already running, skipping"
 fi
 
-log "Deploying contracts"
-DEPLOYER_PRIVATE_KEY=${deployer_private_key} make -C ${mydir}/../packages/ethereum/contracts/ anvil-deploy-all
-log "Deploying contracts finished"
+if [ "${skip_deploy}" != "true" ]; then
+  log "Deploying contracts"
+  DEPLOYER_PRIVATE_KEY=${deployer_private_key} make -C ${mydir}/../packages/ethereum/contracts/ anvil-deploy-all
+  log "Deploying contracts finished"
+fi
+
+if [ "${foreground}" = "true" ]; then
+  wait
+fi

--- a/scripts/setup-local-cluster.sh
+++ b/scripts/setup-local-cluster.sh
@@ -239,12 +239,11 @@ cleanup_local_protocol_config "${protocol_config}" "anvil-localhost2"
 
 # --- Running Mock Blockchain --- {{{
 log "Running anvil local node"
-make -C "${mydir}/.." run-anvil > \
-    "${anvil_rpc_log}" 2>&1 &
+make -C "${mydir}/.." run-anvil
 
 log "Wait for regex"
 wait_for_regex ${anvil_rpc_log} "Started HTTP and WebSocket JSON-RPC server"
-log "Hardhat node started (127.0.0.1:8545)"
+log "Anvil node started (127.0.0.1:8545)"
 
 # need to mirror contract data because of anvil-deploy node only writing to localhost
 update_protocol_config_addresses "${protocol_config}" "${deployments_summary}" "anvil-localhost" "anvil-localhost"

--- a/scripts/setup-local-cluster.sh
+++ b/scripts/setup-local-cluster.sh
@@ -18,19 +18,17 @@ declare api_token="^^LOCAL-testing-123^^"
 declare myne_chat_url="http://app.myne.chat"
 declare init_script=""
 declare hoprd_command="node --experimental-wasm-modules packages/hoprd/lib/main.cjs"
-declare hardhat_basedir="packages/ethereum"
 declare listen_host="127.0.0.1"
 declare node_env="development"
 
 usage() {
   msg
-  msg "Usage: $0 [-h|--help] [-t|--api-token <api_token>] [-m|--myne-chat-url <myne_chat_url>] [-i|--init-script <init_script>] [--hoprd-command <hoprd_command>] [--hardhat-basedir <hardhat_basedir>] [--listen-host|-l <list_host>] [-p|--production]"
+  msg "Usage: $0 [-h|--help] [-t|--api-token <api_token>] [-m|--myne-chat-url <myne_chat_url>] [-i|--init-script <init_script>] [--hoprd-command <hoprd_command>] [--listen-host|-l <list_host>] [-p|--production]"
   msg
   msg "<api_token> is set to '${api_token}' by default"
   msg "<myne_chat_url> is set to '${myne_chat_url}' by default"
   msg "<init_script> is empty by default, expected to be path to a script which is called with all node API endpoints as parameters"
   msg "<hoprd_command> is used to start hoprd, default is '${hoprd_command}'"
-  msg "<hardhat_basedir> is entered before hardhat is started, default is '${hardhat_basedir}'"
   msg "<listen_host> is listened on by all hoprd instances, default is '${listen_host}'"
   msg "-p sets NODE_ENV to 'production'"
 }
@@ -68,11 +66,6 @@ while (( "$#" )); do
       ;;
     --hoprd-command)
       hoprd_command="${2}"
-      shift
-      shift
-      ;;
-    --hardhat-basedir)
-      hardhat_basedir="${2}"
       shift
       shift
       ;;
@@ -197,7 +190,7 @@ function setup_node() {
 
 # --- Log setup info {{{
 log "Node files and directories"
-log "\thardhat"
+log "\tanvil"
 log "\t\tlog: ${anvil_rpc_log}"
 log "\tnode1"
 log "\t\tdata dir: ${node1_dir} (will be removed)"
@@ -277,8 +270,7 @@ wait_for_regex ${node5_log} "unfunded"
 log "Funding nodes"
 
 #  --- Fund nodes --- {{{
-cd "${hardhat_basedir}" && \
-  NODE_OPTIONS=--experimental-wasm-modules yarn faucet --identity-directory "${tmp_dir}"
+make fund-local id_dir="${tmp_dir}"
 # }}}
 
 log "Waiting for nodes startup"

--- a/scripts/toolchain/Dockerfile
+++ b/scripts/toolchain/Dockerfile
@@ -21,8 +21,6 @@ RUN apk add --no-cache --update \
     rm -v /tmp/*.apk && \
     /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
     echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
-    #ln -s /lib/glibc-compat/lib/ld-linux-x86-64.so.2 /lib/ && \
-    #ln -s /lib/glibc-compat/lib64/ld-linux-x86-64.so.2 /lib64/
 
 # Gets yarn executable
 COPY .yarn .yarn/

--- a/scripts/toolchain/Dockerfile
+++ b/scripts/toolchain/Dockerfile
@@ -7,8 +7,22 @@ WORKDIR /app/hoprnet-toolchain
 
 RUN mkdir -p scripts/toolchain
 
-# python, perl are used by some nodejs dependencies as an installation requirement
-RUN apk add --no-cache bash build-base ca-certificates jq curl git
+# install glibc for alpine to be compatible with libc-based software
+ENV GLIBC_REPO=https://github.com/sgerrand/alpine-pkg-glibc
+ENV GLIBC_VERSION=2.34-r0
+
+RUN apk add --no-cache --update \
+      bash build-base ca-certificates jq curl git libstdc++ lsof && \
+    for pkg in glibc-${GLIBC_VERSION} glibc-bin-${GLIBC_VERSION}; do \
+      curl -sSL ${GLIBC_REPO}/releases/download/${GLIBC_VERSION}/${pkg}.apk -o /tmp/${pkg}.apk; \
+    done && \
+    apk add --force-overwrite --allow-untrusted /tmp/*.apk && \
+    apk fix --force-overwrite alpine-baselayout-data && \
+    rm -v /tmp/*.apk && \
+    /usr/glibc-compat/sbin/ldconfig /lib /usr/glibc-compat/lib && \
+    echo 'hosts: files mdns4_minimal [NOTFOUND=return] dns mdns4' >> /etc/nsswitch.conf
+    #ln -s /lib/glibc-compat/lib/ld-linux-x86-64.so.2 /lib/ && \
+    #ln -s /lib/glibc-compat/lib64/ld-linux-x86-64.so.2 /lib64/
 
 # Gets yarn executable
 COPY .yarn .yarn/

--- a/scripts/toolchain/Dockerfile
+++ b/scripts/toolchain/Dockerfile
@@ -3,20 +3,25 @@ FROM alpine:3.16@sha256:3d426b0bfc361d6e8303f51459f17782b219dece42a1c7fe463b6014
 
 LABEL description="Image that contains all utilities necessary to build hopr monorepo, including Rust and Yarn"
 
+WORKDIR /app/hoprnet-toolchain
+
+RUN mkdir -p scripts/toolchain
+
 # python, perl are used by some nodejs dependencies as an installation requirement
 RUN apk add --no-cache bash build-base ca-certificates jq curl git
-
-WORKDIR /app/hoprnet-toolchain
 
 # Gets yarn executable
 COPY .yarn .yarn/
 
-COPY package.json .yarnrc.yml rust-toolchain.toml .nvmrc yarn.lock Cargo.toml ./
-RUN mkdir -p scripts/toolchain
+COPY Makefile package.json .yarnrc.yml rust-toolchain.toml .nvmrc yarn.lock Cargo.toml ./
+
 COPY scripts/toolchain/install-toolchain.sh ./scripts/toolchain
 
 # Make sure that Rust toolchain utilities can be found
-ENV PATH=${PATH}:${HOME}/.cargo/bin
+ENV PATH=${PATH}:${HOME}/.cargo/bin:/app/hoprnet-toolchain/.foundry/bin
+
+# Install foundry
+RUN make install-foundry
 
 # Downloads prebuilt toolchain utilities
 RUN ./scripts/toolchain/install-toolchain.sh

--- a/scripts/toolchain/install-toolchain.sh
+++ b/scripts/toolchain/install-toolchain.sh
@@ -15,8 +15,8 @@ mydir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 # - Node.js -> /usr/local/bin
 # - Yarn -> /usr/local/bin + /opt/yarn-v${version}
 # - Typescript + related utilities, such as ts-node -> ${mydir}/node_modules
-# - Rust (rustc, cargo) -> $HOME/.cargo/bin
-# - wasm-pack + wasm-opt, necessary to build WebAssembly modules -> $HOME/.cargo/bin
+# - Rust (rustc, cargo) -> ./../../.cargo/bin
+# - wasm-pack + wasm-opt, necessary to build WebAssembly modules -> ./../../.cargo/bin
 #
 # Supposed to work for
 #   x86_64: Docker + Alpine
@@ -36,7 +36,9 @@ function usage() {
   msg
 }
 
-export PATH=${PATH}:${mydir}/../../.cargo/bin
+# Set PATH such that `cargo` is available within this script
+export CARGO_BIN_DIR="${mydir}/../../.cargo/bin"
+export PATH=${PATH}:${CARGO_BIN_DIR}
 
 declare install_all with_yarn
 install_all="true"
@@ -87,8 +89,6 @@ function install_rustup() {
         echo "Installing Rustup"
         # Get rustup but install toolchain later
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- ----no-modify-path --default-toolchain none -y
-        # Set PATH such that `cargo` is available within this script
-        PATH=${PATH}:${HOME}/.cargo/bin
     fi
 }
 
@@ -127,9 +127,9 @@ function install_wasm_pack() {
         esac
         curl -fsSLO --compressed "https://github.com/rustwasm/wasm-pack/releases/download/${wasm_pack_release}/wasm-pack-${wasm_pack_release}-${cputype}-${ostype}.tar.gz"
         tar -xzf "wasm-pack-${wasm_pack_release}-${cputype}-${ostype}.tar.gz"
-        local install_dir="${HOME}/.cargo"
-        mkdir -p "${install_dir}/bin"
-        cp "wasm-pack-${wasm_pack_release}-${cputype}-${ostype}/wasm-pack" "${install_dir}/bin"
+        local install_dir="${CARGO_BIN_DIR}"
+        mkdir -p "${install_dir}"
+        cp "wasm-pack-${wasm_pack_release}-${cputype}-${ostype}/wasm-pack" "${install_dir}"
         cd ${mydir}
     fi
 }
@@ -157,9 +157,9 @@ function install_wasm_opt() {
         local binaryen_release="version_$(echo "${wasm_opt_release}" | awk -F. '{ print $2; }')"
         curl -fsSLO --compressed "https://github.com/WebAssembly/binaryen/releases/download/${binaryen_release}/binaryen-${binaryen_release}-${cputype}-${ostype}.tar.gz"
         tar -xzf "binaryen-${binaryen_release}-${cputype}-${ostype}.tar.gz"
-        local install_dir="${HOME}/.cargo"
-        mkdir -p "${install_dir}/bin"
-        cp "binaryen-${binaryen_release}/bin/wasm-opt" "${install_dir}/bin"
+        local install_dir="${CARGO_BIN_DIR}"
+        mkdir -p "${install_dir}"
+        cp "binaryen-${binaryen_release}/bin/wasm-opt" "${install_dir}"
         cp -R "binaryen-${binaryen_release}/lib" "${install_dir}"
         cd ${mydir}
     fi

--- a/scripts/toolchain/install-toolchain.sh
+++ b/scripts/toolchain/install-toolchain.sh
@@ -202,13 +202,17 @@ function install_javascript_utilities() {
 if ${install_all}; then
     install_rustup
     install_cargo
+
+    # launch rustc once so it installs updated components
+    rustc --version
+
     install_wasm_pack
     install_wasm_opt
     install_node_js
     install_yarn
     install_javascript_utilities
 
-   # We got yarn, so let's remove no longer necessary cache
+    # We got yarn, so let's remove no longer necessary cache
     yarn cache clean --all
 else
     # We only need Node.js
@@ -221,14 +225,17 @@ else
 fi
 
 # Show some debug output
+echo ""
 echo "Checking installed tool versions"
 echo "================================"
-[ command -v rustc ] && rustc --version
-[ command -v cargo ] && cargo --version
-[ command -v wasm-pack ] && wasm-pack --version
-[ command -v wasm-opt ] && wasm-opt --version
-[ command -v node ] && echo "node $(node --version)"
-[ command -v yarn ] && echo "yarn $(yarn --version)"
-[ npx --no tsc --version ] && echo "Typescript $(npx tsc --version)"
+echo ""
+command -v rustc >/dev/null && rustc --version
+command -v cargo >/dev/null && cargo --version
+command -v wasm-pack >/dev/null && wasm-pack --version
+command -v wasm-opt >/dev/null && wasm-opt --version
+command -v node >/dev/null && echo "node $(node --version)"
+command -v yarn >/dev/null && echo "yarn $(yarn --version)"
+npx --no tsc --version >/dev/null && echo "Typescript $(npx tsc --version)"
+echo ""
 
 rm -R ${download_dir}

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -6,7 +6,6 @@ test "$?" -eq "0" || { echo "This script should only be sourced." >&2; exit 1; }
 
 # exit on errors, undefined variables, ensure errors in pipes are not hidden
 set -Eeuo pipefail
-set -x
 
 # $1=version string, semver
 function get_version_maj_min() {

--- a/scripts/vm-nat-testing/startup-network.sh
+++ b/scripts/vm-nat-testing/startup-network.sh
@@ -10,21 +10,21 @@ declare anvil_rpc_log="/tmp/anvil.logs"
 if [ "$(curl -s -o /dev/null -w ''%{http_code}'' 127.0.0.1:8545)" != "200" ]; then
 	# make sure other node instances are killed
 	sudo pkill node || :
-	# Start the HardHat network on localhost
-	echo "Starting HardHat network..."
-	make -C "${hopr_dir}" run-anvil > ${anvil_rpc_log} 2>&1 &
+	# Start the Anvil network on localhost
+	echo "Starting Anvil network..."
+	make -C "${hopr_dir}" run-anvil
 fi
 
 while [[
 	"$(curl -s -o /dev/null -w ''%{http_code}'' 127.0.0.1:8545)" != "200" ||
 	! -f "${anvil_rpc_log}" ||
-  -z "$(grep "Started HTTP and WebSocket JSON-RPC server" "${anvil_rpc_log}" || echo "")"
+  -z "$(grep "Listening on 127.0.0.1:8545" "${anvil_rpc_log}" || echo "")"
 	]] ; do
 	echo "Waiting for anvil network to come up..."
 	sleep 5;
 done
 
-echo "HardHat provider started up!"
+echo "Anvil provider started up!"
 # Copies all the deployment files including the .chainId file
 declare protocol_config="${mydir}/../packages/core/protocol-config.json"
 declare deployments_summary="${mydir}/../packages/ethereum/contracts/contracts-addresses.json"


### PR DESCRIPTION
Our Docker images relied heavily on the hardhat-based setup. Therefore, all images had to be adapted to work with anvil/forge. As a part of that the hardhat image has been replaced by the anvil image.

Ref #4230 