### PR TITLE
Remove inactive relay connections during the relay's keep-alive rounds

### DIFF
--- a/packages/connect/src/relay/context.ts
+++ b/packages/connect/src/relay/context.ts
@@ -386,12 +386,12 @@ function RelayContext(
                 flow(`FLOW: relay_incoming: got PING or PONG, continue`)
                 switch (SUFFIX[0]) {
                   case StatusMessages.PING:
-                    verbose(`PING received`)
+                    //verbose(`PING received`)
                     queueStatusMessage(Uint8Array.of(RelayPrefix.STATUS_MESSAGE, StatusMessages.PONG))
                     // Don't forward ping
                     break
                   case StatusMessages.PONG:
-                    verbose(`PONG received`)
+                    //verbose(`PONG received`)
 
                     state._pingResponsePromise?.resolve({
                       type: ConnectionEventTypes.PING_RESPONSE

--- a/packages/connect/src/relay/context.ts
+++ b/packages/connect/src/relay/context.ts
@@ -321,7 +321,7 @@ function RelayContext(
     }
 
     const iterator: Stream['source'] = (async function* () {
-      log(`source called`)
+      //log(`source called`)
 
       let leave = false
       flow(`FLOW: relay_incoming: started loop`)
@@ -479,7 +479,7 @@ function RelayContext(
    * is attached yet.
    */
   const createSink = async (): Promise<void> => {
-    log(`createSink called`)
+    //log(`createSink called`)
     let currentSink = stream.sink
 
     let nextMessagePromise: Promise<PayloadEvent> | undefined

--- a/packages/connect/src/relay/index.ts
+++ b/packages/connect/src/relay/index.ts
@@ -180,7 +180,7 @@ class Relay implements Initializable, ConnectInitializable, Startable {
     this.stopKeepAlive = retimer(
       periodicKeepAlive,
       // TODO: Make these values configurable
-      () => randomInteger(10000, 10000 + 3000)
+      () => randomInteger(25_000, 40_000)
     )
 
     this._isStarted = true
@@ -207,8 +207,9 @@ class Relay implements Initializable, ConnectInitializable, Startable {
   }
 
   protected async keepAliveRelayConnection(): Promise<void> {
-    // TODO: perform ping as well, right now just prints out connection info
     if (this.relayState.relayedConnectionCount() > 0) {
+      await this.relayState.prune()
+
       let outConns = `Current relay connections:\n`
       outConns += await this.relayState.printIds()
       log(outConns.substring(0, outConns.length - 1))
@@ -392,7 +393,6 @@ class Relay implements Initializable, ConnectInitializable, Startable {
 
     log(`handling relay request from ${conn.connection.remotePeer.toString()}`)
     log(`relayed connection count: ${this.relayState.relayedConnectionCount()}`)
-
     try {
       if (this.relayState.relayedConnectionCount() >= (this.options.maxRelayedConnections as number)) {
         log(`relayed request rejected, already at max capacity (${this.options.maxRelayedConnections as number})`)

--- a/packages/connect/src/relay/index.ts
+++ b/packages/connect/src/relay/index.ts
@@ -180,7 +180,7 @@ class Relay implements Initializable, ConnectInitializable, Startable {
     this.stopKeepAlive = retimer(
       periodicKeepAlive,
       // TODO: Make these values configurable
-      () => randomInteger(25_000, 40_000)
+      () => randomInteger(15_000, 35_000)
     )
 
     this._isStarted = true
@@ -207,14 +207,9 @@ class Relay implements Initializable, ConnectInitializable, Startable {
   }
 
   protected async keepAliveRelayConnection(): Promise<void> {
-    if (this.relayState.relayedConnectionCount() > 0) {
-      await this.relayState.prune()
-
-      let outConns = `Current relay connections:\n`
-      outConns += await this.relayState.printIds()
-      log(outConns.substring(0, outConns.length - 1))
-    }
+    await this.relayState.prune()
     metric_countRelayedConns.set(this.relayState.relayedConnectionCount())
+    log(`Current relay connections:\n ${await this.relayState.printIds()}`)
 
     let outRelays = `Currently tracked connections to relays:\n`
     for (const relayPeerId of this.connectedToRelays) {

--- a/packages/connect/src/relay/state.ts
+++ b/packages/connect/src/relay/state.ts
@@ -124,7 +124,7 @@ class RelayState {
 
   async printIds() {
     let ret: string[] = []
-    for await (let [cid, _] of this.relayedConnections.entries()) {
+    for await (let cid of this.relayedConnections.keys()) {
       ret.push(cid)
     }
     return ret.join(',')
@@ -205,13 +205,18 @@ class RelayState {
   }
 
   public async prune(timeout?: number) {
-    let markedForDeletion: string[] = []
+    if (this.relayedConnections.size == 0) return;
+
+    let pruned = 0;
     await Promise.all(Array.from(this.relayedConnections.entries()).map(async([id, ctx]) => {
       for (let [_, conn] of Object.entries(ctx)) {
         try {
           if (await conn.ping(timeout) < 0) {
-            markedForDeletion.push(id);
-            verbose(`${id} relayed connection is inactive and will be evicted from the relay state`)
+            if (this.relayedConnections.delete(id)) {
+              ++pruned
+            } else {
+              error(`could not delete ${id} inactive relayed connection from the relay state`)
+            }
             break;
           }
         }
@@ -221,10 +226,7 @@ class RelayState {
       }
     }))
 
-    for (let del in markedForDeletion) {
-      this.relayedConnections.delete(del)
-    }
-    verbose(`${markedForDeletion.length} relay entries were evicted due to inactivity`)
+    verbose(`Evicted ${pruned} inactive relay entries from the relay state`)
   }
 
   /**
@@ -235,18 +237,17 @@ class RelayState {
    * @returns the identifier
    */
   static getId(a: PeerId, b: PeerId): string {
-    /*const cmpResult = u8aCompare(
-      unmarshalPublicKey(a.publicKey as Uint8Array).marshal(),
-      unmarshalPublicKey(b.publicKey as Uint8Array).marshal()
-    )*/
-    const cmpResult = a.toString().localeCompare(b.toString())
+    let aStr = a.toString();
+    let bStr = b.toString();
+
+    const cmpResult = aStr.localeCompare(bStr)
 
     // human-readable ID
     switch (cmpResult) {
       case 1:
-        return `${a.toString()}-${b.toString()}`
+        return `${aStr}-${bStr}`
       case -1:
-        return `${b.toString()}-${a.toString()}`
+        return `${bStr}-${aStr}`
       default:
         throw Error(`Invalid compare result. Loopbacks are not allowed.`)
     }


### PR DESCRIPTION
This PR adds a pruning mechanism to the Relay code.
The pruning mechanism sends low-level ping to all the relay connections (both source and destination) and if they do not respond within time (currently 300 ms), the relay will evict that connection from the registry.

The keep-alive rounds are done periodically in a random interval between 15 to 35 seconds.

As a follow-up, the keep-alive mechanism should be updated later to work similarly as HOPR protocol heartbeats.