### PR TITLE
Fix makefile typo

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,9 +3,6 @@ name: Build
 
 on:
   pull_request:
-    # branches:
-    #   - master
-    #   - release/*
     types:
       - synchronize
 concurrency:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
     types:
       - synchronize
+      - ready_for_review
 concurrency:
   group: ${{ github.head_ref }}-build
   cancel-in-progress: true

--- a/Makefile
+++ b/Makefile
@@ -493,14 +493,18 @@ endif
 	PRIVATE_KEY=${ACCOUNT_PRIVKEY} make stake-funds
 	PRIVATE_KEY=${ACCOUNT_PRIVKEY} make self-register-node peer_ids=$(shell eval ./scripts/get-hopr-address.sh "$(api_token)" "$(endpoint)")
 
-ensure-environment-and-network-are-set:
+ensure-environment-and-network-are-set: ensure-network-is-set ensure-environment-is-set
+
+ensure-network-is-set:
 ifeq ($(network),)
 	echo "parameter <network> missing" >&2 && exit 1
 else
-environment_type != jq '.networks."$(network)".environment_type // empty' packages/ethereum/contracts/contracts-addresses.json
-ifeq ($(environment_type),)
-	echo "could not read environment type info from contracts-addresses.json" >&2 && exit 1
+environment-type != jq '.networks."$(network)".environment_type // empty' packages/ethereum/contracts/contracts-addresses.json
 endif
+
+ensure-environment-is-set:
+ifeq ($(environment-type),)
+	echo "could not read environment info from contracts-addresses.json" >&2 && exit 1
 endif
 
 .PHONY: run-docker-dev

--- a/Makefile
+++ b/Makefile
@@ -493,6 +493,7 @@ endif
 	PRIVATE_KEY=${ACCOUNT_PRIVKEY} make stake-funds
 	PRIVATE_KEY=${ACCOUNT_PRIVKEY} make self-register-node peer_ids=$(shell eval ./scripts/get-hopr-address.sh "$(api_token)" "$(endpoint)")
 
+# These targets needs to be splitted in macOs systems
 ensure-environment-and-network-are-set: ensure-network-is-set ensure-environment-is-set
 
 ensure-network-is-set:

--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,7 @@ fund-local-all: id_dir=/tmp/
 fund-local-all: id_password=local
 fund-local-all: id_prefix=
 fund-local-all: ## use faucet script to fund all the local identities
-	IDENTITY_PASSWORD="${id_password}" PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
+	ETHERSCAN_API_KEY="" IDENTITY_PASSWORD="${id_password}" PRIVATE_KEY=0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 \
 		hopli faucet \
 		--network anvil-localhost \
 		--identity-prefix "${id_prefix}" \
@@ -500,12 +500,12 @@ ensure-network-is-set:
 ifeq ($(network),)
 	echo "parameter <network> missing" >&2 && exit 1
 else
-environment-type != jq '.networks."$(network)".environment_type // empty' packages/ethereum/contracts/contracts-addresses.json
+environment_type != jq '.networks."$(network)".environment_type // empty' packages/ethereum/contracts/contracts-addresses.json
 endif
 
 ensure-environment-is-set:
-ifeq ($(environment-type),)
-	echo "could not read environment info from contracts-addresses.json" >&2 && exit 1
+ifeq ($(environment_type),)
+	echo "could not read environment info from packages/ethereum/contracts/contracts-addresses.json" >&2 && exit 1
 endif
 
 .PHONY: run-docker-dev

--- a/packages/ethereum/contracts/Makefile
+++ b/packages/ethereum/contracts/Makefile
@@ -206,14 +206,18 @@ endif
 	$(forge-script) script/SingleAction.s.sol:SingleActionFromPrivateKeyScript \
 		--broadcast --sig "syncEligibility(string[])" $(peer_ids)
 
-ensure-environment-and-network-are-set:
+ensure-environment-and-network-are-set: ensure-network-is-set ensure-environment-is-set
+
+ensure-network-is-set:
 ifeq ($(network),)
 	echo "parameter <network> missing" >&2 && exit 1
 else
 environment-type != jq '.networks."$(network)".environment_type // empty' contracts-addresses.json
+endif
+
+ensure-environment-is-set:
 ifeq ($(environment-type),)
 	echo "could not read environment info from contracts-addresses.json" >&2 && exit 1
-endif
 endif
 
 ensure-privatekey-is-set:

--- a/packages/ethereum/contracts/Makefile
+++ b/packages/ethereum/contracts/Makefile
@@ -10,8 +10,7 @@ SHELL := env PATH=$(PATH) $(shell which bash)
 # utility wrapper for forge script to use same options on every invocation
 forge := time forge
 forge-bind = time forge bind
-forge-script = env NETWORK=$(network) FOUNDRY_PROFILE=$(environment-type) time forge script
-
+forge-script = env NETWORK=$(network) FOUNDRY_PROFILE=$(environment-type) ETHERSCAN_API_KEY=$(etherscan_api_key) time forge script
 .PHONY: sc-test
 sc-test:
 	$(forge) test --gas-report
@@ -206,13 +205,23 @@ endif
 	$(forge-script) script/SingleAction.s.sol:SingleActionFromPrivateKeyScript \
 		--broadcast --sig "syncEligibility(string[])" $(peer_ids)
 
-ensure-environment-and-network-are-set: ensure-network-is-set ensure-environment-is-set
+# These targets needs to be splitted in macOs systems
+ensure-environment-and-network-are-set: ensure-network-is-set ensure-environment-is-set ensure-etherscan-api-key-is-set
 
 ensure-network-is-set:
 ifeq ($(network),)
 	echo "parameter <network> missing" >&2 && exit 1
 else
 environment-type != jq '.networks."$(network)".environment_type // empty' contracts-addresses.json
+endif
+
+.PHONY: ensure-etherscan-api-key-is-set
+ensure-etherscan-api-key-is-set:
+ifeq ($(origin ETHERSCAN_API_KEY),undefined)
+# On local testing a dummy key is needed
+	etherscan_api_key=dummyKey
+else
+	etherscan_api_key=${ETHERSCAN_API_KEY}
 endif
 
 ensure-environment-is-set:

--- a/scripts/fixture_local_test_setup.sh
+++ b/scripts/fixture_local_test_setup.sh
@@ -223,7 +223,7 @@ function setup_node() {
       --testUseWeakCrypto \
       --allowLocalNodeConnections \
       --allowPrivateNodeConnections \
-      "${additional_args}" \
+      ${additional_args} \
       > "${log}" 2>&1 &
 }
 

--- a/scripts/run-local-anvil.sh
+++ b/scripts/run-local-anvil.sh
@@ -111,7 +111,7 @@ fi
 
 if ! lsof -i ":8545" -s TCP:LISTEN; then
   log "Start local anvil chain"
-  anvil "${flags}" > "${log_file}" 2>&1 &
+  anvil ${flags} > "${log_file}" 2>&1 &
   wait_for_regex "${log_file}" "Listening on 0.0.0.0:8545"
   log "Anvil chain started (0.0.0.0:8545)"
 else


### PR DESCRIPTION
This PR fixes:
- A makefile typo in the variable `environment_type` 
- Running E2E tests without setting the environment variable `ETHERSCAN_API_KEY`
- Automatic shellcheck errors
- Also start building docker images when the PR changes to `Ready for review`