### PR TITLE
Optimize funding script

### DIFF
--- a/packages/ethereum/contracts/Makefile
+++ b/packages/ethereum/contracts/Makefile
@@ -75,16 +75,18 @@ endif
 	$(forge-script) script/SingleAction.s.sol:SingleActionFromPrivateKeyScript \
 		--broadcast --sig "mintXHopr(address,uint256)" $(recipient) 1000
 
-# E.g. make faucet environment-name=anvil-localhost environment-type=development recipient=0x2402da10A6172ED018AEEa22CA60EDe1F766655C
+# E.g. make faucet environment-name=anvil-localhost environment-type=development recipient=0x2402da10A6172ED018AEEa22CA60EDe1F766655C hopramount=10 nativeamount=1
+# E.g. make faucet environment-name=anvil-localhost environment-type=development recipient=0x2402da10A6172ED018AEEa22CA60EDe1F766655C nativeamount=1
+# E.g. make faucet environment-name=anvil-localhost environment-type=development recipient=0x2402da10A6172ED018AEEa22CA60EDe1F766655C hopramount=10
 .PHONY: faucet
 faucet: ensure-environment-is-set ensure-privatekey-is-set
-faucet: ## Mint 20000 HOPR tokens and send 10 native tokens to the recipient
+faucet: ## Mint some (default: 20000) HOPR tokens and send some (default value: 10) native tokens to the recipient hopramount
 ifeq ($(recipient),)
-	echo "parameter <recipient> missing" >&2 && exit 1
+    echo "parameter <recipient> missing" >&2 && exit 1
 endif
-	$(forge-script) script/SingleAction.s.sol:SingleActionFromPrivateKeyScript \
-		--broadcast --sig "mintHopr(address,uint256)" $(recipient) 20000
-	cast send $(recipient) --value 10ether --private-key $(PRIVATE_KEY)
+    $(forge-script) script/SingleAction.s.sol:SingleActionFromPrivateKeyScript \
+        --broadcast --sig "mintHoprAndSendNative(address,uint256,uint256)" \
+        $(recipient) $(or $(hopramount),20000) $(or $(nativeamount),10)
 
 # E.g. make request-nrnft environment-name=anvil-localhost environment-type=development recipient=0x2402da10A6172ED018AEEa22CA60EDe1F766655C nftrank=developer
 .PHONY: request-nrnft

--- a/packages/ethereum/contracts/Makefile
+++ b/packages/ethereum/contracts/Makefile
@@ -82,9 +82,9 @@ endif
 faucet: ensure-environment-is-set ensure-privatekey-is-set
 faucet: ## Mint some (default: 20000) HOPR tokens and send some (default value: 10) native tokens to the recipient hopramount
 ifeq ($(recipient),)
-    echo "parameter <recipient> missing" >&2 && exit 1
+	echo "parameter <recipient> missing" >&2 && exit 1
 endif
-    $(forge-script) script/SingleAction.s.sol:SingleActionFromPrivateKeyScript \
+	$(forge-script) script/SingleAction.s.sol:SingleActionFromPrivateKeyScript \
         --broadcast --sig "mintHoprAndSendNative(address,uint256,uint256)" \
         $(recipient) $(or $(hopramount),20000) $(or $(nativeamount),10)
 

--- a/packages/ethereum/contracts/script/SingleAction.s.sol
+++ b/packages/ethereum/contracts/script/SingleAction.s.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity >=0.8.0 <0.9.0;
 
