### PR TITLE
[HOTFIX] Ping metrics not being propagated correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Extend the Grafana dashboards with the new mixer metrics (current mixer queue size & average mixer delay) ([#4768](https://github.com/hoprnet/hoprnet/pull/4768))
 - Expose full payment channel graph in `/channels` API ([#4756](https://github.com/hoprnet/hoprnet/pull/4756))
 - Fixed issue with too many channels being opened by the Promiscuous strategy, added option to enforce the maximum number of opened channels ([#4827](https://github.com/hoprnet/hoprnet/pull/4827))
+- Fixed incorrect recording of some Ping metrics ([#4867](https://github.com/hoprnet/hoprnet/pull/4867))
 
 <a name="1.92"></a>
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,6 @@ dependencies = [
  "mockall",
  "more-asserts",
  "rand 0.8.5",
- "scopeguard 1.1.0",
  "serde",
  "thiserror",
  "utils-log",

--- a/packages/core/crates/core-network/Cargo.toml
+++ b/packages/core/crates/core-network/Cargo.toml
@@ -21,7 +21,6 @@ blake2 = "0.10.4"
 futures = "0.3.27"
 libp2p = { version = "0.51.1", features = ["async-std", "wasm-bindgen", "wasm-ext"] }
 rand = { version = "0.8.5", features = ["std_rng"] }
-scopeguard = "1.1.0"
 serde = "1"
 thiserror = "1.0"
 utils-log = { path = "../../../utils/crates/utils-log"}


### PR DESCRIPTION
## What
The scopeguard caused the counters to be moved, thereby always leaving an empty default 0 counter behind it.

Fixed to make sure the timer always gets updated inside a correct object.

Refs #4600 