### PR TITLE
Pin foundry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,11 @@ HOPLI_CRATE := ./packages/hopli
 # Set local foundry directory (for binaries) and versions
 # note: $(mydir) ends with '/'
 FOUNDRY_DIR ?= $(mydir).foundry
-FOUNDRY_VSN := ed9298d
+# Use custom pinned version of foundry from
+# https://github.com/hoprnet/foundry/tree/hopr-release
+FOUNDRY_REPO := hoprnet/foundry
+FOUNDRY_VSN := v0.0.1
+FOUNDRYUP_VSN := ed9298d
 
 # Set local cargo directory (for binaries)
 # note: $(mydir) ends with '/'
@@ -121,13 +125,13 @@ install-foundry: ## install foundry
 	@if [ -f "${FOUNDRY_DIR}/bin/foundryup" ]; then \
 		echo "foundryup already installed under "${FOUNDRY_DIR}/bin", skipping"; \
 	else \
-		echo "installing foundryup (vsn ${FOUNDRY_VSN})"; \
-		curl -L "https://raw.githubusercontent.com/foundry-rs/foundry/${FOUNDRY_VSN}/foundryup/foundryup" > "${FOUNDRY_DIR}/bin/foundryup"; \
+		echo "installing foundryup (vsn ${FOUNDRYUP_VSN})"; \
+		curl -L "https://raw.githubusercontent.com/foundry-rs/foundry/${FOUNDRYUP_VSN}/foundryup/foundryup" > "${FOUNDRY_DIR}/bin/foundryup"; \
 	  chmod +x "${FOUNDRY_DIR}/bin/foundryup"; \
 	fi
 	@if [ ! -f "${FOUNDRY_DIR}/bin/anvil" ] || [ ! -f "${FOUNDRY_DIR}/bin/cast" ] || [ ! -f "${FOUNDRY_DIR}/bin/forge" ]; then \
 		echo "missing foundry binaries, installing via foundryup"; \
-		$(foundryup); \
+		$(foundryup) --repo ${FOUNDRY_REPO} --version ${FOUNDRY_VSN}; \
 	else \
 	  echo "foundry binaries already installed under "${FOUNDRY_DIR}/bin", skipping"; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,8 @@ FOUNDRY_DIR ?= $(mydir).foundry
 # Use custom pinned version of foundry from
 # https://github.com/hoprnet/foundry/tree/hopr-release
 FOUNDRY_REPO := hoprnet/foundry
-FOUNDRY_VSN := v0.0.1
-FOUNDRYUP_VSN := ed9298d
+FOUNDRY_VSN := v0.0.4
+FOUNDRYUP_VSN := fc64e18
 
 # Set local cargo directory (for binaries)
 # note: $(mydir) ends with '/'
@@ -126,7 +126,7 @@ install-foundry: ## install foundry
 		echo "foundryup already installed under "${FOUNDRY_DIR}/bin", skipping"; \
 	else \
 		echo "installing foundryup (vsn ${FOUNDRYUP_VSN})"; \
-		curl -L "https://raw.githubusercontent.com/foundry-rs/foundry/${FOUNDRYUP_VSN}/foundryup/foundryup" > "${FOUNDRY_DIR}/bin/foundryup"; \
+		curl -L "https://raw.githubusercontent.com/${FOUNDRY_REPO}/${FOUNDRYUP_VSN}/foundryup/foundryup" > "${FOUNDRY_DIR}/bin/foundryup"; \
 	  chmod +x "${FOUNDRY_DIR}/bin/foundryup"; \
 	fi
 	@if [ ! -f "${FOUNDRY_DIR}/bin/anvil" ] || [ ! -f "${FOUNDRY_DIR}/bin/cast" ] || [ ! -f "${FOUNDRY_DIR}/bin/forge" ]; then \
@@ -135,6 +135,11 @@ install-foundry: ## install foundry
 	else \
 	  echo "foundry binaries already installed under "${FOUNDRY_DIR}/bin", skipping"; \
 	fi
+	@echo "Patching foundry binaries"
+	patchelf --interpreter `cat ${NIX_CC}/nix-support/dynamic-linker` .foundry/bin/anvil
+	patchelf --interpreter `cat ${NIX_CC}/nix-support/dynamic-linker` .foundry/bin/cast
+	patchelf --interpreter `cat ${NIX_CC}/nix-support/dynamic-linker` .foundry/bin/forge
+	patchelf --interpreter `cat ${NIX_CC}/nix-support/dynamic-linker` .foundry/bin/chisel
 	@forge --version
 	@anvil --version
 	@chisel --version

--- a/Makefile
+++ b/Makefile
@@ -135,11 +135,13 @@ install-foundry: ## install foundry
 	else \
 	  echo "foundry binaries already installed under "${FOUNDRY_DIR}/bin", skipping"; \
 	fi
-	@echo "Patching foundry binaries"
-	patchelf --interpreter `cat ${NIX_CC}/nix-support/dynamic-linker` .foundry/bin/anvil
-	patchelf --interpreter `cat ${NIX_CC}/nix-support/dynamic-linker` .foundry/bin/cast
-	patchelf --interpreter `cat ${NIX_CC}/nix-support/dynamic-linker` .foundry/bin/forge
-	patchelf --interpreter `cat ${NIX_CC}/nix-support/dynamic-linker` .foundry/bin/chisel
+	@if [[ "${name}" =~ nix-shell* ]]; then \
+		echo "Patching foundry binaries"; \
+		patchelf --interpreter `cat ${NIX_CC}/nix-support/dynamic-linker` .foundry/bin/anvil; \
+		patchelf --interpreter `cat ${NIX_CC}/nix-support/dynamic-linker` .foundry/bin/cast; \
+		patchelf --interpreter `cat ${NIX_CC}/nix-support/dynamic-linker` .foundry/bin/forge; \
+		patchelf --interpreter `cat ${NIX_CC}/nix-support/dynamic-linker` .foundry/bin/chisel; \
+	fi
 	@forge --version
 	@anvil --version
 	@chisel --version

--- a/shell.nix
+++ b/shell.nix
@@ -64,5 +64,8 @@ mkShell {
     source .venv/bin/activate
     pip install -r tests/requirements.txt
     deactivate
+
+    echo "Patching additional binaries"
+    patchelf --interpreter `cat $NIX_CC/nix-support/dynamic-linker` .venv/bin/ruff
   '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -53,12 +53,6 @@ mkShell {
     echo "Installing dependencies"
     make deps
 
-    echo "Patching foundry binaries"
-    patchelf --interpreter `cat $NIX_CC/nix-support/dynamic-linker` .foundry/bin/anvil
-    patchelf --interpreter `cat $NIX_CC/nix-support/dynamic-linker` .foundry/bin/cast
-    patchelf --interpreter `cat $NIX_CC/nix-support/dynamic-linker` .foundry/bin/forge
-    patchelf --interpreter `cat $NIX_CC/nix-support/dynamic-linker` .foundry/bin/chisel
-
     echo "Setting up python virtual environment"
     python -m venv .venv
     source .venv/bin/activate


### PR DESCRIPTION
The pinned version lives in our fork:

https://github.com/hoprnet/foundry/tree/hopr-release

The build we are currently using:

https://github.com/hoprnet/foundry/actions/runs/5021989638

An upgrade of foundry requires us to add the commits to the `hopr-release` branch on our fork and push a new tag. Then the CI will build the binaries for that tag and we may start using it in our `Makefile`.