-import "forge-std/Script.sol";
-import "forge-std/Test.sol";
-import "./utils/EnvironmentConfig.s.sol";
-import "./utils/BoostUtilsLib.sol";
+import 'forge-std/Script.sol';
+import 'forge-std/Test.sol';
+import './utils/EnvironmentConfig.s.sol';
+import './utils/BoostUtilsLib.sol';
 
 /**
  * @dev script to interact with contract(s) of a given envirionment where the msg.sender comes from the environment variable `PRIVATE_KEY`
@@ -12,345 +12,438 @@ import "./utils/BoostUtilsLib.sol";
  * Wrapper of contracts (incl. NetworkRegistery, HoprStake) with detection of contract address per environment_name/environment_type
  */
 contract SingleActionFromPrivateKeyScript is Test, EnvironmentConfig {
-    using stdJson for string;
-    using BoostUtilsLib for address;
+  using stdJson for string;
+  using BoostUtilsLib for address;
 
-    address msgSender;
+  address msgSender;
 
-    function getEnvironmentAndMsgSender() private {
-        // 1. Environment check
-        // get envirionment of the script
-        getEnvironment();
-        // read records of deployed files
-        readCurrentEnvironment();
+  function getEnvironmentAndMsgSender() private {
+    // 1. Environment check
+    // get envirionment of the script
+    getEnvironment();
+    // read records of deployed files
+    readCurrentEnvironment();
 
-        // 2. Get private key of caller
-        uint256 privateKey = vm.envUint("PRIVATE_KEY");
-        msgSender = vm.addr(privateKey);
-        vm.startBroadcast(privateKey);
+    // 2. Get private key of caller
+    uint256 privateKey = vm.envUint('PRIVATE_KEY');
+    msgSender = vm.addr(privateKey);
+    vm.startBroadcast(privateKey);
+  }
+
+  /**
+   * @dev On network registry contract, register peers associated with the calling wallet.
+   */
+  function selfRegisterNodes(string[] calldata peerIds) external {
+    // 1. get environment and msg.sender
+    getEnvironmentAndMsgSender();
+
+    // 2. call hoprNetworkRegistry.selfRegister(peerIds);
+    (bool successSelfRegister, ) = currentEnvironmentDetail.networkRegistryContractAddress.call(
+      abi.encodeWithSignature('selfRegister(string[])', peerIds)
+    );
+    if (!successSelfRegister) {
+      emit log_string('Cannot register peers');
+      revert('Cannot register peers');
+    }
+    vm.stopBroadcast();
+  }
+
+  /**
+   * @dev On network registry contract, deregister peers associated with the calling wallet.
+   */
+  function selfDeregisterNodes(string[] calldata peerIds) external {
+    // 1. get environment and msg.sender
+    getEnvironmentAndMsgSender();
+
+    // 2. call hoprNetworkRegistry.selfDeregister(peerIds);
+    (bool successSelfDeregister, ) = currentEnvironmentDetail.networkRegistryContractAddress.call(
+      abi.encodeWithSignature('selfDeregister(string[])', peerIds)
+    );
+    if (!successSelfDeregister) {
+      emit log_string('Cannot deregister peers');
+      revert('Cannot deregister peers');
+    }
+    vm.stopBroadcast();
+  }
+
+  /**
+   * @dev On network registry contract, register nodes to a set of addresses. This function should only be called by the owner
+   */
+  function registerNodes(address[] calldata stakingAddresses, string[] calldata peerIds) external {
+    require(stakingAddresses.length == peerIds.length, 'Input lengths are different');
+
+    // 1. get environment and msg.sender
+    getEnvironmentAndMsgSender();
+
+    // 2. owner registers nodes, depending on the envirionment
+    if (currentEnvironmentType == EnvironmentType.DEVELOPMENT) {
+      // call register accounts on HoprDummyProxyForNetworkRegistry
+      (bool successRegisterNodesOnDummyProxy, ) = currentEnvironmentDetail.networkRegistryProxyContractAddress.call(
+        abi.encodeWithSignature('ownerBatchAddAccounts(address[])', stakingAddresses)
+      );
+      if (!successRegisterNodesOnDummyProxy) {
+        emit log_string('Cannot add stakingAddresses on to the dummy proxy.');
+        revert('Cannot add stakingAddresses on to the dummy proxy.');
+      }
+    }
+    // actual register nodes
+    (bool successRegisterNodes, ) = currentEnvironmentDetail.networkRegistryContractAddress.call(
+      abi.encodeWithSignature('ownerRegister(address[],string[])', stakingAddresses, peerIds)
+    );
+    if (!successRegisterNodes) {
+      emit log_string('Cannot register nodes as an owner');
+      revert('Cannot register nodes as an owner');
+    }
+    vm.stopBroadcast();
+  }
+
+  /**
+   * @dev On network registry contract, deregister nodes from a set of addresses. This function should only be called by the owner
+   */
+  function deregisterNodes(address[] calldata stakingAddresses, string[] calldata peerIds) external {
+    // 1. get environment and msg.sender
+    getEnvironmentAndMsgSender();
+
+    // 2. owner registers nodes, depending on the envirionment
+    if (currentEnvironmentType == EnvironmentType.DEVELOPMENT) {
+      // call deregister accounts on HoprDummyProxyForNetworkRegistry
+      (bool successDeregisterNodesOnDummyProxy, ) = currentEnvironmentDetail.networkRegistryProxyContractAddress.call(
+        abi.encodeWithSignature('ownerBatchRemoveAccounts(address[])', stakingAddresses)
+      );
+      if (!successDeregisterNodesOnDummyProxy) {
+        emit log_string('Cannot remove stakingAddresses from the dummy proxy.');
+        revert('Cannot remove stakingAddresses from the dummy proxy.');
+      }
+    }
+    // actual deregister nodes
+    (bool successDeregisterNodes, ) = currentEnvironmentDetail.networkRegistryContractAddress.call(
+      abi.encodeWithSignature('ownerDeregister(string[])', peerIds)
+    );
+    if (!successDeregisterNodes) {
+      emit log_string('Cannot rdeegister nodes as an owner');
+      revert('Cannot deregister nodes as an owner');
+    }
+    vm.stopBroadcast();
+  }
+
+  /**
+   * @dev On network registry contract, disable it. This function should only be called by the owner
+   */
+  function disableNetworkRegistry() external {
+    // 1. get environment and msg.sender
+    getEnvironmentAndMsgSender();
+
+    // 2. check if current NR is enabled.
+    (bool successReadEnabled, bytes memory returndataReadEnabled) = currentEnvironmentDetail
+      .networkRegistryContractAddress
+      .staticcall(abi.encodeWithSignature('enabled()'));
+    if (!successReadEnabled) {
+      revert('Cannot read enabled from network registry contract.');
+    }
+    bool isEnabled = abi.decode(returndataReadEnabled, (bool));
+
+    // 3. disable if needed
+    if (isEnabled) {
+      (bool successDisableNetworkRegistry, ) = currentEnvironmentDetail.networkRegistryContractAddress.call(
+        abi.encodeWithSignature('disableRegistry()')
+      );
+      if (!successDisableNetworkRegistry) {
+        emit log_string('Cannot disable network registery as an owner');
+        revert('Cannotdisable network registery as an owner');
+      }
+      vm.stopBroadcast();
+    }
+  }
+
+  /**
+   * @dev On network registry contract, enable it. This function should only be called by the owner
+   */
+  function enableNetworkRegistry() external {
+    // 1. get environment and msg.sender
+    getEnvironmentAndMsgSender();
+
+    // 2. check if current NR is enabled.
+    (bool successReadEnabled, bytes memory returndataReadEnabled) = currentEnvironmentDetail
+      .networkRegistryContractAddress
+      .staticcall(abi.encodeWithSignature('enabled()'));
+    if (!successReadEnabled) {
+      revert('Cannot read enabled from network registry contract.');
+    }
+    bool isEnabled = abi.decode(returndataReadEnabled, (bool));
+
+    // 3. enable if needed
+    if (!isEnabled) {
+      (bool successEnableNetworkRegistry, ) = currentEnvironmentDetail.networkRegistryContractAddress.call(
+        abi.encodeWithSignature('enableRegistry()')
+      );
+      if (!successEnableNetworkRegistry) {
+        emit log_string('Cannot enable network registery as an owner');
+        revert('Cannot enable network registery as an owner');
+      }
+      vm.stopBroadcast();
+    }
+  }
+
+  /**
+   * @dev On network registry contract, update eligibility of some staking addresses to the desired . This function should only be called by the owner
+   */
+  function forceEligibilityUpdate(address[] calldata stakingAddresses, bool[] calldata eligibility) external {
+    require(stakingAddresses.length == eligibility.length, 'Input lengths are different');
+
+    // 1. get environment and msg.sender
+    getEnvironmentAndMsgSender();
+
+    // 2. update emit EligibilityUpdate events by the owner
+    (bool successForceEligibilityUpdate, ) = currentEnvironmentDetail.networkRegistryContractAddress.call(
+      abi.encodeWithSignature('ownerForceEligibility(address[],bool[])', stakingAddresses, eligibility)
+    );
+    if (!successForceEligibilityUpdate) {
+      emit log_string('Cannot force update eligibility as an owner');
+      revert('Cannot force update eligibility as an owner');
+    }
+    vm.stopBroadcast();
+  }
+
+  /**
+   * @dev On network registry contract, sync eligibility of some staking addresses. This function should only be called by the owner
+   */
+  function syncEligibility(string[] calldata peerIds) external {
+    // 1. get environment and msg.sender
+    getEnvironmentAndMsgSender();
+
+    // 2. sync peers eligibility according to the latest requirement of its current state
+    (bool successSyncEligibility, ) = currentEnvironmentDetail.networkRegistryContractAddress.call(
+      abi.encodeWithSignature('sync(string[])', peerIds)
+    );
+    if (!successSyncEligibility) {
+      emit log_string('Cannot sync eligibility as an owner');
+      revert('Cannot sync eligibility as an owner');
+    }
+    vm.stopBroadcast();
+  }
+
+  /**
+   * @dev On stake contract, stake xHopr to the target value
+   */
+  function stakeXHopr(uint256 stakeTarget) external {
+    // 1. get environment and msg.sender
+    getEnvironmentAndMsgSender();
+
+    // 2. check the staked value. Return if the target has reached
+    (bool successReadStaked, bytes memory returndataReadStaked) = currentEnvironmentDetail
+      .stakeContractAddress
+      .staticcall(abi.encodeWithSignature('stakedHoprTokens(address)', msgSender));
+    if (!successReadStaked) {
+      revert('Cannot read staked amount on stake contract.');
+    }
+    uint256 stakedAmount = abi.decode(returndataReadStaked, (uint256));
+    if (stakedAmount >= stakeTarget) {
+      emit log_string('Stake target has reached');
+      return;
     }
 
-    /**
-     * @dev On network registry contract, register peers associated with the calling wallet.
-     */
-    function selfRegisterNodes(string[] calldata peerIds) external {
-        // 1. get environment and msg.sender
-        getEnvironmentAndMsgSender();
+    // 3. stake the difference, if allowed
+    uint256 amountToStake = stakeTarget - stakedAmount;
+    (bool successReadBalance, bytes memory returndataReadBalance) = currentEnvironmentDetail
+      .xhoprTokenContractAddress
+      .staticcall(abi.encodeWithSignature('balanceOf(address)', msgSender));
+    if (!successReadBalance) {
+      revert('Cannot read token balance on xHOPR token contract.');
+    }
+    uint256 balance = abi.decode(returndataReadBalance, (uint256));
+    if (stakedAmount >= stakeTarget) {
+      emit log_string('Stake target has reached');
+      return;
+    }
+    if (balance < amountToStake) {
+      revert('Not enough xHOPR token balance to stake to the target.');
+    } else {
+      (bool successStakeXhopr, ) = currentEnvironmentDetail.xhoprTokenContractAddress.call(
+        abi.encodeWithSignature(
+          'transferAndCall(address,uint256,bytes)',
+          currentEnvironmentDetail.stakeContractAddress,
+          amountToStake,
+          hex'00'
+        )
+      );
+      if (!successStakeXhopr) {
+        emit log_string('Cannot stake amountToStake');
+        revert('Cannot stake amountToStake');
+      }
+    }
+    vm.stopBroadcast();
+  }
 
-        // 2. call hoprNetworkRegistry.selfRegister(peerIds);
-        (bool successSelfRegister, ) = currentEnvironmentDetail.networkRegistryContractAddress.call(abi.encodeWithSignature("selfRegister(string[])", peerIds));
-        if (!successSelfRegister) {
-            emit log_string("Cannot register peers");
-            revert("Cannot register peers");
-        }
-        vm.stopBroadcast();
+  /**
+   * @dev On stake contract, stake Network registry NFT to the target value
+   */
+  function stakeNetworkRegistryNft(string calldata nftRank) external {
+    // 1. get environment and msg.sender
+    getEnvironmentAndMsgSender();
+
+    // 2. Check if the msg.sender has staked Network_registry NFT
+    (bool successHasStaked, bytes memory returndataHasStaked) = currentEnvironmentDetail
+      .stakeContractAddress
+      .staticcall(
+        abi.encodeWithSignature(
+          'isNftTypeAndRankRedeemed2(uint256,string,address)',
+          NETWORK_REGISTRY_NFT_INDEX,
+          nftRank,
+          msgSender
+        )
+      );
+    if (!successHasStaked) {
+      revert('Cannot read if caller has staked Network_registry NFTs.');
+    }
+    bool hasStaked = abi.decode(returndataHasStaked, (bool));
+    if (hasStaked) {
+      return;
     }
 
-    /**
-     * @dev On network registry contract, deregister peers associated with the calling wallet.
-     */
-    function selfDeregisterNodes(string[] calldata peerIds) external {
-        // 1. get environment and msg.sender
-        getEnvironmentAndMsgSender();
+    // 3. Check if msg.sender has Network_registry NFT
+    safeTransferNetworkRegistryNft(
+      currentEnvironmentDetail.hoprBoostContractAddress,
+      msgSender,
+      currentEnvironmentDetail.stakeContractAddress,
+      nftRank
+    );
 
-        // 2. call hoprNetworkRegistry.selfDeregister(peerIds);
-        (bool successSelfDeregister, ) = currentEnvironmentDetail.networkRegistryContractAddress.call(abi.encodeWithSignature("selfDeregister(string[])", peerIds));
-        if (!successSelfDeregister) {
-            emit log_string("Cannot deregister peers");
-            revert("Cannot deregister peers");
-        }
-        vm.stopBroadcast();
+    vm.stopBroadcast();
+  }
+
+  /**
+   * @dev Mint some xHOPR to the recipient
+   */
+  function mintXHopr(address recipient, uint256 amountInEther) external {
+    // 1. get environment and msg.sender
+    getEnvironmentAndMsgSender();
+
+    address[] memory addrBook = new address[](1);
+    addrBook[0] = recipient;
+
+    // 2. Check if the msg.sender has staked Network_registry NFT
+    (bool successMintXTokens, ) = currentEnvironmentDetail.xhoprTokenContractAddress.call(
+      abi.encodeWithSignature('batchMintInternal(address[],uint256)', addrBook, amountInEther * 1e18)
+    );
+    if (!successMintXTokens) {
+      emit log_string('Cannot mint xHOPR tokens');
     }
 
-    /**
-     * @dev On network registry contract, register nodes to a set of addresses. This function should only be called by the owner
-     */
-    function registerNodes(address[] calldata stakingAddresses, string[] calldata peerIds) external {
-        require(stakingAddresses.length == peerIds.length, "Input lengths are different");
+    vm.stopBroadcast();
+  }
 
-        // 1. get environment and msg.sender
-        getEnvironmentAndMsgSender();
+  /**
+   * @dev send some HOPR tokens to the recipient address
+   */
+  function mintHopr(address recipient, uint256 tokenamountInEther) external {
+    // 1. get environment and msg.sender
+    getEnvironmentAndMsgSender();
 
-        // 2. owner registers nodes, depending on the envirionment
-        if (currentEnvironmentType == EnvironmentType.DEVELOPMENT) {
-            // call register accounts on HoprDummyProxyForNetworkRegistry
-            (bool successRegisterNodesOnDummyProxy, ) = currentEnvironmentDetail.networkRegistryProxyContractAddress.call(abi.encodeWithSignature("ownerBatchAddAccounts(address[])", stakingAddresses));
-            if (!successRegisterNodesOnDummyProxy) {
-                emit log_string("Cannot add stakingAddresses on to the dummy proxy.");
-                revert("Cannot add stakingAddresses on to the dummy proxy.");
-            }
-        }
-        // actual register nodes
-        (bool successRegisterNodes, ) = currentEnvironmentDetail.networkRegistryContractAddress.call(abi.encodeWithSignature("ownerRegister(address[],string[])", stakingAddresses, peerIds));
-        if (!successRegisterNodes) {
-            emit log_string("Cannot register nodes as an owner");
-            revert("Cannot register nodes as an owner");
-        }
-        vm.stopBroadcast();
+    // 2.Mint some Hopr tokens to the recipient
+    if (tokenamountInEther > 0) {
+      uint256 hoprTokenAmount = tokenamountInEther * 1 ether;
+      (bool successMintTokens, ) = currentEnvironmentDetail.hoprTokenContractAddress.call(
+        abi.encodeWithSignature('mint(address,uint256,bytes,bytes)', recipient, hoprTokenAmount, hex'00', hex'00')
+      );
+      if (!successMintTokens) {
+        emit log_string('Cannot mint HOPR tokens');
+      }
     }
 
-    /**
-     * @dev On network registry contract, deregister nodes from a set of addresses. This function should only be called by the owner
-     */
-    function deregisterNodes(address[] calldata stakingAddresses, string[] calldata peerIds) external {
-        // 1. get environment and msg.sender
-        getEnvironmentAndMsgSender();
+    vm.stopBroadcast();
+  }
 
-        // 2. owner registers nodes, depending on the envirionment
-        if (currentEnvironmentType == EnvironmentType.DEVELOPMENT) {
-            // call deregister accounts on HoprDummyProxyForNetworkRegistry
-            (bool successDeregisterNodesOnDummyProxy, ) = currentEnvironmentDetail.networkRegistryProxyContractAddress.call(abi.encodeWithSignature("ownerBatchRemoveAccounts(address[])", stakingAddresses));
-            if (!successDeregisterNodesOnDummyProxy) {
-                emit log_string("Cannot remove stakingAddresses from the dummy proxy.");
-                revert("Cannot remove stakingAddresses from the dummy proxy.");
-            }
+  /**
+   * @dev Check if msgSender owned the requested rank. If so, transfer one to recipient
+   */
+  function transferNetworkRegistryNft(address recipient, string calldata nftRank) external {
+    // 1. get environment and msg.sender
+    getEnvironmentAndMsgSender();
+
+    // 2. Check if msg.sender has Network_registry NFT
+    safeTransferNetworkRegistryNft(currentEnvironmentDetail.hoprBoostContractAddress, msgSender, recipient, nftRank);
+    vm.stopBroadcast();
+  }
+
+  /**
+   * @dev private function to transfer a NR NFT of nftRank from sender to recipient.
+   */
+  function safeTransferNetworkRegistryNft(
+    address boostContractAddr,
+    address sender,
+    address recipient,
+    string calldata nftRank
+  ) private {
+    // 1. Check sender's Network_registry NFT balance
+    (bool successOwnedNftBalance, bytes memory returndataOwnedNftBalance) = boostContractAddr.staticcall(
+      abi.encodeWithSignature('balanceOf(address)', sender)
+    );
+    if (!successOwnedNftBalance) {
+      revert('Cannot read if the amount of Network_registry NFTs owned by the caller.');
+    }
+    uint256 ownedNftBalance = abi.decode(returndataOwnedNftBalance, (uint256));
+    // get the desired nft uri hash
+    bytes32 desiredHaashedTokenUri = keccak256(bytes(abi.encodePacked(NETWORK_REGISTRY_TYPE_NAME, '/', nftRank)));
+
+    // 2. Loop through balance and compare token URI
+    uint256 index;
+    for (index = 0; index < ownedNftBalance; index++) {
+      (bool successOwnedNftTokenId, bytes memory returndataOwnedNftTokenId) = boostContractAddr.staticcall(
+        abi.encodeWithSignature('tokenOfOwnerByIndex(address,uint256)', sender, index)
+      );
+      if (!successOwnedNftTokenId) {
+        revert('Cannot read owned NFT at a given index.');
+      }
+      uint256 ownedNftTokenId = abi.decode(returndataOwnedNftTokenId, (uint256));
+      (bool successTokenUri, bytes memory returndataTokenUri) = boostContractAddr.staticcall(
+        abi.encodeWithSignature('tokenURI(uint256)', ownedNftTokenId)
+      );
+      if (!successTokenUri) {
+        revert('Cannot read token URI of the given ID.');
+      }
+
+      if (desiredHaashedTokenUri == keccak256(bytes(abi.decode(returndataTokenUri, (string))))) {
+        // 3. find the tokenId, perform safeTransferFrom
+        (bool successStakeNft, ) = boostContractAddr.call(
+          abi.encodeWithSignature('safeTransferFrom(address,address,uint256)', sender, recipient, ownedNftTokenId)
+        );
+        if (!successStakeNft) {
+          revert('Cannot stake the NFT');
         }
-        // actual deregister nodes
-        (bool successDeregisterNodes, ) = currentEnvironmentDetail.networkRegistryContractAddress.call(abi.encodeWithSignature("ownerDeregister(string[])", peerIds));
-        if (!successDeregisterNodes) {
-            emit log_string("Cannot rdeegister nodes as an owner");
-            revert("Cannot deregister nodes as an owner");
-        }
-        vm.stopBroadcast();
+        break;
+      }
     }
 
-    /**
-     * @dev On network registry contract, disable it. This function should only be called by the owner
-     */
-    function disableNetworkRegistry() external {
-        // 1. get environment and msg.sender
-        getEnvironmentAndMsgSender();
+    if (index >= ownedNftBalance) {
+      revert('Failed to find the owned NFT');
+    }
+  }
 
-        // 2. check if current NR is enabled.
-        (bool successReadEnabled, bytes memory returndataReadEnabled) = currentEnvironmentDetail.networkRegistryContractAddress.staticcall(abi.encodeWithSignature("enabled()"));
-        if (!successReadEnabled) {
-            revert("Cannot read enabled from network registry contract.");
-        }
-        bool isEnabled = abi.decode(returndataReadEnabled, (bool));
+  /**
+   * @dev On network registry contract, deregister peers associated with the calling wallet.
+   */
+  function mintHoprAndSendNative(
+    address recipient,
+    uint256 horpTokenAmountInEther,
+    uint256 nativeTokenAmountInEther
+  ) external payable {
+    // 1. get environment and msg.sender
+    getEnvironmentAndMsgSender();
 
-        // 3. disable if needed
-        if (isEnabled) {
-            (bool successDisableNetworkRegistry, ) = currentEnvironmentDetail.networkRegistryContractAddress.call(abi.encodeWithSignature("disableRegistry()"));
-            if (!successDisableNetworkRegistry) {
-                emit log_string("Cannot disable network registery as an owner");
-                revert("Cannotdisable network registery as an owner");
-            }
-            vm.stopBroadcast();
-        }
+    // 2. mint some Hopr tokens to the recipient
+    if (horpTokenAmountInEther > 0) {
+      uint256 hoprTokenAmount = horpTokenAmountInEther * 1 ether;
+      (bool successMintTokens, ) = currentEnvironmentDetail.hoprTokenContractAddress.call(
+        abi.encodeWithSignature('mint(address,uint256,bytes,bytes)', recipient, hoprTokenAmount, hex'00', hex'00')
+      );
+      if (!successMintTokens) {
+        emit log_string('Cannot mint HOPR tokens to the recipient');
+      }
     }
 
-    /**
-     * @dev On network registry contract, enable it. This function should only be called by the owner
-     */
-    function enableNetworkRegistry() external {
-        // 1. get environment and msg.sender
-        getEnvironmentAndMsgSender();
-
-        // 2. check if current NR is enabled.
-        (bool successReadEnabled, bytes memory returndataReadEnabled) = currentEnvironmentDetail.networkRegistryContractAddress.staticcall(abi.encodeWithSignature("enabled()"));
-        if (!successReadEnabled) {
-            revert("Cannot read enabled from network registry contract.");
-        }
-        bool isEnabled = abi.decode(returndataReadEnabled, (bool));
-
-        // 3. enable if needed
-        if (!isEnabled) {
-            (bool successEnableNetworkRegistry, ) = currentEnvironmentDetail.networkRegistryContractAddress.call(abi.encodeWithSignature("enableRegistry()"));
-            if (!successEnableNetworkRegistry) {
-                emit log_string("Cannot enable network registery as an owner");
-                revert("Cannot enable network registery as an owner");
-            }
-            vm.stopBroadcast();
-        }
-    }
-
-    /**
-     * @dev On network registry contract, update eligibility of some staking addresses to the desired . This function should only be called by the owner
-     */
-    function forceEligibilityUpdate(address[] calldata stakingAddresses, bool[] calldata eligibility) external {
-        require(stakingAddresses.length == eligibility.length, "Input lengths are different");
-
-        // 1. get environment and msg.sender
-        getEnvironmentAndMsgSender();
-
-        // 2. update emit EligibilityUpdate events by the owner
-        (bool successForceEligibilityUpdate, ) = currentEnvironmentDetail.networkRegistryContractAddress.call(abi.encodeWithSignature("ownerForceEligibility(address[],bool[])", stakingAddresses, eligibility));
-        if (!successForceEligibilityUpdate) {
-            emit log_string("Cannot force update eligibility as an owner");
-            revert("Cannot force update eligibility as an owner");
-        }
-        vm.stopBroadcast();
-    }
-
-    /**
-     * @dev On network registry contract, sync eligibility of some staking addresses. This function should only be called by the owner
-     */
-    function syncEligibility(string[] calldata peerIds) external {
-        // 1. get environment and msg.sender
-        getEnvironmentAndMsgSender();
-
-        // 2. sync peers eligibility according to the latest requirement of its current state
-        (bool successSyncEligibility, ) = currentEnvironmentDetail.networkRegistryContractAddress.call(abi.encodeWithSignature("sync(string[])", peerIds));
-        if (!successSyncEligibility) {
-            emit log_string("Cannot sync eligibility as an owner");
-            revert("Cannot sync eligibility as an owner");
-        }
-        vm.stopBroadcast();
-    }
-
-    /**
-     * @dev On stake contract, stake xHopr to the target value
-     */
-    function stakeXHopr(uint256 stakeTarget) external {
-        // 1. get environment and msg.sender
-        getEnvironmentAndMsgSender();
-
-        // 2. check the staked value. Return if the target has reached
-        (bool successReadStaked, bytes memory returndataReadStaked) = currentEnvironmentDetail.stakeContractAddress.staticcall(abi.encodeWithSignature("stakedHoprTokens(address)", msgSender));
-        if (!successReadStaked) {
-            revert("Cannot read staked amount on stake contract.");
-        }
-        uint256 stakedAmount = abi.decode(returndataReadStaked, (uint256));
-        if (stakedAmount >= stakeTarget) {
-            emit log_string("Stake target has reached");
-            return;
-        }
-
-        // 3. stake the difference, if allowed
-        uint256 amountToStake = stakeTarget - stakedAmount;
-        (bool successReadBalance, bytes memory returndataReadBalance) = currentEnvironmentDetail.xhoprTokenContractAddress.staticcall(abi.encodeWithSignature("balanceOf(address)", msgSender));
-        if (!successReadBalance) {
-            revert("Cannot read token balance on xHOPR token contract.");
-        }
-        uint256 balance = abi.decode(returndataReadBalance, (uint256));
-        if (stakedAmount >= stakeTarget) {
-            emit log_string("Stake target has reached");
-            return;
-        }
-        if (balance < amountToStake) {
-            revert("Not enough xHOPR token balance to stake to the target.");
-        } else {
-            (bool successStakeXhopr, ) = currentEnvironmentDetail.xhoprTokenContractAddress.call(abi.encodeWithSignature("transferAndCall(address,uint256,bytes)", currentEnvironmentDetail.stakeContractAddress, amountToStake, hex"00"));
-            if (!successStakeXhopr) {
-                emit log_string("Cannot stake amountToStake");
-                revert("Cannot stake amountToStake");
-            }
-        }
-        vm.stopBroadcast();
-    }
-
-    /**
-     * @dev On stake contract, stake Network registry NFT to the target value
-     */
-    function stakeNetworkRegistryNft(string calldata nftRank) external {
-        // 1. get environment and msg.sender
-        getEnvironmentAndMsgSender();
-
-        // 2. Check if the msg.sender has staked Network_registry NFT
-        (bool successHasStaked, bytes memory returndataHasStaked) = currentEnvironmentDetail.stakeContractAddress.staticcall(abi.encodeWithSignature("isNftTypeAndRankRedeemed2(uint256,string,address)", NETWORK_REGISTRY_NFT_INDEX, nftRank, msgSender));
-        if (!successHasStaked) {
-            revert("Cannot read if caller has staked Network_registry NFTs.");
-        }
-        bool hasStaked = abi.decode(returndataHasStaked, (bool));
-        if (hasStaked) {
-            return;
-        }
-
-        // 3. Check if msg.sender has Network_registry NFT
-        safeTransferNetworkRegistryNft(currentEnvironmentDetail.hoprBoostContractAddress, msgSender, currentEnvironmentDetail.stakeContractAddress, nftRank);
-
-        vm.stopBroadcast();
-    }
-
-    /**
-     * @dev Mint some xHOPR to the recipient
-     */
-    function mintXHopr(address recipient, uint256 amountInEther) external {
-        // 1. get environment and msg.sender
-        getEnvironmentAndMsgSender();
-
-        address[] memory addrBook = new address[](1);
-        addrBook[0] = recipient;
-
-        // 2. Check if the msg.sender has staked Network_registry NFT
-        (bool successMintXTokens, ) = currentEnvironmentDetail.xhoprTokenContractAddress.call(abi.encodeWithSignature("batchMintInternal(address[],uint256)", addrBook, amountInEther * 1e18));
-        if (!successMintXTokens) {
-            emit log_string("Cannot mint xHOPR tokens");
-        }
-
-        vm.stopBroadcast();
-    }
-
-    /**
-     * @dev send some HOPR tokens to the recipient address
-     */
-    function mintHopr(address recipient, uint256 tokenamountInEther) external {
-        // 1. get environment and msg.sender
-        getEnvironmentAndMsgSender();
-
-        // 2.Mint some Hopr tokens to the recipient
-        if (tokenamountInEther > 0) {
-            uint256 hoprTokenAmount = tokenamountInEther * 1 ether;
-            (bool successMintTokens, ) = currentEnvironmentDetail.hoprTokenContractAddress.call(abi.encodeWithSignature("mint(address,uint256,bytes,bytes)", recipient, hoprTokenAmount, hex"00", hex"00"));
-            if (!successMintTokens) {
-                emit log_string("Cannot mint HOPR tokens");
-            }
-        }
-
-        vm.stopBroadcast();
-    }
-
-    /**
-     * @dev Check if msgSender owned the requested rank. If so, transfer one to recipient
-     */
-    function transferNetworkRegistryNft(address recipient, string calldata nftRank) external {
-        // 1. get environment and msg.sender
-        getEnvironmentAndMsgSender();
-
-        // 2. Check if msg.sender has Network_registry NFT
-        safeTransferNetworkRegistryNft(currentEnvironmentDetail.hoprBoostContractAddress, msgSender, recipient, nftRank);
-        vm.stopBroadcast();
-    }
-
-    /**
-     * @dev private function to transfer a NR NFT of nftRank from sender to recipient. 
-     */
-    function safeTransferNetworkRegistryNft(address boostContractAddr, address sender, address recipient, string calldata nftRank) private {
-        // 1. Check sender's Network_registry NFT balance
-        (bool successOwnedNftBalance, bytes memory returndataOwnedNftBalance) = boostContractAddr.staticcall(abi.encodeWithSignature("balanceOf(address)", sender));
-        if (!successOwnedNftBalance) {
-            revert("Cannot read if the amount of Network_registry NFTs owned by the caller.");
-        }
-        uint256 ownedNftBalance = abi.decode(returndataOwnedNftBalance, (uint256));
-        // get the desired nft uri hash
-        bytes32 desiredHaashedTokenUri = keccak256(bytes(abi.encodePacked(NETWORK_REGISTRY_TYPE_NAME, "/", nftRank)));
-
-        // 2. Loop through balance and compare token URI
-        uint256 index;
-        for (index = 0; index < ownedNftBalance; index++) {
-            (bool successOwnedNftTokenId, bytes memory returndataOwnedNftTokenId) = boostContractAddr.staticcall(abi.encodeWithSignature("tokenOfOwnerByIndex(address,uint256)", sender, index));
-            if (!successOwnedNftTokenId) {
-                revert("Cannot read owned NFT at a given index.");
-            }
-            uint256 ownedNftTokenId = abi.decode(returndataOwnedNftTokenId, (uint256));
-            (bool successTokenUri, bytes memory returndataTokenUri) = boostContractAddr.staticcall(abi.encodeWithSignature("tokenURI(uint256)", ownedNftTokenId));
-            if (!successTokenUri) {
-                revert("Cannot read token URI of the given ID.");
-            }
-
-            if (desiredHaashedTokenUri == keccak256(bytes(abi.decode(returndataTokenUri, (string))))) {
-               // 3. find the tokenId, perform safeTransferFrom
-                (bool successStakeNft, ) = boostContractAddr.call(abi.encodeWithSignature("safeTransferFrom(address,address,uint256)", sender, recipient, ownedNftTokenId));
-                if (!successStakeNft) {
-                    revert("Cannot stake the NFT");
-                }
-                break;
-            }
-        }
-
-
-        if (index >= ownedNftBalance) {
-            revert("Failed to find the owned NFT");
-        }
-    }
+    // 3. transfer native balance to the recipient
+    (bool nativeTokenTransferSuccess, ) = recipient.call{value: nativeTokenAmountInEther * 1 ether}('');
+    require(nativeTokenTransferSuccess, 'Cannot send native tokens to the recipient');
+    vm.stopBroadcast();
+  }
 }


### PR DESCRIPTION
Allow `faucet` target to specify hopr token amount and native token amount. This facilitates the funding process. 

Test with local anvil instance:

```
make run-anvil
```
```
export NODE_WALLET=<your_node_ethereum_wallet>
export PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
```

Fund 30 HOPR token and 50 native token
```
make -C packages/ethereum/contracts \
	faucet environment-name=anvil_localhost environment-type=development \
	recipient=$NODE_WALLET hopramount=30 nativeamount=50
```
Fund 20000 HOPR token and 10 native token
```
make -C packages/ethereum/contracts \
	faucet environment-name=anvil_localhost environment-type=development \
	recipient=$NODE_WALLET
```