### PR TITLE
Docker: expose udp ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ docker pull gcr.io/hoprassociation/hoprd:riga
 For ease of use you can set up a shell alias to run the latest release as a docker container:
 
 ```sh
-alias hoprd='docker run --pull always -m 2g -ti -v ${HOPRD_DATA_DIR:-$HOME/.hoprd-db}:/app/db -p 9091:9091 -p 3001:3001 gcr.io/hoprassociation/hoprd:riga'
+alias hoprd='docker run --pull always -m 2g -ti -v ${HOPRD_DATA_DIR:-$HOME/.hoprd-db}:/app/db -p 9091:9091/tcp -p 9091:9091/udp -p 3001:3001 gcr.io/hoprassociation/hoprd:riga'
 ```
 
 **IMPORTANT:** Using the above command will map the database folder used by hoprd to a local folder called `.hoprd-db` in your home directory. You can customize the location of that folder further by executing the following command:

--- a/docs/hopr-documentation/docs/node/using-hopr-admin.md
+++ b/docs/hopr-documentation/docs/node/using-hopr-admin.md
@@ -93,7 +93,7 @@ The **_identity file_** contains your private key and is essentially your wallet
 
 ```bash
 export RELEASE_NAME=bogota
-docker run --pull always --restart on-failure -m 2g -ti -v $HOME/.hoprd-db-${RELEASE_NAME}:/app/hoprd-db -p 9091:9091 -p 3000:3000 -p 3001:3001 -e DEBUG="hopr*" gcr.io/hoprassociation/hoprd:${RELEASE_NAME} --environment monte_rosa --init --api --admin --identity /app/hoprd-db/.hopr-id-${RELEASE_NAME} --data /app/hoprd-db --password 'open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0' --apiHost "0.0.0.0" --apiToken 'YOUR_SECURITY_TOKEN' --adminHost "0.0.0.0" --healthCheck --healthCheckHost "0.0.0.0"
+docker run --pull always --restart on-failure -m 2g -ti -v $HOME/.hoprd-db-${RELEASE_NAME}:/app/hoprd-db -p 9091:9091/tcp -p 9091:9091/udp -p 3000:3000 -p 3001:3001 -e DEBUG="hopr*" gcr.io/hoprassociation/hoprd:${RELEASE_NAME} --environment monte_rosa --init --api --admin --identity /app/hoprd-db/.hopr-id-${RELEASE_NAME} --data /app/hoprd-db --password 'open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0' --apiHost "0.0.0.0" --apiToken 'YOUR_SECURITY_TOKEN' --adminHost "0.0.0.0" --healthCheck --healthCheckHost "0.0.0.0"
 ```
 
 `--identity` is a path to where the file is located, and `--password` is used to decrypt the file.

--- a/docs/hopr-documentation/versioned_docs/version-v1.85/node/using-docker.md
+++ b/docs/hopr-documentation/versioned_docs/version-v1.85/node/using-docker.md
@@ -57,7 +57,7 @@ docker pull gcr.io/hoprassociation/hoprd:wildhorn-v2
 Then start a container:
 
 ```bash
-docker run --pull always -ti -v $HOME/.hoprd-db-wildhorn-v2:/app/db -p 9091:9091 -p 3000:3000 -p 8080:8080 hopr/hoprd:wildhorn-v2 --password='h0pR-w1ldhorn-v2' --init --announce --identity /app/db/.hopr-id-wildhorn-v2 --apiToken='<YOUR_SECRET_TOKEN>'
+docker run --pull always -ti -v $HOME/.hoprd-db-wildhorn-v2:/app/db -p 9091:9091/tcp -p 9091:9091/udp -p 3000:3000 -p 8080:8080 hopr/hoprd:wildhorn-v2 --password='h0pR-w1ldhorn-v2' --init --announce --identity /app/db/.hopr-id-wildhorn-v2 --apiToken='<YOUR_SECRET_TOKEN>'
 ```
 
 Also all ports are mapped to your local host, assuming you stick to the default port numbers.

