### PR TITLE
ignore vendor files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+vendor linguist-generated=true


### PR DESCRIPTION
Remove `vendor` directory from language counting in GitHub.

see https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github