### PR TITLE
Fix docker builds to allow local testing

### DIFF
--- a/packages/ethereum/Dockerfile.anvil
+++ b/packages/ethereum/Dockerfile.anvil
@@ -13,6 +13,7 @@ COPY scripts/ scripts
 COPY Makefile .
 
 ENV FOUNDRY_DIR=/app/hoprnet-toolchain/.foundry
+ENV ETHERSCAN_API_KEY="random_giberish"
 
 # install missing process runner
 RUN apt-get update \

--- a/scripts/pluto/Dockerfile
+++ b/scripts/pluto/Dockerfile
@@ -18,7 +18,6 @@ RUN apt-get update \
 WORKDIR /app/hoprnet
 
 COPY --from=hoprd /app/hoprnet/ ./
-COPY --from=hoprd /app/hoprnet/.cargo/ ./.cargo/
 
 COPY packages/ethereum/contracts packages/ethereum/contracts
 COPY scripts/ scripts


### PR DESCRIPTION
## What
The docker images failed to build, this PR fixes those issues:
- [x] Add `ETHERSCAN_API_KEY` dummy value into the anvil image
- [x] Remove `.cargo` directory from pluto copy instructions, as it no longer exists in the hoprd-local image