### PR TITLE
Fix Avado startup in Riga

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,8 @@ Options:
           Set port to which the API server will bind [env: HOPRD_API_PORT=] [default: 3001]
       --apiToken <TOKEN>
           A REST API token and for user authentication [env: HOPRD_API_TOKEN=]
+      --disableApiAuthentication
+          Completely disables the token authentication for the API, overrides any `apiToken` if set [env: HOPRD_DISABLE_API_AUTHENTICATION] [default: false]
       --healthCheck
           Run a health check end point on localhost:8080 [env: HOPRD_HEALTH_CHECK=]
       --healthCheckHost <HOST>

--- a/packages/avado/docker-compose.yml
+++ b/packages/avado/docker-compose.yml
@@ -32,6 +32,7 @@ services:
         'HOPRD_HEALTH_CHECK_PORT=8080',
         'HOPRD_PASSWORD=open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0',
         'HOPRD_DISABLE_API_AUTHENTICATION=true',
+        'HOPRD_API_TOKEN=%TOKEN%',
         'HOPRD_IDENTITY=/app/hoprd-db/.hopr-identity',
         'HOPRD_DATA=/app/hoprd-db/data-%ENV_ID%',
         'HOPRD_INIT=true',

--- a/packages/hoprd/crates/hoprd-misc/src/cli.rs
+++ b/packages/hoprd/crates/hoprd-misc/src/cli.rs
@@ -344,7 +344,7 @@ struct CliArgs {
 
     #[arg(
         long = "disableApiAuthentication",
-        help = "completely disables the token authentication for the API",
+        help = "completely disables the token authentication for the API, overrides any apiToken if set",
         action = ArgAction::SetTrue,
         env = "HOPRD_DISABLE_API_AUTHENTICATION",
         default_value_t = false,

--- a/packages/hoprd/crates/hoprd-misc/src/cli.rs
+++ b/packages/hoprd/crates/hoprd-misc/src/cli.rs
@@ -344,9 +344,9 @@ struct CliArgs {
 
     #[arg(
         long = "disableApiAuthentication",
-        help = "no remote authentication for easier testing",
+        help = "completely disables the token authentication for the API",
         action = ArgAction::SetTrue,
-        env = "HOPRD_TEST_NO_AUTHENTICATION",
+        env = "HOPRD_DISABLE_API_AUTHENTICATION",
         default_value_t = false,
         hide = true
     )]


### PR DESCRIPTION
Adds back missing environment variable to make `supervisord` happy.

Also corrects an invalid name of an environment variable.