### PR TITLE
publish-version: Fix incorrect use of old ethereum package

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -60,7 +60,6 @@ jobs:
           make -j deps-ci
           make -j build-docs
         env:
-          # use the default test private key from foundry
           DEPLOYER_PRIVATE_KEY: 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
 
       - name: Format newly created files

--- a/README.md
+++ b/README.md
@@ -140,36 +140,58 @@ The `hoprd` provides various command-line switches to configure its behaviour. F
 ```sh
 $ hoprd --help
 Options:
-  --help                         Show help  [boolean]
-  --version                      Show version number  [boolean]
-  --environment                  Environment id which the node shall run on (HOPRD_ENVIRONMENT)  [string] [choices: "anvil-localhost", "anvil-localhost2", "master-staging", "debug-staging", "tuttlingen", "prague", "budapest", "athens", "lisbon", "ouagadougou", "paleochora", "monte_rosa"] [default: ""]
-  --host                         The network host to run the HOPR node on [env: HOPRD_HOST]  [string] [default: "0.0.0.0:9091"]
-  --announce                     Announce public IP to the network [env: HOPRD_ANNOUNCE]  [boolean] [default: false]
-  --api                          Expose the API on localhost:3001, requires --apiToken. [env: HOPRD_API]  [boolean] [default: false]
-  --apiHost                      Set host IP to which the API server will bind. [env: HOPRD_API_HOST]  [string] [default: "localhost"]
-  --apiPort                      Set host port to which the API server will bind. [env: HOPRD_API_PORT]  [number] [default: 3001]
-  --healthCheck                  Run a health check end point on localhost:8080 [env: HOPRD_HEALTH_CHECK]  [boolean] [default: false]
-  --healthCheckHost              Updates the host for the healthcheck server [env: HOPRD_HEALTH_CHECK_HOST]  [string] [default: "localhost"]
-  --healthCheckPort              Updates the port for the healthcheck server [env: HOPRD_HEALTH_CHECK_PORT]  [number] [default: 8080]
-  --password                     A password to encrypt your keys [env: HOPRD_PASSWORD]  [string] [default: ""]
-  --apiToken                     A REST API token for user authentication [env: HOPRD_API_TOKEN]  [string]
-  --privateKey                   A private key to be used for the node [env: HOPRD_PRIVATE_KEY]  [string]
-  --provider                     A custom RPC provider to be used for the node to connect to blockchain [env: HOPRD_PROVIDER]  [string]
-  --identity                     The path to the identity file [env: HOPRD_IDENTITY]  [string] [default: "/home/tino/.hopr-identity"]
-  --dryRun                       List all the options used to run the HOPR node, but quit instead of starting [env: HOPRD_DRY_RUN]  [boolean] [default: false]
-  --data                         manually specify the data directory to use [env: HOPRD_DATA]  [string] [default: "/home/tino/work/hopr/hoprnet/packages/hoprd"]
-  --init                         initialize a database if it doesn't already exist [env: HOPRD_INIT]  [boolean] [default: false]
-  --allowLocalNodeConnections    Allow connections to other nodes running on localhost [env: HOPRD_ALLOW_LOCAL_NODE_CONNECTIONS]  [boolean] [default: false]
-  --allowPrivateNodeConnections  Allow connections to other nodes running on private addresses [env: HOPRD_ALLOW_PRIVATE_NODE_CONNECTIONS]  [boolean] [default: false]
-  --testAnnounceLocalAddresses   For testing local testnets. Announce local addresses [env: HOPRD_TEST_ANNOUNCE_LOCAL_ADDRESSES]  [boolean] [default: false]
-  --testPreferLocalAddresses     For testing local testnets. Prefer local peers to remote [env: HOPRD_TEST_PREFER_LOCAL_ADDRESSES]  [boolean] [default: false]
-  --testUseWeakCrypto            weaker crypto for faster node startup [env: HOPRD_TEST_USE_WEAK_CRYPTO]  [boolean] [default: false]
-  --disableApiAuthentication     Disable authentication for the API endpoints [env: HOPRD_DISABLE_API_AUTHENTICATION]  [boolean] [default: false]
-  --heartbeatInterval            Interval in milliseconds in which the availability of other nodes get measured [env: HOPRD_HEARTBEAT_INTERVAL]  [number] [default: 60000]
-  --heartbeatThreshold           Timeframe in milliseconds after which a heartbeat to another peer is performed, if it hasn't been seen since [env: HOPRD_HEARTBEAT_THRESHOLD]  [number] [default: 60000]
-  --heartbeatVariance            Upper bound for variance applied to heartbeat interval in milliseconds [env: HOPRD_HEARTBEAT_VARIANCE]  [number] [default: 2000]
-  --networkQualityThreshold      Miniumum quality of a peer connection to be considered usable [env: HOPRD_NETWORK_QUALITY_THRESHOLD]  [number] [default: 0.5]
-  --onChainConfirmations         Number of confirmations required for on-chain transactions [env: HOPRD_ON_CHAIN_CONFIRMATIONS]  [number] [default: 8]
+      --environment <ENVIRONMENT>
+          Environment id which the node shall run on [env: HOPRD_ENVIRONMENT=] [possible values: anvil-localhost, master-staging, debug-staging, anvil-localhost2, monte_rosa]
+      --identity <identity>
+          The path to the identity file [env: HOPRD_IDENTITY=] [default: /home/tino/.hopr-identity]
+      --data <data>
+          manually specify the data directory to use [env: HOPRD_DATA=] [default: /home/tino/work/hopr/hoprnet/packages/hoprd/hoprd-db]
+      --host <HOST>
+          Host to listen on for P2P connections [env: HOPRD_HOST=] [default: 0.0.0.0:9091]
+      --announce
+          Run as a Public Relay Node (PRN) [env: HOPRD_ANNOUNCE=]
+      --api
+          Expose the API on localhost:3001 [env: HOPRD_API=]
+      --apiHost <HOST>
+          Set host IP to which the API server will bind [env: HOPRD_API_HOST=] [default: localhost]
+      --apiPort <PORT>
+          Set port to which the API server will bind [env: HOPRD_API_PORT=] [default: 3001]
+      --apiToken <TOKEN>
+          A REST API token and for user authentication [env: HOPRD_API_TOKEN=]
+      --healthCheck
+          Run a health check end point on localhost:8080 [env: HOPRD_HEALTH_CHECK=]
+      --healthCheckHost <HOST>
+          Updates the host for the healthcheck server [env: HOPRD_HEALTH_CHECK_HOST=] [default: localhost]
+      --healthCheckPort <PORT>
+          Updates the port for the healthcheck server [env: HOPRD_HEALTH_CHECK_PORT=] [default: 8080]
+      --password <PASSWORD>
+          A password to encrypt your keys [env: HOPRD_PASSWORD=]
+      --provider <PROVIDER>
+          A custom RPC provider to be used for the node to connect to blockchain [env: HOPRD_PROVIDER=]
+      --dryRun
+          List all the options used to run the HOPR node, but quit instead of starting [env: HOPRD_DRY_RUN=]
+      --init
+          initialize a database if it doesn't already exist [env: HOPRD_INIT=]
+      --allowLocalNodeConnections
+          Allow connections to other nodes running on localhost [env: HOPRD_ALLOW_LOCAL_NODE_CONNECTIONS=]
+      --allowPrivateNodeConnections
+          Allow connections to other nodes running on private addresses [env: HOPRD_ALLOW_PRIVATE_NODE_CONNECTIONS=]
+      --testAnnounceLocalAddresses
+          For testing local testnets. Announce local addresses [env: HOPRD_TEST_ANNOUNCE_LOCAL_ADDRESSES=]
+      --heartbeatInterval <MILLISECONDS>
+          Interval in milliseconds in which the availability of other nodes get measured [env: HOPRD_HEARTBEAT_INTERVAL=] [default: 60000]
+      --heartbeatThreshold <MILLISECONDS>
+          Timeframe in milliseconds after which a heartbeat to another peer is performed, if it hasn't been seen since [env: HOPRD_HEARTBEAT_THRESHOLD=] [default: 60000]
+      --heartbeatVariance <MILLISECONDS>
+          Upper bound for variance applied to heartbeat interval in milliseconds [env: HOPRD_HEARTBEAT_VARIANCE=] [default: 2000]
+      --onChainConfirmations <CONFIRMATIONS>
+          Number of confirmations required for on-chain transactions [env: HOPRD_ON_CHAIN_CONFIRMATIONS=] [default: 8]
+      --networkQualityThreshold <THRESHOLD>
+          Miniumum quality of a peer connection to be considered usable [env: HOPRD_NETWORK_QUALITY_THRESHOLD=] [default: 0.5]
+  -h, --help
+          Print help
+  -V, --version
+          Print version
 
 All CLI options can be configured through environment variables as well. CLI parameters have precedence over environment variables.
 ```
