### PR TITLE
core: Handle empty multiaddr in announcement

### DIFF
--- a/packages/core-ethereum/crates/core-ethereum-indexer/src/errors.rs
+++ b/packages/core-ethereum/crates/core-ethereum-indexer/src/errors.rs
@@ -20,6 +20,9 @@ pub enum CoreEthereumIndexerError {
     #[error("Address announcement without a preceding key binding.")]
     AnnounceBeforeKeyBinding,
 
+    #[error("Address announcement contains empty Multiaddr.")]
+    AnnounceEmptyMultiaddr,
+
     #[error("Node has already announced a key binding. Reassigning keys is not supported.")]
     UnsupportedKeyRebinding,
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -23,4 +23,4 @@ export const ACKNOWLEDGEMENT_TIMEOUT = 2000
 
 export const PEER_METADATA_PROTOCOL_VERSION = 'protocol_version'
 
-export const DB_VERSION_TAG = 'indexer_2'
+export const DB_VERSION_TAG = 'indexer_3'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -572,6 +572,10 @@ export class Hopr extends EventEmitter {
     log(`Processing multiaddresses for peer ${peer.id.toString()}: ${peer.multiaddrs}`)
     const addrsToAdd: Multiaddr[] = []
     for (const addr of peer.multiaddrs) {
+      // safeguard against empty multiaddrs, skip
+      if (addr.toString() == '') {
+        continue
+      }
       const tuples = addr.tuples()
 
       if (tuples.length <= 1 && tuples[0][0] == CODE_P2P) {
@@ -1031,6 +1035,12 @@ export class Hopr extends EventEmitter {
       }
     } else {
       addrToAnnounce = new Multiaddr('/p2p/' + this.getId().toString())
+    }
+
+    // skip if no address to announce has been found
+    if (!addrToAnnounce || addrToAnnounce.toString() == '') {
+      log('Error: could not find an address to announce')
+      return
     }
 
     // Check if there was a previous announcement from us


### PR DESCRIPTION
This PR adds safeguards to the announcement flow and indexer to ensure no empty multiaddresses are pushed or end up in the database.

The following error has been see on Dufour nodes:

```
2023-09-09T14:49:13.692Z [DEBUG] core_ethereum_indexer::handlers on_announcement_event - multiaddr: "" - node: "0x1446…c55a"
2023-09-09T14:49:13.692Z hopr-core-ethereum:indexer indexer on_event callback for transaction hash:  0x4ec206e7cce7f40d82f6c316da43b8634fa79a7be105b19b992e7e7e2048ed6a
2023-09-09T14:49:13.695Z hopr-core Processing multiaddresses for peer 12D3KooWSn6RJDpTqaseMpaycVNyYKbxDRsS1HQQpcUwyz26jCxh: /
UnhandledPromiseRejectionWarning
TypeError: Cannot read properties of undefined (reading '0')
    at Hopr.onPeerAnnouncement (file:///app/hoprnet/packages/core/lib/index.js:316:48)
    at Indexer.emit (node:events:513:28)
    at Indexer.onAnnouncementUpdate (file:///app/hoprnet/packages/core-ethereum/lib/indexer/index.js:575:14)
    at __wbg_newAnnouncement_fb73b660c3e05e99 (file:///app/hoprnet/packages/hoprd/lib/hoprd_hoprd_bg.js:12360:10)
    at wasm://wasm/0102c8fa:wasm-function[178]:0x702d9
    at wasm://wasm/0102c8fa:wasm-function[1745]:0x1f4bbe
    at wasm://wasm/0102c8fa:wasm-function[6947]:0x30d4e0
    at wasm://wasm/0102c8fa:wasm-function[7356]:0x316522
    at __wbg_adapter_42 (file:///app/hoprnet/packages/hoprd/lib/hoprd_hoprd_bg.js:203:10)
    at real (file:///app/hoprnet/packages/hoprd/lib/hoprd_hoprd_bg.js:188:20)
2023-09-09T14:49:13.699Z hoprd Process exiting with signal 1
```

The tx: https://gnosisscan.io/tx/0x4ec206e7cce7f40d82f6c316da43b8634fa79a7be105b19b992e7e7e2048ed6a#eventlog