### PR TITLE
fix libp2p address store

### DIFF
--- a/.yarn/patches/@libp2p-peer-store-npm-1.0.17-714b0c0ec5.patch
+++ b/.yarn/patches/@libp2p-peer-store-npm-1.0.17-714b0c0ec5.patch
@@ -1,0 +1,102 @@
+diff --git a/dist/src/address-book.js b/dist/src/address-book.js
+index ecae42c6b6d2024a4f7808e904523f4929132e4b..0daecd4d8ae380e8eaf65ffc6082ea44e603a6dc 100644
+--- a/dist/src/address-book.js
++++ b/dist/src/address-book.js
+@@ -154,22 +154,6 @@ export class PeerStoreAddressBook {
+             if (addresses.length === 0) {
+                 return;
+             }
+-            try {
+-                peer = await this.store.load(peerId);
+-                hasPeer = true;
+-                if (new Set([
+-                    ...addresses.map(({ multiaddr }) => multiaddr.toString()),
+-                    ...peer.addresses.map(({ multiaddr }) => multiaddr.toString())
+-                ]).size === peer.addresses.length && addresses.length === peer.addresses.length) {
+-                    // not changing anything, no need to update
+-                    return;
+-                }
+-            }
+-            catch (err) {
+-                if (err.code !== codes.ERR_NOT_FOUND) {
+-                    throw err;
+-                }
+-            }
+             updatedPeer = await this.store.patchOrCreate(peerId, { addresses });
+             log('set multiaddrs for %p', peerId);
+         }
+@@ -214,21 +198,6 @@ export class PeerStoreAddressBook {
+             if (addresses.length === 0) {
+                 return;
+             }
+-            try {
+-                peer = await this.store.load(peerId);
+-                hasPeer = true;
+-                if (new Set([
+-                    ...addresses.map(({ multiaddr }) => multiaddr.toString()),
+-                    ...peer.addresses.map(({ multiaddr }) => multiaddr.toString())
+-                ]).size === peer.addresses.length) {
+-                    return;
+-                }
+-            }
+-            catch (err) {
+-                if (err.code !== codes.ERR_NOT_FOUND) {
+-                    throw err;
+-                }
+-            }
+             updatedPeer = await this.store.mergeOrCreate(peerId, { addresses });
+             log('added multiaddrs for %p', peerId);
+         }
+diff --git a/src/address-book.ts b/src/address-book.ts
+index 34df045bbb64a460035984b0fd57c7c0b425eec6..3574bd42715bfcf0c9e40fbe39f1dea5b9ba15bd 100644
+--- a/src/address-book.ts
++++ b/src/address-book.ts
+@@ -192,23 +192,6 @@ export class PeerStoreAddressBook {
+         return
+       }
+ 
+-      try {
+-        peer = await this.store.load(peerId)
+-        hasPeer = true
+-
+-        if (new Set([
+-          ...addresses.map(({ multiaddr }) => multiaddr.toString()),
+-          ...peer.addresses.map(({ multiaddr }) => multiaddr.toString())
+-        ]).size === peer.addresses.length && addresses.length === peer.addresses.length) {
+-          // not changing anything, no need to update
+-          return
+-        }
+-      } catch (err: any) {
+-        if (err.code !== codes.ERR_NOT_FOUND) {
+-          throw err
+-        }
+-      }
+-
+       updatedPeer = await this.store.patchOrCreate(peerId, { addresses })
+ 
+       log('set multiaddrs for %p', peerId)
+@@ -261,23 +244,7 @@ export class PeerStoreAddressBook {
+       if (addresses.length === 0) {
+         return
+       }
+-
+-      try {
+-        peer = await this.store.load(peerId)
+-        hasPeer = true
+-
+-        if (new Set([
+-          ...addresses.map(({ multiaddr }) => multiaddr.toString()),
+-          ...peer.addresses.map(({ multiaddr }) => multiaddr.toString())
+-        ]).size === peer.addresses.length) {
+-          return
+-        }
+-      } catch (err: any) {
+-        if (err.code !== codes.ERR_NOT_FOUND) {
+-          throw err
+-        }
+-      }
+-
++      
+       updatedPeer = await this.store.mergeOrCreate(peerId, { addresses })
+ 
+       log('added multiaddrs for %p', peerId)

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "@overnightjs/logger": "1.2.1",
     "colors": "1.4.0",
     "it-length-prefixed": "https://github.com/hoprnet/it-length-prefixed/archive/refs/tags/v7.0.3.tar.gz",
-    "libp2p@0.37.3": "patch:libp2p@npm%3A0.37.3#./.yarn/patches/libp2p-npm-0.37.3-ae5be411f2.patch"
+    "libp2p@0.37.3": "patch:libp2p@npm%3A0.37.3#./.yarn/patches/libp2p-npm-0.37.3-ae5be411f2.patch",
+    "@libp2p/peer-store@^1.0.10": "patch:@libp2p/peer-store@npm%3A1.0.17#./.yarn/patches/@libp2p-peer-store-npm-1.0.17-714b0c0ec5.patch"
   },
   "prettier": {
     "tabWidth": 2,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1396,7 +1396,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@libp2p/peer-store@npm:^1.0.10":
+"@libp2p/peer-store@npm:1.0.17":
   version: 1.0.17
   resolution: "@libp2p/peer-store@npm:1.0.17"
   dependencies:
@@ -1417,6 +1417,30 @@ __metadata:
     protons-runtime: ^1.0.4
     uint8arrays: ^3.0.0
   checksum: d76cf06bcac54c01a380d395db847c8dafbaaaec0835c3f38586d2851403115331995e16df489f70ad8c0bb6e86ece8eeff1286196dd348852278e9e793c78f4
+  languageName: node
+  linkType: hard
+
+"@libp2p/peer-store@patch:@libp2p/peer-store@npm%3A1.0.17#./.yarn/patches/@libp2p-peer-store-npm-1.0.17-714b0c0ec5.patch::locator=hoprnet%40workspace%3A.":
+  version: 1.0.17
+  resolution: "@libp2p/peer-store@patch:@libp2p/peer-store@npm%3A1.0.17#./.yarn/patches/@libp2p-peer-store-npm-1.0.17-714b0c0ec5.patch::version=1.0.17&hash=7a7966&locator=hoprnet%40workspace%3A."
+  dependencies:
+    "@libp2p/interfaces": ^2.0.0
+    "@libp2p/logger": ^1.1.0
+    "@libp2p/peer-id": ^1.1.0
+    "@libp2p/peer-record": ^1.0.0
+    "@multiformats/multiaddr": ^10.1.5
+    err-code: ^3.0.1
+    interface-datastore: ^6.1.0
+    it-all: ^1.0.6
+    it-filter: ^1.0.3
+    it-foreach: ^0.1.1
+    it-map: ^1.0.6
+    it-pipe: ^2.0.3
+    mortice: ^3.0.0
+    multiformats: ^9.6.3
+    protons-runtime: ^1.0.4
+    uint8arrays: ^3.0.0
+  checksum: edf9126a8fa2f07e82fa4c10d51e75524ed09d7f892b1f8d37d1fa22b138a4045116a66151d86f587cd71750d8c839c9ebf88dec193851dec1992fa54c50d286
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Tldr

Adds a patch to a libp2p library used for managing known addresses

### Current situation

*Before* adding new addresses to the PeerStore (== the list of known addresses), there is a check whether the size of the addresses is the same.

If an address in the list *changes*, the *size* stays the same and thus the entire request is ignored.

### New behavior

Remove this check and rather do some additional db queries