### PR TITLE
Fix cli command line args parsing

### DIFF
--- a/packages/hoprd/crates/hoprd-misc/src/cli.rs
+++ b/packages/hoprd/crates/hoprd-misc/src/cli.rs
@@ -120,17 +120,19 @@ pub struct CliArgs {
         long,
         env = "HOPRD_ANNOUNCE",
         help = "Run as a Public Relay Node (PRN)",
-        action = ArgAction::SetTrue
+        action = ArgAction::SetTrue,
+        default_value_t = crate::config::NetworkOptions::default().announce
     )]
-    pub announce: Option<bool>,
+    pub announce: bool,
 
     #[arg(
         long,
         env = "HOPRD_API",
         help = format!("Expose the API on {}:{}", DEFAULT_API_HOST, DEFAULT_API_PORT),
         action = ArgAction::SetTrue,
+        default_value_t = crate::config::Api::default().enable
     )]
-    pub api: Option<bool>,
+    pub api: bool,
 
     #[arg(
         long = "apiHost",
@@ -154,9 +156,10 @@ pub struct CliArgs {
         help = "Completely disables the token authentication for the API, overrides any apiToken if set",
         action = ArgAction::SetTrue,
         env = "HOPRD_DISABLE_API_AUTHENTICATION",
-        hide = true
+        hide = true,
+        default_value_t = crate::config::Api::default().is_auth_disabled()
     )]
-    pub disable_api_authentication: Option<bool>,
+    pub disable_api_authentication: bool,
 
     #[arg(
         long = "apiToken",
@@ -172,9 +175,10 @@ pub struct CliArgs {
         long = "healthCheck",
         env = "HOPRD_HEALTH_CHECK",
         help = "Run a health check end point",
-        action = ArgAction::SetTrue
+        action = ArgAction::SetTrue,
+        default_value_t = crate::config::HealthCheck::default().enable
     )]
-    pub health_check: Option<bool>,
+    pub health_check: bool,
 
     #[arg(
         long = "healthCheckHost",
@@ -223,17 +227,19 @@ pub struct CliArgs {
         long = "autoRedeemTickets",
         env = "HOPRD_AUTO_REDEEEM_TICKETS",
         help = "If enabled automatically redeems winning tickets.",
-        action = ArgAction::SetTrue
+        action = ArgAction::SetTrue,
+        default_value_t = crate::config::Strategy::default().auto_redeem_tickets
     )]
-    pub auto_redeem_tickets: Option<bool>,
+    pub auto_redeem_tickets: bool,
 
     #[arg(
         long = "checkUnrealizedBalance",
         env = "HOPRD_CHECK_UNREALIZED_BALANCE",
         help = "Determines if unrealized balance shall be checked first before validating unacknowledged tickets.",
-        action = ArgAction::SetTrue
+        action = ArgAction::SetTrue,
+        default_value_t = crate::config::Chain::default().check_unrealized_balance
     )]
-    pub check_unrealized_balance: Option<bool>,
+    pub check_unrealized_balance: bool,
 
     #[arg(
         long,
@@ -257,18 +263,18 @@ pub struct CliArgs {
         help = "initialize a database if it doesn't already exist",
         action = ArgAction::SetTrue,
         env = "HOPRD_INIT",
-        action = ArgAction::SetTrue
+        default_value_t = crate::config::Db::default().initialize
     )]
-    pub init: Option<bool>,
+    pub init: bool,
 
     #[arg(
         long = "forceInit",
         help = "initialize a database, even if it already exists",
         action = ArgAction::SetTrue,
         env = "HOPRD_FORCE_INIT",
-        action = ArgAction::SetTrue
+        default_value_t = crate::config::Db::default().force_initialize
     )]
-    pub force_init: Option<bool>,
+    pub force_init: bool,
 
     #[arg(
         long = "privateKey",
@@ -284,16 +290,18 @@ pub struct CliArgs {
         env = "HOPRD_ALLOW_LOCAL_NODE_CONNECTIONS",
         action = ArgAction::SetTrue,
         help = "Allow connections to other nodes running on localhost",
+        default_value_t = crate::config::NetworkOptions::default().allow_local_node_connections
     )]
-    pub allow_local_node_connections: Option<bool>,
+    pub allow_local_node_connections: bool,
 
     #[arg(
         long = "allowPrivateNodeConnections",
         env = "HOPRD_ALLOW_PRIVATE_NODE_CONNECTIONS",
         action = ArgAction::SetTrue,
         help = "Allow connections to other nodes running on private addresses",
+        default_value_t = crate::config::NetworkOptions::default().allow_private_node_connections
     )]
-    pub allow_private_node_connections: Option<bool>,
+    pub allow_private_node_connections: bool,
 
     #[arg(
         long = "maxParallelConnections",
@@ -309,17 +317,19 @@ pub struct CliArgs {
         env = "HOPRD_TEST_ANNOUNCE_LOCAL_ADDRESSES",
         help = "For testing local testnets. Announce local addresses",
         action = ArgAction::SetTrue,
+        default_value_t = crate::config::Testing::default().announce_local_addresses
     )]
