### PR TITLE
Fix ticket auto-redeem and check unrealized balance cli arg logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Upgrade to Node v18 as default runtime ([#5184](https://github.com/hoprnet/hoprnet/pull/5184))
 - Use transitive Rust build features and fix various build issues ([#5187](https://github.com/hoprnet/hoprnet/pull/5187))
 - Change `core-ethereum` to operate on Ethereum `Address`es rather than `PublicKey`s ([#5189](https://github.com/hoprnet/hoprnet/pull/5189))
+- Change the ticket auto redeem and check unrealized balance cli arguments ([#5235](https://github.com/hoprnet/hoprnet/pull/5235))
 
 <a name="1.93"></a>
 

--- a/README.md
+++ b/README.md
@@ -26,16 +26,19 @@
   - [Install via Nix package manager](#install-via-nix-package-manager)
 - [Using](#using)
   - [Using Docker](#using-docker)
-  - [Using Docker Compose with extended monitoring](#using-docker-compose-with-extended-hopr-node-monitoring)
+  - [Using Docker Compose with extended HOPR node monitoring](#using-docker-compose-with-extended-hopr-node-monitoring)
 - [Testnet accessibility](#testnet-accessibility)
 - [Migrating between releases](#migrating-between-releases)
 - [Develop](#develop)
+- [Local cluster](#local-cluster)
 - [Test](#test)
   - [Unit testing](#unit-testing)
     - [Test-driven development](#test-driven-development)
   - [Github Actions CI](#github-actions-ci)
   - [End-to-End Testing](#end-to-end-testing)
     - [Running Tests Locally](#running-tests-locally)
+      - [Testing environment](#testing-environment)
+      - [Test execution](#test-execution)
 - [Deploy](#deploy)
   - [Using Google Cloud Platform](#using-google-cloud-platform)
   - [Using Google Cloud Platform and a Default Topology](#using-google-cloud-platform-and-a-default-topology)
@@ -152,10 +155,10 @@ Options:
           Default channel strategy to use after node starts up [env: HOPRD_DEFAULT_STRATEGY=] [default: passive] [possible values: promiscuous, passive, random]
       --maxAutoChannels <MAX_AUTO_CHANNELS>
           Maximum number of channel a strategy can open. If not specified, square root of number of available peers is used. [env: HOPRD_MAX_AUTO_CHANNELS=]
-      --autoRedeemTickets
-          If enabled automatically redeems winning tickets. [env: HOPRD_AUTO_REDEEEM_TICKETS=]
-      --checkUnrealizedBalance
-          Determines if unrealized balance shall be checked first before validating unacknowledged tickets. [env: HOPRD_CHECK_UNREALIZED_BALANCE=]
+      --disableTicketAutoRedeem
+          Disables automatic redeemeing of winning tickets. [env: HOPRD_DISABLE_AUTO_REDEEEM_TICKETS]
+      --disableUnrealizedBalanceCheck
+          Disables checking of unrealized balance before validating unacknowledged tickets. [env: HOPRD_DISABLE_UNREALIZED_BALANCE_CHECK]
       --provider <PROVIDER>
           A custom RPC provider to be used for the node to connect to blockchain [env: HOPRD_PROVIDER=]
       --dryRun

--- a/packages/hoprd/crates/hoprd-misc/src/cli.rs
+++ b/packages/hoprd/crates/hoprd-misc/src/cli.rs
@@ -224,19 +224,19 @@ pub struct CliArgs {
     pub max_auto_channels: Option<u32>, // Make this a string if we want to supply functions instead in the future.
 
     #[arg(
-        long = "autoRedeemTickets",
-        env = "HOPRD_AUTO_REDEEEM_TICKETS",
-        help = "If enabled automatically redeems winning tickets.",
-        action = ArgAction::SetTrue,
+        long = "disableTicketAutoRedeem",
+        env = "HOPRD_DISABLE_AUTO_REDEEEM_TICKETS",
+        help = "Disables automatic redeemeing of winning tickets.",
+        action = ArgAction::SetFalse,
         default_value_t = crate::config::Strategy::default().auto_redeem_tickets
     )]
     pub auto_redeem_tickets: bool,
 
     #[arg(
-        long = "checkUnrealizedBalance",
-        env = "HOPRD_CHECK_UNREALIZED_BALANCE",
-        help = "Determines if unrealized balance shall be checked first before validating unacknowledged tickets.",
-        action = ArgAction::SetTrue,
+        long = "disableUnrealizedBalanceCheck",
+        env = "HOPRD_DISABLE_UNREALIZED_BALANCE_CHECK",
+        help = "Disables checking of unrealized balance before validating unacknowledged tickets.",
+        action = ArgAction::SetFalse,
         default_value_t = crate::config::Chain::default().check_unrealized_balance
     )]
     pub check_unrealized_balance: bool,

--- a/scripts/check-pr.sh
+++ b/scripts/check-pr.sh
@@ -52,6 +52,7 @@ done
 # Check wether the pushed commits to the PR involve building docker images
 function check_push() {
   rm -rf ${results_file}
+  touch ${results_file}
   if [ -z "${base_branch}" ] || [  -z "${head_branch:-}" ]; then
     log "Parameter 'base_branch' and 'head_branch' are required"
     usage


### PR DESCRIPTION
## What
Some boolean command line arguments have a default true value, the clap parsing logic was adjusted and the naming change to reflect the flag's true actions:
- ticket auto redeem
- unrealized balance check

## Test
```shell
➜   make run-local 
env NODE_OPTIONS="--experimental-wasm-modules" NODE_ENV=development DEBUG="hopr*" node \
        packages/hoprd/lib/main.cjs --init --api \
        --password="local" --identity=`pwd`/.identity-local.id \
        --network anvil-localhost --announce \
        --testUseWeakCrypto --testAnnounceLocalAddresses \
        --testPreferLocalAddresses --disableApiAuthentication
```

generates config:

```
"auto_redeem_tickets":true
```

when a flag is added: `        --disableTicketAutoRedeem \`, it generates:

```
"auto_redeem_tickets":false
```