### PR TITLE
Update our Rust & WASM guidelines

### DIFF
--- a/RUST_WASM.md
+++ b/RUST_WASM.md
@@ -119,7 +119,7 @@ therefore you MUST use only types which are compatible with BOTH. Avoid using WA
 
 Do not use any attribute. Types NOT compatible with WASM can be used freely.
 
-- trait implementations & generic types are NOT supported by `wasm-bindgen` and therefore they can be used only in pure Rust.
+- trait implementations, lifetimes & generic types are NOT supported by `wasm-bindgen` and therefore they can be used only in pure Rust.
 
 ### Something available only to WASM
 


### PR DESCRIPTION
After discussion with @robertkiel , adding new guidelines and tips on how to structure our Rust code with respect to WASM and non-WASM compatible code.

The purpose is to minimize code duplication.