### PR TITLE
Fix `memmon` to properly monitor memory usage of HOPRd on Avado

### DIFF
--- a/packages/avado/build/Dockerfile
+++ b/packages/avado/build/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /app/hoprnet/packages/hoprd
 
 RUN apt-get update \
  && apt-get install -y \
-      pip \
+      pip procps \
  && rm -rf /var/lib/apt/lists/* \
  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 

--- a/packages/avado/build/supervisord.conf
+++ b/packages/avado/build/supervisord.conf
@@ -88,7 +88,7 @@ environment=
   GF_USERS_ALLOW_SIGN_UP="false"
 
 [eventlistener:memmon]
-command=memmon -p hoprd=1GB
+command=memmon -c -p hoprd=1GB
 events=TICK_60
 
 

--- a/scripts/build-avado.sh
+++ b/scripts/build-avado.sh
@@ -26,6 +26,8 @@ usage() {
   msg "\trelease: Release for which the package is built."
   msg "\tupstream_version: hoprd Docker image version to be used. Inferred if not set."
   msg "\tapi_token: API token which is set in the Avado package."
+  msg "You can also use the 'DRY_RUN=true' environment variable to only generate the Docker compose file,"
+  msg "without triggering the build."
   msg
 }
 


### PR DESCRIPTION
This PR fixes the `memmon` introduced in #4898 . 
The reason for `memmon` failing to monitor was missing `ps` command in the HOPRd Avado docker image.

It also introduces the `DRY_RUN` flag that can be used with `build-avado.sh` script to only generate the `docker-compose.yml` file without building the actual Avado image. This is useful for testing.

The order of `upstream_version` and `api_token` in the `build-avado.sh` script was also swapped for convenience.

Refs #4854