### PR TITLE
Early abort heartbeat when timeout

### DIFF
--- a/packages/core/src/network/heartbeat.spec.ts
+++ b/packages/core/src/network/heartbeat.spec.ts
@@ -359,14 +359,10 @@ describe('unit test heartbeat', async () => {
   })
 
   it('should abort heartbeat but not call closeConnectionsTo, if the ping takes 61 seconds to return', async () => {
-    const sendMessageToMoon = (
-      _dest: PeerId,
-      _protocols: string | string[],
-      msg: Uint8Array,
-      _includeReply: true
-    ) => new Promise(resolve => setTimeout(() => resolve([msg]), 61000)) as Promise<Uint8Array[]>
-  
-    const closeConnectionsToFake = sinon.fake();
+    const sendMessageToMoon = (_dest: PeerId, _protocols: string | string[], msg: Uint8Array, _includeReply: true) =>
+      new Promise((resolve) => setTimeout(() => resolve([msg]), 61000)) as Promise<Uint8Array[]>
+
+    const closeConnectionsToFake = sinon.fake()
     let netHealth = new NetworkHealth()
     const myheartbeat = new TestingHeartbeat(
       Me,
@@ -380,21 +376,17 @@ describe('unit test heartbeat', async () => {
       SHORT_TIMEOUTS
     )
 
-    const pingResult = await myheartbeat.pingNode(Alice);
+    const pingResult = await myheartbeat.pingNode(Alice)
 
-    assert.equal(pingResult.lastSeen, -1);
-    assert(closeConnectionsToFake.notCalled);
+    assert.equal(pingResult.lastSeen, -1)
+    assert(closeConnectionsToFake.notCalled)
   }).timeout(300000)
 
   it('should but not call closeConnectionsTo, if the ping timed out ', async () => {
-    const sendMessageToMoon = (
-      _dest: PeerId,
-      _protocols: string | string[],
-      msg: Uint8Array,
-      _includeReply: true
-    ) => new Promise(resolve => setTimeout(() => resolve([msg]), 1000)) as Promise<Uint8Array[]>
-  
-    const closeConnectionsToFake = sinon.fake();
+    const sendMessageToMoon = (_dest: PeerId, _protocols: string | string[], msg: Uint8Array, _includeReply: true) =>
+      new Promise((resolve) => setTimeout(() => resolve([msg]), 1000)) as Promise<Uint8Array[]>
+
+    const closeConnectionsToFake = sinon.fake()
     let netHealth = new NetworkHealth()
     const myheartbeat = new TestingHeartbeat(
       Me,
@@ -408,11 +400,9 @@ describe('unit test heartbeat', async () => {
       SHORT_TIMEOUTS
     )
 
-    const pingResult = await myheartbeat.pingNode(Alice);
+    const pingResult = await myheartbeat.pingNode(Alice)
 
-    assert.notEqual(pingResult.lastSeen, -1);
-    assert(closeConnectionsToFake.notCalled);
+    assert.notEqual(pingResult.lastSeen, -1)
+    assert(closeConnectionsToFake.notCalled)
   }).timeout(300000)
-
-  
 })

--- a/packages/core/src/network/heartbeat.ts
+++ b/packages/core/src/network/heartbeat.ts
@@ -185,7 +185,9 @@ export default class Heartbeat {
     let pingErrorThrown = false
     try {
       // race the HEART_BEAT_ROUND_TIMEOUT. Abort ping action when timeout.
-      pingResponse = await timeout(HEART_BEAT_ROUND_TIMEOUT, () => this.sendMessage(destination, this.protocolHeartbeat, challenge, true))
+      pingResponse = await timeout(HEART_BEAT_ROUND_TIMEOUT, () =>
+        this.sendMessage(destination, this.protocolHeartbeat, challenge, true)
+      )
     } catch (err) {
       pingErrorThrown = true
       pingError = err

--- a/packages/core/src/network/heartbeat.ts
+++ b/packages/core/src/network/heartbeat.ts
@@ -6,6 +6,7 @@ import {
   u8aEquals,
   debug,
   retimer,
+  timeout,
   nAtATime,
   u8aToHex,
   pickVersion,
@@ -33,6 +34,8 @@ import pkg from '../../package.json' assert { type: 'json' }
 const NORMALIZED_VERSION = pickVersion(pkg.version)
 
 const MAX_PARALLEL_HEARTBEATS = 14
+
+const HEART_BEAT_ROUND_TIMEOUT = 60000 // 1 minute in ms;
 
 // Metrics
 const metric_networkHealth = create_gauge('core_gauge_network_health', 'Connectivity health indicator')
@@ -181,7 +184,8 @@ export default class Heartbeat {
     let pingError: any
     let pingErrorThrown = false
     try {
-      pingResponse = await this.sendMessage(destination, this.protocolHeartbeat, challenge, true)
+      // race the HEART_BEAT_ROUND_TIMEOUT. Abort ping action when timeout.
+      pingResponse = await timeout(HEART_BEAT_ROUND_TIMEOUT, () => this.sendMessage(destination, this.protocolHeartbeat, challenge, true))
     } catch (err) {
       pingErrorThrown = true
       pingError = err


### PR DESCRIPTION
- Add `HEART_BEAT_ROUND_TIMEOUT` which is 1 min
- If pinging node takes more than `HEART_BEAT_ROUND_TIMEOUT`, abort the `pingNode` action
Closes #4600 