### PR TITLE
Make check of unrealized balance optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,10 @@ Options:
           Default channel strategy to use when the node is started [env: HOPRD_DEFAULT_STRATEGY=] [default: passive]
       --maxAutoChannels <NUMBER>
           Maximum number of channels a strategy can open [env: HOPRD_MAX_AUTOCHANNELS=] [default: square root of the number of active peers]
+      --autoRedeemTickets
+        Enables automatic ticket redemption when received a winning ticket [env: HOPRD_AUTO_REDEEM_TICKETS=] [default: false]
+      --checkUnrealizedBalance
+        Check unrealized balance in the channel when validating unacknowledged tickets [env: HOPRD_CHECK_UNREALIZED_BALANCE=] [default: false]
       --dryRun
           List all the options used to run the HOPR node, but quit instead of starting [env: HOPRD_DRY_RUN=]
       --init
@@ -273,7 +277,7 @@ These criteria however, are not required when you develop using your local nodes
 At the moment we DO NOT HAVE backward compatibility between releases.
 We attempt to provide instructions on how to migrate your tokens between releases.
 
-1. Set your automatic channel strategy to `MANUAL`.
+1. Set your automatic channel strategy to `passive`.
 2. Redeem all unredeemed tickets.
 3. Close all open payment channels.
 4. Once all payment channels have closed, withdraw your funds to an external

