### PR TITLE
Unblock CI

### DIFF
--- a/packages/ethereum/contracts/contracts-addresses.json
+++ b/packages/ethereum/contracts/contracts-addresses.json
@@ -25,28 +25,28 @@
       "token_contract_address": "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0"
     },
     "master-staging": {
-      "boost_contract_address": "0x43575668AC2c5066697101F27b4DC94819e490B7",
-      "indexer_start_block_number": 25878998,
+      "token_contract_address": "0xf1aDf07D0d4e1beFdDe79066771d057337e55c08",
+      "network_registry_proxy_contract_address": "0x628ED93eEBF1840bF26e8fB62BCe4F1BCCDE9e95",
+      "channels_contract_address": "0xB20ee6e0b714e531CabF2C29fbA147f4e5905B7b",
       "stake_season": 6,
-      "network_registry_proxy_contract_address": "0x32c4F15B80CDD75cA2f4Be9fAeF3503c15895cd0",
-      "token_contract_address": "0xEda0314AE77361e6Ba558053919d10Bcb60F236c",
-      "stake_contract_address": "0x8d9978466161c2897F483A93f51aDEA9e52d8D32",
+      "boost_contract_address": "0x2Fc87247085F4658ADB698cDbF4d732c704f1e06",
       "environment_type": "staging",
-      "channels_contract_address": "0x7e8c876Eab41238E3d03b5E202Ee5bC94425D8C3",
-      "xhopr_contract_address": "0x223c4Fe6d9C19cbdC6C66aa9a6b7Ce5a445BF884",
-      "network_registry_contract_address": "0xDD7b845405E931A7177270e2955E9683da19cFB1"
+      "xhopr_contract_address": "0x4DeCc7e6c63fF6c40630654A3b9C92b937369998",
+      "indexer_start_block_number": 26356392,
+      "network_registry_contract_address": "0x278A44a487D2Ca9303c2B9Abe00605B075cBa69F",
+      "stake_contract_address": "0x84F238243FA06cac8E9811Cc36D49CB6A86d4c62"
     },
     "debug-staging": {
-      "stake_contract_address": "0x6279e6966B5702af5CF28C2643470a42DbAf4886",
-      "channels_contract_address": "0xE6203F94FA1761A4481A365c637b8044dE286f01",
       "stake_season": 6,
+      "network_registry_proxy_contract_address": "0x9937Fa1497bE80C473c14B944E213bb381F18C34",
+      "token_contract_address": "0xf1aDf07D0d4e1beFdDe79066771d057337e55c08",
       "environment_type": "staging",
-      "indexer_start_block_number": 25879150,
-      "network_registry_proxy_contract_address": "0xc1351a3EC7eCD5C57B44798752dBCC5f549932AD",
-      "network_registry_contract_address": "0x0dD5c8A4686a899DB113865df03554b3D8F8c8b0",
-      "boost_contract_address": "0x43575668AC2c5066697101F27b4DC94819e490B7",
-      "token_contract_address": "0xEda0314AE77361e6Ba558053919d10Bcb60F236c",
-      "xhopr_contract_address": "0x223c4Fe6d9C19cbdC6C66aa9a6b7Ce5a445BF884"
+      "xhopr_contract_address": "0x4DeCc7e6c63fF6c40630654A3b9C92b937369998",
+      "indexer_start_block_number": 26356264,
+      "stake_contract_address": "0x27f10230F14c439bBC667433c3dA020e04A6E780",
+      "channels_contract_address": "0xd54eE5aDed3A4d2059A6f01DEbdb033BB5453433",
+      "network_registry_contract_address": "0xED4977EBf25137d5E5e039A7a848149d67679F6c",
+      "boost_contract_address": "0x2Fc87247085F4658ADB698cDbF4d732c704f1e06"
     },
     "monte_rosa": {
       "boost_contract_address": "0x43d13D7B83607F14335cF2cB75E87dA369D056c7",

--- a/packages/ethereum/contracts/script/DeployAll.s.sol
+++ b/packages/ethereum/contracts/script/DeployAll.s.sol
@@ -135,10 +135,6 @@ contract DeployAllContractsScript is
           currentEnvironmentDetail.hoprTokenContractAddress
         )
       );
-      emit log_named_address('boost', currentEnvironmentDetail.hoprBoostContractAddress);
-      emit log_named_address('xhopr', currentEnvironmentDetail.xhoprTokenContractAddress);
-      emit log_named_address('hopr', currentEnvironmentDetail.hoprTokenContractAddress);
-      emit log_named_address('stake', currentEnvironmentDetail.stakeContractAddress);
     }
 
     // 3.6. NetworkRegistryProxy Contract

