### PR TITLE
wipe address manager cache

### DIFF
--- a/packages/connect/src/base/listener.ts
+++ b/packages/connect/src/base/listener.ts
@@ -132,6 +132,12 @@ class Listener extends EventEmitter<ListenerEvents> implements InterfaceListener
         this.connectComponents.getRelay().setUsedRelays(relayPeerIds)
       }
 
+      // Libp2p's addressManager utilizes an internal cache which contradicts
+      // the address upgrade mechanism.
+      // This wipes the cache on address changes.
+      // @ts-ignore
+      this.components.getAddressManager().announce = new Set()
+
       this.dispatchEvent(new CustomEvent('listening'))
     }.bind(this)
 


### PR DESCRIPTION
*Before* announcing addresses to the DHT, `js-libp2p` makes use of an internal cache that prevents the PeerRecordUpdater from using the latest addresses.

The PeerRecordUpdater

https://github.com/libp2p/js-libp2p/blob/v0.37.3/src/peer-record-updater.ts#L25

The cache in libp2p AddressManager

https://github.com/libp2p/js-libp2p/blob/v0.37.3/src/address-manager/index.ts#L107