@@ -532,3 +554,5 @@ whenever you need an issue about a particular tool.
 [10]: https://github.com/hoprnet/hoprnet/pull/1974/commits/331d6e99d1199250a302211be7b8dd9a22fa6e23#diff-83e70acfe04a8f13821ff96a1115f02a4b683a6370568ba9beea16da6d0c2cffR33-R49
 [11]: https://github.com/hoprnet/hoprnet/pull/1974/commits/53663517309d0f8918c5066fd98503afe8d8dd76#diff-9bf7c02325c8f5b6330a15a745a3ad736ee139a78c28a15d594756c406378884R91-R96
 [12]: https://github.com/nomiclabs/hardhat/issues/1116
+
+

--- a/README.md
+++ b/README.md
@@ -554,5 +554,3 @@ whenever you need an issue about a particular tool.
 [10]: https://github.com/hoprnet/hoprnet/pull/1974/commits/331d6e99d1199250a302211be7b8dd9a22fa6e23#diff-83e70acfe04a8f13821ff96a1115f02a4b683a6370568ba9beea16da6d0c2cffR33-R49
 [11]: https://github.com/hoprnet/hoprnet/pull/1974/commits/53663517309d0f8918c5066fd98503afe8d8dd76#diff-9bf7c02325c8f5b6330a15a745a3ad736ee139a78c28a15d594756c406378884R91-R96
 [12]: https://github.com/nomiclabs/hardhat/issues/1116
