### PR TITLE
hopli accept f64, and tranfser or mint HOPR tokens

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ HOPLI_CRATE := ./packages/hopli
 
 # Set local foundry directory (for binaries) and versions
 FOUNDRY_DIR ?= ${CURDIR}/.foundry
-FOUNDRY_VSN := be7084e
+FOUNDRY_VSN := ed9298d
 
 # Set local cargo directory (for binaries)
 CARGO_DIR := ${CURDIR}/.cargo

--- a/packages/ethereum/contracts/Makefile
+++ b/packages/ethereum/contracts/Makefile
@@ -75,18 +75,18 @@ endif
 	$(forge-script) script/SingleAction.s.sol:SingleActionFromPrivateKeyScript \
 		--broadcast --sig "mintXHopr(address,uint256)" $(recipient) 1000
 
-# E.g. make faucet environment-name=anvil-localhost environment-type=development recipient=0x2402da10A6172ED018AEEa22CA60EDe1F766655C hopramount=10 nativeamount=1
-# E.g. make faucet environment-name=anvil-localhost environment-type=development recipient=0x2402da10A6172ED018AEEa22CA60EDe1F766655C nativeamount=1
-# E.g. make faucet environment-name=anvil-localhost environment-type=development recipient=0x2402da10A6172ED018AEEa22CA60EDe1F766655C hopramount=10
+# E.g. make faucet environment-name=anvil-localhost environment-type=development recipient=0x2402da10A6172ED018AEEa22CA60EDe1F766655C hopramount=100000000000000000000 nativeamount=10000000000000000000
+# E.g. make faucet environment-name=anvil-localhost environment-type=development recipient=0x2402da10A6172ED018AEEa22CA60EDe1F766655C nativeamount=10000000000000000000
+# E.g. make faucet environment-name=anvil-localhost environment-type=development recipient=0x2402da10A6172ED018AEEa22CA60EDe1F766655C hopramount=100000000000000000000
 .PHONY: faucet
 faucet: ensure-environment-is-set ensure-privatekey-is-set
-faucet: ## Mint some (default: 20000) HOPR tokens and send some (default value: 10) native tokens to the recipient hopramount
+faucet: ## Mint some (default: 20000) HOPR tokens and send some (default value: 10) native tokens to the recipient hopramount. Token value should be in 18 decimals
 ifeq ($(recipient),)
 	echo "parameter <recipient> missing" >&2 && exit 1
 endif
 	$(forge-script) script/SingleAction.s.sol:SingleActionFromPrivateKeyScript \
-        --broadcast --sig "mintHoprAndSendNative(address,uint256,uint256)" \
-        $(recipient) $(or $(hopramount),20000) $(or $(nativeamount),10)
+        --broadcast --sig "transferOrMintHoprAndSendNative(address,uint256,uint256)" \
+        $(recipient) $(or $(hopramount),20000000000000000000000) $(or $(nativeamount),10000000000000000000)
 
 # E.g. make request-nrnft environment-name=anvil-localhost environment-type=development recipient=0x2402da10A6172ED018AEEa22CA60EDe1F766655C nftrank=developer
 .PHONY: request-nrnft

--- a/packages/hopli/README.md
+++ b/packages/hopli/README.md
@@ -53,7 +53,7 @@ hopli faucet \
     --use-local-identities --identity-directory "/tmp" \
     --address 0x0aa7420c43b8c1a7b165d216948870c8ecfe1ee1 \
     --contracts-root "../ethereum/contracts" \
-    --hopr-amount 10 --native-amount 1
+    --hopr-amount 10 --native-amount 0.1
 ```
 
 Note that only identity files ending with `.id` are recognized by the CLI
@@ -108,7 +108,7 @@ IDENTITY_PASSWORD=local \
     --use-local-identities --identity-directory "/tmp" \
     --address 0x0aa7420c43b8c1a7b165d216948870c8ecfe1ee1 \
     --contracts-root "../ethereum/contracts"  \
-    --hopr-amount 10 --native-amount 1
+    --hopr-amount 10 --native-amount 0.1
 ```
 
 Register some peer ids in the network registry contract

--- a/packages/hopli/src/process.rs
+++ b/packages/hopli/src/process.rs
@@ -70,8 +70,8 @@ pub fn set_process_path_env(
 pub fn child_process_call_foundry_faucet(
     environment_name: &str,
     address: &Address,
-    hopr_amount: &u128,
-    native_amount: &u128,
+    hopr_amount: &str,
+    native_amount: &str,
 ) -> Result<(), HelperErrors> {
     let hopr_amount_str = hopr_amount.to_string();
     let native_amount_str = native_amount.to_string();
@@ -82,7 +82,7 @@ pub fn child_process_call_foundry_faucet(
         "script/SingleAction.s.sol:SingleActionFromPrivateKeyScript",
         "--broadcast",
         "--sig",
-        "mintHoprAndSendNative(address,uint256,uint256)",
+        "transferOrMintHoprAndSendNative(address,uint256,uint256)",
         &addresses_str,
         &hopr_amount_str,
         &native_amount_str,


### PR DESCRIPTION
Closes https://github.com/hoprnet/hoprnet/issues/4697
- hopli faucet command prefers transfer mHOPR to mint tokens
- amount being transferred can be a float
- read identity also accept ids without .id extension. Identity files should contain "id" in its naming.

Test commands
```
export PRIVATE_KEY=<default private key>
export IDENTITY_PASSWORD=<password for id file>
```

```
cargo run -- faucet --environment-name anvil-localhost \
    --use-local-identities --identity-directory "/tmp/.hoprd-db-riga" \
    --contracts-root "./packages/ethereum/contracts" \
    --hopr-amount 10 --native-amount 0.1
```