--- a/packages/ethereum/contracts/script/DeployAll.s.sol
+++ b/packages/ethereum/contracts/script/DeployAll.s.sol
@@ -135,6 +135,10 @@ contract DeployAllContractsScript is
           currentEnvironmentDetail.hoprTokenContractAddress
         )
       );
+      emit log_named_address('boost', currentEnvironmentDetail.hoprBoostContractAddress);
+      emit log_named_address('xhopr', currentEnvironmentDetail.xhoprTokenContractAddress);
+      emit log_named_address('hopr', currentEnvironmentDetail.hoprTokenContractAddress);
+      emit log_named_address('stake', currentEnvironmentDetail.stakeContractAddress);
     }
 
     // 3.6. NetworkRegistryProxy Contract

--- a/packages/ethereum/contracts/src/stake/HoprStakeBase.sol
+++ b/packages/ethereum/contracts/src/stake/HoprStakeBase.sol
@@ -31,9 +31,9 @@ contract HoprStakeBase is Ownable, IERC777Recipient, IERC721Receiver, Reentrancy
   // public constants
   uint256 public constant FACTOR_DENOMINATOR = 1e12; // Denominator of the “Basic reward factor”. Default value is 1e12.
 
-  address public LOCK_TOKEN = 0xD057604A14982FE8D88c5fC25Aac3267eA142a08; // Token that HOPR holders need to lock to the contract: xHOPR address.
-  address public REWARD_TOKEN = 0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1; // Token that HOPR holders can claim as rewards: wxHOPR address
-  IHoprBoost public NFT_CONTRACT = IHoprBoost(0x43d13D7B83607F14335cF2cB75E87dA369D056c7); // Address of the HoprBoost NFT smart contract.
+  address public LOCK_TOKEN = 0xD057604A14982FE8D88c5fC25Aac3267eA142a08; // Token that HOPR holders need to lock to the contract: xHOPR address. Default value: HOPR on xdai
+  address public REWARD_TOKEN = 0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1; // Token that HOPR holders can claim as rewards: wxHOPR address Default value: wxHOPR
+  IHoprBoost public NFT_CONTRACT = IHoprBoost(0x43d13D7B83607F14335cF2cB75E87dA369D056c7); // Address of the HoprBoost NFT smart contract. Default value: HoprBoost
 
   // immutable variables defined in the constructor
   uint256 public immutable PROGRAM_START; // Block timestamp at which incentive program starts.
@@ -94,12 +94,10 @@ contract HoprStakeBase is Ownable, IERC777Recipient, IERC721Receiver, Reentrancy
     BOOST_CAP = _boostCap;
     transferOwnership(_newOwner);
     ERC1820_REGISTRY.setInterfaceImplementer(address(this), TOKENS_RECIPIENT_INTERFACE_HASH, address(this));
-    // implement in favor of testing
-    if (block.chainid != 100) {
-      LOCK_TOKEN = _lockToken;
-      REWARD_TOKEN = _rewardToken;
-      NFT_CONTRACT = IHoprBoost(_nftAddress);
-    }
+    // remove this condition as the staging environment is with Gnosis
+    LOCK_TOKEN = _lockToken;
+    REWARD_TOKEN = _rewardToken;
+    NFT_CONTRACT = IHoprBoost(_nftAddress);
   }
 
   /**

--- a/packages/ethereum/contracts/src/stake/HoprStakeSeason6.sol
+++ b/packages/ethereum/contracts/src/stake/HoprStakeSeason6.sol
@@ -29,18 +29,7 @@ contract HoprStakeSeason6 is HoprStakeBase {
     address _nftAddress,
     address _lockToken,
     address _rewardToken
-  )
-    HoprStakeBase(
-      block.chainid == 100 ? 0xD9a00176Cf49dFB9cA3Ef61805a2850F45Cb1D05 : _newOwner,
-      1674738000,
-      1682510400,
-      396,
-      25e22,
-      block.chainid == 100 ? 0x43d13D7B83607F14335cF2cB75E87dA369D056c7 : _nftAddress,
-      block.chainid == 100 ? 0xD057604A14982FE8D88c5fC25Aac3267eA142a08 : _lockToken,
-      block.chainid == 100 ? 0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1 : _rewardToken
-    )
-  {
+  ) HoprStakeBase(_newOwner, 1674738000, 1682510400, 396, 25e22, _nftAddress, _lockToken, _rewardToken) {
     // block a selection of HoprBoost NFTs
     _ownerBlockNftType(2); // HODLr
     _ownerBlockNftType(3); // Wildhorn_v1


### PR DESCRIPTION
As the staging environment is moved to Gnosis chain, some enforced states should be removed from the contract so that the staking contract in `master-staging` and `debug-staging` can use a different set of xHOPR, wxHOPR and boost tokens.

Fix error in https://github.com/hoprnet/hoprnet/actions/runs/4111808996