-
-

--- a/packages/hoprd/README.md
+++ b/packages/hoprd/README.md
@@ -22,36 +22,58 @@ See `hoprd --help` for full list.
 ```sh
 $ hoprd --help
 Options:
-  --help                         Show help  [boolean]
-  --version                      Show version number  [boolean]
-  --environment                  Environment id which the node shall run on (HOPRD_ENVIRONMENT)  [string] [choices: "anvil-localhost", "anvil-localhost2", "master-staging", "debug-staging", "tuttlingen", "prague", "budapest", "athens", "lisbon", "ouagadougou", "paleochora", "monte_rosa"] [default: ""]
-  --host                         The network host to run the HOPR node on [env: HOPRD_HOST]  [string] [default: "0.0.0.0:9091"]
-  --announce                     Announce public IP to the network [env: HOPRD_ANNOUNCE]  [boolean] [default: false]
-  --api                          Expose the API on localhost:3001, requires --apiToken. [env: HOPRD_API]  [boolean] [default: false]
-  --apiHost                      Set host IP to which the API server will bind. [env: HOPRD_API_HOST]  [string] [default: "localhost"]
-  --apiPort                      Set host port to which the API server will bind. [env: HOPRD_API_PORT]  [number] [default: 3001]
-  --healthCheck                  Run a health check end point on localhost:8080 [env: HOPRD_HEALTH_CHECK]  [boolean] [default: false]
-  --healthCheckHost              Updates the host for the healthcheck server [env: HOPRD_HEALTH_CHECK_HOST]  [string] [default: "localhost"]
-  --healthCheckPort              Updates the port for the healthcheck server [env: HOPRD_HEALTH_CHECK_PORT]  [number] [default: 8080]
-  --password                     A password to encrypt your keys [env: HOPRD_PASSWORD]  [string] [default: ""]
-  --apiToken                     A REST API token for user authentication [env: HOPRD_API_TOKEN]  [string]
-  --privateKey                   A private key to be used for the node [env: HOPRD_PRIVATE_KEY]  [string]
-  --provider                     A custom RPC provider to be used for the node to connect to blockchain [env: HOPRD_PROVIDER]  [string]
-  --identity                     The path to the identity file [env: HOPRD_IDENTITY]  [string] [default: "/home/tino/.hopr-identity"]
-  --dryRun                       List all the options used to run the HOPR node, but quit instead of starting [env: HOPRD_DRY_RUN]  [boolean] [default: false]
-  --data                         manually specify the data directory to use [env: HOPRD_DATA]  [string] [default: "/home/tino/work/hopr/hoprnet/packages/hoprd"]
-  --init                         initialize a database if it doesn't already exist [env: HOPRD_INIT]  [boolean] [default: false]
-  --allowLocalNodeConnections    Allow connections to other nodes running on localhost [env: HOPRD_ALLOW_LOCAL_NODE_CONNECTIONS]  [boolean] [default: false]
-  --allowPrivateNodeConnections  Allow connections to other nodes running on private addresses [env: HOPRD_ALLOW_PRIVATE_NODE_CONNECTIONS]  [boolean] [default: false]
-  --testAnnounceLocalAddresses   For testing local testnets. Announce local addresses [env: HOPRD_TEST_ANNOUNCE_LOCAL_ADDRESSES]  [boolean] [default: false]
-  --testPreferLocalAddresses     For testing local testnets. Prefer local peers to remote [env: HOPRD_TEST_PREFER_LOCAL_ADDRESSES]  [boolean] [default: false]
-  --testUseWeakCrypto            weaker crypto for faster node startup [env: HOPRD_TEST_USE_WEAK_CRYPTO]  [boolean] [default: false]
-  --disableApiAuthentication     Disable authentication for the API endpoints [env: HOPRD_DISABLE_API_AUTHENTICATION]  [boolean] [default: false]
-  --heartbeatInterval            Interval in milliseconds in which the availability of other nodes get measured [env: HOPRD_HEARTBEAT_INTERVAL]  [number] [default: 60000]
-  --heartbeatThreshold           Timeframe in milliseconds after which a heartbeat to another peer is performed, if it hasn't been seen since [env: HOPRD_HEARTBEAT_THRESHOLD]  [number] [default: 60000]
-  --heartbeatVariance            Upper bound for variance applied to heartbeat interval in milliseconds [env: HOPRD_HEARTBEAT_VARIANCE]  [number] [default: 2000]
-  --networkQualityThreshold      Miniumum quality of a peer connection to be considered usable [env: HOPRD_NETWORK_QUALITY_THRESHOLD]  [number] [default: 0.5]
-  --onChainConfirmations         Number of confirmations required for on-chain transactions [env: HOPRD_ON_CHAIN_CONFIRMATIONS]  [number] [default: 8]
+      --environment <ENVIRONMENT>
+          Environment id which the node shall run on [env: HOPRD_ENVIRONMENT=] [possible values: anvil-localhost, master-staging, debug-staging, anvil-localhost2, monte_rosa]
+      --identity <identity>
+          The path to the identity file [env: HOPRD_IDENTITY=] [default: /home/tino/.hopr-identity]
+      --data <data>
+          manually specify the data directory to use [env: HOPRD_DATA=] [default: /home/tino/work/hopr/hoprnet/packages/hoprd/hoprd-db]
+      --host <HOST>
+          Host to listen on for P2P connections [env: HOPRD_HOST=] [default: 0.0.0.0:9091]
+      --announce
+          Run as a Public Relay Node (PRN) [env: HOPRD_ANNOUNCE=]
+      --api
+          Expose the API on localhost:3001 [env: HOPRD_API=]
+      --apiHost <HOST>
+          Set host IP to which the API server will bind [env: HOPRD_API_HOST=] [default: localhost]
+      --apiPort <PORT>
+          Set port to which the API server will bind [env: HOPRD_API_PORT=] [default: 3001]
+      --apiToken <TOKEN>
+          A REST API token and for user authentication [env: HOPRD_API_TOKEN=]
+      --healthCheck
+          Run a health check end point on localhost:8080 [env: HOPRD_HEALTH_CHECK=]
+      --healthCheckHost <HOST>
+          Updates the host for the healthcheck server [env: HOPRD_HEALTH_CHECK_HOST=] [default: localhost]
+      --healthCheckPort <PORT>
+          Updates the port for the healthcheck server [env: HOPRD_HEALTH_CHECK_PORT=] [default: 8080]
+      --password <PASSWORD>
+          A password to encrypt your keys [env: HOPRD_PASSWORD=]
+      --provider <PROVIDER>
+          A custom RPC provider to be used for the node to connect to blockchain [env: HOPRD_PROVIDER=]
+      --dryRun
+          List all the options used to run the HOPR node, but quit instead of starting [env: HOPRD_DRY_RUN=]
+      --init
+          initialize a database if it doesn't already exist [env: HOPRD_INIT=]
+      --allowLocalNodeConnections
+          Allow connections to other nodes running on localhost [env: HOPRD_ALLOW_LOCAL_NODE_CONNECTIONS=]
+      --allowPrivateNodeConnections
+          Allow connections to other nodes running on private addresses [env: HOPRD_ALLOW_PRIVATE_NODE_CONNECTIONS=]
+      --testAnnounceLocalAddresses
+          For testing local testnets. Announce local addresses [env: HOPRD_TEST_ANNOUNCE_LOCAL_ADDRESSES=]
+      --heartbeatInterval <MILLISECONDS>
+          Interval in milliseconds in which the availability of other nodes get measured [env: HOPRD_HEARTBEAT_INTERVAL=] [default: 60000]
+      --heartbeatThreshold <MILLISECONDS>
+          Timeframe in milliseconds after which a heartbeat to another peer is performed, if it hasn't been seen since [env: HOPRD_HEARTBEAT_THRESHOLD=] [default: 60000]
+      --heartbeatVariance <MILLISECONDS>
+          Upper bound for variance applied to heartbeat interval in milliseconds [env: HOPRD_HEARTBEAT_VARIANCE=] [default: 2000]
+      --onChainConfirmations <CONFIRMATIONS>
+          Number of confirmations required for on-chain transactions [env: HOPRD_ON_CHAIN_CONFIRMATIONS=] [default: 8]
+      --networkQualityThreshold <THRESHOLD>
+          Miniumum quality of a peer connection to be considered usable [env: HOPRD_NETWORK_QUALITY_THRESHOLD=] [default: 0.5]
+  -h, --help
+          Print help
+  -V, --version
+          Print version
 
 All CLI options can be configured through environment variables as well. CLI parameters have precedence over environment variables.
 ```