-    pub test_announce_local_addresses: Option<bool>,
+    pub test_announce_local_addresses: bool,
 
     #[arg(
         long = "testPreferLocalAddresses",
         env = "HOPRD_TEST_PREFER_LOCAL_ADDRESSES",
         action = ArgAction::SetTrue,
         help = "For testing local testnets. Prefer local peers to remote",
-        hide = true
+        hide = true,
+        default_value_t = crate::config::Testing::default().prefer_local_addresses
     )]
-    pub test_prefer_local_addresses: Option<bool>,
+    pub test_prefer_local_addresses: bool,
 
     #[arg(
         long = "testUseWeakCrypto",
@@ -327,43 +337,48 @@ pub struct CliArgs {
         action = ArgAction::SetTrue,
         help = "weaker crypto for faster node startup",
         hide = true,
+        default_value_t = crate::config::Testing::default().use_weak_crypto
     )]
-    pub test_use_weak_crypto: Option<bool>,
+    pub test_use_weak_crypto: bool,
 
     #[arg(
         long = "testNoDirectConnections",
         help = "NAT traversal testing: prevent nodes from establishing direct TCP connections",
         env = "HOPRD_TEST_NO_DIRECT_CONNECTIONS",
         action = ArgAction::SetTrue,
-        hide = true
+        hide = true,
+        default_value_t = crate::config::Testing::default().no_direct_connections
     )]
-    pub test_no_direct_connections: Option<bool>,
+    pub test_no_direct_connections: bool,
 
     #[arg(
         long = "testNoWebRTCUpgrade",
         help = "NAT traversal testing: prevent nodes from establishing direct TCP connections",
         env = "HOPRD_TEST_NO_WEBRTC_UPGRADE",
         action = ArgAction::SetTrue,
-        hide = true
+        hide = true,
+        default_value_t = crate::config::Testing::default().no_webrtc_upgrade
     )]
-    pub test_no_webrtc_upgrade: Option<bool>,
+    pub test_no_webrtc_upgrade: bool,
 
     #[arg(
         long = "noRelay",
         help = "disable NAT relay functionality entirely",
         env = "HOPRD_NO_RELAY",
         action = ArgAction::SetTrue,
+        default_value_t = crate::config::NetworkOptions::default().no_relay
     )]
-    pub no_relay: Option<bool>,
+    pub no_relay: bool,
 
     #[arg(
         long = "testLocalModeStun",
         help = "Transport testing: use full-featured STUN with local addresses",
         env = "HOPRD_TEST_LOCAL_MODE_STUN",
         action = ArgAction::SetTrue,
-        hide = true
+        hide = true,
+        default_value_t = crate::config::Testing::default().local_mode_stun
     )]
-    pub test_local_mode_stun: Option<bool>,
+    pub test_local_mode_stun: bool,
 
     #[arg(
         long = "heartbeatInterval",

