### PR TITLE
Fix riga deployment scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ docker pull gcr.io/hoprassociation/hoprd:riga
 For ease of use you can set up a shell alias to run the latest release as a docker container:
 
 ```sh
-alias hoprd='docker run --pull always -m 2g -ti -v ${HOPRD_DATA_DIR:-$HOME/.hoprd-db}:/app/db -p 9091:9091 -p 3000:3000 -p 3001:3001 gcr.io/hoprassociation/hoprd:riga'
+alias hoprd='docker run --pull always -m 2g -ti -v ${HOPRD_DATA_DIR:-$HOME/.hoprd-db}:/app/db -p 9091:9091 -p 3001:3001 gcr.io/hoprassociation/hoprd:riga'
 ```
 
 **IMPORTANT:** Using the above command will map the database folder used by hoprd to a local folder called `.hoprd-db` in your home directory. You can customize the location of that folder further by executing the following command:

--- a/packages/ethereum/contracts/Makefile
+++ b/packages/ethereum/contracts/Makefile
@@ -125,7 +125,8 @@ ifeq ($(peer_ids),)
 	echo "parameter <peer_ids> missing" >&2 && exit 1
 endif
 	$(forge-script) script/SingleAction.s.sol:SingleActionFromPrivateKeyScript \
-		--broadcast --sig "selfRegisterNodes(string[])" $(peer_ids)
+		--broadcast --sig "selfRegisterNodes(string[])" [$(peer_ids)] 
+
 
 # E.g. make self-deregister-node environment-name=anvil-localhost environment-type=development peer_ids="[16Uiu2HAmAmXnq8FtFsBAnSyfujaXbU3B5wdVRPYGfN8S99E5azdH,16Uiu2HAky1FmbdyrY4EC2ZmKVH5t1XTqZqkutnqNf5BpSjHuD9nF]"
 .PHONY: self-deregister-node

--- a/scripts/setup-gcloud-cluster.sh
+++ b/scripts/setup-gcloud-cluster.sh
@@ -236,7 +236,7 @@ IFS=','
 PRIVATE_KEY="${DEPLOYER_PRIVATE_KEY}" make -C "${mydir}/.." self-register-node \
   environment="${environment}" \
   peer_ids="${hopr_addrs[*]}" \
-  network="${network_id}"
+  environment_type="${network_id}"
 unset IFS
 
 # Finally wait for the public nodes to come up, for NAT nodes this isn't possible


### PR DESCRIPTION
- Wrap peersId in brackets to convert into string[]
- Update parameter `network` to `environment_type`

It has been tested locally
<img width="1090" alt="Screenshot 2023-02-07 at 17 19 22" src="https://user-images.githubusercontent.com/29434949/217301824-5ff0161a-319b-48bb-8987-e8813e03be37.png">
