### PR TITLE
Make Mixer more generic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -970,7 +970,7 @@ dependencies = [
 
 [[package]]
 name = "core-mixer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-std",
  "console_error_panic_hook",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,6 +979,7 @@ dependencies = [
  "getrandom 0.2.9",
  "gloo-timers",
  "js-sys",
+ "lazy_static",
  "more-asserts",
  "pin-project",
  "rand 0.8.5",

--- a/packages/core/crates/core-mixer/Cargo.toml
+++ b/packages/core/crates/core-mixer/Cargo.toml
@@ -9,8 +9,9 @@ license = "GPL-3.0-only"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-default = ["console_error_panic_hook", "wasm"]
+default = ["console_error_panic_hook", "wasm", "prometheus"]
 wasm = ["dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:js-sys", "dep:getrandom", "dep:gloo-timers", "dep:utils-misc"]
+prometheus = ["dep:utils-metrics"]
 
 [dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }
@@ -20,7 +21,7 @@ lazy_static = "1.4.0"
 rand = "0.8.5"
 pin-project = "1.0.12"
 utils-log = { path = "../../../utils/crates/utils-log"}
-utils-metrics = { path = "../../../utils/crates/utils-metrics"}
+utils-metrics = { path = "../../../utils/crates/utils-metrics", optional = true }
 # wasm
 console_error_panic_hook = { version = "0.1.7", optional = true }
 #wee_alloc = { version = "0.4.5", optional = true }

--- a/packages/core/crates/core-mixer/Cargo.toml
+++ b/packages/core/crates/core-mixer/Cargo.toml
@@ -16,6 +16,7 @@ wasm = ["dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:js-sys", "dep:getra
 async-std = { version = "1.12.0", features = ["attributes"] }
 futures = "0.3.28"
 futures-lite = "1.12.0"
+lazy_static = "1.4.0"
 rand = "0.8.5"
 pin-project = "1.0.12"
 utils-log = { path = "../../../utils/crates/utils-log"}

--- a/packages/core/crates/core-mixer/Cargo.toml
+++ b/packages/core/crates/core-mixer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-mixer"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 license = "GPL-3.0-only"

--- a/packages/core/crates/core-mixer/src/mixer.rs
+++ b/packages/core/crates/core-mixer/src/mixer.rs
@@ -1,3 +1,4 @@
+use std::marker::PhantomData;
 use std::time::Duration;
 
 use futures::stream::Stream;
@@ -68,18 +69,42 @@ impl MixerConfig {
 /// Aggregation of all Prometheus metrics exported by the mixer.
 struct MixerMetrics {
     /// Current mixer queue size
-    pub queue_size: Option<SimpleGauge>,
+    pub queue_size: SimpleGauge,
     /// Running average of the last N packet delays
-    pub average_delay: Option<SimpleGauge>,
+    pub average_delay: SimpleGauge,
+}
+
+impl Default for MixerMetrics {
+    fn default() -> Self {
+        MixerMetrics {
+            queue_size: SimpleGauge::new("core_gauge_mixer_queue_size", "Current mixer queue size").unwrap(),
+            average_delay: SimpleGauge::new(
+                "core_gauge_mixer_average_packet_delay",
+                "Average mixer packet delay averaged over a packet window",
+            )
+            .unwrap(),
+        }
+    }
 }
 
 /// Mixer implementation using Async instead of a real queue to provide the packet mixing functionality
-struct Mixer {
-    cfg: MixerConfig,
+pub struct Mixer<T> {
+    pub cfg: MixerConfig,
     metrics: MixerMetrics,
+    _data: PhantomData<T>,
 }
 
-impl Mixer {
+impl<T> Default for Mixer<T> {
+    fn default() -> Self {
+        Self {
+            cfg: MixerConfig::default(),
+            metrics: MixerMetrics::default(),
+            _data: PhantomData,
+        }
+    }
+}
+
+impl<T> Mixer<T> {
     /// Async mixing operation on the packet.
     ///
     /// # Arguments
@@ -87,23 +112,20 @@ impl Mixer {
     ///
     /// # Returns
     /// The same packet as ingested on input postponed by a random delay
-    pub async fn mix(&self, packet: Result<Box<[u8]>, String>) -> Result<Box<[u8]>, String> {
+    pub async fn mix(&self, packet: T) -> T {
         let random_delay = self.cfg.random_delay();
         debug!("Mixer created a random packet delay of {}ms", random_delay.as_millis());
 
-        if let Some(m) = &self.metrics.queue_size {
-            m.increment(1.0f64)
-        }
+        self.metrics.queue_size.increment(1.0f64);
 
         sleep(random_delay).await;
 
-        if let Some(m) = &self.metrics.queue_size {
-            m.decrement(1.0f64);
-        }
-        if let Some(m) = &self.metrics.average_delay {
-            let weight = 1.0f64 / self.cfg.metric_delay_window as f64;
-            m.set((weight * random_delay.as_millis() as f64) + ((1.0f64 - weight) * m.get()))
-        };
+        self.metrics.queue_size.decrement(1.0f64);
+
+        let weight = 1.0f64 / self.cfg.metric_delay_window as f64;
+        self.metrics
+            .average_delay
+            .set((weight * random_delay.as_millis() as f64) + ((1.0f64 - weight) * self.metrics.average_delay.get()));
 
         packet
     }
@@ -128,17 +150,7 @@ pub mod wasm {
     /// Async closure interaction was inspired by: https://www.fpcomplete.com/blog/captures-closures-async/
     #[wasm_bindgen]
     pub fn new_mixer(packet_input: AsyncIterator) -> Result<AsyncIterableHelperMixer, JsValue> {
-        let mixer = std::sync::Arc::new(Mixer {
-            cfg: MixerConfig::default(),
-            metrics: MixerMetrics {
-                queue_size: SimpleGauge::new("core_gauge_mixer_queue_size", "Current mixer queue size").ok(),
-                average_delay: SimpleGauge::new(
-                    "core_gauge_mixer_average_packet_delay",
-                    "Average mixer packet delay averaged over a packet window",
-                )
-                .ok(),
-            },
-        });
+        let mixer = std::sync::Arc::new(Mixer::<Result<Box<[u8]>, String>>::default());
 
         Ok(AsyncIterableHelperMixer {
             stream: Box::new(

--- a/packages/core/crates/core-mixer/src/mixer.rs
+++ b/packages/core/crates/core-mixer/src/mixer.rs
@@ -105,7 +105,6 @@ impl<T> Mixer<T> {
         let random_delay = self.cfg.random_delay();
         debug!("Mixer created a random packet delay of {}ms", random_delay.as_millis());
 
-
         #[cfg(all(feature = "prometheus", not(test)))]
         METRIC_QUEUE_SIZE.increment(1.0f64);
 


### PR DESCRIPTION
This PR makes `core-mixer::Mixer` a generic class which could accept any type for mixing.
It also adds default implementation of configuration, making the entire `Mixer` type default-able.

Metrics creation for mixer is not per-instance, but rather using `lazy_static` which registers it per-crate. This follows the recommended approach here: https://docs.rs/prometheus/latest/prometheus/#static-metrics

For future development, non-default configurable instance should be created.

This change is needed as a prerequisite for #5074 