--- a/packages/hoprd/crates/hoprd-misc/src/config.rs
+++ b/packages/hoprd/crates/hoprd-misc/src/config.rs
@@ -373,22 +373,14 @@ impl HoprdConfig {
 
         // db
         cfg.db.data = cli_args.data;
-        if let Some(x) = cli_args.init {
-            cfg.db.initialize = x
-        };
-        if let Some(x) = cli_args.force_init {
-            cfg.db.force_initialize = x
-        };
+        cfg.db.initialize = cli_args.init;
+        cfg.db.force_initialize = cli_args.force_init;
 
         // api
-        if let Some(x) = cli_args.api {
-            cfg.api.enable = x
-        };
-        if let Some(x) = cli_args.disable_api_authentication {
-            if x {
-                if &cfg.api.auth != &Auth::None {
-                    cfg.api.auth = Auth::None;
-                }
+        cfg.api.enable = cli_args.api;
+        if cli_args.disable_api_authentication {
+            if &cfg.api.auth != &Auth::None {
+                cfg.api.auth = Auth::None;
             }
         };
         if let Some(x) = cli_args.api_token {
@@ -413,15 +405,9 @@ impl HoprdConfig {
         };
 
         // network options
-        if let Some(x) = cli_args.announce {
-            cfg.network_options.announce = x
-        };
-        if let Some(x) = cli_args.allow_local_node_connections {
-            cfg.network_options.allow_local_node_connections = x
-        };
-        if let Some(x) = cli_args.allow_private_node_connections {
-            cfg.network_options.allow_private_node_connections = x
-        };
+        cfg.network_options.announce = cli_args.announce;
+        cfg.network_options.allow_local_node_connections = cli_args.allow_local_node_connections;
+        cfg.network_options.allow_private_node_connections = cli_args.allow_private_node_connections;
         if let Some(x) = cli_args.max_parallel_connections {
             cfg.network_options.max_parallel_connections = x
         } else if cfg.network_options.announce {
@@ -430,14 +416,10 @@ impl HoprdConfig {
         if let Some(x) = cli_args.network_quality_threshold {
             cfg.network_options.network_quality_threshold = x
         };
-        if let Some(x) = cli_args.no_relay {
-            cfg.network_options.no_relay = x
-        }
+        cfg.network_options.no_relay = cli_args.no_relay;
 
         // healthcheck
-        if let Some(x) = cli_args.health_check {
-            cfg.healthcheck.enable = x
-        };
+        cfg.healthcheck.enable = cli_args.health_check;
         if let Some(x) = cli_args.health_check_host {
             cfg.healthcheck.host = x
         };
@@ -461,40 +443,25 @@ impl HoprdConfig {
         if let Some(x) = cli_args.max_auto_channels {
             cfg.strategy.max_auto_channels = Some(x)
         };
-        if let Some(x) = cli_args.auto_redeem_tickets {
-            cfg.strategy.auto_redeem_tickets = x
-        };
+
+        cfg.strategy.auto_redeem_tickets = cli_args.auto_redeem_tickets;
 
         // chain
         if let Some(x) = cli_args.provider {
             cfg.chain.provider = Some(x)
         };
-        if let Some(x) = cli_args.check_unrealized_balance {
-            cfg.chain.check_unrealized_balance = x
-        };
+        cfg.chain.check_unrealized_balance = cli_args.check_unrealized_balance;
         if let Some(x) = cli_args.on_chain_confirmations {
             cfg.chain.on_chain_confirmations = x
         };
 
         // test
-        if let Some(x) = cli_args.test_announce_local_addresses {
-            cfg.test.announce_local_addresses = x
-        };
-        if let Some(x) = cli_args.test_prefer_local_addresses {
-            cfg.test.prefer_local_addresses = x
-        };
-        if let Some(x) = cli_args.test_local_mode_stun {
-            cfg.test.local_mode_stun = x
-        };
-        if let Some(x) = cli_args.test_no_webrtc_upgrade {
-            cfg.test.no_webrtc_upgrade = x
-        };
-        if let Some(x) = cli_args.test_no_direct_connections {
-            cfg.test.no_direct_connections = x
-        };
-        if let Some(x) = cli_args.test_use_weak_crypto {
-            cfg.test.use_weak_crypto = x
-        };
+        cfg.test.announce_local_addresses = cli_args.test_announce_local_addresses;
+        cfg.test.prefer_local_addresses = cli_args.test_prefer_local_addresses;
+        cfg.test.local_mode_stun = cli_args.test_local_mode_stun;
+        cfg.test.no_webrtc_upgrade = cli_args.test_no_webrtc_upgrade;
+        cfg.test.no_direct_connections = cli_args.test_no_direct_connections;
+        cfg.test.use_weak_crypto = cli_args.test_use_weak_crypto;
 
         if skip_validation {
             Ok(cfg)
@@ -533,8 +500,6 @@ pub mod wasm {
     pub fn fetch_configuration(cli_args: JsValue) -> Result<HoprdConfig, JsValue> {
         let args: crate::cli::CliArgs = serde_wasm_bindgen::from_value(cli_args)?;
         HoprdConfig::from_cli_args(args, false).map_err(|e| wasm_bindgen::JsValue::from(e.to_string()))
-        // let cfg = HoprdConfig::from_cli_args(args, false).map_err(|e| wasm_bindgen::JsValue::from(e.to_string()))?;
-        // ok_or_jserr!(serde_wasm_bindgen::to_value(&cfg))
     }
 }
 

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -29,8 +29,11 @@ import {
   parse_private_key,
   HoprdConfig,
   type Api,
-  type CliArgs
+  type CliArgs,
+  hoprd_misc_initialize_crate
 } from '../lib/hoprd_misc.js'
+hoprd_misc_initialize_crate()
+
 import type { State } from './types.js'
 import setupAPI from './api/index.js'
 import setupHealthcheck from './healthcheck.js'


### PR DESCRIPTION
## What
The cli command args were not passed in properly and the default were overridden with incorrect values, this PR fixes that.
- [x] Fix cli command args passing
- [x] Fix log output and panic output missing from the hoprd index.ts 

Output of `make run-local`:

```sh
Node configuration: {"host":{"ip":"0.0.0.0","port":9091},"identity":{"file":"/Users/teebor/dev/hopr/hoprnet/.identity-local.id","password":"<REDACTED>","private_key":null},"db":{"data":"/Users/teebor/dev/hopr/hoprnet/packages/hoprd/hoprd-db","initialize":true,"force_initialize":false},"api":{"enable":true,"auth":"None","host":{"ip":"127.0.0.1","port":3001}},"strategy":{"name":"passive","max_auto_channels":null,"auto_redeem_tickets":true},"heartbeat":{"interval":60000,"threshold":60000,"variance":2000},"network_options":{"announce":true,"allow_local_node_connections":false,"allow_private_node_connections":false,"max_parallel_connections":50000,"network_quality_threshold":0.5,"no_relay":false},"healthcheck":{"enable":false,"host":"127.0.0.1","port":8080},"network":"anvil-localhost","chain":{"provider":null,"check_unrealized_balance":true,"on_chain_confirmations":8},"test":{"announce_local_addresses":true,"prefer_local_addresses":true,"use_weak_crypto":true,"no_direct_connections":false,"no_webrtc_upgrade":false,"local_mode_stun":false}}
```