### PR TITLE
Use proper serde structure for send message protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1035,7 +1035,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-crypto"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "aes 0.8.3",
  "async-std",
@@ -1291,6 +1291,7 @@ dependencies = [
  "async-std",
  "console_error_panic_hook",
  "core-network",
+ "core-packet",
  "core-types",
  "env_logger",
  "futures",
@@ -1314,7 +1315,7 @@ dependencies = [
 
 [[package]]
 name = "core-packet"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "async-lock",
  "async-process",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "core-p2p"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "async-std",
  "console_error_panic_hook",

--- a/packages/core/crates/core-crypto/Cargo.toml
+++ b/packages/core/crates/core-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-crypto"
-version = "0.5.0"
+version = "0.5.1"
 description = "Core cryptographic primitives and functions used in the HOPR protocol"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"

--- a/packages/core/crates/core-hopr/src/p2p.rs
+++ b/packages/core/crates/core-hopr/src/p2p.rs
@@ -7,7 +7,10 @@ use futures_concurrency::stream::Merge;
 use core_network::network::{Network, NetworkEvent, PeerOrigin};
 pub use core_p2p::{api, libp2p_identity};
 use core_p2p::{libp2p_request_response, libp2p_swarm::SwarmEvent, HoprNetworkBehaviorEvent, Ping, Pong};
-use core_packet::{interaction::{AckProcessed, AcknowledgementInteraction, MsgProcessed, PacketInteraction}, packet::MixerPayload};
+use core_packet::{
+    interaction::{AckProcessed, AcknowledgementInteraction, MsgProcessed, PacketInteraction},
+    packet::MixerPayload,
+};
 use core_types::acknowledgement::Acknowledgement;
 use utils_log::{debug, error, info};
 

--- a/packages/core/crates/core-p2p/Cargo.toml
+++ b/packages/core/crates/core-p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-p2p"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 license = "GPL-3.0-only"

--- a/packages/core/crates/core-p2p/Cargo.toml
+++ b/packages/core/crates/core-p2p/Cargo.toml
@@ -37,6 +37,7 @@ wasm-bindgen-futures = { version = "0.4.36", optional = true }
 #wee_alloc = { version = "0.4.5", optional = true }
 
 core-network = { workspace = true }
+core-packet = { workspace = true }
 core-types = { workspace = true }
 utils-log = { workspace = true }
 utils-misc = { workspace = true }

--- a/packages/core/crates/core-p2p/src/lib.rs
+++ b/packages/core/crates/core-p2p/src/lib.rs
@@ -3,6 +3,7 @@ pub mod errors;
 
 use std::fmt::Debug;
 
+use core_packet::packet::MixerPayload;
 use libp2p::StreamProtocol;
 
 pub use libp2p::identity;
@@ -44,7 +45,7 @@ const HOPR_ACKNOWLEDGEMENT_REQUEST_TIMEOUT: std::time::Duration = std::time::Dur
 #[behaviour(to_swarm = "HoprNetworkBehaviorEvent")]
 pub struct HoprNetworkBehavior {
     pub heartbeat: libp2p_request_response::cbor::Behaviour<Ping, Pong>,
-    pub msg: libp2p_request_response::cbor::Behaviour<Box<[u8]>, ()>,
+    pub msg: libp2p_request_response::cbor::Behaviour<MixerPayload, ()>,
     pub ack: libp2p_request_response::cbor::Behaviour<Acknowledgement, ()>,
     keep_alive: libp2p_swarm::keep_alive::Behaviour, // run the business logic loop indefinitely
 }
@@ -59,7 +60,7 @@ impl Debug for HoprNetworkBehavior {
 #[derive(Debug)]
 pub enum HoprNetworkBehaviorEvent {
     Heartbeat(libp2p_request_response::Event<Ping, Pong>),
-    Message(libp2p_request_response::Event<Box<[u8]>, ()>),
+    Message(libp2p_request_response::Event<MixerPayload, ()>),
     Acknowledgement(libp2p_request_response::Event<Acknowledgement, ()>),
     KeepAlive(void::Void),
 }
@@ -76,8 +77,8 @@ impl From<libp2p_request_response::Event<Ping, Pong>> for HoprNetworkBehaviorEve
     }
 }
 
-impl From<libp2p_request_response::Event<Box<[u8]>, ()>> for HoprNetworkBehaviorEvent {
-    fn from(event: libp2p_request_response::Event<Box<[u8]>, ()>) -> Self {
+impl From<libp2p_request_response::Event<MixerPayload, ()>> for HoprNetworkBehaviorEvent {
+    fn from(event: libp2p_request_response::Event<MixerPayload, ()>) -> Self {
         Self::Message(event)
     }
 }
@@ -103,7 +104,7 @@ impl Default for HoprNetworkBehavior {
                     cfg
                 },
             ),
-            msg: libp2p_request_response::cbor::Behaviour::<Box<[u8]>, ()>::new(
+            msg: libp2p_request_response::cbor::Behaviour::<MixerPayload, ()>::new(
                 [(
                     StreamProtocol::new(HOPR_MESSAGE_PROTOCOL_V_0_1_0),
                     libp2p_request_response::ProtocolSupport::Full,

--- a/packages/core/crates/core-p2p/src/lib.rs
+++ b/packages/core/crates/core-p2p/src/lib.rs
@@ -29,7 +29,7 @@ pub struct Ping(pub ControlMessage);
 pub struct Pong(pub ControlMessage, pub String);
 
 pub const HOPR_HEARTBEAT_PROTOCOL_V_0_1_0: &str = "/hopr/heartbeat/0.1.0";
-pub const HOPR_MESSAGE_PROTOCOL_V_0_1_0: &str = "/hopr/msg/0.1.0";
+pub const HOPR_MESSAGE_PROTOCOL_V_0_1_0: &str = "/hopr/msg/0.2.0";
 pub const HOPR_ACKNOWLEDGE_PROTOCOL_V_0_1_0: &str = "/hopr/ack/0.1.0";
 
 const HOPR_HEARTBEAT_CONNECTION_KEEPALIVE: std::time::Duration = std::time::Duration::from_secs(3600); // 1 hour

--- a/packages/core/crates/core-packet/Cargo.toml
+++ b/packages/core/crates/core-packet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-packet"
-version = "0.6.2"
+version = "0.6.3"
 description = "Contains high-level HOPR protocol building blocks for packet interaction"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"

--- a/packages/core/crates/core-packet/src/interaction.rs
+++ b/packages/core/crates/core-packet/src/interaction.rs
@@ -3,7 +3,7 @@ use crate::errors::PacketError::{
     PacketConstructionError, PacketDecodingError, PathError, PathPositionMismatch, Retry, TagReplay, TransportError,
 };
 use crate::errors::Result;
-use crate::packet::{Packet, PacketState, MixerPayload};
+use crate::packet::{MixerPayload, Packet, PacketState};
 use async_lock::RwLock;
 use core_crypto::keypairs::{ChainKeypair, Keypair, OffchainKeypair};
 use core_crypto::types::{HalfKeyChallenge, Hash, OffchainPublicKey};

--- a/packages/core/crates/core-packet/src/packet.rs
+++ b/packages/core/crates/core-packet/src/packet.rs
@@ -71,7 +71,6 @@ fn remove_padding(msg: &[u8]) -> Option<&[u8]> {
 struct MetaPacket<S: SphinxSuite> {
     packet: Box<[u8]>,
     alpha: Alpha<<S::G as GroupElement<S::E>>::AlphaLen>,
-    header_len: usize,
 }
 
 #[allow(dead_code)]
@@ -93,6 +92,8 @@ enum ForwardedMetaPacket<S: SphinxSuite> {
 }
 
 impl<S: SphinxSuite> MetaPacket<S> {
+    pub const HEADER_LEN: usize = header_length::<S>(INTERMEDIATE_HOPS + 1, POR_SECRET_LENGTH, 0);
+
     pub fn new(
         shared_keys: SharedKeys<S::E, S::G>,
         msg: &[u8],
@@ -104,7 +105,7 @@ impl<S: SphinxSuite> MetaPacket<S> {
     ) -> Self {
         assert!(msg.len() <= PAYLOAD_SIZE, "message too long to fit into a packet");
 
-        let mut padded = add_padding(msg);
+        let mut payload = add_padding(msg);
         let routing_info = RoutingInfo::new::<S>(
             max_hops,
             path,
@@ -117,77 +118,49 @@ impl<S: SphinxSuite> MetaPacket<S> {
         // Encrypt packet payload using the derived shared secrets
         for secret in shared_keys.secrets.iter().rev() {
             let prp = PRP::from_parameters(PRPParameters::new(secret));
-            prp.forward_inplace(&mut padded)
+            prp.forward_inplace(&mut payload)
                 .unwrap_or_else(|e| panic!("onion encryption error {e}"))
         }
 
-        Self::new_from_parts(
-            shared_keys.alpha,
-            &routing_info.routing_information,
-            &routing_info.mac,
-            &padded,
-        )
+        Self::new_from_parts(shared_keys.alpha, routing_info, &payload)
     }
 
     fn new_from_parts(
         alpha: Alpha<<S::G as GroupElement<S::E>>::AlphaLen>,
-        routing_info: &[u8],
-        mac: &[u8],
+        routing_info: RoutingInfo,
         payload: &[u8],
     ) -> Self {
-        assert!(!routing_info.is_empty(), "routing info must not be empty");
-        assert_eq!(SimpleMac::SIZE, mac.len(), "mac has incorrect length");
+        assert!(
+            !routing_info.routing_information.is_empty(),
+            "routing info must not be empty"
+        );
         assert_eq!(PAYLOAD_SIZE, payload.len(), "payload has incorrect length");
 
-        let mut packet = Vec::with_capacity(Self::size(routing_info.len()));
+        let mut packet = Vec::with_capacity(Self::SIZE);
         packet.extend_from_slice(&alpha);
-        packet.extend_from_slice(routing_info);
-        packet.extend_from_slice(mac);
+        packet.extend_from_slice(&routing_info.routing_information);
+        packet.extend_from_slice(&routing_info.mac);
         packet.extend_from_slice(payload);
 
         Self {
             packet: packet.into_boxed_slice(),
-            header_len: routing_info.len(),
             alpha,
         }
     }
 
     pub fn routing_info(&self) -> &[u8] {
         let base = <S::G as GroupElement<S::E>>::AlphaLen::USIZE;
-        &self.packet[base..base + self.header_len]
+        &self.packet[base..base + Self::HEADER_LEN]
     }
 
     pub fn mac(&self) -> &[u8] {
-        let base = <S::G as GroupElement<S::E>>::AlphaLen::USIZE + self.header_len;
+        let base = <S::G as GroupElement<S::E>>::AlphaLen::USIZE + Self::HEADER_LEN;
         &self.packet[base..base + SimpleMac::SIZE]
     }
 
     pub fn payload(&self) -> &[u8] {
-        let base = <S::G as GroupElement<S::E>>::AlphaLen::USIZE + self.header_len + SimpleMac::SIZE;
+        let base = <S::G as GroupElement<S::E>>::AlphaLen::USIZE + Self::HEADER_LEN + SimpleMac::SIZE;
         &self.packet[base..base + PAYLOAD_SIZE]
-    }
-
-    pub const fn size(header_len: usize) -> usize {
-        <S::G as GroupElement<S::E>>::AlphaLen::USIZE + header_len + SimpleMac::SIZE + PAYLOAD_SIZE
-    }
-
-    pub fn from_bytes(packet: &[u8], header_len: usize) -> utils_types::errors::Result<Self> {
-        if packet.len() == Self::size(header_len) {
-            let mut ret = Self {
-                packet: packet.into(),
-                header_len,
-                alpha: Default::default(),
-            };
-            ret.alpha
-                .copy_from_slice(&packet[..<S::G as GroupElement<S::E>>::AlphaLen::USIZE]);
-            Ok(ret)
-        } else {
-            Err(ParseError)
-        }
-    }
-
-    pub fn to_bytes(&self) -> &[u8] {
-        &self.packet
     }
 
     pub fn forward(
@@ -224,7 +197,14 @@ impl<S: SphinxSuite> MetaPacket<S> {
                 next_node,
                 additional_info,
             } => RelayedPacket {
-                packet: Self::new_from_parts(alpha, &header, &mac, &decrypted),
+                packet: Self::new_from_parts(
+                    alpha,
+                    RoutingInfo {
+                        routing_information: header,
+                        mac,
+                    },
+                    &decrypted,
+                ),
                 packet_tag: derive_packet_tag(&secret),
                 derived_secret: secret,
                 next_node: <S::P as Keypair>::Public::from_bytes(&next_node)
@@ -244,6 +224,29 @@ impl<S: SphinxSuite> MetaPacket<S> {
                 additional_data,
             },
         })
+    }
+}
+
+impl<S: SphinxSuite> BinarySerializable for MetaPacket<S> {
+    const SIZE: usize =
+        <S::G as GroupElement<S::E>>::AlphaLen::USIZE + Self::HEADER_LEN + SimpleMac::SIZE + PAYLOAD_SIZE;
+
+    fn from_bytes(data: &[u8]) -> utils_types::errors::Result<Self> {
+        if data.len() == Self::SIZE {
+            let mut ret = Self {
+                packet: data.into(),
+                alpha: Default::default(),
+            };
+            ret.alpha
+                .copy_from_slice(&data[..<S::G as GroupElement<S::E>>::AlphaLen::USIZE]);
+            Ok(ret)
+        } else {
+            Err(ParseError)
+        }
+    }
+
+    fn to_bytes(&self) -> Box<[u8]> {
+        self.packet.clone()
     }
 }
 
@@ -346,8 +349,7 @@ impl Packet {
             let (pre_packet, pre_ticket) = data.split_at(PACKET_LENGTH);
             let previous_hop = OffchainPublicKey::from_peerid(sender)?;
 
-            let header_len = header_length::<CurrentSphinxSuite>(INTERMEDIATE_HOPS + 1, POR_SECRET_LENGTH, 0);
-            let mp = MetaPacket::<CurrentSphinxSuite>::from_bytes(pre_packet, header_len)?;
+            let mp = MetaPacket::<CurrentSphinxSuite>::from_bytes(pre_packet)?;
 
             match mp.forward(node_keypair, INTERMEDIATE_HOPS + 1, POR_SECRET_LENGTH, 0)? {
                 RelayedPacket {
@@ -434,7 +436,7 @@ impl Packet {
 impl Packet {
     pub fn to_bytes(&self) -> Box<[u8]> {
         let mut ret = Vec::with_capacity(Self::SIZE);
-        ret.extend_from_slice(self.packet.to_bytes());
+        ret.extend_from_slice(&self.packet.to_bytes());
         ret.extend_from_slice(&self.ticket.to_bytes());
         ret.into_boxed_slice()
     }

--- a/packages/core/crates/core-packet/src/packet.rs
+++ b/packages/core/crates/core-packet/src/packet.rs
@@ -12,7 +12,7 @@ use core_path::path::Path;
 use core_types::protocol::{INTERMEDIATE_HOPS, PAYLOAD_SIZE};
 use core_types::{acknowledgement::Acknowledgement, channels::Ticket};
 use libp2p_identity::PeerId;
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
 use typenum::Unsigned;
 use utils_types::{
@@ -72,14 +72,14 @@ fn remove_padding(msg: &[u8]) -> Option<&[u8]> {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MixerPayload {
     data: Box<[u8]>,
-    ticket: Ticket
+    ticket: Ticket,
 }
 
 impl From<Packet> for MixerPayload {
     fn from(value: Packet) -> Self {
         Self {
             data: value.packet.packet,
-            ticket: value.ticket
+            ticket: value.ticket,
         }
     }
 }
@@ -89,7 +89,7 @@ impl MixerPayload {
         self.data.clone()
     }
 
-    pub fn ticket(&self) -> Ticket{
+    pub fn ticket(&self) -> Ticket {
         self.ticket.clone()
     }
 
@@ -100,7 +100,6 @@ impl MixerPayload {
         ret.into_boxed_slice()
     }
 }
-
 
 struct MetaPacket<S: SphinxSuite> {
     packet: Box<[u8]>,


### PR DESCRIPTION
## What
In the current implementation only the `Box<[u8]>` data was transferred along the `msg` protocol, which then used `cbor` to transform it into the `on-the-wire` octets.

This new implementation uses an explicit type called `MixerPayload` to allow versioning of `msg` types for future protocol backwards compatibility. 

## Note
This is a backwards incompatible change and all nodes must update to it, otherwise it will not be possible for them to communicate, the protocol version for the `hopr/msg/` protocol was also bumped to `0.2.0`.

Fixes #5662