### PR TITLE
Fix heartbeat metrics

### DIFF
--- a/packages/core/crates/core-network/src/ping.rs
+++ b/packages/core/crates/core-network/src/ping.rs
@@ -155,7 +155,7 @@ impl Ping {
         }
 
         if let Some(metric_time_to_heartbeat) = &self.metric_time_to_heartbeat {
-            metric_time_to_heartbeat.cancel_measure(heartbeat_round_timer.unwrap());
+            metric_time_to_heartbeat.record_measure(heartbeat_round_timer.unwrap());
         };
     }
 
@@ -208,7 +208,7 @@ impl Ping {
             };
 
             if let Some(metric_time_to_ping) = &self.metric_time_to_ping {
-                metric_time_to_ping.cancel_measure(ping_peer_timer.unwrap());
+                metric_time_to_ping.record_measure(ping_peer_timer.unwrap());
             }
 
             match &ping_result {


### PR DESCRIPTION
## What
The histogram metrics for heartbeat were cancelled instead of recorded.
