### PR TITLE
Attempt to import hopli to pluto

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -80,8 +80,10 @@ steps:
       - --cache-ttl=96h
       - --build-arg=ANVIL_IMAGE=gcr.io/${PROJECT_ID}/hopr-anvil:${_IMAGE_VERSION}
       - --build-arg=HOPRD_IMAGE=gcr.io/${PROJECT_ID}/hoprd:${_IMAGE_VERSION}
+      - --build-arg=HOPLI_IMAGE=gcr.io/${PROJECT_ID}/hopli:${_IMAGE_VERSION}
     timeout: 1200s
     waitFor:
+      - buildHopli
       - buildHoprd
       - buildAnvil
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
@@ -90,7 +92,7 @@ steps:
       #!/usr/bin/env bash
       set -Eeuo pipefail
       [ "${NO_TAGS}" = "true" ] && { exit 0; }
-      for image in hoprd hoprd-nat hopr-anvil hopr-pluto; do
+      for image in hoprd hoprd-nat hopr-anvil hopr-pluto hopli; do
         full_image="gcr.io/${PROJECT_ID}/${image}"
         gcloud container images add-tag ${full_image}:${IMAGE_VERSION} ${full_image}:${PACKAGE_VERSION}
         for release in ${RELEASES}; do

--- a/packages/hopli/Dockerfile
+++ b/packages/hopli/Dockerfile
@@ -42,9 +42,5 @@ RUN apt-get update && \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false && \
     rm /root/Makefile
 
-# Make sure that hopli can be found
-ENV PATH=${PATH}:/bin/hopli
-RUN echo "export PATH=${PATH}:/bin/hopli" >> /root/.bashrc
-
 ENTRYPOINT ["/bin/hopli"]
 CMD ["--help"]

--- a/packages/hopli/Dockerfile
+++ b/packages/hopli/Dockerfile
@@ -42,5 +42,9 @@ RUN apt-get update && \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false && \
     rm /root/Makefile
 
+# Make sure that hopli can be found
+ENV PATH=${PATH}:/bin/hopli
+RUN echo "export PATH=${PATH}:/bin/hopli" >> /root/.bashrc
+
 ENTRYPOINT ["/bin/hopli"]
 CMD ["--help"]

--- a/scripts/build-docker.sh
+++ b/scripts/build-docker.sh
@@ -105,7 +105,7 @@ build_and_tag_images() {
         -f packages/ethereum/Dockerfile.anvil . &
     fi
 
-    if [ -z "${image_name}" ] || [ "${image_name}" = "hopli" ]; then
+    if [ -z "${image_name}" ] || [ "${image_name}" = "hopli" ] || [ "${image_name}" = "pluto" ] || [ "${image_name}" = "pluto-complete" ]; then
       log "Building Docker image hopli-local:latest"
       docker build -t hopli-local:latest \
         --build-arg=HOPR_TOOLCHAIN_IMAGE="hopr-toolchain-local:latest" \
@@ -119,6 +119,7 @@ build_and_tag_images() {
       log "Building Docker image hopr-pluto-local:latest"
       docker build -q -t hopr-pluto-local:latest \
         --build-arg=ANVIL_IMAGE="hopr-anvil-local:latest" \
+        --build-arg=HOPLI_IMAGE="hopli-local:latest" \
         --build-arg=HOPRD_IMAGE="hoprd-local:latest" \
         -f scripts/pluto/Dockerfile . &
     fi

--- a/scripts/pluto/Dockerfile
+++ b/scripts/pluto/Dockerfile
@@ -2,11 +2,14 @@ ARG HOPRD_IMAGE=${HOPRD_IMAGE:-hoprd-local:latest}
 ARG HOPLI_IMAGE=${HOPLI_IMAGE:-hopli-local:latest}
 ARG ANVIL_IMAGE=${ANVIL_IMAGE:-hopr-anvil-local:latest}
 
+# import hopli image to copy in files later
 FROM ${HOPLI_IMAGE} as hopli
 
-# simply import hoprd image to copy in files later
+# import hoprd image to copy in files later
 FROM ${HOPRD_IMAGE} as hoprd
 
+# the anvil image is our base runtime image since it includes most relevant
+# tools already
 FROM ${ANVIL_IMAGE} as runtime
 
 LABEL description="Docker image running a HOPR-enabled anvil network with 5 hoprd nodes using it and being fully interconnected."
@@ -18,11 +21,8 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/* \
  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 
-# Get hopli binary from base image
-WORKDIR /app/hopli
-COPY --from=hopli /bin/hopli ./
-# Make sure that hopli can be found
-ENV PATH=${PATH}:/app/hopli
+# Get hopli binary
+COPY --from=hopli /bin/hopli /bin/
 
 WORKDIR /app/hoprnet
 

--- a/scripts/pluto/Dockerfile
+++ b/scripts/pluto/Dockerfile
@@ -1,5 +1,8 @@
 ARG HOPRD_IMAGE=${HOPRD_IMAGE:-hoprd-local:latest}
+ARG HOPLI_IMAGE=${HOPLI_IMAGE:-hopli-local:latest}
 ARG ANVIL_IMAGE=${ANVIL_IMAGE:-hopr-anvil-local:latest}
+
+FROM ${HOPLI_IMAGE} as hopli
 
 # simply import hoprd image to copy in files later
 FROM ${HOPRD_IMAGE} as hoprd
@@ -14,6 +17,12 @@ RUN apt-get update \
       bash curl jq lsof \
  && rm -rf /var/lib/apt/lists/* \
  && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false
+
+# Get hopli binary from base image
+WORKDIR /app/hopli
+COPY --from=hopli /bin/hopli ./
+# Make sure that hopli can be found
+ENV PATH=${PATH}:/app/hopli
 
 WORKDIR /app/hoprnet
 


### PR DESCRIPTION
RE https://github.com/hoprnet/hoprnet/issues/4848, hopli artifact was not import to pluto. 

<img src="https://github.com/hoprnet/hoprnet/assets/10935300/b62c0e02-e4f7-496e-812e-7e03adfa2b47" width="200" />


The idea is to fix the docker build so that Pluto can invoke hopli when funding nodes with 
```
make -C "${mydir}/../" fund-local-all \
  id_dir="${tmp_dir}"` 
```
