### PR TITLE
Create the peer discovery network behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,6 +1048,8 @@ checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 name = "core-hopr"
 version = "0.1.0"
 dependencies = [
+ "async-lock",
+ "async-trait",
  "console_error_panic_hook",
  "core-ethereum-db",
  "core-ethereum-misc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,8 @@ members = [
 ]
 
 [workspace.dependencies]
+async-lock = "2.7.0"
+async-trait = "0.1"
 futures = "0.3.28"
 futures-lite = "1.12.0"
 futures-concurrency = "7.3.0"

--- a/packages/core/crates/core-hopr/Cargo.toml
+++ b/packages/core/crates/core-hopr/Cargo.toml
@@ -19,6 +19,8 @@ wasm = ["dep:wasm-bindgen", "dep:wasm-bindgen-futures", "dep:js-sys",
 prometheus = ["dep:utils-metrics", "core-packet/prometheus"]
 
 [dependencies]
+async-trait = { workspace = true } 
+async-lock = { workspace = true }
 futures = { workspace = true }
 futures-concurrency = "7.3.0"
 console_error_panic_hook = { version = "0.1.7", optional = true }

--- a/packages/core/crates/core-hopr/src/adaptors/mod.rs
+++ b/packages/core/crates/core-hopr/src/adaptors/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod heartbeat;
+pub(crate) mod network;
 pub(crate) mod ping;

--- a/packages/core/crates/core-hopr/src/adaptors/network.rs
+++ b/packages/core/crates/core-hopr/src/adaptors/network.rs
@@ -27,6 +27,7 @@ pub(crate) mod wasm {
     use wasm_bindgen::prelude::*;
 
     #[wasm_bindgen]
+    #[derive(Clone)]
     pub struct WasmNetwork {
         network: Arc<RwLock<Network<ExternalNetworkInteractions>>>,
     }

--- a/packages/core/crates/core-hopr/src/adaptors/network.rs
+++ b/packages/core/crates/core-hopr/src/adaptors/network.rs
@@ -2,39 +2,51 @@ use std::sync::Arc;
 
 use async_lock::RwLock;
 
-use core_network::network::Network;
+use core_network::{
+    PeerId,
+    network::{Network, NetworkExternalActions, PeerStatus}
+};
+use utils_log::{warn};
+
+pub struct ExternalNetworkInteractions {}
+
+impl NetworkExternalActions for ExternalNetworkInteractions {
+    fn is_public(&self, _: &PeerId) -> bool {
+        // NOTE: In the Providence release all nodes are public
+        true
+    }
+}
+
 
 #[cfg(feature = "wasm")]
 pub(crate) mod wasm {
+    use std::str::FromStr;
+
     use super::*;
+    use js_sys::JsString;
     use wasm_bindgen::prelude::*;
 
     #[wasm_bindgen]
     pub struct WasmNetwork {
-        network: Arc<RwLock<Network>>,
+        network: Arc<RwLock<Network<ExternalNetworkInteractions>>>,
+    }
+
+    impl WasmNetwork {
+        pub(crate) fn new(network: Arc<RwLock<Network<ExternalNetworkInteractions>>>) -> Self {
+            Self { network }
+        }
     }
 
     #[wasm_bindgen]
     impl WasmNetwork {
-        pub(crate) fn new(network: Network) -> Self {
-            Self { network: Arc::new(RwLock::new(network)) }
-        }
-    }
-
-    impl WasmNetwork {
         #[wasm_bindgen]
-        pub fn peers_to_ping(&self, threshold: u64) -> Vec<JsString> {
-            self.networkfind_peers_to_ping(threshold)
-                .iter()
-                .map(|x| x.to_base58().into())
-                .collect::<Vec<JsString>>()
-        }
-
-        #[wasm_bindgen]
-        pub fn contains(&self, peer: JsString) -> bool {
+        pub async fn contains(&self, peer: JsString) -> bool {
             let peer: String = peer.into();
             match PeerId::from_str(&peer) {
-                Ok(p) => self.has(&p),
+                Ok(p) => {
+                    let reader = self.network.read().await;
+                    (*reader).has(&p)
+                },
                 Err(err) => {
                     warn!(
                         "Failed to parse peer id {}, network assumes it is not present: {}",
@@ -47,70 +59,10 @@ pub(crate) mod wasm {
         }
 
         #[wasm_bindgen]
-        pub fn register(&mut self, peer: JsString, origin: PeerOrigin) {
-            self.register_with_metadata(peer, origin, &js_sys::Map::from(JsValue::undefined()))
-        }
-
-        #[wasm_bindgen]
-        pub fn register_with_metadata(&mut self, peer: JsString, origin: PeerOrigin, metadata: &js_sys::Map) {
+        pub async fn quality_of(&self, peer: JsString) -> f64 {
             let peer: String = peer.into();
             match PeerId::from_str(&peer) {
-                Ok(p) => self.add_with_metadata(&p, origin, js_map_to_hash_map(metadata)),
-                Err(err) => {
-                    warn!(
-                        "Failed to parse peer id {}, network ignores the register attempt: {}",
-                        peer,
-                        err.to_string()
-                    );
-                }
-            }
-        }
-
-        #[wasm_bindgen]
-        pub fn unregister(&mut self, peer: JsString) {
-            let peer: String = peer.into();
-            match PeerId::from_str(&peer) {
-                Ok(p) => self.remove(&p),
-                Err(err) => {
-                    warn!(
-                        "Failed to parse peer id {}, network ignores the unregister attempt: {}",
-                        peer,
-                        err.to_string()
-                    );
-                }
-            }
-        }
-
-        #[wasm_bindgen]
-        pub fn refresh(&mut self, peer: JsString, timestamp: JsValue) {
-            self.refresh_with_metadata(peer, timestamp, &js_sys::Map::from(JsValue::undefined()))
-        }
-
-        #[wasm_bindgen]
-        pub fn refresh_with_metadata(&mut self, peer: JsString, timestamp: JsValue, metadata: &js_sys::Map) {
-            let peer: String = peer.into();
-            let result: crate::types::Result = if timestamp.is_undefined() {
-                Err(())
-            } else {
-                timestamp.as_f64().map(|v| v as u64).ok_or(())
-            };
-            match PeerId::from_str(&peer) {
-                Ok(p) => self.update_with_metadata(&p, result, js_map_to_hash_map(metadata)),
-                Err(err) => {
-                    warn!(
-                        "Failed to parse peer id {}, network ignores the regresh attempt: {}",
-                        peer,
-                        err.to_string()
-                    );
-                }
-            }
-        }
-
-        #[wasm_bindgen]
-        pub fn quality_of(&self, peer: JsString) -> f64 {
-            let peer: String = peer.into();
-            match PeerId::from_str(&peer) {
-                Ok(p) => match self.get_peer_status(&p) {
+                Ok(p) => match (*self.network.read().await).get_peer_status(&p) {
                     Some(v) => v.quality,
                     _ => 0.0f64,
                 },
@@ -126,18 +78,18 @@ pub(crate) mod wasm {
         }
 
         #[wasm_bindgen]
-        pub fn all(&self) -> Vec<JsString> {
-            self.filter(|_| true)
+        pub async fn all(&self) -> js_sys::Array {
+            js_sys::Array::from_iter((*self.network.read().await)
+                .filter(|_| true)
                 .iter()
-                .map(|x| x.to_base58().into())
-                .collect::<Vec<JsString>>()
+                .map(|x| JsValue::from(x.to_base58())))
         }
 
         #[wasm_bindgen]
-        pub fn get_peer_info(&self, peer: JsString) -> Option<PeerStatus> {
+        pub async fn get_peer_info(&self, peer: JsString) -> Option<PeerStatus> {
             let peer: String = peer.into();
             match PeerId::from_str(&peer) {
-                Ok(p) => self.get_peer_status(&p),
+                Ok(p) => (*self.network.read().await).get_peer_status(&p),
                 Err(err) => {
                     warn!(
                         "Failed to parse peer id {}, peer info unavailable: {}",
@@ -148,5 +100,66 @@ pub(crate) mod wasm {
                 }
             }
         }
+    
+        // TODO: use `NetworkEvent` mechanism with polled reactions in the swarm loop
+        // #[wasm_bindgen]
+        // pub fn register(&mut self, peer: JsString, origin: PeerOrigin) {
+        //     self.register_with_metadata(peer, origin, &js_sys::Map::from(JsValue::undefined()))
+        // }
+
+        // #[wasm_bindgen]
+        // pub fn register_with_metadata(&mut self, peer: JsString, origin: PeerOrigin, metadata: &js_sys::Map) {
+        //     let peer: String = peer.into();
+        //     match PeerId::from_str(&peer) {
+        //         Ok(p) => self.add_with_metadata(&p, origin, js_map_to_hash_map(metadata)),
+        //         Err(err) => {
+        //             warn!(
+        //                 "Failed to parse peer id {}, network ignores the register attempt: {}",
+        //                 peer,
+        //                 err.to_string()
+        //             );
+        //         }
+        //     }
+        // }
+
+        // #[wasm_bindgen]
+        // pub fn unregister(&mut self, peer: JsString) {
+        //     let peer: String = peer.into();
+        //     match PeerId::from_str(&peer) {
+        //         Ok(p) => self.remove(&p),
+        //         Err(err) => {
+        //             warn!(
+        //                 "Failed to parse peer id {}, network ignores the unregister attempt: {}",
+        //                 peer,
+        //                 err.to_string()
+        //             );
+        //         }
+        //     }
+        // }
+
+        // #[wasm_bindgen]
+        // pub fn refresh(&mut self, peer: JsString, timestamp: JsValue) {
+        //     self.refresh_with_metadata(peer, timestamp, &js_sys::Map::from(JsValue::undefined()))
+        // }
+
+        // #[wasm_bindgen]
+        // pub fn refresh_with_metadata(&mut self, peer: JsString, timestamp: JsValue, metadata: &js_sys::Map) {
+        //     let peer: String = peer.into();
+        //     let result: crate::types::Result = if timestamp.is_undefined() {
+        //         Err(())
+        //     } else {
+        //         timestamp.as_f64().map(|v| v as u64).ok_or(())
+        //     };
+        //     match PeerId::from_str(&peer) {
+        //         Ok(p) => self.update_with_metadata(&p, result, js_map_to_hash_map(metadata)),
+        //         Err(err) => {
+        //             warn!(
+        //                 "Failed to parse peer id {}, network ignores the regresh attempt: {}",
+        //                 peer,
+        //                 err.to_string()
+        //             );
+        //         }
+        //     }
+        // }
     }
 }

--- a/packages/core/crates/core-hopr/src/adaptors/network.rs
+++ b/packages/core/crates/core-hopr/src/adaptors/network.rs
@@ -1,0 +1,152 @@
+use std::sync::Arc;
+
+use async_lock::RwLock;
+
+use core_network::network::Network;
+
+#[cfg(feature = "wasm")]
+pub(crate) mod wasm {
+    use super::*;
+    use wasm_bindgen::prelude::*;
+
+    #[wasm_bindgen]
+    pub struct WasmNetwork {
+        network: Arc<RwLock<Network>>,
+    }
+
+    #[wasm_bindgen]
+    impl WasmNetwork {
+        pub(crate) fn new(network: Network) -> Self {
+            Self { network: Arc::new(RwLock::new(network)) }
+        }
+    }
+
+    impl WasmNetwork {
+        #[wasm_bindgen]
+        pub fn peers_to_ping(&self, threshold: u64) -> Vec<JsString> {
+            self.networkfind_peers_to_ping(threshold)
+                .iter()
+                .map(|x| x.to_base58().into())
+                .collect::<Vec<JsString>>()
+        }
+
+        #[wasm_bindgen]
+        pub fn contains(&self, peer: JsString) -> bool {
+            let peer: String = peer.into();
+            match PeerId::from_str(&peer) {
+                Ok(p) => self.has(&p),
+                Err(err) => {
+                    warn!(
+                        "Failed to parse peer id {}, network assumes it is not present: {}",
+                        peer,
+                        err.to_string()
+                    );
+                    false
+                }
+            }
+        }
+
+        #[wasm_bindgen]
+        pub fn register(&mut self, peer: JsString, origin: PeerOrigin) {
+            self.register_with_metadata(peer, origin, &js_sys::Map::from(JsValue::undefined()))
+        }
+
+        #[wasm_bindgen]
+        pub fn register_with_metadata(&mut self, peer: JsString, origin: PeerOrigin, metadata: &js_sys::Map) {
+            let peer: String = peer.into();
+            match PeerId::from_str(&peer) {
+                Ok(p) => self.add_with_metadata(&p, origin, js_map_to_hash_map(metadata)),
+                Err(err) => {
+                    warn!(
+                        "Failed to parse peer id {}, network ignores the register attempt: {}",
+                        peer,
+                        err.to_string()
+                    );
+                }
+            }
+        }
+
+        #[wasm_bindgen]
+        pub fn unregister(&mut self, peer: JsString) {
+            let peer: String = peer.into();
+            match PeerId::from_str(&peer) {
+                Ok(p) => self.remove(&p),
+                Err(err) => {
+                    warn!(
+                        "Failed to parse peer id {}, network ignores the unregister attempt: {}",
+                        peer,
+                        err.to_string()
+                    );
+                }
+            }
+        }
+
+        #[wasm_bindgen]
+        pub fn refresh(&mut self, peer: JsString, timestamp: JsValue) {
+            self.refresh_with_metadata(peer, timestamp, &js_sys::Map::from(JsValue::undefined()))
+        }
+
+        #[wasm_bindgen]
+        pub fn refresh_with_metadata(&mut self, peer: JsString, timestamp: JsValue, metadata: &js_sys::Map) {
+            let peer: String = peer.into();
+            let result: crate::types::Result = if timestamp.is_undefined() {
+                Err(())
+            } else {
+                timestamp.as_f64().map(|v| v as u64).ok_or(())
+            };
+            match PeerId::from_str(&peer) {
+                Ok(p) => self.update_with_metadata(&p, result, js_map_to_hash_map(metadata)),
+                Err(err) => {
+                    warn!(
+                        "Failed to parse peer id {}, network ignores the regresh attempt: {}",
+                        peer,
+                        err.to_string()
+                    );
+                }
+            }
+        }
+
+        #[wasm_bindgen]
+        pub fn quality_of(&self, peer: JsString) -> f64 {
+            let peer: String = peer.into();
+            match PeerId::from_str(&peer) {
+                Ok(p) => match self.get_peer_status(&p) {
+                    Some(v) => v.quality,
+                    _ => 0.0f64,
+                },
+                Err(err) => {
+                    warn!(
+                        "Failed to parse peer id {}, using lowest possible quality: {}",
+                        peer,
+                        err.to_string()
+                    );
+                    0.0f64
+                }
+            }
+        }
+
+        #[wasm_bindgen]
+        pub fn all(&self) -> Vec<JsString> {
+            self.filter(|_| true)
+                .iter()
+                .map(|x| x.to_base58().into())
+                .collect::<Vec<JsString>>()
+        }
+
+        #[wasm_bindgen]
+        pub fn get_peer_info(&self, peer: JsString) -> Option<PeerStatus> {
+            let peer: String = peer.into();
+            match PeerId::from_str(&peer) {
+                Ok(p) => self.get_peer_status(&p),
+                Err(err) => {
+                    warn!(
+                        "Failed to parse peer id {}, peer info unavailable: {}",
+                        peer,
+                        err.to_string()
+                    );
+                    None
+                }
+            }
+        }
+    }
+}

--- a/packages/core/crates/core-hopr/src/adaptors/ping.rs
+++ b/packages/core/crates/core-hopr/src/adaptors/ping.rs
@@ -1,5 +1,25 @@
-use core_network::{PeerId, ping::PingExternalAPI, types::Result};
+use std::sync::Arc;
+
+use async_lock::RwLock;
+use async_trait::async_trait;
+
+use core_network::{PeerId, network::Network, ping::PingExternalAPI, types::Result};
 use utils_log::error;
+
+#[derive(Clone)]
+pub(crate) struct PingAdaptor {
+    network: Arc<RwLock<Network>>
+}
+
+#[async_trait]
+impl PingExternalAPI for PingAdaptor {
+    async fn on_finished_ping(&self, peer: &PeerId, result: Result) {
+        let writer = self.network.write().await;
+        (*writer).update_with_metadata(peer, result, None)
+    }
+}
+
+
 
 #[cfg(feature = "wasm")]
 pub mod wasm {

--- a/packages/core/crates/core-hopr/src/adaptors/ping.rs
+++ b/packages/core/crates/core-hopr/src/adaptors/ping.rs
@@ -4,55 +4,25 @@ use async_lock::RwLock;
 use async_trait::async_trait;
 
 use core_network::{PeerId, network::Network, ping::PingExternalAPI, types::Result};
-use utils_log::error;
+
+use crate::adaptors::network::ExternalNetworkInteractions;
+
 
 #[derive(Clone)]
-pub(crate) struct PingAdaptor {
-    network: Arc<RwLock<Network>>
+pub struct PingExternalInteractions {
+    network: Arc<RwLock<Network<ExternalNetworkInteractions>>>
+}
+
+impl PingExternalInteractions {
+    pub fn new(network: Arc<RwLock<Network<ExternalNetworkInteractions>>>) -> Self {
+        Self { network }
+    }
 }
 
 #[async_trait]
-impl PingExternalAPI for PingAdaptor {
+impl PingExternalAPI for PingExternalInteractions {
     async fn on_finished_ping(&self, peer: &PeerId, result: Result) {
-        let writer = self.network.write().await;
+        let mut writer = self.network.write().await;
         (*writer).update_with_metadata(peer, result, None)
     }
-}
-
-
-
-#[cfg(feature = "wasm")]
-pub mod wasm {
-    use super::*;
-    use wasm_bindgen::prelude::*;
-
-    #[wasm_bindgen]
-    #[derive(Debug, Clone)]
-    pub struct WasmPingApi {
-        on_finished_ping_cb: js_sys::Function,
-    }
-
-    impl PingExternalAPI for WasmPingApi {
-        fn on_finished_ping(&self, peer: &PeerId, result: Result) {
-            let this = JsValue::null();
-            let peer = JsValue::from(peer.to_base58());
-            let res = {
-                if let Ok(v) = result {
-                    JsValue::from(v as f64)
-                } else {
-                    JsValue::undefined()
-                }
-            };
-
-            if let Err(err) = self.on_finished_ping_cb.call2(&this, &peer, &res) {
-                error!(
-                    "Failed to perform on peer offline operation with: {}",
-                    err.as_string()
-                        .unwrap_or_else(|| { "Unspecified error occurred on registering the ping result".to_owned() })
-                        .as_str()
-                )
-            };
-        }
-    }
-
 }

--- a/packages/core/crates/core-hopr/src/lib.rs
+++ b/packages/core/crates/core-hopr/src/lib.rs
@@ -3,6 +3,7 @@ mod helpers;
 mod p2p;
 
 use std::str::FromStr;
+use std::sync::Arc;
 
 use futures::{StreamExt, FutureExt, future::BoxFuture};
 
@@ -22,13 +23,14 @@ use crate::p2p::api;
 #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
 pub struct HoprTools {
     ping: Ping
+    peers: Arc<RwLock<Network>>
 }
 
 #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
 impl HoprTools {
     // pub async fn ping()
-    pub fn new(ping: Ping) -> Self {
-        Self { ping }
+    pub fn new(ping: Ping, peers: Network) -> Self {
+        Self { ping, Arc::new(RwLock::new(peers)) }
     }
 }
 

--- a/packages/core/crates/core-network/src/network.rs
+++ b/packages/core/crates/core-network/src/network.rs
@@ -108,12 +108,12 @@ impl std::fmt::Display for Health {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum NetworkEvent {
     CloseConnection(PeerId),
     PeerOffline(PeerId),
-    Register(PeerId),
-    Unregister(PeerId)
+    Register(PeerId, PeerOrigin),
+    Unregister(PeerId),
 }
 
 impl std::fmt::Display for NetworkEvent {

--- a/packages/core/crates/core-network/src/network.rs
+++ b/packages/core/crates/core-network/src/network.rs
@@ -1,11 +1,15 @@
+use std::collections::VecDeque;
 use std::collections::hash_map::{Entry, HashMap};
 use std::collections::hash_set::HashSet;
 use std::time::Duration;
 
 use libp2p_identity::PeerId;
 
-use utils_log::{error, info, warn};
-use utils_metrics::metrics::{MultiGauge, SimpleGauge};
+use utils_log::{log, error, info, warn};
+use utils_metrics::{
+    histogram_start_measure,
+    metrics::{MultiGauge, SimpleGauge}
+};
 
 #[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
@@ -15,6 +19,7 @@ use utils_misc::time::native::current_timestamp;
 
 #[cfg(all(feature = "wasm", not(test)))]
 use utils_misc::time::wasm::current_timestamp;
+
 
 #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -103,15 +108,23 @@ impl std::fmt::Display for Health {
     }
 }
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum NetworkEvent {
+    CloseConnection(PeerId),
+    PeerOffline(PeerId),
+    Register(PeerId),
+    Unregister(PeerId)
+}
+
+impl std::fmt::Display for NetworkEvent {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
 #[cfg_attr(test, mockall::automock)]
 pub trait NetworkExternalActions {
     fn is_public(&self, peer: &PeerId) -> bool;
-
-    fn close_connection(&self, peer: &PeerId);
-
-    fn on_peer_offline(&self, peer: &PeerId);
-
-    fn on_network_health_change(&self, old: Health, new: Health);
 }
 
 #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
@@ -156,30 +169,30 @@ impl std::fmt::Display for PeerStatus {
     }
 }
 
-#[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
-pub struct Network {
+pub struct Network<T: NetworkExternalActions> {
     me: PeerId,
     cfg: NetworkConfig,
-    entries: HashMap<String, PeerStatus>,
-    ignored: HashMap<String, u64>, // timestamp
-    excluded: HashSet<String>,
+    events_to_emit: VecDeque<NetworkEvent>,
+    entries: HashMap<PeerId, PeerStatus>,
+    ignored: HashMap<PeerId, u64>, // timestamp
+    excluded: HashSet<PeerId>,
     good_quality_public: HashSet<PeerId>,
     bad_quality_public: HashSet<PeerId>,
     good_quality_non_public: HashSet<PeerId>,
     bad_quality_non_public: HashSet<PeerId>,
     last_health: Health,
-    network_actions_api: Box<dyn NetworkExternalActions>,
+    network_actions_api: T,
     metric_network_health: Option<SimpleGauge>,
     metric_peers_by_quality: Option<MultiGauge>,
     metric_peer_count: Option<SimpleGauge>,
 }
 
-impl Network {
+impl<T: NetworkExternalActions> Network<T> {
     pub fn new(
         my_peer_id: PeerId,
         network_quality_threshold: f64,
-        network_actions_api: Box<dyn NetworkExternalActions>,
-    ) -> Network {
+        network_actions_api: T,
+    ) -> Self {
         let cfg = NetworkConfig {
             quality_offline_threshold: network_quality_threshold,
             ..NetworkConfig::default()
@@ -193,11 +206,12 @@ impl Network {
         }
 
         let mut excluded = HashSet::new();
-        excluded.insert(my_peer_id.to_string());
+        excluded.insert(my_peer_id);
 
         let instance = Network {
             me: my_peer_id,
             cfg,
+            events_to_emit: VecDeque::new(),
             entries: HashMap::new(),
             ignored: HashMap::new(),
             excluded,
@@ -222,7 +236,7 @@ impl Network {
 
     /// Check whether the PeerId is present in the network
     pub fn has(&self, peer: &PeerId) -> bool {
-        self.entries.contains_key(peer.to_string().as_str())
+        self.entries.contains_key(peer)
     }
 
     /// Add a new PeerId into the network
@@ -236,18 +250,17 @@ impl Network {
     ///
     /// Each PeerId must have an origin specification.
     pub fn add_with_metadata(&mut self, peer: &PeerId, origin: PeerOrigin, metadata: Option<HashMap<String, String>>) {
-        let id = peer.to_string();
         let now = current_timestamp();
 
         // assumes disjoint sets
-        let has_entry = self.entries.contains_key(id.as_str());
-        let is_excluded = !has_entry && self.excluded.contains(id.as_str());
+        let has_entry = self.entries.contains_key(peer);
+        let is_excluded = !has_entry && self.excluded.contains(peer);
 
         if !is_excluded {
-            let is_ignored = if !has_entry && self.ignored.contains_key(id.as_str()) {
-                let timestamp = self.ignored.get(id.as_str()).unwrap();
+            let is_ignored = if !has_entry && self.ignored.contains_key(peer) {
+                let timestamp = self.ignored.get(peer).unwrap();
                 if Duration::from_millis(now - timestamp) > self.cfg.ignore_timeframe {
-                    self.ignored.remove(id.as_str());
+                    self.ignored.remove(peer);
                     false
                 } else {
                     true
@@ -264,7 +277,7 @@ impl Network {
                 }
                 self.refresh_network_status(&entry);
 
-                if let Some(x) = self.entries.insert(peer.to_string(), entry) {
+                if let Some(x) = self.entries.insert(peer.clone(), entry) {
                     warn!("Evicting an existing record for {}, this should not happen!", &x);
                 }
             }
@@ -274,7 +287,7 @@ impl Network {
     /// Remove PeerId from the network
     pub fn remove(&mut self, peer: &PeerId) {
         self.prune_from_network_status(&peer);
-        self.entries.remove(peer.to_string().as_str());
+        self.entries.remove(peer);
     }
 
     /// Update the PeerId record in the network
@@ -289,7 +302,7 @@ impl Network {
         ping_result: crate::types::Result,
         metadata: Option<HashMap<String, String>>,
     ) {
-        if let Some(existing) = self.entries.get(peer.to_string().as_str()) {
+        if let Some(existing) = self.entries.get(peer) {
             let mut entry = existing.clone();
             entry.heartbeats_sent = entry.heartbeats_sent + 1;
             entry.is_public = self.network_actions_api.is_public(&peer);
@@ -311,14 +324,14 @@ impl Network {
                 entry.quality = 0.0_f64.max(entry.quality - self.cfg.quality_step);
 
                 if entry.quality < (self.cfg.quality_step / 2.0) {
-                    self.network_actions_api.close_connection(&entry.id);
+                    self.events_to_emit.push_back(NetworkEvent::CloseConnection(entry.id.clone()));
                     self.prune_from_network_status(&entry.id);
-                    self.entries.remove(entry.id.to_string().as_str());
+                    self.entries.remove(&entry.id);
                     return;
                 } else if entry.quality < self.cfg.quality_bad_threshold {
-                    self.ignored.insert(entry.id.to_string(), current_timestamp());
+                    self.ignored.insert(entry.id, current_timestamp());
                 } else if entry.quality < self.cfg.quality_offline_threshold {
-                    self.network_actions_api.on_peer_offline(&entry.id);
+                    self.events_to_emit.push_back(NetworkEvent::PeerOffline(entry.id.clone()));
                 }
             } else {
                 entry.last_seen = ping_result.ok().unwrap();
@@ -328,9 +341,9 @@ impl Network {
             }
 
             self.refresh_network_status(&entry);
-            self.entries.insert(entry.id.to_string(), entry);
+            self.entries.insert(entry.id.clone(), entry);
         } else {
-            info!("Ignoring update request for unknown peer {:?}", peer);
+            info!("Ignoring update request for unknown peer {}", peer);
         }
     }
 
@@ -371,9 +384,9 @@ impl Network {
         }
 
         if health != self.last_health {
-            info!("Network health changed from {} to {}", self.last_health, health);
-            self.network_actions_api
-                .on_network_health_change(self.last_health, health);
+            info!("Network health indicator changed {} -> {}", self.last_health, health);
+            info!("NETWORK HEALTH: {}", health);
+
             self.last_health = health;
         }
 
@@ -403,7 +416,7 @@ impl Network {
     }
 
     pub fn get_peer_status(&self, peer: &PeerId) -> Option<PeerStatus> {
-        return match self.entries.get(peer.to_string().as_str()) {
+        return match self.entries.get(peer) {
             Some(entry) => Some(entry.clone()),
             None => None,
         };
@@ -429,8 +442,8 @@ impl Network {
             (v.last_seen + (delay.as_millis() as u64)) < threshold
         });
         data.sort_by(|a, b| {
-            if self.entries.get(a.to_string().as_str()).unwrap().last_seen
-                < self.entries.get(b.to_string().as_str()).unwrap().last_seen
+            if self.entries.get(a).unwrap().last_seen
+                < self.entries.get(b).unwrap().last_seen
             {
                 std::cmp::Ordering::Less
             } else {
@@ -440,10 +453,11 @@ impl Network {
 
         data
     }
-}
 
-#[cfg(not(feature = "wasm"))]
-impl Network {
+    pub fn events_since_last_poll(&mut self) -> Vec<NetworkEvent> {
+        self.events_to_emit.drain(..).collect()
+    }
+
     /// Total count of the peers observed withing the network
     pub fn length(&self) -> usize {
         self.entries.len()
@@ -454,33 +468,6 @@ impl Network {
         self.last_health
     }
 
-    pub fn debug_output(&self) -> String {
-        let mut output = "".to_string();
-
-        for (_, entry) in &self.entries {
-            output.push_str(format!("{}\n", entry).as_str());
-        }
-
-        output
-    }
-}
-
-#[cfg(feature = "wasm")]
-#[wasm_bindgen]
-impl Network {
-    /// Total count of the peers observed withing the network
-    #[wasm_bindgen]
-    pub fn length(&self) -> usize {
-        self.entries.len()
-    }
-
-    /// Returns the quality of the network as a network health indicator.
-    #[wasm_bindgen]
-    pub fn health(&self) -> Health {
-        self.last_health
-    }
-
-    #[wasm_bindgen]
     pub fn debug_output(&self) -> String {
         let mut output = "".to_string();
 
@@ -555,219 +542,6 @@ pub mod wasm {
             }
         }
     }
-
-    #[wasm_bindgen]
-    struct WasmNetworkApi {
-        on_peer_offline_cb: js_sys::Function,
-        on_network_health_change_cb: js_sys::Function,
-        is_public_cb: js_sys::Function,
-        close_connection_cb: js_sys::Function,
-    }
-
-    impl NetworkExternalActions for WasmNetworkApi {
-        fn is_public(&self, peer: &PeerId) -> bool {
-            let this = JsValue::null();
-            match self.is_public_cb.call1(&this, &JsValue::from(peer.to_base58())) {
-                Ok(v) => v.as_bool().unwrap_or_else(|| {
-                    error!("Failed to extract 'is_public_cb` result as bool, defaulting to 'false'");
-                    false
-                }),
-                _ => {
-                    error!(
-                        "Encountered error when trying to find out whether peer {} is public",
-                        peer
-                    );
-                    false
-                }
-            }
-        }
-
-        fn close_connection(&self, peer: &PeerId) {
-            let this = JsValue::null();
-            if let Err(err) = self.close_connection_cb.call1(&this, &JsValue::from(peer.to_base58())) {
-                error!(
-                    "Failed to perform close connection for peer {} with: {}",
-                    peer,
-                    err.as_string().unwrap_or_else(|| "unknown error".to_owned()).as_str()
-                )
-            };
-        }
-
-        fn on_peer_offline(&self, peer: &PeerId) {
-            let this = JsValue::null();
-            if let Err(err) = self.on_peer_offline_cb.call1(&this, &JsValue::from(peer.to_base58())) {
-                error!(
-                    "Failed to perform on peer offline operation for peer {} with: {}",
-                    peer,
-                    err.as_string().unwrap_or_else(|| "unknown error".to_owned()).as_str()
-                )
-            };
-        }
-
-        fn on_network_health_change(&self, old: Health, new: Health) {
-            let this = JsValue::null();
-            let old = JsValue::from(old as i32);
-            let new = JsValue::from(new as i32);
-            if let Err(err) = self.on_network_health_change_cb.call2(&this, &old, &new) {
-                error!(
-                    "Failed to perform the network health change operation with: {}",
-                    err.as_string().unwrap_or_else(|| "unknown error".to_owned()).as_str()
-                )
-            };
-        }
-    }
-
-    #[wasm_bindgen]
-    impl Network {
-        #[wasm_bindgen]
-        pub fn build(
-            me: JsString,
-            quality_threshold: f64,
-            on_peer_offline: js_sys::Function,
-            on_network_health_change: js_sys::Function,
-            is_public: js_sys::Function,
-            close_connection: js_sys::Function,
-        ) -> Self {
-            let me: String = me.into();
-            let api = Box::new(WasmNetworkApi {
-                on_peer_offline_cb: on_peer_offline,
-                on_network_health_change_cb: on_network_health_change,
-                is_public_cb: is_public,
-                close_connection_cb: close_connection,
-            });
-
-            let me = PeerId::from_str(&me).expect("Failed to parse own peer id from JsString");
-
-            Self::new(me, quality_threshold, api)
-        }
-
-        #[wasm_bindgen]
-        pub fn peers_to_ping(&self, threshold: u64) -> Vec<JsString> {
-            self.find_peers_to_ping(threshold)
-                .iter()
-                .map(|x| x.to_base58().into())
-                .collect::<Vec<JsString>>()
-        }
-
-        #[wasm_bindgen]
-        pub fn contains(&self, peer: JsString) -> bool {
-            let peer: String = peer.into();
-            match PeerId::from_str(&peer) {
-                Ok(p) => self.has(&p),
-                Err(err) => {
-                    warn!(
-                        "Failed to parse peer id {}, network assumes it is not present: {}",
-                        peer,
-                        err.to_string()
-                    );
-                    false
-                }
-            }
-        }
-
-        #[wasm_bindgen]
-        pub fn register(&mut self, peer: JsString, origin: PeerOrigin) {
-            self.register_with_metadata(peer, origin, &js_sys::Map::from(JsValue::undefined()))
-        }
-
-        #[wasm_bindgen]
-        pub fn register_with_metadata(&mut self, peer: JsString, origin: PeerOrigin, metadata: &js_sys::Map) {
-            let peer: String = peer.into();
-            match PeerId::from_str(&peer) {
-                Ok(p) => self.add_with_metadata(&p, origin, js_map_to_hash_map(metadata)),
-                Err(err) => {
-                    warn!(
-                        "Failed to parse peer id {}, network ignores the register attempt: {}",
-                        peer,
-                        err.to_string()
-                    );
-                }
-            }
-        }
-
-        #[wasm_bindgen]
-        pub fn unregister(&mut self, peer: JsString) {
-            let peer: String = peer.into();
-            match PeerId::from_str(&peer) {
-                Ok(p) => self.remove(&p),
-                Err(err) => {
-                    warn!(
-                        "Failed to parse peer id {}, network ignores the unregister attempt: {}",
-                        peer,
-                        err.to_string()
-                    );
-                }
-            }
-        }
-
-        #[wasm_bindgen]
-        pub fn refresh(&mut self, peer: JsString, timestamp: JsValue) {
-            self.refresh_with_metadata(peer, timestamp, &js_sys::Map::from(JsValue::undefined()))
-        }
-
-        #[wasm_bindgen]
-        pub fn refresh_with_metadata(&mut self, peer: JsString, timestamp: JsValue, metadata: &js_sys::Map) {
-            let peer: String = peer.into();
-            let result: crate::types::Result = if timestamp.is_undefined() {
-                Err(())
-            } else {
-                timestamp.as_f64().map(|v| v as u64).ok_or(())
-            };
-            match PeerId::from_str(&peer) {
-                Ok(p) => self.update_with_metadata(&p, result, js_map_to_hash_map(metadata)),
-                Err(err) => {
-                    warn!(
-                        "Failed to parse peer id {}, network ignores the regresh attempt: {}",
-                        peer,
-                        err.to_string()
-                    );
-                }
-            }
-        }
-
-        #[wasm_bindgen]
-        pub fn quality_of(&self, peer: JsString) -> f64 {
-            let peer: String = peer.into();
-            match PeerId::from_str(&peer) {
-                Ok(p) => match self.get_peer_status(&p) {
-                    Some(v) => v.quality,
-                    _ => 0.0f64,
-                },
-                Err(err) => {
-                    warn!(
-                        "Failed to parse peer id {}, using lowest possible quality: {}",
-                        peer,
-                        err.to_string()
-                    );
-                    0.0f64
-                }
-            }
-        }
-
-        #[wasm_bindgen]
-        pub fn all(&self) -> Vec<JsString> {
-            self.filter(|_| true)
-                .iter()
-                .map(|x| x.to_base58().into())
-                .collect::<Vec<JsString>>()
-        }
-
-        #[wasm_bindgen]
-        pub fn get_peer_info(&self, peer: JsString) -> Option<PeerStatus> {
-            let peer: String = peer.into();
-            match PeerId::from_str(&peer) {
-                Ok(p) => self.get_peer_status(&p),
-                Err(err) => {
-                    warn!(
-                        "Failed to parse peer id {}, peer info unavailable: {}",
-                        peer,
-                        err.to_string()
-                    );
-                    None
-                }
-            }
-        }
-    }
 }
 
 #[cfg(test)]
@@ -780,22 +554,10 @@ mod tests {
         fn is_public(&self, _: &PeerId) -> bool {
             false
         }
-
-        fn close_connection(&self, _: &PeerId) {
-            ()
-        }
-
-        fn on_peer_offline(&self, _: &PeerId) {
-            ()
-        }
-
-        fn on_network_health_change(&self, _: Health, _: Health) {
-            ()
-        }
     }
 
-    fn basic_network(my_id: &PeerId) -> Network {
-        Network::new(my_id.clone(), 0.6, Box::new(DummyNetworkAction {}))
+    fn basic_network(my_id: &PeerId) -> Network<DummyNetworkAction> {
+        Network::new(my_id.clone(), 0.6, DummyNetworkAction{})
     }
 
     #[test]
@@ -1042,9 +804,8 @@ mod tests {
 
         let mut mock = MockNetworkExternalActions::new();
         mock.expect_is_public().times(1).returning(|_| false);
-        mock.expect_on_network_health_change().times(1).return_const(());
 
-        let mut peers = Network::new(PeerId::random(), 0.6, Box::new(mock));
+        let mut peers = Network::new(PeerId::random(), 0.6, mock);
 
         peers.add(&peer, PeerOrigin::IncomingConnection);
 
@@ -1058,8 +819,7 @@ mod tests {
 
         let mut mock = MockNetworkExternalActions::new();
         mock.expect_is_public().times(2).returning(move |x| x == &public);
-        mock.expect_on_network_health_change().times(1).return_const(());
-        let mut peers = Network::new(PeerId::random(), 0.6, Box::new(mock));
+        let mut peers = Network::new(PeerId::random(), 0.6, mock);
 
         peers.add(&peer, PeerOrigin::IncomingConnection);
 
@@ -1075,16 +835,15 @@ mod tests {
 
         let mut mock = MockNetworkExternalActions::new();
         mock.expect_is_public().times(3).returning(move |x| x == &public);
-        mock.expect_on_network_health_change().times(1).return_const(());
-        mock.expect_close_connection().times(1).return_const(());
 
-        let mut peers = Network::new(PeerId::random(), 0.6, Box::new(mock));
+        let mut peers = Network::new(PeerId::random(), 0.6, mock);
 
         peers.add(&peer, PeerOrigin::IncomingConnection);
 
         peers.update(&peer, Ok(current_timestamp()));
         peers.update(&peer, Err(()));
 
+        assert_eq!(peers.events_since_last_poll(), vec![NetworkEvent::CloseConnection(peer.clone())]);
         assert!(!peers.has(&public));
     }
 
@@ -1096,8 +855,7 @@ mod tests {
 
         let mut mock = MockNetworkExternalActions::new();
         mock.expect_is_public().times(5).returning(move |x| public.contains(&x));
-        mock.expect_on_network_health_change().times(2).return_const(());
-        let mut peers = Network::new(me, 0.3, Box::new(mock));
+        let mut peers = Network::new(me, 0.3, mock);
 
         peers.add(&peer, PeerOrigin::IncomingConnection);
 
@@ -1118,8 +876,7 @@ mod tests {
         let mut mock = MockNetworkExternalActions::new();
 
         mock.expect_is_public().times(8).returning(move |x| public.contains(&x));
-        mock.expect_on_network_health_change().times(2).return_const(());
-        let mut peers = Network::new(PeerId::random(), 0.3, Box::new(mock));
+        let mut peers = Network::new(PeerId::random(), 0.3, mock);
 
         peers.add(&peer, PeerOrigin::IncomingConnection);
         peers.add(&peer2, PeerOrigin::IncomingConnection);

--- a/packages/core/crates/core-network/src/network.rs
+++ b/packages/core/crates/core-network/src/network.rs
@@ -169,6 +169,7 @@ impl std::fmt::Display for PeerStatus {
     }
 }
 
+#[derive(Debug)]
 pub struct Network<T: NetworkExternalActions> {
     me: PeerId,
     cfg: NetworkConfig,

--- a/packages/utils/crates/utils-metrics/src/metrics.rs
+++ b/packages/utils/crates/utils-metrics/src/metrics.rs
@@ -168,6 +168,7 @@ impl MultiCounter {
 /// Represents a simple gauge with floating point values.
 /// Wrapper for Gauge type
 #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
+#[derive(Debug)]
 pub struct SimpleGauge {
     name: String,
     gg: Gauge,
@@ -214,6 +215,7 @@ impl SimpleGauge {
 /// Represents a vector of gauges with floating point values.
 /// Wrapper for GaugeVec type
 #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
+#[derive(Debug)]
 pub struct MultiGauge {
     name: String,
     labels: Vec<String>,


### PR DESCRIPTION
## What
The peer discovery mechanism is missing and will have to be created from scratch using the libp2p loop and chain loading behavior. Also, the `core-network::network::Network` object and it's functionality needs to be synchronized with this feature, as well, as modified to simplify `core-hopr` object construction.
- [x] Move as much functionality from `Network` outside of `wasm-bindgen`, as possible
- [x] Move `Network` into `core-hopr`
- [x] Normalize object construction and pass the network object to dependant components (ping, heartbeat...)
- [x] Create an input stream for managing network operations (register, unregister...) and integrate it with the swarm loop and the `Network`