### PR TITLE
Fix formatting of Ed25519 public key & other fixes

### DIFF
--- a/packages/core-ethereum/src/ethereum.ts
+++ b/packages/core-ethereum/src/ethereum.ts
@@ -27,7 +27,7 @@ import {
 import NonceTracker from './nonce-tracker.js'
 import TransactionManager, { type TransactionPayload } from './transaction-manager.js'
 import { debug } from '@hoprnet/hopr-utils'
-import { CORE_ETHEREUM_CONSTANTS, get_announce_payload } from '../lib/core_ethereum_misc.js'
+import { CORE_ETHEREUM_CONSTANTS, get_announce_payload, OffchainKeypair as Ethereum_OffchainKeypair, Address as Ethereum_Address } from '../lib/core_ethereum_misc.js'
 import type { Block } from '@ethersproject/abstract-provider'
 
 // @ts-ignore untyped library
@@ -455,11 +455,11 @@ export async function createChainWrapper(
     multiaddr: Multiaddr,
     txHandler: (tx: string) => DeferType<string>
   ): Promise<string> => {
-    let confirmationEssentialTxPayload: TransactionPayload
-
-    confirmationEssentialTxPayload.data = u8aToHex(get_announce_payload(keypair, chain_key, multiaddr.toString()))
-    confirmationEssentialTxPayload.to = deploymentExtract.hoprAnnouncementsAddress
-
+    let confirmationEssentialTxPayload: TransactionPayload = {
+      data: u8aToHex(get_announce_payload(new Ethereum_OffchainKeypair(keypair.secret()), Ethereum_Address.deserialize(chain_key.serialize()), multiaddr.toString())),
+      to: deploymentExtract.hoprAnnouncementsAddress,
+      value: BigNumber.from(0)
+    }
     // @ts-ignore fixme: treat result
     let sendResult: SendTransactionReturn
     // @ts-ignore fixme: treat result

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -22,7 +22,7 @@ import {
   LevelDb,
   ChainKeypair,
   OffchainKeypair,
-  Address as Packet_Address
+  Address as Packet_Address, stringToU8a, u8aConcat
 } from '@hoprnet/hopr-utils'
 import HoprCoreEthereum from '@hoprnet/hopr-core-ethereum'
 
@@ -56,8 +56,10 @@ export async function createLibp2pInstance(
   isAllowedToAccessNetwork: Hopr['isAllowedAccessToNetwork']
 ): Promise<Libp2p> {
   let libp2p: Libp2p
-  // TODO: verify key formatting here
-  const peerId = await peerIdFromKeys(packetKeypair.public().serialize(), packetKeypair.secret())
+
+  // Hack until migrated to rs-libp2p: put the public key to the protobuf format expected by JS PeerId
+  let protoBufPrefixedPubKey = u8aConcat(stringToU8a("08011220"), packetKeypair.public().serialize())
+  const peerId = await peerIdFromKeys(protoBufPrefixedPubKey, packetKeypair.secret())
 
   if (options.testing?.useMockedLibp2p) {
     // Used for quick integration testing
@@ -97,6 +99,7 @@ export async function createLibp2pInstance(
       return { id: env.id, versionRange: env.version_range }
     })
 
+    log(`creating libp2p with peer id ${peerId.toString()}`)
     libp2p = await createLibp2p({
       peerId,
       addresses: { listen: getAddrs(peerId, options).map((x: Multiaddr) => x.toString()) },


### PR DESCRIPTION
Fixes:

- preformats Ed25519 public key in protobuf encoding so it can be consumed by js-peerid
- fixes missing essential TX payload value for Announcement
- proper Address and OffchainKeypair usage