### PR TITLE
Update network objects to account for possibly failing inputs

### DIFF
--- a/packages/core/crates/core-network/src/network.rs
+++ b/packages/core/crates/core-network/src/network.rs
@@ -446,14 +446,12 @@ pub mod wasm {
                      origin: PeerOrigin, is_public: bool, last_seen: u64,
                      quality: f64, heartbeats_sent: u64, heartbeats_succeeded: u64,
                      backoff: f64) -> Self {
-            let peer = match peer.as_string() {
-                Some(peer) => peer,
-                None => panic!("Own peer id was not passed as a string")
-            };
-            let peer = match PeerId::from_str(peer.as_str()) {
-                Ok(peer) => peer,
-                Err(err) => panic!("Failed to parse PeerId from string: {}", err.to_string())
-            };
+            let peer = peer.as_string()
+                .ok_or_else(|| "Own peer id was not passed as a string".to_owned())
+                .and_then(|peer| PeerId::from_str(peer.as_str()).map_err(|e| e.to_string()))
+                .map_err(|e| panic!("Failed to parse PeerId from string: {}", e.to_string()))
+                .expect("Unknown peer parsing failure occurred");
+
             Self {
                 id: peer,
                 origin,

--- a/packages/core/crates/core-network/src/ping.rs
+++ b/packages/core/crates/core-network/src/ping.rs
@@ -271,7 +271,10 @@ pub mod wasm {
             };
 
             if let Err(err) = self.on_finished_ping_cb.call2(&this, &peer, &res) {
-                error!("Failed to perform on peer offline operation with: {}", err.as_string().unwrap().as_str())
+                error!("Failed to perform on peer offline operation with: {}",
+                    err.as_string()
+                    .unwrap_or_else(|| "Unspecified error occurred on registering the ping result".to_owned())
+                    .as_str())
             };
         }
     }
@@ -317,9 +320,9 @@ pub mod wasm {
         #[wasm_bindgen]
         pub async fn ping(&self, mut peers: Vec<JsString>) {
             let converted = peers.drain(..)
-                .map(|x| {
+                .filter_map(|x| {
                     let x: String = x.into();
-                    PeerId::from_str(&x).ok().unwrap()
+                    PeerId::from_str(&x).ok()
                 })
                 .collect::<Vec<_>>();
 
@@ -344,7 +347,10 @@ pub mod wasm {
                             data
                         },
                         Err(e) => {
-                            error!("The message transport could not be established: {}", e.as_string().unwrap().as_str());
+                            error!("The message transport could not be established: {}",
+                                e.as_string()
+                                .unwrap_or_else(|| "The message transport failed with unknown error".to_owned())
+                                .as_str());
                             Err(format!("Failed to extract transport error as string: {:?}", e))
                         }
                     }


### PR DESCRIPTION
## What
The original implementation relied on API objects to behave correctly (e.g. PeerIds being always parsable...) by utilizing an `unwrap` operation on the `Option` instances. Since the APIs can be passed any type of data from the JavaScript realm, it is safer to implement boundary checks with appropriate handling that will not trigger panics and ensure the node functionality in cases of recoverable situations.