### PR TITLE
Fix then_concurrent to avoid possible cx abuse

### DIFF
--- a/packages/core/crates/core-mixer/src/future_extensions.rs
+++ b/packages/core/crates/core-mixer/src/future_extensions.rs
@@ -3,12 +3,13 @@
 //! `ThenConcurrent` extension adds the `then_concurrent` method to any `futures::stream::Stream`
 //! object allowing a concurrent execution of futures over the stream items.
 
-use std::future::Future;
-use std::pin::Pin;
-use std::task::{Context, Poll};
-
 use futures::stream::{FuturesUnordered, Stream};
 use pin_project::pin_project;
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
 
 /// Stream for the [`Stream::then_concurrent()`] method.
 #[pin_project(project = ThenConcurrentProj)]
@@ -35,28 +36,28 @@ where
             fun,
         } = self.project();
 
-        match stream.as_mut().poll_next(cx) {
-            Poll::Ready(Some(n)) => {
-                futures.push(fun(n));
-            }
-            Poll::Pending => {
-                if futures.is_empty() {
-                    return Poll::Pending;
-                }
-            }
-            _ => (),
-        }
-
-        let x = futures.as_mut().poll_next(cx);
-        if let Poll::Pending = x {
+        // Eagerly fetch all ready items from the stream
+        loop {
             match stream.as_mut().poll_next(cx) {
                 Poll::Ready(Some(n)) => {
                     futures.push(fun(n));
                 }
-                _ => (),
+                Poll::Ready(None) => {
+                    if futures.is_empty() {
+                        return Poll::Ready(None);
+                    }
+                    break;
+                }
+                Poll::Pending => {
+                    if futures.is_empty() {
+                        return Poll::Pending;
+                    }
+                    break;
+                }
             }
         }
-        x
+
+        futures.as_mut().poll_next(cx)
     }
 }
 
@@ -86,5 +87,82 @@ impl<S: Stream> StreamThenConcurrentExt for S {
             futures: FuturesUnordered::new(),
             fun: f,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::{channel::mpsc::unbounded, StreamExt};
+
+    #[async_std::test]
+    async fn no_items() {
+        let stream = futures::stream::iter::<Vec<u64>>(vec![]).then_concurrent(|_| async move {
+            panic!("must not be called");
+        });
+
+        assert_eq!(stream.collect::<Vec<_>>().await, vec![]);
+    }
+
+    #[async_std::test]
+    async fn paused_stream() {
+        let (mut tx, rx) = unbounded::<u64>();
+
+        let mut stream = rx.then_concurrent(|x| async move {
+            if x == 0 {
+                x
+            } else {
+                async_std::task::sleep(std::time::Duration::from_millis(x)).await;
+                x
+            }
+        });
+
+        // we need to poll the stream such that FuturesUnordered gets empty
+        let first_item = stream.next();
+
+        tx.start_send(0).unwrap();
+
+        assert_eq!(first_item.await, Some(0));
+
+        let second_item = stream.next();
+
+        // item produces a delay
+        tx.start_send(5).unwrap();
+
+        assert_eq!(second_item.await, Some(5));
+    }
+
+    #[async_std::test]
+    async fn fast_items() {
+        let item_1 = 0u64; // 3rd in the output
+        let item_2 = 0u64; // 1st in the output
+        let item_3 = 7u64; // 2nd in the output
+
+        let stream = futures::stream::iter(vec![item_1, item_2, item_3]).then_concurrent(|x| async move {
+            if x == 0 {
+                x
+            } else {
+                async_std::task::sleep(std::time::Duration::from_millis(x)).await;
+                x
+            }
+        });
+        let actual_packets = stream.collect::<Vec<u64>>().await;
+
+        assert_eq!(actual_packets, vec![0, 0, 7]);
+    }
+
+    #[async_std::test]
+    async fn reorder_items() {
+        let item_1 = 10u64; // 3rd in the output
+        let item_2 = 5u64; // 1st in the output
+        let item_3 = 7u64; // 2nd in the output
+
+        let stream = futures::stream::iter(vec![item_1, item_2, item_3]).then_concurrent(|x| async move {
+            async_std::task::sleep(std::time::Duration::from_millis(x)).await;
+            x
+        });
+        let actual_packets = stream.collect::<Vec<u64>>().await;
+
+        assert_eq!(actual_packets, vec![5, 7, 10]);
     }
 }

--- a/packages/core/crates/core-mixer/src/future_extensions.rs
+++ b/packages/core/crates/core-mixer/src/future_extensions.rs
@@ -134,9 +134,9 @@ mod tests {
 
     #[async_std::test]
     async fn fast_items() {
-        let item_1 = 0u64; // 3rd in the output
-        let item_2 = 0u64; // 1st in the output
-        let item_3 = 7u64; // 2nd in the output
+        let item_1 = 0u64;
+        let item_2 = 0u64;
+        let item_3 = 7u64;
 
         let stream = futures::stream::iter(vec![item_1, item_2, item_3]).then_concurrent(|x| async move {
             if x == 0 {


### PR DESCRIPTION
Enhances `then_concurrent` to prevent infinite loops and add extensive unit tests