### PR TITLE
fix wrong default value

### DIFF
--- a/packages/hoprd/crates/hoprd-misc/src/cli.rs
+++ b/packages/hoprd/crates/hoprd-misc/src/cli.rs
@@ -315,7 +315,7 @@ struct CliArgs {
         env = "HOPRD_TEST_PREFER_LOCAL_ADDRESSES",
         action = ArgAction::SetTrue,
         help = "For testing local testnets. Prefer local peers to remote",
-        default_value_t = true,
+        default_value_t = false,
         hide = true
     )]
     pub test_prefer_local_addresses: bool,


### PR DESCRIPTION
Default value must be set to `false`

closes #4595 
closes #4577 