### PR TITLE
fix unit test suite

### DIFF
--- a/packages/connect/src/utils/libp2p.mock.spec.ts
+++ b/packages/connect/src/utils/libp2p.mock.spec.ts
@@ -258,6 +258,7 @@ export function disconnectEvent(addr: Multiaddr) {
 function createConnection(self: PeerId, remoteComponents: Components, throwError: boolean = false): Connection {
   const conn = {
     remotePeer: remoteComponents.getPeerId(),
+    remoteAddr: new Multiaddr('/ip4/1.2.3.4/tcp/567'),
     _closed: false,
     close: async () => {
       // @ts-ignore

--- a/packages/utils/src/libp2p/index.spec.ts
+++ b/packages/utils/src/libp2p/index.spec.ts
@@ -128,7 +128,8 @@ function getFakeLibp2p(
                   } as ProtocolStream['stream'],
                   protocol
                 }),
-              remotePeer: destination
+              remotePeer: destination,
+              remoteAddr: new Multiaddr('/ip4/1.2.3.4/tcp/567')
             } as Connection)
           }
         }


### PR DESCRIPTION
Adds mock for a missing method that made the unit test break after #5004 

re https://github.com/hoprnet/hoprnet/actions/runs/4820700047/jobs/8585558510?pr=5006