--- a/packages/hoprd/crates/hoprd-misc/src/cli.rs
+++ b/packages/hoprd/crates/hoprd-misc/src/cli.rs
@@ -170,7 +170,7 @@ struct CliArgs {
         value_parser = clap::value_parser!(u16),
         value_name = "PORT",
         help = "Set port to which the API server will bind",
-        env = "HOPRD_API_HOST"
+        env = "HOPRD_API_PORT"
     )]
     pub api_port: u16,
 

--- a/scripts/publish-version.sh
+++ b/scripts/publish-version.sh
@@ -54,7 +54,8 @@ if [ ! "${version_type}" = "patch" ] &&
 fi
 
 # define packages
-declare -a versioned_packages=( utils connect ethereum core-ethereum core real hoprd )
+# does not include ethereum, which isn't a real package anymore, just a folder
+declare -a versioned_packages=( utils connect core-ethereum core real hoprd )
 
 # ensure local copy is up-to-date with origin
 branch=$(git rev-parse --abbrev-ref HEAD)
@@ -85,10 +86,10 @@ environment_id="$("${mydir}/get-default-environment.sh")"
 log "using version template ${current_version} + ${version_type}"
 declare new_version
 new_version=$(npx semver --preid next -i "${version_type}" "${current_version}")
-log "creating new version ${new_version}"
 
 # create new version in each package
 for p in "${versioned_packages[@]}"; do
