### PR TITLE
Generate docs on push to master

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -1,0 +1,67 @@
+---
+
+name: "Build docs"
+
+# yamllint disable-line rule:truthy
+on:
+  pull_request:
+    types:
+      - synchronize
+      - ready_for_review
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.head_ref }}-docs
+  cancel-in-progress: true
+
+jobs:
+  rust:
+    name: Rust docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v18
+        with:
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+      - uses: cachix/cachix-action@v12
+        if: ${{ !env.ACT }}
+        with:
+          name: hoprnet
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+        continue-on-error: true
+
+      - name: restore cargo cache
+        uses: actions/cache@v3
+        with:
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock', 'rust-toolchain.toml') }}
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+            .cargo/.package-cache/
+            .foundry/bin/
+
+      - name: Generate rust docs
+        uses: workflow/nix-shell-action@v3.3.0
+        with:
+          flakes-from-devshell: true
+          script: |
+            cargo doc --no-deps
+
+      - name: Deploy
+        if: github.ref == 'refs/heads/master'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./target/doc/
+          force_orphan: true

--- a/packages/core/crates/core-crypto/src/derivation.rs
+++ b/packages/core/crates/core-crypto/src/derivation.rs
@@ -99,7 +99,7 @@ pub(crate) fn generate_key_iv(secret: &SecretKey, info: &[u8], key: &mut [u8], i
 
 /// Sample a random secp256k1 field element that can represent a valid secp256k1 point.
 /// The implementation uses `hash_to_field` function as defined in
-/// https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-13.html#name-hashing-to-a-finite-field
+/// `<https://www.ietf.org/archive/id/draft-irtf-cfrg-hash-to-curve-13.html#name-hashing-to-a-finite-field>`
 /// The `secret` must be at least `SecretKey::LENGTH` long.
 /// The `tag` parameter will be used as an additional Domain Separation Tag.
 pub fn sample_secp256k1_field_element(secret: &[u8], tag: &str) -> Result<HalfKey> {

--- a/packages/core/crates/core-crypto/src/types.rs
+++ b/packages/core/crates/core-crypto/src/types.rs
@@ -50,7 +50,7 @@ use utils_types::{
 /// Extend support for arbitrary array sizes in serde
 ///
 /// Array of arbitrary sizes are not supported in serde due to backwards compatibility.
-/// Read more in: https://github.com/serde-rs/serde/issues/1937
+/// Read more in: `<https://github.com/serde-rs/serde/issues/1937>`
 mod arrays {
     use std::{convert::TryInto, marker::PhantomData};
 
@@ -1206,9 +1206,9 @@ impl PartialEq for Signature {
 impl Eq for Signature {}
 
 /// A method that turns all lower-cased hexadecimal address to a checksum-ed address
-/// according to https://eips.ethereum.org/EIPS/eip-55
+/// according to `<https://eips.ethereum.org/EIPS/eip-55>`
 pub trait ToChecksum {
-    /// Checksum of self according to https://eips.ethereum.org/EIPS/eip-55
+    /// Checksum of self according to `<https://eips.ethereum.org/EIPS/eip-55>`
     fn to_checksum(&self) -> String;
 }
 

--- a/packages/core/crates/core-protocol/src/msg/chain.rs
+++ b/packages/core/crates/core-protocol/src/msg/chain.rs
@@ -1,7 +1,6 @@
 use core_crypto::{
     derivation::{derive_ack_key_share, PacketTag},
     keypairs::{ChainKeypair, OffchainKeypair},
-    routing::header_length,
     shared_keys::SphinxSuite,
     types::{Challenge, HalfKey, HalfKeyChallenge, Hash, OffchainPublicKey},
 };

--- a/packages/core/crates/core-types/src/announcement.rs
+++ b/packages/core/crates/core-types/src/announcement.rs
@@ -80,7 +80,7 @@ impl Display for KeyBinding {
 }
 
 /// Structure containing data used for on-chain announcement.
-/// That is the decapsulated multiaddress (with the /p2p/<peer id> suffix removed) and
+/// That is the decapsulated multiaddress (with the /p2p/{peer_id} suffix removed) and
 /// optional `KeyBinding` (announcement can be done with key bindings or without)
 #[derive(Clone, Debug, PartialEq)]
 #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen(getter_with_clone))]

--- a/packages/hoprd/crates/hoprd-hoprd/src/config.rs
+++ b/packages/hoprd/crates/hoprd-hoprd/src/config.rs
@@ -358,34 +358,130 @@ pub struct Protocol {
     pub ticket_aggregation: core_protocol::ticket_aggregation::config::TicketAggregationProtocolConfig,
 }
 
+/// The main configuration object of the entire node.
+/// 
+/// The configuration is composed of individual configuration of corresponding 
+/// component configuration objects.
+/// 
+/// An always up-to-date config YAML example can be found in [`EXAMPLE_YAML`].
+/// 
+/// The default configuration as it would appear from the configuration YAML file.
+/// ```yaml
+/// ---
+/// 
+/// host:
+///   address: !IPv4 127.0.0.1
+///   port: 47462
+/// identity:
+///   file: identity
+///   password: ''
+///   private_key: ''
+/// db:
+///   data: /tmp/db
+///   initialize: false
+///   force_initialize: false
+/// inbox:
+///   capacity: 512
+///   max_age: 900
+///   excluded_tags:
+///   - 0
+/// api:
+///   enable: true
+///   auth: !Token sdjkghsfg
+/// host:
+///   address: !IPv4 127.0.0.1
+///   port: 1233
+/// strategy:
+///   on_fail_continue: true
+///   allow_recursive: true
+///   strategies: []
+/// heartbeat:
+///   variance: 0
+///   interval: 0
+///   threshold: 0
+/// network_options:
+///   min_delay: 1
+///   max_delay: 300
+///   quality_bad_threshold: 0.2
+///   quality_offline_threshold: 0.0
+///   quality_step: 0.1
+///   ignore_timeframe: 600
+///   backoff_exponent: 1.5
+///   backoff_min: 2.0
+///   backoff_max: 300.0
+/// healthcheck:
+///   enable: false
+///   host: 127.0.0.1
+///   port: 0
+/// protocol:
+///   ack:
+///     timeout: 15
+///   heartbeat:
+///     timeout: 15
+///   msg:
+///     timeout: 15
+///   ticket_aggregation:
+///     timeout: 15
+/// network: testing
+/// chain:
+///   announce: false
+///   provider: null
+///   check_unrealized_balance: true
+/// safe_module:
+///   safe_transaction_service_provider: null
+///   safe_address: null
+///   module_address: null
+/// test:
+///   announce_local_addresses: false
+///   prefer_local_addresses: false
+///   use_weak_crypto: false
+/// ```
+/// 
 #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen(getter_with_clone))]
 #[derive(Debug, Serialize, Deserialize, Validate, Clone, PartialEq)]
 pub struct HoprdConfig {
+    /// Configuration related to host specifics
     #[validate]
     pub host: Host,
+    /// Configuration regarding the identity of the node
     #[validate]
     pub identity: Identity,
+    /// Configuration of the underlying database engine
     #[validate]
     pub db: Db,
+    /// Configuration of the message inbox
     #[validate]
     inbox: MessageInboxConfiguration,
+    /// Configuration relevant for the API of the node
     #[validate]
     pub api: Api,
+    /// Configuration of underlying node behavior in the form strategies
+    /// 
+    /// Strategies represent automatically executable behavior performed by 
+    /// the node given pre-configured triggers.
     #[validate]
     pub strategy: StrategyConfig,
+    /// Configuration of the protocol heartbeat mechanism
     #[validate]
     pub heartbeat: HeartbeatConfig,
+    /// Configuration of network properties
     #[validate]
     pub network_options: NetworkConfig,
+    /// Configuration of the health check mechanism
     #[validate]
     pub healthcheck: HealthCheck,
+    /// Configuration specific to protocol execution on the p2p layer
     #[validate]
     pub protocol: Protocol,
+    /// Network name
     pub network: String,
+    /// Blockchain specific configuration
     #[validate]
     pub chain: Chain,
+    /// Configuration of the `Safe` mechanism
     #[validate]
     pub safe_module: SafeModule,
+    /// Configuration for enabling test specific behavior
     #[validate]
     pub test: Testing,
 }
@@ -420,6 +516,7 @@ use real_base::file::native::read_to_string;
 #[cfg(all(feature = "wasm", not(test)))]
 use real_base::file::wasm::read_to_string;
 use utils_log::debug;
+
 
 impl HoprdConfig {
     pub fn from_cli_args(cli_args: crate::cli::CliArgs, skip_validation: bool) -> crate::errors::Result<HoprdConfig> {
@@ -587,6 +684,75 @@ pub mod wasm {
     }
 }
 
+/// Used in the testing and documentation
+pub const EXAMPLE_YAML: &'static str = r#"host:
+  address: !IPv4 127.0.0.1
+  port: 47462
+identity:
+  file: identity
+  password: ''
+  private_key: ''
+db:
+  data: /tmp/db
+  initialize: false
+  force_initialize: false
+inbox:
+  capacity: 512
+  max_age: 900
+  excluded_tags:
+  - 0
+api:
+  enable: false
+  auth: None
+  host:
+    address: !IPv4 127.0.0.1
+    port: 1233
+strategy:
+  on_fail_continue: true
+  allow_recursive: true
+  strategies: []
+heartbeat:
+  variance: 0
+  interval: 0
+  threshold: 0
+network_options:
+  min_delay: 1
+  max_delay: 300
+  quality_bad_threshold: 0.2
+  quality_offline_threshold: 0.0
+  quality_step: 0.1
+  ignore_timeframe: 600
+  backoff_exponent: 1.5
+  backoff_min: 2.0
+  backoff_max: 300.0
+healthcheck:
+  enable: false
+  host: 127.0.0.1
+  port: 0
+protocol:
+  ack:
+    timeout: 15
+  heartbeat:
+    timeout: 15
+  msg:
+    timeout: 15
+  ticket_aggregation:
+    timeout: 15
+network: testing
+chain:
+  announce: false
+  provider: null
+  check_unrealized_balance: true
+safe_module:
+  safe_transaction_service_provider: null
+  safe_address: null
+  module_address: null
+test:
+  announce_local_addresses: false
+  prefer_local_addresses: false
+  use_weak_crypto: false
+"#;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -654,74 +820,6 @@ mod tests {
             },
         }
     }
-
-    const EXAMPLE_YAML: &'static str = r#"host:
-  address: !IPv4 127.0.0.1
-  port: 47462
-identity:
-  file: identity
-  password: ''
-  private_key: ''
-db:
-  data: /tmp/db
-  initialize: false
-  force_initialize: false
-inbox:
-  capacity: 512
-  max_age: 900
-  excluded_tags:
-  - 0
-api:
-  enable: false
-  auth: None
-  host:
-    address: !IPv4 127.0.0.1
-    port: 1233
-strategy:
-  on_fail_continue: true
-  allow_recursive: true
-  strategies: []
-heartbeat:
-  variance: 0
-  interval: 0
-  threshold: 0
-network_options:
-  min_delay: 1
-  max_delay: 300
-  quality_bad_threshold: 0.2
-  quality_offline_threshold: 0.0
-  quality_step: 0.1
-  ignore_timeframe: 600
-  backoff_exponent: 1.5
-  backoff_min: 2.0
-  backoff_max: 300.0
-healthcheck:
-  enable: false
-  host: 127.0.0.1
-  port: 0
-protocol:
-  ack:
-    timeout: 15
-  heartbeat:
-    timeout: 15
-  msg:
-    timeout: 15
-  ticket_aggregation:
-    timeout: 15
-network: testing
-chain:
-  announce: false
-  provider: null
-  check_unrealized_balance: true
-safe_module:
-  safe_transaction_service_provider: null
-  safe_address: null
-  module_address: null
-test:
-  announce_local_addresses: false
-  prefer_local_addresses: false
-  use_weak_crypto: false
-"#;
 
     #[test]
     fn test_config_should_be_serializable_into_string() -> Result<(), Box<dyn std::error::Error>> {

--- a/packages/hoprd/crates/hoprd-hoprd/src/config.rs
+++ b/packages/hoprd/crates/hoprd-hoprd/src/config.rs
@@ -359,16 +359,16 @@ pub struct Protocol {
 }
 
 /// The main configuration object of the entire node.
-/// 
-/// The configuration is composed of individual configuration of corresponding 
+///
+/// The configuration is composed of individual configuration of corresponding
 /// component configuration objects.
-/// 
+///
 /// An always up-to-date config YAML example can be found in [`EXAMPLE_YAML`].
-/// 
+///
 /// The default configuration as it would appear from the configuration YAML file.
 /// ```yaml
 /// ---
-/// 
+///
 /// host:
 ///   address: !IPv4 127.0.0.1
 ///   port: 47462
@@ -436,7 +436,7 @@ pub struct Protocol {
 ///   prefer_local_addresses: false
 ///   use_weak_crypto: false
 /// ```
-/// 
+///
 #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen(getter_with_clone))]
 #[derive(Debug, Serialize, Deserialize, Validate, Clone, PartialEq)]
 pub struct HoprdConfig {
@@ -456,8 +456,8 @@ pub struct HoprdConfig {
     #[validate]
     pub api: Api,
     /// Configuration of underlying node behavior in the form strategies
-    /// 
-    /// Strategies represent automatically executable behavior performed by 
+    ///
+    /// Strategies represent automatically executable behavior performed by
     /// the node given pre-configured triggers.
     #[validate]
     pub strategy: StrategyConfig,
@@ -516,7 +516,6 @@ use real_base::file::native::read_to_string;
 #[cfg(all(feature = "wasm", not(test)))]
 use real_base::file::wasm::read_to_string;
 use utils_log::debug;
-
 
 impl HoprdConfig {
     pub fn from_cli_args(cli_args: crate::cli::CliArgs, skip_validation: bool) -> crate::errors::Result<HoprdConfig> {

--- a/packages/hoprd/crates/hoprd-keypair/src/key_pair.rs
+++ b/packages/hoprd/crates/hoprd-keypair/src/key_pair.rs
@@ -294,7 +294,7 @@ impl HoprKeys {
 
     /// Reads a keystore file using custom FS operations
     ///
-    /// Highly inspired by https://github.com/roynalnaruto/eth-keystore-rs
+    /// Highly inspired by `<https://github.com/roynalnaruto/eth-keystore-rs>`
     pub fn read_eth_keystore(path: &str, password: &str) -> Result<(Self, bool)> {
         let json_string = read_to_string(path)?;
         let keystore: EthKeystore = from_json_string(&json_string)?;
@@ -385,7 +385,7 @@ impl HoprKeys {
 
     /// Writes a keystore file using custom FS operation and custom entropy source
     ///
-    /// Highly inspired by https://github.com/roynalnaruto/eth-keystore-rs
+    /// Highly inspired by `<https://github.com/roynalnaruto/eth-keystore-rs>`
     pub fn write_eth_keystore(&self, path: &str, password: &str, use_weak_crypto: bool) -> Result<()> {
         // Generate a random salt.
         let salt: [u8; HOPR_KEY_SIZE] = random_bytes();

--- a/packages/utils/crates/utils-misc/src/lib.rs
+++ b/packages/utils/crates/utils-misc/src/lib.rs
@@ -31,7 +31,7 @@ macro_rules! ok_or_str {
     };
 }
 
-/// Macro used to convert Vec<JsString> to Vec<&str>
+/// Macro used to convert `Vec<JsString>` to `Vec<&str>`
 #[cfg(feature = "wasm")]
 #[macro_export]
 macro_rules! convert_from_jstrvec {
@@ -41,7 +41,7 @@ macro_rules! convert_from_jstrvec {
     };
 }
 
-/// Macro used to convert Vec<&str> or Vec<String> to Vec<JString>
+/// Macro used to convert `Vec<&str>` or `Vec<String>` to `Vec<JString>`
 #[cfg(feature = "wasm")]
 #[macro_export]
 macro_rules! convert_to_jstrvec {


### PR DESCRIPTION
Add support for generating the docs:
- [x] Fix docstrings for Rust code
- [x] Build Rust docs on each PR
- [x] Publish a new Rust doc page on push to master
