### PR TITLE
add max parallel connections command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Improve Grafana dashboards & compose setup ([#4479](https://github.com/hoprnet/hoprnet/pull/4479))
 - API: Prevent API privilege escalation ([#4625](https://github.com/hoprnet/hoprnet/pull/4625))
 - Assign commitent at ticket redemption, so that tickets can be redeemed with a gap in ticket index ([#4643](https://github.com/hoprnet/hoprnet/pull/4643))
+- Make maximum parallel connections configurable (#[4675](https://github.com/hoprnet/hoprnet/pull/4675))
 
 <a name="1.91"></a>
 

--- a/packages/core/crates/core-misc/src/constants.rs
+++ b/packages/core/crates/core-misc/src/constants.rs
@@ -9,6 +9,11 @@ pub const DEFAULT_HEARTBEAT_INTERVAL_VARIANCE: u32 = 2000;
 /// Network quality threshold from which a node is considered
 /// available enough to be used
 pub const DEFAULT_NETWORK_QUALITY_THRESHOLD: f32 = 0.5;
+/// Number of parallel connection handled by js-libp2p
+pub const DEFAULT_MAX_PARALLEL_CONNECTIONS: u32 = 100;
+/// Number of parallel connection handled by js-libp2p
+/// when running as a public relay node (i.e. the --announce flag is set)
+pub const DEFAULT_MAX_PARALLEL_CONNECTION_PUBLIC_RELAY: u32 = 50_000;
 
 #[cfg(feature = "wasm")]
 pub mod wasm {
@@ -25,6 +30,10 @@ pub mod wasm {
         pub default_heartbeat_interval_variance: u32,
         #[wasm_bindgen(readonly, js_name = "DEFAULT_NETWORK_QUALITY_THRESHOLD")]
         pub default_network_quality_threshold: f32,
+        #[wasm_bindgen(readonly, js_name = "DEFAULT_MAX_PARALLEL_CONNECTIONS")]
+        pub default_max_parallel_connections: u32,
+        #[wasm_bindgen(readonly, js_name = "DEFAULT_MAX_PARALLEL_CONNECTIONS_PUBLIC_RELAY")]
+        pub default_max_parallel_connections_public_relay: u32,
     }
 
     /// Returns a struct with readonly constants, needs to be a function
@@ -36,6 +45,9 @@ pub mod wasm {
             default_heartbeat_threshold: super::DEFAULT_HEARTBEAT_THRESHOLD,
             default_heartbeat_interval_variance: super::DEFAULT_HEARTBEAT_INTERVAL_VARIANCE,
             default_network_quality_threshold: super::DEFAULT_NETWORK_QUALITY_THRESHOLD,
+            default_max_parallel_connections: super::DEFAULT_MAX_PARALLEL_CONNECTIONS,
+            default_max_parallel_connections_public_relay:
+                super::DEFAULT_MAX_PARALLEL_CONNECTION_PUBLIC_RELAY,
         }
     }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -154,7 +154,7 @@ export type HoprOptions = {
   networkQualityThreshold?: number
   onChainConfirmations?: number
   checkUnrealizedBalance?: boolean
-
+  maxParallelConnections?: number
   testing?: {
     // when true, assume that the node is running in an isolated network and does
     // not need any connection to nodes outside of the subnet

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -141,7 +141,7 @@ export async function createLibp2pInstance(
         maxDialsPerPeer: 1,
         // If we are a public node, assume that our system is able to handle
         // more connections
-        maxParallelDials: options.announce ? 250 : 50,
+        maxParallelDials: options.maxParallelConnections,
         // default timeout of 30s appears to be too long
         dialTimeout: 10e3
       },

--- a/packages/hoprd/crates/hoprd-misc/src/cli.rs
+++ b/packages/hoprd/crates/hoprd-misc/src/cli.rs
@@ -6,7 +6,7 @@ use clap::{Arg, ArgAction, ArgMatches, Args, Command, FromArgMatches as _};
 use core_ethereum_misc::constants::DEFAULT_CONFIRMATIONS;
 use core_misc::constants::{
     DEFAULT_HEARTBEAT_INTERVAL, DEFAULT_HEARTBEAT_INTERVAL_VARIANCE, DEFAULT_HEARTBEAT_THRESHOLD,
-    DEFAULT_NETWORK_QUALITY_THRESHOLD,
+    DEFAULT_NETWORK_QUALITY_THRESHOLD, DEFAULT_MAX_PARALLEL_CONNECTIONS, DEFAULT_MAX_PARALLEL_CONNECTION_PUBLIC_RELAY
 };
 use core_misc::environment::{Environment, FromJsonFile, PackageJsonFile, ProtocolConfig};
 use core_strategy::{passive::PassiveStrategy, random::RandomStrategy, promiscuous::PromiscuousStrategy, generic::ChannelStrategy};
@@ -148,7 +148,7 @@ struct CliArgs {
         }, 
         env = "HOPRD_HOST", 
         help = "Host to listen on for P2P connections",
-        value_parser = ValueParser::new(parse_host)
+        value_parser = ValueParser::new(parse_host),
     )]
     pub host: Host,
 
@@ -233,37 +233,37 @@ struct CliArgs {
     pub password: Option<String>,
 
     #[arg(
-    long = "defaultStrategy",
-    help = "Default channel strategy to use after node starts up",
-    env = "HOPRD_DEFAULT_STRATEGY",
-    value_name = "DEFAULT_STRATEGY",
-    default_value = "passive",
-    value_parser = PossibleValuesParser::new([PromiscuousStrategy::NAME, PassiveStrategy::NAME, RandomStrategy::NAME])
+        long = "defaultStrategy",
+        help = "Default channel strategy to use after node starts up",
+        env = "HOPRD_DEFAULT_STRATEGY",
+        value_name = "DEFAULT_STRATEGY",
+        default_value = "passive",
+        value_parser = PossibleValuesParser::new([PromiscuousStrategy::NAME, PassiveStrategy::NAME, RandomStrategy::NAME])
     )]
     pub default_strategy: Option<String>,
 
     #[arg(
-    long = "maxAutoChannels",
-    help = "Maximum number of channel a strategy can open. If not specified, square root of number of available peers is used.",
-    env = "HOPRD_MAX_AUTO_CHANNELS",
-    value_name = "MAX_AUTO_CHANNELS",
-    value_parser = clap::value_parser!(u32)
+        long = "maxAutoChannels",
+        help = "Maximum number of channel a strategy can open. If not specified, square root of number of available peers is used.",
+        env = "HOPRD_MAX_AUTO_CHANNELS",
+        value_name = "MAX_AUTO_CHANNELS",
+        value_parser = clap::value_parser!(u32)
     )]
     pub max_auto_channels: Option<u32>, // Make this a string if we want to supply functions instead in the future.
 
     #[arg(
-    long = "autoRedeemTickets",
-    default_value_t = false,
-    env = "HOPRD_AUTO_REDEEEM_TICKETS",
-    help = "If enabled automatically redeems winning tickets."
+        long = "autoRedeemTickets",
+        default_value_t = false,
+        env = "HOPRD_AUTO_REDEEEM_TICKETS",
+        help = "If enabled automatically redeems winning tickets."
     )]
     pub auto_redeem_tickets: bool,
 
     #[arg(
-    long = "checkUnrealizedBalance",
-    default_value_t = false,
-    env = "HOPRD_CHECK_UNREALIZED_BALANCE",
-    help = "Determines if unrealized balance shall be checked first before validating unacknowledged tickets."
+        long = "checkUnrealizedBalance",
+        default_value_t = false,
+        env = "HOPRD_CHECK_UNREALIZED_BALANCE",
+        help = "Determines if unrealized balance shall be checked first before validating unacknowledged tickets."
     )]
     pub check_unrealized_balance: bool,
 
