### PR TITLE
Fix missing error handler on secondary TCP STUN socket

### DIFF
--- a/packages/connect/src/base/stun/tcp/server.ts
+++ b/packages/connect/src/base/stun/tcp/server.ts
@@ -114,12 +114,12 @@ export async function handleTcpStunRequest(
               secondarySocket.end()
             })
           })
-          secondarySocket.once('timeout', () => {
-            secondarySocket.destroy()
-          })
-          secondarySocket.once('error', () => {
-            secondarySocket.destroy()
-          })
+            .once('timeout', () => {
+              secondarySocket.destroy()
+            })
+            .once('error', () => {
+              secondarySocket.destroy()
+            })
           socket.end()
         } else {
           socket.write(response.toBuffer(), () => {

--- a/packages/connect/src/base/stun/tcp/server.ts
+++ b/packages/connect/src/base/stun/tcp/server.ts
@@ -114,6 +114,12 @@ export async function handleTcpStunRequest(
               secondarySocket.end()
             })
           })
+          secondarySocket.once('timeout', () => {
+            secondarySocket.destroy()
+          })
+          secondarySocket.once('error', () => {
+            secondarySocket.destroy()
+          })
           socket.end()
         } else {
           socket.write(response.toBuffer(), () => {


### PR DESCRIPTION
Fixes a missing handler on the STUN TCP socket, closes https://github.com/hoprnet/hoprnet/issues/4607