### PR TITLE
remove secp256k1 public key announcement

### DIFF
--- a/packages/ethereum/contracts/src/Announcements.sol
+++ b/packages/ethereum/contracts/src/Announcements.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.19;
 
-error PublicKeyDoesNotMatchSender(address pubkey, address sender);
-
 import 'openzeppelin-contracts-4.8.3/utils/Multicall.sol';
 
 /**

--- a/packages/ethereum/contracts/src/Announcements.sol
+++ b/packages/ethereum/contracts/src/Announcements.sol
@@ -23,8 +23,7 @@ import 'openzeppelin-contracts-4.8.3/utils/Multicall.sol';
  * Publishes transport-layer information in the hopr network.
  **/
 contract HoprAnnouncements is Multicall {
-  event KeyBindingOdd(bytes32 secp256k1_x, bytes32 ed25519_sig_0, bytes32 ed25519_sig_1, bytes32 ed25519_pub_key);
-  event KeyBindingEven(bytes32 secp256k1_x, bytes32 ed25519_sig_0, bytes32 ed25519_sig_1, bytes32 ed25519_pub_key);
+  event KeyBinding(bytes32 ed25519_sig_0, bytes32 ed25519_sig_1, bytes32 ed25519_pub_key, address chain_key);
 
   event AddressAnnouncement4(address node, bytes4 ip4, bytes2 port);
   event AddressAnnouncement6(address node, bytes16 ip6, bytes2 port);
@@ -43,36 +42,30 @@ contract HoprAnnouncements is Multicall {
 
   function bindKeysSafe(
     address self,
-    bytes32 secp256k1_x,
-    bytes32 secp256k1_y,
     bytes32 ed25519_sig_0,
     bytes32 ed25519_sig_1,
     bytes32 ed25519_pub_key
   ) external onlySafe {
-    _bindKeysInternal(self, secp256k1_x, secp256k1_y, ed25519_sig_0, ed25519_sig_1, ed25519_pub_key);
+    _bindKeysInternal(self, ed25519_sig_0, ed25519_sig_1, ed25519_pub_key);
   }
 
   function bindKeys(
-    bytes32 secp256k1_x,
-    bytes32 secp256k1_y,
     bytes32 ed25519_sig_0,
     bytes32 ed25519_sig_1,
     bytes32 ed25519_pub_key
   ) external noSafeSet {
-    _bindKeysInternal(msg.sender, secp256k1_x, secp256k1_y, ed25519_sig_0, ed25519_sig_1, ed25519_pub_key);
+    _bindKeysInternal(msg.sender, ed25519_sig_0, ed25519_sig_1, ed25519_pub_key);
   }
 
   function bindKeysAnnounce4Safe(
     address self,
-    bytes32 secp256k1_x,
-    bytes32 secp256k1_y,
     bytes32 ed25519_sig_0,
     bytes32 ed25519_sig_1,
     bytes32 ed25519_pub_key,
     bytes4 ip,
     bytes2 port
   ) external onlySafe {
-    _bindKeysInternal(self, secp256k1_x, secp256k1_y, ed25519_sig_0, ed25519_sig_1, ed25519_pub_key);
+    _bindKeysInternal(self, ed25519_sig_0, ed25519_sig_1, ed25519_pub_key);
     _announce4Internal(self, ip, port);
   }
 
@@ -80,29 +73,25 @@ contract HoprAnnouncements is Multicall {
    * Convenience method to bind keys and announce a IPv4 address in one call.
    */
   function bindKeysAnnounce4(
-    bytes32 secp256k1_x,
-    bytes32 secp256k1_y,
     bytes32 ed25519_sig_0,
     bytes32 ed25519_sig_1,
     bytes32 ed25519_pub_key,
     bytes4 ip,
     bytes2 port
   ) external noSafeSet {
-    _bindKeysInternal(msg.sender, secp256k1_x, secp256k1_y, ed25519_sig_0, ed25519_sig_1, ed25519_pub_key);
+    _bindKeysInternal(msg.sender,  ed25519_sig_0, ed25519_sig_1, ed25519_pub_key);
     _announce4Internal(msg.sender, ip, port);
   }
 
   function bindKeysAnnounce6Safe(
     address self,
-    bytes32 secp256k1_x,
-    bytes32 secp256k1_y,
     bytes32 ed25519_sig_0,
     bytes32 ed25519_sig_1,
     bytes32 ed25519_pub_key,
     bytes16 ip,
     bytes2 port
   ) external onlySafe {
-    _bindKeysInternal(self, secp256k1_x, secp256k1_y, ed25519_sig_0, ed25519_sig_1, ed25519_pub_key);
+    _bindKeysInternal(self, ed25519_sig_0, ed25519_sig_1, ed25519_pub_key);
     _announce6Internal(self, ip, port);
   }
 
@@ -110,15 +99,13 @@ contract HoprAnnouncements is Multicall {
    * Convenience method to bind keys and announce a IPv6 address in one call.
    */
   function bindKeysAnnounce6(
-    bytes32 secp256k1_x,
-    bytes32 secp256k1_y,
     bytes32 ed25519_sig_0,
     bytes32 ed25519_sig_1,
     bytes32 ed25519_pub_key,
     bytes16 ip,
     bytes2 port
   ) external noSafeSet {
-    _bindKeysInternal(msg.sender, secp256k1_x, secp256k1_y, ed25519_sig_0, ed25519_sig_1, ed25519_pub_key);
+    _bindKeysInternal(msg.sender, ed25519_sig_0, ed25519_sig_1, ed25519_pub_key);
     _announce6Internal(msg.sender, ip, port);
   }
 
@@ -158,32 +145,17 @@ contract HoprAnnouncements is Multicall {
    *
    * @dev Key binding and address announcements can happen in one call using `multicall`.
    *
-   * @param secp256k1_x first component of the public key
-   * @param secp256k1_y second component of the public key
    * @param ed25519_sig_0 first component of the EdDSA signature
    * @param ed25519_sig_1 second component of the EdDSA signature
    * @param ed25519_pub_key EdDSA public key
    */
   function _bindKeysInternal(
     address self,
-    bytes32 secp256k1_x,
-    bytes32 secp256k1_y,
     bytes32 ed25519_sig_0,
     bytes32 ed25519_sig_1,
     bytes32 ed25519_pub_key
   ) internal {
-    // Derive Ethereum address from uncompressed secp256k1 public key
-    address sender_addr = address(uint160(uint256(keccak256(abi.encodePacked(secp256k1_x, secp256k1_y)))));
-
-    if (self != sender_addr) {
-      revert PublicKeyDoesNotMatchSender({pubkey: sender_addr, sender: msg.sender});
-    }
-
-    if (uint256(secp256k1_y) % 2 == 1) {
-      emit KeyBindingOdd(secp256k1_x, ed25519_sig_0, ed25519_sig_1, ed25519_pub_key);
-    } else {
-      emit KeyBindingEven(secp256k1_x, ed25519_sig_0, ed25519_sig_1, ed25519_pub_key);
-    }
+    emit KeyBinding(ed25519_sig_0, ed25519_sig_1, ed25519_pub_key, self);
   }
 
   /**

--- a/packages/ethereum/contracts/test/Announcements.t.sol
+++ b/packages/ethereum/contracts/test/Announcements.t.sol
@@ -5,13 +5,6 @@ import './utils/Accounts.sol';
 import 'forge-std/Test.sol';
 import '../src/Announcements.sol';
 
-address constant odd_addr = 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266;
-bytes32 constant odd_secp256k1_x = 0x8318535b54105d4a7aae60c08fc45f9687181b4fdfc625bd1a753fa7397fed75;
-bytes32 constant odd_secp256k1_y = 0x3547f11ca8696646f2f3acb08e31016afac23e630c5d11f59f61fef57b0d2aa5;
-
-address constant even_addr = 0x70997970C51812dc3A010C7d01b50e0d17dc79C8;
-bytes32 constant even_secp256k1_x = 0xba5734d8f7091719471e7f7ed6b9df170dc70cc661ca05e688601ad984f068b0;
-bytes32 constant even_secp256k1_y = 0xd67351e5f06073092499336ab0839ef8a521afd334e53807205fa2f08eec74f4;
 // Dummy since there is no verification happening on-chain
 bytes32 constant ed25519_sig_0 = 0x000000000000000000000000000000000000000000000000000000000ed25519;
 bytes32 constant ed25519_sig_1 = 0x100000000000000000000000000000000000000000000000000000000ed25519;
@@ -22,11 +15,10 @@ bytes2 constant port = 0xffff; // port 65535
 
 bytes32 constant ed25519_pub_key = 0x3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c;
 
-contract AccountTest is Test {
+contract AccountTest is Test, AccountsFixtureTest {
   HoprAnnouncements public announcements;
 
-  event KeyBindingOdd(bytes32 secp256k1_x, bytes32 ed25519_sig_0, bytes32 ed25519_sig_1, bytes32 ed25519_pub_key);
-  event KeyBindingEven(bytes32 secp256k1_x, bytes32 ed25519_sig_0, bytes32 ed25519_sig_1, bytes32 ed25519_pub_key);
+  event KeyBinding(bytes32 ed25519_sig_0, bytes32 ed25519_sig_1, bytes32 ed25519_pub_key, address chain_key);
 
   function setUp() public {
     announcements = new HoprAnnouncements();
@@ -34,22 +26,10 @@ contract AccountTest is Test {
 
   function testKeyBinding() public {
     vm.expectEmit(true, false, false, false, address(announcements));
-    emit KeyBindingOdd(odd_secp256k1_x, ed25519_sig_0, ed25519_sig_1, ed25519_pub_key);
+    emit KeyBinding(ed25519_sig_0, ed25519_sig_1, ed25519_pub_key, accountA.accountAddr);
 
-    vm.prank(odd_addr);
-    announcements.bindKeys(odd_secp256k1_x, odd_secp256k1_y, ed25519_sig_0, ed25519_sig_1, ed25519_pub_key);
-
-    vm.expectEmit(true, false, false, false, address(announcements));
-    emit KeyBindingEven(even_secp256k1_x, ed25519_sig_0, ed25519_sig_1, ed25519_pub_key);
-
-    vm.prank(even_addr);
-    announcements.bindKeys(even_secp256k1_x, even_secp256k1_y, ed25519_sig_0, ed25519_sig_1, ed25519_pub_key);
-  }
-
-  function testKeyBindingError() public {
-    vm.expectRevert(abi.encodeWithSelector(PublicKeyDoesNotMatchSender.selector, odd_addr, even_addr));
-    vm.prank(even_addr);
-    announcements.bindKeys(odd_secp256k1_x, odd_secp256k1_y, ed25519_sig_0, ed25519_sig_1, ed25519_pub_key);
+    vm.prank(accountA.accountAddr);
+    announcements.bindKeys(ed25519_sig_0, ed25519_sig_1, ed25519_pub_key);
   }
 
   event AddressAnnouncement4(address node, bytes4 ip4, bytes2 port);
@@ -57,15 +37,15 @@ contract AccountTest is Test {
 
   function testIpPortAnnouncements() public {
     vm.expectEmit(true, false, false, false, address(announcements));
-    emit AddressAnnouncement4(vm.addr(1), ipv4, port);
+    emit AddressAnnouncement4(accountA.accountAddr, ipv4, port);
 
-    vm.prank(vm.addr(1));
+    vm.prank(accountA.accountAddr);
     announcements.announce4(ipv4, port);
 
     vm.expectEmit(true, false, false, false, address(announcements));
-    emit AddressAnnouncement6(vm.addr(1), ipv6, port);
+    emit AddressAnnouncement6(accountA.accountAddr, ipv6, port);
 
-    vm.prank(vm.addr(1));
+    vm.prank(accountA.accountAddr);
     announcements.announce6(ipv6, port);
   }
 
@@ -73,60 +53,46 @@ contract AccountTest is Test {
 
   function testAddressRevocation() public {
     vm.expectEmit(true, false, false, false, address(announcements));
-    emit RevokeAnnouncement(vm.addr(1));
+    emit RevokeAnnouncement(accountA.accountAddr);
 
-    vm.prank(vm.addr(1));
+    vm.prank(accountA.accountAddr);
     announcements.revoke();
   }
 
   function testAllInOneAnnouncement() public {
     vm.expectEmit(true, false, false, false, address(announcements));
-    emit KeyBindingOdd(odd_secp256k1_x, ed25519_sig_0, ed25519_sig_1, ed25519_pub_key);
+    emit KeyBinding(ed25519_sig_0, ed25519_sig_1, ed25519_pub_key, accountA.accountAddr);
 
     vm.expectEmit(true, false, false, false, address(announcements));
-    emit AddressAnnouncement4(odd_addr, ipv4, port);
+    emit AddressAnnouncement4(accountA.accountAddr, ipv4, port);
 
     vm.expectEmit(true, false, false, false, address(announcements));
-    emit AddressAnnouncement6(odd_addr, ipv6, port);
+    emit AddressAnnouncement6(accountA.accountAddr, ipv6, port);
 
     bytes[] memory calls = new bytes[](3);
 
     calls[0] = abi.encodeCall(
       announcements.bindKeys,
-      (odd_secp256k1_x, odd_secp256k1_y, ed25519_sig_0, ed25519_sig_1, ed25519_pub_key)
+      (ed25519_sig_0, ed25519_sig_1, ed25519_pub_key)
     );
 
     calls[1] = abi.encodeCall(announcements.announce4, (ipv4, port));
 
     calls[2] = abi.encodeCall(announcements.announce6, (ipv6, port));
 
-    vm.prank(odd_addr);
+    vm.prank(accountA.accountAddr);
     announcements.multicall(calls);
   }
 
   function testBindKeyAnnounce4() public {
     vm.expectEmit(true, false, false, false, address(announcements));
-    emit KeyBindingOdd(odd_secp256k1_x, ed25519_sig_0, ed25519_sig_1, ed25519_pub_key);
+    emit KeyBinding(ed25519_sig_0, ed25519_sig_1, ed25519_pub_key, accountA.accountAddr);
 
     vm.expectEmit(true, false, false, false, address(announcements));
-    emit AddressAnnouncement4(odd_addr, ipv4, port);
+    emit AddressAnnouncement4(accountA.accountAddr, ipv4, port);
 
-    vm.prank(odd_addr);
+    vm.prank(accountB.accountAddr);
     announcements.bindKeysAnnounce4(
-      odd_secp256k1_x,
-      odd_secp256k1_y,
-      ed25519_sig_0,
-      ed25519_sig_1,
-      ed25519_pub_key,
-      ipv4,
-      port
-    );
-
-    vm.expectRevert();
-    vm.prank(even_addr);
-    announcements.bindKeysAnnounce4(
-      odd_secp256k1_x,
-      odd_secp256k1_y,
       ed25519_sig_0,
       ed25519_sig_1,
       ed25519_pub_key,
@@ -137,31 +103,17 @@ contract AccountTest is Test {
 
   function testBindKeyAnnounce6() public {
     vm.expectEmit(true, false, false, false, address(announcements));
-    emit KeyBindingOdd(odd_secp256k1_x, ed25519_sig_0, ed25519_sig_1, ed25519_pub_key);
+    emit KeyBinding(ed25519_sig_0, ed25519_sig_1, ed25519_pub_key, accountA.accountAddr);
 
     vm.expectEmit(true, false, false, false, address(announcements));
-    emit AddressAnnouncement6(odd_addr, ipv6, port);
+    emit AddressAnnouncement6(accountA.accountAddr, ipv6, port);
 
-    vm.prank(odd_addr);
+    vm.prank(accountA.accountAddr);
     announcements.bindKeysAnnounce6(
-      odd_secp256k1_x,
-      odd_secp256k1_y,
       ed25519_sig_0,
       ed25519_sig_1,
       ed25519_pub_key,
       ipv6,
-      port
-    );
-
-    vm.expectRevert();
-    vm.prank(even_addr);
-    announcements.bindKeysAnnounce6(
-      odd_secp256k1_x,
-      odd_secp256k1_y,
-      ed25519_sig_0,
-      ed25519_sig_1,
-      ed25519_pub_key,
-      ipv4,
       port
     );
   }


### PR DESCRIPTION
Removes announcement of secp256k1 public keys because they are no longer needed in `hoprd`.