### PR TITLE
sc: Add function to check node registration

### DIFF
--- a/packages/ethereum/contracts/src/NetworkRegistry.sol
+++ b/packages/ethereum/contracts/src/NetworkRegistry.sol
@@ -263,10 +263,25 @@ contract HoprNetworkRegistry is AccessControlEnumerable {
     }
 
     /**
+     * @dev Returns if a hopr address is registered by a given account.
+     * @param nodeAddress hopr node address
+     * @param account account address
+     */
+    function isNodeRegisteredByAccount(address nodeAddress, address account) public view returns (bool) {
+        if (nodeAddress == address(0) || account == address(0)) {
+            return false;
+        }
+        return account == nodeRegisterdToAccount[nodeAddress];
+    }
+
+    /**
      * @dev Returns if a hopr address is registered and its associated account is eligible or not.
      * @param nodeAddress hopr node address
      */
     function isNodeRegisteredAndEligible(address nodeAddress) public view returns (bool) {
+        if (nodeAddress == address(0)) {
+            return false;
+        }
         // check if peer id is registered
         address registeredAccount = nodeRegisterdToAccount[nodeAddress];
         if (registeredAccount == address(0)) {

--- a/packages/ethereum/contracts/test/NetworkRegistry.t.sol
+++ b/packages/ethereum/contracts/test/NetworkRegistry.t.sol
@@ -230,6 +230,7 @@ contract HoprNetworkRegistryTest is Test {
         // registered nodes are eligible
         for (uint256 j = 0; j < nodeAddresses.length; j++) {
             assertTrue(hoprNetworkRegistry.isNodeRegisteredAndEligible(nodeAddresses[j]));
+            assertTrue(hoprNetworkRegistry.isNodeRegisteredByAccount(nodeAddresses[j], stakingAccount));
         }
         vm.clearMockedCalls();
     }
@@ -311,6 +312,7 @@ contract HoprNetworkRegistryTest is Test {
         // registerd nodes are beyond their eligibility
         for (uint256 j = 0; j < nodeAddresses.length; j++) {
             assertFalse(hoprNetworkRegistry.isNodeRegisteredAndEligible(nodeAddresses[j]));
+            assertTrue(hoprNetworkRegistry.isNodeRegisteredByAccount(nodeAddresses[j], stakingAccounts[j]));
         }
         vm.clearMockedCalls();
     }


### PR DESCRIPTION
Refs #5249 

Added separate function `isNodeRegisteredByAccount` to `NodeRegistry` for easy cross-check.