### PR TITLE
api: Fix handling of uncaught errors

### DIFF
--- a/packages/hoprd/src/api/v3.ts
+++ b/packages/hoprd/src/api/v3.ts
@@ -275,8 +275,11 @@ export async function setupRestApi(
     }
   }
 
-  service.use(urlPath, ((err, _req, res, _next) => {
-    res.status(err.status).json(err)
+  service.use(urlPath, ((err, _req, res, next) => {
+    if (res.headersSent) {
+      return next(err)
+    }
+    res.status(500).json(err)
   }) as express.ErrorRequestHandler)
 
   return apiInstance

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 black==23.3.0
-hoprd-sdk @ git+https://github.com/hoprnet/hoprd-sdk-python@kauki/update/2.0.0-rc7
+hoprd-sdk @ git+https://github.com/hoprnet/hoprd-sdk-python@main
 pytest==7.2.1
 pytest-asyncio==0.21.0
 requests==2.28.2


### PR DESCRIPTION
The handling of `500` errors would use the wrong status field which led to another crash and no response sent back.