### PR TITLE
Fixing E2E tests in CI Pipeline

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,6 +10,7 @@ on:
   pull_request:
     types:
       - synchronize
+      - ready_for_review
     paths-ignore:
       - 'docs/**/*'
       - '**/*.md'

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -92,13 +92,13 @@ jobs:
           docker tag ${{ env.DOCKER_REGISTRY }}/hopr-toolchain:${{ env.DOCKER_PR_TAG }} ${{ env.DOCKER_REGISTRY }}/hopr-toolchain:${{ env.DOCKER_STABLE_TAG }}
           docker push ${{ env.DOCKER_REGISTRY }}/hopr-toolchain:${{ env.DOCKER_STABLE_TAG }}
       - name: Docker Tag Hopli
-        if: env.build_hopli
+        if: env.build_toolchain || env.build_hopli
         run: |
           docker pull ${{ env.DOCKER_REGISTRY }}/hopli:${{ env.DOCKER_PR_TAG }}
           docker tag ${{ env.DOCKER_REGISTRY }}/hopli:${{ env.DOCKER_PR_TAG }} ${{ env.DOCKER_REGISTRY }}/hopli:${{ env.DOCKER_STABLE_TAG }}
           docker push ${{ env.DOCKER_REGISTRY }}/hopli:${{ env.DOCKER_STABLE_TAG }}
       - name: Docker Tag Hoprd
-        if: env.build_hoprd
+        if: env.build_toolchain || env.build_hoprd
         run: |
           docker pull ${{ env.DOCKER_REGISTRY }}/hoprd:${{ env.DOCKER_PR_TAG }}
           docker tag ${{ env.DOCKER_REGISTRY }}/hoprd:${{ env.DOCKER_PR_TAG }} ${{ env.DOCKER_REGISTRY }}/hoprd:${{ env.DOCKER_STABLE_TAG }}
@@ -277,9 +277,9 @@ jobs:
         run: |
           images=('hopli' 'hoprd' 'hopr-anvil' 'hopr-pluto' 'hopr-toolchain' 'hoprd')
           for image in "${images[@]}"; do
-            image_tags=$(gcloud artifacts docker images list --include-tags europe-west3-docker.pkg.dev/hoprassociation/docker-images/${image} --format="json" 2> /dev/null | jq -r --arg date "$date"  '.[] | select(.tags | length > 0) | select(.tags | contains("-pr.${{ github.event.pull_request.number }}")).version')
+            image_tags=$(gcloud artifacts docker images list --include-tags europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/docker-images/${image} --format="json" 2> /dev/null | jq -r --arg date "$date"  '.[] | select(.tags | length > 0) | select(.tags | contains("-pr.${{ github.event.pull_request.number }}")).version')
             for image_tag in $image_tags; do
-              gcloud artifacts docker images delete --quiet --delete-tags --async europe-west3-docker.pkg.dev/hoprassociation/docker-images/${image}@${image_tag}
+              gcloud artifacts docker images delete --quiet --delete-tags --async europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/docker-images/${image}@${image_tag}
             done
           done
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -178,7 +178,7 @@ jobs:
           # Prevent the tar command file because the path of the ${test_path}.tgz is being changed while it is being created 
           test_path=/tmp/test-e2e-${{ github.run_id }}-${{ github.run_number }}
           mkdir -p ${test_path}
-          cp /tmp/hopr-smoke-test* ${test_path}
+          cp -r /tmp/hopr-smoke-test* ${test_path}
           cd ${test_path}
           tar -czvf ${test_path}.tgz ${test_path}
         working-directory: "/tmp"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -179,7 +179,7 @@ jobs:
           # Prevent the tar command file because the path of the ${gzip_file} is being changed while it is being created 
           # https://stackoverflow.com/a/37993307
           touch ${gzip_file}
-          tar -czvf --warning=no-file-changed ${gzip_file} hopr-smoke-test*        
+          tar -czvf --exclude=${gzip_file} --warning=no-file-changed ${gzip_file} hopr-smoke-test*        
         working-directory: "/tmp"
 
       - name: Upload test logs

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -175,7 +175,7 @@ jobs:
       - name: Compress test logs
         if: always()
         run: |
