### PR TITLE
Add output to the e2e bash integration tests when it fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,8 +229,7 @@ endif
 
 .PHONY: smoke-test
 smoke-test: ## run smoke tests
-	source .venv/bin/activate && python3 -m pytest tests/
-
+	source .venv/bin/activate && (python3 -m pytest tests/ || (cat /tmp/integration_test_out && false))
 
 .PHONY: smart-contract-test
 smart-contract-test: # forge test smart contracts

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -22,7 +22,7 @@ def test_hoprd_protocol_integration_tests(setup_7_nodes):
 
     nodes_api_as_str = " ".join(list(map(lambda x: f"\"localhost:{x['api_port']}\"", setup_7_nodes.values())))
 
-    subprocess.run(f'./tests/integration-test.sh {nodes_api_as_str}',
+    subprocess.run(f'./tests/integration-test.sh {nodes_api_as_str} >| /tmp/integration_test_out 2>&1',
                    shell=True,
                    capture_output=True,
                    env=env_vars,


### PR DESCRIPTION
## What
The output of integration tests could be hidden by other failures in test fixtures, this adds a compulsory output from the logs of integration tests, if the integration e2e test fails.
