### PR TITLE
tests: Fix smoke test runs

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -91,10 +91,9 @@ jobs:
         uses: actions/upload-artifact@v3
         if: ${{ always() && runner.os == 'Linux' }}
         with:
-          name: hopr-linux-e2e-source-node-logs
+          name: hopr-linux-smoke-test-logs
           path: |
-            /tmp/hopr-source-node-*.log
-            /tmp/hopr-source-anvil-rpc.log
+            /tmp/hopr-smoke-test*.log
 
       - name: Send notification if anything failed on master or release branches
         if: ${{ failure() && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release/')) && !env.ACT }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -31,6 +31,7 @@ packages/avado/releases.json
 packages/ethereum/contracts/broadcast
 packages/ethereum/contracts/build-info
 packages/ethereum/contracts/out
+packages/ethereum/contracts/cache
 
 # Compiled rust code cache
 target/

--- a/Makefile
+++ b/Makefile
@@ -234,7 +234,7 @@ endif
 
 .PHONY: smoke-test
 smoke-test: ## run smoke tests
-	source .venv/bin/activate && (python3 -m pytest tests/ || (cat /tmp/integration_test_out && false))
+	source .venv/bin/activate && (python3 -m pytest tests/ || (cat /tmp/hopr-smoke-test_integration.log && false))
 
 .PHONY: smart-contract-test
 smart-contract-test: # forge test smart contracts

--- a/scripts/api.sh
+++ b/scripts/api.sh
@@ -171,20 +171,24 @@ api_set_setting() {
 
 # $1 = node api endpoint
 # $2 = counterparty peer id
+# $3 = OPTIONAL: call timeout
 api_redeem_tickets_in_channel() {
   local node_api="${1}"
   local peer_id="${2}"
+  local timeout="${3:-600}"
 
   log "redeeming tickets in specific channel, this can take up to 5 minutes depending on the amount of unredeemed tickets in that channel"
-  api_call ${node_api} "/channels/${peer_id}/tickets/redeem" "POST" "" "" 600 600
+  api_call ${node_api} "/channels/${peer_id}/tickets/redeem" "POST" "" "" ${timeout} ${timeout}
 }
 
 # $1 = node api endpoint
+# $2 = OPTIONAL: call timeout
 api_redeem_tickets() {
   local node_api="${1}"
+  local timeout="${2:-600}"
 
   log "redeeming all tickets, this can take up to 5 minutes depending on the amount of unredeemed tickets"
-  api_call ${node_api} "/tickets/redeem" "POST" "" "" 600 600
+  api_call ${node_api} "/tickets/redeem" "POST" "" "" ${timeout} ${timeout}
 }
 
 # $1 = node api endpoint

--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -68,10 +68,10 @@ redeem_tickets() {
   [[ ${rejected} -gt 0 ]] && { msg "rejected tickets count on node ${node_id} is ${rejected}"; exit 1; }
   last_redeemed="${redeemed}"
 
-  # Trigger a redemption run, but cap it at 1 minute. We only want to measure
+  # Trigger a redemption run, but cap it at 20 seconds. We only want to measure
   # progress, not redeeem all tickets which takes too long.
   log "Node ${node_id} should redeem all tickets"
-  result=$(api_redeem_tickets ${node_api})
+  result=$(api_redeem_tickets ${node_api} 20)
   log "--${result}"
 
   # Get ticket statistics again and compare with previous state. Ensure we
@@ -84,11 +84,11 @@ redeem_tickets() {
   [[ ${redeemed} -gt 0 && ${redeemed} -gt ${last_redeemed} ]] || { msg "redeemed tickets count on node ${node_id} is ${redeemed}, previously ${last_redeemed}"; exit 1; }
   last_redeemed="${redeemed}"
 
-  # Trigger another redemption run, but cap it at 1 minute. We only want to measure
+  # Trigger another redemption run, but cap it at 20 seconds. We only want to measure
   # progress, not redeeem all tickets which takes too long.
   log "Node ${node_id} should redeem all tickets (again to ensure re-run of operation)"
   # add 60 second timeout
-  result=$(api_redeem_tickets ${node_api})
+  result=$(api_redeem_tickets ${node_api} 20)
   log "--${result}"
 
   # Get final ticket statistics

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -23,8 +23,9 @@ def test_hoprd_protocol_integration_tests(setup_7_nodes):
 
     nodes_api_as_str = " ".join(list(map(lambda x: f"\"localhost:{x['api_port']}\"", setup_7_nodes.values())))
 
+    log_file_path = f"/tmp/hopr-smoke-{__name__}.log"
     subprocess.run(
-        f"./tests/integration-test.sh {nodes_api_as_str} >| /tmp/integration_test_out 2>&1",
+        f"./tests/integration-test.sh {nodes_api_as_str} 2>&1 | tee {log_file_path}",
         shell=True,
         capture_output=True,
         env=env_vars,


### PR DESCRIPTION
This reduces the time the tests wait for ticket redemption in order to ensure that not all tickets are redeemed at once and we can verify progress.