### PR TITLE
scripts: Set host IP for GCP nodes

### DIFF
--- a/scripts/setup-hoprd-nodes.sh
+++ b/scripts/setup-hoprd-nodes.sh
@@ -28,11 +28,11 @@ setup_node(){
   gcloud compute scp --zone ${zone}  $identities_path/$identity/{.hoprd.id,.env} ${instance}:/opt/hoprd/
   echo "Ensure host ip is set in environment file"
   gcloud compute ssh --zone ${zone} ${instance} --command '
-    curl -H "Metadata-Flavor:Google" http://metadata/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip > myip.txt
-    echo "HOPRD_HOST=\$(<myip.txt)" >> /opt/hoprd/.env
-    rm myip.txt
+    ip=$(curl -s -H "Metadata-Flavor:Google" http://metadata/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)
+    sudo echo "HOPRD_HOST=${ip}:9091" >> /opt/hoprd/.env
   '
   gcloud compute ssh --zone ${zone} ${instance} --command 'sudo chown root:root -R /opt/hoprd'
+  echo "Restarting VM ${instance}"
   gcloud compute ssh --zone ${zone} ${instance} --command 'sudo service hoprd restart'
 }
 

--- a/scripts/setup-hoprd-nodes.sh
+++ b/scripts/setup-hoprd-nodes.sh
@@ -26,6 +26,12 @@ setup_node(){
   echo "Setting up ${instance} with $identities_path/$identity"
   gcloud compute ssh --zone ${zone} ${instance} --command 'sudo rm -f /opt/hoprd/{.hoprd.id,.env}'
   gcloud compute scp --zone ${zone}  $identities_path/$identity/{.hoprd.id,.env} ${instance}:/opt/hoprd/
+  echo "Ensure host ip is set in environment file"
+  gcloud compute ssh --zone ${zone} ${instance} --command '
+    curl -H "Metadata-Flavor:Google" http://metadata/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip > myip.txt
+    echo "HOPRD_HOST=\$(<myip.txt)" >> /opt/hoprd/.env
+    rm myip.txt
+  '
   gcloud compute ssh --zone ${zone} ${instance} --command 'sudo chown root:root -R /opt/hoprd'
   gcloud compute ssh --zone ${zone} ${instance} --command 'sudo service hoprd restart'
 }


### PR DESCRIPTION
The `hoprd` node must have `HOPRD_HOST` set to the public IP which other peers may use to connect to it. This PR adapts the GCP setup script to have that entry in the `.env` file.