### PR TITLE
Adding time command needed for register nodes

### DIFF
--- a/scripts/toolchain/Dockerfile
+++ b/scripts/toolchain/Dockerfile
@@ -11,19 +11,20 @@ WORKDIR /app/hoprnet-toolchain
 RUN mkdir -p scripts/toolchain
 
 RUN apt-get update \
- && apt-get install -y \
-      bash \
-      build-essential \
-      ca-certificates \
-      curl \
-      git \
-      jq \
-      lsof \
-      python3 \
-      unzip \
-      xz-utils \
- && rm -rf /var/lib/apt/lists/* \
- && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
+     && apt-get install -y \
+     bash \
+     build-essential \
+     ca-certificates \
+     curl \
+     git \
+     jq \
+     lsof \
+     python3 \
+     unzip \
+     xz-utils \
+     time \
+     && rm -rf /var/lib/apt/lists/* \
+     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 
 # Gets yarn executable
 COPY .yarn .yarn/

--- a/scripts/toolchain/Dockerfile
+++ b/scripts/toolchain/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /app/hoprnet-toolchain
 RUN mkdir -p scripts/toolchain
 
 RUN apt-get update \
-&& apt-get install -y \
+ && apt-get install -y \
       bash \
       build-essential \
       ca-certificates \
@@ -23,8 +23,8 @@ RUN apt-get update \
       unzip \
       xz-utils \
       time \
-&& rm -rf /var/lib/apt/lists/* \
-&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
+ && rm -rf /var/lib/apt/lists/* \
+ && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 
 # Gets yarn executable
 COPY .yarn .yarn/

--- a/scripts/toolchain/Dockerfile
+++ b/scripts/toolchain/Dockerfile
@@ -11,20 +11,20 @@ WORKDIR /app/hoprnet-toolchain
 RUN mkdir -p scripts/toolchain
 
 RUN apt-get update \
-     && apt-get install -y \
-     bash \
-     build-essential \
-     ca-certificates \
-     curl \
-     git \
-     jq \
-     lsof \
-     python3 \
-     unzip \
-     xz-utils \
-     time \
-     && rm -rf /var/lib/apt/lists/* \
-     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
+&& apt-get install -y \
+   bash \
+   build-essential \
+   ca-certificates \
+   curl \
+   git \
+   jq \
+   lsof \
+   python3 \
+   unzip \
+   xz-utils \
+   time \
+&& rm -rf /var/lib/apt/lists/* \
+&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 
 # Gets yarn executable
 COPY .yarn .yarn/

--- a/scripts/toolchain/Dockerfile
+++ b/scripts/toolchain/Dockerfile
@@ -12,17 +12,17 @@ RUN mkdir -p scripts/toolchain
 
 RUN apt-get update \
 && apt-get install -y \
-   bash \
-   build-essential \
-   ca-certificates \
-   curl \
-   git \
-   jq \
-   lsof \
-   python3 \
-   unzip \
-   xz-utils \
-   time \
+      bash \
+      build-essential \
+      ca-certificates \
+      curl \
+      git \
+      jq \
+      lsof \
+      python3 \
+      unzip \
+      xz-utils \
+      time \
 && rm -rf /var/lib/apt/lists/* \
 && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 


### PR DESCRIPTION
While registering the node in the Network registry, I'm using the docker image Toolchain, and the command time is not included but used in command `make self-register-node peer_ids="${HOPRD_PEER_ID}" environment="${HOPRD_ENVIRONMENT}" environment_type=${ENVIRONMENT_TYPE}`