### PR TITLE
compose: Add local dev setup

### DIFF
--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -74,11 +74,11 @@ build_and_tag_images() {
   cd "${mydir}/.."
 
   if [ "${local_build:-}" = "true" ]; then
-    log "Building Docker toolchain image"
+    log "Building Docker image hopr-toolchain-local"
     docker build -q -t hopr-toolchain-local \
       -f scripts/toolchain/Dockerfile . &
 
-    log "Waiting for toolchain image to finish"
+    log "Waiting for Docker builds (part 1) to finish"
     wait
 
     if [ -z "${image_name}" ] || \
@@ -105,7 +105,14 @@ build_and_tag_images() {
         -f packages/ethereum/Dockerfile.anvil . &
     fi
 
-    log "Waiting for Docker builds (part 1) to finish"
+    if [ -z "${image_name}" ] || [ "${image_name}" = "hopli" ]; then
+      log "Building Docker image hopli-local"
+      docker build -t hopli-local \
+        --build-arg=HOPR_TOOLCHAIN_IMAGE="hopr-toolchain-local" \
+        -f packages/hopli/Dockerfile . &
+    fi
+
+    log "Waiting for Docker builds (part 2) to finish"
     wait
 
     if [ -z "${image_name}" ] || [ "${image_name}" = "pluto" ] || [ "${image_name}" = "pluto-complete" ]; then
@@ -116,7 +123,7 @@ build_and_tag_images() {
         -f scripts/pluto/Dockerfile . &
     fi
 
-    log "Waiting for Docker builds (part 2) to finish"
+    log "Waiting for Docker builds (part 3) to finish"
     wait
   else
     gcloud builds submit --config cloudbuild.yaml \

--- a/scripts/compose/docker-compose.local-dev.yml
+++ b/scripts/compose/docker-compose.local-dev.yml
@@ -18,7 +18,7 @@ services:
     networks:
       - hopr-net
     extra_hosts:
-      - "host.docker.internal:host-gateway"
+      - 'host.docker.internal:host-gateway'
     deploy:
       resources:
         limits:
@@ -86,7 +86,7 @@ services:
     networks:
       - hopr-net
     extra_hosts:
-      - "host.docker.internal:host-gateway"
+      - 'host.docker.internal:host-gateway'
 
   grafana:
     image: grafana/grafana:9.3.2

--- a/scripts/compose/docker-compose.local-dev.yml
+++ b/scripts/compose/docker-compose.local-dev.yml
@@ -1,0 +1,107 @@
+---
+version: '3.8'
+
+networks:
+  hopr-net:
+    driver: bridge
+
+volumes:
+  prometheus_data: {}
+  grafana_data: {}
+
+services:
+  admin:
+    image: ${HOPR_ADMIN_DOCKER_IMAGE}
+    ports:
+      - '3000:3000'
+    restart: unless-stopped
+    networks:
+      - hopr-net
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    deploy:
+      resources:
+        limits:
+          memory: 256M
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.45.0
+    container_name: cadvisor
+    hostname: cadvisor
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+    privileged: true
+    expose:
+      - 9093
+    ports:
+      - '9093:8080'
+    networks:
+      - hopr-net
+    devices:
+      - /dev/kmsg:/dev/kmsg
+
+  nodeexporter:
+    image: prom/node-exporter:v1.4.0
+    container_name: nodeexporter
+    hostname: nodeexporter
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - '--path.procfs=/host/proc'
+      - '--path.rootfs=/rootfs'
+      - '--path.sysfs=/host/sys'
+      - '--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($$|/)'
+    restart: unless-stopped
+    expose:
+      - 9100
+    ports:
+      - '9100:9100'
+    networks:
+      - hopr-net
+
+  prometheus:
+    image: prom/prometheus:v2.41.0
+    restart: always
+    container_name: prometheus
+    hostname: prometheus
+    command: |
+      --web.listen-address=0.0.0.0:9090
+      --config.file=/etc/prometheus/prometheus.yml
+      --storage.tsdb.path=/prometheus
+      --web.console.libraries=/usr/share/prometheus/console_libraries
+      --web.console.templates=/usr/share/prometheus/consoles
+    ports:
+      - '9090:9090'
+    volumes:
+      - ./prometheus/prometheus.local-dev.yml:/etc/prometheus/prometheus.yml
+      - prometheus_data:/prometheus
+    environment:
+      DATA_RETENTION_DAYS: 30
+    networks:
+      - hopr-net
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  grafana:
+    image: grafana/grafana:9.3.2
+    user: '472'
+    restart: always
+    environment:
+      GF_INSTALL_PLUGINS: 'grafana-clock-panel,grafana-simple-json-datasource'
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning/:/etc/grafana/provisioning/
+    env_file:
+      - ./grafana/config.monitoring
+    ports:
+      - '3030:3000'
+    depends_on:
+      - prometheus
+    networks:
+      - hopr-net

--- a/scripts/compose/prometheus/prometheus.local-dev.yml
+++ b/scripts/compose/prometheus/prometheus.local-dev.yml
@@ -1,0 +1,27 @@
+global:
+  scrape_interval: 15s
+
+  external_labels:
+    monitor: 'hoprd'
+
+scrape_configs:
+  - job_name: 'hoprd'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['host.docker.internal:3001']
+        labels:
+          group: 'hopr'
+    metrics_path: /api/v2/node/metrics
+
+  - job_name: 'cadvisor'
+    scrape_interval: 10s
+    metrics_path: '/metrics'
+    static_configs:
+      - targets: ['cadvisor:8080']
+        labels:
+          group: 'cadvisor'
+
+  - job_name: 'node'
+    scrape_interval: 10s
+    static_configs:
+      - targets: ['nodeexporter:9100']


### PR DESCRIPTION
The new make target will start local Anvil and Hoprd instances and Grafana/Prometheus via  our Docker compose configuration. That way one can more easily develop in Hoprd while seeing metrics.