### PR TITLE
Do not remove contracts from image as they are needed by hopli

### DIFF
--- a/packages/hoprd/Dockerfile
+++ b/packages/hoprd/Dockerfile
@@ -25,8 +25,6 @@ RUN make deps-docker package=hoprd && \
     find ./packages -type f -name '*.ts' -delete && \
     # No need for these packages
     rm -R packages/avado packages/cover-traffic-daemon && \
-    # Everything that we don't need in ethereum package
-    rm -R packages/ethereum/contracts && \
     # Remove node_modules as they include devDependencies
     rm -R node_modules && \
     # As we are on *nix, use hardlinks in node_modules to save some space


### PR DESCRIPTION
In the command line of hopli it requires access to the contracts folder