### PR TITLE
fetch all stream chunks

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -54,7 +54,6 @@ import {
   isSecp256k1PeerId,
   type LibP2PHandlerFunction,
   libp2pSendMessage,
-  libp2pSubscribe,
   MIN_NATIVE_BALANCE,
   NativeBalance,
   PublicKey,
@@ -327,13 +326,6 @@ class Hopr extends EventEmitter {
     this.stopLibp2p = libp2p.stop.bind(libp2p)
 
     this.libp2pComponents = libp2p.components
-    // Subscribe to p2p events from libp2p. Wraps our instance of libp2p.
-    const subscribe = (
-      protocols: string | string[],
-      handler: LibP2PHandlerFunction<Promise<Uint8Array> | Promise<void> | void>,
-      includeReply: boolean,
-      errHandler: (err: any) => void
-    ) => libp2pSubscribe(this.libp2pComponents, protocols, handler, errHandler, includeReply)
 
     const sendMessage = ((
       dest: PeerId,
@@ -431,7 +423,7 @@ class Hopr extends EventEmitter {
 
     this.acknowledgements = new AcknowledgementInteraction(
       sendMessage,
-      subscribe,
+      this.libp2pComponents,
       this.getId(),
       this.db,
       (ackChallenge: HalfKeyChallenge) => {
@@ -446,7 +438,7 @@ class Hopr extends EventEmitter {
 
     const onMessage = (msg: Uint8Array) => this.emit('hopr:message', msg)
     this.forward = new PacketForwardInteraction(
-      subscribe,
+      this.libp2pComponents,
       sendMessage,
       this.getId(),
       onMessage,

--- a/packages/core/src/interactions/packet/acknowledgement.ts
+++ b/packages/core/src/interactions/packet/acknowledgement.ts
@@ -9,12 +9,14 @@ import {
   create_counter
 } from '@hoprnet/hopr-utils'
 import { findCommitmentPreImage, bumpCommitment } from '@hoprnet/hopr-core-ethereum'
-import type { SendMessage, Subscribe } from '../../index.js'
+import type { SendMessage } from '../../index.js'
 import type { PeerId } from '@libp2p/interface-peer-id'
 import { ACKNOWLEDGEMENT_TIMEOUT } from '../../constants.js'
 import { Acknowledgement, Packet } from '../../messages/index.js'
 import { Pushable, pushable } from 'it-pushable'
 import type { ResolvedEnvironment } from '../../environment.js'
+import type { Components } from '@libp2p/interfaces/components'
+
 const log = debug('hopr-core:acknowledgement')
 
 type OnAcknowledgement = (halfKey: HalfKeyChallenge) => void
@@ -52,7 +54,7 @@ export class AcknowledgementInteraction {
 
   constructor(
     private sendMessage: SendMessage,
-    private subscribe: Subscribe,
+    private libp2pComponents: Components,
     private privKey: PeerId,
     private db: HoprDB,
     private onAcknowledgement: OnAcknowledgement,
@@ -73,16 +75,15 @@ export class AcknowledgementInteraction {
     this.handleAcknowledgement = this.handleAcknowledgement.bind(this)
   }
   async start() {
-    await this.subscribe(
-      this.protocols,
-      (msg: Uint8Array, remotePeer: PeerId) => {
-        this.incomingAcks.push([msg, remotePeer])
-      },
-      false,
-      (err: any) => {
+    this.libp2pComponents.getRegistrar().handle(this.protocols, async ({ connection, stream }) => {
+      try {
+        for await (const chunk of stream.source) {
+          this.incomingAcks.push([chunk, connection.remotePeer])
+        }
+      } catch (err) {
         log(`Error while receiving acknowledgement`, err)
       }
-    )
+    })
 
     this.startHandleIncoming()
     this.startSendAcknowledgements()

--- a/packages/core/src/interactions/packet/acknowledgement.ts
+++ b/packages/core/src/interactions/packet/acknowledgement.ts
@@ -75,7 +75,7 @@ export class AcknowledgementInteraction {
     this.handleAcknowledgement = this.handleAcknowledgement.bind(this)
   }
   async start() {
-    this.libp2pComponents.getRegistrar().handle(this.protocols, async ({ connection, stream }) => {
+    await this.libp2pComponents.getRegistrar().handle(this.protocols, async ({ connection, stream }) => {
       try {
         for await (const chunk of stream.source) {
           this.incomingAcks.push([chunk, connection.remotePeer])

--- a/packages/core/src/interactions/packet/forward.ts
+++ b/packages/core/src/interactions/packet/forward.ts
@@ -57,7 +57,7 @@ export class PacketForwardInteraction {
   }
 
   async start() {
-    this.libp2pComponents.getRegistrar().handle(this.protocols, async ({ connection, stream }) => {
+    await this.libp2pComponents.getRegistrar().handle(this.protocols, async ({ connection, stream }) => {
       try {
         for await (const chunk of stream.source) {
           // TODO: this is a temporary quick-and-dirty solution to be used until

--- a/packages/core/src/interactions/packet/forward.ts
+++ b/packages/core/src/interactions/packet/forward.ts
@@ -6,8 +6,9 @@ import { debug } from '@hoprnet/hopr-utils'
 import { Packet } from '../../messages/index.js'
 import { Mixer } from '../../mixer.js'
 import type { AcknowledgementInteraction } from './acknowledgement.js'
-import type { HoprOptions, SendMessage, Subscribe } from '../../index.js'
+import type { HoprOptions, SendMessage } from '../../index.js'
 import type { ResolvedEnvironment } from '../../environment.js'
+import type { Components } from '@libp2p/interfaces/components'
 
 const log = debug('hopr-core:packet:forward')
 const error = debug('hopr-core:packet:forward:error')
@@ -30,7 +31,7 @@ export class PacketForwardInteraction {
   public readonly protocols: string | string[]
 
   constructor(
-    private subscribe: Subscribe,
+    private libp2pComponents: Components,
     private sendMessage: SendMessage,
     private privKey: PeerId,
     private emitMessage: (msg: Uint8Array) => void,
@@ -42,7 +43,6 @@ export class PacketForwardInteraction {
     nextRandomInt?: () => number
   ) {
     this.mixer = new Mixer(nextRandomInt)
-    this.handlePacket = this.handlePacket.bind(this)
 
     this.protocols = [
       // current
@@ -57,7 +57,19 @@ export class PacketForwardInteraction {
   }
 
   async start() {
-    await this.subscribe(this.protocols, this.handlePacket, false, this.errHandler)
+    this.libp2pComponents.getRegistrar().handle(this.protocols, async ({ connection, stream }) => {
+      try {
+        for await (const chunk of stream.source) {
+          // TODO: this is a temporary quick-and-dirty solution to be used until
+          // packet transformation logic has been ported to Rust
+          const packet = Packet.deserialize(chunk, this.privKey, connection.remotePeer)
+
+          this.mixer.push(packet)
+        }
+      } catch (err) {
+        this.errHandler(err)
+      }
+    })
 
     this.handleMixedPackets()
   }
@@ -77,12 +89,6 @@ export class PacketForwardInteraction {
     await this.sendMessage(counterparty, this.protocols, packet.serialize(), false, {
       timeout: FORWARD_TIMEOUT
     })
-  }
-
-  async handlePacket(msg: Uint8Array, remotePeer: PeerId) {
-    const packet = Packet.deserialize(msg, this.privKey, remotePeer)
-
-    this.mixer.push(packet)
   }
 
   async handleMixedPacket(packet: Packet) {

--- a/packages/core/src/messages/acknowledgement.ts
+++ b/packages/core/src/messages/acknowledgement.ts
@@ -36,7 +36,7 @@ export class Acknowledgement {
 
     let arr: Uint8Array
     if (typeof Buffer !== 'undefined' && Buffer.isBuffer(preArray)) {
-      arr = Uint8Array.from(arr)
+      arr = new Uint8Array(preArray.buffer, preArray.byteOffset, preArray.byteLength)
     } else {
       arr = preArray
     }

--- a/packages/core/src/messages/acknowledgementChallenge.ts
+++ b/packages/core/src/messages/acknowledgementChallenge.ts
@@ -25,7 +25,7 @@ export class AcknowledgementChallenge {
 
     let arr: Uint8Array
     if (typeof Buffer !== 'undefined' && Buffer.isBuffer(preArray)) {
-      arr = Uint8Array.from(preArray)
+      arr = new Uint8Array(preArray.buffer, preArray.byteOffset, preArray.byteLength)
     } else {
       arr = preArray
     }

--- a/packages/core/src/messages/packet.ts
+++ b/packages/core/src/messages/packet.ts
@@ -330,7 +330,7 @@ export class Packet {
 
     let arr: Uint8Array
     if (typeof Buffer !== 'undefined' && Buffer.isBuffer(preArray)) {
-      arr = Uint8Array.from(arr)
+      arr = new Uint8Array(preArray.buffer, preArray.byteOffset, preArray.byteLength)
     } else {
       arr = preArray
     }


### PR DESCRIPTION
Removes an abstraction that fetches only the very first chunk of a stream, meaning

```
chunk_0
chunk_1
...
```

Current situation:
```
chunk_0
// all other messages are dropped
```

New behavior, applies to packet forwarding (consuming mixer output) and acknowledgement processing:
```
chunk_0
chunk_1
...
(until stream finishes)
```