+  log "creating new version ${new_version} in package ${p}"
   cd "${mydir}/../packages/${p}"
   jq ".version = \"${new_version}\"" package.json > package.json.new
   mv package.json.new package.json
@@ -123,17 +124,16 @@ if [ "${CI:-}" = "true" ] && [ -z "${ACT:-}" ]; then
     --exclude @hoprnet/hoprd \
     npm publish --access public
 
-  "${mydir}/wait-for-npm-package.sh" utils
-  "${mydir}/wait-for-npm-package.sh" connect
-  "${mydir}/wait-for-npm-package.sh" ethereum
-  "${mydir}/wait-for-npm-package.sh" core-ethereum
-  "${mydir}/wait-for-npm-package.sh" core
-  "${mydir}/wait-for-npm-package.sh" real
+  for p in "${versioned_packages[@]}"; do
+    if [ "${p}" != "hoprd" ]; then
+      "${mydir}/wait-for-npm-package.sh" "${p}"
+    fi
+  done
 
   trap cleanup SIGINT SIGTERM ERR
 
   # set default environments
-  log "adding default environments to packages"
+  log "adding default environment ${environment_id} to hoprd package"
   echo "{\"id\": \"${environment_id}\"}" > "${mydir}/../packages/hoprd/default-environment.json"
 
   # special treatment for end-of-chain packages


### PR DESCRIPTION
Fixes the issue seen during publishing: https://github.com/hoprnet/hoprnet/actions/runs/3984409154/jobs/6830591979

Also fixes issue generating the API spec due to a typo in the CLI environment variables handler