### PR TITLE
Add metrics & logs relevant for RPCh debugging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - Add pruning in the relay connections keep-alive mechanism ([#4916](https://github.com/hoprnet/hoprnet/pull/4916))
 - Enforce closing and clean-up of libp2p2 connections ([#4957](https://github.com/hoprnet/hoprnet/pull/4957))
 - Wipe libp2p's AddressManager cache when publishing new addresses to the DHT ([#4958](https://github.com/hoprnet/hoprnet/pull/4958))
-- Add metrics & logs relevant for RPCh debugging ([]())
+- Add metrics & logs relevant for RPCh debugging ([#4995](https://github.com/hoprnet/hoprnet/pull/4995))
 
 <a name="1.92"></a>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Add pruning in the relay connections keep-alive mechanism ([#4916](https://github.com/hoprnet/hoprnet/pull/4916))
 - Enforce closing and clean-up of libp2p2 connections ([#4957](https://github.com/hoprnet/hoprnet/pull/4957))
 - Wipe libp2p's AddressManager cache when publishing new addresses to the DHT ([#4958](https://github.com/hoprnet/hoprnet/pull/4958))
+- Add metrics & logs relevant for RPCh debugging ([]())
 
 <a name="1.92"></a>
 

--- a/METRICS.md
+++ b/METRICS.md
@@ -52,10 +52,11 @@ The following sections document the metrics per package:
 ### core
 
 | Name                                       | Type        | Description                                                    | Note                            |
-| ------------------------------------------ | ----------- | -------------------------------------------------------------- | ------------------------------- |
+|--------------------------------------------|-------------|----------------------------------------------------------------| ------------------------------- |
 | `core_gauge_num_outgoing_channels`         | gauge       | Number of outgoing channels                                    |                                 |
 | `core_gauge_num_incoming_channels`         | gauge       | Number of incoming channels                                    |                                 |
 | `core_counter_sent_messages`               | counter     | Number of sent messages                                        |                                 |
+| `core_counter_failed_send_messages`        | counter     | Number of send message failures                                |                                 |
 | `core_histogram_path_length`               | histogram   | Distribution of number of hops of sent messages                | buckets: 0-4                    |
 | `core_counter_received_successful_acks`    | counter     | Number of received successful message acknowledgements         |                                 |
 | `core_counter_received_failed_acks`        | counter     | Number of received failed message acknowledgements             |                                 |
@@ -98,7 +99,7 @@ The following sections document the metrics per package:
 ### hoprd
 
 | Name                                            | Type        | Description                                                       | Note                                     |
-| ----------------------------------------------- | ----------- | ----------------------------------------------------------------- | ---------------------------------------- |
+| ----------------------------------------------- |-------------| ----------------------------------------------------------------- | ---------------------------------------- |
 | `hoprd_gauge_startup_unix_time_seconds`         | gauge       | The unix timestamp at which the process was started               | seconds since Epoch                      |
 | `hoprd_histogram_startup_time_seconds`          | histogram   | Time it takes for a node to start up                              | unit: seconds                            |
 | `hoprd_histogram_time_to_green_seconds`         | histogram   | Time it takes for a node to transition to the GREEN network state | unit: seconds                            |
@@ -109,6 +110,8 @@ The following sections document the metrics per package:
 | `hoprd_gauge_nodejs_total_available_heap_bytes` | gauge       | V8 total available heap size in bytes                             | unit: bytes                              |
 | `hoprd_gauge_nodejs_num_native_contexts`        | gauge       | V8 number of active top-level native contexts                     | unit: bytes, increase indicates mem leak |
 | `hoprd_gauge_nodejs_num_detached_contexts`      | gauge       | V8 number of detached contexts which are not GCd                  | unit: bytes, non-zero indicates mem leak |
+| `hoprd_counter_api_successful_send_msg`         | counter     | Number of successful API calls to POST message endpoint           |                                          |
+| `hoprd_counter_api_failed_send_msg`             | counter     | Number of failed API calls to POST message endpoint               |                                          |
 
 ### utils
 

--- a/METRICS.md
+++ b/METRICS.md
@@ -52,7 +52,7 @@ The following sections document the metrics per package:
 ### core
 
 | Name                                       | Type        | Description                                                    | Note                            |
-|--------------------------------------------|-------------|----------------------------------------------------------------| ------------------------------- |
+| ------------------------------------------ | ----------- | -------------------------------------------------------------- | ------------------------------- |
 | `core_gauge_num_outgoing_channels`         | gauge       | Number of outgoing channels                                    |                                 |
 | `core_gauge_num_incoming_channels`         | gauge       | Number of incoming channels                                    |                                 |
 | `core_counter_sent_messages`               | counter     | Number of sent messages                                        |                                 |
@@ -99,7 +99,7 @@ The following sections document the metrics per package:
 ### hoprd
 
 | Name                                            | Type        | Description                                                       | Note                                     |
-| ----------------------------------------------- |-------------| ----------------------------------------------------------------- | ---------------------------------------- |
+| ----------------------------------------------- | ----------- | ----------------------------------------------------------------- | ---------------------------------------- |
 | `hoprd_gauge_startup_unix_time_seconds`         | gauge       | The unix timestamp at which the process was started               | seconds since Epoch                      |
 | `hoprd_histogram_startup_time_seconds`          | histogram   | Time it takes for a node to start up                              | unit: seconds                            |
 | `hoprd_histogram_time_to_green_seconds`         | histogram   | Time it takes for a node to transition to the GREEN network state | unit: seconds                            |

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -117,7 +117,10 @@ const metric_channelBalances = create_multi_gauge(
   ['counterparty', 'direction']
 )
 const metric_sentMessageCount = create_counter('core_counter_sent_messages', 'Number of sent messages')
-const metric_sentMessageFailCount = create_counter('core_counter_failed_send_messages', 'Number of sent messages failures')
+const metric_sentMessageFailCount = create_counter(
+  'core_counter_failed_send_messages',
+  'Number of sent messages failures'
+)
 const metric_pathLength = create_histogram_with_buckets(
   'core_histogram_path_length',
   'Distribution of number of hops of sent messages',
@@ -990,10 +993,9 @@ class Hopr extends EventEmitter {
       // Validate the manually specified intermediate path
       try {
         await this.validateIntermediatePath(intermediatePath)
-      }
-      catch (e) {
-          metric_sentMessageFailCount.increment()
-          throw  e
+      } catch (e) {
+        metric_sentMessageFailCount.increment()
+        throw e
       }
     } else {
       intermediatePath = await this.getIntermediateNodes(PublicKey.fromPeerId(destination), hops)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -117,6 +117,7 @@ const metric_channelBalances = create_multi_gauge(
   ['counterparty', 'direction']
 )
 const metric_sentMessageCount = create_counter('core_counter_sent_messages', 'Number of sent messages')
+const metric_sentMessageFailCount = create_counter('core_counter_failed_send_messages', 'Number of sent messages failures')
 const metric_pathLength = create_histogram_with_buckets(
   'core_histogram_path_length',
   'Distribution of number of hops of sent messages',
@@ -976,20 +977,29 @@ class Hopr extends EventEmitter {
    */
   public async sendMessage(msg: Uint8Array, destination: PeerId, intermediatePath?: PublicKey[], hops?: number) {
     if (this.status != 'RUNNING') {
+      metric_sentMessageFailCount.increment()
       throw new Error('Cannot send message until the node is running')
     }
 
     if (msg.length > PACKET_SIZE) {
+      metric_sentMessageFailCount.increment()
       throw Error(`Message does not fit into one packet. Please split message into chunks of ${PACKET_SIZE} bytes`)
     }
 
     if (intermediatePath != undefined) {
       // Validate the manually specified intermediate path
-      await this.validateIntermediatePath(intermediatePath)
+      try {
+        await this.validateIntermediatePath(intermediatePath)
+      }
+      catch (e) {
+          metric_sentMessageFailCount.increment()
+          throw  e
+      }
     } else {
       intermediatePath = await this.getIntermediateNodes(PublicKey.fromPeerId(destination), hops)
 
       if (intermediatePath == null || !intermediatePath.length) {
+        metric_sentMessageFailCount.increment()
         throw Error(`Failed to find automatic path`)
       }
     }
@@ -1007,6 +1017,7 @@ class Hopr extends EventEmitter {
       )
     } catch (err) {
       log(`Could not create packet ${err}`)
+      metric_sentMessageFailCount.increment()
       throw Error(`Error while creating packet.`)
     }
 
@@ -1016,6 +1027,7 @@ class Hopr extends EventEmitter {
       await this.forward.interact(path[0].toPeerId(), packet)
     } catch (err) {
       log(`Could not send packet ${err}`)
+      metric_sentMessageFailCount.increment()
       throw Error(`Failed to send packet.`)
     }
 

--- a/packages/hoprd/src/api/v2.ts
+++ b/packages/hoprd/src/api/v2.ts
@@ -60,6 +60,8 @@ async function authenticateAndAuthorize(
   return AuthResult.Failed
 }
 
+export const RPCH_MESSAGE_REGEXP = /^(\d+)\|\d+\|\d+\|[\w\W]+$/
+
 // The Rest API v2 is uses JSON for input and output, is validated through a
 // Swagger schema which is also accessible for testing at:
 // http://localhost:3001/api/v2/_swagger

--- a/packages/hoprd/src/api/v2/paths/messages/index.ts
+++ b/packages/hoprd/src/api/v2/paths/messages/index.ts
@@ -6,8 +6,14 @@ import { encodeMessage } from '../../../utils.js'
 import { RPCH_MESSAGE_REGEXP } from '../../../v2.js'
 import { log } from 'debug'
 
-const metric_successfulSendApiCalls = create_counter('hoprd_counter_api_successful_send_msg', 'Number of successful API calls to POST message endpoint')
-const metric_failedSendApiCalls = create_counter('hoprd_counter_api_failed_send_msg', 'Number of failed API calls to POST message endpoint')
+const metric_successfulSendApiCalls = create_counter(
+  'hoprd_counter_api_successful_send_msg',
+  'Number of successful API calls to POST message endpoint'
+)
+const metric_failedSendApiCalls = create_counter(
+  'hoprd_counter_api_failed_send_msg',
+  'Number of failed API calls to POST message endpoint'
+)
 
 const POST: Operation = [
   async (req, res, _next) => {

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -29,6 +29,7 @@ import { LogStream } from './logs.js'
 import { getIdentity } from './identity.js'
 import { decodeMessage } from './api/utils.js'
 import { type ChannelStrategyInterface, StrategyFactory } from '@hoprnet/hopr-core/lib/channel-strategy.js'
+import { RPCH_MESSAGE_REGEXP } from './api/v2.js'
 
 // Metrics
 const metric_processStartTime = create_gauge(
@@ -207,6 +208,10 @@ async function main() {
       logs.log(`Message: ${decodedMsg.msg}`)
       logs.log(`Latency: ${decodedMsg.latency} ms`)
       metric_latency.observe(decodedMsg.latency)
+
+      if (RPCH_MESSAGE_REGEXP.test(decodedMsg.msg)) {
+        logs.log(`RPCh: received message [${decodedMsg.msg}]`)
+      }
 
       // also send it tagged as message for apps to use
       logs.logMessage(decodedMsg.msg)


### PR DESCRIPTION
This PR add some metrics relevant to RPCh failed request debugging.

It also adds a regex distinguisher of raw RPCh messages in order to log them in hoprd logs for further processing.