### PR TITLE
Enforce closing and clean-up of libp2p2 connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Added RelayState cleanup which prevents excessive connection leakage on public relay nodes ([#4912](https://github.com/hoprnet/hoprnet/pull/4912))
 - Reduced maximum number of relay connections to 2000 ([#4912](https://github.com/hoprnet/hoprnet/pull/4912))
 - Add pruning in the relay connections keep-alive mechanism ([#4916](https://github.com/hoprnet/hoprnet/pull/4916))
+- Enforce closing and clean-up of libp2p2 connections ([#4957](https://github.com/hoprnet/hoprnet/pull/4957))
 
 <a name="1.92"></a>
 

--- a/packages/connect/src/relay/handshake.ts
+++ b/packages/connect/src/relay/handshake.ts
@@ -4,7 +4,7 @@ import type { PeerId } from '@libp2p/interface-peer-id'
 import { unmarshalPublicKey } from '@libp2p/crypto/keys'
 
 import chalk from 'chalk'
-import { dial, DialStatus, pubKeyToPeerId } from '@hoprnet/hopr-utils'
+import { dial, DialStatus, pubKeyToPeerId, safeCloseConnection } from '@hoprnet/hopr-utils'
 
 import type { RelayState } from './state.js'
 
@@ -245,11 +245,9 @@ export async function negotiateRelayHandshake(
   if (errThrown) {
     shakerWrite(shaker, RelayHandshakeMessage.FAIL_COULD_NOT_REACH_COUNTERPARTY)
     destinationShaker.rest()
-    try {
-      await result.resp.conn.close()
-    } catch (err) {
-      error(`Error while closing connection to destination ${destination.toString()}.`, err)
-    }
+    await safeCloseConnection(result.resp.conn, components, (err) => {
+      error(`Error while closing connection to destination ${destination?.toString()}.`, err)
+    })
     return
   }
 
@@ -265,11 +263,9 @@ export async function negotiateRelayHandshake(
     shakerWrite(shaker, RelayHandshakeMessage.FAIL_COULD_NOT_REACH_COUNTERPARTY)
 
     destinationShaker.rest()
-    try {
-      await result.resp.conn.close()
-    } catch (err) {
-      error(`Error while closing connection to destination ${destination.toString()}.`, err)
-    }
+    await safeCloseConnection(result.resp.conn, components, (err) => {
+      error(`Error while closing connection to destination ${destination?.toString()}.`, err)
+    })
     return
   }
 

--- a/packages/connect/src/relay/index.ts
+++ b/packages/connect/src/relay/index.ts
@@ -33,7 +33,8 @@ import {
   dial,
   DialStatus,
   randomInteger,
-  retimer
+  retimer,
+  safeCloseConnection
 } from '@hoprnet/hopr-utils'
 
 import { handshake } from 'it-handshake'
@@ -268,11 +269,9 @@ class Relay implements Initializable, ConnectInitializable, Startable {
       // Only close the connection to the relay if it does not perform relay services
       // for us.
       if (this.usedRelays.findIndex((usedRelay: PeerId) => usedRelay.equals(relay)) < 0) {
-        try {
-          await response.resp.conn.close()
-        } catch (err) {
+        await safeCloseConnection(response.resp.conn, this.getComponents(), (err) => {
           error(`Error while closing unused connection to relay ${relay.toString()}`, err)
-        }
+        })
       }
       metric_countFailedConnects.increment()
       return

--- a/packages/utils/src/libp2p/connection.ts
+++ b/packages/utils/src/libp2p/connection.ts
@@ -1,0 +1,37 @@
+import type { Connection } from '@libp2p/interface-connection'
+import type { Components } from '@libp2p/interfaces/components'
+import { CustomEvent } from '@libp2p/interfaces/events'
+
+import { debug } from '../process/index.js'
+
+const log = debug('hopr-core:libp2p:connection')
+
+export async function safeCloseConnection(
+  conn: Connection,
+  components: Components,
+  onErrorFun: (err: Error) => void
+): Promise<void> {
+  try {
+    // await result to prevent race conditions of other logic using this
+    // connection which we are trying to close
+    await conn.close()
+  } catch (err) {
+    onErrorFun(err)
+  }
+
+  // Verify that the connection has been removed from the connection manager.
+  // If not, which could be a bug, trigger the removal manually.
+  const existingConnections = components.getConnectionManager().getConnections(conn.remotePeer)
+  const storedConn = existingConnections.find((c) => c.id === conn.id)
+
+  // If the connection is still stored, trigger the event.
+  if (storedConn) {
+    log(`Trigger onDisconnect event for connection ${conn.id} to ${conn.remotePeer.toString()} manually`)
+    // @ts-ignore
+    components.getConnectionManager().onDisconnect(
+      new CustomEvent<Connection>('connectionEnd', {
+        detail: conn
+      })
+    )
+  }
+}

--- a/packages/utils/src/libp2p/index.ts
+++ b/packages/utils/src/libp2p/index.ts
@@ -22,6 +22,7 @@ export * from './pubKeyToPeerId.js'
 export * from './privKeyToPeerId.js'
 export * from './relayCode.js'
 export * from './verifySignatureFromPeerId.js'
+export * from './connection.js'
 
 /**
  * Regular expresion used to match b58Strings


### PR DESCRIPTION
Dead connections are not properly cleaned from the libp2p connection managers internal data. This PR tries to ensure that this happens, such that these entries are properly freed.

```
2023-04-22T21:34:59.585Z hopr-core:libp2p dead connections to 16Uiu2HAmQ3CgoDqZE4eub44nZ7RUnNTqd1eTsk1vZxUhA5uaa97i [ 'abgzy41682198229621', '58xi1c1682198490514', '9rm2d01682198736128' ]
```