### PR TITLE
Deadlock database fixes and improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,6 +975,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
+name = "core-hopr"
+version = "0.1.0"
+dependencies = [
+ "console_error_panic_hook",
+ "core-ethereum-db",
+ "core-ethereum-misc",
+ "core-packet",
+ "env_logger",
+ "futures",
+ "futures-lite",
+ "js-sys",
+ "lazy_static",
+ "utils-log",
+ "utils-metrics",
+ "utils-misc",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+]
+
+[[package]]
 name = "core-misc"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,6 +939,8 @@ dependencies = [
  "console_error_panic_hook",
  "core-crypto",
  "core-ethereum-db",
+ "core-types",
+ "env_logger",
  "futures",
  "hex-literal 0.4.1",
  "js-sys",
@@ -982,17 +984,11 @@ dependencies = [
  "core-ethereum-db",
  "core-ethereum-misc",
  "core-packet",
- "env_logger",
- "futures",
- "futures-lite",
  "js-sys",
- "lazy_static",
  "utils-log",
  "utils-metrics",
  "utils-misc",
  "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-bindgen-test",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 
 members = [
     "packages/core/crates/core-crypto",
+    "packages/core/crates/core-hopr",
     "packages/core/crates/core-misc",
     "packages/core/crates/core-mixer",
     "packages/core/crates/core-network",

--- a/packages/core-ethereum/crates/core-ethereum-misc/Cargo.toml
+++ b/packages/core-ethereum/crates/core-ethereum-misc/Cargo.toml
@@ -37,6 +37,8 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 # wee_alloc = { version = "0.4.5", optional = true }
 
 [dev-dependencies]
+env_logger = "0.10"
+core-types = { path = "../../../core/crates/core-types" }
 mockall = "0.11.4"
 hex-literal = "0.4"
 wasm-bindgen-test = "0.3.36"

--- a/packages/core-ethereum/src/db.ts
+++ b/packages/core-ethereum/src/db.ts
@@ -12,14 +12,14 @@ import {
   Snapshot as Ethereum_Snapshot,
   Ticket as Ethereum_Ticket,
   U256 as Ethereum_U256,
-  core_ethereum_misc_initialize_crate,
+  core_hopr_initialize_crate,
   initialize_commitment,
   find_commitment_preimage,
   bump_commitment,
   ChannelCommitmentInfo
-} from '../lib/core_ethereum_misc.js'
+} from '../../core/lib/core_hopr.js'
 
-core_ethereum_misc_initialize_crate()
+core_hopr_initialize_crate()
 
 export {
   Ethereum_AccountEntry,

--- a/packages/core-ethereum/src/index.ts
+++ b/packages/core-ethereum/src/index.ts
@@ -44,18 +44,18 @@ const log = debug('hopr-core-ethereum')
 
 export type RedeemTicketResponse =
   | {
-    status: 'SUCCESS'
-    receipt: string
-    ackTicket: AcknowledgedTicket
-  }
+      status: 'SUCCESS'
+      receipt: string
+      ackTicket: AcknowledgedTicket
+    }
   | {
-    status: 'FAILURE'
-    message: string
-  }
+      status: 'FAILURE'
+      message: string
+    }
   | {
-    status: 'ERROR'
-    error: Error | string
-  }
+      status: 'ERROR'
+      error: Error | string
+    }
 
 export type ChainOptions = {
   provider: string
@@ -387,7 +387,8 @@ export default class HoprCoreEthereum extends EventEmitter {
         ticket = fetched
 
         log(
-          `redeeming ticket ${ticket.response.to_hex()} in channel from ${channel.source} to ${channel.destination
+          `redeeming ticket ${ticket.response.to_hex()} in channel from ${channel.source} to ${
+            channel.destination
           }, preImage ${ticket.pre_image.to_hex()}, porSecret ${ticket.response.to_hex()}`
         )
 
@@ -559,7 +560,7 @@ export default class HoprCoreEthereum extends EventEmitter {
       c = ChannelEntry.deserialize(
         (await this.db.get_channel_to(Ethereum_PublicKey.deserialize(dest.serialize(false)))).serialize()
       )
-    } catch { }
+    } catch {}
     if (c && c.status !== ChannelStatus.Closed) {
       throw Error('Channel is already opened')
     }

--- a/packages/core-ethereum/src/index.ts
+++ b/packages/core-ethereum/src/index.ts
@@ -277,10 +277,6 @@ export default class HoprCoreEthereum extends EventEmitter {
         this.setTxHandler(`channel-updated-${txHash}`, txHash)
       )
     }
-    const getCommitment = async () =>
-      ChannelEntry.deserialize(
-        (await this.db.get_channel(Ethereum_Hash.deserialize(c.get_id().serialize()))).serialize()
-      ).commitment
 
     // Get all channel information required to build the initial commitment
     const cci = new ChannelCommitmentInfo(
@@ -290,7 +286,8 @@ export default class HoprCoreEthereum extends EventEmitter {
       Ethereum_U256.deserialize(c.channel_epoch.serialize())
     )
 
-    await initialize_commitment(this.db, this.privateKey, cci, getCommitment, setCommitment)
+    log(`initializing commitment`)
+    await initialize_commitment(this.db, this.privateKey, cci, setCommitment)
   }
 
   public async redeemAllTickets(): Promise<void> {

--- a/packages/core/crates/Makefile
+++ b/packages/core/crates/Makefile
@@ -1,5 +1,5 @@
 # Append here when new Rust WASM crate is added (the list is space separated)
-PACKAGES = core-crypto core-misc core-mixer core-network core-packet core-strategy core-types
+PACKAGES = core-crypto core-hopr core-misc core-mixer core-network core-packet core-strategy core-types
 ##########################################
 
 PKG_DIRS = $(addsuffix /pkg, $(PACKAGES))

--- a/packages/core/crates/core-crypto/Cargo.toml
+++ b/packages/core/crates/core-crypto/Cargo.toml
@@ -17,6 +17,7 @@ wasm = ["dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:js-sys"]
 
 [dependencies]
 aes = "0.8"
+async-std = { version = "1", features = ["attributes"] }
 blake2 = "0.10"
 chacha20 = "0.9"
 ctr = "0.9"
@@ -51,7 +52,6 @@ console_error_panic_hook = { version = "0.1.7", optional = true }
 #wee_alloc = { version = "0.4.5", optional = true }
 
 [dev-dependencies]
-async-std = { version = "1.12.0", features = ["attributes"] }
 parameterized = "1.0"
 wasm-bindgen-test = "0.3.36"
 

--- a/packages/core/crates/core-hopr/.gitignore
+++ b/packages/core/crates/core-hopr/.gitignore
@@ -1,0 +1,6 @@
+/target
+**/*.rs.bk
+Cargo.lock
+bin/
+pkg/
+wasm-pack.log

--- a/packages/core/crates/core-hopr/Cargo.toml
+++ b/packages/core/crates/core-hopr/Cargo.toml
@@ -11,27 +11,20 @@ crate-type = ["cdylib", "rlib"]
 
 [features]
 default = ["console_error_panic_hook", "wasm", "prometheus"]
-wasm = ["dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:js-sys"]
+console_error_panic_hook = ["dep:console_error_panic_hook"]
+wasm = ["dep:wasm-bindgen", "dep:js-sys", "core-ethereum-db/wasm", "core-ethereum-misc/wasm", "core-packet/wasm"]
 prometheus = ["dep:utils-metrics"]
 
 [dependencies]
 console_error_panic_hook = { version = "0.1.7", optional = true }
-core-ethereum-db = { path = "../../../core-ethereum/crates/core-ethereum-db" }
-core-ethereum-misc = { path = "../../../core-ethereum/crates/core-ethereum-misc" } 
-core-packet = { path = "../core-packet" }
-futures = "0.3.28"
-futures-lite = "1.12.0"
+core-ethereum-db = { path = "../../../core-ethereum/crates/core-ethereum-db", default-features = false }
+core-ethereum-misc = { path = "../../../core-ethereum/crates/core-ethereum-misc", default-features = false }
+core-packet = { path = "../core-packet", default-features = false }
 js-sys = { version = "0.3.63", optional = true }
-lazy_static = "1.4.0"
 utils-log = { path = "../../../utils/crates/utils-log"}
 utils-misc = { path = "../../../utils/crates/utils-misc" }
 utils-metrics = { path = "../../../utils/crates/utils-metrics", optional = true }
 wasm-bindgen = { workspace = true, optional = true }
-wasm-bindgen-futures = { version = "0.4.36", optional = true }
-
-[dev-dependencies]
-env_logger = "0.10.0"
-wasm-bindgen-test = "0.3.36"
 
 [package.metadata.wasm-pack.profile.dev]
 wasm-opt = false

--- a/packages/core/crates/core-hopr/Cargo.toml
+++ b/packages/core/crates/core-hopr/Cargo.toml
@@ -13,7 +13,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["console_error_panic_hook", "wasm", "prometheus"]
 console_error_panic_hook = ["dep:console_error_panic_hook"]
 wasm = ["dep:wasm-bindgen", "dep:js-sys", "core-ethereum-db/wasm", "core-ethereum-misc/wasm", "core-packet/wasm"]
-prometheus = ["dep:utils-metrics"]
+prometheus = ["dep:utils-metrics", "core-packet/prometheus"]
 
 [dependencies]
 console_error_panic_hook = { version = "0.1.7", optional = true }

--- a/packages/core/crates/core-hopr/Cargo.toml
+++ b/packages/core/crates/core-hopr/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "core-hopr"
+version = "0.1.0"
+authors = ["HOPR Association <tech@hoprnet.org>"]
+description = "Implements the main HOPR interface for the core library"
+edition = "2021"
+license = "GPL-3.0-only"
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[features]
+default = ["console_error_panic_hook", "wasm", "prometheus"]
+wasm = ["dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:js-sys"]
+prometheus = ["dep:utils-metrics"]
+
+[dependencies]
+console_error_panic_hook = { version = "0.1.7", optional = true }
+core-ethereum-db = { path = "../../../core-ethereum/crates/core-ethereum-db" }
+core-ethereum-misc = { path = "../../../core-ethereum/crates/core-ethereum-misc" } 
+core-packet = { path = "../core-packet" }
+futures = "0.3.28"
+futures-lite = "1.12.0"
+js-sys = { version = "0.3.63", optional = true }
+lazy_static = "1.4.0"
+utils-log = { path = "../../../utils/crates/utils-log"}
+utils-misc = { path = "../../../utils/crates/utils-misc" }
+utils-metrics = { path = "../../../utils/crates/utils-metrics", optional = true }
+wasm-bindgen = { workspace = true, optional = true }
+wasm-bindgen-futures = { version = "0.4.36", optional = true }
+
+[dev-dependencies]
+env_logger = "0.10.0"
+wasm-bindgen-test = "0.3.36"
+
+[package.metadata.wasm-pack.profile.dev]
+wasm-opt = false
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = ['-O', '--enable-reference-types']

--- a/packages/core/crates/core-hopr/README.md
+++ b/packages/core/crates/core-hopr/README.md
@@ -1,0 +1,3 @@
+# core-hopr
+
+Implements the main public interface for the core HOPR library - that is the `Hopr` type.

--- a/packages/core/crates/core-hopr/src/lib.rs
+++ b/packages/core/crates/core-hopr/src/lib.rs
@@ -12,7 +12,6 @@ pub mod wasm {
     #[allow(unused_imports)]
     use core_ethereum_misc::commitment::wasm::*;
 
-
     // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global allocator.
     #[cfg(feature = "wee_alloc")]
     #[global_allocator]

--- a/packages/core/crates/core-hopr/src/lib.rs
+++ b/packages/core/crates/core-hopr/src/lib.rs
@@ -1,0 +1,42 @@
+#[cfg(feature = "wasm")]
+pub mod wasm {
+    use utils_log::logger::JsLogger;
+    use utils_misc::utils::wasm::JsResult;
+    use wasm_bindgen::prelude::*;
+
+    // Temporarily re-export core-packet
+    #[allow(unused_imports)]
+    use core_packet::interaction::wasm::*;
+
+    // Temporarily re-export core-ethereum-misc commitments
+    #[allow(unused_imports)]
+    use core_ethereum_misc::commitment::wasm::*;
+
+
+    // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global allocator.
+    #[cfg(feature = "wee_alloc")]
+    #[global_allocator]
+    static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
+
+    static LOGGER: JsLogger = JsLogger {};
+
+    #[allow(dead_code)]
+    #[wasm_bindgen]
+    pub fn core_hopr_initialize_crate() {
+        let _ = JsLogger::install(&LOGGER, None);
+
+        // When the `console_error_panic_hook` feature is enabled, we can call the
+        // `set_panic_hook` function at least once during initialization, and then
+        // we will get better error messages if our code ever panics.
+        //
+        // For more details see
+        // https://github.com/rustwasm/console_error_panic_hook#readme
+        #[cfg(feature = "console_error_panic_hook")]
+        console_error_panic_hook::set_once();
+    }
+
+    #[wasm_bindgen]
+    pub fn core_hopr_gather_metrics() -> JsResult<String> {
+        utils_metrics::metrics::wasm::gather_all_metrics()
+    }
+}

--- a/packages/core/crates/core-packet/src/lib.rs
+++ b/packages/core/crates/core-packet/src/lib.rs
@@ -34,6 +34,7 @@ pub mod wasm {
         console_error_panic_hook::set_once();
     }
 
+    #[cfg(feature = "prometheus")]
     #[wasm_bindgen]
     pub fn core_packet_gather_metrics() -> JsResult<String> {
         utils_metrics::metrics::wasm::gather_all_metrics()

--- a/packages/core/crates/core-packet/src/path.rs
+++ b/packages/core/crates/core-packet/src/path.rs
@@ -45,7 +45,7 @@ impl Display for Path {
             f,
             "{}{} ] ({} hops)",
             if self.valid { "[ " } else { "[ !! " },
-            self.hops.join("->"),
+            self.hops.iter().map(|p| p.to_string()).collect::<Vec<_>>().join("->"),
             self.length()
         )
     }

--- a/packages/core/crates/core-packet/src/path.rs
+++ b/packages/core/crates/core-packet/src/path.rs
@@ -41,11 +41,13 @@ impl Path {
 
 impl Display for Path {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "[{}", if self.valid { " " } else { " !! " })?;
-        for peer in &self.hops {
-            write!(f, "{peer}->")?;
-        }
-        write!(f, " ]")
+        write!(
+            f,
+            "{}{} ] ({} hops)",
+            if self.valid { "[ " } else { "[ !! " },
+            self.hops.join("->"),
+            self.length()
+        )
     }
 }
 
@@ -87,6 +89,11 @@ pub mod wasm {
                 .into_iter()
                 .map(|p| PeerId::from_str(&p.as_string().unwrap()).map_err(|_| Other(ParseError)))
                 .collect::<Result<Vec<PeerId>>>())?))
+        }
+
+        #[wasm_bindgen(js_name = "to_string")]
+        pub fn _to_string(&self) -> String {
+            self.to_string()
         }
     }
 }

--- a/packages/core/src/index.spec.ts
+++ b/packages/core/src/index.spec.ts
@@ -9,7 +9,7 @@ import { setTimeout } from 'timers/promises'
 import { Multiaddr } from '@multiformats/multiaddr'
 import { startStunServer } from '@hoprnet/hopr-connect'
 import type { PeerId } from '@libp2p/interface-peer-id'
-import { Database, PublicKey } from '../lib/core_packet.js'
+import { Database, PublicKey } from '../lib/core_hopr.js'
 
 /**
  * Synchronous function to sample PeerIds

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -96,8 +96,8 @@ import type { EventEmitter as Libp2pEmitter } from '@libp2p/interfaces/events'
 import { utils as ethersUtils } from 'ethers/lib/ethers.js'
 import { peerIdFromString } from '@libp2p/peer-id'
 import {
-  core_packet_initialize_crate,
-  core_packet_gather_metrics,
+  core_hopr_initialize_crate,
+  core_hopr_gather_metrics,
   Database,
   Address as Packet_Address,
   PacketInteractionConfig,
@@ -107,9 +107,9 @@ import {
   WasmAckInteraction,
   WasmPacketInteraction,
   WasmVecAcknowledgedTicket
-} from '../lib/core_packet.js'
-core_packet_initialize_crate()
-registerMetricsCollector(core_packet_gather_metrics)
+} from '../lib/core_hopr.js'
+core_hopr_initialize_crate()
+registerMetricsCollector(core_hopr_gather_metrics)
 
 import pkg from '../package.json' assert { type: 'json' }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1446,13 +1446,13 @@ class Hopr extends EventEmitter {
     try {
       if (channel.status === ChannelStatus.Open || channel.status == ChannelStatus.WaitingForCommitment) {
         log('initiating closure of channel', channel.get_id().to_hex())
-        txHash = await connector.initializeClosure(channel.source, channel.destination)
+        txHash = await connector.initializeClosure(PublicKey.deserialize(channel.source.serialize(false)), PublicKey.deserialize(channel.destination.serialize(false)))
       } else {
         // verify that we passed the closure waiting period to prevent failing
         // on-chain transactions
 
         if (channel.closure_time_passed()) {
-          txHash = await connector.finalizeClosure(channel.source, channel.destination)
+          txHash = await connector.finalizeClosure(PublicKey.deserialize(channel.source.serialize(false)), PublicKey.deserialize(channel.destination.serialize(false)))
         } else {
           log(
             `ignoring finalizing closure of channel ${channel

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -25,11 +25,7 @@ import { getAddrs } from './identity.js'
 import { createLibp2pMock } from './libp2p.mock.js'
 import { getContractData, supportedNetworks } from './network.js'
 import { MultiaddrConnection } from '@libp2p/interfaces/transport'
-import {
-  Database,
-  PublicKey as Database_PublicKey,
-  core_hopr_initialize_crate
-} from '../lib/core_hopr.js'
+import { Database, PublicKey as Database_PublicKey, core_hopr_initialize_crate } from '../lib/core_hopr.js'
 core_hopr_initialize_crate()
 
 const log = debug(`hopr-core:create-hopr`)

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -32,7 +32,6 @@ import {
 } from '../lib/core_hopr.js'
 core_hopr_initialize_crate()
 
-
 const log = debug(`hopr-core:create-hopr`)
 const error = debug(`hopr-core:error`)
 

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -26,18 +26,12 @@ import { createLibp2pMock } from './libp2p.mock.js'
 import { getContractData, supportedNetworks } from './network.js'
 import { MultiaddrConnection } from '@libp2p/interfaces/transport'
 import {
-  Database as Packet_Database,
-  PublicKey as Packet_PublicKey,
-  core_packet_initialize_crate
-} from '../lib/core_packet.js'
-core_packet_initialize_crate()
+  Database,
+  PublicKey as Database_PublicKey,
+  core_hopr_initialize_crate
+} from '../lib/core_hopr.js'
+core_hopr_initialize_crate()
 
-import {
-  Database as Ethereum_Database,
-  PublicKey as Ethereum_PublicKey,
-  core_ethereum_misc_initialize_crate
-} from '../../core-ethereum/lib/core_ethereum_misc.js'
-core_ethereum_misc_initialize_crate()
 
 const log = debug(`hopr-core:create-hopr`)
 const error = debug(`hopr-core:error`)
@@ -258,9 +252,11 @@ export async function createHoprNode(
     throw err
   }
 
+  let db = new Database(levelDb, Database_PublicKey.from_peerid_str(peerId.toString()))
+
   log(`using provider URL: ${options.network.chain.default_provider}`)
   const chain = HoprCoreEthereum.createInstance(
-    new Ethereum_Database(levelDb, Ethereum_PublicKey.from_peerid_str(peerId.toString())),
+    db,
     PublicKey.from_peerid_str(peerId.toString()),
     keysPBM.PrivateKey.decode(peerId.privateKey as Uint8Array).Data,
     {
@@ -280,5 +276,5 @@ export async function createHoprNode(
   // Initialize connection to the blockchain
   await chain.initializeChainWrapper(resolvedContractAddresses)
 
-  return new Hopr(peerId, new Packet_Database(levelDb, Packet_PublicKey.from_peerid_str(peerId.toString())), options)
+  return new Hopr(peerId, db, options)
 }

--- a/packages/hoprd/src/api/token.spec.ts
+++ b/packages/hoprd/src/api/token.spec.ts
@@ -14,8 +14,8 @@ import {
 
 import type { default as Hopr } from '@hoprnet/hopr-core'
 import type { Capability } from './token.js'
-import { Database, PublicKey, core_packet_initialize_crate } from '@hoprnet/hopr-core/lib/core_packet.js'
-core_packet_initialize_crate()
+import { Database, PublicKey, core_hopr_initialize_crate } from '@hoprnet/hopr-core/lib/core_hopr.js'
+core_hopr_initialize_crate()
 import { LevelDb } from '@hoprnet/hopr-utils'
 
 chai.should()

--- a/packages/hoprd/src/api/token.spec.ts
+++ b/packages/hoprd/src/api/token.spec.ts
@@ -14,7 +14,7 @@ import {
 
 import type { default as Hopr } from '@hoprnet/hopr-core'
 import type { Capability } from './token.js'
-import { Database, PublicKey, core_hopr_initialize_crate } from '../../../lib/core_hopr.js'
+import { Database, PublicKey, core_hopr_initialize_crate } from '../../../core/lib/core_hopr.js'
 core_hopr_initialize_crate()
 import { LevelDb } from '@hoprnet/hopr-utils'
 

--- a/packages/hoprd/src/api/token.ts
+++ b/packages/hoprd/src/api/token.ts
@@ -5,7 +5,7 @@ import { createHash } from 'crypto'
 // List of endpoints which are supported as capabilitities.
 // Each entry also specifies supported endpoint-specific limits.
 import supportedCapabilities from './../supported-api-capabilities.json' assert { type: 'json' }
-import { AuthorizationToken, Database } from '@hoprnet/hopr-core/lib/core_packet.js'
+import { AuthorizationToken, Database } from '@hoprnet/hopr-core/lib/core_hopr.js'
 
 enum LimitType {
   calls

--- a/packages/hoprd/src/api/v2.ts
+++ b/packages/hoprd/src/api/v2.ts
@@ -26,7 +26,7 @@ import type Hopr from '@hoprnet/hopr-core'
 import { SettingKey, StateOps } from '../types.js'
 import type { LogStream } from './../logs.js'
 import type { Token } from './token.js'
-import { Database } from '@hoprnet/hopr-core/lib/core_packet.js'
+import { Database } from '@hoprnet/hopr-core/lib/core_hopr.js'
 
 const debugLog = debug('hoprd:api:v2')
 

--- a/packages/hoprd/src/api/v2/paths/channels/{peerid}/{direction}/index.ts
+++ b/packages/hoprd/src/api/v2/paths/channels/{peerid}/{direction}/index.ts
@@ -12,6 +12,7 @@ import {
   PublicKey,
   type DeferType
 } from '@hoprnet/hopr-utils'
+import { log } from 'debug'
 
 const closingRequests = new Map<string, DeferType<void>>()
 
@@ -58,6 +59,7 @@ export async function closeChannel(
     const { status: channelStatus, receipt } = await node.closeChannel(peerId, direction)
     return { success: true, channelStatus, receipt }
   } catch (err) {
+    log(`${err}`)
     const errString = err instanceof Error ? err.message : err?.toString?.() ?? 'Unknown error'
 
     if (errString.match(/Channel is already closed/)) {

--- a/packages/hoprd/src/api/v2/paths/token.integration.spec.ts
+++ b/packages/hoprd/src/api/v2/paths/token.integration.spec.ts
@@ -9,7 +9,7 @@ import { createAuthenticatedTestApiInstance } from './../fixtures.js'
 
 import type { default as Hopr } from '@hoprnet/hopr-core'
 import { LevelDb } from '@hoprnet/hopr-utils'
-import { Database, PublicKey } from '@hoprnet/hopr-core/lib/core_packet.js'
+import { Database, PublicKey } from '@hoprnet/hopr-core/lib/core_hopr.js'
 
 describe('GET /token', function () {
   let node: Hopr

--- a/packages/hoprd/src/api/v2/paths/tokens/index.integration.spec.ts
+++ b/packages/hoprd/src/api/v2/paths/tokens/index.integration.spec.ts
@@ -8,7 +8,7 @@ import { STATUS_CODES } from './../../utils.js'
 
 import type { default as Hopr } from '@hoprnet/hopr-core'
 import { LevelDb } from '@hoprnet/hopr-utils'
-import { Database, PublicKey } from '@hoprnet/hopr-core/lib/core_packet.js'
+import { Database, PublicKey } from '@hoprnet/hopr-core/lib/core_hopr.js'
 
 describe('POST /tokens', function () {
   let node: Hopr

--- a/packages/hoprd/src/api/v2/paths/tokens/{id}.integration.spec.ts
+++ b/packages/hoprd/src/api/v2/paths/tokens/{id}.integration.spec.ts
@@ -10,7 +10,7 @@ import { createAuthenticatedTestApiInstance } from '../../fixtures.js'
 import type { default as Hopr } from '@hoprnet/hopr-core'
 import type { Token } from './../../../token.js'
 import { LevelDb } from '@hoprnet/hopr-utils'
-import { Database, PublicKey } from '@hoprnet/hopr-core/lib/core_packet.js'
+import { Database, PublicKey } from '@hoprnet/hopr-core/lib/core_hopr.js'
 
 describe('DELETE /tokens/{id}', function () {
   let node: Hopr

--- a/packages/utils/crates/utils-db/src/db.rs
+++ b/packages/utils/crates/utils-db/src/db.rs
@@ -107,9 +107,7 @@ pub struct DB<T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>>> {
 
 impl<T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>>> DB<T> {
     pub fn new(backend: T) -> Self {
-        Self {
-            backend,
-        }
+        Self { backend }
     }
 
     pub async fn contains(&self, key: Key) -> bool {
@@ -128,7 +126,8 @@ impl<T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>>> DB<T> {
         let key: T::Key = key.into();
 
         if self.backend.contains(key.clone()).await {
-            self.backend.get(key.into())
+            self.backend
+                .get(key.into())
                 .await
                 .and_then(|v| {
                     bincode::deserialize(v.as_ref()).map_err(|e| {

--- a/packages/utils/crates/utils-types/src/primitives.rs
+++ b/packages/utils/crates/utils-types/src/primitives.rs
@@ -73,10 +73,11 @@ impl std::str::FromStr for Address {
             hex::decode(&value[2..])
         } else {
             hex::decode(value)
-        }.map_err(|_| ParseError)?;
+        }
+        .map_err(|_| ParseError)?;
         if decoded.len() == Self::SIZE {
             let mut res = Self {
-                addr: [0u8; Self::SIZE]
+                addr: [0u8; Self::SIZE],
             };
             res.addr.copy_from_slice(&decoded);
             Ok(res)

--- a/packages/utils/crates/utils-types/src/primitives.rs
+++ b/packages/utils/crates/utils-types/src/primitives.rs
@@ -309,6 +309,16 @@ pub struct Snapshot {
     pub log_index: U256,
 }
 
+impl Default for Snapshot {
+    fn default() -> Self {
+        Self {
+            block_number: U256::zero(),
+            transaction_index: U256::zero(),
+            log_index: U256::zero(),
+        }
+    }
+}
+
 #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
 impl Snapshot {
     #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen(constructor))]


### PR DESCRIPTION
This PR adds the following changes to the DB related code:

### 1) Removal of the lower-level RwLock (in `DB` backend)
This lock is not necessary, because database is always accessed through the business logic objects.

### 2) TS code now uses only single `Database` instance.
This was made possible by introducing the `core-hopr` crate, which unified the types from `core-packet`, `core-ethereum-db` and `core-ethereum-db-misc` for the TS code

### 3) Deadlock in `initialize_commitment`

The `initialize_commitment` function was taking the `set_commitment` and `get_commitment` closures. The `initialize_commitment` function acquires a write lock to the DB, and the calling the `get_commitment` closure. The `get_commitment` JS closure attempted a read in the DB (from the JS context), which caused a deadlock due to already acquired lock previously.

**Resolution**: The `get_commitment` closure has been removed, because it is never needed by the TS code for anything else than for a channel commitment retrieval. As such, this operation has been moved into the Rust code (under the acquired write lock).

**Take-away**: be careful when DB operations need to be done by JS closures, while at the same time, having the DB lock acquired in the caller context.

### 4) makes `iterate_hash` asynchronous
Since this operation is potentially long-running, it yields at every step (~ 10k iterations).