-          # Prevent the tar command file because the path of the ${test_path}.tgz is being changed while it is being created 
+          # Copy all the logs to a directory to avoid log file changes and simplify tar command
           test_path=/tmp/test-e2e-${{ github.run_id }}-${{ github.run_number }}
           mkdir -p ${test_path}
           cp -r /tmp/hopr-smoke-test* ${test_path}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -178,7 +178,7 @@ jobs:
           gzip_file=test-e2e-${{ github.run_id }}-${{ github.run_number }}.tgz
           # Prevent the tar command file because the path of the ${gzip_file} is being changed while it is being created 
           # https://stackoverflow.com/a/37993307
-          touch gzip_file
+          touch ${gzip_file}
           tar -czvf --warning=no-file-changed ${gzip_file} hopr-smoke-test*        
         working-directory: "/tmp"
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -170,7 +170,7 @@ jobs:
       - name: Test with pytest
         run: |
           nix develop -c make smoke-test
-        # timeout-minutes: 50
+        timeout-minutes: 60
 
       - name: Compress test logs
         if: always()

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -175,11 +175,12 @@ jobs:
       - name: Compress test logs
         if: always()
         run: |
-          gzip_file=test-e2e-${{ github.run_id }}-${{ github.run_number }}.tgz
-          # Prevent the tar command file because the path of the ${gzip_file} is being changed while it is being created 
-          # https://stackoverflow.com/a/37993307
-          touch ${gzip_file}
-          tar -czvf --exclude=${gzip_file} --warning=no-file-changed ${gzip_file} hopr-smoke-test*        
+          # Prevent the tar command file because the path of the ${test_path}.tgz is being changed while it is being created 
+          test_path=/tmp/test-e2e-${{ github.run_id }}-${{ github.run_number }}
+          mkdir -p ${test_path}
+          cp /tmp/hopr-smoke-test* ${test_path}
+          cd ${test_path}
+          tar -czvf ${test_path}.tgz ${test_path}
         working-directory: "/tmp"
 
       - name: Upload test logs

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -169,7 +169,6 @@ jobs:
 
       - name: Test with pytest
         run: |
-          sleep 1000000000
           nix develop -c make smoke-test
         # timeout-minutes: 50
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -160,16 +160,16 @@ jobs:
       - name: Install dependencies
         run: nix develop -c make -j deps-ci
 
-      - name: Setup Hoprd Runtime
-        run: |
-          sudo ./scripts/toolchain/install-toolchain.sh --runtime-only
+      # - name: Setup Hoprd Runtime
+      #   run: |
+      #     sudo ./scripts/toolchain/install-toolchain.sh --runtime-only
 
       - name: Build application
         run: nix develop -c make -j build
 
       - name: Test with pytest
         run: |
-          sleep 10000000
+          sleep 1000000000
           nix develop -c make smoke-test
         # timeout-minutes: 50
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -13,6 +13,7 @@ on:
   pull_request:
     types:
       - synchronize
+      - ready_for_review
     paths-ignore:
       - '.processes/**/*'
       - 'docs/**/*'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -171,7 +171,15 @@ jobs:
       - name: Compress test logs
         if: always()
         run: |
-          tar -czvf test-e2e-${{ github.run_id }}-${{ github.run_number }}.tgz hopr-smoke-test*
+          sleep 120
+          # Log files are still being written while executing this step
+          set +e 
+          tar -czvf --warning=no-file-changed test-e2e-${{ github.run_id }}-${{ github.run_number }}.tgz hopr-smoke-test*
+          exitcode=$?
+          if [ "$exitcode" != "1" ] && [ "$exitcode" != "0" ]; then
+              exit $exitcode
+          fi
+          set -e          
         working-directory: "/tmp"
 
       - name: Upload test logs

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -165,13 +165,14 @@ jobs:
 
       - name: Test with pytest
         run: |
+          sleep 100000
           nix develop -c make smoke-test
         timeout-minutes: 50
 
       - name: Compress test logs
         if: always()
         run: |
-          sleep 120
+          sleep 120 
           # Log files are still being written while executing this step
           set +e 
           tar -czvf --warning=no-file-changed test-e2e-${{ github.run_id }}-${{ github.run_number }}.tgz hopr-smoke-test*

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -162,7 +162,7 @@ jobs:
 
       - name: Setup Hoprd Runtime
         run: |
