### PR TITLE
Add RelayState cleanup and set a limit of maximum relayed connections to 2000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Added mitigation for connection leakage to prevent DHT and p2p connection failures ([#4870](https://github.com/hoprnet/hoprnet/pull/4870))
 - Fixed incorrect recording of some Ping metrics ([#4867](https://github.com/hoprnet/hoprnet/pull/4867))
 - Enforced 1 GB memory usage limit of HOPRd on Avado ([#4898](https://github.com/hoprnet/hoprnet/pull/4898))
+- Added RelayState cleanup which prevents excessive connection leakage on public relay nodes ([#4912](https://github.com/hoprnet/hoprnet/pull/4912))
+- Reduced maximum number of relay connections to 2000 ([#4912](https://github.com/hoprnet/hoprnet/pull/4912))
 
 <a name="1.92"></a>
 

--- a/packages/connect/src/relay/handshake.spec.ts
+++ b/packages/connect/src/relay/handshake.spec.ts
@@ -20,6 +20,7 @@ const destination = privKeyToPeerId('0xf2462c7eec43cde144e025c8feeac547d8f87fb9a
 
 function getRelayState(existing: boolean = false): Parameters<typeof negotiateRelayHandshake>[3] {
   return {
+    delete: () => {},
     exists: () => existing,
     isActive: async () => false,
     updateExisting: () => false,

--- a/packages/connect/src/relay/handshake.ts
+++ b/packages/connect/src/relay/handshake.ts
@@ -150,7 +150,7 @@ export async function negotiateRelayHandshake(
   stream: Stream,
   source: PeerId,
   components: Components,
-  state: Pick<RelayState, 'exists' | 'isActive' | 'updateExisting' | 'createNew'>,
+  state: Pick<RelayState, 'exists' | 'isActive' | 'updateExisting' | 'createNew' | 'delete'>,
   options: HoprConnectOptions
 ): Promise<void> {
   log(`handling relay request`)
@@ -195,6 +195,7 @@ export async function negotiateRelayHandshake(
   }
 
   const relayedConnectionExists = state.exists(source, destination)
+  log(`checked relay entry existence ${source.toString()} ${destination.toString()}: ${relayedConnectionExists}`)
 
   if (relayedConnectionExists) {
     // Relayed connection could exist but connection is dead
@@ -208,6 +209,9 @@ export async function negotiateRelayHandshake(
         // Updated connection, so everything done
         return
       }
+    } else {
+      state.delete(source, destination)
+      log(`deleted inactive relay entry: ${source.toString()} ${destination.toString()}`)
     }
   }
 

--- a/packages/connect/src/relay/index.ts
+++ b/packages/connect/src/relay/index.ts
@@ -210,19 +210,7 @@ class Relay implements Initializable, ConnectInitializable, Startable {
     // TODO: perform ping as well, right now just prints out connection info
     if (this.relayState.relayedConnectionCount() > 0) {
       let outConns = `Current relay connections:\n`
-
-      let outConnIds: string[] = []
-      await this.relayState.forEach(async (dst) => {
-        outConnIds.push(dst)
-      })
-
-      outConnIds.sort()
-
-      for (const outConnId of outConnIds) {
-        outConns += `- ${outConnId}\n`
-      }
-
-      // Remove occurence of last `\n`
+      outConns += await this.relayState.printIds()
       log(outConns.substring(0, outConns.length - 1))
     }
     metric_countRelayedConns.set(this.relayState.relayedConnectionCount())

--- a/packages/connect/src/relay/state.ts
+++ b/packages/connect/src/relay/state.ts
@@ -123,11 +123,11 @@ class RelayState {
   }
 
   async printIds() {
-    let ret: string[] = [];
+    let ret: string[] = []
     for await (let [cid, _] of this.relayedConnections.entries()) {
       ret.push(cid)
     }
-    return ret.join(",")
+    return ret.join(',')
   }
 
   /**

--- a/packages/connect/src/relay/state.ts
+++ b/packages/connect/src/relay/state.ts
@@ -1,8 +1,7 @@
 import type { HoprConnectOptions, Stream } from '../types.js'
 import type { PeerId } from '@libp2p/interface-peer-id'
-import { unmarshalPublicKey } from '@libp2p/crypto/keys'
 
-import { nAtATime, u8aCompare } from '@hoprnet/hopr-utils'
+import { nAtATime } from '@hoprnet/hopr-utils'
 import { RelayContext, type RelayContextInterface } from './context.js'
 
 import debug from 'debug'
@@ -123,6 +122,23 @@ class RelayState {
     )
   }
 
+  async printIds() {
+    let ret: string[] = [];
+    for await (let [cid, _] of this.relayedConnections.entries()) {
+      ret.push(cid)
+    }
+    return ret.join(",")
+  }
+
+  /**
+   * Deletes the inactive relay entry given the source and destination
+   * @param source
+   * @param destination
+   */
+  delete(source: PeerId, destination: PeerId) {
+    this.relayedConnections.delete(RelayState.getId(source, destination))
+  }
+
   /**
    * Creates and stores a new relayed connection
    * This function returns only when the relay connection is terminated.
@@ -196,10 +212,11 @@ class RelayState {
    * @returns the identifier
    */
   static getId(a: PeerId, b: PeerId): string {
-    const cmpResult = u8aCompare(
+    /*const cmpResult = u8aCompare(
       unmarshalPublicKey(a.publicKey as Uint8Array).marshal(),
       unmarshalPublicKey(b.publicKey as Uint8Array).marshal()
-    )
+    )*/
+    const cmpResult = a.toString().localeCompare(b.toString())
 
     // human-readable ID
     switch (cmpResult) {

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -98,8 +98,8 @@ export async function createLibp2pInstance(
             supportedEnvironments: supportedEnvironmentsInfo,
             allowLocalConnections: options.allowLocalConnections,
             allowPrivateConnections: options.allowPrivateConnections,
-            // Amount of nodes for which we are willing to act as a relay
-            maxRelayedConnections: 50_000,
+            // Amount of nodes for which we are willing to act as a relay with 2GB memory limit
+            maxRelayedConnections: 2_000,
             announce: options.announce,
             isAllowedToAccessNetwork
           },


### PR DESCRIPTION
Fixes the bug of ever-growing number of relayed connections on a relay node.

Fixes https://github.com/hoprnet/hoprnet/issues/4507