### PR TITLE
Adjust naming scheme of identity files created by hopli

### DIFF
--- a/packages/hopli/src/identity.rs
+++ b/packages/hopli/src/identity.rs
@@ -4,10 +4,7 @@ use crate::password::PasswordArgs;
 use crate::utils::{Cmd, HelperErrors};
 use clap::{builder::RangedU64ValueParser, Parser};
 use log::{debug, error, info};
-use std::{
-    str::FromStr,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::str::FromStr;
 
 #[derive(clap::ValueEnum, Debug, Clone, PartialEq, Eq)]
 pub enum IdentityActionType {
@@ -81,12 +78,11 @@ impl IdentityArgs {
                 }
                 let local_id = local_identity.identity_from_directory.unwrap();
                 let id_dir = local_id.identity_directory.unwrap();
-                for _n in 1..=number {
+                for index in 0..=number-1 {
                     // build file name
                     let file_prefix = match &local_id.identity_prefix {
                         Some(ref provided_name) => Some(
-                            provided_name.to_owned()
-                                + &SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs().to_string(),
+                            provided_name.to_owned() + &index.to_string(),
                         ),
                         None => None,
                     };

--- a/packages/hopli/src/key_pair.rs
+++ b/packages/hopli/src/key_pair.rs
@@ -1,7 +1,7 @@
 use crate::utils::HelperErrors;
 use hoprd_keypair::key_pair::HoprKeys;
 use log::warn;
-use std::{fs, path::PathBuf};
+use std::{fs, path::{PathBuf, Path}};
 
 /// Decrypt identity files and returns an vec of PeerIds and Ethereum Addresses
 ///
@@ -62,7 +62,11 @@ pub fn create_identity(dir_name: &str, password: &str, maybe_name: &Option<Strin
         None => format!("{dir_name}/{}.id", { keys.id().to_string() }),
     };
 
-    keys.write_eth_keystore(&file_path, password, false)?;
+    if Path::new(&file_path).exists() {
+        return Err(HelperErrors::IdentityFileExists(file_path));
+    } else {
+        keys.write_eth_keystore(&file_path, password, false)?;
+    }
 
     Ok(keys)
 }

--- a/packages/hopli/src/utils.rs
+++ b/packages/hopli/src/utils.rs
@@ -24,6 +24,9 @@ pub enum HelperErrors {
     #[error("incorrect filename: {0}")]
     IncorrectFilename(String),
 
+    #[error("identity file exists: {0}")]
+    IdentityFileExists(String),
+
     #[error("unable to read identity")]
     UnableToReadIdentity,
 


### PR DESCRIPTION
Replace UNIX timestamp from identity file name and use a counter (staring from 0) as suffix.
Throw and error when a file with the same name exisits.