--- a/docs/hopr-documentation/versioned_docs/version-v1.86/node/using-docker.md
+++ b/docs/hopr-documentation/versioned_docs/version-v1.86/node/using-docker.md
@@ -75,7 +75,7 @@ This ensures the node cannot be accessed by a malicious user residing in the sam
 :::
 
 ```bash
-docker run --pull always -ti -v $HOME/.hoprd-db:/app/db -p 9091:9091 -p 3000:3000 -p 3001:3001 gcr.io/hoprassociation/hoprd:athens --admin --password 'open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0' --init --api --apiHost "0.0.0.0" --apiPort 3001 --identity /app/db/.hopr-id-athens --apiToken 'YOUR_SECURITY_TOKEN' --adminHost "0.0.0.0" --adminPort 3000 --host "0.0.0.0:9091"
+docker run --pull always -ti -v $HOME/.hoprd-db:/app/db -p 9091:9091/tcp -p 9091:9091/udp -p 3000:3000 -p 3001:3001 gcr.io/hoprassociation/hoprd:athens --admin --password 'open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0' --init --api --apiHost "0.0.0.0" --apiPort 3001 --identity /app/db/.hopr-id-athens --apiToken 'YOUR_SECURITY_TOKEN' --adminHost "0.0.0.0" --adminPort 3000 --host "0.0.0.0:9091"
 ```
 
 Also all ports are mapped to your local host, assuming you stick to the default port numbers.

--- a/docs/hopr-documentation/versioned_docs/version-v1.87/node/using-docker.md
+++ b/docs/hopr-documentation/versioned_docs/version-v1.87/node/using-docker.md
@@ -75,7 +75,7 @@ This ensures the node cannot be accessed by a malicious user residing in the sam
 :::
 
 ```bash
-docker run --pull always -ti -v $HOME/.hoprd-db:/app/db -p 9091:9091 -p 3000:3000 -p 3001:3001 gcr.io/hoprassociation/hoprd:ouagadougou --admin --password 'open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0' --init --rest --restHost "0.0.0.0" --restPort 3001 --identity /app/db/.hopr-id-ouagadougou --apiToken 'YOUR_SECURITY_TOKEN' --adminHost "0.0.0.0" --adminPort 3000 --host "0.0.0.0:9091"
+docker run --pull always -ti -v $HOME/.hoprd-db:/app/db -p 9091:9091/tcp -p 9091:9091/udp -p 3000:3000 -p 3001:3001 gcr.io/hoprassociation/hoprd:ouagadougou --admin --password 'open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0' --init --rest --restHost "0.0.0.0" --restPort 3001 --identity /app/db/.hopr-id-ouagadougou --apiToken 'YOUR_SECURITY_TOKEN' --adminHost "0.0.0.0" --adminPort 3000 --host "0.0.0.0:9091"
 ```
 
 Also all ports are mapped to your local host, assuming you stick to the default port numbers.

--- a/docs/hopr-documentation/versioned_docs/version-v1.90/node/using-docker.md
+++ b/docs/hopr-documentation/versioned_docs/version-v1.90/node/using-docker.md
@@ -161,7 +161,7 @@ cp -r $HOME/.hoprd-db-valencia/.hopr-id-valencia $HOME/.hoprd-db-bogota/.hopr-id
 Following the above example of migration from Valencia to Bogota, you would just use the new Bogota command with the old directories/location: `$HOME/.hoprd-db-valencia/.hopr-id-valencia`
 
 ```bash
-docker run --pull always --restart on-failure -m 2g -ti -v $HOME/.hoprd-db-valencia:/app/hoprd-db -p 9091:9091 -p 3000:3000 -p 3001:3001 -e DEBUG="hopr*" gcr.io/hoprassociation/hoprd:bogota --environment monte_rosa --init --api --admin --identity /app/hoprd-db/.hopr-id-valencia --data /app/hoprd-db --password 'open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0' --apiHost "0.0.0.0" --apiToken 'YOUR_SECURITY_TOKEN' --adminHost "0.0.0.0" --healthCheck --healthCheckHost "0.0.0.0"
+docker run --pull always --restart on-failure -m 2g -ti -v $HOME/.hoprd-db-valencia:/app/hoprd-db -p 9091:9091/tcp -p 9091:9091/udp -p 3000:3000 -p 3001:3001 -e DEBUG="hopr*" gcr.io/hoprassociation/hoprd:bogota --environment monte_rosa --init --api --admin --identity /app/hoprd-db/.hopr-id-valencia --data /app/hoprd-db --password 'open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0' --apiHost "0.0.0.0" --apiToken 'YOUR_SECURITY_TOKEN' --adminHost "0.0.0.0" --healthCheck --healthCheckHost "0.0.0.0"
 ```
 
 This also works fine as long as the other flags and details remain the same.

