### PR TITLE
enhance address sorting

### DIFF
--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -11,7 +11,12 @@ import type { PeerId } from '@libp2p/interface-peer-id'
 import { keysPBM } from '@libp2p/crypto/keys'
 import type { AddressSorter, Address } from '@libp2p/interfaces/peer-store'
 
-import { HoprConnect, compareAddressesLocalMode, type PublicNodesEmitter } from '@hoprnet/hopr-connect'
+import {
+  HoprConnect,
+  compareAddressesLocalMode,
+  type PublicNodesEmitter,
+  compareAddressesPublicMode
+} from '@hoprnet/hopr-connect'
 import { HoprDB, PublicKey, debug, isAddressWithPeerId } from '@hoprnet/hopr-utils'
 import HoprCoreEthereum from '@hoprnet/hopr-core-ethereum'
 
@@ -53,13 +58,13 @@ export async function createLibp2pInstance(
 
     if (options.testing?.preferLocalAddresses) {
       addressSorter = (a: Address, b: Address) => compareAddressesLocalMode(a.multiaddr, b.multiaddr)
-      log('Preferring local addresses')
+      log('Address sorting: prefer local addresses')
     } else {
       // Overwrite address sorter with identity function since
       // libp2p's own address sorter function is unable to handle
       // p2p addresses, e.g. /p2p/<RELAY>/p2p-circuit/p2p/<DESTINATION>
-      addressSorter = (_addr) => 0
-      log('Addresses are sorted by default')
+      addressSorter = (a: Address, b: Address) => compareAddressesPublicMode(a.multiaddr, b.multiaddr)
+      log('Address sorting: start with most promising addresses')
     }
 
     // Store the peerstore on-disk under the main data path. Ensure store is


### PR DESCRIPTION
Enhances libp2p's address sorting 

# Current situation

When dialing peers, `core` / `libp2p` use naive address sorting which just places public IP addresses first, e.g.

```
avado_public (172.33.0.0/16)
public
relayed
localhost
relayed
```

# New behavior

Use class-based address sorting from `connect`

```
public
...
public
relayed
...
relayed
private
...
private
localhost
```

see https://github.com/hoprnet/hoprnet/blob/76fa88940a19bf63803f5cf264b473173536b64d/packages/connect/src/utils/addressSorters.ts#L30-L53
