### PR TITLE
Add back metadata storage on register to Network object

### DIFF
--- a/packages/core/crates/core-hopr/src/adaptors/network.rs
+++ b/packages/core/crates/core-hopr/src/adaptors/network.rs
@@ -54,6 +54,7 @@ pub mod wasm {
     use futures::{future::poll_fn, StreamExt};
     use js_sys::JsString;
     use utils_types::traits::PeerIdLike;
+    use utils_misc::utils::wasm::js_map_to_hash_map;
     use wasm_bindgen::prelude::*;
 
     /// Wrapper object for the `Network` functionality to be callable from outside
@@ -236,14 +237,12 @@ pub mod wasm {
         }
 
         #[wasm_bindgen]
-        pub async fn register_with_metadata(&mut self, peer: JsString, origin: PeerOrigin, _metadata: &js_sys::Map) {
+        pub async fn register_with_metadata(&mut self, peer: JsString, origin: PeerOrigin, metadata: &js_sys::Map) {
             let peer: String = peer.into();
             match PeerId::from_str(&peer) {
                 Ok(p) => {
-                    // TODO: ignoring metadata for now
-                    // self.add_with_metadata(&p, origin, js_map_to_hash_map(metadata))
                     match poll_fn(|cx| Pin::new(&mut self.change_notifier).poll_ready(cx)).await {
-                        Ok(_) => match self.change_notifier.start_send(NetworkEvent::Register(p, origin)) {
+                        Ok(_) => match self.change_notifier.start_send(NetworkEvent::Register(p, origin, js_map_to_hash_map(metadata))) {
                             Ok(_) => {}
                             Err(e) => error!("Failed to sent network update 'register' to the receiver: {}", e),
                         },

--- a/packages/core/crates/core-hopr/src/constants.rs
+++ b/packages/core/crates/core-hopr/src/constants.rs
@@ -1,0 +1,23 @@
+/// Application version as presented externally using the heartbeat mechanism
+pub const APP_VERSION: &str = "2.0.0";
+
+/// Name of the metadata key holding the protocol version
+pub const PEER_METADATA_PROTOCOL_VERSION: &str = "protocol_version";
+
+#[cfg(feature = "wasm")]
+pub mod wasm {
+    use js_sys::JsString;
+    use wasm_bindgen::prelude::wasm_bindgen;
+
+    use super::*;
+
+    #[wasm_bindgen]
+    pub fn app_version() -> JsString {
+        JsString::from(APP_VERSION)
+    }
+
+    #[wasm_bindgen]
+    pub fn peer_metadata_protocol_version_name() -> JsString {
+        JsString::from(PEER_METADATA_PROTOCOL_VERSION)
+    }
+}

--- a/packages/core/crates/core-hopr/src/lib.rs
+++ b/packages/core/crates/core-hopr/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod adaptors;
+pub mod constants;
 pub mod errors;
 mod helpers;
 mod p2p;
@@ -151,7 +152,8 @@ pub fn build_components(
     );
 
     let (ping_tx, ping_rx) = futures::channel::mpsc::unbounded::<(PeerId, ControlMessage)>();
-    let (pong_tx, pong_rx) = futures::channel::mpsc::unbounded::<(PeerId, std::result::Result<ControlMessage, ()>)>();
+    let (pong_tx, pong_rx) =
+        futures::channel::mpsc::unbounded::<(PeerId, std::result::Result<(ControlMessage, String), ()>)>();
 
     // manual ping explicitly called by the API
     let ping = Ping::new(
@@ -176,7 +178,7 @@ pub fn build_components(
 
     let (hb_ping_tx, hb_ping_rx) = futures::channel::mpsc::unbounded::<(PeerId, ControlMessage)>();
     let (hb_pong_tx, hb_pong_rx) =
-        futures::channel::mpsc::unbounded::<(PeerId, std::result::Result<ControlMessage, ()>)>();
+        futures::channel::mpsc::unbounded::<(PeerId, std::result::Result<(ControlMessage, String), ()>)>();
 
     let heartbeat_network_clone = network.clone();
     let ping_network_clone = network.clone();
@@ -328,6 +330,8 @@ pub mod wasm {
     use utils_log::logger::wasm::JsLogger;
     use utils_misc::utils::wasm::JsResult;
     use wasm_bindgen::prelude::*;
+
+    pub use crate::constants::wasm::*;
 
     // When the `wee_alloc` feature is enabled, use `wee_alloc` as the global allocator.
     #[cfg(feature = "wee_alloc")]

--- a/packages/core/crates/core-hopr/src/p2p.rs
+++ b/packages/core/crates/core-hopr/src/p2p.rs
@@ -144,11 +144,11 @@ pub(crate) async fn p2p_loop(
                         }
                     },
                     NetworkEvent::PeerOffline(_peer) => {
-                        // TODO: this functionality may not be needed after swtich to rust-libp2p
+                        // NOTE: this functionality is not be needed after swtich to rust-libp2p
                     },
-                    NetworkEvent::Register(peer, origin) => {
+                    NetworkEvent::Register(peer, origin, metadata) => {
                         let mut writer = network.write().await;
-                        (*writer).add(&peer, origin)
+                        (*writer).add_with_metadata(&peer, origin, metadata)
                     },
                     NetworkEvent::Unregister(peer) => {
                         let mut writer = network.write().await;

--- a/packages/core/crates/core-hopr/src/p2p.rs
+++ b/packages/core/crates/core-hopr/src/p2p.rs
@@ -302,7 +302,7 @@ pub(crate) async fn p2p_loop(
                 })) => {
                     info!("Received a Ping request {} from {}", request_id, peer);
                     let challenge_response = api::HeartbeatResponder::generate_challenge_response(&request.0);
-                    match swarm.behaviour_mut().heartbeat.send_response(channel, Pong(challenge_response)) {
+                    match swarm.behaviour_mut().heartbeat.send_response(channel, Pong(challenge_response, crate::constants::APP_VERSION.to_owned())) {
                         Ok(_) => {},
                         Err(_) => {
                             error!("An error occured during the ping response, channel is either closed or timed out.");
@@ -319,7 +319,7 @@ pub(crate) async fn p2p_loop(
                     info!("Received a Pong response from {} (#{}) ", peer, request_id);
                     if active_manual_pings.take(&request_id).is_some() {
                         debug!("Processing manual ping response from peer {}", peer);
-                        match manual_ping_responds.record_pong((peer, Ok(response.0))).await {
+                        match manual_ping_responds.record_pong((peer, Ok((response.0, response.1)))).await {
                             Ok(_) => {},
                             Err(e) => {
                                 error!("Manual ping mechanism could not be updated with pong messages: {}", e);
@@ -327,7 +327,7 @@ pub(crate) async fn p2p_loop(
                         }
                     } else {
                         debug!("Processing heartbeat ping response from peer {}", peer);
-                        match heartbeat_responds.record_pong((peer, Ok(response.0))).await {
+                        match heartbeat_responds.record_pong((peer, Ok((response.0, response.1)))).await {
                             Ok(_) => {},
                             Err(e) => {
                                 error!("Heartbeat mechanism could not be updated with pong messages: {}", e);

--- a/packages/core/crates/core-network/src/network.rs
+++ b/packages/core/crates/core-network/src/network.rs
@@ -105,11 +105,11 @@ impl std::fmt::Display for Health {
     }
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NetworkEvent {
     CloseConnection(PeerId),
     PeerOffline(PeerId),
-    Register(PeerId, PeerOrigin),
+    Register(PeerId, PeerOrigin, Option<HashMap<String, String>>),
     Unregister(PeerId),
 }
 

--- a/packages/core/crates/core-p2p/src/lib.rs
+++ b/packages/core/crates/core-p2p/src/lib.rs
@@ -25,7 +25,7 @@ use core_types::acknowledgement::Acknowledgement;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Ping(pub ControlMessage);
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct Pong(pub ControlMessage);
+pub struct Pong(pub ControlMessage, pub String);
 
 pub const HOPR_HEARTBEAT_PROTOCOL_V_0_1_0: &str = "/hopr/heartbeat/0.1.0";
 pub const HOPR_MESSAGE_PROTOCOL_V_0_1_0: &str = "/hopr/msg/0.1.0";

--- a/packages/core/protocol-config.json
+++ b/packages/core/protocol-config.json
@@ -12,8 +12,8 @@
         "token": "0x9A676e781A523b5d0C0e43731313A708CB607508",
         "module_implementation": "0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
         "node_safe_registry": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
-        "ticket_price_oracle": "0x59b670e9fA9D0A427751Af201D676719a970857b",
-        "announcements": "0x4ed7c70F96B99c776995fB64377f0d4aB3B0e1C1",
+        "ticket_price_oracle": "0x7a2088a1bFc9d81c55368AE168C2C02570cB814F",
+        "announcements": "0x09635F643e140090A9A8Dcd712eD6285858ceBef",
         "node_stake_v2_factory": "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e"
       },
       "tags": []
@@ -30,8 +30,8 @@
         "token": "0x9A676e781A523b5d0C0e43731313A708CB607508",
         "module_implementation": "0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
         "node_safe_registry": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
-        "ticket_price_oracle": "0x59b670e9fA9D0A427751Af201D676719a970857b",
-        "announcements": "0x4ed7c70F96B99c776995fB64377f0d4aB3B0e1C1",
+        "ticket_price_oracle": "0x7a2088a1bFc9d81c55368AE168C2C02570cB814F",
+        "announcements": "0x09635F643e140090A9A8Dcd712eD6285858ceBef",
         "node_stake_v2_factory": "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e"
       },
       "tags": []

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ import retimer from 'retimer'
 import { compareAddressesLocalMode, compareAddressesPublicMode } from '@hoprnet/hopr-connect'
 
 import {
+  app_version,
   create_counter,
   create_gauge,
   create_histogram_with_buckets,
@@ -56,7 +57,7 @@ import {
   PingConfig
 } from '@hoprnet/hopr-utils'
 
-import { FULL_VERSION, INTERMEDIATE_HOPS, MAX_HOPS, PACKET_SIZE, VERSION, MAX_PARALLEL_PINGS } from './constants.js'
+import { INTERMEDIATE_HOPS, MAX_HOPS, PACKET_SIZE, VERSION, MAX_PARALLEL_PINGS } from './constants.js'
 
 import { findPath } from './path/index.js'
 
@@ -694,7 +695,7 @@ export class Hopr extends EventEmitter {
    * Returns the version of hopr-core.
    */
   public getVersion() {
-    return FULL_VERSION
+    return app_version()
   }
 
   /**

--- a/packages/ethereum/contracts/contracts-addresses.json
+++ b/packages/ethereum/contracts/contracts-addresses.json
@@ -2,32 +2,32 @@
   "networks": {
     "anvil-localhost": {
       "environment_type": "local",
-      "indexer_start_block_number": 34,
+      "indexer_start_block_number": 6,
       "addresses": {
-        "network_registry": "0x4EE6eCAD1c2Dae9f525404De8555724e3c35d07B",
-        "network_registry_proxy": "0x172076E0166D1F9Cc711C77Adf8488051744980C",
-        "channels": "0xf4B146FbA71F41E0592668ffbF264F1D186b2Ca8",
-        "token": "0x8198f5d8F8CfFE8f9C413d98a0A55aEB8ab9FbB7",
-        "module_implementation": "0x51A1ceB83B83F1985a81C295d1fF28Afef186E02",
-        "node_safe_registry": "0x36b58F5C1969B7b6591D752ea6F5486D069010AB",
-        "ticket_price_oracle": "0x1c85638e118b37167e9298c2268758e058DdfDA0",
-        "announcements": "0x367761085BF3C12e5DA2Df99AC6E1a824612b8fb",
-        "node_stake_v2_factory": "0xDC11f7E700A4c898AE5CAddB1082cFfa76512aDD"
+        "network_registry": "0x3Aa5ebB10DC797CAC828524e59A333d0A371443c",
+        "network_registry_proxy": "0x68B1D87F95878fE05B998F19b66F4baba5De1aed",
+        "channels": "0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE",
+        "token": "0x9A676e781A523b5d0C0e43731313A708CB607508",
+        "module_implementation": "0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
+        "node_safe_registry": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
+        "ticket_price_oracle": "0x7a2088a1bFc9d81c55368AE168C2C02570cB814F",
+        "announcements": "0x09635F643e140090A9A8Dcd712eD6285858ceBef",
+        "node_stake_v2_factory": "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e"
       }
     },
     "anvil-localhost2": {
       "environment_type": "local",
-      "indexer_start_block_number": 34,
+      "indexer_start_block_number": 6,
       "addresses": {
-        "network_registry": "0x4EE6eCAD1c2Dae9f525404De8555724e3c35d07B",
-        "network_registry_proxy": "0x172076E0166D1F9Cc711C77Adf8488051744980C",
-        "channels": "0xf4B146FbA71F41E0592668ffbF264F1D186b2Ca8",
-        "token": "0x8198f5d8F8CfFE8f9C413d98a0A55aEB8ab9FbB7",
-        "module_implementation": "0x51A1ceB83B83F1985a81C295d1fF28Afef186E02",
-        "node_safe_registry": "0x36b58F5C1969B7b6591D752ea6F5486D069010AB",
-        "ticket_price_oracle": "0x1c85638e118b37167e9298c2268758e058DdfDA0",
-        "announcements": "0x367761085BF3C12e5DA2Df99AC6E1a824612b8fb",
-        "node_stake_v2_factory": "0xDC11f7E700A4c898AE5CAddB1082cFfa76512aDD"
+        "network_registry": "0x3Aa5ebB10DC797CAC828524e59A333d0A371443c",
+        "network_registry_proxy": "0x68B1D87F95878fE05B998F19b66F4baba5De1aed",
+        "channels": "0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE",
+        "token": "0x9A676e781A523b5d0C0e43731313A708CB607508",
+        "module_implementation": "0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
+        "node_safe_registry": "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
+        "ticket_price_oracle": "0x7a2088a1bFc9d81c55368AE168C2C02570cB814F",
+        "announcements": "0x09635F643e140090A9A8Dcd712eD6285858ceBef",
+        "node_stake_v2_factory": "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e"
       }
     },
     "rotsee": {

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -12,6 +12,7 @@ export * from './ethereum/index.js'
 export * from './utils.js'
 
 export {
+  app_version,
   create_counter,
   SimpleCounter,
   create_multi_counter,

--- a/scripts/setup-local-cluster.sh
+++ b/scripts/setup-local-cluster.sh
@@ -110,7 +110,7 @@ function cleanup {
 
   # Cleaning up everything
   log "Wiping databases"
-  find -L "${tmp_dir}" -type d -name "${node_prefix}_*" -exec rm -rf {} +
+  find -L "${tmp_dir}" -type d -name "${node_prefix}_*" -exec rm -rf {} + || true
 
   log "Cleaning up processes"
   for port in 8545 13301 13302 13303 13304 13305 19091 19092 19093 19094 19095; do
@@ -192,8 +192,8 @@ function generate_local_identities() {
   log "Generate local identities"
 
   # remove existing identity files, .safe.args
-  find -L "${tmp_dir}" -type f -name "${node_prefix}_*.safe.args" -delete
-  find -L "${tmp_dir}" -type f -name "${node_prefix}_*.id" -delete
+  find -L "${tmp_dir}" -type f -name "${node_prefix}_*.safe.args" -delete || true
+  find -L "${tmp_dir}" -type f -name "${node_prefix}_*.id" -delete || true
 
   env ETHERSCAN_API_KEY="" IDENTITY_PASSWORD="${password}" \
     hopli identity \
@@ -208,7 +208,7 @@ function generate_local_identities() {
 function create_local_safes() {
   log "Create safe"
 
-  mapfile -t id_files <<< "$(find -L "${tmp_dir}" -type f -name "${node_prefix}_*.id" | sort)"
+  mapfile -t id_files <<< "$(find -L "${tmp_dir}" -type f -name "${node_prefix}_*.id" | sort || true)"
 
   # create a loop so safes are created for all the nodes TODO:
   for id_file in ${id_files[@]}; do


### PR DESCRIPTION
## What
Metadata was skipped during the rust-libp2p migration and never made its way back into the register operation. This PR fixes that and removes some obsolete comments as well.
- [x] Fixes the version propagation through ping
- [x] Fixes the local cluster failing on Darwin
- [x] Minor comment fixes 

## Notes
Fixes #5395

## Testing
![image](https://github.com/hoprnet/hoprnet/assets/9529609/b1cd7c19-14b5-498a-aa26-a12f3d9b860a)
