### PR TITLE
adjust timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - API: Prevent API privilege escalation ([#4625](https://github.com/hoprnet/hoprnet/pull/4625))
 - Assign commitent at ticket redemption, so that tickets can be redeemed with a gap in ticket index ([#4643](https://github.com/hoprnet/hoprnet/pull/4643))
 - Make maximum parallel connections configurable (#[4675](https://github.com/hoprnet/hoprnet/pull/4675))
+- Reduce overall connection timeout from 10s to 3s (#[4680](https://github.com/hoprnet/hoprnet/pull/4680))
 
 <a name="1.91"></a>
 

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -143,7 +143,7 @@ export async function createLibp2pInstance(
         // more connections
         maxParallelDials: options.maxParallelConnections,
         // default timeout of 30s appears to be too long
-        dialTimeout: 10e3
+        dialTimeout: 3e3
       },
       connectionGater: {
         denyDialPeer: async (peer: PeerId) => !(await isAllowedToAccessNetwork(peer)),


### PR DESCRIPTION
This PR reduces the overall timeout that establishing a connection is allowed to take.

# Current situation

The node waits 10s to establish a TCP connection *before* it tries the next address, which appears to be too long.

# New behavior

Connection attempts get canceled after 3s