### PR TITLE
core: Fix channel closure

### DIFF
--- a/packages/core-ethereum/crates/core-ethereum-misc/src/constants.rs
+++ b/packages/core-ethereum/crates/core-ethereum-misc/src/constants.rs
@@ -1,11 +1,3 @@
-/// Number of blockchain block to wait until an on-chain
-/// state-change is considered to be final
-///
-/// Note that the probability that on-chain state changes will get pruned due to
-/// block reorganizations increases exponentially in the number of confirmations, e.g.
-/// after one block it is `0.5` whereas after two blocks it is `0.25 = 0.5^2`  etc.
-pub const DEFAULT_CONFIRMATIONS: u32 = 8;
-
 /// specifies in milliseconds for how long various
 /// ethereum requests like `eth_getBalance` should be cached for
 pub const PROVIDER_CACHE_TTL: u32 = 30_000; // 30 seconds
@@ -33,8 +25,6 @@ pub mod wasm {
 
     #[wasm_bindgen]
     pub struct CoreEthereumConstants {
-        #[wasm_bindgen(readonly, js_name = "DEFAULT_CONFIRMATIONS")]
-        pub default_confirmations: u32,
         #[wasm_bindgen(readonly, js_name = "PROVIDER_CACHE_TTL")]
         pub provider_cache_ttl: u32,
         #[wasm_bindgen(readonly, js_name = "TX_CONFIRMATION_WAIT")]
@@ -52,7 +42,6 @@ pub mod wasm {
     #[wasm_bindgen(js_name = "CORE_ETHEREUM_CONSTANTS")]
     pub fn get_constants() -> CoreEthereumConstants {
         CoreEthereumConstants {
-            default_confirmations: super::DEFAULT_CONFIRMATIONS,
             provider_cache_ttl: super::PROVIDER_CACHE_TTL,
             indexer_block_range: super::INDEXER_BLOCK_RANGE,
             indexer_timeout: super::INDEXER_TIMEOUT,

--- a/packages/core-ethereum/src/ethereum.mock.ts
+++ b/packages/core-ethereum/src/ethereum.mock.ts
@@ -6,5 +6,6 @@ export const sampleChainOptions: ChainOptions = {
   maxFeePerGas: '10 gwei',
   maxPriorityFeePerGas: '1 gwei',
   chain: 'anvil',
-  provider: 'http://localhost:8545'
+  provider: 'http://localhost:8545',
+  confirmations: 2
 }

--- a/packages/core-ethereum/src/index.ts
+++ b/packages/core-ethereum/src/index.ts
@@ -40,7 +40,7 @@ const log = debug('hopr-core-ethereum')
 
 export type ChainOptions = {
   provider: string
-  maxConfirmations?: number
+  confirmations: number
   chainId: number
   maxFeePerGas: string
   maxPriorityFeePerGas: string
@@ -80,7 +80,7 @@ export default class HoprCoreEthereum extends EventEmitter {
     this.indexer = new Indexer(
       this.chainKeypair.public().to_address(),
       this.db,
-      this.options.maxConfirmations ?? constants.DEFAULT_CONFIRMATIONS,
+      this.options.confirmations,
       constants.INDEXER_BLOCK_RANGE
     )
   }

--- a/packages/core-ethereum/src/indexer/utils.ts
+++ b/packages/core-ethereum/src/indexer/utils.ts
@@ -21,6 +21,6 @@ export function snapshotComparator(snapA: IndexerSnapshot, snapB: IndexerSnapsho
  * if blockNumber is considered confirmed.
  * @returns boolean
  */
-export function isConfirmedBlock(blockNumber: number, onChainBlockNumber: number, maxConfirmations: number): boolean {
-  return blockNumber + maxConfirmations <= onChainBlockNumber
+export function isConfirmedBlock(blockNumber: number, onChainBlockNumber: number, confirmations: number): boolean {
+  return blockNumber + confirmations <= onChainBlockNumber
 }

--- a/packages/core/crates/core-hopr/src/p2p.rs
+++ b/packages/core/crates/core-hopr/src/p2p.rs
@@ -266,7 +266,7 @@ pub(crate) async fn p2p_loop(
                             error!("Ticket aggregation: Failed send reply to {}", peer);
                         }
                     },
-                    TicketAggregationProcessed::Receive(_peer, acked_ticket, request) => {
+                    TicketAggregationProcessed::Receive(_peer, _acked_ticket, request) => {
                         // TODO: uncomment once strategies need to get the value
                         // if let Err(e) = on_acknowledged_ticket.unbounded_send(acked_ticket) {
                         //     error!("failed to emit acknowledged aggregated ticket: {e}");

--- a/packages/core/crates/core-types/src/channels.rs
+++ b/packages/core/crates/core-types/src/channels.rs
@@ -130,8 +130,8 @@ impl ChannelEntry {
 
         if self.closure_time.eq(&U256::zero()) {
             None
-        } else if now_seconds >= self.closure_time {
-            Some((now_seconds - self.closure_time).as_u64())
+        } else if self.closure_time > now_seconds {
+            Some((self.closure_time - now_seconds).as_u64())
         } else {
             Some(0u64)
         }
@@ -161,11 +161,12 @@ impl Display for ChannelEntry {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "{} channel {}: {} -> {}",
+            "{} channel {} ({}): {} -> {}",
             self.status,
             self.get_id(),
+            self.closure_time,
             self.source,
-            self.destination
+            self.destination,
         )
     }
 }

--- a/packages/core/protocol-config.json
+++ b/packages/core/protocol-config.json
@@ -16,6 +16,7 @@
         "announcements": "0x09635F643e140090A9A8Dcd712eD6285858ceBef",
         "node_stake_v2_factory": "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e"
       },
+      "confirmations": 2,
       "tags": []
     },
     "anvil-localhost2": {
@@ -34,6 +35,7 @@
         "announcements": "0x09635F643e140090A9A8Dcd712eD6285858ceBef",
         "node_stake_v2_factory": "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e"
       },
+      "confirmations": 2,
       "tags": []
     },
     "dufour": {
@@ -52,6 +54,7 @@
         "ticket_price_oracle": "0xcA5656Fe6F2d847ACA32cf5f38E51D2054cA1273",
         "announcements": "0x619eabE23FD0E2291B50a507719aa633fE6069b8"
       },
+      "confirmations": 8,
       "tags": ["etherscan"]
     },
     "rotsee": {
@@ -70,6 +73,7 @@
         "ticket_price_oracle": "0x442df1d946303fB088C9377eefdaeA84146DA0A6",
         "announcements": "0xf1c143B1bA20C7606d56aA2FA94502D25744b982"
       },
+      "confirmations": 8,
       "tags": ["etherscan"]
     },
     "debug-staging": {
@@ -88,133 +92,8 @@
         "ticket_price_oracle": "0x281a91FeA199a3bAB5D7d5f05833B257E2fd7741",
         "announcements": "0xD78BCa8452B8Ea281a659f380E0eF710C64EB85b"
       },
+      "confirmations": 8,
       "tags": ["development"]
-    },
-    "tuttlingen": {
-      "environment_type": "production",
-      "chain": "xdai",
-      "version_range": "1.83",
-      "indexer_start_block_number": 0,
-      "addresses": {
-        "channels": "0xd2229d5d54bE8ABC9A2b2d5cFdEd22B48FB8ce2c",
-        "network_registry": "0x0000000000000000000000000000000000000000",
-        "network_registry_proxy": "0x0000000000000000000000000000000000000000",
-        "token": "0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1",
-        "node_stake_v2_factory": "0x0000000000000000000000000000000000000000",
-        "node_safe_registry": "0x0000000000000000000000000000000000000000",
-        "module_implementation": "0x0000000000000000000000000000000000000000",
-        "ticket_price_oracle": "0x0000000000000000000000000000000000000000",
-        "announcements": "0x0000000000000000000000000000000000000000"
-      },
-      "tags": []
-    },
-    "prague": {
-      "chain": "xdai",
-      "environment_type": "production",
-      "version_range": "1.84",
-      "indexer_start_block_number": 0,
-      "addresses": {
-        "channels": "0x4f98F01cb02083eb5457CA0DDC6B37073ec5388a",
-        "network_registry": "0x0000000000000000000000000000000000000000",
-        "network_registry_proxy": "0x0000000000000000000000000000000000000000",
-        "token": "0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1",
-        "node_stake_v2_factory": "0x0000000000000000000000000000000000000000",
-        "node_safe_registry": "0x0000000000000000000000000000000000000000",
-        "module_implementation": "0x0000000000000000000000000000000000000000",
-        "ticket_price_oracle": "0x0000000000000000000000000000000000000000",
-        "announcements": "0x0000000000000000000000000000000000000000"
-      },
-      "tags": []
-    },
-    "budapest": {
-      "chain": "xdai",
-      "environment_type": "production",
-      "version_range": "1.85",
-      "indexer_start_block_number": 0,
-      "addresses": {
-        "channels": "0xEee8AB66b7169b3f9024676165fB1D2a25E472c5",
-        "network_registry": "0x0000000000000000000000000000000000000000",
-        "network_registry_proxy": "0x0000000000000000000000000000000000000000",
-        "token": "0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1",
-        "node_stake_v2_factory": "0x0000000000000000000000000000000000000000",
-        "node_safe_registry": "0x0000000000000000000000000000000000000000",
-        "module_implementation": "0x0000000000000000000000000000000000000000",
-        "ticket_price_oracle": "0x0000000000000000000000000000000000000000",
-        "announcements": "0x0000000000000000000000000000000000000000"
-      },
-      "tags": []
-    },
-    "athens": {
-      "chain": "xdai",
-      "environment_type": "production",
-      "version_range": "1.86",
-      "indexer_start_block_number": 0,
-      "addresses": {
-        "channels": "0xD2F008718EEdD7aF7E9a466F5D68bb77D03B8F7A",
-        "network_registry": "0x0000000000000000000000000000000000000000",
-        "network_registry_proxy": "0x0000000000000000000000000000000000000000",
-        "token": "0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1",
-        "node_stake_v2_factory": "0x0000000000000000000000000000000000000000",
-        "node_safe_registry": "0x0000000000000000000000000000000000000000",
-        "module_implementation": "0x0000000000000000000000000000000000000000",
-        "ticket_price_oracle": "0x0000000000000000000000000000000000000000",
-        "announcements": "0x0000000000000000000000000000000000000000"
-      },
-      "tags": []
-    },
-    "lisbon": {
-      "chain": "xdai",
-      "environment_type": "production",
-      "version_range": "1.87",
-      "indexer_start_block_number": 0,
-      "addresses": {
-        "channels": "0x1753C9eE656c54f443ce2Fe7248076f9bA4eC100",
-        "network_registry": "0x0000000000000000000000000000000000000000",
-        "network_registry_proxy": "0x0000000000000000000000000000000000000000",
-        "token": "0x978D91ddFdb0c6eaCC22A258fE498957a79c5F4C",
-        "node_stake_v2_factory": "0x0000000000000000000000000000000000000000",
-        "node_safe_registry": "0x0000000000000000000000000000000000000000",
-        "module_implementation": "0x0000000000000000000000000000000000000000",
-        "ticket_price_oracle": "0x0000000000000000000000000000000000000000",
-        "announcements": "0x0000000000000000000000000000000000000000"
-      },
-      "tags": []
-    },
-    "ouagadougou": {
-      "chain": "xdai",
-      "environment_type": "production",
-      "version_range": "1.88",
-      "indexer_start_block_number": 0,
-      "addresses": {
-        "channels": "0x0BB1Ff7A9b3f2c87267626630aa0195cAE3ed5E3",
-        "network_registry": "0x0000000000000000000000000000000000000000",
-        "network_registry_proxy": "0x0000000000000000000000000000000000000000",
-        "token": "0x978D91ddFdb0c6eaCC22A258fE498957a79c5F4C",
-        "node_stake_v2_factory": "0x0000000000000000000000000000000000000000",
-        "node_safe_registry": "0x0000000000000000000000000000000000000000",
-        "module_implementation": "0x0000000000000000000000000000000000000000",
-        "ticket_price_oracle": "0x0000000000000000000000000000000000000000",
-        "announcements": "0x0000000000000000000000000000000000000000"
-      },
-      "tags": []
-    },
-    "paleochora": {
-      "chain": "xdai",
-      "environment_type": "production",
-      "version_range": "1.89",
-      "indexer_start_block_number": 0,
-      "addresses": {
-        "channels": "0xCe7209FD81ED129C2ea8369715c168419e4148Ef",
-        "network_registry": "0xf0D4D48866C4F9665212B29A64c14A1f0FEDFD4c",
-        "network_registry_proxy": "0x15e068Ef1f76319b1848b1fcB3e49D68724AEE07",
-        "token": "0x978D91ddFdb0c6eaCC22A258fE498957a79c5F4C",
-        "node_stake_v2_factory": "0x0000000000000000000000000000000000000000",
-        "node_safe_registry": "0x0000000000000000000000000000000000000000",
-        "module_implementation": "0x0000000000000000000000000000000000000000",
-        "ticket_price_oracle": "0x0000000000000000000000000000000000000000",
-        "announcements": "0x0000000000000000000000000000000000000000"
-      },
-      "tags": ["etherscan"]
     },
     "monte_rosa": {
       "chain": "xdai",
@@ -232,6 +111,7 @@
         "ticket_price_oracle": "0x0000000000000000000000000000000000000000",
         "announcements": "0x0000000000000000000000000000000000000000"
       },
+      "confirmations": 8,
       "tags": ["etherscan"]
     }
   },

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -65,7 +65,8 @@ export async function createHoprNode(
       maxFeePerGas: network.chain.max_fee_per_gas,
       maxPriorityFeePerGas: network.chain.max_priority_fee_per_gas,
       chain: network.chain.id,
-      provider: network.chain.default_provider
+      provider: network.chain.default_provider,
+      confirmations: network.confirmations
     },
     {
       safeTransactionServiceProvider: cfg.safe_module.safe_transaction_service_provider,

--- a/packages/hoprd/crates/hoprd-hoprd/src/cli.rs
+++ b/packages/hoprd/crates/hoprd-hoprd/src/cli.rs
@@ -354,15 +354,6 @@ pub struct CliArgs {
     pub heartbeat_variance: Option<u64>,
 
     #[arg(
-        long = "onChainConfirmations",
-        help = "Number of confirmations required for on-chain transactions",
-        value_name = "CONFIRMATIONS",
-        value_parser = clap::value_parser ! (u32),
-        env = "HOPRD_ON_CHAIN_CONFIRMATIONS",
-    )]
-    pub on_chain_confirmations: Option<u32>,
-
-    #[arg(
         long = "networkQualityThreshold",
         help = "Minimum quality of a peer connection to be considered usable",
         value_name = "THRESHOLD",

