### PR TITLE
Replace official swagger-codegen-cli with a multi-platform one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -589,10 +589,10 @@ endif
 
 .PHONY: generate-python-sdk
 generate-python-sdk: ## generate Python SDK via Swagger Codegen
-generate-python-sdk: build-docs-api
+generate-python-sdk: build-docs-api			# not using the official swagger-codegen-cli as it does not offer a multiplatform image
 	mkdir -p ./hoprd-sdk-python/
 	rm -rf ./hoprd-sdk-python/*
-	docker run --rm -v $$(pwd):/local swaggerapi/swagger-codegen-cli-v3 generate -l python \
+	docker run --rm -v $$(pwd):/local parsertongue/swagger-codegen-cli:latest generate -l python \
 		-o /local/hoprd-sdk-python -i /local/packages/hoprd/rest-api-v3-full-spec.json \
 		-c /local/scripts/python-sdk-config.json
 


### PR DESCRIPTION
Replacing the official swagger-codegen-cli enables deployment from the arm64 machines.