### PR TITLE
exclude address zero in testFuzz_ScopeTargetSendFromModule

### DIFF
--- a/packages/ethereum/contracts/test/node-stake/permissioned-modules/NodeManagementModule.t.sol
+++ b/packages/ethereum/contracts/test/node-stake/permissioned-modules/NodeManagementModule.t.sol
@@ -341,6 +341,11 @@ contract HoprNodeManagementModuleTest is Test, CapabilityPermissionsLibFixtureTe
 
         // add nodes and take one from the added node
         _helperAddNodes(accounts);
+
+        if (accounts[index] == address(0)) {
+            return;
+        }
+
         assertTrue(moduleProxy.isNode(accounts[index]));
 
         Target sendTarget = TargetUtils.encodeDefaultPermissions(
@@ -1287,6 +1292,7 @@ contract HoprNodeManagementModuleTest is Test, CapabilityPermissionsLibFixtureTe
 
     function _helperAddNodes(address[] memory accounts) private {
         for (uint256 i = 0; i < accounts.length; i++) {
+            emit log_named_uint("i", i);
             if (moduleProxy.isNode(accounts[i])) continue;
             moduleProxy.addNode(accounts[i]);
         }

--- a/packages/ethereum/contracts/test/node-stake/permissioned-modules/NodeManagementModule.t.sol
+++ b/packages/ethereum/contracts/test/node-stake/permissioned-modules/NodeManagementModule.t.sol
@@ -342,9 +342,7 @@ contract HoprNodeManagementModuleTest is Test, CapabilityPermissionsLibFixtureTe
         // add nodes and take one from the added node
         _helperAddNodes(accounts);
 
-        if (accounts[index] == address(0)) {
-            return;
-        }
+        vm.assume(accounts[index] != address(0));
 
         assertTrue(moduleProxy.isNode(accounts[index]));
 


### PR DESCRIPTION
Close https://github.com/hoprnet/hoprnet/issues/5263

Address zero was part of the fuzz generated array of addresses, which is supposed to be reverted with error `AddressIsZero`