### PR TITLE
git: Remove ignore line which prevented gcloud docker builds to succeed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,7 +87,6 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-build/
 develop-eggs/
 dist/
 downloads/

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,6 @@ deps: ## Installs dependencies for development setup
 	$(MAKE) cargo-update
 	command -v wasm-opt || $(cargo) install wasm-opt
 	command -v wasm-pack || $(cargo) install wasm-pack
-	command -v wasm-bindgen || $(cargo) install wasm-bindgen
 	yarn workspaces focus ${YARNFLAGS}
 # install foundry (cast + forge + anvil)
 	$(MAKE) install-foundry


### PR DESCRIPTION
The vendor directory contains dependencies which also might have a build
directory in place. Previously, this line would have filtered those out
when trying to build Docker images via gcloud.