--- a/packages/hoprd/crates/hoprd-hoprd/src/config.rs
+++ b/packages/hoprd/crates/hoprd-hoprd/src/config.rs
@@ -5,7 +5,6 @@ use proc_macro_regex::regex;
 use serde::{Deserialize, Serialize};
 use validator::{Validate, ValidationError};
 
-use core_ethereum_misc::constants::DEFAULT_CONFIRMATIONS;
 use core_network::{heartbeat::HeartbeatConfig, network::NetworkConfig};
 use core_strategy::Strategy::AutoRedeeming;
 use core_strategy::{Strategy, StrategyConfig};
@@ -221,7 +220,6 @@ pub struct Chain {
     pub announce: bool,
     pub provider: Option<String>,
     pub check_unrealized_balance: bool,
-    pub on_chain_confirmations: u32,
 }
 
 impl Default for Chain {
@@ -230,7 +228,6 @@ impl Default for Chain {
             announce: false,
             provider: None,
             check_unrealized_balance: true,
-            on_chain_confirmations: DEFAULT_CONFIRMATIONS,
         }
     }
 }
@@ -527,9 +524,6 @@ impl HoprdConfig {
             cfg.chain.provider = Some(x)
         };
         cfg.chain.check_unrealized_balance = cli_args.check_unrealized_balance;
