### PR TITLE
Remove unused imports

### DIFF
--- a/packages/ethereum/foundry-tool/src/key_pair.rs
+++ b/packages/ethereum/foundry-tool/src/key_pair.rs
@@ -46,6 +46,7 @@ pub fn read_identities(
 mod tests {
 
     use super::*;
+    use ethers::core::rand::thread_rng;
 
     #[test]
     fn read_identities_from_directory_with_id_files() {

--- a/packages/ethereum/foundry-tool/src/key_pair.rs
+++ b/packages/ethereum/foundry-tool/src/key_pair.rs
@@ -1,5 +1,4 @@
 use ethers::core::k256::ecdsa::SigningKey;
-use ethers::core::rand::thread_rng;
 use ethers::signers::Signer;
 use ethers::signers::Wallet;
 use ethers::types::Address;

--- a/packages/ethereum/foundry-tool/src/main.rs
+++ b/packages/ethereum/foundry-tool/src/main.rs
@@ -1,7 +1,5 @@
 use clap::{Parser, Subcommand};
 use ethers::types::Address;
-use std::path::Path;
-use std::process::Command;
 
 mod helper_errors;
 mod key_pair;


### PR DESCRIPTION
Removes unused imports from `foundry-tool` to keep the compiler quiet :)

````
warning: unused import: `ethers::core::rand::thread_rng`
 --> packages/ethereum/foundry-tool/src/key_pair.rs:2:5
  |
2 | use ethers::core::rand::thread_rng;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: `foundry-tool` (lib) generated 1 warning
warning: unused import: `std::path::Path`
 --> packages/ethereum/foundry-tool/src/main.rs:3:5
  |
3 | use std::path::Path;
  |     ^^^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused import: `std::process::Command`
 --> packages/ethereum/foundry-tool/src/main.rs:4:5
  |
4 | use std::process::Command;
  |     ^^^^^^^^^^^^^^^^^^^^^

warning: unused import: `ethers::core::rand::thread_rng`
 --> packages/ethereum/foundry-tool/src/key_pair.rs:2:5
  |
2 | use ethers::core::rand::thread_rng;
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

````