--- a/docs/hopr-documentation/versioned_docs/version-v1.90/node/using-hopr-admin.md
+++ b/docs/hopr-documentation/versioned_docs/version-v1.90/node/using-hopr-admin.md
@@ -92,7 +92,7 @@ Now that you have started your node, what exactly is your node and what are its 
 The **_identity file_** contains your private key and is essentially your wallet for the node. When you installed your node, you supplied `--identity` and `--password` arguments.
 
 ```bash
-docker run --pull always --restart on-failure -m 2g -ti -v $HOME/.hoprd-db-bogota:/app/hoprd-db -p 9091:9091 -p 3000:3000 -p 3001:3001 -e DEBUG="hopr*" gcr.io/hoprassociation/hoprd:bogota --environment monte_rosa --init --api --admin --identity /app/hoprd-db/.hopr-id-bogota --data /app/hoprd-db --password 'open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0' --apiHost "0.0.0.0" --apiToken 'YOUR_SECURITY_TOKEN' --adminHost "0.0.0.0" --healthCheck --healthCheckHost "0.0.0.0"
+docker run --pull always --restart on-failure -m 2g -ti -v $HOME/.hoprd-db-bogota:/app/hoprd-db -p 9091:9091/tcp -p 9091:9091/udp -p 3000:3000 -p 3001:3001 -e DEBUG="hopr*" gcr.io/hoprassociation/hoprd:bogota --environment monte_rosa --init --api --admin --identity /app/hoprd-db/.hopr-id-bogota --data /app/hoprd-db --password 'open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0' --apiHost "0.0.0.0" --apiToken 'YOUR_SECURITY_TOKEN' --adminHost "0.0.0.0" --healthCheck --healthCheckHost "0.0.0.0"
 ```
 
 `--identity` is a path to where the file is located, and `--password` is used to decrypt the file.

--- a/docs/hopr-documentation/versioned_docs/version-v1.91/node/using-docker.md
+++ b/docs/hopr-documentation/versioned_docs/version-v1.91/node/using-docker.md
@@ -119,7 +119,7 @@ This ensures the node cannot be accessed by a malicious user residing in the sam
 (**3**) Copy the following command and replace **YOUR_SECURITY_TOKEN** with your own.
 
 ```bash
-docker run --pull always --restart on-failure -m 2g -ti -v $HOME/.hoprd-db-bogota:/app/hoprd-db -p 9091:9091 -p 3000:3000 -p 3001:3001 -e DEBUG="hopr*" gcr.io/hoprassociation/hoprd:bogota --environment monte_rosa --init --api --admin --identity /app/hoprd-db/.hopr-id-bogota --data /app/hoprd-db --password 'open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0' --apiHost "0.0.0.0" --apiToken 'YOUR_SECURITY_TOKEN' --adminHost "0.0.0.0" --healthCheck --healthCheckHost "0.0.0.0"
+docker run --pull always --restart on-failure -m 2g -ti -v $HOME/.hoprd-db-bogota:/app/hoprd-db -p 9091:9091/tcp -p 9091:9091/udp -p 3000:3000 -p 3001:3001 -e DEBUG="hopr*" gcr.io/hoprassociation/hoprd:bogota --environment monte_rosa --init --api --admin --identity /app/hoprd-db/.hopr-id-bogota --data /app/hoprd-db --password 'open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0' --apiHost "0.0.0.0" --apiToken 'YOUR_SECURITY_TOKEN' --adminHost "0.0.0.0" --healthCheck --healthCheckHost "0.0.0.0"
 ```
 
 If you are not logged in as the root user, add sudo to the start of the above command. E.g. `sudo docker run ...`. If you are using a VPS, you are likely a root user and can use the default command.
