### PR TITLE
ensure that private key does not belong to a contract

### DIFF
--- a/packages/ethereum/contracts/test/node-stake/NodeSafeRegistry.t.sol
+++ b/packages/ethereum/contracts/test/node-stake/NodeSafeRegistry.t.sol
@@ -60,6 +60,7 @@ contract HoprNodeSafeRegistryTest is Test, HoprNodeSafeRegistryEvents {
      */
     function testFuzz_RegisterSafeWithNodeSig(uint256 nodePrivateKey, address safeAddress) public {
         nodePrivateKey = bound(nodePrivateKey, 1, 1e36);
+        vm.assume(!Address.isContract(vm.addr(nodePrivateKey)));
         vm.assume(
             !PrecompileUtils.isPrecompileAddress(safeAddress) && !Address.isContract(safeAddress)
                 && safeAddress != address(0) && safeAddress != address(this) && safeAddress != address(nodeSafeRegistry)
@@ -92,6 +93,7 @@ contract HoprNodeSafeRegistryTest is Test, HoprNodeSafeRegistryEvents {
      */
     function testRevert_RegisterSafeWithNodeSigNonceReused(uint256 nodePrivateKey, address safeAddress) public {
         nodePrivateKey = bound(nodePrivateKey, 1, 1e36);
+        vm.assume(!Address.isContract(vm.addr(nodePrivateKey)));
         vm.assume(
             !PrecompileUtils.isPrecompileAddress(safeAddress) && !Address.isContract(safeAddress)
                 && safeAddress != address(0) && safeAddress != address(this) && safeAddress != address(nodeSafeRegistry)


### PR DESCRIPTION
fixes a smart-contract unit test where fuzzy-tested private key could belong to a deployed smart contract