### PR TITLE
Fixing makefile compatibility

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,9 +3,6 @@ name: Build
 
 on:
   pull_request:
-    # branches:
-    #   - master
-    #   - release/*
     types:
       - synchronize
 concurrency:

--- a/Makefile
+++ b/Makefile
@@ -493,14 +493,18 @@ endif
 	PRIVATE_KEY=${ACCOUNT_PRIVKEY} make stake-funds
 	PRIVATE_KEY=${ACCOUNT_PRIVKEY} make self-register-node peer_ids=$(shell eval ./scripts/get-hopr-address.sh "$(api_token)" "$(endpoint)")
 
-ensure-environment-and-network-are-set:
+ensure-environment-and-network-are-set: ensure-network-is-set ensure-environment-is-set
+
+ensure-network-is-set:
 ifeq ($(network),)
 	echo "parameter <network> missing" >&2 && exit 1
 else
-environment_type != jq '.networks."$(network)".environment_type // empty' packages/ethereum/contracts/contracts-addresses.json
-ifeq ($(environment_type),)
-	echo "could not read environment type info from contracts-addresses.json" >&2 && exit 1
+environment-type != jq '.networks."$(network)".environment_type // empty' packages/ethereum/contracts/contracts-addresses.json
 endif
+
+ensure-environment-is-set:
+ifeq ($(environment-type),)
+	echo "could not read environment info from contracts-addresses.json" >&2 && exit 1
 endif
 
 .PHONY: run-docker-dev

--- a/Makefile
+++ b/Makefile
@@ -493,6 +493,7 @@ endif
 	PRIVATE_KEY=${ACCOUNT_PRIVKEY} make stake-funds
 	PRIVATE_KEY=${ACCOUNT_PRIVKEY} make self-register-node peer_ids=$(shell eval ./scripts/get-hopr-address.sh "$(api_token)" "$(endpoint)")
 
+# These targets needs to be splitted in macOs systems
 ensure-environment-and-network-are-set: ensure-network-is-set ensure-environment-is-set
 
 ensure-network-is-set:

--- a/packages/ethereum/contracts/Makefile
+++ b/packages/ethereum/contracts/Makefile
@@ -206,14 +206,18 @@ endif
 	$(forge-script) script/SingleAction.s.sol:SingleActionFromPrivateKeyScript \
 		--broadcast --sig "syncEligibility(string[])" $(peer_ids)
 
-ensure-environment-and-network-are-set:
+ensure-environment-and-network-are-set: ensure-network-is-set ensure-environment-is-set
+
+ensure-network-is-set:
 ifeq ($(network),)
 	echo "parameter <network> missing" >&2 && exit 1
 else
 environment-type != jq '.networks."$(network)".environment_type // empty' contracts-addresses.json
+endif
+
+ensure-environment-is-set:
 ifeq ($(environment-type),)
 	echo "could not read environment info from contracts-addresses.json" >&2 && exit 1
-endif
 endif
 
 ensure-privatekey-is-set:

--- a/scripts/run-local-anvil.sh
+++ b/scripts/run-local-anvil.sh
@@ -111,7 +111,7 @@ fi
 
 if ! lsof -i ":8545" -s TCP:LISTEN; then
   log "Start local anvil chain"
-  anvil "${flags}" > "${log_file}" 2>&1 &
+  anvil ${flags} > "${log_file}" 2>&1 &
   wait_for_regex "${log_file}" "Listening on 0.0.0.0:8545"
   log "Anvil chain started (0.0.0.0:8545)"
 else


### PR DESCRIPTION
In MacOS systems the makefile target `ensure-environment-and-network-are-set` is not working if specified the `environment-type` within the same target.
This PR fixes this compatibility problem and also an issue invoking anvil localhost.