### PR TITLE
Add missing AccountEntry type for use in the DB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1166,7 +1166,7 @@ dependencies = [
 
 [[package]]
 name = "core-types"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "console_error_panic_hook",
  "core-crypto",
@@ -1174,6 +1174,7 @@ dependencies = [
  "ethnum",
  "hex-literal 0.3.4",
  "js-sys",
+ "multiaddr",
  "serde",
  "serde_repr",
  "utils-misc",

--- a/packages/core/crates/core-db/src/db.rs
+++ b/packages/core/crates/core-db/src/db.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 use core_crypto::types::{HalfKeyChallenge, Hash, PublicKey};
-use core_types::acknowledgment::UnacknowledgedTicket;
+use core_types::acknowledgement::UnacknowledgedTicket;
 use core_types::channels::{ChannelEntry, Ticket};
 use utils_db::{db::DB, traits::BinaryAsyncKVStorage};
 use utils_types::primitives::{Address, Balance, U256};

--- a/packages/core/crates/core-db/src/traits.rs
+++ b/packages/core/crates/core-db/src/traits.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 
 use core_crypto::types::{HalfKeyChallenge, Hash, PublicKey};
-use core_types::acknowledgment::UnacknowledgedTicket;
+use core_types::acknowledgement::UnacknowledgedTicket;
 use core_types::channels::{ChannelEntry, Ticket};
 use utils_types::primitives::{Address, Balance, U256};
 

--- a/packages/core/crates/core-types/Cargo.toml
+++ b/packages/core/crates/core-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-types"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 homepage = "https://hoprnet.org/"
@@ -19,6 +19,7 @@ core-crypto = { path = "../../../core/crates/core-crypto" }
 enum-iterator = "1.4.0"
 ethnum = { version = "1.3.2", features = ["serde"] }
 js-sys = { version = "0.3", optional = true }
+multiaddr = "0.17"
 serde = { version = "1.0", features = ["derive"] }
 serde_repr = "0.1"
 utils-misc = { path = "../../../utils/crates/utils-misc" }

--- a/packages/core/crates/core-types/src/account.rs
+++ b/packages/core/crates/core-types/src/account.rs
@@ -1,0 +1,91 @@
+use multiaddr::{Multiaddr, Protocol};
+use core_crypto::types::PublicKey;
+use utils_types::errors::GeneralError::ParseError;
+use utils_types::primitives::{Address, U256};
+use utils_types::traits::{BinarySerializable, PeerIdLike};
+
+#[derive(Clone, Debug, PartialEq)]
+#[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen(getter_with_clone))]
+pub struct AccountEntry {
+    pub public_key: PublicKey,
+    multiaddr: Option<Multiaddr>,
+    pub updated_block: u32
+}
+
+impl AccountEntry {
+    const MAX_MULTI_ADDR_LENGTH: usize = 200;
+    const MA_LENGTH_PREFIX: usize = std::mem::size_of::<u32>();
+
+    pub fn get_address(&self) -> Address {
+        self.public_key.to_address()
+    }
+
+    pub fn get_peer_id_str(&self) -> String {
+        self.public_key.to_peerid_str()
+    }
+
+    pub fn get_multiaddress_str(&self) -> Option<String> {
+        self.multiaddr.map(|m| m.to_string())
+    }
+
+    pub fn has_announced(&self) -> bool {
+        self.multiaddr.is_some()
+    }
+
+    pub fn contains_routing_info(&self) -> bool {
+        match &self.multiaddr {
+            None => false,
+            Some(ma) => {
+                ma.protocol_stack()
+                    .find(|p| p == "ip4" || p == "ip6")
+                    .is_some() &&
+                ma.protocol_stack()
+                    .find(|p| p == "tcp")
+                    .is_some()
+            }
+        }
+    }
+}
+
+impl BinarySerializable<'_> for AccountEntry {
+    const SIZE: usize = PublicKey::SIZE_UNCOMPRESSED + Self::MA_LENGTH_PREFIX +
+        Self::MAX_MULTI_ADDR_LENGTH + 4;
+
+    fn deserialize(data: &[u8]) -> utils_types::errors::Result<Self> {
+        if data.len() == Self::SIZE {
+            let mut buf = data.to_vec();
+            let public_key = PublicKey::deserialize(buf.drain(..PublicKey::SIZE_UNCOMPRESSED).as_ref())?;
+            let ma_len = u32::from_be_bytes(buf.drain(..MA_LENGTH_PREFIX).as_ref().try_into().unwrap());
+            let multiaddr = if ma_len > 0 {
+                Some(Multiaddr::try_from(buf.drain(..ma_len).collect::<Vec<u8>>()).map_err(|_| ParseError)?)
+            } else {
+                None
+            };
+            let updated_block = u32::from_be_bytes(buf.drain(..std::mem::size_of::<u32>()).as_ref().try_into().unwrap());
+            Ok(Self {
+                public_key, multiaddr, updated_block
+            })
+        } else {
+            Err(ParseError)
+        }
+    }
+
+    fn serialize(&self) -> Box<[u8]> {
+        let mut ret = Vec::with_capacity(Self::SIZE);
+        ret.extend_from_slice(&self.public_key.serialize(false));
+        match &self.multiaddr {
+            None => {
+                ret.extend_from_slice(&(0 as u32).to_be_bytes());
+                ret.extend_from_slice(&[0u8; Self::MAX_MULTI_ADDR_LENGTH]);
+            },
+            Some(ma) => {
+                let ma_bytes = ma.to_vec();
+                assert!(ma_bytes.len() <= Self::MAX_MULTI_ADDR_LENGTH, "multi address too long");
+                ret.extend_from_slice(&(ma_bytes.len() as u32).to_be_bytes());
+                ret.extend_from_slice(&ma_bytes);
+            }
+        }
+        ret.extend_from_slice(&self.updated_block.to_be_bytes());
+        ret.into_boxed_slice()
+    }
+}

--- a/packages/core/crates/core-types/src/account.rs
+++ b/packages/core/crates/core-types/src/account.rs
@@ -1,49 +1,113 @@
-use multiaddr::{Multiaddr, Protocol};
+use std::fmt::{Display, Formatter};
+use multiaddr::Multiaddr;
 use core_crypto::types::PublicKey;
 use utils_types::errors::GeneralError::ParseError;
-use utils_types::primitives::{Address, U256};
+use utils_types::primitives::Address;
 use utils_types::traits::{BinarySerializable, PeerIdLike};
+use crate::account::AccountType::{Announced, NotAnnounced};
 
-#[derive(Clone, Debug, PartialEq)]
+/// Type of the node account.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AccountType {
+    /// Node is not announced.
+    NotAnnounced,
+    /// Node is announced with a multi-address
+    Announced {
+      multiaddr: Multiaddr, updated_block: u32
+    }
+}
+
+/// Represents a node announcement entry on the block chain.
+/// This contains node's public key and optional announcement information (multiaddress, block number).
+#[derive(Clone, Debug, PartialEq, Eq)]
 #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen(getter_with_clone))]
 pub struct AccountEntry {
     pub public_key: PublicKey,
-    multiaddr: Option<Multiaddr>,
-    pub updated_block: u32
+    entry_type: AccountType
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
+impl AccountEntry {
+    /// Gets public key as an address
+    pub fn get_address(&self) -> Address {
+        self.public_key.to_address()
+    }
+
+    /// Gets public key as a PeerId string
+    pub fn get_peer_id_str(&self) -> String {
+        self.public_key.to_peerid_str()
+    }
+
+    /// Gets multiaddress as string if this peer ID has been announced.
+    pub fn get_multiaddress_str(&self) -> Option<String> {
+        match &self.entry_type {
+            NotAnnounced => None,
+            Announced { multiaddr, .. } => {
+                Some(multiaddr.to_string())
+            }
+        }
+    }
+
+    /// Gets the block number of the announcement if this peer ID has been announced.
+    pub fn updated_at(&self) -> Option<u32> {
+        match &self.entry_type {
+            NotAnnounced => None,
+            Announced { updated_block, .. } => {
+                Some(*updated_block)
+            }
+        }
+    }
+
+    /// Is the node announced?
+    pub fn has_announced(&self) -> bool {
+        match &self.entry_type {
+            NotAnnounced => false,
+            Announced { .. } => true
+        }
+    }
+
+    /// If the node has announced, did it announce with routing information ?
+    pub fn contains_routing_info(&self) -> bool {
+        match &self.entry_type {
+            NotAnnounced => false,
+            Announced { multiaddr, .. } => {
+                multiaddr.protocol_stack()
+                    .find(|p| p == &"ip4" || p == &"ip6")
+                    .is_some() &&
+                multiaddr.protocol_stack()
+                    .find(|p| p == &"tcp")
+                    .is_some()
+            }
+        }
+    }
 }
 
 impl AccountEntry {
     const MAX_MULTI_ADDR_LENGTH: usize = 200;
     const MA_LENGTH_PREFIX: usize = std::mem::size_of::<u32>();
 
-    pub fn get_address(&self) -> Address {
-        self.public_key.to_address()
+    pub fn new(public_key: PublicKey, entry_type: AccountType) -> Self {
+        Self { public_key, entry_type }
     }
+}
 
-    pub fn get_peer_id_str(&self) -> String {
-        self.public_key.to_peerid_str()
-    }
-
-    pub fn get_multiaddress_str(&self) -> Option<String> {
-        self.multiaddr.map(|m| m.to_string())
-    }
-
-    pub fn has_announced(&self) -> bool {
-        self.multiaddr.is_some()
-    }
-
-    pub fn contains_routing_info(&self) -> bool {
-        match &self.multiaddr {
-            None => false,
-            Some(ma) => {
-                ma.protocol_stack()
-                    .find(|p| p == "ip4" || p == "ip6")
-                    .is_some() &&
-                ma.protocol_stack()
-                    .find(|p| p == "tcp")
-                    .is_some()
+impl Display for AccountEntry {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "AccountEntry {}:", self.public_key.to_peerid_str())?;
+        write!(f, " PublicKey: {}", self.public_key.to_hex(true))?;
+        match &self.entry_type {
+            NotAnnounced => {
+                write!(f, " Multiaddr: not announced")?;
+                write!(f, " UpdatedAt: not announced")?;
+                write!(f, " RoutingInfo: false")?;
+            }
+            Announced { multiaddr, updated_block } => {
+                write!(f, " Multiaddr: {}", multiaddr)?;
+                write!(f, " UpdatedAt: {}", updated_block)?;
+                write!(f, " RoutingInfo: {}", self.contains_routing_info())?;
             }
         }
+        Ok(())
     }
 }
 
@@ -55,16 +119,18 @@ impl BinarySerializable<'_> for AccountEntry {
         if data.len() == Self::SIZE {
             let mut buf = data.to_vec();
             let public_key = PublicKey::deserialize(buf.drain(..PublicKey::SIZE_UNCOMPRESSED).as_ref())?;
-            let ma_len = u32::from_be_bytes(buf.drain(..MA_LENGTH_PREFIX).as_ref().try_into().unwrap());
-            let multiaddr = if ma_len > 0 {
-                Some(Multiaddr::try_from(buf.drain(..ma_len).collect::<Vec<u8>>()).map_err(|_| ParseError)?)
+            let ma_len = u32::from_be_bytes(buf.drain(..Self::MA_LENGTH_PREFIX).as_ref().try_into().unwrap()) as usize;
+            let entry_type = if ma_len > 0 {
+                let multiaddr = Multiaddr::try_from(buf.drain(..ma_len).collect::<Vec<u8>>()).map_err(|_| ParseError)?;
+                buf.drain(..Self::MAX_MULTI_ADDR_LENGTH - ma_len);
+                Announced{
+                    multiaddr,
+                    updated_block: u32::from_be_bytes(buf.drain(..std::mem::size_of::<u32>()).as_ref().try_into().unwrap())
+                }
             } else {
-                None
+                NotAnnounced
             };
-            let updated_block = u32::from_be_bytes(buf.drain(..std::mem::size_of::<u32>()).as_ref().try_into().unwrap());
-            Ok(Self {
-                public_key, multiaddr, updated_block
-            })
+            Ok(Self { public_key, entry_type })
         } else {
             Err(ParseError)
         }
@@ -73,19 +139,127 @@ impl BinarySerializable<'_> for AccountEntry {
     fn serialize(&self) -> Box<[u8]> {
         let mut ret = Vec::with_capacity(Self::SIZE);
         ret.extend_from_slice(&self.public_key.serialize(false));
-        match &self.multiaddr {
-            None => {
+
+        match &self.entry_type {
+            NotAnnounced => {
                 ret.extend_from_slice(&(0 as u32).to_be_bytes());
                 ret.extend_from_slice(&[0u8; Self::MAX_MULTI_ADDR_LENGTH]);
+                ret.extend_from_slice(&(0 as u32).to_be_bytes());
             },
-            Some(ma) => {
-                let ma_bytes = ma.to_vec();
+            Announced{multiaddr, updated_block} => {
+                let ma_bytes = multiaddr.to_vec();
                 assert!(ma_bytes.len() <= Self::MAX_MULTI_ADDR_LENGTH, "multi address too long");
                 ret.extend_from_slice(&(ma_bytes.len() as u32).to_be_bytes());
                 ret.extend_from_slice(&ma_bytes);
+                ret.extend((0..Self::MAX_MULTI_ADDR_LENGTH - ma_bytes.len()).map(|_| 0u8));
+                ret.extend_from_slice(&updated_block.to_be_bytes());
             }
         }
-        ret.extend_from_slice(&self.updated_block.to_be_bytes());
+
         ret.into_boxed_slice()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use hex_literal::hex;
+    use multiaddr::Multiaddr;
+    use core_crypto::types::PublicKey;
+    use utils_types::traits::BinarySerializable;
+    use crate::account::AccountEntry;
+    use crate::account::AccountType::{Announced, NotAnnounced};
+
+    const PRIVATE_KEY: [u8; 32] = hex!("c14b8faa0a9b8a5fa4453664996f23a7e7de606d42297d723fc4a794f375e260");
+
+    #[test]
+    fn test_account_entry_non_routable() {
+        let pub_key = PublicKey::from_privkey(&PRIVATE_KEY).unwrap();
+
+        let ae1 = AccountEntry::new(pub_key.clone(), Announced {
+            multiaddr: "/p2p/16Uiu2HAm3rUQdpCz53tK1MVUUq9NdMAU6mFgtcXrf71Ltw6AStzk".parse::<Multiaddr>().unwrap(),
+            updated_block: 1
+        });
+
+        assert!(ae1.has_announced());
+        assert_eq!(1, ae1.updated_at().unwrap());
+        assert!(!ae1.contains_routing_info());
+
+        let ae2 = AccountEntry::deserialize(&ae1.serialize()).unwrap();
+        assert_eq!(ae1, ae2);
+    }
+
+    #[test]
+    fn test_account_entry_routable() {
+        let pub_key = PublicKey::from_privkey(&PRIVATE_KEY).unwrap();
+
+        let ae1 = AccountEntry::new(pub_key.clone(), Announced {
+            multiaddr: "/ip4/34.65.237.196/tcp/9091/p2p/16Uiu2HAm3rUQdpCz53tK1MVUUq9NdMAU6mFgtcXrf71Ltw6AStzk".parse::<Multiaddr>().unwrap(),
+            updated_block: 1
+        });
+
+        assert!(ae1.has_announced());
+        assert_eq!(1, ae1.updated_at().unwrap());
+        assert!(ae1.contains_routing_info());
+
+        let ae2 = AccountEntry::deserialize(&ae1.serialize()).unwrap();
+        assert_eq!(ae1, ae2);
+    }
+
+    #[test]
+    fn test_account_entry_not_announced() {
+        let pub_key = PublicKey::from_privkey(&PRIVATE_KEY).unwrap();
+
+        let ae1 = AccountEntry::new(pub_key.clone(), NotAnnounced);
+
+        assert!(!ae1.has_announced());
+        assert!(ae1.updated_at().is_none());
+        assert!(!ae1.contains_routing_info());
+
+        let ae2 = AccountEntry::deserialize(&ae1.serialize()).unwrap();
+        assert_eq!(ae1, ae2);
+    }
+}
+
+#[cfg(feature = "wasm")]
+pub mod wasm {
+    use std::str::FromStr;
+    use multiaddr::Multiaddr;
+    use wasm_bindgen::prelude::wasm_bindgen;
+    use core_crypto::types::PublicKey;
+    use utils_misc::ok_or_jserr;
+    use utils_misc::utils::wasm::JsResult;
+    use utils_types::traits::BinarySerializable;
+    use crate::account::AccountEntry;
+    use crate::account::AccountType::{Announced, NotAnnounced};
+
+    #[wasm_bindgen]
+    impl AccountEntry {
+        #[wasm_bindgen(constructor)]
+        pub fn _new(public_key: PublicKey, multiaddr: Option<String>, updated_at: Option<u32>) -> JsResult<AccountEntry> {
+            if (multiaddr.is_some() && updated_at.is_some()) || (multiaddr.is_none() && updated_at.is_none()) {
+                Ok(Self {
+                    public_key,
+                    entry_type: match multiaddr {
+                        None => NotAnnounced,
+                        Some(multiaddr) => Announced {
+                            multiaddr: ok_or_jserr!(Multiaddr::from_str(multiaddr.as_str()))?,
+                            updated_block: updated_at.unwrap()
+                        }
+                    }
+                })
+            } else {
+                Err("must either specify both: multiaddr and updated_at or none".into())
+            }
+        }
+
+        #[wasm_bindgen(js_name = "serialize")]
+        pub fn _serialize(&self) -> Box<[u8]> {
+            self.serialize()
+        }
+
+        #[wasm_bindgen(js_name = "deserialize")]
+        pub fn _deserialize(data: &[u8]) -> JsResult<AccountEntry> {
+            ok_or_jserr!(Self::deserialize(data))
+        }
     }
 }

--- a/packages/core/crates/core-types/src/acknowledgement.rs
+++ b/packages/core/crates/core-types/src/acknowledgement.rs
@@ -1,4 +1,4 @@
-use crate::acknowledgment::PendingAcknowledgement::{WaitingAsRelayer, WaitingAsSender};
+use crate::acknowledgement::PendingAcknowledgement::{WaitingAsRelayer, WaitingAsSender};
 use crate::channels::Ticket;
 use core_crypto::primitives::{DigestLike, SimpleDigest};
 use core_crypto::types::{HalfKey, HalfKeyChallenge, Hash, PublicKey, Response, Signature};
@@ -32,7 +32,7 @@ impl Acknowledgement {
     }
 
     /// Validates the acknowledgement. Must be called immediately after deserialization or otherwise
-    /// any operations with the deserialized acknowledgment will panic.
+    /// any operations with the deserialized acknowledgement will panic.
     pub fn validate(&mut self, own_public_key: &PublicKey, sender_public_key: &PublicKey) -> bool {
         let mut digest = SimpleDigest::default();
         digest.update(&self.ack_key_share.to_challenge().serialize());
@@ -50,7 +50,7 @@ impl Acknowledgement {
         self.validated
     }
 
-    /// Obtains the acknowledged challenge out of this acknowledgment.
+    /// Obtains the acknowledged challenge out of this acknowledgement.
     pub fn ack_challenge(&self) -> HalfKeyChallenge {
         assert!(self.validated, "acknowledgement not validated");
         self.ack_key_share.to_challenge()
@@ -87,7 +87,7 @@ impl BinarySerializable<'_> for Acknowledgement {
     }
 }
 
-/// Contains acknowledgment information and the respective ticket
+/// Contains acknowledgement information and the respective ticket
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen(getter_with_clone))]
 pub struct AcknowledgedTicket {
@@ -301,7 +301,7 @@ impl BinarySerializable<'_> for PendingAcknowledgement {
 
 #[cfg(test)]
 pub mod test {
-    use crate::acknowledgment::PendingAcknowledgement;
+    use crate::acknowledgement::PendingAcknowledgement;
     use utils_types::traits::BinarySerializable;
 
     // TODO: Add tests to all remaining types
@@ -317,7 +317,7 @@ pub mod test {
 
 #[cfg(feature = "wasm")]
 pub mod wasm {
-    use crate::acknowledgment::{AcknowledgedTicket, Acknowledgement, UnacknowledgedTicket};
+    use crate::acknowledgement::{AcknowledgedTicket, Acknowledgement, UnacknowledgedTicket};
     use utils_misc::ok_or_jserr;
     use utils_misc::utils::wasm::JsResult;
     use utils_types::traits::BinarySerializable;

--- a/packages/core/crates/core-types/src/lib.rs
+++ b/packages/core/crates/core-types/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod account;
-pub mod acknowledgment;
+pub mod acknowledgement;
 pub mod channels;
 
 #[cfg(feature = "wasm")]

--- a/packages/core/crates/core-types/src/lib.rs
+++ b/packages/core/crates/core-types/src/lib.rs
@@ -1,6 +1,6 @@
+pub mod account;
 pub mod acknowledgment;
 pub mod channels;
-pub mod account;
 
 #[cfg(feature = "wasm")]
 pub mod wasm {

--- a/packages/core/crates/core-types/src/lib.rs
+++ b/packages/core/crates/core-types/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod acknowledgment;
 pub mod channels;
+pub mod account;
 
 #[cfg(feature = "wasm")]
 pub mod wasm {


### PR DESCRIPTION
Added `AccountEntry` type to `core-types` crate, because it was missing.
Prerequisite for DB migration to Rust #4543 

Also fixes a typo in `acknowledgement` module name in `core-types`