### PR TITLE
Fix channel funding TX

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,7 +1076,7 @@ dependencies = [
 
 [[package]]
 name = "core-ethereum-actions"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "async-lock",
  "async-std",

--- a/packages/core-ethereum/crates/core-ethereum-actions/Cargo.toml
+++ b/packages/core-ethereum/crates/core-ethereum-actions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-ethereum-actions"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "High-level Core-Ethereum functions that translate to on-chain transactions"

--- a/packages/core-ethereum/crates/core-ethereum-actions/src/channels.rs
+++ b/packages/core-ethereum/crates/core-ethereum-actions/src/channels.rs
@@ -447,13 +447,11 @@ mod tests {
             .await
             .unwrap();
 
-        let channel_id = channel.get_id();
-
         let mut tx_exec = MockTransactionExecutor::new();
         tx_exec
             .expect_fund_channel()
             .times(1)
-            .withf(move |id, balance| channel_id.eq(id) && stake.eq(balance))
+            .withf(move |id, balance| channel.destination.eq(id) && stake.eq(balance))
             .returning(move |_, _| TransactionResult::FundChannel { tx_hash: random_hash });
 
         let tx_queue = TransactionQueue::new(db.clone(), Box::new(tx_exec));

--- a/packages/core-ethereum/crates/core-ethereum-actions/src/channels.rs
+++ b/packages/core-ethereum/crates/core-ethereum-actions/src/channels.rs
@@ -451,7 +451,7 @@ mod tests {
         tx_exec
             .expect_fund_channel()
             .times(1)
-            .withf(move |id, balance| channel.destination.eq(id) && stake.eq(balance))
+            .withf(move |dst, balance| channel.destination.eq(dst) && stake.eq(balance))
             .returning(move |_, _| TransactionResult::FundChannel { tx_hash: random_hash });
 
         let tx_queue = TransactionQueue::new(db.clone(), Box::new(tx_exec));

--- a/packages/core/crates/core-strategy/src/aggregating.rs
+++ b/packages/core/crates/core-strategy/src/aggregating.rs
@@ -216,7 +216,7 @@ mod tests {
         impl TransactionExecutor for TxExec {
             async fn redeem_ticket(&self, ticket: AcknowledgedTicket) -> TransactionResult;
             async fn open_channel(&self, destination: Address, balance: Balance) -> TransactionResult;
-            async fn fund_channel(&self, channel_id: Hash, amount: Balance) -> TransactionResult;
+            async fn fund_channel(&self, destination: Address, amount: Balance) -> TransactionResult;
             async fn close_channel_initialize(&self, src: Address, dst: Address) -> TransactionResult;
             async fn close_channel_finalize(&self, src: Address, dst: Address) -> TransactionResult;
             async fn withdraw(&self, recipient: Address, amount: Balance) -> TransactionResult;

--- a/packages/core/crates/core-strategy/src/auto_funding.rs
+++ b/packages/core/crates/core-strategy/src/auto_funding.rs
@@ -103,7 +103,7 @@ mod tests {
         impl TransactionExecutor for TxExec {
             async fn redeem_ticket(&self, ticket: AcknowledgedTicket) -> TransactionResult;
             async fn open_channel(&self, destination: Address, balance: Balance) -> TransactionResult;
-            async fn fund_channel(&self, channel_id: Hash, amount: Balance) -> TransactionResult;
+            async fn fund_channel(&self, destination: Address, amount: Balance) -> TransactionResult;
             async fn close_channel_initialize(&self, src: Address, dst: Address) -> TransactionResult;
             async fn close_channel_finalize(&self, src: Address, dst: Address) -> TransactionResult;
             async fn withdraw(&self, recipient: Address, amount: Balance) -> TransactionResult;
@@ -186,9 +186,9 @@ mod tests {
         tx_exec
             .expect_fund_channel()
             .times(1)
-            .withf(move |id, balance| c2.get_id().eq(id) && c2.balance.add(&fund_amount_c).eq(&balance))
-            .return_once(move |id, _| {
-                if id.eq(&c2.get_id()) {
+            .withf(move |dst, balance| c2.destination.eq(dst) && c2.balance.add(&fund_amount_c).eq(&balance))
+            .return_once(move |dst, _| {
+                if dst.eq(&c2.destination) {
                     tx.send(()).unwrap();
                 }
                 TransactionResult::FundChannel {

--- a/packages/core/crates/core-strategy/src/auto_redeeming.rs
+++ b/packages/core/crates/core-strategy/src/auto_redeeming.rs
@@ -135,7 +135,7 @@ mod tests {
         impl TransactionExecutor for TxExec {
             async fn redeem_ticket(&self, ticket: AcknowledgedTicket) -> TransactionResult;
             async fn open_channel(&self, destination: Address, balance: Balance) -> TransactionResult;
-            async fn fund_channel(&self, channel_id: Hash, amount: Balance) -> TransactionResult;
+            async fn fund_channel(&self, destination: Address, amount: Balance) -> TransactionResult;
             async fn close_channel_initialize(&self, src: Address, dst: Address) -> TransactionResult;
             async fn close_channel_finalize(&self, src: Address, dst: Address) -> TransactionResult;
             async fn withdraw(&self, recipient: Address, amount: Balance) -> TransactionResult;

--- a/packages/core/crates/core-strategy/src/promiscuous.rs
+++ b/packages/core/crates/core-strategy/src/promiscuous.rs
@@ -392,7 +392,7 @@ mod tests {
                 channel_id: Hash::default(),
             }
         }
-        async fn fund_channel(&self, _channel_id: Hash, _amount: Balance) -> TransactionResult {
+        async fn fund_channel(&self, _destination: Address, _amount: Balance) -> TransactionResult {
             TransactionResult::FundChannel {
                 tx_hash: Hash::default(),
             }

--- a/packages/utils/crates/utils-types/src/primitives.rs
+++ b/packages/utils/crates/utils-types/src/primitives.rs
@@ -46,13 +46,6 @@ impl Address {
         ret.into_boxed_slice()
     }
 
-    // impl std::string::ToString {
-    #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen(js_name = "to_string"))]
-    pub fn _to_string(&self) -> String {
-        self.to_hex()
-    }
-    // }
-
     /// Creates a random Ethereum address, mostly used for testing
     pub fn random() -> Self {
         let mut addr = [0u8; Self::SIZE];
@@ -98,7 +91,7 @@ impl TryFrom<H160> for Address {
     }
 }
 
-impl std::str::FromStr for Address {
+impl FromStr for Address {
     type Err = GeneralError;
 
     fn from_str(value: &str) -> Result<Address> {
@@ -821,6 +814,11 @@ pub mod wasm {
         #[wasm_bindgen(js_name = "deserialize")]
         pub fn _deserialize(data: &[u8]) -> JsResult<Address> {
             ok_or_jserr!(Address::from_bytes(data))
+        }
+
+        #[wasm_bindgen(js_name = "to_string")]
+        pub fn _to_string(&self) -> String {
+            self.to_string()
         }
 
         #[wasm_bindgen(js_name = "to_hex")]

--- a/packages/utils/crates/utils-types/src/primitives.rs
+++ b/packages/utils/crates/utils-types/src/primitives.rs
@@ -91,7 +91,7 @@ impl TryFrom<H160> for Address {
     }
 }
 
-impl FromStr for Address {
+impl std::str::FromStr for Address {
     type Err = GeneralError;
 
     fn from_str(value: &str) -> Result<Address> {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,7 +12,6 @@ SEED = int.from_bytes(random_data, byteorder="big")
 random.seed(SEED)
 
 LOCALHOST = "127.0.0.1"
-
 OPEN_CHANNEL_FUNDING_VALUE = "1000000000000000000000"
 
 TICKET_AGGREGATION_THRESHOLD = 100

--- a/tests/hopr.py
+++ b/tests/hopr.py
@@ -87,20 +87,17 @@ class HoprdAPI:
         status, _ = self.__call_api(AliasesApi, "aliases_remove_alias", alias)
         return status
 
-    async def balances(self, type: str or list[str] = "all"):
+    async def balances(self):
         """
         Returns the balance of the node.
         :param: type: str =  "all" | "hopr" | "native" | "safe_native" | "safe_hopr"
         :return: balances: dict | int
         """
-        all_types = ["hopr", "native", "safe_native", "safe_hopr"]
-        assert type in all_types
-
         status, response = self.__call_api(AccountApi, "account_get_balances")
         if status:
-            return int(getattr(response, type))
-        else:
             return response
+        else:
+            return None
 
     async def open_channel(self, peer_address: str, amount: str):
         """

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -242,7 +242,6 @@ async def test_hoprd_should_be_able_to_send_0_hop_messages_without_open_channels
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("src,dest", random_distinct_pairs_from(nodes(), count=PARAMETERIZED_SAMPLE_SIZE))
-@pytest.mark.skip(reason="Failing due to a bug in the application")
 async def test_hoprd_channel_should_register_fund_increase_using_funding_endpoint(src, dest, swarm7):
     hopr_amount = "1"
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -243,25 +243,18 @@ async def test_hoprd_should_be_able_to_send_0_hop_messages_without_open_channels
 @pytest.mark.asyncio
 @pytest.mark.parametrize("src,dest", random_distinct_pairs_from(nodes(), count=PARAMETERIZED_SAMPLE_SIZE))
 async def test_hoprd_channel_should_register_fund_increase_using_funding_endpoint(src, dest, swarm7):
-    hopr_amount = "1"
+    hopr_amount = OPEN_CHANNEL_FUNDING_VALUE
 
     async with create_channel(swarm7[src], swarm7[dest], funding=TICKET_PRICE_PER_HOP) as channel:
         balance_before = await swarm7[src]["api"].balances()
 
         assert await swarm7[src]["api"].channels_fund_channel(channel, hopr_amount)
 
-        async def check_balance_changed():
-            while True:
-                balance = await swarm7[src]["api"].balances()
-                if balance["safe_hopr"] > balance_before["safe_hopr"]:
-                    break
-                else:
-                    await asyncio.sleep(CHECK_RETRY_INTERVAL)
+        balance_after = await swarm7[src]["api"].balances()
 
-        await asyncio.wait_for(check_balance_changed(), 10.0)
-
-        balance = await swarm7[src]["api"].balances()
-        assert balance["safe_hopr"] - balance_before["safe_hopr"] == 1
+        assert int(balance_before.safe_hopr) - int(balance_after.safe_hopr) == int(hopr_amount)
+        assert int(balance_before.safe_hopr_allowance) - int(balance_after.safe_hopr_allowance) == int(hopr_amount)
+        assert int(balance_after.native) < int(balance_before.native)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes the funding TX function call to properly pass the `Address` of the destination instead of the channel ID.

Fixes #5555