--- a/packages/avado/releases.json
+++ b/packages/avado/releases.json
@@ -2588,10 +2588,10 @@
     }
   },
   "0.200.0": {
-    "hash": "/ipfs/Qmcm7BMxkdmsdNM5yzyePd9yBKNuJgQKpYCQQRi2BVPj8d",
+    "hash": "/ipfs/QmYsJ2hJ5zbVhnU2MatQgtrnUTiHynEV2ZWLSbsGtZM4KG",
     "type": "manifest",
     "uploadedTo": {
-      "http://80.208.229.228:5001": "Thu, 09 Feb 2023 16:10:18 GMT"
+      "http://80.208.229.228:5001": "Thu, 09 Feb 2023 16:53:00 GMT"
     }
   },
   "1.91.19": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -636,7 +636,7 @@ class Hopr extends EventEmitter {
         error(`Protocol error: strategy wants to open channel to non-registered peer ${destination.toString()}`)
       }
     } catch (e) {
-      error(`strategy could not open channel to ${status.peer_id}`)
+      error(`strategy could not open channel to ${status.peer_id}`,e)
     }
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -636,7 +636,7 @@ class Hopr extends EventEmitter {
         error(`Protocol error: strategy wants to open channel to non-registered peer ${destination.toString()}`)
       }
     } catch (e) {
-      error(`strategy could not open channel to ${status.peer_id}`,e)
+      error(`strategy could not open channel to ${status.peer_id}`, e)
     }
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -154,6 +154,8 @@ export type HoprOptions = {
   heartbeatVariance?: number
   networkQualityThreshold?: number
   onChainConfirmations?: number
+  checkUnrealizedBalance?: boolean
+
   testing?: {
     // when true, assume that the node is running in an isolated network and does
     // not need any connection to nodes outside of the subnet
@@ -450,7 +452,8 @@ class Hopr extends EventEmitter {
       onMessage,
       this.db,
       this.environment,
-      this.acknowledgements
+      this.acknowledgements,
+      this.options
     )
 
     // Attach socket listener and check availability of entry nodes

--- a/packages/core/src/interactions/packet/forward.ts
+++ b/packages/core/src/interactions/packet/forward.ts
@@ -6,7 +6,7 @@ import { debug } from '@hoprnet/hopr-utils'
 import { Packet } from '../../messages/index.js'
 import { Mixer } from '../../mixer.js'
 import type { AcknowledgementInteraction } from './acknowledgement.js'
-import type { SendMessage, Subscribe } from '../../index.js'
+import type { HoprOptions, SendMessage, Subscribe } from '../../index.js'
 import type { ResolvedEnvironment } from '../../environment.js'
 
 const log = debug('hopr-core:packet:forward')
@@ -37,8 +37,9 @@ export class PacketForwardInteraction {
     private db: HoprDB,
     private environment: ResolvedEnvironment,
     private acknowledgements: AcknowledgementInteraction,
+    private options: HoprOptions,
     // used for testing
-    nextRandomInt?: () => number
+    nextRandomInt?: () => number,
   ) {
     this.mixer = new Mixer(nextRandomInt)
     this.handlePacket = this.handlePacket.bind(this)
@@ -98,7 +99,7 @@ export class PacketForwardInteraction {
 
     // Packet should be forwarded
     try {
-      await packet.validateUnacknowledgedTicket(this.db)
+      await packet.validateUnacknowledgedTicket(this.db, this.options.checkUnrealizedBalance)
     } catch (err) {
       log(`Ticket validation failed. Dropping packet`, err)
       return

--- a/packages/core/src/interactions/packet/forward.ts
+++ b/packages/core/src/interactions/packet/forward.ts
@@ -39,7 +39,7 @@ export class PacketForwardInteraction {
     private acknowledgements: AcknowledgementInteraction,
     private options: HoprOptions,
     // used for testing
-    nextRandomInt?: () => number,
+    nextRandomInt?: () => number
   ) {
     this.mixer = new Mixer(nextRandomInt)
     this.handlePacket = this.handlePacket.bind(this)

--- a/packages/core/src/interactions/packet/index.spec.ts
+++ b/packages/core/src/interactions/packet/index.spec.ts
@@ -28,6 +28,7 @@ import { PacketForwardInteraction } from './forward.js'
 import { initializeCommitment } from '@hoprnet/hopr-core-ethereum'
 import { ChannelCommitmentInfo } from '@hoprnet/hopr-core-ethereum'
 import type { ResolvedEnvironment } from '../../environment.js'
+import { HoprOptions } from '../../index.js'
 
 const SECRET_LENGTH = 32
 
@@ -48,6 +49,12 @@ const COUNTERPARTY = privKeyToPeerId(stringToU8a('0x0726a9704d56a013980a9077d195
 const nodes: PeerId[] = [SELF, RELAY0, RELAY1, RELAY2, COUNTERPARTY]
 
 const TestingSnapshot = new Snapshot(new BN(0), new BN(0), new BN(0))
+
+const TestOptions: HoprOptions = {
+  environment: undefined,
+  dataPath: '',
+  checkUnrealizedBalance: false
+}
 
 /**
  * Creates a mocked network to send and receive acknowledgements and packets
@@ -326,6 +333,7 @@ describe('packet acknowledgement', function () {
         id: 'testing'
       } as ResolvedEnvironment,
       ackRelay0Interaction,
+      TestOptions,
       () => 1
     )
     await interaction.start()
@@ -416,6 +424,7 @@ describe('packet relaying interaction', function () {
           id: 'testing'
         } as ResolvedEnvironment,
         acknowledgementInteraction,
+        TestOptions,
         () => 1
       )
       await interaction.start()

--- a/packages/core/src/messages/packet.ts
+++ b/packages/core/src/messages/packet.ts
@@ -201,6 +201,7 @@ export async function validateUnacknowledgedTicket(
 
   if (checkUnrealizedBalance) {
     // find out pending balance from unredeemed tickets
+    log(`checking unrealized balances for channel ${channel.getId().toHex()}`)
 
     // all tickets from sender
     const tickets = await getTickets().then((ts) => {

--- a/packages/core/src/messages/validations.spec.ts
+++ b/packages/core/src/messages/validations.spec.ts
@@ -72,7 +72,7 @@ describe('messages/validations.spec.ts - unit test validateUnacknowledgedTicket'
     const signedTicket = createMockTicket({})
 
     return expect(
-      validateUnacknowledgedTicket(SENDER, new BN(1), new BN(1), signedTicket, await mockChannelEntry(), getTicketsMock)
+      validateUnacknowledgedTicket(SENDER, new BN(1), new BN(1), signedTicket, await mockChannelEntry(), getTicketsMock, true)
     ).to.not.eventually.rejected
   })
 
@@ -80,7 +80,7 @@ describe('messages/validations.spec.ts - unit test validateUnacknowledgedTicket'
     const signedTicket = createMockTicket({})
 
     return expect(
-      validateUnacknowledgedTicket(TARGET, new BN(2), new BN(1), signedTicket, await mockChannelEntry(), getTicketsMock)
+      validateUnacknowledgedTicket(TARGET, new BN(2), new BN(1), signedTicket, await mockChannelEntry(), getTicketsMock, true)
     ).to.eventually.rejectedWith('The signer of the ticket does not match the sender')
   })
 
@@ -88,7 +88,7 @@ describe('messages/validations.spec.ts - unit test validateUnacknowledgedTicket'
     const signedTicket = createMockTicket({})
 
     return expect(
-      validateUnacknowledgedTicket(SENDER, new BN(2), new BN(1), signedTicket, await mockChannelEntry(), getTicketsMock)
+      validateUnacknowledgedTicket(SENDER, new BN(2), new BN(1), signedTicket, await mockChannelEntry(), getTicketsMock, true)
     ).to.eventually.rejectedWith('Ticket amount')
   })
 
@@ -98,7 +98,7 @@ describe('messages/validations.spec.ts - unit test validateUnacknowledgedTicket'
     })
 
     return expect(
-      validateUnacknowledgedTicket(SENDER, new BN(1), new BN(1), signedTicket, await mockChannelEntry(), getTicketsMock)
+      validateUnacknowledgedTicket(SENDER, new BN(1), new BN(1), signedTicket, await mockChannelEntry(), getTicketsMock, true)
     ).to.eventually.rejectedWith('Ticket winning probability')
   })
 
@@ -112,7 +112,8 @@ describe('messages/validations.spec.ts - unit test validateUnacknowledgedTicket'
         new BN(1),
         signedTicket,
         await mockChannelEntry(false),
-        getTicketsMock
+        getTicketsMock,
+        true
       )
     ).to.eventually.rejectedWith('is not open')
   })
@@ -122,7 +123,7 @@ describe('messages/validations.spec.ts - unit test validateUnacknowledgedTicket'
     const mockChannel = await mockChannelEntry(true, new Balance(new BN(100)), new UINT256(new BN(2)))
 
     return expect(
-      validateUnacknowledgedTicket(SENDER, new BN(1), new BN(1), signedTicket, mockChannel, getTicketsMock)
+      validateUnacknowledgedTicket(SENDER, new BN(1), new BN(1), signedTicket, mockChannel, getTicketsMock, true)
     ).to.eventually.rejectedWith('does not match our account epoch')
   })
 
@@ -132,7 +133,7 @@ describe('messages/validations.spec.ts - unit test validateUnacknowledgedTicket'
     })
 
     return expect(
-      validateUnacknowledgedTicket(SENDER, new BN(1), new BN(1), signedTicket, await mockChannelEntry(), getTicketsMock)
+      validateUnacknowledgedTicket(SENDER, new BN(1), new BN(1), signedTicket, await mockChannelEntry(), getTicketsMock, true)
     ).to.eventually.rejectedWith('Ticket was created for a different channel iteration')
   })
 
@@ -145,7 +146,7 @@ describe('messages/validations.spec.ts - unit test validateUnacknowledgedTicket'
       new UINT256(new BN(2))
     )
 
-    return expect(validateUnacknowledgedTicket(SENDER, new BN(1), new BN(1), signedTicket, mockChannel, getTicketsMock))
+    return expect(validateUnacknowledgedTicket(SENDER, new BN(1), new BN(1), signedTicket, mockChannel, getTicketsMock, true))
       .to.not.eventually.rejected
   })
 
@@ -165,7 +166,7 @@ describe('messages/validations.spec.ts - unit test validateUnacknowledgedTicket'
     ]
 
     return expect(
-      validateUnacknowledgedTicket(SENDER, new BN(1), new BN(1), signedTicket, mockChannel, async () => ticketsInDb)
+      validateUnacknowledgedTicket(SENDER, new BN(1), new BN(1), signedTicket, mockChannel, async () => ticketsInDb, true)
     ).to.not.eventually.rejected
   })
 
@@ -179,7 +180,8 @@ describe('messages/validations.spec.ts - unit test validateUnacknowledgedTicket'
         new BN(1),
         signedTicket,
         await mockChannelEntry(true, new Balance(new BN(0))),
-        getTicketsMock
+        getTicketsMock,
+        true
       )
     ).to.eventually.rejectedWith(
       'Payment channel 0x434c7d4fdeadfc5b67c251d1a421d2d73e90c81355ade7744af5dddf160c27df does not have enough funds'
@@ -201,7 +203,8 @@ describe('messages/validations.spec.ts - unit test validateUnacknowledgedTicket'
         new BN(1),
         signedTicket,
         await mockChannelEntry(),
-        async () => ticketsInDb
+        async () => ticketsInDb,
+        true
       )
     ).to.eventually.rejectedWith(
       'Payment channel 0x434c7d4fdeadfc5b67c251d1a421d2d73e90c81355ade7744af5dddf160c27df does not have enough funds'

--- a/packages/hoprd/crates/hoprd-misc/src/cli.rs
+++ b/packages/hoprd/crates/hoprd-misc/src/cli.rs
@@ -233,7 +233,7 @@ struct CliArgs {
     pub password: Option<String>,
 
     #[arg(
-    long,
+    long = "defaultStrategy",
     help = "Default channel strategy to use after node starts up",
     env = "HOPRD_DEFAULT_STRATEGY",
     value_name = "DEFAULT_STRATEGY",
@@ -243,7 +243,7 @@ struct CliArgs {
     pub default_strategy: Option<String>,
 
     #[arg(
-    long,
+    long = "maxAutoChannels",
     help = "Maximum number of channel a strategy can open. If not specified, square root of number of available peers is used.",
     env = "HOPRD_MAX_AUTO_CHANNELS",
     value_name = "MAX_AUTO_CHANNELS",

--- a/packages/hoprd/crates/hoprd-misc/src/cli.rs
+++ b/packages/hoprd/crates/hoprd-misc/src/cli.rs
@@ -262,7 +262,7 @@ struct CliArgs {
     #[arg(
     long = "checkUnrealizedBalance",
     default_value_t = false,
-    env = "HOPRD_AUTO_REDEEEM_TICKETS",
+    env = "HOPRD_CHECK_UNREALIZED_BALANCE",
     help = "Determines if unrealized balance shall be checked first before validating unacknowledged tickets."
     )]
     pub check_unrealized_balance: bool,

--- a/packages/hoprd/crates/hoprd-misc/src/cli.rs
+++ b/packages/hoprd/crates/hoprd-misc/src/cli.rs
@@ -260,6 +260,14 @@ struct CliArgs {
     pub auto_redeem_tickets: bool,
 
     #[arg(
+    long = "checkUnrealizedBalance",
+    default_value_t = false,
+    env = "HOPRD_AUTO_REDEEEM_TICKETS",
+    help = "Determines if unrealized balance shall be checked first before validating unacknowledged tickets."
+    )]
+    pub check_unrealized_balance: bool,
+
+    #[arg(
         long,
         help = "A custom RPC provider to be used for the node to connect to blockchain",
         env = "HOPRD_PROVIDER",

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -70,6 +70,7 @@ function generateNodeOptions(argv: CliArgs, environment: ResolvedEnvironment): H
     heartbeatVariance: argv.heartbeat_variance,
     networkQualityThreshold: argv.network_quality_threshold,
     onChainConfirmations: argv.on_chain_confirmations,
+    checkUnrealizedBalance: argv.check_unrealized_balance,
     testing: {
       announceLocalAddresses: argv.test_announce_local_addresses,
       preferLocalAddresses: argv.test_prefer_local_addresses,


### PR DESCRIPTION
Check for unrealized balance should be optional per default as requested by RPCh.

It also creates adds a new CLI argument: `--checkUnrealizedBalance` to explicitly enable the check for unrealized balances.

Other minor fixes:
- fix some long parameter names
- fix printing out of an error stack trace when the strategy cannot open a channel


Refs #4535, closes #4609