### PR TITLE
eagerly issue dht requests

### DIFF
--- a/packages/utils/src/libp2p/dialHelper.ts
+++ b/packages/utils/src/libp2p/dialHelper.ts
@@ -381,10 +381,12 @@ async function fetchCircuitAddressesAndDial(
       relay = await nextRelay
     }
 
-    if (!relay.done) {
-      // Initiate query for next relay but don't await its result
-      nextRelay = dhtIterator.next()
+    if (relay.done) {
+      break
     }
+
+    // Initiate query for next relay but don't await its result
+    nextRelay = dhtIterator.next()
 
     // Make sure we don't use self as relay
     if (relay.value.equals(components.getPeerId())) {


### PR DESCRIPTION
Optimizes connection setup to query for relays in advance while attempting to establish relayed connections

### Current behavior

```
while (!successful) {
  await fetchPotentialRelay
  await tryConnection
}
```

### New behavior

The dialing code eagerly fetches new potential relays from the DHT while trying to establish relayed connections
```
await fetchFirstRelay
while (!successful) {
  if pendingRequest {
    await pendingDHTRequest
  }
  fetchAnotherRelay
  await tryConnection
}