@@ -322,8 +322,21 @@ struct CliArgs {
     pub allow_private_node_connections: bool,
 
     #[arg(
+        long = "maxParallelConnections",
+        default_value_t = DEFAULT_MAX_PARALLEL_CONNECTIONS,
+        default_value_ifs = [
+            ("announce", "true", DEFAULT_MAX_PARALLEL_CONNECTION_PUBLIC_RELAY.to_string()),
+        ],
+        value_parser = clap::value_parser!(u32),
+        value_name = "CONNECTIONS",
+        help = "Set maximum parallel connections",
+        env = "HOPRD_MAX_PARALLEL_CONNECTIONS"
+    )]
+    pub max_parallel_connections: u32,
+
+    #[arg(
         long = "testAnnounceLocalAddresses",
-        env = "HOPRD_TEST_ANNOUNCE_LOCAL_ADDRESSES",
+        env = "HOPRD_TEST_ANNOUNCE_LOCAL_ADDRESSES"
         help = "For testing local testnets. Announce local addresses",
         action = ArgAction::SetTrue,
         default_value_t = false

--- a/packages/hoprd/crates/hoprd-misc/src/cli.rs
+++ b/packages/hoprd/crates/hoprd-misc/src/cli.rs
@@ -327,7 +327,7 @@ struct CliArgs {
         default_value_ifs = [
             ("announce", "true", DEFAULT_MAX_PARALLEL_CONNECTION_PUBLIC_RELAY.to_string()),
         ],
-        value_parser = clap::value_parser!(u32),
+        value_parser = clap::value_parser!(u32).range(1..),
         value_name = "CONNECTIONS",
         help = "Set maximum parallel connections",
         env = "HOPRD_MAX_PARALLEL_CONNECTIONS"

--- a/packages/hoprd/crates/hoprd-misc/src/cli.rs
+++ b/packages/hoprd/crates/hoprd-misc/src/cli.rs
@@ -336,7 +336,7 @@ struct CliArgs {
 
     #[arg(
         long = "testAnnounceLocalAddresses",
-        env = "HOPRD_TEST_ANNOUNCE_LOCAL_ADDRESSES"
+        env = "HOPRD_TEST_ANNOUNCE_LOCAL_ADDRESSES",
         help = "For testing local testnets. Announce local addresses",
         action = ArgAction::SetTrue,
         default_value_t = false

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -71,6 +71,7 @@ function generateNodeOptions(argv: CliArgs, environment: ResolvedEnvironment): H
     networkQualityThreshold: argv.network_quality_threshold,
     onChainConfirmations: argv.on_chain_confirmations,
     checkUnrealizedBalance: argv.check_unrealized_balance,
+    maxParallelConnections: argv.max_parallel_connections,
     testing: {
       announceLocalAddresses: argv.test_announce_local_addresses,
       preferLocalAddresses: argv.test_prefer_local_addresses,


### PR DESCRIPTION
## Context

`js-libp2p` allows to configure a maximum number of parallel connections. This is useful to limit the number of connections of NATed nodes since some routers appear to have issues with too many connections.

In case the limit is reached, `js-libp2p` fails with stack traces such as

```
Feb 28 11:07:47 files bash[2865580]: 2023-02-28T10:07:47.881Z hopr-core:libp2p:error Dial error: Error: No dial tokens available
Feb 28 11:07:47 files bash[2865580]:     at DialRequest.run (file:///home/hopr/hoprnet/node_modules/libp2p/dist/src/connection-manager/dialer/dial-request.js:26:27)
Feb 28 11:07:47 files bash[2865580]:     at Dialer._createPendingDial (file:///home/hopr/hoprnet/node_modules/libp2p/dist/src/connection-manager/dialer/index.js:205:34)
Feb 28 11:07:47 files bash[2865580]:     at Dialer.dial (file:///home/hopr/hoprnet/node_modules/libp2p/dist/src/connection-manager/dialer/index.js:98:74)
Feb 28 11:07:47 files bash[2865580]:     at async establishNewConnection (file:///home/hopr/hoprnet/packages/utils/lib/libp2p/dialHelper.js:115:17)
Feb 28 11:07:47 files bash[2865580]:     at async doDirectDial (file:///home/hopr/hoprnet/packages/utils/lib/libp2p/dialHelper.js:217:18)
Feb 28 11:07:47 files bash[2865580]:     at async dial (file:///home/hopr/hoprnet/packages/utils/lib/libp2p/dialHelper.js:306:17)
Feb 28 11:07:47 files bash[2865580]:     at async Relay.connect (file:///home/hopr/hoprnet/packages/connect/lib/relay/index.js:162:26)
Feb 28 11:07:47 files bash[2865580]:     at async HoprConnect.dialWithRelay (file:///home/hopr/hoprnet/packages/connect/lib/index.js:197:22)
Feb 28 11:07:47 files bash[2865580]:     at async HoprConnect.dial (file:///home/hopr/hoprnet/packages/connect/lib/index.js:154:32)
Feb 28 11:07:47 files bash[2865580]:     at async EventTarget.dial (file:///home/hopr/hoprnet/node_modules/libp2p/dist/src/transport-manager.js:78:20) {
Feb 28 11:07:47 files bash[2865580]:   code: 'ERR_NO_DIAL_TOKENS'
Feb 28 11:07:47 files bash[2865580]: }
```

## Current situation

There are two modes:

- *edge node* aka *NATed node*: max parallel connections set to `50`
- *relay node* aka *PRN* aka *relay node*: max parallel connections set to `250`

## New behavior

Defaults:

- *NATed node*: 100 connections
- *relay nodes*: 50_000 connections

In addition:

- CLI parameter `--max-parallel-connections` to set max parallel connection to any value between `0..2**32-1`

## Related issue

https://github.com/hoprnet/hoprnet/issues/4672 (no full fix)