### PR TITLE
Hotfix Add force sync task

### DIFF
--- a/packages/ethereum/contracts/script/SingleAction.s.sol
+++ b/packages/ethereum/contracts/script/SingleAction.s.sol
@@ -200,7 +200,7 @@ contract SingleActionFromPrivateKeyScript is Test, NetworkConfig {
         // bytes memory
         vm.stopBroadcast();
 
-        // prepare data paylaods for manager 
+        // prepare data paylaods for manager
         address[] memory stakingSafeAddresses = new address[](nodeAddresses.length);
         for (uint256 m = 0; m < nodeAddresses.length; m++) {
             stakingSafeAddresses[m] = safe;
@@ -530,7 +530,9 @@ contract SingleActionFromPrivateKeyScript is Test, NetworkConfig {
 
         // 1. check if nodes have been registered, if so, skip
         for (uint256 i = 0; i < nodeAddresses.length; i++) {
-            try HoprNetworkRegistry(nrContractAddress).nodeRegisterdToAccount(nodeAddresses[i]) returns (address registeredAccount) {
+            try HoprNetworkRegistry(nrContractAddress).nodeRegisterdToAccount(nodeAddresses[i]) returns (
+                address registeredAccount
+            ) {
                 if (registeredAccount == address(0)) {
                     accounts.push(stakingAccounts[i]);
                     nodes.push(nodeAddresses[i]);
@@ -566,7 +568,9 @@ contract SingleActionFromPrivateKeyScript is Test, NetworkConfig {
 
         // 2. check if nodes have been registered, if not, skip
         for (uint256 i = 0; i < nodeAddresses.length; i++) {
-            try HoprNetworkRegistry(nrContractAddress).nodeRegisterdToAccount(nodeAddresses[i]) returns (address registeredAccount) {
+            try HoprNetworkRegistry(nrContractAddress).nodeRegisterdToAccount(nodeAddresses[i]) returns (
+                address registeredAccount
+            ) {
                 if (registeredAccount != address(0)) {
                     nodes.push(nodeAddresses[i]);
                 }
@@ -657,7 +661,9 @@ contract SingleActionFromPrivateKeyScript is Test, NetworkConfig {
         getNetworkAndMsgSender();
 
         // 2. sync peers eligibility according to the latest requirement of its current state
-        try HoprNetworkRegistry(currentNetworkDetail.addresses.networkRegistryContractAddress).managerSync(stakingAccounts) {
+        try HoprNetworkRegistry(currentNetworkDetail.addresses.networkRegistryContractAddress).managerSync(
+            stakingAccounts
+        ) {
             emit log_string("Manager synced eligibility on network regsitry");
         } catch (bytes memory lowlevelData) {
             emit log_named_bytes("sync eligibility on network registry error", lowlevelData);
@@ -670,16 +676,13 @@ contract SingleActionFromPrivateKeyScript is Test, NetworkConfig {
      * @dev On network registry contract, set eligibility of some staking addresses to desired values
      * This function should only be called by a manager
      */
-    function forceSyncEligibility(
-        address[] memory stakingAccounts,
-        bool[] memory eligibilities
-    ) public {
+    function forceSyncEligibility(address[] memory stakingAccounts, bool[] memory eligibilities) public {
         // 1. get network and msg.sender
         getNetworkAndMsgSender();
 
         // 2. call private function to set eligibility
         _forceSyncEligibility(stakingAccounts, eligibilities);
-    
+
         vm.stopBroadcast();
     }
 
@@ -687,14 +690,13 @@ contract SingleActionFromPrivateKeyScript is Test, NetworkConfig {
      * @dev On network registry contract, set eligibility of some staking addresses to desired values
      * This function should only be called by a manager
      */
-    function _forceSyncEligibility(
-        address[] memory stakingAccounts,
-        bool[] memory eligibilities
-    ) private {
+    function _forceSyncEligibility(address[] memory stakingAccounts, bool[] memory eligibilities) private {
         require(stakingAccounts.length == eligibilities.length, "Input lengths are different");
 
         // 2. sync peers eligibility according to the latest requirement of its current state
-        try HoprNetworkRegistry(currentNetworkDetail.addresses.networkRegistryContractAddress).managerForceSync(stakingAccounts, eligibilities) {
+        try HoprNetworkRegistry(currentNetworkDetail.addresses.networkRegistryContractAddress).managerForceSync(
+            stakingAccounts, eligibilities
+        ) {
             emit log_string("Manager set eligibility on network regsitry");
         } catch (bytes memory lowlevelData) {
             emit log_named_bytes("set eligibility on network registry error", lowlevelData);

--- a/packages/hopli/README.md
+++ b/packages/hopli/README.md
@@ -142,7 +142,7 @@ hopli migrate-safe-module --network anvil-localhost \
     --contracts-root "../ethereum/contracts"
 ```
 
-Sync or Force sync eligibility on Network Registry. Provide a comma-separated string of safe adresses in `safe-addresses`. 
+Sync or Force sync eligibility on Network Registry. Provide a comma-separated string of safe adresses in `safe-addresses`.
 If `sync-type` sets to `normal-sync`, it will update the eligibility according to the actual eligibility of the staking account
 
 ```
@@ -265,7 +265,7 @@ PRIVATE_KEY=<safe_owner_private_key> DEPLOYER_PRIVATE_KEY=<network_registry_mana
     --contracts-root "../ethereum/contracts"
 ```
 
-Sync or Force sync eligibility on Network Registry. Provide a comma-separated string of safe adresses in `safe-addresses`. 
+Sync or Force sync eligibility on Network Registry. Provide a comma-separated string of safe adresses in `safe-addresses`.
 If `sync-type` sets to `normal-sync`, it will update the eligibility according to the actual eligibility of the staking account
 
 ```

--- a/packages/hopli/README.md
+++ b/packages/hopli/README.md
@@ -142,6 +142,18 @@ hopli migrate-safe-module --network anvil-localhost \
     --contracts-root "../ethereum/contracts"
 ```
 
+Sync or Force sync eligibility on Network Registry. Provide a comma-separated string of safe adresses in `safe-addresses`. 
+If `sync-type` sets to `normal-sync`, it will update the eligibility according to the actual eligibility of the staking account
+
+```
+PRIVATE_KEY=<network_registry_manager_key> DEPLOYER_PRIVATE_KEY=<network_registry_manager_key> \
+hopli sync-network-registry --network anvil-localhost \
+    --contracts-root "../ethereum/contracts" \
+    --safe-addresses 0x4AAf51e0b43d8459AF85E33eEf3Ffb7EACb5532C,0x7d852faebb35adaed925869e028d9325bdd555a4,0xff7570ba5fc8bac26d4536565c48474e09f37b0d \
+    --sync-type forced-sync \
+    --eligibility true
+```
+
 ## Development
 
 ### Run local development
@@ -251,6 +263,18 @@ PRIVATE_KEY=<safe_owner_private_key> DEPLOYER_PRIVATE_KEY=<network_registry_mana
     --safe-address <safe_address> \
     --module-address <module_address> \
     --contracts-root "../ethereum/contracts"
+```
+
+Sync or Force sync eligibility on Network Registry. Provide a comma-separated string of safe adresses in `safe-addresses`. 
+If `sync-type` sets to `normal-sync`, it will update the eligibility according to the actual eligibility of the staking account
+
+```
+PRIVATE_KEY=<network_registry_manager_key> DEPLOYER_PRIVATE_KEY=<network_registry_manager_key> \
+    cargo run -- sync-network-registry --network anvil-localhost \
+    --contracts-root "../ethereum/contracts" \
+    --safe-addresses 0x4AAf51e0b43d8459AF85E33eEf3Ffb7EACb5532C,0x7d852faebb35adaed925869e028d9325bdd555a4,0xff7570ba5fc8bac26d4536565c48474e09f37b0d \
+    --sync-type forced-sync \
+    --eligibility true
 ```
 
 ### Test

--- a/packages/hopli/src/main.rs
+++ b/packages/hopli/src/main.rs
@@ -4,6 +4,7 @@ use crate::faucet::FaucetArgs;
 use crate::identity::IdentityArgs;
 use crate::initialize_node::InitializeNodeArgs;
 use crate::network_registry::RegisterInNetworkRegistryArgs;
+use crate::sync_network_registry::SyncNetworkRegistryArgs;
 use crate::utils::{Cmd, HelperErrors};
 use clap::{Parser, Subcommand};
 pub mod create_safe_module;
@@ -18,6 +19,7 @@ pub mod network_registry;
 pub mod password;
 pub mod process;
 pub mod utils;
+pub mod sync_network_registry;
 
 #[derive(Parser, Debug)]
 #[clap(name = "hopli")]
@@ -46,6 +48,8 @@ enum Commands {
     CreateSafeModule(CreateSafeModuleArgs),
     #[clap(about = "Migrate an exising set of node(d) with safe and module to a new network, with default permissions")]
     MigrateSafeModule(MigrateSafeModuleArgs),
+    #[clap(about = "Sync eligibility of safes on network registry")]
+    SyncNetworkRegistry(SyncNetworkRegistryArgs),
 }
 
 fn main() -> Result<(), HelperErrors> {
@@ -68,6 +72,9 @@ fn main() -> Result<(), HelperErrors> {
             opt.run()?;
         }
         Commands::MigrateSafeModule(opt) => {
+            opt.run()?;
+        }
+        Commands::SyncNetworkRegistry(opt) => {
             opt.run()?;
         }
     }

--- a/packages/hopli/src/process.rs
+++ b/packages/hopli/src/process.rs
@@ -156,7 +156,7 @@ pub fn child_process_call_foundry_express_setup_safe_module(
     native_amount: &str,
 ) -> Result<(), HelperErrors> {
     // add brackets to around the string
-    let self_register_args = vec![
+    let express_setup_safe_args = vec![
         "script",
         "script/SingleAction.s.sol:SingleActionFromPrivateKeyScript",
         "--broadcast",
@@ -167,7 +167,7 @@ pub fn child_process_call_foundry_express_setup_safe_module(
         &native_amount,
     ];
 
-    child_process_call_foundry(network, &self_register_args)
+    child_process_call_foundry(network, &express_setup_safe_args)
 }
 
 /// Launch a child process to call foundry  command
@@ -190,6 +190,48 @@ pub fn child_process_call_foundry_self_register(network: &str, peer_ids: &String
     ];
 
     child_process_call_foundry(network, &self_register_args)
+}
+
+/// Launch a child process to call foundry command
+///
+/// # Arguments
+///
+/// * `network` - Name of the network that nodes run in
+/// * `staking_address` - Addresses of staking accounts
+/// * `eligibilities` - Array of eligibility 
+pub fn child_process_call_foundry_set_eligibility(network: &str, staking_address: &String, eligibilities: &String) -> Result<(), HelperErrors> {
+    // add brackets to around the string
+    let set_eligibility_args = vec![
+        "script",
+        "script/SingleAction.s.sol:SingleActionFromPrivateKeyScript",
+        "--broadcast",
+        "--sig",
+        "forceSyncEligibility(address[],bool[])",
+        &staking_address,
+        &eligibilities,
+    ];
+
+    child_process_call_foundry(network, &set_eligibility_args)
+}
+
+/// Launch a child process to call foundry command
+///
+/// # Arguments
+///
+/// * `network` - Name of the network that nodes run in
+/// * `staking_address` - Addresses of staking accounts
+pub fn child_process_call_foundry_sync_eligibility(network: &str, staking_address: &String) -> Result<(), HelperErrors> {
+    // add brackets to around the string
+    let sync_eligibility_args = vec![
+        "script",
+        "script/SingleAction.s.sol:SingleActionFromPrivateKeyScript",
+        "--broadcast",
+        "--sig",
+        "syncEligibility(address[])",
+        &staking_address,
+    ];
+
+    child_process_call_foundry(network, &sync_eligibility_args)
 }
 
 /// Launch a child process to call a foundry script

--- a/packages/hopli/src/sync_network_registry.rs
+++ b/packages/hopli/src/sync_network_registry.rs
@@ -1,0 +1,122 @@
+use crate::{
+    process::{child_process_call_foundry_set_eligibility, child_process_call_foundry_sync_eligibility, set_process_path_env},
+    utils::{Cmd, HelperErrors},
+};
+use clap::Parser;
+use log::{log, error, Level};
+use std::{env, str::FromStr, iter};
+use utils_types::primitives::Address;
+use core_crypto::types::ToChecksum;
+
+#[derive(clap::ValueEnum, Debug, Clone, PartialEq, Eq)]
+pub enum SyncNetworkRegistryType {
+    ForcedSync,
+    NormalSync,
+}
+
+impl FromStr for SyncNetworkRegistryType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "f" | "forced" => Ok(SyncNetworkRegistryType::ForcedSync),
+            "n" | "normal" => Ok(SyncNetworkRegistryType::NormalSync),
+            _ => Err(format!("Unknown network registry sync type: {s}")),
+        }
+    }
+}
+
+/// CLI arguments for `hopli manage-network-registry`
+#[derive(Parser, Clone, Debug)]
+pub struct SyncNetworkRegistryArgs {
+    #[clap(help = "Network name. E.g. monte_rosa", long)]
+    network: String,
+
+    #[clap(
+        help = "Specify path pointing to the contracts root",
+        long,
+        short,
+        default_value = None
+    )]
+    contracts_root: Option<String>,
+
+    #[clap(
+        value_enum,
+        long,
+        short = 't',
+        help_heading = "Sync type",
+        help = "Type of syncing eligibility: `forced` or `normal`"
+    )]
+    pub sync_type: SyncNetworkRegistryType,
+
+    #[clap(help = "Comma separated Ethereum addresses of safes", long, short)]
+    safe_addresses: String,
+
+    #[clap(
+        help = "Desired eligibility in forced sync",
+        long,
+    )]
+    eligibility: Option<bool>,
+}
+
+impl SyncNetworkRegistryArgs {
+    fn execute_sync_eligibility(self) -> Result<(), HelperErrors> {
+        let SyncNetworkRegistryArgs {
+            network,
+            contracts_root,
+            sync_type,
+            safe_addresses,
+            eligibility,
+        } = self;
+
+        // 1. `PRIVATE_KEY` - Private key is required to send on-chain transactions
+        if let Err(_) = env::var("PRIVATE_KEY") {
+            return Err(HelperErrors::UnableToReadPrivateKey);
+        }
+
+        // 2. Read addresses of safes
+        let all_safes_addresses: Vec<String> = safe_addresses.split(",").map(|addr| Address::from_str(addr).unwrap().to_checksum()).collect();
+        
+        log!(target: "sync_eligibility", Level::Info, "Safe addresses {:?}", all_safes_addresses);
+        
+        // set directory and environment variables
+        if let Err(e) = set_process_path_env(&contracts_root, &network) {
+            return Err(e);
+        }
+        
+        // Prepare payload and call function according to differnt types of sync
+        match sync_type {
+            SyncNetworkRegistryType::ForcedSync => {
+                if let Some(desired_eligibility) = eligibility {
+                    let all_eligibilities: Vec<String> = iter::repeat(desired_eligibility.to_string()).take(all_safes_addresses.len()).collect();
+                    log!(target: "sync_eligibility", Level::Info, "Eligibilities {:?}", all_eligibilities);
+                    
+                    log!(target: "sync_eligibility::forced", Level::Debug, "Calling foundry...");
+                    // iterate and collect execution result. If error occurs, the entire operation failes.
+                    child_process_call_foundry_set_eligibility(
+                        &network,
+                        &format!("[{}]", &&all_safes_addresses.join(",")),
+                        &format!("[{}]", &&all_eligibilities.join(",")),
+                    )
+                } else {
+                    error!("Eligibility must be specified");
+                    return Err(HelperErrors::MissingParameter("eligibility".to_string()));
+                }
+            }
+            SyncNetworkRegistryType::NormalSync => {
+                log!(target: "sync_eligibility::normal", Level::Debug, "Calling foundry...");
+                child_process_call_foundry_sync_eligibility(
+                    &network,
+                    &format!("[{}]", &&all_safes_addresses.join(",")),
+                )
+            }
+        }
+    }
+}
+
+impl Cmd for SyncNetworkRegistryArgs {
+    /// Run the execute_sync_eligibility function
+    fn run(self) -> Result<(), HelperErrors> {
+        self.execute_sync_eligibility()
+    }
+}

--- a/packages/hopli/src/utils.rs
+++ b/packages/hopli/src/utils.rs
@@ -51,6 +51,9 @@ pub enum HelperErrors {
     #[error("unable read private key")]
     UnableToReadPrivateKey,
 
+    #[error("missing parameter: {0}")]
+    MissingParameter(String),
+
     #[error(transparent)]
     KeyStoreError(#[from] KeyPairError),
 }


### PR DESCRIPTION
- Create foundry script to "force sync eligibility" of safes
- Add "force sync eligibility" step in "express setup safe and module" as well as "migrate safe module"
- Create hopli command to force sync eligibility

To update eligibility for Rotsee and Dufour nodes, run
```
PRIVATE_KEY=<deployer_key> DEPLOYER_PRIVATE_KEY=<network_registry_manager_key> \
hopli sync-network-registry --network <rotsee_or_dufour> \
    --contracts-root "../ethereum/contracts" \
    --safe-addresses <address_of_all_registgered_safe> \
    --sync-type forced-sync \
    --eligibility true
```
where `<address_of_all_registgered_safe>` is a comma separated value, e.g. for "dufour" `0x4dcd3aa8655f766c69a0c30124b56a91b97da946,0x679bc9610e4c68ee8dc3e5c5046d599ad0e72f27,0x22be10812cd4ffbaa9a075ea8256359b436885a6,0xdd362a8da84aa03f1d6053f8a9dec84e6d4aaa96,0x99e8d9164803a64783376d1f30ee74116ac017c8,0x392b4485cb859fe49fdb9699be67b845c84effd5,0x0f81490a99c99e744ec941662a742d9c1297f268,0x7c8b6c46bc4f405b343b8af753a3c3edb387f6b3,0x5e777f25ab693469deb7085d9e82a8793490e054,0xdba78b0e81b94aa38e94ad72bcde7e2cd8172520,0x08bb65f98e81b108758e03cf1e9ca763dad72abe,0xd2b0cc920b2e003ddfc2200bb75c158a85680df7`