### PR TITLE
coerce libp2p addrs

### DIFF
--- a/.yarn/patches/libp2p-npm-0.37.3-ae5be411f2.patch
+++ b/.yarn/patches/libp2p-npm-0.37.3-ae5be411f2.patch
@@ -1,0 +1,70 @@
+diff --git a/dist/src/circuit/transport.js b/dist/src/circuit/transport.js
+index e856e727f9590436691291ece1af52029083ebff..5bc80f3c03105bd7b897a162353396adcdee4ecb 100644
+--- a/dist/src/circuit/transport.js
++++ b/dist/src/circuit/transport.js
+@@ -1,7 +1,7 @@
+ import { logger } from '@libp2p/logger';
+ import errCode from 'err-code';
+ import * as mafmt from '@multiformats/mafmt';
+-import { Multiaddr } from '@multiformats/multiaddr';
++import { Multiaddr, protocols } from '@multiformats/multiaddr';
+ import { CircuitRelay as CircuitPB } from './pb/index.js';
+ import { codes } from '../errors.js';
+ import { streamToMaConnection } from '@libp2p/utils/stream-to-ma-conn';
+@@ -142,7 +142,7 @@ export class Circuit {
+                     type: CircuitPB.Type.HOP,
+                     srcPeer: {
+                         id: this.components.getPeerId().toBytes(),
+-                        addrs: this.components.getAddressManager().getAddresses().map(addr => addr.bytes)
++                        addrs: this.components.getAddressManager().getAddresses().map(ma => ma.decapsulateCode(protocols('p2p').code).bytes)
+                     },
+                     dstPeer: {
+                         id: destinationPeer.toBytes(),
+diff --git a/dist/src/identify/index.js b/dist/src/identify/index.js
+index b4b5d11ea497682591f6a95092eb554a2780a4dd..e865a1d2dbe2197bc835c853a5d8f553ee49d614 100644
+--- a/dist/src/identify/index.js
++++ b/dist/src/identify/index.js
+@@ -80,7 +80,7 @@ export class IdentifyService {
+      */
+     async push(connections) {
+         const signedPeerRecord = await this.components.getPeerStore().addressBook.getRawEnvelope(this.components.getPeerId());
+-        const listenAddrs = this.components.getAddressManager().getAddresses().map((ma) => ma.bytes);
++        const listenAddrs = this.components.getAddressManager().getAddresses().map(ma => ma.decapsulateCode(protocols('p2p').code).bytes);
+         const protocols = await this.components.getPeerStore().protoBook.get(this.components.getPeerId());
+         const pushes = connections.map(async (connection) => {
+             const timeoutController = new TimeoutController(this.init.timeout ?? IDENTIFY_TIMEOUT);
+diff --git a/src/circuit/transport.ts b/src/circuit/transport.ts
+index 1ff71d4ed7e3ab4498a083ea1f2f33d088fe9e02..d0360cefab8b8b312936bbb4fba651fd51d58575 100644
+--- a/src/circuit/transport.ts
++++ b/src/circuit/transport.ts
+@@ -1,7 +1,7 @@
+ import { logger } from '@libp2p/logger'
+ import errCode from 'err-code'
+ import * as mafmt from '@multiformats/mafmt'
+-import { Multiaddr } from '@multiformats/multiaddr'
++import { Multiaddr, protocols } from '@multiformats/multiaddr'
+ import { CircuitRelay as CircuitPB } from './pb/index.js'
+ import { codes } from '../errors.js'
+ import { streamToMaConnection } from '@libp2p/utils/stream-to-ma-conn'
+@@ -165,7 +165,7 @@ export class Circuit implements Transport, Initializable {
+           type: CircuitPB.Type.HOP,
+           srcPeer: {
+             id: this.components.getPeerId().toBytes(),
+-            addrs: this.components.getAddressManager().getAddresses().map(addr => addr.bytes)
++            addrs: this.components.getAddressManager().getAddresses().map(ma => ma.decapsulateCode(protocols('p2p').code).bytes)
+           },
+           dstPeer: {
+             id: destinationPeer.toBytes(),
+diff --git a/src/identify/index.ts b/src/identify/index.ts
+index 777c35c1aa7ab4000c32e731077bce4100a1507f..c2541aa24f4a61b917f9225a7ccf1c554927ac81 100644
+--- a/src/identify/index.ts
++++ b/src/identify/index.ts
+@@ -151,7 +151,7 @@ export class IdentifyService implements Startable {
+    */
+   async push (connections: Connection[]): Promise<void> {
+     const signedPeerRecord = await this.components.getPeerStore().addressBook.getRawEnvelope(this.components.getPeerId())
+-    const listenAddrs = this.components.getAddressManager().getAddresses().map((ma) => ma.bytes)
++    const listenAddrs = this.components.getAddressManager().getAddresses().map(ma => ma.decapsulateCode(protocols('p2p').code).bytes)
+     const protocols = await this.components.getPeerStore().protoBook.get(this.components.getPeerId())
+ 
+     const pushes = connections.map(async connection => {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Wipe libp2p's AddressManager cache when publishing new addresses to the DHT ([#4958](https://github.com/hoprnet/hoprnet/pull/4958))
 - Add metrics & logs relevant for RPCh debugging ([#4995](https://github.com/hoprnet/hoprnet/pull/4995))
 - Enhance debug logs in dialing logic to enhance debugging ([#5004](https://github.com/hoprnet/hoprnet/pull/5004))
+- Fix address coercion issue in libp2p address handling ([#5020](https://github.com/hoprnet/hoprnet/pull/5020))
 
 <a name="1.92"></a>
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "@libp2p/kad-dht": "https://github.com/hoprnet/js-libp2p-kad-dht/archive/refs/tags/v1.0.17.tar.gz",
     "@overnightjs/logger": "1.2.1",
     "colors": "1.4.0",
-    "it-length-prefixed": "https://github.com/hoprnet/it-length-prefixed/archive/refs/tags/v7.0.3.tar.gz"
+    "it-length-prefixed": "https://github.com/hoprnet/it-length-prefixed/archive/refs/tags/v7.0.3.tar.gz",
+    "libp2p@0.37.3": "patch:libp2p@npm%3A0.37.3#./.yarn/patches/libp2p-npm-0.37.3-ae5be411f2.patch"
   },
   "prettier": {
     "tabWidth": 2,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1489,26 +1489,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mapbox/node-pre-gyp@npm:^1.0.0":
-  version: 1.0.9
-  resolution: "@mapbox/node-pre-gyp@npm:1.0.9"
-  dependencies:
-    detect-libc: ^2.0.0
-    https-proxy-agent: ^5.0.0
-    make-dir: ^3.1.0
-    node-fetch: ^2.6.7
-    nopt: ^5.0.0
-    npmlog: ^5.0.1
-    rimraf: ^3.0.2
-    semver: ^7.3.5
-    tar: ^6.1.11
-  bin:
-    node-pre-gyp: bin/node-pre-gyp
-  checksum: 1b9c4c87a68d200daa13151d0fe033aa7aa8f7b26f3585255424dd8dfee2ec672c3e9bea4071c624469bc0aebbbcde08f8a300c8a958db52c50abadd5fb56920
-  languageName: node
-  linkType: hard
-
-"@mapbox/node-pre-gyp@npm:^1.0.8":
+"@mapbox/node-pre-gyp@npm:^1.0.0, @mapbox/node-pre-gyp@npm:^1.0.8":
   version: 1.0.10
   resolution: "@mapbox/node-pre-gyp@npm:1.0.10"
   dependencies:
@@ -2119,14 +2100,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/chai@npm:*":
-  version: 4.3.3
-  resolution: "@types/chai@npm:4.3.3"
-  checksum: 20cd094753e137cfc35939cae7f0ed78ecda7861e5c94704efab6979b9121a63807e9b631bdcf3a2792d6c6dba44050b13387262f9e63ebb040741c01c345f0a
-  languageName: node
-  linkType: hard
-
-"@types/chai@npm:4.3.4":
+"@types/chai@npm:*, @types/chai@npm:4.3.4":
   version: 4.3.4
   resolution: "@types/chai@npm:4.3.4"
   checksum: 571184967beb03bf64c4392a13a7d44e72da9af5a1e83077ff81c39cf59c0fda2a5c78d2005084601cf8f3d11726608574d8b5b4a0e3e9736792807afd926cd0
@@ -2265,17 +2239,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/semver@npm:^7":
+"@types/semver@npm:^7, @types/semver@npm:^7.0.0":
   version: 7.3.13
   resolution: "@types/semver@npm:7.3.13"
   checksum: 00c0724d54757c2f4bc60b5032fe91cda6410e48689633d5f35ece8a0a66445e3e57fa1d6e07eb780f792e82ac542948ec4d0b76eb3484297b79bd18b8cf1cb0
-  languageName: node
-  linkType: hard
-
-"@types/semver@npm:^7.0.0":
-  version: 7.3.12
-  resolution: "@types/semver@npm:7.3.12"
-  checksum: 35536b2fc5602904f21cae681f6c9498e177dab3f54ae37c92f9a1b7e43c35f18bcd81e1c98c1cf0d33ee046bb06c771e9928c1c00a401d56a03f56549252a15
   languageName: node
   linkType: hard
 
@@ -3695,14 +3662,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"content-type@npm:^1.0.4, content-type@npm:~1.0.4":
-  version: 1.0.4
-  resolution: "content-type@npm:1.0.4"
-  checksum: 3d93585fda985d1554eca5ebd251994327608d2e200978fdbfba21c0c679914d5faf266d17027de44b34a72c7b0745b18584ecccaa7e1fdfb6a68ac7114f12e0
-  languageName: node
-  linkType: hard
-
-"content-type@npm:~1.0.5":
+"content-type@npm:^1.0.4, content-type@npm:~1.0.4, content-type@npm:~1.0.5":
   version: 1.0.5
   resolution: "content-type@npm:1.0.5"
   checksum: 566271e0a251642254cde0f845f9dd4f9856e52d988f4eb0d0dcffbb7a1f8ec98de7a5215fc628f3bce30fe2fb6fd2bc064b562d721658c59b544e2d34ea2766
@@ -6801,23 +6761,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"it-pair@npm:2.0.4":
+"it-pair@npm:2.0.4, it-pair@npm:^2.0.2":
   version: 2.0.4
   resolution: "it-pair@npm:2.0.4"
   dependencies:
     it-stream-types: ^1.0.3
     p-defer: ^4.0.0
   checksum: 7eedc5712c860b3741a26efdbfb747b9757acd328b7ffd48c73f46710f76b3e0462e4649044ca3210f9e6cae1a5f011bcf2b603ff3ef3ac6c3c5ce91f951804c
-  languageName: node
-  linkType: hard
-
-"it-pair@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "it-pair@npm:2.0.2"
-  dependencies:
-    it-stream-types: ^1.0.3
-    p-defer: ^4.0.0
-  checksum: 55440cd292a53690566e4c337d015ca2422e053ee31691241ba9a81f9479e45766de04a70246c8fe76fda4982fcc959b5258a97782737e026ec64acf8a5a712f
   languageName: node
   linkType: hard
 
@@ -7383,6 +7333,65 @@ __metadata:
   languageName: node
   linkType: hard
 
+"libp2p@patch:libp2p@npm%3A0.37.3#./.yarn/patches/libp2p-npm-0.37.3-ae5be411f2.patch::locator=hoprnet%40workspace%3A.":
+  version: 0.37.3
+  resolution: "libp2p@patch:libp2p@npm%3A0.37.3#./.yarn/patches/libp2p-npm-0.37.3-ae5be411f2.patch::version=0.37.3&hash=57a3d4&locator=hoprnet%40workspace%3A."
+  dependencies:
+    "@achingbrain/nat-port-mapper": ^1.0.3
+    "@libp2p/connection": ^2.0.2
+    "@libp2p/crypto": ^0.22.11
+    "@libp2p/interfaces": ^2.0.2
+    "@libp2p/logger": ^1.1.4
+    "@libp2p/multistream-select": ^1.0.4
+    "@libp2p/peer-collections": ^1.0.2
+    "@libp2p/peer-id": ^1.1.10
+    "@libp2p/peer-id-factory": ^1.0.9
+    "@libp2p/peer-record": ^1.0.8
+    "@libp2p/peer-store": ^1.0.10
+    "@libp2p/tracked-map": ^1.0.5
+    "@libp2p/utils": ^1.0.10
+    "@multiformats/mafmt": ^11.0.2
+    "@multiformats/multiaddr": ^10.1.8
+    abortable-iterator: ^4.0.2
+    any-signal: ^3.0.0
+    datastore-core: ^7.0.0
+    err-code: ^3.0.1
+    events: ^3.3.0
+    hashlru: ^2.3.0
+    interface-datastore: ^6.1.0
+    it-all: ^1.0.6
+    it-drain: ^1.0.5
+    it-filter: ^1.0.3
+    it-first: ^1.0.6
+    it-foreach: ^0.1.1
+    it-handshake: ^3.0.1
+    it-length-prefixed: ^7.0.1
+    it-map: ^1.0.6
+    it-merge: ^1.0.3
+    it-pair: ^2.0.2
+    it-pipe: ^2.0.3
+    it-sort: ^1.0.1
+    it-stream-types: ^1.0.4
+    merge-options: ^3.0.4
+    multiformats: ^9.6.3
+    mutable-proxy: ^1.0.0
+    node-forge: ^1.2.1
+    p-fifo: ^1.0.0
+    p-retry: ^5.0.0
+    p-settle: ^5.0.0
+    private-ip: ^2.3.3
+    protons-runtime: ^1.0.4
+    retimer: ^3.0.0
+    sanitize-filename: ^1.6.3
+    set-delayed-interval: ^1.0.0
+    timeout-abort-controller: ^3.0.0
+    uint8arrays: ^3.0.0
+    wherearewe: ^1.0.0
+    xsalsa20: ^1.1.0
+  checksum: 9391bbe3ecc4504c43e2dec265bf4a2a7092e858cdb4de6be5b02705512547d57b0c0eeaf2b2a4b87a333491c777613197fefe17415ded1b7f70b9268151ede2
+  languageName: node
+  linkType: hard
+
 "listr-silent-renderer@npm:^1.1.1":
   version: 1.1.1
   resolution: "listr-silent-renderer@npm:1.1.1"
@@ -7926,12 +7935,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:*":
-  version: 6.2.0
-  resolution: "minimatch@npm:6.2.0"
+"minimatch@npm:*, minimatch@npm:^7.1.3":
+  version: 7.4.3
+  resolution: "minimatch@npm:7.4.3"
   dependencies:
     brace-expansion: ^2.0.1
-  checksum: 0ffb77d05bd483fcc344ba3e64a501d569e658fa6c592d94e9716ffc7925de7a8c2ac294cafa822b160bd8b2cbf7e01012917e06ffb9a85cfa9604629b3f2c04
+  checksum: daa954231b6859e3ba0e5fbd2486986d3cae283bb69acb7ed3833c84a293f8d7edb8514360ea62c01426ba791446b2a1e1cc0d718bed15c0212cef35c59a6b95
   languageName: node
   linkType: hard
 
@@ -7959,15 +7968,6 @@ __metadata:
   dependencies:
     brace-expansion: ^2.0.1
   checksum: 215edd0978320a3354188f84a537d45841f2449af4df4379f79b9b777e71aa4f5722cc9d1717eabd2a70d38ef76ab7b708d24d83ea6a6c909dfd8833de98b437
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^7.1.3":
-  version: 7.4.3
-  resolution: "minimatch@npm:7.4.3"
-  dependencies:
-    brace-expansion: ^2.0.1
-  checksum: daa954231b6859e3ba0e5fbd2486986d3cae283bb69acb7ed3833c84a293f8d7edb8514360ea62c01426ba791446b2a1e1cc0d718bed15c0212cef35c59a6b95
   languageName: node
   linkType: hard
 
@@ -8652,7 +8652,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"object.assign@npm:^4.1.0":
+"object.assign@npm:^4.1.0, object.assign@npm:^4.1.2":
   version: 4.1.4
   resolution: "object.assign@npm:4.1.4"
   dependencies:
@@ -8661,18 +8661,6 @@ __metadata:
     has-symbols: ^1.0.3
     object-keys: ^1.1.1
   checksum: 76cab513a5999acbfe0ff355f15a6a125e71805fcf53de4e9d4e082e1989bdb81d1e329291e1e4e0ae7719f0e4ef80e88fb2d367ae60500d79d25a6224ac8864
-  languageName: node
-  linkType: hard
-
-"object.assign@npm:^4.1.2":
-  version: 4.1.3
-  resolution: "object.assign@npm:4.1.3"
-  dependencies:
-    call-bind: ^1.0.2
-    define-properties: ^1.1.4
-    has-symbols: ^1.0.3
-    object-keys: ^1.1.1
-  checksum: fe87c8acd60e0d7140e1eae8886804e7497bf6a019bae715084083c2abd1760bd5aa9c3f0e5b02c82ca5cc33b641dc908c42c86c6f7d6dfd9f083a7baa95d318
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
`hopr` uses libp2p for peer-to-peer communication. libp2p uses multiformats/Multiaddr to address nodes. Multiaddrs *can* include the PeerId of the destination, e.g.

```
/p2p/16Uiu2HAkwecC3n6BG3odw4WC3PjEPv36HyHsHE4dxGotXWgXynrh/p2p-circuit/p2p/16Uiu2HAmEcAW62hrT2Rd19SFLJvx7ZxvtuDFFf8pbUwMRZx4xyfv
```

but they don't need to since the destination peerId is already known when dialing a peer. this is why they are stored and transferred as:

```
/p2p/16Uiu2HAkwecC3n6BG3odw4WC3PjEPv36HyHsHE4dxGotXWgXynrh/p2p-circuit
``` 

unfortunately, there is no *coercing* method foreseen to automatically convert *long* addresses into *short* addresses.

This PR adds a `yarn patch` to add the missing coercion from *long* addresses to *short* address when pushing address information to other peers.