### PR TITLE
indexer: Remove calls which require an archive node

### DIFF
--- a/packages/core-ethereum/src/index.ts
+++ b/packages/core-ethereum/src/index.ts
@@ -169,11 +169,6 @@ export default class HoprCoreEthereum extends EventEmitter {
       try {
         await this.chain.waitUntilReady()
 
-        // update token balance
-        //const hoprBalance = await this.chain.getBalance(this.chainKeypair.to_address())
-        //await this.db.set_hopr_balance(hoprBalance)
-        //log(`set own HOPR balance to ${hoprBalance.to_formatted_string()}`)
-
         // indexer starts
         await this.indexer.start(this.chain, this.chain.getGenesisBlock(), this.safeModuleOptions.safeAddress)
 

--- a/packages/core-ethereum/src/indexer/index.ts
+++ b/packages/core-ethereum/src/indexer/index.ts
@@ -6,8 +6,6 @@ import { Multiaddr } from '@multiformats/multiaddr'
 import {
   defer,
   ChannelStatus,
-  Balance,
-  BalanceType,
   Address,
   ChannelEntry,
   AccountEntry,
@@ -163,24 +161,6 @@ class Indexer extends (EventEmitter as new () => IndexerEventEmitter) {
     }
     // no need to query before HoprChannels or HoprNetworkRegistry existed
     fromBlock = Math.max(fromBlock, this.genesisBlock)
-
-    // update the base valuse of balance and allowance of token for safe
-    if (!this.lastSnapshot) {
-      // update safe's HOPR token balance
-      log(`get safe ${this.safeAddress.to_string()} HOPR balance at block ${fromBlock}`)
-      const hoprBalance = await this.chain.getBalanceAtBlock(this.safeAddress, fromBlock)
-      await this.db.set_hopr_balance(Balance.deserialize(hoprBalance.serialize_value(), BalanceType.HOPR))
-      log(`set safe HOPR balance to ${hoprBalance.to_formatted_string()}`)
-
-      // update safe's HORP token allowance granted to Channels contract
-      log(`get safe ${this.safeAddress.to_string()} HOPR allowance at block ${fromBlock}`)
-      const safeAllowance = await this.chain.getTokenAllowanceGrantedToChannelsAt(this.safeAddress, fromBlock)
-      await this.db.set_staking_safe_allowance(
-        Balance.deserialize(safeAllowance.serialize_value(), BalanceType.HOPR),
-        new Snapshot(new U256('0'), new U256('0'), new U256('0')) // dummy snapshot
-      )
-      log(`set safe allowance to ${safeAllowance.to_formatted_string()}`)
-    }
 
     log('Starting to index from block %d, sync progress 0%%', fromBlock)
 

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -23,4 +23,4 @@ export const ACKNOWLEDGEMENT_TIMEOUT = 2000
 
 export const PEER_METADATA_PROTOCOL_VERSION = 'protocol_version'
 
-export const DB_VERSION_TAG = 'indexer_4'
+export const DB_VERSION_TAG = 'main_1'

--- a/packages/hoprd/src/api/v3/paths/channels/{channelid}/index.ts
+++ b/packages/hoprd/src/api/v3/paths/channels/{channelid}/index.ts
@@ -16,8 +16,6 @@ import type { Operation } from 'express-openapi'
 
 const closingRequests = new Map<string, DeferType<void>>()
 
-const log = debug('hoprd:api:v3:channel-close')
-
 /**
  * Closes a channel with channel id.
  * @returns Channel status and receipt.
@@ -36,6 +34,8 @@ export async function closeChannel(
       receipt: string
     }
 > {
+  const log = debug('hoprd:api:v3:channel-close')
+
   const channelIdHash = Hash.deserialize(stringToU8a(channelIdStr))
   const channel = await node.db.get_channel(channelIdHash)
   const channelId = channel.get_id()
@@ -172,39 +172,26 @@ DELETE.apiDoc = {
   }
 }
 
-/**
- * Fetches channel information by channel id.
- * @returns the channel information
- */
-export const getChannel = async (node: Hopr, channelIdStr: string): Promise<ChannelTopologyInfo> => {
-  try {
-    const channel = await node.db.get_channel(Hash.deserialize(new TextEncoder().encode(channelIdStr)))
-
-    return formatChannelTopologyInfo(node, channel)
-  } catch {
-    throw Error(STATUS_CODES.CHANNEL_NOT_FOUND)
-  }
-}
-
 const GET: Operation = [
   async (req, res, _next) => {
+    const log = debug('hoprd:api:v3:channel-get')
+
     const { node }: { node: Hopr } = req.context
     const { channelid } = req.params
 
     try {
-      const channel = await getChannel(node, channelid)
-      return res.status(200).send(channel)
-    } catch (err) {
-      const errString = err instanceof Error ? err.message : err?.toString?.() ?? 'Unknown error'
-
-      switch (errString) {
-        case STATUS_CODES.INVALID_CHANNELID:
-          return res.status(400).send({ status: STATUS_CODES.INVALID_CHANNELID })
-        case STATUS_CODES.CHANNEL_NOT_FOUND:
-          return res.status(404).send({ status: STATUS_CODES.CHANNEL_NOT_FOUND })
-        default:
-          return res.status(422).send({ status: STATUS_CODES.UNKNOWN_FAILURE, error: errString })
+      const channelIdHash = Hash.deserialize(stringToU8a(channelid))
+      const channel = await node.db.get_channel(channelIdHash)
+      if (!channel) {
+        return res.status(404).send()
       }
+      const response = formatChannelTopologyInfo(node, channel)
+      return res.status(200).send(response)
+    } catch (err) {
+      log(`${err}`)
+      const error = err instanceof Error ? err.message : err?.toString?.() ?? 'Unknown error'
+      const status = STATUS_CODES.UNKNOWN_FAILURE
+      res.status(422).send({ status, error })
     }
   }
 ]
@@ -256,17 +243,7 @@ GET.apiDoc = {
       $ref: '#/components/responses/Forbidden'
     },
     '404': {
-      description: 'Channel with that channel id was not found. You can list all channels using /channels/ endpoint.',
-      content: {
-        'application/json': {
-          schema: {
-            $ref: '#/components/schemas/RequestStatus'
-          },
-          example: {
-            status: STATUS_CODES.CHANNEL_NOT_FOUND
-          }
-        }
-      }
+      $ref: '#/components/responses/NotFound'
     },
     '422': {
       description: 'Unknown failure.',


### PR DESCRIPTION
Currently when a node restarts the indexer tried getting the balance and allowance at the last indexed block. If that failed, which it would if the RPC provider does not support archive operations, the local data in the database would be incorrectly overwritten. Thus, the state of the indexer and what is on-chain would diverge.

Since the indexer reliably indexes these two values we don't need to ask for that particular information anymore. Thus, reducing the need for an archive RPC provider and removing these specific error cases.

The database must be cleaned and chain data must be re-indexed to fix the incoherence. Therefore, the db version was bumped.

- Also fix an issue in channel id generation in the api call for getting channel details