### PR TITLE
nix: Remove unstable packages with unstable bugs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -38,27 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1694948089,
-        "narHash": "sha256-d2B282GmQ9o8klc22/Rbbbj6r99EnELQpOQjWMyv0rU=",
+        "lastModified": 1695675437,
+        "narHash": "sha256-4dBT8mbbmederQ1ENGSgph0n5GMMr6zgWIaVftDolL8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5148520bfab61f99fd25fb9ff7bfbb50dad3c9db",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-dev": {
-      "locked": {
-        "lastModified": 1695072453,
-        "narHash": "sha256-7nn06EjvKo40oF8ctdxaItgYB3hSNfLk88hjwfDeLV8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e7ba2fba05ca4383efcea971fb8d280943e13af8",
+        "rev": "0dd560f0abbe9e0b09bd1626ab44f05c80a68b26",
         "type": "github"
       },
       "original": {
@@ -90,21 +74,22 @@
       "inputs": {
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-dev": "nixpkgs-dev",
         "rust-overlay": "rust-overlay"
       }
     },
     "rust-overlay": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": ["nixpkgs"]
+        "nixpkgs": [
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1695003086,
-        "narHash": "sha256-d1/ZKuBRpxifmUf7FaedCqhy0lyVbqj44Oc2s+P5bdA=",
+        "lastModified": 1695607919,
+        "narHash": "sha256-PU6yIbHXdm3W8bBlhO6aL+VIjK5UQCRnOvCqa1lYQ6M=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "b87a14abea512d956f0b89d0d8a1e9b41f3e20ff",
+        "rev": "014e0035c262e5506f904829e6b925ee3cfdb55e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,15 +2,14 @@
   description = "hoprnet monorepo";
 
   inputs.flake-parts.url = github:hercules-ci/flake-parts;
-  inputs.nixpkgs.url = github:NixOS/nixpkgs/nixpkgs-unstable;
-  inputs.nixpkgs-dev.url = github:NixOS/nixpkgs/master;
+  inputs.nixpkgs.url = github:NixOS/nixpkgs/master;
   inputs.rust-overlay.url = github:oxalica/rust-overlay;
 
   inputs.rust-overlay.inputs = {
     nixpkgs.follows = "nixpkgs";
   };
 
-  outputs = { self, nixpkgs, nixpkgs-dev, flake-parts, rust-overlay, ... }@inputs:
+  outputs = { self, nixpkgs, flake-parts, rust-overlay, ... }@inputs:
     flake-parts.lib.mkFlake { inherit inputs; } {
       perSystem = { config, self', inputs', system, ... }:
         let
@@ -18,13 +17,10 @@
           pkgs = import nixpkgs {
             inherit system overlays;
           };
-          pkgs-dev = import nixpkgs-dev {
-            inherit system overlays;
-          };
         in
         {
           devShells.default = import ./shell.nix {
-            inherit pkgs pkgs-dev;
+            inherit pkgs;
           };
         };
       systems = [ "x86_64-linux" "aarch64-darwin" ];

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,4 @@
 { pkgs ? import <nixpkgs> { }
-, pkgs-dev
 , ...
 }:
 let
@@ -25,8 +24,8 @@ let
     ## rust for core development and required utils
     (rust-bin.fromRustupToolchainFile ./rust-toolchain.toml)
     protobuf # v3.21.12
-    pkgs-dev.wasm-pack # v0.11.1
-    pkgs-dev.binaryen # v113 (includes wasm-opt)
+    pkgs.wasm-pack # v0.12.1
+    pkgs.binaryen # v114 (includes wasm-opt)
     wasm-bindgen-cli # v0.2.83
     pkg-config
 


### PR DESCRIPTION
The unstable packages are no longer necessary, as wasm-opt and wasm-pack are in high version in the stable channels. This removes the issues with bash on Darwin derived environments, where smoke-tests could not be run properly.