### PR TITLE
Fix generation procedure for hoprd-python-sdk

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,5 @@
 nix_direnv_watch_file shell.nix
 nix_direnv_watch_file rust-toolchain.toml
 use flake
+
+PATH_add .cargo/bin

--- a/Makefile
+++ b/Makefile
@@ -330,7 +330,7 @@ kill-anvil: ## kill process running at port 8545 (default port of anvil)
 	lsof -i :8545 -s TCP:LISTEN -t | xargs -I {} -n 1 kill {} || :
 
 .PHONY: create-local-identity
-create-local-identity: id_dir=`pwd`
+create-local-identity: id_dir=/tmp/
 create-local-identity: id_password=local
 create-local-identity: id_prefix=.identity-local_
 create-local-identity: ## run HOPRd from local repo


### PR DESCRIPTION
The hoprd-python-sdk failed to generate due to minor issues fixed in this PR.