-        if let Some(x) = cli_args.on_chain_confirmations {
-            cfg.chain.on_chain_confirmations = x
-        };
 
         // safe module
         if let Some(x) = cli_args.safe_transaction_service_provider {
@@ -647,7 +641,6 @@ mod tests {
                 announce: false,
                 provider: None,
                 check_unrealized_balance: true,
-                on_chain_confirmations: 0,
             },
             safe_module: SafeModule {
                 safe_transaction_service_provider: None,
@@ -720,7 +713,6 @@ chain:
   announce: false
   provider: null
   check_unrealized_balance: true
-  on_chain_confirmations: 0
 safe_module:
   safe_transaction_service_provider: null
   safe_address: null

--- a/scripts/fixture_local_test_setup.sh
+++ b/scripts/fixture_local_test_setup.sh
@@ -288,7 +288,6 @@ function setup_node() {
     HOPRD_HEARTBEAT_THRESHOLD=2500 \
     HOPRD_HEARTBEAT_VARIANCE=1000 \
     HOPRD_NETWORK_QUALITY_THRESHOLD="0.3" \
-    HOPRD_ON_CHAIN_CONFIRMATIONS=2 \
     NODE_OPTIONS="--experimental-wasm-modules" \
     node packages/hoprd/lib/main.cjs \
       --data="${dir}" \

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -42,8 +42,12 @@ async def create_channel(src, dest, funding: int):
     finally:
         assert await src["api"].close_channel(channel)
         await asyncio.wait_for(check_channel_status(src, dest, status="PendingToClose"), 10.0)
+
+        # need to wait some more time until closure time has passed
+        await asyncio.sleep(10)
+
         assert await src["api"].close_channel(channel)
-        await asyncio.wait_for(check_channel_status(src, dest, status="Closed"), 30.0)
+        await asyncio.wait_for(check_channel_status(src, dest, status="Closed"), 10.0)
 
 
 async def get_channel(src, dest, include_closed=False):


### PR DESCRIPTION
Also only use 2 blocks as confirmations in local and testing environments, instead of 8.