### PR TITLE
enhance dialing logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Add pruning in the relay connections keep-alive mechanism ([#4916](https://github.com/hoprnet/hoprnet/pull/4916))
 - Enforce closing and clean-up of libp2p2 connections ([#4957](https://github.com/hoprnet/hoprnet/pull/4957))
 - Wipe libp2p's AddressManager cache when publishing new addresses to the DHT ([#4958](https://github.com/hoprnet/hoprnet/pull/4958))
+- Enhance debug logs in dialing logic to enhance debugging ([#5004](https://github.com/hoprnet/hoprnet/pull/5004))
 
 <a name="1.92"></a>
 


### PR DESCRIPTION
Enhancements to the dialing logic to make its debugging easier

- when outputting known addresses, sort them in the order in which they are dialed
- add connection identifiers whenever possible to debug logs
- when establishing a connection, add the utilized Multiaddr to the debug logs