### PR TITLE
enhance dht and libp2p config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 - Assign commitent at ticket redemption, so that tickets can be redeemed with a gap in ticket index ([#4643](https://github.com/hoprnet/hoprnet/pull/4643))
 - Make maximum parallel connections configurable (#[4675](https://github.com/hoprnet/hoprnet/pull/4675))
 - Reduce overall connection timeout from 10s to 3s (#[4680](https://github.com/hoprnet/hoprnet/pull/4680))
+- Automatically switch to DHT `server`-mode if node announces public addresses to DHT ([#4685](https://github.com/hoprnet/hoprnet/pull/4685))
+- Enhance address to sorting when dialing nodes ([#4684](https://github.com/hoprnet/hoprnet/pull/4684))
 
 <a name="1.91"></a>
 

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -363,7 +363,7 @@ class HoprConnect implements Transport, Initializable, Startable {
 }
 
 export type { PublicNodesEmitter, HoprConnectConfig }
-export { compareAddressesLocalMode, compareAddressesPublicMode } from './utils/index.js'
+export { compareAddressesLocalMode, compareAddressesPublicMode, maToClass, AddressClass } from './utils/index.js'
 export { startStunServer } from './base/stun/utils.js'
 
 export { HoprConnect, PeerConnectionType }

--- a/packages/connect/src/utils/addressSorters.ts
+++ b/packages/connect/src/utils/addressSorters.ts
@@ -81,6 +81,11 @@ function addressPriorityLocal(addrClass: AddressClass) {
   }
 }
 
+/**
+ * Map a given Multiaddr to a network class, e.g. `Public` address
+ * @param ma Multiaddr to determine class
+ * @returns the assigned class
+ */
 export function maToClass(ma: Multiaddr): AddressClass {
   const tuples = ma.tuples() as [code: number, addr: Uint8Array][]
 
@@ -122,6 +127,11 @@ export function maToClass(ma: Multiaddr): AddressClass {
   }
 }
 
+/**
+ * Comparator used to sort addresses in local-mode, see `addressPriorityLocal` function
+ * @param addrA first Multiaddr
+ * @param addrB second Multiaddr
+ */
 export function compareAddressesLocalMode(addrA: Multiaddr, addrB: Multiaddr): -1 | 0 | 1 {
   const result = addressPriorityLocal(maToClass(addrA)) - addressPriorityLocal(maToClass(addrB))
 
@@ -134,6 +144,12 @@ export function compareAddressesLocalMode(addrA: Multiaddr, addrB: Multiaddr): -
   }
 }
 
+/**
+ * Comparator used to sort adresses according to their priority
+ * defined by `addressPriorityPublic` function
+ * @param addrA first Multiaddr
+ * @param addrB second Multiaddr
+ */
 export function compareAddressesPublicMode(addrA: Multiaddr, addrB: Multiaddr): -1 | 0 | 1 {
   const result = addressPriorityPublic(maToClass(addrA)) - addressPriorityPublic(maToClass(addrB))
 

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -176,16 +176,20 @@ export async function createLibp2pInstance(
         enabled: false
       },
       ping: {
-        protocolPrefix
+        // libp2p automatically adds a leading `/`
+        protocolPrefix: protocolPrefix.slice(1)
       },
       fetch: {
-        protocolPrefix
+        // libp2p automatically adds a leading `/`
+        protocolPrefix: protocolPrefix.slice(1)
       },
       push: {
-        protocolPrefix
+        // libp2p automatically adds a leading `/`
+        protocolPrefix: protocolPrefix.slice(1)
       },
       identify: {
-        protocolPrefix
+        // libp2p automatically adds a leading `/`
+        protocolPrefix: protocolPrefix.slice(1)
       },
       peerStore: {
         // Prevents peer-store from storing addresses twice, e.g.

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -176,20 +176,24 @@ export async function createLibp2pInstance(
         enabled: false
       },
       ping: {
-        // libp2p automatically adds a leading `/`
-        protocolPrefix: protocolPrefix.startsWith('/') ? protocolPrefix.slice(1) : protocolPrefix
+        // FIXME: libp2p automatically adds a leading `/`
+        // protocolPrefix: protocolPrefix.startsWith('/') ? protocolPrefix.slice(1) : protocolPrefix
+        protocolPrefix // for compatibility
       },
       fetch: {
-        // libp2p automatically adds a leading `/`
-        protocolPrefix: protocolPrefix.startsWith('/') ? protocolPrefix.slice(1) : protocolPrefix
+        // FIXME: libp2p automatically adds a leading `/`
+        // protocolPrefix: protocolPrefix.startsWith('/') ? protocolPrefix.slice(1) : protocolPrefix
+        protocolPrefix // for compatibility
       },
       push: {
-        // libp2p automatically adds a leading `/`
-        protocolPrefix: protocolPrefix.startsWith('/') ? protocolPrefix.slice(1) : protocolPrefix
+        // FIXME: libp2p automatically adds a leading `/`
+        // protocolPrefix: protocolPrefix.startsWith('/') ? protocolPrefix.slice(1) : protocolPrefix
+        protocolPrefix // for compatibility
       },
       identify: {
-        // libp2p automatically adds a leading `/`
-        protocolPrefix: protocolPrefix.startsWith('/') ? protocolPrefix.slice(1) : protocolPrefix
+        // FIXME: libp2p automatically adds a leading `/`
+        // protocolPrefix: protocolPrefix.startsWith('/') ? protocolPrefix.slice(1) : protocolPrefix
+        protocolPrefix // for compatibility
       },
       peerStore: {
         // Prevents peer-store from storing addresses twice, e.g.

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -177,19 +177,19 @@ export async function createLibp2pInstance(
       },
       ping: {
         // libp2p automatically adds a leading `/`
-        protocolPrefix: protocolPrefix.slice(1)
+        protocolPrefix: protocolPrefix.startsWith('/') ? protocolPrefix.slice(1) : protocolPrefix
       },
       fetch: {
         // libp2p automatically adds a leading `/`
-        protocolPrefix: protocolPrefix.slice(1)
+        protocolPrefix: protocolPrefix.startsWith('/') ? protocolPrefix.slice(1) : protocolPrefix
       },
       push: {
         // libp2p automatically adds a leading `/`
-        protocolPrefix: protocolPrefix.slice(1)
+        protocolPrefix: protocolPrefix.startsWith('/') ? protocolPrefix.slice(1) : protocolPrefix
       },
       identify: {
         // libp2p automatically adds a leading `/`
-        protocolPrefix: protocolPrefix.slice(1)
+        protocolPrefix: protocolPrefix.startsWith('/') ? protocolPrefix.slice(1) : protocolPrefix
       },
       peerStore: {
         // Prevents peer-store from storing addresses twice, e.g.


### PR DESCRIPTION
Once node detects that it is running on an exposed host, switch to DHT `server`-mode. ~Also corrects some typos in libp2p protocol prefixes that led to issues.~ postponed for `monte_rosa_2.0`

# Current situation

If started with `--announce` flag, answer to DHT requests, otherwise don't (DHT `client`-mode).

# New behavior

If node announces publicly routable addresses *to the DHT*, switch DHT to `server`-mode.