### PR TITLE
Disable automatic compilation of Rust SC bindings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .POSIX:
 
 # Gets all packages that include a Rust crates
-WORKSPACES_WITH_RUST_MODULES := $(wildcard $(addsuffix /crates, $(wildcard ./packages/*)))
+# Disable automatic compilation of SC bindings. Can still be done manually.
+WORKSPACES_WITH_RUST_MODULES := $(filter-out ./packages/ethereum/crates,$(wildcard $(addsuffix /crates, $(wildcard ./packages/*))))
 
 # Gets all individual crates such that they can get built
 CRATES := $(foreach crate,${WORKSPACES_WITH_RUST_MODULES},$(dir $(wildcard $(crate)/*/Cargo.toml)))
@@ -138,7 +139,7 @@ build-solidity-types: ## generate Solidity typings
 
 .PHONY: build-yarn
 build-yarn: ## build yarn packages
-build-yarn: build-solidity-types build-cargo
+build-yarn: build-cargo
 ifeq ($(package),)
 	npx tsc --build tsconfig.build.json
 else
@@ -151,7 +152,8 @@ build-yarn-watch: build-solidity-types build-cargo
 	npx tsc --build tsconfig.build.json -w
 
 .PHONY: build-cargo
-build-cargo: build-solidity-types ## build cargo packages and create boilerplate JS code
+build-cargo: ## build cargo packages and create boilerplate JS code
+# build-cargo: build-solidity-types ## build cargo packages and create boilerplate JS code
 # Skip building Rust crates
 ifeq ($(origin NO_CARGO),undefined)
 # First compile Rust crates and create bindings


### PR DESCRIPTION
This prevents issue from using Foundry nightly to carry over into our CI. The bindings can still be compiled manually. Once we actually use them we have to figure out a way to pin Foundry versions.

Fixes issue seen in CI: https://github.com/hoprnet/hoprnet/actions/runs/4096580671/jobs/7064345676