### PR TITLE
core: Fix reading of existing identities files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4874,6 +4874,7 @@ dependencies = [
 name = "real-base"
 version = "0.1.0"
 dependencies = [
+ "bitflags 2.4.0",
  "thiserror",
  "wasm-bindgen",
  "wasm-opt",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1514,14 +1514,15 @@ export class Hopr extends EventEmitter {
               const nativeBalance = await HoprCoreEthereum.getInstance().getNativeBalance(
                 this.getEthereumAddress().to_string()
               )
+              log(`waitforfunds: current balance is ${nativeBalance.to_formatted_string()}`)
               if (nativeBalance.gte(nativeBalance.of_same(MIN_NATIVE_BALANCE.toString(10)))) {
                 resolve()
               } else {
-                log('still unfunded, trying again soon')
+                log('waitforfunds: still unfunded, trying again soon')
                 reject()
               }
             } catch (e) {
-              log('error with native balance call, trying again soon')
+              log('waitforfunds: error with native balance call, trying again soon')
               reject()
             }
           }),

--- a/packages/hoprd/crates/hoprd-keypair/src/key_pair.rs
+++ b/packages/hoprd/crates/hoprd-keypair/src/key_pair.rs
@@ -15,7 +15,7 @@ use serde_json::{from_str as from_json_string, to_string as to_json_string};
 use sha3::{digest::Update, Digest, Keccak256};
 use std::fmt::Debug;
 use typenum::Unsigned;
-use utils_log::error;
+use utils_log::{error, info};
 use utils_types::traits::{PeerIdLike, ToHex};
 use uuid::Uuid;
 
@@ -228,9 +228,16 @@ impl HoprKeys {
 
 impl HoprKeys {
     pub fn init(opts: IdentityOptions) -> Result<Self> {
-        let exists = metadata(&opts.id_path).is_ok();
+        let exists = metadata(&opts.id_path).map_or_else(
+            |e| {
+                info!("identity file {} not found: {}", &opts.id_path, e);
+                false
+            },
+            |_v| true,
+        );
 
         if !exists && opts.private_key.is_some() {
+            info!("using provided private key and writing new identity file");
             let keys = if let Some(private_key) = opts.private_key {
                 if private_key.len() != PACKET_KEY_LENGTH + CHAIN_KEY_LENGTH {
                     return Err(KeyPairError::InvalidPrivateKeySize {
@@ -262,6 +269,7 @@ impl HoprKeys {
         if exists {
             match HoprKeys::read_eth_keystore(&opts.id_path, &opts.password) {
                 Ok((keys, needs_migration)) => {
+                    info!("migration needed = {}", needs_migration);
                     if needs_migration {
                         keys.write_eth_keystore(
                             &opts.id_path,
@@ -282,6 +290,10 @@ impl HoprKeys {
         }
 
         if opts.initialize {
+            info!(
+                "identity file {} not found, initializing and writing new identity file",
+                &opts.id_path
+            );
             let keys = HoprKeys::random();
             keys.write_eth_keystore(
                 &opts.id_path,

--- a/packages/real/crates/real-base/Cargo.toml
+++ b/packages/real/crates/real-base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "real-base"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Rust WASM modules for HOPR"
@@ -14,11 +14,11 @@ crate-type = ["cdylib", "rlib"] # rlib is necessary to run integration tests
 
 [features]
 default = [ "wasm" ]
-wasm = [ "dep:wasm-bindgen" ]
+wasm = [ "dep:wasm-bindgen", "dep:bitflags" ]
 
 [dependencies]
 thiserror = "1.0"
-bitflags = "2.4"
+bitflags = { version = "2.4", optional = true }
 wasm-bindgen = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.build-dependencies]

--- a/packages/real/crates/real-base/Cargo.toml
+++ b/packages/real/crates/real-base/Cargo.toml
@@ -18,6 +18,7 @@ wasm = [ "dep:wasm-bindgen" ]
 
 [dependencies]
 thiserror = "1.0"
+bitflags = "2.4"
 wasm-bindgen = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.build-dependencies]

--- a/scripts/fixture_local_test_setup.sh
+++ b/scripts/fixture_local_test_setup.sh
@@ -187,6 +187,7 @@ function reuse_pregenerated_identities() {
     native_address="$(echo "${ids_info}" | jq -r "to_entries[] | select(.key==\"${id_file}\").value.native_address")"
 
     log "\tnode ${i}"
+    log "\t\tidentity file: ${tmp_dir}/${node_prefix}_${i}.id"
     log "\t\tpeer id: ${peer_id}"
     log "\t\tnative address: ${native_address}"
   done


### PR DESCRIPTION
The access check was incorrectly expecting a number return value when `undefined` was returned. This led to identity files being overwritten.