### PR TITLE
Cleanup wasm and core object construction

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
   "solidity.compileUsingRemoteVersion": "v0.8.19+commit.7dd6d404",
   "typescript.tsdk": "node_modules/typescript/lib",
   "editor.formatOnSave": false,
-  "git.ignoreLimitWarning": true
+  "git.ignoreLimitWarning": true,
+  "rust-analyzer.showUnlinkedFileNotification": false
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1051,13 +1051,17 @@ dependencies = [
  "console_error_panic_hook",
  "core-ethereum-db",
  "core-ethereum-misc",
+ "core-network",
  "core-p2p",
  "core-packet",
+ "futures",
+ "futures-concurrency",
  "js-sys",
  "utils-log",
  "utils-metrics",
  "utils-misc",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -1138,7 +1142,6 @@ dependencies = [
  "core-network",
  "env_logger",
  "futures",
- "futures-concurrency",
  "futures-lite",
  "getrandom 0.2.10",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,15 +26,21 @@ members = [
 [workspace.dependencies]
 futures = "0.3.28"
 futures-lite = "1.12.0"
+futures-concurrency = "7.3.0"
 libp2p = { git = "https://github.com/hoprnet/rust-libp2p.git", branch = "release/providence" }
 serde = { version = "1.0" }
 thiserror = "1.0"
 wasm-pack = "0.12.0"
 wasm-opt = "0.112.0"
 wasm-bindgen = "0.2.86"
+wasm-bindgen-futures = "0.4.36"
 
+core-ethereum-db = { path = "packages/core-ethereum/crates/core-ethereum-db", default-features = false }
+core-ethereum-misc = { path = "packages/core-ethereum/crates/core-ethereum-misc", default-features = false }
 core-crypto = { path = "packages/core/crates/core-crypto", default-features = false }
 core-network = { path = "packages/core/crates/core-network", default-features = false }
+core-packet = { path = "packages/core/crates/core-packet", default-features = false }
+core-p2p = { path = "packages/core/crates/core-p2p", default-features = false }
 utils-log = { path = "packages/utils/crates/utils-log", default-features = false }
 utils-misc = { path = "packages/utils/crates/utils-misc", default-features = false}
 utils-metrics = { path = "packages/utils/crates/utils-metrics", default-features = false }

--- a/packages/core/crates/core-hopr/Cargo.toml
+++ b/packages/core/crates/core-hopr/Cargo.toml
@@ -12,21 +12,25 @@ crate-type = ["cdylib", "rlib"]
 [features]
 default = ["console_error_panic_hook", "wasm", "prometheus"]
 console_error_panic_hook = ["dep:console_error_panic_hook"]
-wasm = ["dep:wasm-bindgen", "dep:js-sys",
+wasm = ["dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:js-sys",
     "core-ethereum-db/wasm", "core-ethereum-misc/wasm", "core-packet/wasm", "core-p2p/wasm",
     "utils-log/wasm", "utils-misc/wasm", "utils-metrics?/wasm"
 ]
 prometheus = ["dep:utils-metrics", "core-packet/prometheus"]
 
 [dependencies]
+futures = { workspace = true }
+futures-concurrency = "7.3.0"
 console_error_panic_hook = { version = "0.1.7", optional = true }
 js-sys = { version = "0.3.63", optional = true }
 wasm-bindgen = { workspace = true, optional = true }
+wasm-bindgen-futures = { workspace = true, optional = true }
 
-core-ethereum-db = { path = "../../../core-ethereum/crates/core-ethereum-db", default-features = false }
-core-ethereum-misc = { path = "../../../core-ethereum/crates/core-ethereum-misc", default-features = false }
-core-packet = { path = "../core-packet", default-features = false }
-core-p2p = { path = "../core-p2p", default-features = false }
+core-ethereum-db = { workspace = true }
+core-ethereum-misc = { workspace = true }
+core-network = { workspace = true }
+core-packet = { workspace = true }
+core-p2p = { workspace = true }
 utils-log = { workspace = true }
 utils-misc = { workspace = true }
 utils-metrics = { workspace = true, optional = true }

--- a/packages/core/crates/core-hopr/src/adaptors/heartbeat.rs
+++ b/packages/core/crates/core-hopr/src/adaptors/heartbeat.rs
@@ -1,0 +1,48 @@
+use core_network::{PeerId, heartbeat::HeartbeatExternalApi};
+use utils_log::error;
+
+
+#[cfg(feature = "wasm")]
+pub(crate) mod wasm {
+    use super::*;
+    use std::str::FromStr;
+    use wasm_bindgen::prelude::*;
+
+    #[wasm_bindgen]
+    pub struct WasmHeartbeatApi {
+        get_peers: js_sys::Function,
+    }
+
+    #[wasm_bindgen]
+    impl WasmHeartbeatApi {
+        pub(crate) fn new(get_peers: js_sys::Function) -> Self {
+            Self { get_peers }
+        }
+    }
+
+    impl HeartbeatExternalApi for WasmHeartbeatApi {
+        fn get_peers(&self, from_timestamp: u64) -> Vec<PeerId> {
+            let this = JsValue::null();
+            let timestamp = JsValue::from(from_timestamp);
+
+            return match self.get_peers.call1(&this, &timestamp) {
+                Ok(v) => {
+                    js_sys::Array::from(&v)
+                        .to_vec()
+                        .into_iter()
+                        .filter_map(|v| PeerId::from_str(String::from(js_sys::JsString::from(v)).as_str()).ok())
+                        .collect()
+                }
+                Err(err) => {
+                    error!(
+                        "Failed to perform on peer offline operation with: {}",
+                        err.as_string()
+                            .unwrap_or_else(|| { "Unknown error occurred on fetching the peers to ping".to_owned() })
+                            .as_str()
+                    );
+                    Vec::new()
+                }
+            };
+        }
+    }
+}

--- a/packages/core/crates/core-hopr/src/adaptors/mod.rs
+++ b/packages/core/crates/core-hopr/src/adaptors/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod heartbeat;
+pub(crate) mod ping;

--- a/packages/core/crates/core-hopr/src/adaptors/ping.rs
+++ b/packages/core/crates/core-hopr/src/adaptors/ping.rs
@@ -1,0 +1,38 @@
+use core_network::{PeerId, ping::PingExternalAPI, types::Result};
+use utils_log::error;
+
+#[cfg(feature = "wasm")]
+pub mod wasm {
+    use super::*;
+    use wasm_bindgen::prelude::*;
+
+    #[wasm_bindgen]
+    #[derive(Debug, Clone)]
+    pub struct WasmPingApi {
+        on_finished_ping_cb: js_sys::Function,
+    }
+
+    impl PingExternalAPI for WasmPingApi {
+        fn on_finished_ping(&self, peer: &PeerId, result: Result) {
+            let this = JsValue::null();
+            let peer = JsValue::from(peer.to_base58());
+            let res = {
+                if let Ok(v) = result {
+                    JsValue::from(v as f64)
+                } else {
+                    JsValue::undefined()
+                }
+            };
+
+            if let Err(err) = self.on_finished_ping_cb.call2(&this, &peer, &res) {
+                error!(
+                    "Failed to perform on peer offline operation with: {}",
+                    err.as_string()
+                        .unwrap_or_else(|| { "Unspecified error occurred on registering the ping result".to_owned() })
+                        .as_str()
+                )
+            };
+        }
+    }
+
+}

--- a/packages/core/crates/core-hopr/src/helpers.rs
+++ b/packages/core/crates/core-hopr/src/helpers.rs
@@ -1,0 +1,11 @@
+use futures::stream::FuturesUnordered;
+
+/// Add multiple futures into a FuturesUnordered obejct to setup concurrent execution of futures
+pub(super) fn to_futures_unordered<F>(mut fs: Vec<F>) -> FuturesUnordered<F> {
+    let futures: FuturesUnordered<F> = FuturesUnordered::new();
+    for f in fs.drain(..) {
+        futures.push(f);
+    }
+
+    futures
+}

--- a/packages/core/crates/core-hopr/src/lib.rs
+++ b/packages/core/crates/core-hopr/src/lib.rs
@@ -1,6 +1,128 @@
-pub async fn start_core_application() {
-    let mut swarm = core_p2p::build_p2p_network(&core_p2p::identity::PeerId::random());
-    ()
+mod adaptors;
+mod helpers;
+mod p2p;
+
+use std::str::FromStr;
+
+use futures::{StreamExt, FutureExt, future::BoxFuture};
+
+use core_network::{
+    PeerId,
+    network::Network,
+    heartbeat::{Heartbeat, HeartbeatConfig},
+    messaging::ControlMessage,
+    ping::{Ping, PingConfig}
+};
+use core_p2p::libp2p_identity;
+use utils_log::error;
+
+use crate::p2p::api;
+
+
+#[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
+pub struct HoprTools {
+    ping: Ping
+}
+
+#[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
+impl HoprTools {
+    // pub async fn ping()
+    pub fn new(ping: Ping) -> Self {
+        Self { ping }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum HoprLoopComponents {
+    Swarm,
+    Heartbeat,
+}
+
+impl std::fmt::Display for HoprLoopComponents {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HoprLoopComponents::Swarm => write!(f, "libp2p component responsible for the handling of the p2p communication"),
+            HoprLoopComponents::Heartbeat => write!(f, "heartbeat component responsible for maintaining the network quality measurements"),
+        }
+    }
+}
+
+/// The main core loop containing all of the individual core components running indefinitely
+/// or until the first error/panic.
+/// 
+/// # Arguments
+/// me: Placeholder for an object that can transform to the libp2p_identity::Keypair
+// #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
+pub async fn build_components(me: String,
+    hb_cfg: HeartbeatConfig, hb_api: adaptors::heartbeat::wasm::WasmHeartbeatApi,
+    ping_cfg: PingConfig, ping_api: adaptors::ping::wasm::WasmPingApi
+) -> (HoprTools, futures::future::BoxFuture<'static, ()>) {
+    let (ping_tx, ping_rx) = futures::channel::mpsc::unbounded::<(PeerId, ControlMessage)>();
+    let (pong_tx, pong_rx) = futures::channel::mpsc::unbounded::<(PeerId, std::result::Result<ControlMessage, ()>)>();
+    
+    // manual ping explicitly called by the API
+    let ping = Ping::new(ping_cfg.clone(), ping_tx, pong_rx, Box::new(ping_api.clone()));
+
+    let main_loop = async move {
+        let (hb_ping_tx, hb_ping_rx) = futures::channel::mpsc::unbounded::<(PeerId, ControlMessage)>();
+        let (hb_pong_tx, hb_pong_rx) = futures::channel::mpsc::unbounded::<(PeerId, std::result::Result<ControlMessage, ()>)>();
+    
+        let ready_loops: Vec<std::pin::Pin<Box<dyn futures::Future<Output = HoprLoopComponents>>>> = vec![
+            // heartbeat mechanism
+            Box::pin(async move {
+                let hb_pinger = Ping::new(ping_cfg, hb_ping_tx, hb_pong_rx, Box::new(ping_api));
+                Heartbeat::<Ping, adaptors::heartbeat::wasm::WasmHeartbeatApi>::new(hb_cfg, hb_pinger, hb_api)
+                    .heartbeat_loop()
+                    .map(|_| HoprLoopComponents::Heartbeat).await
+                }
+            ),
+            // TODO: this needs to be passed from above, packet key
+            Box::pin(p2p::p2p_loop(libp2p_identity::Keypair::generate_ed25519(),
+                api::HeartbeatRequester::new(hb_ping_rx), api::HeartbeatResponder::new(hb_pong_tx),
+                api::ManualPingRequester::new(ping_rx), api::HeartbeatResponder::new(pong_tx)
+            ).map(|_| HoprLoopComponents::Swarm))
+        ];
+
+        let mut futs = helpers::to_futures_unordered(ready_loops);
+        while let Some(process) = futs.next().await {
+            error!("CRITICAL: the core system loop unexpectadly stopped: '{}'", process);
+            unreachable!("Futures inside the main loop should never terminate, but run in the background");
+        };
+    };
+
+    // TODO: once main_loop is Send, it can be used
+    // (HoprTools::new(ping), Box::pin(main_loop))
+    (HoprTools::new(ping), Box::pin(async {}))
+}
+
+#[cfg(feature = "wasm")]
+pub mod wasm_impl {
+    use super::*;
+    use std::str::FromStr;
+    use wasm_bindgen::prelude::*;
+    
+    use core_network::ping::Pinging;
+
+    #[wasm_bindgen]
+    impl HoprTools {
+        /// Ping the peers represented as a Vec<JsString> values that are converted into usable
+        /// PeerIds.
+        ///
+        /// # Arguments
+        /// * `peers` - Vector of String representations of the PeerIds to be pinged.
+        #[wasm_bindgen]
+        pub async fn ping(&mut self, mut peers: Vec<js_sys::JsString>) {
+            let converted = peers
+                .drain(..)
+                .filter_map(|x| {
+                    let x: String = x.into();
+                    core_network::PeerId::from_str(&x).ok()
+                })
+                .collect::<Vec<_>>();
+
+            self.ping.ping(converted).await;
+        }
+    }
 }
 
 #[cfg(feature = "wasm")]

--- a/packages/core/crates/core-hopr/src/p2p.rs
+++ b/packages/core/crates/core-hopr/src/p2p.rs
@@ -1,3 +1,129 @@
-pub fn start_libp2p_network() -> Result<bool, String> {
-    Ok(true)
+use futures::{select, StreamExt};
+use futures_concurrency::stream::Merge;
+
+pub use core_p2p::{libp2p_identity, api};
+use core_p2p::{
+    HoprSwarm, HoprNetworkBehaviorEvent,
+    Ping, Pong,
+    libp2p_request_response, libp2p_swarm::SwarmEvent
+};
+use utils_log::{debug, info, error};
+
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Inputs {
+    Heartbeat(api::HeartbeatChallenge),
+    ManualPing(api::ManualPingChallenge),
+    // Message(String),                 // TODO: This should hold the `Packet` object
+    // Acknowledgement(String),         // TODO: This should hold the `Acknowledgment` object
+}
+
+impl From<api::HeartbeatChallenge> for Inputs {
+    fn from(value: api::HeartbeatChallenge) -> Self {
+        Self::Heartbeat(value)
+    }
+}
+
+impl From<api::ManualPingChallenge> for Inputs {
+    fn from(value: api::ManualPingChallenge) -> Self {
+        Self::ManualPing(value)
+    }
+}
+
+
+/// Main p2p loop that will instantiate a new libp2p::Swarm instance and setup listeining and reacting pipelines
+/// running in a neverending loop future.
+/// 
+/// This future can only be resolved by an error or a panic.
+pub(crate) async fn p2p_loop(me: libp2p_identity::Keypair,
+    heartbeat_requests: api::HeartbeatRequester,
+    heartbeat_responds: api::HeartbeatResponder,
+    manual_ping_requests: api::ManualPingRequester,
+    manual_ping_responds: api::HeartbeatResponder)
+{
+    let mut swarm = core_p2p::build_p2p_network(me);
+    let mut heartbeat_responds = heartbeat_responds;
+    let mut manual_ping_responds = manual_ping_responds;
+    
+    let mut active_manual_pings: std::collections::HashSet<libp2p_request_response::RequestId> = std::collections::HashSet::new();
+    
+    let mut inputs = (
+        heartbeat_requests.map(Inputs::Heartbeat),
+        manual_ping_requests.map(Inputs::ManualPing)
+    ).merge().fuse();
+    
+    loop {
+        select! {
+            input = inputs.select_next_some() => match input {
+                Inputs::Heartbeat(api::HeartbeatChallenge(peer, challenge)) => {
+                    swarm.behaviour_mut().heartbeat.send_request(&peer, Ping(challenge));
+                },
+                Inputs::ManualPing(api::ManualPingChallenge(peer, challenge)) => {
+                    let req_id = swarm.behaviour_mut().heartbeat.send_request(&peer, Ping(challenge));
+                    active_manual_pings.insert(req_id);
+                }
+            },
+            event = swarm.select_next_some() => match event {
+                SwarmEvent::Behaviour(HoprNetworkBehaviorEvent::Heartbeat(libp2p_request_response::Event::<Ping,Pong>::Message {
+                    peer,
+                    message:
+                    libp2p_request_response::Message::<Ping,Pong>::Request {
+                        request_id, request, channel
+                    },
+                })) => {
+                    info!("Received a heartbeat Ping request {} from {}", request_id, peer);
+                    let challenge_response = api::HeartbeatResponder::generate_challenge_response(&request.0);
+                    match swarm.behaviour_mut().heartbeat.send_response(channel, Pong(challenge_response)) {
+                        Ok(_) => {},
+                        Err(_) => {
+                            error!("An error occured during the ping response, channel is either closed or timed out.");
+                        }    
+                    };
+                },
+                SwarmEvent::Behaviour(HoprNetworkBehaviorEvent::Heartbeat(libp2p_request_response::Event::<Ping,Pong>::Message {
+                    peer,
+                    message:
+                    libp2p_request_response::Message::<Ping,Pong>::Response {
+                        request_id, response
+                    },
+                })) => {
+                    info!("Heartbeat protocol: Received a Pong response for request {} from {}", request_id, peer);
+                    if let Some(_) = active_manual_pings.take(&request_id) {
+                        debug!("Processing manual ping response from peer {}", peer);
+                        match manual_ping_responds.record_pong((peer, Ok(response.0))).await {
+                            Ok(_) => {},
+                            Err(e) => {
+                                error!("Manual ping mechanism could not be updated with pong messages: {}", e);
+                            }
+                        }
+                    } else {
+                        match heartbeat_responds.record_pong((peer, Ok(response.0))).await {
+                            Ok(_) => {},
+                            Err(e) => {
+                                error!("Heartbeat mechanism could not be updated with pong messages: {}", e);
+                            }
+                        }
+                    }
+                },
+                SwarmEvent::Behaviour(HoprNetworkBehaviorEvent::Heartbeat(libp2p_request_response::Event::<Ping,Pong>::OutboundFailure {
+                    peer, request_id, error,
+                })) => {
+                    info!("Heartbeat protocol: Failed to send a Ping message {} to {} with an error: {}", request_id, peer, error);
+                    match heartbeat_responds.record_pong((peer, Err(()))).await {
+                        Ok(_) => {},
+                        Err(e) => {
+                            error!("Heartbeat mechanism could not be updated with pong messages: {}", e);
+                        }
+                    }
+                },
+                SwarmEvent::Behaviour(HoprNetworkBehaviorEvent::Heartbeat(libp2p_request_response::Event::<Ping,Pong>::InboundFailure {..}))
+                | SwarmEvent::Behaviour(HoprNetworkBehaviorEvent::Heartbeat(libp2p_request_response::Event::<Ping,Pong>::ResponseSent {..})) => {
+                    // debug!("Discarded messages not relevant for the protocol!");
+                },
+                _ => {
+                    todo!("Not relevant for protocol implementation, connection items!");
+                }
+            }
+        }
+    };
 }

--- a/packages/core/crates/core-network/src/lib.rs
+++ b/packages/core/crates/core-network/src/lib.rs
@@ -3,7 +3,8 @@ pub mod heartbeat;
 pub mod messaging;
 pub mod network;
 pub mod ping;
-pub(crate) mod types;
+pub mod types;
+pub use libp2p_identity::PeerId;
 
 #[allow(dead_code)]
 #[cfg(feature = "wasm")]

--- a/packages/core/crates/core-network/src/network.rs
+++ b/packages/core/crates/core-network/src/network.rs
@@ -152,7 +152,7 @@ impl PeerStatus {
 impl std::fmt::Display for PeerStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         write!(f, "Entry: [id={}, origin={}, last seen on={}, quality={}, heartbeats sent={}, heartbeats succeeded={}, backoff={}]",
-               self.id, self.origin, self.last_seen, self.quality, self.heartbeats_sent, self.heartbeats_succeeded, self.backoff)
+            self.id, self.origin, self.last_seen, self.quality, self.heartbeats_sent, self.heartbeats_succeeded, self.backoff)
     }
 }
 

--- a/packages/core/crates/core-p2p/Cargo.toml
+++ b/packages/core/crates/core-p2p/Cargo.toml
@@ -38,7 +38,6 @@ wasm-bindgen-futures = { version = "0.4.36", optional = true }
 core-network = { workspace = true }
 utils-log = { workspace = true }
 utils-misc = { workspace = true }
-futures-concurrency = "7.3.0"
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }

--- a/packages/core/crates/core-p2p/src/lib.rs
+++ b/packages/core/crates/core-p2p/src/lib.rs
@@ -1,16 +1,15 @@
 pub mod api;
 pub mod errors;
 
-use futures::{select, StreamExt};
 use libp2p::StreamProtocol;
 
 pub use libp2p::identity;
 
-use libp2p::identity as libp2p_identity;
+pub use libp2p::identity as libp2p_identity;
+pub use libp2p::swarm as libp2p_swarm;
+pub use libp2p::request_response as libp2p_request_response;
 use libp2p::core as libp2p_core;
-use libp2p::swarm as libp2p_swarm;
 use libp2p::noise as libp2p_noise;
-use libp2p::request_response as libp2p_request_response;
 
 use libp2p_identity::PeerId;
 use libp2p_core::{upgrade, Transport};
@@ -19,14 +18,11 @@ use libp2p_swarm::{NetworkBehaviour, SwarmBuilder, SwarmEvent};
 use serde::{Serialize, Deserialize};
 
 use core_network::messaging::ControlMessage;
-use utils_log::{debug, info, error};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Ping(ControlMessage);
+pub struct Ping(pub ControlMessage);
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Pong(ControlMessage);
-
-use futures_concurrency::stream::Merge;
+pub struct Pong(pub ControlMessage);
 
 pub const HOPR_HEARTBEAT_PROTOCOL_V_0_1_0: &str = "/hopr/heartbeat/0.1.0";
 pub const HOPR_MESSAGE_PROTOCOL_V_0_1_0: &str = "/hopr/msg/0.1.0";
@@ -40,7 +36,7 @@ const HOPR_HEARTBEAT_REQUEST_TIMEOUT_SECS: u64 = 30;
 #[behaviour(to_swarm = "HoprNetworkBehaviorEvent")]
 pub struct HoprNetworkBehavior {
     // TODO: consider including regular ipfs/ping/1.0.0 for socket keep alive
-    heartbeat: libp2p_request_response::cbor::Behaviour<Ping, Pong>,
+    pub heartbeat: libp2p_request_response::cbor::Behaviour<Ping, Pong>,
     keep_alive: libp2p_swarm::keep_alive::Behaviour     // run the business logic loop indefinitely
 }
 
@@ -81,134 +77,20 @@ impl Default for HoprNetworkBehavior {
     }
 }
 
-pub fn build_p2p_network(me: &PeerId) -> libp2p_swarm::Swarm<HoprNetworkBehavior> {
-    // TODO: this needs to be passed from above, packet key
-    let id_keys = libp2p_identity::Keypair::generate_ed25519();
-
+pub fn build_p2p_network(me: libp2p_identity::Keypair) -> libp2p_swarm::Swarm<HoprNetworkBehavior> {
     let transport = libp2p_wasm_ext::ExtTransport::new(libp2p_wasm_ext::ffi::tcp_transport())
         .upgrade(upgrade::Version::V1)
-        .authenticate(libp2p_noise::Config::new(&id_keys).expect("signing libp2p-noise static keypair"))
+        .authenticate(libp2p_noise::Config::new(&me).expect("signing libp2p-noise static keypair"))
         .multiplex(libp2p_mplex::MplexConfig::default())
         .timeout(std::time::Duration::from_secs(20))
         .boxed();
 
     let behavior = HoprNetworkBehavior::default();
 
-    SwarmBuilder::with_wasm_executor(transport, behavior, me.clone()).build()
+    SwarmBuilder::with_wasm_executor(transport, behavior, PeerId::from(me.public())).build()
 }
 
-#[derive(Debug, Clone, PartialEq)]
-pub enum Inputs {
-    Heartbeat(api::HeartbeatChallenge),
-    ManualPing(api::ManualPingChallenge),
-    MixerMessage(String),       // TODO: This should hold the `Packet` object
-}
-
-impl From<api::HeartbeatChallenge> for Inputs {
-    fn from(value: api::HeartbeatChallenge) -> Self {
-        Self::Heartbeat(value)
-    }
-}
-
-impl From<api::ManualPingChallenge> for Inputs {
-    fn from(value: api::ManualPingChallenge) -> Self {
-        Self::ManualPing(value)
-    }
-}
-
-
-pub async fn build_p2p_main_loop(swarm: libp2p_swarm::Swarm<HoprNetworkBehavior>,
-    heartbeat_requests: api::HeartbeatRequester, heartbeat_responds: api::HeartbeatResponder,
-    manual_ping_requests: api::ManualPingRequester, manual_ping_responds: api::HeartbeatResponder)
-{
-    let mut swarm = swarm;
-    let mut heartbeat_responds = heartbeat_responds;
-    let mut manual_ping_responds = manual_ping_responds;
-
-    let mut active_manual_pings: std::collections::HashSet<libp2p_request_response::RequestId> = std::collections::HashSet::new();
-
-    // TODO: return this loop
-    let a = async move {
-        let mut inputs = (
-            heartbeat_requests.map(Inputs::Heartbeat),
-            manual_ping_requests.map(Inputs::ManualPing)).merge().fuse();
-        loop {
-            select! {
-                input = inputs.select_next_some() => match input {
-                    Inputs::Heartbeat(api::HeartbeatChallenge(peer, challenge)) => {
-                        swarm.behaviour_mut().heartbeat.send_request(&peer, Ping(challenge));
-                    },
-                    Inputs::ManualPing(api::ManualPingChallenge(peer, challenge)) => {
-                        let req_id = swarm.behaviour_mut().heartbeat.send_request(&peer, Ping(challenge));
-                        active_manual_pings.insert(req_id);
-                    }
-                    _ => {}
-                },
-                event = swarm.select_next_some() => match event {
-                    SwarmEvent::Behaviour(HoprNetworkBehaviorEvent::Heartbeat(libp2p_request_response::Event::<Ping,Pong>::Message {
-                        peer,
-                        message:
-                            libp2p_request_response::Message::<Ping,Pong>::Request {
-                                request_id, request, channel
-                            },
-                    })) => {
-                        info!("Received a heartbeat Ping request {} from {}", request_id, peer);
-                        let challenge_response = api::HeartbeatResponder::generate_challenge_response(&request.0);
-                        match swarm.behaviour_mut().heartbeat.send_response(channel, Pong(challenge_response)) {
-                            Ok(_) => {},
-                            Err(_) => {
-                                error!("An error occured during the ping response, channel is either closed or timed out.");
-                            }    
-                        };
-                    },
-                    SwarmEvent::Behaviour(HoprNetworkBehaviorEvent::Heartbeat(libp2p_request_response::Event::<Ping,Pong>::Message {
-                        peer,
-                        message:
-                            libp2p_request_response::Message::<Ping,Pong>::Response {
-                                request_id, response
-                            },
-                    })) => {
-                        info!("Heartbeat protocol: Received a Pong response for request {} from {}", request_id, peer);
-                        if let Some(_) = active_manual_pings.take(&request_id) {
-                            debug!("Processing manual ping response from peer {}", peer);
-                            match manual_ping_responds.record_pong((peer, Ok(response.0))).await {
-                                Ok(_) => {},
-                                Err(e) => {
-                                    error!("Manual ping mechanism could not be updated with pong messages: {}", e);
-                                }
-                            }
-                        } else {
-                            match heartbeat_responds.record_pong((peer, Ok(response.0))).await {
-                                Ok(_) => {},
-                                Err(e) => {
-                                    error!("Heartbeat mechanism could not be updated with pong messages: {}", e);
-                                }
-                            }
-                        }
-                    },
-                    SwarmEvent::Behaviour(HoprNetworkBehaviorEvent::Heartbeat(libp2p_request_response::Event::<Ping,Pong>::OutboundFailure {
-                        peer, request_id, error,
-                    })) => {
-                        info!("Heartbeat protocol: Failed to send a Ping message {} to {} with an error: {}", request_id, peer, error);
-                        match heartbeat_responds.record_pong((peer, Err(()))).await {
-                            Ok(_) => {},
-                            Err(e) => {
-                                error!("Heartbeat mechanism could not be updated with pong messages: {}", e);
-                            }
-                        }
-                    },
-                    SwarmEvent::Behaviour(HoprNetworkBehaviorEvent::Heartbeat(libp2p_request_response::Event::<Ping,Pong>::InboundFailure {..}))
-                    | SwarmEvent::Behaviour(HoprNetworkBehaviorEvent::Heartbeat(libp2p_request_response::Event::<Ping,Pong>::ResponseSent {..})) => {
-                        // debug!("Discarded messages not relevant for the protocol!");
-                    },
-                    _ => {
-                        todo!("Not relevant for protocol implementation, connection items!");
-                    }
-                }
-            }
-        }
-    };
-}
+pub type HoprSwarm = libp2p_swarm::Swarm<HoprNetworkBehavior>;
 
 #[cfg(feature = "wasm")]
 pub mod wasm {


### PR DESCRIPTION
## What
The project at this point is unbuildable due to libp2p changes. Much of the original WASM border is now obsolete and needs to be shifted further away from the core. This results in core-hopr objects construction in a single package, where the WASM inputs are tightly controlled.

- [x] Migrate object creation into the core-hopr package
- [x] Create adaptors for object that require the functionality intreraction with WASM
- [ ] Put the constructed objects in their place in the TS index.ts for the core startup procedure