@@ -161,7 +161,7 @@ cp -r $HOME/.hoprd-db-valencia/.hopr-id-valencia $HOME/.hoprd-db-bogota/.hopr-id
 Following the above example of migration from Valencia to Bogota, you would just use the new Bogota command with the old directories/location: `$HOME/.hoprd-db-valencia/.hopr-id-valencia`
 
 ```bash
-docker run --pull always --restart on-failure -m 2g -ti -v $HOME/.hoprd-db-valencia:/app/hoprd-db -p 9091:9091 -p 3000:3000 -p 3001:3001 -e DEBUG="hopr*" gcr.io/hoprassociation/hoprd:bogota --environment monte_rosa --init --api --admin --identity /app/hoprd-db/.hopr-id-valencia --data /app/hoprd-db --password 'open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0' --apiHost "0.0.0.0" --apiToken 'YOUR_SECURITY_TOKEN' --adminHost "0.0.0.0" --healthCheck --healthCheckHost "0.0.0.0"
+docker run --pull always --restart on-failure -m 2g -ti -v $HOME/.hoprd-db-valencia:/app/hoprd-db -p 9091:9091/tcp 9091:9091/udp -p 3000:3000 -p 3001:3001 -e DEBUG="hopr*" gcr.io/hoprassociation/hoprd:bogota --environment monte_rosa --init --api --admin --identity /app/hoprd-db/.hopr-id-valencia --data /app/hoprd-db --password 'open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0' --apiHost "0.0.0.0" --apiToken 'YOUR_SECURITY_TOKEN' --adminHost "0.0.0.0" --healthCheck --healthCheckHost "0.0.0.0"
 ```
 
 This also works fine as long as the other flags and details remain the same.

--- a/docs/hopr-documentation/versioned_docs/version-v1.91/node/using-hopr-admin.md
+++ b/docs/hopr-documentation/versioned_docs/version-v1.91/node/using-hopr-admin.md
@@ -92,7 +92,7 @@ Now that you have started your node, what exactly is your node and what are its 
 The **_identity file_** contains your private key and is essentially your wallet for the node. When you installed your node, you supplied `--identity` and `--password` arguments.
 
 ```bash
-docker run --pull always --restart on-failure -m 2g -ti -v $HOME/.hoprd-db-bogota:/app/hoprd-db -p 9091:9091 -p 3000:3000 -p 3001:3001 -e DEBUG="hopr*" gcr.io/hoprassociation/hoprd:bogota --environment monte_rosa --init --api --admin --identity /app/hoprd-db/.hopr-id-bogota --data /app/hoprd-db --password 'open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0' --apiHost "0.0.0.0" --apiToken 'YOUR_SECURITY_TOKEN' --adminHost "0.0.0.0" --healthCheck --healthCheckHost "0.0.0.0"
+docker run --pull always --restart on-failure -m 2g -ti -v $HOME/.hoprd-db-bogota:/app/hoprd-db -p 9091:9091/tcp -p 9091:9091/udp -p 3000:3000 -p 3001:3001 -e DEBUG="hopr*" gcr.io/hoprassociation/hoprd:bogota --environment monte_rosa --init --api --admin --identity /app/hoprd-db/.hopr-id-bogota --data /app/hoprd-db --password 'open-sesame-iTwnsPNg0hpagP+o6T0KOwiH9RQ0' --apiHost "0.0.0.0" --apiToken 'YOUR_SECURITY_TOKEN' --adminHost "0.0.0.0" --healthCheck --healthCheckHost "0.0.0.0"
 ```
 
 `--identity` is a path to where the file is located, and `--password` is used to decrypt the file.

--- a/packages/cover-traffic-daemon/Dockerfile
+++ b/packages/cover-traffic-daemon/Dockerfile
@@ -72,7 +72,8 @@ ENV NODE_ENV production
 ENV DEBUG 'hopr*'
 ENV NODE_OPTIONS='--max_old_space_size=4096 --experimental-wasm-modules'
 
-# p2p
-EXPOSE 9091
+# p2p UDP + TCP
+EXPOSE 9091/udp
+EXPOSE 9091/tcp
 
 ENTRYPOINT ["/sbin/tini", "--", "node", "lib/main.cjs"]

--- a/packages/hoprd/Dockerfile
+++ b/packages/hoprd/Dockerfile
@@ -45,17 +45,17 @@ COPY .nvmrc package.json ./
 COPY scripts/toolchain/install-toolchain.sh ./scripts/toolchain
 
 RUN apt-get update \
