### PR TITLE
Fix a typo in Avado Dockerfile

### DIFF
--- a/packages/avado/build/Dockerfile
+++ b/packages/avado/build/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update \
  && apt-get install -y \
       supervisor \
  && rm -rf /var/lib/apt/lists/* \
- && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+ && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 
 COPY supervisord.conf /etc/supervisord.conf
 


### PR DESCRIPTION
There has been a typo in the Dockerbuild of Avado