### PR TITLE
hotfix import of OZ library v4.8.3

### DIFF
--- a/packages/ethereum/contracts/remappings.txt
+++ b/packages/ethereum/contracts/remappings.txt
@@ -1,3 +1,4 @@
 ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
-openzeppelin-contracts-4.4.2=lib/openzeppelin-contracts-4.4.2/contracts/
+openzeppelin-contracts-4.4.2/=lib/openzeppelin-contracts-4.4.2/contracts/
+openzeppelin-contracts-4.8.3/=lib/openzeppelin-contracts-4.8.3/contracts/

--- a/packages/ethereum/contracts/src/HoprChannels.sol
+++ b/packages/ethereum/contracts/src/HoprChannels.sol
@@ -2,13 +2,13 @@
 pragma solidity ^0.8;
 pragma abicoder v2;
 
-import 'openzeppelin-contracts-4.8.3/contracts/utils/Multicall.sol';
-import 'openzeppelin-contracts-4.8.3/contracts/utils/introspection/IERC1820Registry.sol';
-import 'openzeppelin-contracts-4.8.3/contracts/utils/introspection/ERC1820Implementer.sol';
-import 'openzeppelin-contracts-4.8.3/contracts/token/ERC20/IERC20.sol';
-import 'openzeppelin-contracts-4.8.3/contracts/token/ERC777/IERC777Recipient.sol';
-import 'openzeppelin-contracts-4.8.3/contracts/token/ERC20/utils/SafeERC20.sol';
-import 'openzeppelin-contracts-4.8.3/contracts/utils/cryptography/ECDSA.sol';
+import 'openzeppelin-contracts-4.8.3/utils/Multicall.sol';
+import 'openzeppelin-contracts-4.8.3/utils/introspection/IERC1820Registry.sol';
+import 'openzeppelin-contracts-4.8.3/utils/introspection/ERC1820Implementer.sol';
+import 'openzeppelin-contracts-4.8.3/token/ERC20/IERC20.sol';
+import 'openzeppelin-contracts-4.8.3/token/ERC777/IERC777Recipient.sol';
+import 'openzeppelin-contracts-4.8.3/token/ERC20/utils/SafeERC20.sol';
+import 'openzeppelin-contracts-4.8.3/utils/cryptography/ECDSA.sol';
 
 contract HoprChannels is IERC777Recipient, ERC1820Implementer, Multicall {
   using SafeERC20 for IERC20;

--- a/packages/ethereum/contracts/src/HoprNetworkRegistry.sol
+++ b/packages/ethereum/contracts/src/HoprNetworkRegistry.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.0;
 
-import 'openzeppelin-contracts-4.8.3/contracts/access/Ownable.sol';
+import 'openzeppelin-contracts-4.8.3/access/Ownable.sol';
 import './IHoprNetworkRegistryRequirement.sol';
 
 /**

--- a/packages/ethereum/contracts/src/proxy/HoprDummyProxyForNetworkRegistry.sol
+++ b/packages/ethereum/contracts/src/proxy/HoprDummyProxyForNetworkRegistry.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.0;
 
-import 'openzeppelin-contracts-4.8.3/contracts/access/Ownable.sol';
+import 'openzeppelin-contracts-4.8.3/access/Ownable.sol';
 import '../IHoprNetworkRegistryRequirement.sol';
 
 /**

--- a/packages/ethereum/contracts/src/proxy/HoprStakingProxyForNetworkRegistry.sol
+++ b/packages/ethereum/contracts/src/proxy/HoprStakingProxyForNetworkRegistry.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.0;
 
-import 'openzeppelin-contracts-4.8.3/contracts/access/Ownable.sol';
-import 'openzeppelin-contracts-4.8.3/contracts/utils/math/Math.sol';
+import 'openzeppelin-contracts-4.8.3/access/Ownable.sol';
+import 'openzeppelin-contracts-4.8.3/utils/math/Math.sol';
 import '../IHoprNetworkRegistryRequirement.sol';
 
 /**


### PR DESCRIPTION
Addressing error 
```
Compiler run failed
error[6275]: ParserError: Source "openzeppelin-contracts-4.8.3/contracts/utils/Multicall.sol" not found: File not found. Searched the following locations: "/home/luc/repos/hopr/hoprnet/packages/ethereum/contracts".
 --> src/HoprChannels.sol:5:1:
  |
5 | import 'openzeppelin-contracts-4.8.3/contracts/utils/Multicall.sol';
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```