-&& apt-get install -y \
-bash curl jq tini ca-certificates tar xz-utils \
-&& rm -rf /var/lib/apt/lists/* \
-&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-# Install Node.js
-&& ./scripts/toolchain/install-toolchain.sh --runtime-only \
-# Remove unused files and config
-&& rm -R scripts .nvmrc \
-# create directory which is later used for the database, so that it inherits
-# permissions when mapped to a volume
-&& mkdir -p hoprd-db
+ && apt-get install -y \
+ bash curl jq tini ca-certificates tar xz-utils \
+ && rm -rf /var/lib/apt/lists/* \
+ && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+ # Install Node.js
+ && ./scripts/toolchain/install-toolchain.sh --runtime-only \
+ # Remove unused files and config
+ && rm -R scripts .nvmrc \
+ # create directory which is later used for the database, so that it inherits
+ # permissions when mapped to a volume
+ && mkdir -p hoprd-db
 
 COPY --from=build /app/hoprnet/packages ./packages
 COPY --from=build /app/hoprnet/node_modules ./node_modules

--- a/packages/hoprd/Dockerfile
+++ b/packages/hoprd/Dockerfile
@@ -45,17 +45,17 @@ COPY .nvmrc package.json ./
 COPY scripts/toolchain/install-toolchain.sh ./scripts/toolchain
 
 RUN apt-get update \
-    && apt-get install -y \
-    bash curl jq tini ca-certificates tar xz-utils \
-    && rm -rf /var/lib/apt/lists/* \
-    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
-    # Install Node.js
-    && ./scripts/toolchain/install-toolchain.sh --runtime-only \
-    # Remove unused files and config
-    && rm -R scripts .nvmrc \
-    # create directory which is later used for the database, so that it inherits
-    # permissions when mapped to a volume
-    && mkdir -p hoprd-db
+&& apt-get install -y \
+bash curl jq tini ca-certificates tar xz-utils \
+&& rm -rf /var/lib/apt/lists/* \
+&& apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+# Install Node.js
+&& ./scripts/toolchain/install-toolchain.sh --runtime-only \
+# Remove unused files and config
+&& rm -R scripts .nvmrc \
+# create directory which is later used for the database, so that it inherits
+# permissions when mapped to a volume
+&& mkdir -p hoprd-db
 
 COPY --from=build /app/hoprnet/packages ./packages
 COPY --from=build /app/hoprnet/node_modules ./node_modules

--- a/packages/hoprd/Dockerfile
+++ b/packages/hoprd/Dockerfile
@@ -45,17 +45,17 @@ COPY .nvmrc package.json ./
 COPY scripts/toolchain/install-toolchain.sh ./scripts/toolchain
 
 RUN apt-get update \
- && apt-get install -y \
-      bash curl jq tini ca-certificates tar xz-utils \
- && rm -rf /var/lib/apt/lists/* \
- && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
- # Install Node.js
- && ./scripts/toolchain/install-toolchain.sh --runtime-only \
- # Remove unused files and config
- && rm -R scripts .nvmrc \
- # create directory which is later used for the database, so that it inherits
- # permissions when mapped to a volume
- && mkdir -p hoprd-db
+    && apt-get install -y \
+    bash curl jq tini ca-certificates tar xz-utils \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
+    # Install Node.js
+    && ./scripts/toolchain/install-toolchain.sh --runtime-only \
+    # Remove unused files and config
+    && rm -R scripts .nvmrc \
+    # create directory which is later used for the database, so that it inherits
+    # permissions when mapped to a volume
+    && mkdir -p hoprd-db
 
 COPY --from=build /app/hoprnet/packages ./packages
 COPY --from=build /app/hoprnet/node_modules ./node_modules
@@ -91,7 +91,8 @@ EXPOSE 3000
 EXPOSE 3001
 # Healthcheck server
 EXPOSE 8080
-# p2p
-EXPOSE 9091
+# p2p UDP + TCP
+EXPOSE 9091/udp
+EXPOSE 9091/tcp
 
 ENTRYPOINT ["/usr/bin/tini", "--", "node", "./lib/main.cjs"]


### PR DESCRIPTION
Hopr uses UDP traffic to determine its external IP address and detect if the process is running on an exposed host.

# Current situation

Neither the Dockerfile nor the `docker run` suggestions include the UDP port, hence nodes running in Docker always assume that they are running behind a restrictive NAT

# New behavior

All Dockerfile + all `docker run` instruction include port forwarding for UDP traffic.