### PR TITLE
Allow individual channel closure to pass on fail

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -632,8 +632,7 @@ class Hopr extends EventEmitter {
       } else {
         error(`Protocol error: strategy wants to open channel to non-registered peer ${destination.toString()}`)
       }
-    }
-    catch (e) {
+    } catch (e) {
       error(`strategy could not open channel to ${status.peer_id}`)
     }
   }
@@ -643,8 +642,7 @@ class Hopr extends EventEmitter {
       await this.closeChannel(peerIdFromString(destination), 'outgoing')
       verbose(`closed channel to ${destination.toString()}`)
       this.emit('hopr:channel:closed', destination)
-    }
-    catch (e) {
+    } catch (e) {
       error(`strategy could not close channel ${destination}`)
     }
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -619,24 +619,34 @@ class Hopr extends EventEmitter {
   }
 
   private async strategyOpenChannel(status: OutgoingChannelStatus) {
-    const destination = peerIdFromString(status.peer_id)
-    const stake = new BN(status.stake_str)
+    try {
+      const destination = peerIdFromString(status.peer_id)
+      const stake = new BN(status.stake_str)
 
-    if (await this.isAllowedAccessToNetwork(destination)) {
-      this.networkPeers.register(destination, NetworkPeersOrigin.STRATEGY_NEW_CHANNEL)
+      if (await this.isAllowedAccessToNetwork(destination)) {
+        this.networkPeers.register(destination, NetworkPeersOrigin.STRATEGY_NEW_CHANNEL)
 
-      const hash = await this.openChannel(destination, stake)
-      verbose('- opened channel', destination, hash)
-      this.emit('hopr:channel:opened', status)
-    } else {
-      error(`Protocol error: strategy wants to open channel to non-registered peer ${destination.toString()}`)
+        const hash = await this.openChannel(destination, stake)
+        verbose('- opened channel', destination, hash)
+        this.emit('hopr:channel:opened', status)
+      } else {
+        error(`Protocol error: strategy wants to open channel to non-registered peer ${destination.toString()}`)
+      }
+    }
+    catch (e) {
+      error(`strategy could not open channel to ${status.peer_id}`)
     }
   }
 
   private async strategyCloseChannel(destination: string) {
-    await this.closeChannel(peerIdFromString(destination), 'outgoing')
-    verbose(`closed channel to ${destination.toString()}`)
-    this.emit('hopr:channel:closed', destination)
+    try {
+      await this.closeChannel(peerIdFromString(destination), 'outgoing')
+      verbose(`closed channel to ${destination.toString()}`)
+      this.emit('hopr:channel:closed', destination)
+    }
+    catch (e) {
+      error(`strategy could not close channel ${destination}`)
+    }
   }
 
   private async updateChannelMetrics() {
@@ -664,7 +674,7 @@ class Hopr extends EventEmitter {
       metric_inChannelCount.set(incomingChannels)
       metric_outChannelCount.set(outgoingChannels)
     } catch (e) {
-      log(`error: failed to update channel metrics`, e)
+      error(`error: failed to update channel metrics`, e)
     }
   }
 
@@ -712,7 +722,7 @@ class Hopr extends EventEmitter {
       metric_strategyTicks.increment()
       metric_strategyMaxChannels.set(tickResult.max_auto_channels)
     } catch (e) {
-      log(`failed to do a strategy tick`, e)
+      error(`failed to do a strategy tick`, e)
       throw new Error('error while performing strategy tick')
     }
 
@@ -728,7 +738,7 @@ class Hopr extends EventEmitter {
       await Promise.all(allClosedChannels.map(this.strategyCloseChannel.bind(this)))
       await Promise.all(allOpenedChannels.map(this.strategyOpenChannel.bind(this)))
     } catch (e) {
-      log(`error when strategy was trying to open or close channels`, e)
+      error(`error when strategy was trying to open or close channels`, e)
     }
   }
 


### PR DESCRIPTION
Add a try-catch to `strategyOpenChannel` and `strategyCloseChannel` functions, allowing the upper level loop to continue when individual attempts to open/close fail.