### PR TITLE
Fix validation of out-of-order tickets

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -92,9 +92,8 @@ jobs:
         if: ${{ !env.ACT }}
         run: ./scripts/deploy-smart-contracts.sh
         env:
-          DEPLOYER_WALLET_PRIVATE_KEY: ${{ secrets.DEPLOYER_WALLET_PRIVATE_KEY }}
+          DEPLOYER_PRIVATE_KEY: ${{ secrets.DEPLOYER_WALLET_PRIVATE_KEY }}
           ETHERSCAN_API_KEY: ${{ secrets.ETHERSCAN }}
-          BLOCKSCOUT_KEY: ${{ secrets.BLOCKSCOUT }}
           GNOSISSCAN_API_KEY: ${{ secrets.GNOSISSCAN_API_KEY }}
 
       - name: "[SMART-CONTRACTS] Commit & push changes"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Migrate hoprd CLI to Rust ([#4491](https://github.com/hoprnet/hoprnet/pull/4491))
 - Smart contract toolchain upgrade ([#4382](https://github.com/hoprnet/hoprnet/pull/4230))
 - Switch staging environment to using Gnosis Chain instead of Goerli ([#4497](https://github.com/hoprnet/hoprnet/pull/4497))
+- Fix of ticket validation to be order-independent, thus not rejecting older tickets ([#4527]((https://github.com/hoprnet/hoprnet/pull/4527))
 
 <a name="1.91"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Migrate hoprd CLI to Rust ([#4491](https://github.com/hoprnet/hoprnet/pull/4491))
 - Smart contract toolchain upgrade ([#4382](https://github.com/hoprnet/hoprnet/pull/4230))
 - Switch staging environment to using Gnosis Chain instead of Goerli ([#4497](https://github.com/hoprnet/hoprnet/pull/4497))
-- Fix of ticket validation to be order-independent, thus not rejecting older tickets ([#4527]((https://github.com/hoprnet/hoprnet/pull/4527))
+- Fix of ticket validation to be order-independent, thus not rejecting older tickets ([#4527](<(https://github.com/hoprnet/hoprnet/pull/4527)>)
 
 <a name="1.91"></a>
 

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ ifeq ($(package),)
 # cargo test --target wasm32-unknown-unknow
 else
 	yarn workspace @hoprnet/${package} run test
-	yarn workspace @horpnet/${package} run test:wasm
+	yarn workspace @hoprnet/${package} run test:wasm
 endif
 
 .PHONY: smart-contract-test

--- a/packages/core/src/messages/packet.ts
+++ b/packages/core/src/messages/packet.ts
@@ -206,32 +206,15 @@ export async function validateUnacknowledgedTicket(
     })
   })
 
-  const { unrealizedBalance, unrealizedIndex } = tickets.reduce(
+  const unrealizedBalance = tickets.reduce(
     (result, t) => {
-      // update index
-      if (result.unrealizedIndex.toBN().lt(t.index.toBN())) {
-        result.unrealizedIndex = t.index
-      }
-
       // update balance
-      result.unrealizedBalance = result.unrealizedBalance.sub(t.amount)
+      result = result.sub(t.amount)
 
       return result
     },
-    {
-      unrealizedBalance: channel.balance,
-      unrealizedIndex: channel.ticketIndex
-    }
+      channel.balance,
   )
-
-  // ticket's index MUST be higher than the channel's ticket index
-  if (ticket.index.toBN().lt(unrealizedIndex.toBN())) {
-    throw Error(
-      `Ticket index ${ticket.index.toBN().toString()} for channel ${channel
-        .getId()
-        .toHex()} must be higher than last ticket index ${unrealizedIndex.toBN().toString()}`
-    )
-  }
 
   // ensure sender has enough funds
   if (ticket.amount.toBN().gt(unrealizedBalance.toBN())) {

--- a/packages/core/src/messages/packet.ts
+++ b/packages/core/src/messages/packet.ts
@@ -141,7 +141,9 @@ export function createZeroHopTicket(dest: PublicKey, challenge: Challenge, privK
 // are always an integer multiple of the base unit.
 
 /**
- * Validate unacknowledged tickets as we receive them
+ * Validate unacknowledged tickets as we receive them. 
+ * Out of order validation is allowed. Ordering is enforced
+ * when tickets are redeemed.
  */
 export async function validateUnacknowledgedTicket(
   themPeerId: PeerId,
@@ -196,8 +198,7 @@ export async function validateUnacknowledgedTicket(
     )
   }
 
-  // find out latest index and pending balance
-  // from unredeemed tickets
+  // find out pending balance from unredeemed tickets
 
   // all tickets from sender
   const tickets = await getTickets().then((ts) => {

--- a/packages/core/src/messages/packet.ts
+++ b/packages/core/src/messages/packet.ts
@@ -141,7 +141,7 @@ export function createZeroHopTicket(dest: PublicKey, challenge: Challenge, privK
 // are always an integer multiple of the base unit.
 
 /**
- * Validate unacknowledged tickets as we receive them. 
+ * Validate unacknowledged tickets as we receive them.
  * Out of order validation is allowed. Ordering is enforced
  * when tickets are redeemed.
  */
@@ -207,15 +207,12 @@ export async function validateUnacknowledgedTicket(
     })
   })
 
-  const unrealizedBalance = tickets.reduce(
-    (result, t) => {
-      // update balance
-      result = result.sub(t.amount)
+  const unrealizedBalance = tickets.reduce((result, t) => {
+    // update balance
+    result = result.sub(t.amount)
 
-      return result
-    },
-      channel.balance,
-  )
+    return result
+  }, channel.balance)
 
   // ensure sender has enough funds
   if (ticket.amount.toBN().gt(unrealizedBalance.toBN())) {

--- a/packages/core/src/messages/validations.spec.ts
+++ b/packages/core/src/messages/validations.spec.ts
@@ -145,9 +145,8 @@ describe('messages/validations.spec.ts - unit test validateUnacknowledgedTicket'
       new UINT256(new BN(2))
     )
 
-    return expect(
-      validateUnacknowledgedTicket(SENDER, new BN(1), new BN(1), signedTicket, mockChannel, getTicketsMock)
-    ).to.not.eventually.rejected
+    return expect(validateUnacknowledgedTicket(SENDER, new BN(1), new BN(1), signedTicket, mockChannel, getTicketsMock))
+      .to.not.eventually.rejected
   })
 
   it("should not throw if ticket's index is smaller than the last ticket index when you include unredeemed tickets", async function () {

--- a/packages/core/src/messages/validations.spec.ts
+++ b/packages/core/src/messages/validations.spec.ts
@@ -136,7 +136,7 @@ describe('messages/validations.spec.ts - unit test validateUnacknowledgedTicket'
     ).to.eventually.rejectedWith('Ticket was created for a different channel iteration')
   })
 
-  it("should throw if ticket's index is smaller than the last ticket index", async function () {
+  it("should not throw if ticket's index is smaller than the last ticket index", async function () {
     const signedTicket = createMockTicket({})
     const mockChannel = await mockChannelEntry(
       true,
@@ -147,14 +147,14 @@ describe('messages/validations.spec.ts - unit test validateUnacknowledgedTicket'
 
     return expect(
       validateUnacknowledgedTicket(SENDER, new BN(1), new BN(1), signedTicket, mockChannel, getTicketsMock)
-    ).to.eventually.rejectedWith('must be higher than last ticket index')
+    ).to.not.eventually.rejected
   })
 
-  it("should throw if ticket's index is smaller than the last ticket index when you include unredeemed tickets", async function () {
+  it("should not throw if ticket's index is smaller than the last ticket index when you include unredeemed tickets", async function () {
     const signedTicket = createMockTicket({})
     const mockChannel = await mockChannelEntry(
       true,
-      new Balance(new BN(100)),
+      new Balance(new BN(200)),
       new UINT256(new BN(1)),
       new UINT256(new BN(1))
     )
@@ -167,7 +167,7 @@ describe('messages/validations.spec.ts - unit test validateUnacknowledgedTicket'
 
     return expect(
       validateUnacknowledgedTicket(SENDER, new BN(1), new BN(1), signedTicket, mockChannel, async () => ticketsInDb)
-    ).to.eventually.rejectedWith('must be higher than last ticket index')
+    ).to.not.eventually.rejected
   })
 
   it('should throw if channel does not have enough funds', async function () {

--- a/scripts/api.sh
+++ b/scripts/api.sh
@@ -261,7 +261,7 @@ api_close_channel() {
   if [ "${close_check}" = "true" ]; then
     result="$(api_call ${source_api} "/channels/${destination_peer_id}/${channel_direction}" "DELETE" "" 'Closed|Channel is already closed' 600)"
   else
-    result="$(api_call ${source_api} "/channels/${destination_peer_id}/${channel_direction}" "DELETE" "" 'PendingToClose|Closed' 20 20)"
+    result="$(api_call ${source_api} "/channels/${destination_peer_id}/${channel_direction}" "DELETE" "" 'PendingToClose|Closed' 60 20)"
   fi
 
   log "Node ${source_id} close channel to Node ${destination_id} result -- ${result}"


### PR DESCRIPTION
Refs #4505 

This PR changes the ticket validation to be order-independent. The order is still being enforced at the ticket redemption stage. This unlocks the smoke tests which are green again.

Moreover, some minor build issues were fixed.