### PR TITLE
Add missing TS binding and small Rust types fixes

### DIFF
--- a/packages/core/crates/core-crypto/src/types.rs
+++ b/packages/core/crates/core-crypto/src/types.rs
@@ -1164,7 +1164,12 @@ pub mod tests {
         let hash2 = Hash::from_bytes(&hash1.to_bytes()).unwrap();
         assert_eq!(hash1, hash2, "failed to match deserialized hash");
 
-        assert_eq!(hash1.hash(), Hash::new(&hex!("1c4d8d521eccee7225073ea180e0fa075a6443afb7ca06076a9566b07d29470f")));
+        assert_eq!(
+            hash1.hash(),
+            Hash::new(&hex!(
+                "1c4d8d521eccee7225073ea180e0fa075a6443afb7ca06076a9566b07d29470f"
+            ))
+        );
     }
 
     #[test]

--- a/packages/core/crates/core-crypto/src/types.rs
+++ b/packages/core/crates/core-crypto/src/types.rs
@@ -1441,6 +1441,11 @@ pub mod wasm {
             ok_or_jserr!(PublicKey::from_bytes(bytes))
         }
 
+        #[wasm_bindgen(js_name = "serialize")]
+        pub fn _serialize(&self, compressed: bool) -> Box<[u8]> {
+            self.to_bytes(compressed)
+        }
+
         #[wasm_bindgen(js_name = "from_peerid_str")]
         pub fn _from_peerid_str(peer_id: &str) -> JsResult<PublicKey> {
             ok_or_jserr!(PublicKey::from_peerid_str(peer_id))

--- a/packages/core/crates/core-crypto/src/types.rs
+++ b/packages/core/crates/core-crypto/src/types.rs
@@ -433,6 +433,11 @@ impl Hash {
         ret.hash.copy_from_slice(hash);
         ret
     }
+
+    /// Convenience method that creates a new hash by hashing this.
+    pub fn hash(&self) -> Self {
+        Self::create(&[&self.hash])
+    }
 }
 
 impl BinarySerializable<'_> for Hash {
@@ -1158,6 +1163,8 @@ pub mod tests {
 
         let hash2 = Hash::from_bytes(&hash1.to_bytes()).unwrap();
         assert_eq!(hash1, hash2, "failed to match deserialized hash");
+
+        assert_eq!(hash1.hash(), Hash::new(&hex!("1c4d8d521eccee7225073ea180e0fa075a6443afb7ca06076a9566b07d29470f")));
     }
 
     #[test]

--- a/packages/core/crates/core-crypto/src/types.rs
+++ b/packages/core/crates/core-crypto/src/types.rs
@@ -575,7 +575,13 @@ impl PublicKey {
     }
 
     pub fn from_bytes(data: &[u8]) -> utils_types::errors::Result<Self> {
-        if [ Self::SIZE_UNCOMPRESSED, Self::SIZE_UNCOMPRESSED-1, Self::SIZE_COMPRESSED ].contains(&data.len()) {
+        if [
+            Self::SIZE_UNCOMPRESSED,
+            Self::SIZE_UNCOMPRESSED - 1,
+            Self::SIZE_COMPRESSED,
+        ]
+        .contains(&data.len())
+        {
             let key;
             if data.len() == Self::SIZE_UNCOMPRESSED - 1 {
                 key = elliptic_curve::PublicKey::<Secp256k1>::from_sec1_bytes(&[&[4u8], &data[..]].concat())

--- a/packages/utils/crates/utils-types/src/primitives.rs
+++ b/packages/utils/crates/utils-types/src/primitives.rs
@@ -94,7 +94,7 @@ impl Balance {
     #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen(constructor))]
     pub fn from_str(value: &str, balance_type: BalanceType) -> Self {
         Self {
-            value: u256::from_str_radix(value, 10).unwrap(),
+            value: u256::from_str_radix(value, 10).expect(&format!("invalid number {}", value)),
             balance_type,
         }
     }

--- a/packages/utils/crates/utils-types/src/primitives.rs
+++ b/packages/utils/crates/utils-types/src/primitives.rs
@@ -421,14 +421,16 @@ impl U256 {
 /// Unit tests of pure Rust code
 #[cfg(test)]
 mod tests {
+    use hex_literal::hex;
     use super::*;
 
     #[test]
     fn address_tests() {
-        let addr_1 = Address::default();
+        let addr_1 = Address::from_bytes(&hex!("Cf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9")).unwrap();
         let addr_2 = Address::from_bytes(&addr_1.to_bytes()).unwrap();
 
         assert_eq!(addr_1, addr_2, "deserialized address does not match");
+        assert_eq!(addr_1, Address::from_str("Cf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9").unwrap());
     }
 
     #[test]

--- a/packages/utils/crates/utils-types/src/primitives.rs
+++ b/packages/utils/crates/utils-types/src/primitives.rs
@@ -421,8 +421,8 @@ impl U256 {
 /// Unit tests of pure Rust code
 #[cfg(test)]
 mod tests {
-    use hex_literal::hex;
     use super::*;
+    use hex_literal::hex;
 
     #[test]
     fn address_tests() {
@@ -430,7 +430,10 @@ mod tests {
         let addr_2 = Address::from_bytes(&addr_1.to_bytes()).unwrap();
 
         assert_eq!(addr_1, addr_2, "deserialized address does not match");
-        assert_eq!(addr_1, Address::from_str("Cf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9").unwrap());
+        assert_eq!(
+            addr_1,
+            Address::from_str("Cf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9").unwrap()
+        );
     }
 
     #[test]


### PR DESCRIPTION
This PR improves the following:
- better error handling when parsing Balance
- PublicKey type now supports also non-prefixed deserialized forms (64 bytes)
- adds missing `serialize` TS binding for the PublicKey type 
- add unit tests for `Address` type
- add convenience `hash` method to `Hash` type in Rust

Prerequisite for https://github.com/hoprnet/hoprnet/pull/5039