### PR TITLE
Rename `serialize`/`deserialize` to `to_bytes`/`from_bytes` in the `BinarySerializable` trait

### DIFF
--- a/packages/core/crates/core-crypto/src/iterated_hash.rs
+++ b/packages/core/crates/core-crypto/src/iterated_hash.rs
@@ -143,7 +143,7 @@ mod tests {
 
         assert_eq!(recovered.iteration, hint_idx + 7);
         assert_eq!(
-            Hash::create(&[recovered.intermediate.as_ref()]).serialize().as_ref(),
+            Hash::create(&[recovered.intermediate.as_ref()]).to_bytes().as_ref(),
             &target
         );
     }

--- a/packages/core/crates/core-crypto/src/shared_keys.rs
+++ b/packages/core/crates/core-crypto/src/shared_keys.rs
@@ -125,7 +125,7 @@ impl SharedKeys {
         let alpha_projective = alpha.to_projective_point();
 
         let s_k = (alpha_projective * private_scalar.as_ref()).to_affine();
-        let secret = extract_key_from_group_element(&s_k.into(), &public_key.serialize(true));
+        let secret = extract_key_from_group_element(&s_k.into(), &public_key.to_bytes(true));
 
         let b_k = expand_key_from_group_element(&s_k.into(), &alpha.serialize_compressed());
         let b_k_checked = to_checked_secret_scalar(&b_k)?;
@@ -227,7 +227,7 @@ pub mod tests {
             hex!("038d2b50a77fd43eeae9b37856358c7f1aee773b3e3c9d26f30b8706c02cbbfbb6"),
         ]
         .into_iter()
-        .map(|p| PublicKey::deserialize(&p))
+        .map(|p| PublicKey::from_bytes(&p))
         .collect::<utils_types::errors::Result<Vec<_>>>()
         .unwrap();
 
@@ -286,7 +286,7 @@ pub mod wasm {
         pub fn _generate(peer_public_keys: Vec<Uint8Array>) -> JsResult<SharedKeys> {
             let public_keys = ok_or_jserr!(peer_public_keys
                 .into_iter()
-                .map(|v| PublicKey::deserialize(&v.to_vec()))
+                .map(|v| PublicKey::from_bytes(&v.to_vec()))
                 .collect::<utils_types::errors::Result<Vec<PublicKey>>>())?;
             ok_or_jserr!(super::SharedKeys::generate(&mut OsRng, &public_keys))
         }

--- a/packages/core/crates/core-crypto/src/types.rs
+++ b/packages/core/crates/core-crypto/src/types.rs
@@ -94,8 +94,8 @@ pub struct CurvePoint {
 impl CurvePoint {
     /// Converts the uncompressed representation of the curve point to Ethereum address.
     pub fn to_address(&self) -> Address {
-        let serialized = self.serialize();
-        let hash = <Hash as BinarySerializable>::serialize(&Hash::create(&[&serialized[1..]]));
+        let serialized = self.to_bytes();
+        let hash = Hash::create(&[&serialized[1..]]).to_bytes();
         Address::new(&hash[12..])
     }
 }
@@ -120,7 +120,7 @@ impl From<AffinePoint> for CurvePoint {
 
 impl From<HalfKeyChallenge> for CurvePoint {
     fn from(value: HalfKeyChallenge) -> Self {
-        CurvePoint::deserialize(&value.hkc).unwrap()
+        CurvePoint::from_bytes(&value.hkc).unwrap()
     }
 }
 
@@ -128,24 +128,24 @@ impl FromStr for CurvePoint {
     type Err = CryptoError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        Ok(CurvePoint::deserialize(&hex::decode(s).map_err(|_| ParseError)?)?)
+        Ok(CurvePoint::from_bytes(&hex::decode(s).map_err(|_| ParseError)?)?)
     }
 }
 
 impl PeerIdLike for CurvePoint {
     fn from_peerid(peer_id: &PeerId) -> utils_types::errors::Result<Self> {
-        CurvePoint::deserialize(&PublicKey::from_peerid(peer_id)?.serialize(false))
+        CurvePoint::from_bytes(&PublicKey::from_peerid(peer_id)?.to_bytes(false))
     }
 
     fn to_peerid(&self) -> PeerId {
-        PublicKey::deserialize(&self.serialize()).unwrap().to_peerid()
+        PublicKey::from_bytes(&self.to_bytes()).unwrap().to_peerid()
     }
 }
 
 impl BinarySerializable<'_> for CurvePoint {
     const SIZE: usize = 65; // Stores uncompressed data
 
-    fn deserialize(bytes: &[u8]) -> utils_types::errors::Result<Self> {
+    fn from_bytes(bytes: &[u8]) -> utils_types::errors::Result<Self> {
         // Deserializes both compressed and uncompressed
         elliptic_curve::sec1::EncodedPoint::<Secp256k1>::from_bytes(bytes)
             .map_err(|_| ParseError)
@@ -153,7 +153,7 @@ impl BinarySerializable<'_> for CurvePoint {
             .map(|affine| Self { affine })
     }
 
-    fn serialize(&self) -> Box<[u8]> {
+    fn to_bytes(&self) -> Box<[u8]> {
         self.affine.to_encoded_point(false).to_bytes()
     }
 }
@@ -214,7 +214,7 @@ impl Challenge {
     /// This is a one-way (lossy) operation, since the corresponding curve point is hashed
     /// with the hash value then truncated.
     pub fn to_ethereum_challenge(&self) -> EthereumChallenge {
-        EthereumChallenge::new(&BinarySerializable::serialize(&self.curve_point.to_address()))
+        EthereumChallenge::new(&self.curve_point.to_address().to_bytes())
     }
 }
 
@@ -228,8 +228,8 @@ impl Challenge {
     /// Obtains the PoR challenge by adding the two EC points represented by the half-key challenges
     pub fn from_hint_and_share(own_share: &HalfKeyChallenge, hint: &HalfKeyChallenge) -> Result<Self> {
         let curve_point: CurvePoint = PublicKey::combine(&[
-            &PublicKey::deserialize(&own_share.hkc)?,
-            &PublicKey::deserialize(&hint.hkc)?,
+            &PublicKey::from_bytes(&own_share.hkc)?,
+            &PublicKey::from_bytes(&hint.hkc)?,
         ])
         .into();
         Ok(curve_point.into())
@@ -257,12 +257,12 @@ impl From<Response> for Challenge {
 impl BinarySerializable<'_> for Challenge {
     const SIZE: usize = PublicKey::SIZE_COMPRESSED;
 
-    fn deserialize(data: &[u8]) -> utils_types::errors::Result<Self> {
+    fn from_bytes(data: &[u8]) -> utils_types::errors::Result<Self> {
         // Accepts both compressed and uncompressed points
-        CurvePoint::deserialize(data).map(|curve_point| Challenge { curve_point })
+        CurvePoint::from_bytes(data).map(|curve_point| Challenge { curve_point })
     }
 
-    fn serialize(&self) -> Box<[u8]> {
+    fn to_bytes(&self) -> Box<[u8]> {
         // Serializes only compressed points
         self.curve_point.serialize_compressed()
     }
@@ -314,7 +314,7 @@ impl HalfKey {
 impl BinarySerializable<'_> for HalfKey {
     const SIZE: usize = 32;
 
-    fn deserialize(data: &[u8]) -> utils_types::errors::Result<Self> {
+    fn from_bytes(data: &[u8]) -> utils_types::errors::Result<Self> {
         if data.len() == Self::SIZE {
             let mut ret = HalfKey::default();
             ret.hkey.copy_from_slice(data);
@@ -324,7 +324,7 @@ impl BinarySerializable<'_> for HalfKey {
         }
     }
 
-    fn serialize(&self) -> Box<[u8]> {
+    fn to_bytes(&self) -> Box<[u8]> {
         self.hkey.into()
     }
 }
@@ -362,7 +362,7 @@ impl HalfKeyChallenge {
     }
 
     pub fn to_address(&self) -> Address {
-        PublicKey::deserialize(&self.hkc)
+        PublicKey::from_bytes(&self.hkc)
             .expect("invalid half-key")
             .to_address()
     }
@@ -371,7 +371,7 @@ impl HalfKeyChallenge {
 impl BinarySerializable<'_> for HalfKeyChallenge {
     const SIZE: usize = PublicKey::SIZE_COMPRESSED; // Size of the compressed secp256k1 point.
 
-    fn deserialize(data: &[u8]) -> utils_types::errors::Result<Self> {
+    fn from_bytes(data: &[u8]) -> utils_types::errors::Result<Self> {
         if data.len() == Self::SIZE {
             let mut ret = HalfKeyChallenge::default();
             ret.hkc.copy_from_slice(data);
@@ -381,18 +381,18 @@ impl BinarySerializable<'_> for HalfKeyChallenge {
         }
     }
 
-    fn serialize(&self) -> Box<[u8]> {
+    fn to_bytes(&self) -> Box<[u8]> {
         self.hkc.into()
     }
 }
 
 impl PeerIdLike for HalfKeyChallenge {
     fn from_peerid(peer_id: &PeerId) -> utils_types::errors::Result<Self> {
-        <HalfKeyChallenge as BinarySerializable>::deserialize(&PublicKey::from_peerid(peer_id)?.serialize(true))
+        HalfKeyChallenge::from_bytes(&PublicKey::from_peerid(peer_id)?.to_bytes(true))
     }
 
     fn to_peerid(&self) -> PeerId {
-        PublicKey::deserialize(&self.hkc).expect("invalid half-key").to_peerid()
+        PublicKey::from_bytes(&self.hkc).expect("invalid half-key").to_peerid()
     }
 }
 
@@ -400,7 +400,7 @@ impl FromStr for HalfKeyChallenge {
     type Err = GeneralError;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        <Self as BinarySerializable>::deserialize(&hex::decode(s).map_err(|_| ParseError)?)
+        Self::from_bytes(&hex::decode(s).map_err(|_| ParseError)?)
     }
 }
 
@@ -440,7 +440,7 @@ impl Hash {
 impl BinarySerializable<'_> for Hash {
     const SIZE: usize = 32; // Defined by Keccak256.
 
-    fn deserialize(data: &[u8]) -> utils_types::errors::Result<Self> {
+    fn from_bytes(data: &[u8]) -> utils_types::errors::Result<Self> {
         if data.len() == Self::SIZE {
             let mut ret = Self {
                 hash: [0u8; Self::SIZE],
@@ -452,7 +452,7 @@ impl BinarySerializable<'_> for Hash {
         }
     }
 
-    fn serialize(&self) -> Box<[u8]> {
+    fn to_bytes(&self) -> Box<[u8]> {
         self.hash.into()
     }
 }
@@ -491,13 +491,13 @@ impl PublicKey {
 
     /// Converts the public key to an Ethereum address
     pub fn to_address(&self) -> Address {
-        let uncompressed = self.serialize(false);
-        let serialized = BinarySerializable::serialize(&Hash::create(&[&uncompressed[1..]]));
+        let uncompressed = self.to_bytes(false);
+        let serialized = Hash::create(&[&uncompressed[1..]]).to_bytes();
         Address::new(&serialized[12..])
     }
 
     /// Serializes the public key to a binary form.
-    pub fn serialize(&self, compressed: bool) -> Box<[u8]> {
+    pub fn to_bytes(&self, compressed: bool) -> Box<[u8]> {
         if compressed {
             self.compressed.clone()
         } else {
@@ -508,7 +508,7 @@ impl PublicKey {
     /// Serializes the public key to a binary form and converts it to hexadecimal string representation.
     pub fn to_hex(&self, compressed: bool) -> String {
         let offset = if compressed { 0 } else { 1 };
-        hex::encode(&self.serialize(compressed)[offset..])
+        hex::encode(&self.to_bytes(compressed)[offset..])
     }
 }
 
@@ -520,7 +520,7 @@ impl PeerIdLike for PublicKey {
             // Here we explicitly assume non-RSA PeerId, so that multihash bytes are the actual public key
             let pid = peer_id.to_bytes();
             let (_, mh) = pid.split_at(6);
-            Self::deserialize(mh).map_err(|e| Other(e.into()))
+            Self::from_bytes(mh).map_err(|e| Other(e.into()))
         } else if peer_id_str.starts_with("12D") {
             // TODO: support for Ed25519 peer ids needs to be added here
             warn!("Ed25519-based peer id not yet supported");
@@ -576,7 +576,7 @@ impl PublicKey {
         (private, PublicKey::try_from(cp).unwrap())
     }
 
-    pub fn deserialize(data: &[u8]) -> utils_types::errors::Result<Self> {
+    pub fn from_bytes(data: &[u8]) -> utils_types::errors::Result<Self> {
         if data.len() == Self::SIZE_COMPRESSED || data.len() == Self::SIZE_UNCOMPRESSED {
             let key = elliptic_curve::PublicKey::<Secp256k1>::from_sec1_bytes(data).map_err(|_| ParseError)?;
             Ok(PublicKey {
@@ -612,7 +612,7 @@ impl PublicKey {
                 .map_err(|_| ParseError)?;
         let recovered_key = recovery_method(msg, &signature, recid).map_err(|_| CalculationError)?;
 
-        Ok(Self::deserialize(&recovered_key.to_encoded_point(false).to_bytes())?)
+        Ok(Self::from_bytes(&recovered_key.to_encoded_point(false).to_bytes())?)
     }
 
     pub fn from_signature(msg: &[u8], signature: &Signature) -> Result<PublicKey> {
@@ -709,9 +709,9 @@ impl Response {
     /// Derives the response from two half-keys.
     /// This is done by adding the two non-zero scalars that the given half-keys represent.
     pub fn from_half_keys(first: &HalfKey, second: &HalfKey) -> Result<Self> {
-        let res = NonZeroScalar::<Secp256k1>::try_from(<HalfKey as BinarySerializable>::serialize(&first).as_ref())
+        let res = NonZeroScalar::<Secp256k1>::try_from(HalfKey::to_bytes(&first).as_ref())
             .and_then(|s1| {
-                NonZeroScalar::<Secp256k1>::try_from(<HalfKey as BinarySerializable>::serialize(&second).as_ref())
+                NonZeroScalar::<Secp256k1>::try_from(second.to_bytes().as_ref())
                     .map(|s2| s1.as_ref() + s2.as_ref())
             })
             .map_err(|_| CalculationError)?; // One of the scalars was 0
@@ -723,7 +723,7 @@ impl Response {
 impl BinarySerializable<'_> for Response {
     const SIZE: usize = 32;
 
-    fn deserialize(data: &[u8]) -> utils_types::errors::Result<Self> {
+    fn from_bytes(data: &[u8]) -> utils_types::errors::Result<Self> {
         if data.len() == Self::SIZE {
             Ok(Response::new(data))
         } else {
@@ -731,7 +731,7 @@ impl BinarySerializable<'_> for Response {
         }
     }
 
-    fn serialize(&self) -> Box<[u8]> {
+    fn to_bytes(&self) -> Box<[u8]> {
         self.response.into()
     }
 }
@@ -813,7 +813,7 @@ impl Signature {
 
     /// Verifies this signature against the given message and a public key object
     pub fn verify_message_with_pubkey(&self, message: &[u8], public_key: &PublicKey) -> bool {
-        self.verify_message(message, &public_key.serialize(false))
+        self.verify_message(message, &public_key.to_bytes(false))
     }
 
     /// Verifies this signature against the given hash and a public key (compressed or uncompressed)
@@ -823,7 +823,7 @@ impl Signature {
 
     /// Verifies this signature against the given message and a public key object
     pub fn verify_hash_with_pubkey(&self, hash: &[u8], public_key: &PublicKey) -> bool {
-        self.verify_hash(hash, &public_key.serialize(false))
+        self.verify_hash(hash, &public_key.to_bytes(false))
     }
 
     /// Returns the raw signature, without the encoded public key recovery bit.
@@ -835,7 +835,7 @@ impl Signature {
 impl BinarySerializable<'_> for Signature {
     const SIZE: usize = 64;
 
-    fn deserialize(data: &[u8]) -> utils_types::errors::Result<Self> {
+    fn from_bytes(data: &[u8]) -> utils_types::errors::Result<Self> {
         if data.len() == Self::SIZE {
             // Read & clear the top-most bit in S
             let mut ret = Signature {
@@ -851,7 +851,7 @@ impl BinarySerializable<'_> for Signature {
         }
     }
 
-    fn serialize(&self) -> Box<[u8]> {
+    fn to_bytes(&self) -> Box<[u8]> {
         let mut compressed = Vec::from(self.signature);
         compressed[Self::SIZE / 2] &= 0x7f;
         compressed[Self::SIZE / 2] |= self.recovery << 7;
@@ -924,7 +924,7 @@ pub mod tests {
         assert!(sgn.verify_message(msg, &PUBLIC_KEY));
 
         let extracted_pk = PublicKey::from_signature(msg, &sgn).unwrap();
-        let expected_pk = PublicKey::deserialize(&PUBLIC_KEY).unwrap();
+        let expected_pk = PublicKey::from_bytes(&PUBLIC_KEY).unwrap();
         assert_eq!(expected_pk, extracted_pk, "key extracted from signature does not match");
     }
 
@@ -933,13 +933,13 @@ pub mod tests {
         let msg = b"test000000";
         let sgn = Signature::sign_message(msg, &PRIVATE_KEY);
 
-        let deserialized = Signature::deserialize(&sgn.serialize()).unwrap();
+        let deserialized = Signature::from_bytes(&sgn.to_bytes()).unwrap();
         assert_eq!(sgn, deserialized, "signatures don't match");
     }
 
     #[test]
     fn public_key_peerid_test() {
-        let pk1 = PublicKey::deserialize(&PUBLIC_KEY).expect("failed to deserialize");
+        let pk1 = PublicKey::from_bytes(&PUBLIC_KEY).expect("failed to deserialize");
 
         let pk2 = PublicKey::from_peerid_str(pk1.to_peerid_str().as_str()).expect("peer id serialization failed");
 
@@ -1039,9 +1039,9 @@ pub mod tests {
 
     #[test]
     fn public_key_serialize_test() {
-        let pk1 = PublicKey::deserialize(&PUBLIC_KEY).expect("failed to deserialize 1");
-        let pk2 = PublicKey::deserialize(&pk1.serialize(true)).expect("failed to deserialize 2");
-        let pk3 = PublicKey::deserialize(&pk1.serialize(false)).expect("failed to deserialize 3");
+        let pk1 = PublicKey::from_bytes(&PUBLIC_KEY).expect("failed to deserialize 1");
+        let pk2 = PublicKey::from_bytes(&pk1.to_bytes(true)).expect("failed to deserialize 2");
+        let pk3 = PublicKey::from_bytes(&pk1.to_bytes(false)).expect("failed to deserialize 3");
 
         assert_eq!(pk1, pk2, "pub keys 1 2 don't match");
         assert_eq!(pk2, pk3, "pub keys 2 3 don't match");
@@ -1049,15 +1049,15 @@ pub mod tests {
 
     #[test]
     fn public_key_curve_point() {
-        let cp1: CurvePoint = PublicKey::deserialize(&PUBLIC_KEY).unwrap().into();
-        let cp2 = CurvePoint::deserialize(&cp1.serialize()).unwrap();
+        let cp1: CurvePoint = PublicKey::from_bytes(&PUBLIC_KEY).unwrap().into();
+        let cp2 = CurvePoint::from_bytes(&cp1.to_bytes()).unwrap();
         assert_eq!(cp1, cp2);
     }
 
     #[test]
     fn public_key_from_privkey() {
         let pk1 = PublicKey::from_privkey(&PRIVATE_KEY).expect("failed to convert from private key");
-        let pk2 = PublicKey::deserialize(&PUBLIC_KEY).expect("failed to deserialize");
+        let pk2 = PublicKey::from_bytes(&PUBLIC_KEY).expect("failed to deserialize");
 
         assert_eq!(pk1, pk2, "failed to match deserialized pub key");
     }
@@ -1065,7 +1065,7 @@ pub mod tests {
     #[test]
     pub fn response_test() {
         let r1 = Response::new(&[0u8; Response::SIZE]);
-        let r2 = Response::deserialize(&r1.serialize()).unwrap();
+        let r2 = Response::from_bytes(&r1.to_bytes()).unwrap();
         assert_eq!(r1, r2, "deserialized response does not match");
     }
 
@@ -1076,7 +1076,7 @@ pub mod tests {
 
         let cp1 = CurvePoint::from_str(hex::encode(test_point.to_encoded_point(false).to_bytes()).as_str()).unwrap();
 
-        let cp2 = CurvePoint::deserialize(&cp1.serialize()).unwrap();
+        let cp2 = CurvePoint::from_bytes(&cp1.to_bytes()).unwrap();
 
         assert_eq!(cp1, cp2, "failed to match deserialized curve point");
 
@@ -1103,8 +1103,8 @@ pub mod tests {
         let compressed = uncompressed.compress();
         assert!(compressed.is_compressed(), "failed to compress points");
 
-        let cp3 = CurvePoint::deserialize(uncompressed.as_bytes()).unwrap();
-        let cp4 = CurvePoint::deserialize(compressed.as_bytes()).unwrap();
+        let cp3 = CurvePoint::from_bytes(uncompressed.as_bytes()).unwrap();
+        let cp4 = CurvePoint::from_bytes(compressed.as_bytes()).unwrap();
 
         assert_eq!(
             cp3, cp4,
@@ -1115,16 +1115,16 @@ pub mod tests {
     #[test]
     fn half_key_test() {
         let hk1 = HalfKey::new(&[0u8; HalfKey::SIZE]);
-        let hk2 = HalfKey::deserialize(&hk1.serialize()).unwrap();
+        let hk2 = HalfKey::from_bytes(&hk1.to_bytes()).unwrap();
 
         assert_eq!(hk1, hk2, "failed to match deserialized half-key");
     }
 
     #[test]
     fn half_key_challenge_test() {
-        let peer_id = PublicKey::deserialize(&PUBLIC_KEY).unwrap().to_peerid();
+        let peer_id = PublicKey::from_bytes(&PUBLIC_KEY).unwrap().to_peerid();
         let hkc1 = HalfKeyChallenge::from_peerid(&peer_id).unwrap();
-        let hkc2 = HalfKeyChallenge::deserialize(&hkc1.serialize()).unwrap();
+        let hkc2 = HalfKeyChallenge::from_bytes(&hkc1.to_bytes()).unwrap();
         assert_eq!(hkc1, hkc2, "failed to match deserialized half key challenge");
         assert_eq!(peer_id, hkc2.to_peerid(), "failed to match half-key challenge peer id");
     }
@@ -1138,7 +1138,7 @@ pub mod tests {
             "hash test vector failed to match"
         );
 
-        let hash2 = Hash::deserialize(&hash1.serialize()).unwrap();
+        let hash2 = Hash::from_bytes(&hash1.to_bytes()).unwrap();
         assert_eq!(hash1, hash2, "failed to match deserialized hash");
     }
 
@@ -1244,7 +1244,7 @@ pub mod wasm {
 
         #[wasm_bindgen(js_name = "deserialize")]
         pub fn _deserialize(bytes: &[u8]) -> JsResult<CurvePoint> {
-            ok_or_jserr!(Self::deserialize(bytes))
+            ok_or_jserr!(Self::from_bytes(bytes))
         }
 
         #[wasm_bindgen(js_name = "to_hex")]
@@ -1254,7 +1254,7 @@ pub mod wasm {
 
         #[wasm_bindgen(js_name = "serialize")]
         pub fn _serialize(&self) -> Box<[u8]> {
-            self.serialize()
+            self.to_bytes()
         }
 
         #[wasm_bindgen(js_name = "serialize_compressed")]
@@ -1291,7 +1291,7 @@ pub mod wasm {
 
         #[wasm_bindgen(js_name = "deserialize")]
         pub fn _deserialize(data: &[u8]) -> JsResult<Challenge> {
-            ok_or_jserr!(Self::deserialize(data))
+            ok_or_jserr!(Self::from_bytes(data))
         }
 
         #[wasm_bindgen(js_name = "to_hex")]
@@ -1301,7 +1301,7 @@ pub mod wasm {
 
         #[wasm_bindgen(js_name = "serialize")]
         pub fn _serialize(&self) -> Box<[u8]> {
-            self.serialize()
+            self.to_bytes()
         }
 
         #[wasm_bindgen(js_name = "clone")]
@@ -1318,7 +1318,7 @@ pub mod wasm {
     impl HalfKey {
         #[wasm_bindgen(js_name = "deserialize")]
         pub fn _deserialize(data: &[u8]) -> JsResult<HalfKey> {
-            ok_or_jserr!(Self::deserialize(data))
+            ok_or_jserr!(Self::from_bytes(data))
         }
 
         #[wasm_bindgen(js_name = "to_hex")]
@@ -1328,7 +1328,7 @@ pub mod wasm {
 
         #[wasm_bindgen(js_name = "serialize")]
         pub fn _serialize(&self) -> Box<[u8]> {
-            self.serialize()
+            self.to_bytes()
         }
 
         #[wasm_bindgen(js_name = "clone")]
@@ -1375,12 +1375,12 @@ pub mod wasm {
 
         #[wasm_bindgen(js_name = "deserialize")]
         pub fn _deserialize(data: &[u8]) -> JsResult<HalfKeyChallenge> {
-            ok_or_jserr!(HalfKeyChallenge::deserialize(data))
+            ok_or_jserr!(HalfKeyChallenge::from_bytes(data))
         }
 
         #[wasm_bindgen(js_name = "serialize")]
         pub fn _serialize(&self) -> Box<[u8]> {
-            self.serialize()
+            self.to_bytes()
         }
 
         #[wasm_bindgen(js_name = "clone")]
@@ -1409,7 +1409,7 @@ pub mod wasm {
 
         #[wasm_bindgen(js_name = "deserialize")]
         pub fn _deserialize(data: &[u8]) -> JsResult<Hash> {
-            ok_or_jserr!(Self::deserialize(data))
+            ok_or_jserr!(Self::from_bytes(data))
         }
 
         #[wasm_bindgen(js_name = "to_hex")]
@@ -1419,7 +1419,7 @@ pub mod wasm {
 
         #[wasm_bindgen(js_name = "serialize")]
         pub fn _serialize(&self) -> Box<[u8]> {
-            self.serialize()
+            self.to_bytes()
         }
 
         #[wasm_bindgen(js_name = "eq")]
@@ -1441,7 +1441,7 @@ pub mod wasm {
     impl PublicKey {
         #[wasm_bindgen(js_name = "deserialize")]
         pub fn _deserialize(bytes: &[u8]) -> JsResult<PublicKey> {
-            ok_or_jserr!(PublicKey::deserialize(bytes))
+            ok_or_jserr!(PublicKey::from_bytes(bytes))
         }
 
         #[wasm_bindgen(js_name = "from_peerid_str")]
@@ -1493,12 +1493,12 @@ pub mod wasm {
     impl Response {
         #[wasm_bindgen(js_name = "deserialize")]
         pub fn _deserialize(data: &[u8]) -> JsResult<Response> {
-            ok_or_jserr!(Response::deserialize(data))
+            ok_or_jserr!(Response::from_bytes(data))
         }
 
         #[wasm_bindgen(js_name = "serialize")]
         pub fn _serialize(&self) -> Box<[u8]> {
-            self.serialize()
+            self.to_bytes()
         }
 
         #[wasm_bindgen(js_name = "to_hex")]
@@ -1525,7 +1525,7 @@ pub mod wasm {
     impl Signature {
         #[wasm_bindgen(js_name = "deserialize")]
         pub fn _deserialize(signature: &[u8]) -> JsResult<Signature> {
-            ok_or_jserr!(Signature::deserialize(signature))
+            ok_or_jserr!(Signature::from_bytes(signature))
         }
 
         #[wasm_bindgen(js_name = "to_hex")]
@@ -1535,7 +1535,7 @@ pub mod wasm {
 
         #[wasm_bindgen(js_name = "serialize")]
         pub fn _serialize(&self) -> Box<[u8]> {
-            self.serialize()
+            self.to_bytes()
         }
 
         #[wasm_bindgen(js_name = "clone")]

--- a/packages/core/crates/core-crypto/src/types.rs
+++ b/packages/core/crates/core-crypto/src/types.rs
@@ -362,9 +362,7 @@ impl HalfKeyChallenge {
     }
 
     pub fn to_address(&self) -> Address {
-        PublicKey::from_bytes(&self.hkc)
-            .expect("invalid half-key")
-            .to_address()
+        PublicKey::from_bytes(&self.hkc).expect("invalid half-key").to_address()
     }
 }
 
@@ -711,8 +709,7 @@ impl Response {
     pub fn from_half_keys(first: &HalfKey, second: &HalfKey) -> Result<Self> {
         let res = NonZeroScalar::<Secp256k1>::try_from(HalfKey::to_bytes(&first).as_ref())
             .and_then(|s1| {
-                NonZeroScalar::<Secp256k1>::try_from(second.to_bytes().as_ref())
-                    .map(|s2| s1.as_ref() + s2.as_ref())
+                NonZeroScalar::<Secp256k1>::try_from(second.to_bytes().as_ref()).map(|s2| s1.as_ref() + s2.as_ref())
             })
             .map_err(|_| CalculationError)?; // One of the scalars was 0
 

--- a/packages/core/crates/core-network/src/heartbeat.rs
+++ b/packages/core/crates/core-network/src/heartbeat.rs
@@ -59,10 +59,10 @@ pub mod wasm {
     /// Used to pre-compute ping responses
     #[wasm_bindgen]
     pub fn generate_ping_response(u8a: &[u8]) -> JsResult<Box<[u8]>> {
-        ok_or_jserr!(PingMessage::deserialize(u8a)
+        ok_or_jserr!(PingMessage::from_bytes(u8a)
             .map_err(|_| NetworkingError::DecodingError)
             .and_then(|req| ControlMessage::generate_pong_response(&Ping(req)))
-            .and_then(|msg| msg.get_ping_message().map(PingMessage::serialize)))
+            .and_then(|msg| msg.get_ping_message().map(PingMessage::to_bytes)))
     }
 
     #[wasm_bindgen]

--- a/packages/core/crates/core-network/src/messaging.rs
+++ b/packages/core/crates/core-network/src/messaging.rs
@@ -82,7 +82,7 @@ impl BinarySerializable<'_> for PingMessage {
 
     // This implementation is backwards compatible with older HOPR versions
 
-    fn deserialize(data: &[u8]) -> utils_types::errors::Result<Self> {
+    fn from_bytes(data: &[u8]) -> utils_types::errors::Result<Self> {
         if data.len() >= Self::SIZE {
             let mut ret = PingMessage::default();
             let mut buf: Vec<u8> = data.into();
@@ -93,7 +93,7 @@ impl BinarySerializable<'_> for PingMessage {
         }
     }
 
-    fn serialize(&self) -> Box<[u8]> {
+    fn to_bytes(&self) -> Box<[u8]> {
         let mut ret = Vec::<u8>::with_capacity(Self::SIZE);
         ret.extend_from_slice(&self.nonce);
         ret.into_boxed_slice()
@@ -113,20 +113,20 @@ mod tests {
         let sent_req: ControlMessage;
         {
             sent_req = ControlMessage::generate_ping_request();
-            sent_req_s = sent_req.get_ping_message().unwrap().serialize();
+            sent_req_s = sent_req.get_ping_message().unwrap().to_bytes();
         }
 
         // pong responder
         let sent_resp_s: Box<[u8]>;
         {
-            let recv_req = PingMessage::deserialize(sent_req_s.as_ref()).unwrap();
+            let recv_req = PingMessage::from_bytes(sent_req_s.as_ref()).unwrap();
             let send_resp = ControlMessage::generate_pong_response(&Ping(recv_req)).unwrap();
-            sent_resp_s = send_resp.get_ping_message().unwrap().serialize();
+            sent_resp_s = send_resp.get_ping_message().unwrap().to_bytes();
         }
 
         // verify pong
         {
-            let recv_resp = PingMessage::deserialize(sent_resp_s.as_ref()).unwrap();
+            let recv_resp = PingMessage::from_bytes(sent_resp_s.as_ref()).unwrap();
             assert!(ControlMessage::validate_pong_response(&sent_req, &Pong(recv_resp)).is_ok());
         }
     }

--- a/packages/core/crates/core-network/src/ping.rs
+++ b/packages/core/crates/core-network/src/ping.rs
@@ -182,7 +182,7 @@ impl Ping {
             let timeout = sleep(std::cmp::min(timeout_duration, self.config.timeout)).fuse();
             let ping = async {
                 send_msg(
-                    sent_ping.get_ping_message().unwrap().serialize(),
+                    sent_ping.get_ping_message().unwrap().to_bytes(),
                     destination.to_string(),
                 )
                 .await
@@ -194,7 +194,7 @@ impl Ping {
             let ping_result: Result<(), NetworkingError> = match select(timeout, ping).await {
                 Either::Left(_) => Err(Timeout(timeout_duration.as_secs())),
                 Either::Right((v, _)) => match v {
-                    Ok(received) => PingMessage::deserialize(received.as_ref())
+                    Ok(received) => PingMessage::from_bytes(received.as_ref())
                         .map_err(|_| DecodingError)
                         .and_then(|deserialized| {
                             ControlMessage::validate_pong_response(&sent_ping, &Pong(deserialized))
@@ -415,10 +415,10 @@ mod tests {
 
     // Testing override
     pub async fn send_ping(msg: Box<[u8]>, peer: String) -> Result<Box<[u8]>, String> {
-        let mut reply = PingMessage::deserialize(msg.as_ref())
+        let mut reply = PingMessage::from_bytes(msg.as_ref())
             .map_err(|_| DecodingError)
             .and_then(|chall| ControlMessage::generate_pong_response(&ControlMessage::Ping(chall)))
-            .and_then(|msg| msg.get_ping_message().map(PingMessage::serialize))
+            .and_then(|msg| msg.get_ping_message().map(PingMessage::to_bytes))
             .unwrap();
 
         match peer.as_str() {

--- a/packages/core/crates/core-types/src/channels.rs
+++ b/packages/core/crates/core-types/src/channels.rs
@@ -230,10 +230,7 @@ impl Ticket {
 
     /// Signs the ticket using the given private key.
     pub fn sign(&mut self, signing_key: &[u8]) {
-        self.signature = Some(Signature::sign_message(
-            &self.get_hash().to_bytes(),
-            signing_key,
-        ));
+        self.signature = Some(Signature::sign_message(&self.get_hash().to_bytes(), signing_key));
     }
 
     /// Convenience method for creating a zero-hop ticket

--- a/packages/hopli/src/key_pair.rs
+++ b/packages/hopli/src/key_pair.rs
@@ -20,7 +20,7 @@ pub struct NodeIdentity {
 
 impl NodeIdentity {
     pub fn new(verifying_key: VerifyingKey) -> Self {
-        let public_key = PublicKey::deserialize(&verifying_key.to_encoded_point(false).to_bytes()).unwrap();
+        let public_key = PublicKey::from_bytes(&verifying_key.to_encoded_point(false).to_bytes()).unwrap();
 
         // derive PeerId
         let peer_id = public_key.to_peerid_str();

--- a/packages/utils/crates/utils-types/src/traits.rs
+++ b/packages/utils/crates/utils-types/src/traits.rs
@@ -23,10 +23,10 @@ pub trait BinarySerializable<'a>: Sized {
     const SIZE: usize;
 
     /// Deserializes the type from a binary blob.
-    fn deserialize(data: &'a [u8]) -> Result<Self>;
+    fn from_bytes(data: &'a [u8]) -> Result<Self>;
 
     /// Serializes the type into a fixed size binary blob.
-    fn serialize(&self) -> Box<[u8]>;
+    fn to_bytes(&self) -> Box<[u8]>;
 }
 
 /// Type implementing this trait has automatic binary serialization/deserialization capability
@@ -43,12 +43,12 @@ where
     const SIZE: usize = Self::SIZE;
 
     /// Deserializes the type from a binary blob.
-    fn deserialize(data: &'a [u8]) -> Result<Self> {
+    fn from_bytes(data: &'a [u8]) -> Result<Self> {
         bincode::deserialize(data).map_err(|_| ParseError)
     }
 
     /// Serializes the type into a fixed size binary blob.
-    fn serialize(&self) -> Box<[u8]> {
+    fn to_bytes(&self) -> Box<[u8]> {
         bincode::serialize(&self).unwrap().into_boxed_slice()
     }
 }
@@ -58,7 +58,7 @@ where
     T: BinarySerializable<'a>,
 {
     fn to_hex(&self) -> String {
-        hex::encode(&self.serialize())
+        hex::encode(&self.to_bytes())
     }
 }
 


### PR DESCRIPTION
Simple renaming of methods of the `BinarySerializable` trait to make it compatible with `serde`