### PR TITLE
Allow to redeem tickets with a gap in ticket index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Bring back `fund` command, to open outgoing and incoming channels with counterpart ([#4566](https://github.com/hoprnet/hoprnet/pull/4566))
 - Improve Grafana dashboards & compose setup ([#4479](https://github.com/hoprnet/hoprnet/pull/4479))
 - API: Prevent API privilege escalation ([#4625](https://github.com/hoprnet/hoprnet/pull/4625))
+- Assign commitent at ticket redemption, so that tickets can be redeemed with a gap in ticket index ([#4643](https://github.com/hoprnet/hoprnet/pull/4643))
 
 <a name="1.91"></a>
 

--- a/packages/core-ethereum/src/index.ts
+++ b/packages/core-ethereum/src/index.ts
@@ -368,7 +368,7 @@ export default class HoprCoreEthereum extends EventEmitter {
         )
 
         log(ticket.ticket.toString())
-        
+
         const result = await boundRedeemTicket(channel.source, channelId, ticket)
 
         if (result.status !== 'SUCCESS') {
@@ -398,7 +398,11 @@ export default class HoprCoreEthereum extends EventEmitter {
   }
 
   // Private as out of order redemption will break things - redeem all at once.
-  private async redeemTicket(counterparty: PublicKey, channelId: Hash, ackTicket: AcknowledgedTicket): Promise<RedeemTicketResponse> {
+  private async redeemTicket(
+    counterparty: PublicKey,
+    channelId: Hash,
+    ackTicket: AcknowledgedTicket
+  ): Promise<RedeemTicketResponse> {
     if (!ackTicket.verify(counterparty)) {
       return {
         status: 'FAILURE',
@@ -410,7 +414,6 @@ export default class HoprCoreEthereum extends EventEmitter {
 
     try {
       commitmentPreImage = await findCommitmentPreImage(this.db, channelId)
-
     } catch (err) {
       log(`Channel ${channelId.toHex()} is out of commitments`)
       // TODO: How should we handle this ticket if it's out of commitment
@@ -460,7 +463,7 @@ export default class HoprCoreEthereum extends EventEmitter {
       }
     }
     log('Successfully submitted ticket', ackTicket.response.toHex())
-    
+
     // bump commitment when on-chain ticket redemption is successful
     await bumpCommitment(this.db, channelId, commitmentPreImage)
     log(`Successfully bump local commitment after ${commitmentPreImage.toHex()}`)

--- a/packages/core-ethereum/src/index.ts
+++ b/packages/core-ethereum/src/index.ts
@@ -342,6 +342,7 @@ export default class HoprCoreEthereum extends EventEmitter {
 
     const boundRedeemTicket = this.redeemTicket.bind(this)
     const boundGetAckdTickets = this.db.getAcknowledgedTickets.bind(this.db)
+    const boundMarkLosingAckedTicket = this.db.markLosingAckedTicket.bind(this.db)
 
     // Use an async iterator to make execution interruptable and allow
     // Node.JS to schedule iterations at any time
@@ -376,6 +377,10 @@ export default class HoprCoreEthereum extends EventEmitter {
             // We need to abort as tickets require ordered redemption.
             // delete operation before returning
             throw result.error
+          } else {
+            // May fail due to out-of-commits, preimage-is-empty, not-a-winning-ticket
+            // Treat those acked tickets as losing tickets, and remove them from the DB.
+            await boundMarkLosingAckedTicket(ticket)
           }
         }
 

--- a/packages/core-ethereum/src/index.ts
+++ b/packages/core-ethereum/src/index.ts
@@ -397,8 +397,7 @@ export default class HoprCoreEthereum extends EventEmitter {
     }
   }
 
-  // Private as out of order redemption will break things - redeem all at once.
-  private async redeemTicket(
+  public async redeemTicket(
     counterparty: PublicKey,
     channelId: Hash,
     ackTicket: AcknowledgedTicket

--- a/packages/core-ethereum/src/index.ts
+++ b/packages/core-ethereum/src/index.ts
@@ -317,10 +317,10 @@ export default class HoprCoreEthereum extends EventEmitter {
     // start new operation and store it
     return new Promise((resolve, reject) => {
       try {
-        this.ticketRedemtionInChannelOperations.set(channelId, this.redeemTicketsInChannelLoop(channel).then(
-          resolve,
-          reject
-        ))
+        this.ticketRedemtionInChannelOperations.set(
+          channelId,
+          this.redeemTicketsInChannelLoop(channel).then(resolve, reject)
+        )
       } catch (err) {
         reject(err)
       }

--- a/packages/core-ethereum/src/index.ts
+++ b/packages/core-ethereum/src/index.ts
@@ -469,6 +469,7 @@ export default class HoprCoreEthereum extends EventEmitter {
     log('Successfully submitted ticket', ackTicket.response.toHex())
 
     // bump commitment when on-chain ticket redemption is successful
+    // FIXME: bump commitment can fail if channel runs out of commitments
     await bumpCommitment(this.db, channelId, commitmentPreImage)
     log(`Successfully bump local commitment after ${commitmentPreImage.toHex()}`)
 

--- a/packages/core/src/channel-strategy.ts
+++ b/packages/core/src/channel-strategy.ts
@@ -59,7 +59,7 @@ export interface ChannelStrategyInterface {
   ): StrategyTickResult
 
   onChannelWillClose(channel: ChannelEntry): Promise<void> // Before a channel closes
-  onWinningTicket(t: AcknowledgedTicket): Promise<void>
+  onAckedTicket(t: AcknowledgedTicket): Promise<void>
   shouldCommitToChannel(c: ChannelEntry): boolean
 
   tickInterval: number
@@ -73,7 +73,7 @@ export interface ChannelStrategyInterface {
 export abstract class SaneDefaults {
   protected autoRedeemTickets: boolean = false
 
-  async onWinningTicket(ackTicket: AcknowledgedTicket) {
+  async onAckedTicket(ackTicket: AcknowledgedTicket) {
     if (this.autoRedeemTickets) {
       const counterparty = ackTicket.signer
       log(`auto redeeming tickets in channel to ${counterparty.toPeerId().toString()}`)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -431,8 +431,7 @@ class Hopr extends EventEmitter {
         this.emit(`hopr:message-acknowledged:${ackChallenge.toHex()}`)
         this.emit('hopr:message-acknowledged', ackChallenge.toHex())
       },
-      (ack: AcknowledgedTicket) => connector.emit('ticket:win', ack),
-      () => {},
+      (ack: AcknowledgedTicket) => connector.emit('ticket:acknowledged', ack),
       this.environment
     )
 
@@ -1144,11 +1143,11 @@ class Hopr extends EventEmitter {
     log('setting channel strategy from', this.strategy?.name, 'to', strategy.name)
     this.strategy = strategy
 
-    HoprCoreEthereum.getInstance().on('ticket:win', async (ack: AcknowledgedTicket) => {
+    HoprCoreEthereum.getInstance().on('ticket:acknowledged', async (ack: AcknowledgedTicket) => {
       try {
-        await this.strategy.onWinningTicket(ack)
+        await this.strategy.onAckedTicket(ack)
       } catch (err) {
-        error(`Strategy error while handling winning ticket`, err)
+        error(`Strategy error while handling acknowledged ticket`, err)
       }
     })
   }

--- a/packages/core/src/interactions/packet/acknowledgement.ts
+++ b/packages/core/src/interactions/packet/acknowledgement.ts
@@ -43,7 +43,7 @@ const metric_sentAcks = create_counter('core_counter_sent_acks', 'Number of sent
 
 const metric_ackedTickets = create_counter('core_counter_acked_tickets', 'Number of acknowledged tickets')
 
-const PREIMAGE_PLACE_HOLDER = new Hash(new Uint8Array({ length: Hash.SIZE }).fill(1))
+const PREIMAGE_PLACE_HOLDER = new Hash(new Uint8Array(Hash.SIZE).fill(0xff))
 
 export class AcknowledgementInteraction {
   private incomingAcks: Pushable<Incoming>

--- a/packages/core/src/interactions/packet/acknowledgement.ts
+++ b/packages/core/src/interactions/packet/acknowledgement.ts
@@ -196,7 +196,7 @@ export class AcknowledgementInteraction {
     const ack = new AcknowledgedTicket(ticket, response, opening, unacknowledged.signer)
     log(`Acknowledging ticket. Using not-up-to-date opening ${opening.toHex()} and response ${response.toHex()}`)
     // replace the unAcked ticket with Acked ticket.
-  
+
     try {
       await this.db.replaceUnAckWithAck(acknowledgement.ackChallenge, ack)
       log(`Stored acknowledged ticket`)

--- a/packages/core/src/interactions/packet/acknowledgement.ts
+++ b/packages/core/src/interactions/packet/acknowledgement.ts
@@ -4,7 +4,8 @@ import {
   AcknowledgedTicket,
   type HoprDB,
   type PendingAckowledgement,
-  type HalfKeyChallenge, Hash,
+  type HalfKeyChallenge,
+  Hash,
   create_counter
 } from '@hoprnet/hopr-utils'
 import type { SendMessage } from '../../index.js'
@@ -175,7 +176,6 @@ export class AcknowledgementInteraction {
     }
     const response = unacknowledged.getResponse(acknowledgement.ackKeyShare)
     const ticket = unacknowledged.ticket
-
 
     // Store the acknowledged ticket, regardless if it's a win or a loss
     // create an acked ticket with a pre image place holder

--- a/packages/core/src/interactions/packet/index.spec.ts
+++ b/packages/core/src/interactions/packet/index.spec.ts
@@ -253,7 +253,6 @@ describe('packet acknowledgement', function () {
         }
       },
       () => {},
-      () => {},
       {
         id: 'testing'
       } as ResolvedEnvironment
@@ -264,7 +263,6 @@ describe('packet acknowledgement', function () {
       libp2pCounterparty.components,
       COUNTERPARTY,
       dbs[1],
-      () => {},
       () => {},
       () => {},
       {
@@ -323,7 +321,6 @@ describe('packet acknowledgement', function () {
       () => {
         ackReceived.resolve()
       },
-      () => {},
       {
         id: 'testing'
       } as ResolvedEnvironment
@@ -334,7 +331,6 @@ describe('packet acknowledgement', function () {
       libp2pCounterparty.components,
       COUNTERPARTY,
       dbs[2],
-      () => {},
       () => {},
       () => {},
       {
@@ -434,7 +430,6 @@ describe('packet relaying interaction', function () {
         components,
         pId,
         dbs[index],
-        () => {},
         () => {},
         () => {},
         {

--- a/packages/cover-traffic-daemon/src/strategy.ts
+++ b/packages/cover-traffic-daemon/src/strategy.ts
@@ -211,8 +211,8 @@ export class CoverTrafficStrategy extends SaneDefaults implements ChannelStrateg
     return new StrategyTickResult(MAX_CT_AUTO_CHANNELS, toOpen, toClose)
   }
 
-  async onWinningTicket() {
-    log('cover traffic ignores winning ticket.')
+  async onAckedTicket() {
+    log('cover traffic ignores acknowledged ticket.')
   }
 
   async onChannelWillClose() {

--- a/packages/utils/src/db/db.ts
+++ b/packages/utils/src/db/db.ts
@@ -801,12 +801,6 @@ export class HoprDB {
     await this.subBalance(createPendingTicketsCountKey(a.ticket.counterparty), a.ticket.amount)
   }
 
-  public async markLosing(t: UnacknowledgedTicket): Promise<void> {
-    await this.increment(LOSING_TICKET_COUNT)
-    await this.del(createPendingAcknowledgement(t.getChallenge()))
-    await this.subBalance(createPendingTicketsCountKey(t.ticket.counterparty), t.ticket.amount)
-  }
-
   public async getRejectedTicketsValue(): Promise<Balance> {
     return await this.getCoercedOrDefault<Balance>(REJECTED_TICKETS_VALUE, Balance.deserialize, Balance.ZERO)
   }

--- a/packages/utils/src/db/db.ts
+++ b/packages/utils/src/db/db.ts
@@ -795,6 +795,12 @@ export class HoprDB {
     await this.subBalance(createPendingTicketsCountKey(a.ticket.counterparty), a.ticket.amount)
   }
 
+  public async markLosingAckedTicket(a: AcknowledgedTicket): Promise<void> {
+    await this.increment(LOSING_TICKET_COUNT)
+    await this.delAcknowledgedTicket(a)
+    await this.subBalance(createPendingTicketsCountKey(a.ticket.counterparty), a.ticket.amount)
+  }
+
   public async markLosing(t: UnacknowledgedTicket): Promise<void> {
     await this.increment(LOSING_TICKET_COUNT)
     await this.del(createPendingAcknowledgement(t.getChallenge()))

--- a/packages/utils/src/types/acknowledgedTicket.ts
+++ b/packages/utils/src/types/acknowledgedTicket.ts
@@ -5,12 +5,16 @@ export class AcknowledgedTicket {
   constructor(
     public readonly ticket: Ticket,
     public readonly response: Response,
-    public readonly preImage: Hash,
+    public preImage: Hash,
     public readonly signer: PublicKey
   ) {
     if (signer.toAddress().eq(this.ticket.counterparty)) {
       throw Error(`Given signer public key must be different from counterparty`)
     }
+  }
+
+  public setPreImage(preImg: Hash) {
+    this.preImage = preImg
   }
 
   public serialize(): Uint8Array {


### PR DESCRIPTION
Fixes #4623, #4617 and #4549
- Remove the assignment of preImage from ticket acknowledgment to ticket redemption.
- Save all the tickets, regardless if it's a winning ticket
- Allow to remove an acked ticket right before doing redemption on-chain, when 
   - the ticket will be a loss
   - node is out of commits
   - ticket preimage is empty
- remove `markLosing` method in database and add `markLosingAckedTicket`
- `onWinningTicket` hook for strategies is replaced with `onAckedTicket`