### PR TITLE
core: Don't use destination in path finding

### DIFF
--- a/packages/core/crates/core-packet/src/interaction.rs
+++ b/packages/core/crates/core-packet/src/interaction.rs
@@ -554,7 +554,7 @@ where
 
         // Decide whether to create 0-hop or multihop ticket
         let next_ticket = if path.length() == 1 {
-            Ticket::new_zero_hop(&next_peer, &self.cfg.chain_keypair, &domain_separator)
+            Ticket::new_zero_hop(&next_peer, &self.cfg.chain_keypair, &domain_separator)?
         } else {
             self.create_multihop_ticket(next_peer, path.length() as u8).await?
         };
@@ -737,7 +737,7 @@ where
 
                 // Create next ticket for the packet
                 next_ticket = if ticket_path_pos == 1 {
-                    Ticket::new_zero_hop(&next_hop_addr, &self.cfg.chain_keypair, &domain_separator)
+                    Ticket::new_zero_hop(&next_hop_addr, &self.cfg.chain_keypair, &domain_separator)?
                 } else {
                     self.create_multihop_ticket(next_hop_addr, ticket_path_pos).await?
                 };

--- a/packages/core/crates/core-packet/src/packet.rs
+++ b/packages/core/crates/core-packet/src/packet.rs
@@ -567,7 +567,7 @@ mod tests {
             )
             .unwrap()
         } else {
-            Ticket::new_zero_hop(&next_peer_channel_key.to_address(), private_key, &Hash::default())
+            Ticket::new_zero_hop(&next_peer_channel_key.to_address(), private_key, &Hash::default()).unwrap()
         }
     }
 

--- a/packages/core/crates/core-types/src/channels.rs
+++ b/packages/core/crates/core-types/src/channels.rs
@@ -568,7 +568,7 @@ impl Ticket {
     }
 
     /// Convenience method for creating a zero-hop ticket
-    pub fn new_zero_hop(destination: &Address, private_key: &ChainKeypair, domain_separator: &Hash) -> Self {
+    pub fn new_zero_hop(destination: &Address, private_key: &ChainKeypair, domain_separator: &Hash) -> Result<Self> {
         Self::new(
             destination,
             &Balance::new(0u32.into(), BalanceType::HOPR),
@@ -580,7 +580,6 @@ impl Ticket {
             private_key,
             domain_separator,
         )
-        .expect("Failed to create zero-hop ticket")
     }
 
     /// Based on the price of this ticket, determines the path position (hop number) this ticket
@@ -965,7 +964,7 @@ pub mod tests {
 
     #[test]
     pub fn test_zero_hop() {
-        let zero_hop_ticket = Ticket::new_zero_hop(&BOB.public().to_address(), &ALICE, &Hash::default());
+        let zero_hop_ticket = Ticket::new_zero_hop(&BOB.public().to_address(), &ALICE, &Hash::default()).unwrap();
         assert!(zero_hop_ticket
             .verify(&ALICE.public().to_address(), &Hash::default())
             .is_ok());

--- a/packages/hoprd/src/api/v3/paths/channels/{channelid}/index.ts
+++ b/packages/hoprd/src/api/v3/paths/channels/{channelid}/index.ts
@@ -194,7 +194,7 @@ const GET: Operation = [
       if (!channel) {
         return res.status(404).send()
       }
-      const response = formatChannelTopologyInfo(node, channel)
+      const response = await formatChannelTopologyInfo(node, channel)
       return res.status(200).send(response)
     } catch (err) {
       log(`${err}`)

--- a/scripts/api.sh
+++ b/scripts/api.sh
@@ -311,7 +311,7 @@ api_open_channel() {
   local amount="${5:-1000000000000000000000}"
   local result balances hopr_balance
 
-  balances=$(api_get_balances ${api1})
+  balances=$(api_get_balances ${source_api})
   hopr_balance=$(echo ${balances} | jq -r .safeHopr)
   log "Safe balance of node ${source_api} before opening new channel: ${hopr_balance} weiHOPR, need ${amount} weiHOPR"
 

--- a/tests/integration-test.sh
+++ b/tests/integration-test.sh
@@ -396,7 +396,9 @@ test_aggregate_redeem_in_specific_channel() {
 
   channel_info=$(api_open_channel "${node_id}" "${second_node_id}" "${node_api}" "${second_node_addr}")
   channel_id=$(echo "${channel_info}" | jq -r '.channelId')
-  log "Aggregate/Redeem in channel: Opened channel from node ${node_id} to ${second_node_id}: ${channel_id}"
+  channel_info_detail=$(api_get_channel_info "${node_api}" "${channel_id}" "${second_node_addr}" "outgoing")
+  channel_id=$(echo "${channel_info_detail}" | jq -r '.channelId')
+  log "Aggregate/Redeem in channel: Opened channel ${channel_id} from node ${node_id} to ${second_node_id}: ${channel_info_detail}"
 
   second_peer_id=$(get_hopr_address ${api_token}@${second_node_api})
 
@@ -444,7 +446,9 @@ test_redeem_in_specific_channel() {
 
   channel_info=$(api_open_channel "${node_id}" "${second_node_id}" "${node_api}" "${second_node_addr}")
   channel_id=$(echo "${channel_info}" | jq -r '.channelId')
-  log "Redeem in channel: Opened channel from node ${node_id} to ${second_node_id}: ${channel_id}"
+  channel_info_detail=$(api_get_channel_info "${node_api}" "${channel_id}" "${second_node_addr}" "outgoing")
+  channel_id=$(echo "${channel_info_detail}" | jq -r '.channelId')
+  log "Redeem in channel: Opened channel ${channel_id} from node ${node_id} to ${second_node_id}: ${channel_info_detail}"
 
   second_peer_id=$(get_hopr_address ${api_token}@${second_node_api})
 


### PR DESCRIPTION
Fixes #5526 

The path finding algorithm was choosing paths where the last hop could involve the final destination as source. This isn't possible, therefore has been fixed.