### PR TITLE
fix: call uint8array constructor

### DIFF
--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -112,6 +112,10 @@ export function parseCliArguments(args: string[]) {
     console.error(err)
     process.exit(1)
   }
+  if (argv.private_key) {
+    // wasm-bindgen returns number array but does not call the Uint8Array constructor
+    argv.private_key = new Uint8Array(argv.private_key)
+  }
   return argv
 }
 


### PR DESCRIPTION
wasm-bindgen seems to properly export Uint8Array but does not call the constructor

test with:
```
yarn run:hoprd --environment monte_rosa --private_key <some privkey>
```