### PR TITLE
Add status to acknowledged tickets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1404,6 +1404,7 @@ dependencies = [
 name = "core-types"
 version = "0.4.1"
 dependencies = [
+ "bincode",
  "bindings",
  "bloomfilter",
  "console_error_panic_hook",

--- a/docs/changelog/changelog-2.0.0-rc.4.md
+++ b/docs/changelog/changelog-2.0.0-rc.4.md
@@ -1,20 +1,18 @@
 Below there is a list with the contents of this release
 
- ### 🚀 New Features
+### 🚀 New Features
 
- - #5452 - acknowledged tickets: database changes
+- #5452 - acknowledged tickets: database changes
 
- ### 🐛 Bug
+### 🐛 Bug
 
- - #5485 - core: Fix allowance check on open channel
- - #5477 - Fix manual ping would to not await indefinitely once failed
- - #5471 - Update channel balances in indexer
- - #5467 - core: Handle empty multiaddr in announcement
+- #5485 - core: Fix allowance check on open channel
+- #5477 - Fix manual ping would to not await indefinitely once failed
+- #5471 - Update channel balances in indexer
+- #5467 - core: Handle empty multiaddr in announcement
 
- ### ⚡ Other
+### ⚡ Other
 
- - #5472 - chore(deps): update dependency @types/cookie to v0.5.2
- - #5470 - indexer: Reset channel balance on close
- - #5464 - api: Expose safe allowance in balances endpoint
-
-
+- #5472 - chore(deps): update dependency @types/cookie to v0.5.2
+- #5470 - indexer: Reset channel balance on close
+- #5464 - api: Expose safe allowance in balances endpoint

--- a/packages/core/crates/core-types/Cargo.toml
+++ b/packages/core/crates/core-types/Cargo.toml
@@ -32,6 +32,9 @@ utils-log = { path = "../../../utils/crates/utils-log", default-features = false
 utils-misc = { path = "../../../utils/crates/utils-misc", default-features = false }
 utils-types = { path = "../../../utils/crates/utils-types", default-features = false }
 
+[dev-dependencies]
+bincode = "1.3.3"
+
 [package.metadata.wasm-pack.profile.dev]
 wasm-opt = false
 

--- a/packages/core/crates/core-types/src/acknowledgement.rs
+++ b/packages/core/crates/core-types/src/acknowledgement.rs
@@ -81,9 +81,26 @@ impl BinarySerializable for Acknowledgement {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum AcknowledgedTicketStatus {
+    Untouched,
+    BeingRedeemed { tx_hash: Hash },
+    BeingAggregated { start: u64, end: u64 },
+}
+
+impl Default for AcknowledgedTicketStatus {
+    fn default() -> Self {
+        AcknowledgedTicketStatus::Untouched
+    }
+}
+
 /// Contains acknowledgment information and the respective ticket
+///
+/// FIXME: think about serialization and deserialization
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct AcknowledgedTicket {
+    #[serde(default)]
+    pub status: AcknowledgedTicketStatus,
     pub ticket: Ticket,
     pub response: Response,
     pub vrf_params: VrfParameters,
@@ -112,6 +129,8 @@ impl AcknowledgedTicket {
         )?;
 
         Ok(Self {
+            // FIXME: think about serialization and deserialization
+            status: AcknowledgedTicketStatus::Untouched,
             ticket,
             response,
             vrf_params,
@@ -182,49 +201,14 @@ impl AcknowledgedTicket {
         let mut computed_ticket_luck = [0u8; 8];
         computed_ticket_luck[1..].copy_from_slice(&self.get_luck(domain_separator).expect("unsigned ticket"));
 
-        u64::from_be_bytes(signed_ticket_luck) <= u64::from_be_bytes(signed_ticket_luck)
-    }
-}
-
-impl BinarySerializable for AcknowledgedTicket {
-    const SIZE: usize = Ticket::SIZE + Response::SIZE + VrfParameters::SIZE + Address::SIZE;
-
-    fn from_bytes(data: &[u8]) -> Result<Self> {
-        if data.len() == Self::SIZE {
-            let ticket = Ticket::from_bytes(&data[0..Ticket::SIZE])?;
-            let response = Response::from_bytes(&data[Ticket::SIZE..Ticket::SIZE + Response::SIZE])?;
-            let vrf_params = VrfParameters::from_bytes(
-                &data[Ticket::SIZE + Response::SIZE..Ticket::SIZE + Response::SIZE + VrfParameters::SIZE],
-            )?;
-            let signer = Address::from_bytes(
-                &data[Ticket::SIZE + Response::SIZE + VrfParameters::SIZE
-                    ..Ticket::SIZE + Response::SIZE + VrfParameters::SIZE + Address::SIZE],
-            )?;
-
-            Ok(Self {
-                ticket,
-                response,
-                vrf_params,
-                signer,
-            })
-        } else {
-            Err(ParseError)
-        }
-    }
-
-    fn to_bytes(&self) -> Box<[u8]> {
-        let mut ret = Vec::with_capacity(Self::SIZE);
-        ret.extend_from_slice(&self.ticket.to_bytes());
-        ret.extend_from_slice(&self.response.to_bytes());
-        ret.extend_from_slice(&self.vrf_params.to_bytes());
-        ret.extend_from_slice(&self.signer.to_bytes());
-        ret.into_boxed_slice()
+        u64::from_be_bytes(computed_ticket_luck) <= u64::from_be_bytes(signed_ticket_luck)
     }
 }
 
 impl std::fmt::Display for AcknowledgedTicket {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AcknowledgedTicket")
+            .field("status", &self.status)
             .field("ticket", &self.ticket)
             .field("response", &self.response)
             .field("vrf_params", &self.vrf_params)
@@ -375,8 +359,11 @@ impl BinarySerializable for PendingAcknowledgement {
 
 #[cfg(test)]
 pub mod test {
-    use crate::acknowledgement::{AcknowledgedTicket, Acknowledgement, PendingAcknowledgement, UnacknowledgedTicket};
-    use crate::channels::Ticket;
+    use crate::{
+        acknowledgement::{AcknowledgedTicket, Acknowledgement, PendingAcknowledgement, UnacknowledgedTicket},
+        channels::Ticket,
+    };
+    use bincode::{deserialize, serialize};
     use core_crypto::{
         keypairs::{ChainKeypair, Keypair, OffchainKeypair},
         types::{Challenge, CurvePoint, HalfKey, Hash, OffchainPublicKey, Response},
@@ -387,9 +374,10 @@ pub mod test {
         traits::BinarySerializable,
     };
 
-    const ALICE: [u8; 32] = hex!("492057cf93e99b31d2a85bc5e98a9c3aa0021feec52c227cc8170e8f7d047775");
-
-    const BOB: [u8; 32] = hex!("48680484c6fc31bc881a0083e6e32b6dc789f9eaba0f8b981429fd346c697f8c");
+    lazy_static::lazy_static! {
+        static ref ALICE: ChainKeypair = ChainKeypair::from_secret(&hex!("492057cf93e99b31d2a85bc5e98a9c3aa0021feec52c227cc8170e8f7d047775")).unwrap();
+        static ref BOB: ChainKeypair = ChainKeypair::from_secret(&hex!("48680484c6fc31bc881a0083e6e32b6dc789f9eaba0f8b981429fd346c697f8c")).unwrap();
+    }
 
     fn mock_ticket(
         pk: &ChainKeypair,
@@ -449,13 +437,10 @@ pub mod test {
 
     #[test]
     fn test_unacknowledged_ticket_serialize_deserialize() {
-        let keypair = ChainKeypair::from_secret(&ALICE).unwrap();
-        let keypair_counterparty = ChainKeypair::from_secret(&BOB).unwrap();
-
         let unacked_ticket = UnacknowledgedTicket::new(
-            mock_ticket(&keypair, &keypair_counterparty.public().to_address(), None, None),
+            mock_ticket(&ALICE, &BOB.public().to_address(), None, None),
             HalfKey::default(),
-            keypair.public().to_address(),
+            ALICE.public().to_address(),
         );
 
         assert_eq!(
@@ -466,13 +451,10 @@ pub mod test {
 
     #[test]
     fn test_unacknowledged_ticket_sign_verify() {
-        let keypair = ChainKeypair::from_secret(&ALICE).unwrap();
-        let keypair_counterparty = ChainKeypair::from_secret(&BOB).unwrap();
-
         let unacked_ticket = UnacknowledgedTicket::new(
-            mock_ticket(&keypair, &keypair_counterparty.public().to_address(), None, None),
+            mock_ticket(&ALICE, &BOB.public().to_address(), None, None),
             HalfKey::default(),
-            keypair.public().to_address(),
+            ALICE.public().to_address(),
         );
 
         assert!(unacked_ticket.verify_signature(&Hash::default()).is_ok());
@@ -480,9 +462,6 @@ pub mod test {
 
     #[test]
     fn test_unacknowledged_ticket_challenge_response() {
-        let keypair = ChainKeypair::from_secret(&ALICE).unwrap();
-        let keypair_counterparty = ChainKeypair::from_secret(&BOB).unwrap();
-
         let hk1 = HalfKey::new(&hex!(
             "3477d7de923ba3a7d5d72a7d6c43fd78395453532d03b2a1e2b9a7cc9b61bafa"
         ));
@@ -494,13 +473,13 @@ pub mod test {
         let cp_sum = CurvePoint::combine(&[&cp1, &cp2]);
 
         let ticket = mock_ticket(
-            &keypair,
-            &keypair_counterparty.public().to_address(),
+            &ALICE,
+            &BOB.public().to_address(),
             None,
             Some(Challenge::from(cp_sum).to_ethereum_challenge()),
         );
 
-        let unacked_ticket = UnacknowledgedTicket::new(ticket, hk1, keypair.public().to_address());
+        let unacked_ticket = UnacknowledgedTicket::new(ticket, hk1, ALICE.public().to_address());
 
         assert!(unacked_ticket.verify_signature(&Hash::default()).is_ok());
         assert!(unacked_ticket.verify_challenge(&hk2).is_ok())
@@ -508,9 +487,6 @@ pub mod test {
 
     #[test]
     fn test_unack_transformation() {
-        let keypair = ChainKeypair::from_secret(&ALICE).unwrap();
-        let keypair_counterparty = ChainKeypair::from_secret(&BOB).unwrap();
-
         let hk1 = HalfKey::new(&hex!(
             "3477d7de923ba3a7d5d72a7d6c43fd78395453532d03b2a1e2b9a7cc9b61bafa"
         ));
@@ -522,22 +498,20 @@ pub mod test {
         let cp_sum = CurvePoint::combine(&[&cp1, &cp2]);
 
         let ticket = mock_ticket(
-            &keypair,
-            &keypair_counterparty.public().to_address(),
+            &ALICE,
+            &BOB.public().to_address(),
             None,
             Some(Challenge::from(cp_sum).to_ethereum_challenge()),
         );
 
-        let unacked_ticket = UnacknowledgedTicket::new(ticket, hk1, keypair.public().to_address());
+        let unacked_ticket = UnacknowledgedTicket::new(ticket, hk1, ALICE.public().to_address());
 
-        let acked_ticket = unacked_ticket
-            .acknowledge(&hk2, &keypair_counterparty, &Hash::default())
-            .unwrap();
+        let acked_ticket = unacked_ticket.acknowledge(&hk2, &BOB, &Hash::default()).unwrap();
 
         assert!(acked_ticket
             .verify(
-                &keypair.public().to_address(),
-                &keypair_counterparty.public().to_address(),
+                &ALICE.public().to_address(),
+                &BOB.public().to_address(),
                 &Hash::default()
             )
             .is_ok());
@@ -545,42 +519,27 @@ pub mod test {
 
     #[test]
     fn test_acknowledged_ticket() {
-        let keypair = ChainKeypair::from_secret(&ALICE).unwrap();
-        let keypair_counterparty = ChainKeypair::from_secret(&BOB).unwrap();
-
         let response = Response::from_bytes(&hex!(
             "876a41ee5fb2d27ac14d8e8d552692149627c2f52330ba066f9e549aef762f73"
         ))
         .unwrap();
 
         let ticket = mock_ticket(
-            &keypair,
-            &keypair_counterparty.public().to_address(),
+            &ALICE,
+            &BOB.public().to_address(),
             None,
             Some(response.to_challenge().into()),
         );
 
-        let keypair = ChainKeypair::from_secret(&ALICE).unwrap();
-        let keypair_counterparty = ChainKeypair::from_secret(&BOB).unwrap();
+        let acked_ticket =
+            AcknowledgedTicket::new(ticket, response, ALICE.public().to_address(), &BOB, &Hash::default()).unwrap();
 
-        let acked_ticket = AcknowledgedTicket::new(
-            ticket,
-            response,
-            keypair.public().to_address(),
-            &keypair_counterparty,
-            &Hash::default(),
-        )
-        .unwrap();
-
-        assert_eq!(
-            acked_ticket,
-            AcknowledgedTicket::from_bytes(&acked_ticket.to_bytes()).unwrap()
-        );
+        assert_eq!(acked_ticket, deserialize(&serialize(&acked_ticket).unwrap()).unwrap());
 
         assert!(acked_ticket
             .verify(
-                &keypair.public().to_address(),
-                &keypair_counterparty.public().to_address(),
+                &ALICE.public().to_address(),
+                &BOB.public().to_address(),
                 &Hash::default()
             )
             .is_ok());

--- a/packages/core/crates/core-types/src/acknowledgement.rs
+++ b/packages/core/crates/core-types/src/acknowledgement.rs
@@ -588,7 +588,10 @@ pub mod test {
 
         deserialized_ticket.status(super::AcknowledgedTicketStatus::BeingAggregated { start: 1u64, end: 2u64 });
 
-        assert_eq!(deserialized_ticket, deserialize(&serialize(&deserialized_ticket).unwrap()).unwrap());
+        assert_eq!(
+            deserialized_ticket,
+            deserialize(&serialize(&deserialized_ticket).unwrap()).unwrap()
+        );
     }
 
     #[test]

--- a/packages/core/crates/core-types/src/channels.rs
+++ b/packages/core/crates/core-types/src/channels.rs
@@ -8,7 +8,10 @@ use core_crypto::{
 use enum_iterator::{all, Sequence};
 use ethers::contract::EthCall;
 use hex_literal::hex;
-use serde::{Deserialize, Serialize};
+use serde::{
+    de::{self, Deserializer, Visitor},
+    Deserialize, Serialize,
+};
 use serde_repr::*;
 use std::fmt::{Display, Formatter};
 use utils_types::primitives::{Address, Balance, BalanceType, EthereumChallenge, U256};
@@ -193,7 +196,7 @@ pub fn generate_channel_id(source: &Address, destination: &Address) -> Hash {
 }
 
 /// Contains the overall description of a ticket with a signature
-#[derive(Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, PartialEq)]
 pub struct Ticket {
     pub channel_id: Hash,
     pub amount: Balance,
@@ -203,6 +206,40 @@ pub struct Ticket {
     pub channel_epoch: u32,
     pub challenge: EthereumChallenge,
     pub signature: Option<Signature>,
+}
+
+impl Serialize for Ticket {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_bytes(self.to_bytes().as_ref())
+    }
+}
+
+struct TicketVisitor {}
+
+impl<'de> Visitor<'de> for TicketVisitor {
+    type Value = Ticket;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_fmt(format_args!("a byte-array with {} elements", Ticket::SIZE))
+    }
+    fn visit_bytes<E>(self, v: &[u8]) -> std::result::Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ticket::from_bytes(v).map_err(|e| de::Error::custom(e.to_string()))
+    }
+}
+
+impl<'de> Deserialize<'de> for Ticket {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_bytes(TicketVisitor {})
+    }
 }
 
 impl Default for Ticket {
@@ -664,16 +701,19 @@ pub mod tests {
         traits::BinarySerializable,
     };
 
-    const ADDRESS_1: [u8; 20] = hex!("3829b806aea42200c623c4d6b9311670577480ed");
-    const ADDRESS_2: [u8; 20] = hex!("1a34729c69e95d6e11c3a9b9be3ea0c62c6dc5b1");
-    const ALICE: [u8; 32] = hex!("e17fe86ce6e99f4806715b0c9412f8dad89334bf07f72d5834207a9d8f19d7f8");
-    const BOB: [u8; 32] = hex!("07af9653b11d609139597aecd26360fce1f9c23864d0c6ce1035bdb77ea4e27c");
+    lazy_static::lazy_static! {
+        static ref ALICE: ChainKeypair = ChainKeypair::from_secret(&hex!("492057cf93e99b31d2a85bc5e98a9c3aa0021feec52c227cc8170e8f7d047775")).unwrap();
+        static ref BOB: ChainKeypair = ChainKeypair::from_secret(&hex!("48680484c6fc31bc881a0083e6e32b6dc789f9eaba0f8b981429fd346c697f8c")).unwrap();
+
+        static ref ADDRESS_1: Address = Address::from_bytes(&hex!("3829b806aea42200c623c4d6b9311670577480ed")).unwrap();
+        static ref ADDRESS_2: Address = Address::from_bytes(&hex!("1a34729c69e95d6e11c3a9b9be3ea0c62c6dc5b1")).unwrap();
+    }
 
     #[test]
     pub fn channel_entry_test() {
         let ce1 = ChannelEntry::new(
-            Address::from_bytes(&ADDRESS_1).unwrap(),
-            Address::from_bytes(&ADDRESS_2).unwrap(),
+            *ADDRESS_1,
+            *ADDRESS_2,
             Balance::new(10u64.into(), BalanceType::HOPR),
             23u64.into(),
             ChannelStatus::PendingToClose,
@@ -739,18 +779,15 @@ pub mod tests {
 
     #[test]
     pub fn test_ticket_serialize_deserialize() {
-        let alice = ChainKeypair::from_secret(&ALICE).unwrap();
-        let bob = ChainKeypair::from_secret(&BOB).unwrap();
-
         let initial_ticket = super::Ticket::new(
-            &bob.public().to_address(),
+            &BOB.public().to_address(),
             &Balance::new(U256::one(), BalanceType::HOPR),
             U256::zero(),
             U256::one(),
             1.0,
             U256::one(),
             EthereumChallenge::default(),
-            &alice,
+            &ALICE,
             &Hash::default(),
         )
         .unwrap();
@@ -761,19 +798,37 @@ pub mod tests {
     }
 
     #[test]
-    pub fn test_ticket_sign_verify() {
-        let alice = ChainKeypair::from_secret(&ALICE).unwrap();
-        let bob = ChainKeypair::from_secret(&BOB).unwrap();
-
+    pub fn test_ticket_serialize_deserialize_serde() {
         let initial_ticket = super::Ticket::new(
-            &bob.public().to_address(),
+            &BOB.public().to_address(),
             &Balance::new(U256::one(), BalanceType::HOPR),
             U256::zero(),
             U256::one(),
             1.0,
             U256::one(),
             EthereumChallenge::default(),
-            &alice,
+            &ALICE,
+            &Hash::default(),
+        )
+        .unwrap();
+
+        assert_eq!(
+            initial_ticket,
+            bincode::deserialize(&bincode::serialize(&initial_ticket).unwrap()).unwrap()
+        );
+    }
+
+    #[test]
+    pub fn test_ticket_sign_verify() {
+        let initial_ticket = super::Ticket::new(
+            &BOB.public().to_address(),
+            &Balance::new(U256::one(), BalanceType::HOPR),
+            U256::zero(),
+            U256::one(),
+            1.0,
+            U256::one(),
+            EthereumChallenge::default(),
+            &ALICE,
             &Hash::default(),
         )
         .unwrap();
@@ -781,18 +836,15 @@ pub mod tests {
         assert_ne!(*initial_ticket.get_hash(&Hash::default()).to_bytes(), [0u8; Hash::SIZE]);
 
         assert!(initial_ticket
-            .verify(&alice.public().to_address(), &Hash::default())
+            .verify(&ALICE.public().to_address(), &Hash::default())
             .is_ok());
     }
 
     #[test]
     pub fn test_ticket_expected_payout() {
-        let alice = ChainKeypair::from_secret(&ALICE).unwrap();
-        let bob = ChainKeypair::from_secret(&BOB).unwrap();
-
         let mut ticket = Ticket::new_partial(
-            &alice.public().to_address(),
-            &bob.public().to_address(),
+            &ALICE.public().to_address(),
+            &BOB.public().to_address(),
             &Balance::new(U256::one(), BalanceType::HOPR),
             U256::zero(),
             U256::one(),
@@ -814,11 +866,9 @@ pub mod tests {
 
     #[test]
     pub fn test_path_position() {
-        let alice = ChainKeypair::from_secret(&ALICE).unwrap();
-        let bob = ChainKeypair::from_secret(&BOB).unwrap();
         let mut ticket = Ticket::new_partial(
-            &alice.public().to_address(),
-            &bob.public().to_address(),
+            &ALICE.public().to_address(),
+            &BOB.public().to_address(),
             &Balance::new(U256::one(), BalanceType::HOPR),
             U256::zero(),
             U256::one(),
@@ -846,11 +896,9 @@ pub mod tests {
 
     #[test]
     pub fn test_path_position_bad_examples() {
-        let alice = ChainKeypair::from_secret(&ALICE).unwrap();
-        let bob = ChainKeypair::from_secret(&BOB).unwrap();
         let ticket = Ticket::new_partial(
-            &alice.public().to_address(),
-            &bob.public().to_address(),
+            &ALICE.public().to_address(),
+            &BOB.public().to_address(),
             &Balance::new(256u64.into(), BalanceType::HOPR),
             U256::zero(),
             U256::one(),
@@ -864,12 +912,9 @@ pub mod tests {
 
     #[test]
     pub fn test_zero_hop() {
-        let alice = ChainKeypair::from_secret(&ALICE).unwrap();
-        let bob = ChainKeypair::from_secret(&BOB).unwrap();
-
-        let zero_hop_ticket = Ticket::new_zero_hop(&bob.public().to_address(), &alice, &Hash::default());
+        let zero_hop_ticket = Ticket::new_zero_hop(&BOB.public().to_address(), &ALICE, &Hash::default());
         assert!(zero_hop_ticket
-            .verify(&alice.public().to_address(), &Hash::default())
+            .verify(&ALICE.public().to_address(), &Hash::default())
             .is_ok());
     }
 }

--- a/packages/core/crates/core-types/src/channels.rs
+++ b/packages/core/crates/core-types/src/channels.rs
@@ -208,6 +208,7 @@ pub struct Ticket {
     pub signature: Option<Signature>,
 }
 
+// Use compact serialization for ticket as they are used very often
 impl Serialize for Ticket {
     fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
     where
@@ -225,6 +226,7 @@ impl<'de> Visitor<'de> for TicketVisitor {
     fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
         formatter.write_fmt(format_args!("a byte-array with {} elements", Ticket::SIZE))
     }
+
     fn visit_bytes<E>(self, v: &[u8]) -> std::result::Result<Self::Value, E>
     where
         E: de::Error,
@@ -233,6 +235,7 @@ impl<'de> Visitor<'de> for TicketVisitor {
     }
 }
 
+// Use compact deserialization for tickets as they are used very often
 impl<'de> Deserialize<'de> for Ticket {
     fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
     where

--- a/yarn.lock
+++ b/yarn.lock
@@ -1850,9 +1850,9 @@ __metadata:
   linkType: hard
 
 "@types/cookie@npm:^0.5.1":
-  version: 0.5.1
-  resolution: "@types/cookie@npm:0.5.1"
-  checksum: 9a8d60fc84797122bc399d6bd330fe5780dc7aab032321de705049ea925339f74658bfa418de483a625d51858770efef58df633ff2e20f1bdf7fbd74a52847e2
+  version: 0.5.2
+  resolution: "@types/cookie@npm:0.5.2"
+  checksum: 4a1e46379d877f5a3cc687a9799dd72e5f7e68c4764d45cb469789dec92b4b4a7a5bb8b10a08c90be15939fa7b9b402f87ed339dfac0cabf43699c5189880e88
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# General architecture

`serde` normal encoding -> local usage, e.g. DB storage

`BinarySerializable` ->over-the-wire`, non-local usage

custom `serde` serializer / deserializer -> often used structs, e.g. tickets

# Main change

- Adds an additional field to `AcknowledgedTicket` showing whether that ticket is part of an ongoing aggregation or being redeemed on-chain
- change Ticket `serde` serialization / deserialization to position encoding