### PR TITLE
Response to preliminary report 4

### DIFF
--- a/docs/sc-audit-08-2023/docs/02-response-to-preliminary-report.md
+++ b/docs/sc-audit-08-2023/docs/02-response-to-preliminary-report.md
@@ -54,6 +54,7 @@ _Commit Hash:_ [2ca5c86d334950c0e40e06d5999f5996c5eccc37](https://github.com/hop
 
 - Removed the `immutable` keyword from `domainSeparator` in "HoprNodeSafeRegistry" and "HoprChannels" contracts.
 - Introduced publicly callable functions `updateDomainSeparator` and `updateLedgerDomainSeparator` to adjust domain separators in relevant contracts in case of a fork.
+- Emitted an event when the domain separator gets updated to a different value.
 
 **Commit Hash:** [d51ce5d2bec87a81004488327d7282b22f97f38b](https://github.com/hoprnet/hoprnet/commit/d51ce5d2bec87a81004488327d7282b22f97f38b)
 

--- a/docs/sc-audit-08-2023/docs/02-response-to-preliminary-report.md
+++ b/docs/sc-audit-08-2023/docs/02-response-to-preliminary-report.md
@@ -224,6 +224,9 @@ _Commit Hash:_ [2ca5c86d334950c0e40e06d5999f5996c5eccc37](https://github.com/hop
 - Import `IERC20`, `IERC777` interfaces for definition of selector
 - Make all the selector definition public
 
-#### 8. Format
+#### 8. Improve NodeSafeRegistry
+- Unwrap struct `NodeSafe` into flattened `address safeAddress, address nodeChainKeyAddress`
+
+#### 9. Format
 - Format all the contracts
 - Include HOPR logo

--- a/packages/ethereum/contracts/src/Channels.sol
+++ b/packages/ethereum/contracts/src/Channels.sol
@@ -278,6 +278,8 @@ contract HoprChannels is
 
     /**
      * @dev recompute the domain seperator in case of a fork
+     * This function should be called by anyone when required.
+     * An event is emitted when the domain separator is updated
      */
     function updateDomainSeparator() public {
         // following encoding guidelines of EIP712

--- a/packages/ethereum/contracts/src/Channels.sol
+++ b/packages/ethereum/contracts/src/Channels.sol
@@ -54,6 +54,11 @@ abstract contract HoprChannelsEvents {
      * since this value is necessary for issuing and validating tickets.
      */
     event TicketRedeemed(bytes32 indexed channelId, HoprChannels.TicketIndex newTicketIndex);
+
+    /**
+     * Emitted once the domain separator is updated.
+     */
+    event DomainSeparatorUpdated(bytes32 indexed domainSeparator);
 }
 
 /**
@@ -276,7 +281,7 @@ contract HoprChannels is
      */
     function updateDomainSeparator() public {
         // following encoding guidelines of EIP712
-        domainSeparator = keccak256(
+        bytes32 newDomainSeparator = keccak256(
             abi.encode(
                 keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
                 keccak256(bytes("HoprChannels")),
@@ -285,6 +290,11 @@ contract HoprChannels is
                 address(this)
             )
         );
+
+        if (newDomainSeparator != domainSeparator) {
+            domainSeparator = newDomainSeparator;
+            emit DomainSeparatorUpdated(domainSeparator);
+        }
     }
 
     /**

--- a/packages/ethereum/contracts/src/Ledger.sol
+++ b/packages/ethereum/contracts/src/Ledger.sol
@@ -1,6 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity 0.8.19;
 
+abstract contract HoprLedgerEvents {
+    /**
+     * Emitted once the ledger domain separator is updated.
+     */
+    event LedgerDomainSeparatorUpdated(bytes32 indexed ledgerDomainSeparator);
+}
+
 /**
  *    &&&&
  *    &&&&
@@ -18,7 +25,7 @@ pragma solidity 0.8.19;
  *
  * Indexes data trustlessly to allow a fast-sync for nodes in the network.
  */
-abstract contract HoprLedger {
+abstract contract HoprLedger is HoprLedgerEvents {
     string public constant LEDGER_VERSION = "1.0.0";
 
     uint256 immutable snapshotInterval;
@@ -59,7 +66,7 @@ abstract contract HoprLedger {
      */
     function updateLedgerDomainSeparator() public {
         // following encoding guidelines of EIP712
-        ledgerDomainSeparator = keccak256(
+        bytes32 newLedgerDomainSeparator = keccak256(
             abi.encode(
                 keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
                 keccak256(bytes("HoprLedger")),
@@ -68,6 +75,10 @@ abstract contract HoprLedger {
                 address(this)
             )
         );
+        if (newLedgerDomainSeparator != ledgerDomainSeparator) {
+            ledgerDomainSeparator = newLedgerDomainSeparator;
+            emit LedgerDomainSeparatorUpdated(ledgerDomainSeparator);
+        }
     }
 
     function indexEvent(bytes memory payload) internal {

--- a/packages/ethereum/contracts/src/Ledger.sol
+++ b/packages/ethereum/contracts/src/Ledger.sol
@@ -63,6 +63,8 @@ abstract contract HoprLedger is HoprLedgerEvents {
 
     /**
      * @dev recompute the domain seperator in case of a fork
+     * This function should be called by anyone when required.
+     * An event is emitted when the domain separator is updated
      */
     function updateLedgerDomainSeparator() public {
         // following encoding guidelines of EIP712

--- a/packages/ethereum/contracts/src/node-stake/NodeSafeRegistry.sol
+++ b/packages/ethereum/contracts/src/node-stake/NodeSafeRegistry.sol
@@ -7,8 +7,18 @@ import { IHoprNodeManagementModule } from "../interfaces/INodeManagementModule.s
 import { Address } from "openzeppelin-contracts/utils/Address.sol";
 
 abstract contract HoprNodeSafeRegistryEvents {
+    /**
+     * Emitted once a safe and node pair gets registered
+     */
     event RegisteredNodeSafe(address indexed safeAddress, address indexed nodeAddress);
+    /**
+     * Emitted once a safe and node pair gets deregistered
+     */
     event DergisteredNodeSafe(address indexed safeAddress, address indexed nodeAddress);
+    /**
+     * Emitted once the domain separator is updated.
+     */
+    event DomainSeparatorUpdated(bytes32 indexed domainSeparator);
 }
 
 /**
@@ -191,10 +201,11 @@ contract HoprNodeSafeRegistry is HoprNodeSafeRegistryEvents {
     /**
      * @dev Recomputes the domain separator in case of a network fork or update.
      * This function should be called by anyone when required.
+     * An event is emitted when the domain separator is updated
      */
     function updateDomainSeparator() public {
         // following encoding guidelines of EIP712
-        domainSeparator = keccak256(
+        bytes32 newDomainSeparator = keccak256(
             abi.encode(
                 keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
                 keccak256(bytes("NodeSafeRegistry")),
@@ -203,6 +214,10 @@ contract HoprNodeSafeRegistry is HoprNodeSafeRegistryEvents {
                 address(this)
             )
         );
+        if (newDomainSeparator != domainSeparator) {
+            domainSeparator = newDomainSeparator;
+            emit DomainSeparatorUpdated(domainSeparator);
+        }
     }
 
     /**

--- a/packages/ethereum/contracts/src/node-stake/NodeSafeRegistry.sol
+++ b/packages/ethereum/contracts/src/node-stake/NodeSafeRegistry.sol
@@ -77,13 +77,7 @@ contract HoprNodeSafeRegistry is HoprNodeSafeRegistryEvents {
         uint96 nodeSigNonce;
     }
 
-    // Structure to represent a NodeSafe pair
-    struct NodeSafe {
-        address safeAddress;
-        address nodeChainKeyAddress;
-    }
-
-    // Structure to represent a NodeSafe pair with a nonce
+    // Structure to represent a node-safe pair with a nonce
     struct NodeSafeNonce {
         address safeAddress;
         address nodeChainKeyAddress;
@@ -131,43 +125,45 @@ contract HoprNodeSafeRegistry is HoprNodeSafeRegistryEvents {
     }
 
     /**
-     * @dev Checks whether a specific NodeSafe combination is registered.
-     * @param nodeSafe The NodeSafe struct containing the safe and node addresses.
-     * @return registered Whether the NodeSafe combination is registered.
+     * @dev Checks whether a specific node-safe combination is registered.
+     * @param safeAddress Address of safe
+     * @param nodeChainKeyAddress Address of node
+     * @return registered Whether the node-safe combination is registered.
      */
-    function isNodeSafeRegistered(NodeSafe memory nodeSafe) external view returns (bool) {
+    function isNodeSafeRegistered(address safeAddress, address nodeChainKeyAddress) external view returns (bool) {
         // If node is not registered to any safe, return false
-        if (_nodeToSafe[nodeSafe.nodeChainKeyAddress].safeAddress == address(0)) {
+        if (_nodeToSafe[nodeChainKeyAddress].safeAddress == address(0)) {
             return false;
         }
 
-        return _nodeToSafe[nodeSafe.nodeChainKeyAddress].safeAddress == nodeSafe.safeAddress;
+        return _nodeToSafe[nodeChainKeyAddress].safeAddress == safeAddress;
     }
 
     /**
      * @dev Register the Safe with a signature from the node.
      * This function can be called by any party.
-     * @param nodeSafe The NodeSafe struct containing the safe and node addresses.
+     * @param safeAddress Address of safe
+     * @param nodeChainKeyAddress Address of node
      * @param sig The signature provided by the node.
      */
-    function registerSafeWithNodeSig(NodeSafe memory nodeSafe, bytes calldata sig) external {
+    function registerSafeWithNodeSig(address safeAddress, address nodeChainKeyAddress, bytes calldata sig) external {
         // check adminKeyAddress has added HOPR tokens to the staking contract.
 
         // Compute the hash of the struct according to EIP712 guidelines
         bytes32 hashStruct =
-            keccak256(abi.encode(NODE_SAFE_TYPEHASH, nodeSafe, _nodeToSafe[nodeSafe.nodeChainKeyAddress].nodeSigNonce));
+            keccak256(abi.encode(NODE_SAFE_TYPEHASH, safeAddress, nodeChainKeyAddress, _nodeToSafe[nodeChainKeyAddress].nodeSigNonce));
 
         // Build the typed digest for signature verification
         bytes32 registerHash = keccak256(abi.encodePacked(bytes1(0x19), bytes1(0x01), domainSeparator, hashStruct));
 
         // Verify that the signature is from nodeChainKeyAddress
         (address recovered, ECDSA.RecoverError error) = ECDSA.tryRecover(registerHash, sig);
-        if (error != ECDSA.RecoverError.NoError || recovered != nodeSafe.nodeChainKeyAddress) {
+        if (error != ECDSA.RecoverError.NoError || recovered != nodeChainKeyAddress) {
             revert NotValidSignatureFromNode();
         }
 
         // store those state, emit events etc.
-        addNodeSafe(nodeSafe);
+        addNodeSafe(safeAddress, nodeChainKeyAddress);
     }
 
     /**
@@ -182,7 +178,7 @@ contract HoprNodeSafeRegistry is HoprNodeSafeRegistryEvents {
         }
 
         // Ensure that node is a member of the module
-        ensureNodeIsSafeModuleMember(NodeSafe({ safeAddress: msg.sender, nodeChainKeyAddress: nodeAddr }));
+        ensureNodeIsSafeModuleMember(msg.sender, nodeAddr);
 
         // Update the state and emit the event
         _nodeToSafe[nodeAddr].safeAddress = address(0);
@@ -195,7 +191,7 @@ contract HoprNodeSafeRegistry is HoprNodeSafeRegistryEvents {
      * @param safeAddr The address of the Safe to be registered.
      */
     function registerSafeByNode(address safeAddr) external {
-        addNodeSafe(NodeSafe({ safeAddress: safeAddr, nodeChainKeyAddress: msg.sender }));
+        addNodeSafe(safeAddr, msg.sender);
     }
 
     /**
@@ -222,58 +218,60 @@ contract HoprNodeSafeRegistry is HoprNodeSafeRegistryEvents {
 
     /**
      * @dev Internal function to store a node-safe pair and emit relevant events.
-     * @param nodeSafe The NodeSafe struct containing the safe and node addresses.
+     * @param safeAddress Address of safe
+     * @param nodeChainKeyAddress Address of node
      */
-    function addNodeSafe(NodeSafe memory nodeSafe) internal {
+    function addNodeSafe(address safeAddress, address nodeChainKeyAddress) internal {
         // Safe address cannot be zero
-        if (nodeSafe.safeAddress == address(0)) {
+        if (safeAddress == address(0)) {
             revert SafeAddressZero();
         }
         // Safe address cannot be zero
-        if (nodeSafe.nodeChainKeyAddress == address(0)) {
+        if (nodeChainKeyAddress == address(0)) {
             revert NodeAddressZero();
         }
 
         // Ensure that the node address is not a contract address
-        if (nodeSafe.nodeChainKeyAddress.isContract()) {
+        if (nodeChainKeyAddress.isContract()) {
             revert NodeIsContract();
         }
 
         // check this node hasn't been registered ower
-        if (_nodeToSafe[nodeSafe.nodeChainKeyAddress].safeAddress != address(0)) {
+        if (_nodeToSafe[nodeChainKeyAddress].safeAddress != address(0)) {
             revert NodeHasSafe();
         }
 
         // ensure that node is a member of the (enabled) NodeManagementModule
-        ensureNodeIsSafeModuleMember(nodeSafe);
+        ensureNodeIsSafeModuleMember(safeAddress, nodeChainKeyAddress);
 
-        NodeSafeRecord storage record = _nodeToSafe[nodeSafe.nodeChainKeyAddress];
+        NodeSafeRecord storage record = _nodeToSafe[nodeChainKeyAddress];
 
         // update record
-        record.safeAddress = nodeSafe.safeAddress;
+        record.safeAddress = safeAddress;
         record.nodeSigNonce = record.nodeSigNonce + 1; // as of Solidity 0.8, this reverts on overflows
 
         // update and emit event
-        emit RegisteredNodeSafe(nodeSafe.safeAddress, nodeSafe.nodeChainKeyAddress);
+        emit RegisteredNodeSafe(safeAddress, nodeChainKeyAddress);
     }
 
     /**
      * @dev Ensure that the node address is a member of
      * the enabled node management module of the safe
-     * @param nodeSafe The NodeSafe struct containing the safe and node addresses.
+     * @param safeAddress Address of safe
+     * @param nodeChainKeyAddress Address of node
      */
-    function ensureNodeIsSafeModuleMember(NodeSafe memory nodeSafe) internal view {
+    function ensureNodeIsSafeModuleMember(address safeAddress, address nodeChainKeyAddress) internal view {
         // nodeChainKeyAddress must be a member of the enabled node management module
         address nextModule;
         address[] memory modules;
         // there may be many modules, loop through them. Stop at the end point of the linked list
         while (nextModule != SENTINEL_MODULES) {
             // get modules for safe
-            (modules, nextModule) = IAvatar(nodeSafe.safeAddress).getModulesPaginated(SENTINEL_MODULES, pageSize);
+            (modules, nextModule) = IAvatar(safeAddress).getModulesPaginated(SENTINEL_MODULES, pageSize);
             for (uint256 i = 0; i < modules.length; i++) {
                 if (
                     IHoprNodeManagementModule(modules[i]).isHoprNodeManagementModule()
-                        && IHoprNodeManagementModule(modules[i]).isNode(nodeSafe.nodeChainKeyAddress)
+                        && IHoprNodeManagementModule(modules[i]).isNode(nodeChainKeyAddress)
                 ) {
                     return;
                 }

--- a/packages/ethereum/contracts/src/node-stake/NodeSafeRegistry.sol
+++ b/packages/ethereum/contracts/src/node-stake/NodeSafeRegistry.sol
@@ -150,8 +150,11 @@ contract HoprNodeSafeRegistry is HoprNodeSafeRegistryEvents {
         // check adminKeyAddress has added HOPR tokens to the staking contract.
 
         // Compute the hash of the struct according to EIP712 guidelines
-        bytes32 hashStruct =
-            keccak256(abi.encode(NODE_SAFE_TYPEHASH, safeAddress, nodeChainKeyAddress, _nodeToSafe[nodeChainKeyAddress].nodeSigNonce));
+        bytes32 hashStruct = keccak256(
+            abi.encode(
+                NODE_SAFE_TYPEHASH, safeAddress, nodeChainKeyAddress, _nodeToSafe[nodeChainKeyAddress].nodeSigNonce
+            )
+        );
 
         // Build the typed digest for signature verification
         bytes32 registerHash = keccak256(abi.encodePacked(bytes1(0x19), bytes1(0x01), domainSeparator, hashStruct));

--- a/packages/ethereum/contracts/test/Channels.t.sol
+++ b/packages/ethereum/contracts/test/Channels.t.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.6.0 <0.9.0;
 import { Test } from "forge-std/Test.sol";
 import { ERC1820RegistryFixtureTest } from "./utils/ERC1820Registry.sol";
 import { HoprChannels, HoprChannelsEvents } from "../src/Channels.sol";
+import { HoprLedgerEvents } from "../src/Ledger.sol";
 import { CryptoUtils } from "./utils/Crypto.sol";
 import { HoprMultiSig } from "../src/MultiSig.sol";
 import { ERC777 } from "openzeppelin-contracts/token/ERC777/ERC777.sol";
@@ -68,7 +69,7 @@ contract MyHoprChannels is HoprChannels {
     { }
 }
 
-contract HoprChannelsTest is Test, ERC1820RegistryFixtureTest, CryptoUtils, HoprChannelsEvents {
+contract HoprChannelsTest is Test, ERC1820RegistryFixtureTest, CryptoUtils, HoprChannelsEvents, HoprLedgerEvents {
     HoprChannels.Timestamp constant closureNoticePeriod = HoprChannels.Timestamp.wrap(15);
 
     bytes32 constant PROOF_OF_RELAY_SECRET_0 = keccak256(abi.encodePacked("PROOF_OF_RELAY_SECRET_0"));
@@ -1871,6 +1872,18 @@ contract HoprChannelsTest is Test, ERC1820RegistryFixtureTest, CryptoUtils, Hopr
 
         // call updateDomainSeparator when chainid is different
         vm.chainId(newChaidId);
+        vm.expectEmit(true, true, false, false, address(hoprChannels));
+        emit DomainSeparatorUpdated(
+            keccak256(
+                abi.encode(
+                    keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                    keccak256(bytes("HoprChannels")),
+                    keccak256(bytes(hoprChannels.VERSION())),
+                    newChaidId,
+                    address(hoprChannels)
+                )
+            )
+        );
         hoprChannels.updateDomainSeparator();
         assertTrue(hoprChannels.domainSeparator() != domainSeparatorOnDeployment);
     }
@@ -1886,6 +1899,18 @@ contract HoprChannelsTest is Test, ERC1820RegistryFixtureTest, CryptoUtils, Hopr
 
         // call updateLedgerDomainSeparator when chainid is different
         vm.chainId(newChaidId);
+        vm.expectEmit(true, true, false, false, address(hoprChannels));
+        emit LedgerDomainSeparatorUpdated(
+            keccak256(
+                abi.encode(
+                    keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                    keccak256(bytes("HoprLedger")),
+                    keccak256(bytes(hoprChannels.LEDGER_VERSION())),
+                    newChaidId,
+                    address(hoprChannels)
+                )
+            )
+        );
         hoprChannels.updateLedgerDomainSeparator();
         assertTrue(hoprChannels.ledgerDomainSeparator() != ledgerDomainSeparatorOnDeployment);
     }

--- a/packages/ethereum/contracts/test/node-stake/NodeSafeRegistry.t.sol
+++ b/packages/ethereum/contracts/test/node-stake/NodeSafeRegistry.t.sol
@@ -294,6 +294,18 @@ contract HoprNodeSafeRegistryTest is Test, HoprNodeSafeRegistryEvents {
 
         // call updateDomainSeparator when chainid is different
         vm.chainId(newChaidId);
+            vm.expectEmit(true, true, false, false, address(nodeSafeRegistry));
+        emit DomainSeparatorUpdated(
+            keccak256(
+                abi.encode(
+                    keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                    keccak256(bytes("NodeSafeRegistry")),
+                    keccak256(bytes(nodeSafeRegistry.VERSION())),
+                    newChaidId,
+                    address(nodeSafeRegistry)
+                )
+            )
+        );
         nodeSafeRegistry.updateDomainSeparator();
         assertTrue(nodeSafeRegistry.domainSeparator() != domainSeparatorOnDeployment);
     }

--- a/packages/ethereum/contracts/test/node-stake/NodeSafeRegistry.t.sol
+++ b/packages/ethereum/contracts/test/node-stake/NodeSafeRegistry.t.sol
@@ -60,23 +60,22 @@ contract HoprNodeSafeRegistryTest is Test, HoprNodeSafeRegistryEvents {
                 && safeAddress != address(this) && safeAddress != address(nodeSafeRegistry) && safeAddress != vm.addr(303)
         );
 
-        HoprNodeSafeRegistry.NodeSafe memory nodeSafe =
-            HoprNodeSafeRegistry.NodeSafe(safeAddress, vm.addr(nodePrivateKey));
+        address nodeChainKeyAddress = vm.addr(nodePrivateKey);
 
         // verify the registration is not known beforehand
-        assertFalse(nodeSafeRegistry.isNodeSafeRegistered(nodeSafe));
+        assertFalse(nodeSafeRegistry.isNodeSafeRegistered(safeAddress, nodeChainKeyAddress));
 
-        uint256 nodeSigNonce = nodeSafeRegistry.nodeSigNonce(nodeSafe.nodeChainKeyAddress);
-        (address nodeAddress, bytes memory sig) = _helperBuildSig(nodePrivateKey, nodeSafe, nodeSigNonce);
+        uint256 nodeSigNonce = nodeSafeRegistry.nodeSigNonce(nodeChainKeyAddress);
+        (address nodeAddress, bytes memory sig) = _helperBuildSig(nodePrivateKey, safeAddress, nodeChainKeyAddress, nodeSigNonce);
 
         _helperMockSafe(safeAddress, nodeAddress, true, true);
 
         vm.expectEmit(true, true, false, false, address(nodeSafeRegistry));
         emit RegisteredNodeSafe(safeAddress, nodeAddress);
-        nodeSafeRegistry.registerSafeWithNodeSig(nodeSafe, sig);
+        nodeSafeRegistry.registerSafeWithNodeSig(safeAddress, nodeChainKeyAddress, sig);
 
         // verify the registration worked
-        assertTrue(nodeSafeRegistry.isNodeSafeRegistered(nodeSafe));
+        assertTrue(nodeSafeRegistry.isNodeSafeRegistered(safeAddress, nodeChainKeyAddress));
 
         vm.clearMockedCalls();
     }
@@ -91,22 +90,21 @@ contract HoprNodeSafeRegistryTest is Test, HoprNodeSafeRegistryEvents {
                 && safeAddress != address(this) && safeAddress != address(nodeSafeRegistry) && safeAddress != vm.addr(303)
         );
 
-        HoprNodeSafeRegistry.NodeSafe memory nodeSafe =
-            HoprNodeSafeRegistry.NodeSafe(safeAddress, vm.addr(nodePrivateKey));
+        address nodeChainKeyAddress = vm.addr(nodePrivateKey);
 
         // verify the registration is not known beforehand
-        assertFalse(nodeSafeRegistry.isNodeSafeRegistered(nodeSafe));
+        assertFalse(nodeSafeRegistry.isNodeSafeRegistered(safeAddress, nodeChainKeyAddress));
 
-        uint256 nodeSigNonce = nodeSafeRegistry.nodeSigNonce(nodeSafe.nodeChainKeyAddress);
-        (address nodeAddress, bytes memory sig) = _helperBuildSig(nodePrivateKey, nodeSafe, nodeSigNonce);
+        uint256 nodeSigNonce = nodeSafeRegistry.nodeSigNonce(nodeChainKeyAddress);
+        (address nodeAddress, bytes memory sig) = _helperBuildSig(nodePrivateKey, safeAddress, nodeChainKeyAddress, nodeSigNonce);
 
         _helperMockSafe(safeAddress, nodeAddress, true, true);
 
-        nodeSafeRegistry.registerSafeWithNodeSig(nodeSafe, sig);
+        nodeSafeRegistry.registerSafeWithNodeSig(safeAddress, nodeChainKeyAddress, sig);
 
         // fail to re-use the signature
         vm.expectRevert(HoprNodeSafeRegistry.NotValidSignatureFromNode.selector);
-        nodeSafeRegistry.registerSafeWithNodeSig(nodeSafe, sig);
+        nodeSafeRegistry.registerSafeWithNodeSig(safeAddress, nodeChainKeyAddress, sig);
 
         vm.clearMockedCalls();
     }
@@ -335,15 +333,16 @@ contract HoprNodeSafeRegistryTest is Test, HoprNodeSafeRegistryEvents {
      */
     function _helperBuildSig(
         uint256 mockNodePrivateKey,
-        HoprNodeSafeRegistry.NodeSafe memory nodeSafe,
+        address safeAddress,
+        address nodeChainKeyAddress,
         uint256 nonce
     )
         private
         returns (address, bytes memory)
     {
         HoprNodeSafeRegistry.NodeSafeNonce memory nodeSafeNonce = HoprNodeSafeRegistry.NodeSafeNonce({
-            safeAddress: nodeSafe.safeAddress,
-            nodeChainKeyAddress: nodeSafe.nodeChainKeyAddress,
+            safeAddress: safeAddress,
+            nodeChainKeyAddress: nodeChainKeyAddress,
             nodeSigNonce: nonce
         });
         bytes32 hashStruct = keccak256(abi.encode(nodeSafeRegistry.NODE_SAFE_TYPEHASH(), nodeSafeNonce));

--- a/packages/ethereum/contracts/test/node-stake/NodeSafeRegistry.t.sol
+++ b/packages/ethereum/contracts/test/node-stake/NodeSafeRegistry.t.sol
@@ -66,7 +66,8 @@ contract HoprNodeSafeRegistryTest is Test, HoprNodeSafeRegistryEvents {
         assertFalse(nodeSafeRegistry.isNodeSafeRegistered(safeAddress, nodeChainKeyAddress));
 
         uint256 nodeSigNonce = nodeSafeRegistry.nodeSigNonce(nodeChainKeyAddress);
-        (address nodeAddress, bytes memory sig) = _helperBuildSig(nodePrivateKey, safeAddress, nodeChainKeyAddress, nodeSigNonce);
+        (address nodeAddress, bytes memory sig) =
+            _helperBuildSig(nodePrivateKey, safeAddress, nodeChainKeyAddress, nodeSigNonce);
 
         _helperMockSafe(safeAddress, nodeAddress, true, true);
 
@@ -96,7 +97,8 @@ contract HoprNodeSafeRegistryTest is Test, HoprNodeSafeRegistryEvents {
         assertFalse(nodeSafeRegistry.isNodeSafeRegistered(safeAddress, nodeChainKeyAddress));
 
         uint256 nodeSigNonce = nodeSafeRegistry.nodeSigNonce(nodeChainKeyAddress);
-        (address nodeAddress, bytes memory sig) = _helperBuildSig(nodePrivateKey, safeAddress, nodeChainKeyAddress, nodeSigNonce);
+        (address nodeAddress, bytes memory sig) =
+            _helperBuildSig(nodePrivateKey, safeAddress, nodeChainKeyAddress, nodeSigNonce);
 
         _helperMockSafe(safeAddress, nodeAddress, true, true);
 
@@ -292,7 +294,7 @@ contract HoprNodeSafeRegistryTest is Test, HoprNodeSafeRegistryEvents {
 
         // call updateDomainSeparator when chainid is different
         vm.chainId(newChaidId);
-            vm.expectEmit(true, true, false, false, address(nodeSafeRegistry));
+        vm.expectEmit(true, true, false, false, address(nodeSafeRegistry));
         emit DomainSeparatorUpdated(
             keccak256(
                 abi.encode(


### PR DESCRIPTION
- Added events to be emitted when domain separators change in Channels, Ledger and NodeSafeRegistry
- Replace `NodeSafe` struct with flattened addresses
- Update relevant tests