### PR TITLE
Adding temporary Rotsee

### DIFF
--- a/packages/core/protocol-config.json
+++ b/packages/core/protocol-config.json
@@ -28,7 +28,7 @@
       "network_registry_contract_address": "0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
       "tags": []
     },
-    "master": {
+    "rotsee": {
       "chain": "xdai",
       "environment_type": "development",
       "version_range": "*",


### PR DESCRIPTION
Add a temporary Network Rotsee to enable Faucet API to be able to fund it because it needs to download it
https://github.com/hoprnet/api/blob/main/api/package.json#L6