### PR TITLE
Update channel balances in indexer

### DIFF
--- a/packages/core-ethereum/crates/core-ethereum-indexer/src/handlers.rs
+++ b/packages/core-ethereum/crates/core-ethereum-indexer/src/handlers.rs
@@ -240,9 +240,7 @@ where
                 let maybe_channel = db.get_channel(&balance_decreased.channel_id.try_into()?).await?;
 
                 if let Some(mut channel) = maybe_channel {
-                    channel.balance = channel
-                        .balance
-                        .sub(&Balance::new(balance_decreased.new_balance.into(), BalanceType::HOPR));
+                    channel.balance = Balance::new(balance_decreased.new_balance.into(), BalanceType::HOPR);
 
                     db.update_channel_and_snapshot(&balance_decreased.channel_id.try_into()?, &channel, snapshot)
                         .await?;
@@ -258,9 +256,7 @@ where
                 let maybe_channel = db.get_channel(&balance_increased.channel_id.try_into()?).await?;
 
                 if let Some(mut channel) = maybe_channel {
-                    channel.balance = channel
-                        .balance
-                        .add(&Balance::new(balance_increased.new_balance.into(), BalanceType::HOPR));
+                    channel.balance = Balance::new(balance_increased.new_balance.into(), BalanceType::HOPR);
 
                     db.update_channel_and_snapshot(&balance_increased.channel_id.try_into()?, &channel, snapshot)
                         .await?;

--- a/packages/core-ethereum/crates/core-ethereum-indexer/src/handlers.rs
+++ b/packages/core-ethereum/crates/core-ethereum-indexer/src/handlers.rs
@@ -1334,7 +1334,7 @@ pub mod tests {
 
         assert_eq!(
             *db.get_channel(&channel_id).await.unwrap().unwrap().balance.value(),
-            U256::zero()
+            solidity_balance
         );
     }
 


### PR DESCRIPTION
Following the bug fixed in https://github.com/hoprnet/hoprnet/pull/5470, issue https://github.com/hoprnet/hoprnet/issues/5468 actually reveals another bug in the indexer, as described [here](https://github.com/hoprnet/hoprnet/issues/5468#issuecomment-1713136451), which manifests when `ChannelBalance{Increased,Decreased}` events get emitted. 
Balance of a channel should be "set" instead of "updated" when relevant events are emitted.