-          ./scripts/toolchain/install-toolchain.sh --runtime-only
+          sudo ./scripts/toolchain/install-toolchain.sh --runtime-only
 
       - name: Build application
         run: nix develop -c make -j build

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -160,14 +160,18 @@ jobs:
       - name: Install dependencies
         run: nix develop -c make -j deps-ci
 
+      - name: Setup Hoprd Runtime
+        run: |
+          ./scripts/toolchain/install-toolchain.sh --runtime-only
+
       - name: Build application
         run: nix develop -c make -j build
 
       - name: Test with pytest
         run: |
-          sleep 100000
+          sleep 10000000
           nix develop -c make smoke-test
-        timeout-minutes: 50
+        # timeout-minutes: 50
 
       - name: Compress test logs
         if: always()

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -172,15 +172,11 @@ jobs:
       - name: Compress test logs
         if: always()
         run: |
-          sleep 120 
-          # Log files are still being written while executing this step
-          set +e 
-          tar -czvf --warning=no-file-changed test-e2e-${{ github.run_id }}-${{ github.run_number }}.tgz hopr-smoke-test*
-          exitcode=$?
-          if [ "$exitcode" != "1" ] && [ "$exitcode" != "0" ]; then
-              exit $exitcode
-          fi
-          set -e          
+          gzip_file=test-e2e-${{ github.run_id }}-${{ github.run_number }}.tgz
+          # Prevent the tar command file because the path of the ${gzip_file} is being changed while it is being created 
+          # https://stackoverflow.com/a/37993307
+          touch gzip_file
+          tar -czvf --warning=no-file-changed ${gzip_file} hopr-smoke-test*        
         working-directory: "/tmp"
 
       - name: Upload test logs

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -160,9 +160,9 @@ jobs:
       - name: Install dependencies
         run: nix develop -c make -j deps-ci
 
-      # - name: Setup Hoprd Runtime
-      #   run: |
-      #     sudo ./scripts/toolchain/install-toolchain.sh --runtime-only
+      - name: Setup Hoprd Runtime
+        run: |
+          sudo ./scripts/toolchain/install-toolchain.sh --runtime-only
 
       - name: Build application
         run: nix develop -c make -j build

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -97,9 +97,7 @@
       "type": "python",
       "module": "pytest",
       "justMyCode": true,
-      "args": [
-              "${workspaceFolder}/tests"
-          ],
+      "args": ["${workspaceFolder}/tests"],
       "console": "integratedTerminal",
       "env": {
         "environment_name": "local",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -90,6 +90,21 @@
       "args": ["test"],
       "cwd": "${workspaceFolder}/packages/ethereum",
       "outFiles": ["${workspaceFolder}/packages/ethereum/**/*.{ts,js}"]
+    },
+    {
+      "name": "Run E2E tests",
+      "request": "launch",
+      "type": "python",
+      "module": "pytest",
+      "justMyCode": true,
+      "args": [
+              "${workspaceFolder}/tests/test_integration.py"
+          ],
+      "console": "integratedTerminal",
+      "env": {
+        "environment_name": "local",
+        "ETHERSCAN_API_KEY": "someDummyKey"
+      }
     }
   ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -92,13 +92,13 @@
       "outFiles": ["${workspaceFolder}/packages/ethereum/**/*.{ts,js}"]
     },
     {
-      "name": "Run E2E tests",
+      "name": "Run Tests - E2E",
       "request": "launch",
       "type": "python",
       "module": "pytest",
       "justMyCode": true,
       "args": [
-              "${workspaceFolder}/tests/test_integration.py"
+              "${workspaceFolder}/tests"
           ],
       "console": "integratedTerminal",
       "env": {


### PR DESCRIPTION
- Fixes the merge pipeline by building hoprd and hopli when toolchain is modified
- Creates a VsCode launch to run tests using VsCode
- Triggers Lint and tests on the event of `Ready for review`
- Fixes running [E2E tests in pipeline](https://github.com/hoprnet/hoprnet/actions/runs/5691428536)