### PR TITLE
Show reasonable error on failure to load config

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,41 +125,43 @@ The `hoprd` provides various command-line switches to configure its behaviour. F
 
 ```sh
 $ hoprd --help
+Usage: hoprd [OPTIONS] --network <NETWORK>
+
 Options:
       --network <NETWORK>
-          Network id which the node shall run on [env: HOPRD_NETWORK=] [possible values: anvil-localhost, rotsee, debug-staging, anvil-localhost2, monte_rosa]
+          Network id which the node shall run on [env: HOPRD_NETWORK=] [possible values: anvil-localhost2, anvil-localhost, rotsee, dufour, debug-staging]
       --identity <identity>
-          The path to the identity file [env: HOPRD_IDENTITY=] [default: <IDENTITY_DIR>]
+          The path to the identity file [env: HOPRD_IDENTITY=] [default: /Users/teebor/.hopr-identity]
       --data <data>
-          manually specify the data directory to use [env: HOPRD_DATA=] [default: <DATA_DIR>]
+          manually specify the data directory to use [env: HOPRD_DATA=] [default: /Users/teebor/dev/hoprnet.org/hoprnet/packages/hoprd/hoprd-db]
       --host <HOST>
-          Host to listen on for P2P connections [env: HOPRD_HOST=] [default: 0.0.0.0:9091]
+          Host to listen on for P2P connections [env: HOPRD_HOST=]
       --announce
-          Run as a Public Relay Node (PRN) [env: HOPRD_ANNOUNCE=]
+          Announce the node on chain with a public address [env: HOPRD_ANNOUNCE=]
       --api
           Expose the API on localhost:3001 [env: HOPRD_API=]
       --apiHost <HOST>
-          Set host IP to which the API server will bind [env: HOPRD_API_HOST=] [default: localhost]
+          Set host IP to which the API server will bind [env: HOPRD_API_HOST=]
       --apiPort <PORT>
-          Set port to which the API server will bind [env: HOPRD_API_PORT=] [default: 3001]
+          Set port to which the API server will bind [env: HOPRD_API_PORT=]
       --apiToken <TOKEN>
           A REST API token and for user authentication [env: HOPRD_API_TOKEN=]
       --healthCheck
-          Run a health check end point on localhost:8080 [env: HOPRD_HEALTH_CHECK=]
+          Run a health check end point [env: HOPRD_HEALTH_CHECK=]
       --healthCheckHost <HOST>
-          Updates the host for the healthcheck server [env: HOPRD_HEALTH_CHECK_HOST=] [default: localhost]
+          Updates the host for the healthcheck server [env: HOPRD_HEALTH_CHECK_HOST=]
       --healthCheckPort <PORT>
-          Updates the port for the healthcheck server [env: HOPRD_HEALTH_CHECK_PORT=] [default: 8080]
+          Updates the port for the healthcheck server [env: HOPRD_HEALTH_CHECK_PORT=]
       --password <PASSWORD>
           A password to encrypt your keys [env: HOPRD_PASSWORD=]
       --defaultStrategy <DEFAULT_STRATEGY>
-          Default channel strategy to use after node starts up [env: HOPRD_DEFAULT_STRATEGY=] [default: passive] [possible values: promiscuous, passive, random]
+          Default channel strategy to use after node starts up [env: HOPRD_DEFAULT_STRATEGY=] [possible values: promiscuous, aggregating, auto_redeeming, auto_funding, multi, passive]
       --maxAutoChannels <MAX_AUTO_CHANNELS>
           Maximum number of channel a strategy can open. If not specified, square root of number of available peers is used. [env: HOPRD_MAX_AUTO_CHANNELS=]
       --disableTicketAutoRedeem
-          Disables automatic redeemeing of winning tickets. [env: HOPRD_DISABLE_AUTO_REDEEEM_TICKETS]
+          Disables automatic redeeming of winning tickets. [env: HOPRD_DISABLE_AUTO_REDEEEM_TICKETS=]
       --disableUnrealizedBalanceCheck
-          Disables checking of unrealized balance before validating unacknowledged tickets. [env: HOPRD_DISABLE_UNREALIZED_BALANCE_CHECK]
+          Disables checking of unrealized balance before validating unacknowledged tickets. [env: HOPRD_DISABLE_UNREALIZED_BALANCE_CHECK=]
       --provider <PROVIDER>
           A custom RPC provider to be used for the node to connect to blockchain [env: HOPRD_PROVIDER=]
       --dryRun
@@ -168,22 +170,26 @@ Options:
           initialize a database if it doesn't already exist [env: HOPRD_INIT=]
       --forceInit
           initialize a database, even if it already exists [env: HOPRD_FORCE_INIT=]
+      --inbox-capacity <INBOX_CAPACITY>
+          Set maximum capacity of the HOPRd inbox [env: HOPRD_INBOX_CAPACITY=]
       --testAnnounceLocalAddresses
           For testing local testnets. Announce local addresses [env: HOPRD_TEST_ANNOUNCE_LOCAL_ADDRESSES=]
       --heartbeatInterval <MILLISECONDS>
-          Interval in milliseconds in which the availability of other nodes get measured [env: HOPRD_HEARTBEAT_INTERVAL=] [default: 60000]
+          Interval in milliseconds in which the availability of other nodes get measured [env: HOPRD_HEARTBEAT_INTERVAL=]
       --heartbeatThreshold <MILLISECONDS>
-          Timeframe in milliseconds after which a heartbeat to another peer is performed, if it hasn't been seen since [env: HOPRD_HEARTBEAT_THRESHOLD=] [default: 60000]
+          Timeframe in milliseconds after which a heartbeat to another peer is performed, if it hasn't been seen since [env: HOPRD_HEARTBEAT_THRESHOLD=]
       --heartbeatVariance <MILLISECONDS>
-          Upper bound for variance applied to heartbeat interval in milliseconds [env: HOPRD_HEARTBEAT_VARIANCE=] [default: 2000]
-      --onChainConfirmations <CONFIRMATIONS>
-          Number of confirmations required for on-chain transactions [env: HOPRD_ON_CHAIN_CONFIRMATIONS=] [default: 8]
+          Upper bound for variance applied to heartbeat interval in milliseconds [env: HOPRD_HEARTBEAT_VARIANCE=]
       --networkQualityThreshold <THRESHOLD>
-          Miniumum quality of a peer connection to be considered usable [env: HOPRD_NETWORK_QUALITY_THRESHOLD=] [default: 0.5]
-      --safeAddress <HOPRD_SAFE_ADDRESS>
-          The Safe instance for a node where its HOPR tokens are held [env: HOPRD_SAFE_ADDRESS=]
-      --moduleAddress <HOPRD_MODULE_ADDRESS>
-          The node management module instance that manages node permission to assets held in safe [env: HOPRD_MODULE_ADDRESS=]
+          Minimum quality of a peer connection to be considered usable [env: HOPRD_NETWORK_QUALITY_THRESHOLD=]
+      --configurationFilePath <CONFIG_FILE_PATH>
+          Path to a file containing the entire HOPRd configuration [env: HOPRD_CONFIGURATION_FILE_PATH=]
+      --safeTransactionServiceProvider <HOPRD_SAFE_TX_SERVICE_PROVIDER>
+          Base URL for safe transaction service [env: HOPRD_SAFE_TRANSACTION_SERVICE_PROVIDER=]
+      --safeAddress <HOPRD_SAFE_ADDR>
+          Address of Safe that safeguards tokens [env: HOPRD_SAFE_ADDRESS=]
+      --moduleAddress <HOPRD_MODULE_ADDR>
+          Address of the node mangement module [env: HOPRD_MODULE_ADDRESS=]
   -h, --help
           Print help
   -V, --version

--- a/packages/hoprd/crates/hoprd-hoprd/src/config.rs
+++ b/packages/hoprd/crates/hoprd-hoprd/src/config.rs
@@ -677,9 +677,10 @@ pub mod wasm {
     }
 
     #[wasm_bindgen]
-    pub fn fetch_configuration(cli_args: JsValue) -> Result<HoprdConfig, JsValue> {
-        let args: crate::cli::CliArgs = serde_wasm_bindgen::from_value(cli_args)?;
-        HoprdConfig::from_cli_args(args, false).map_err(|e| wasm_bindgen::JsValue::from(e.to_string()))
+    pub fn fetch_configuration(cli_args: JsValue) -> Result<HoprdConfig, JsError> {
+        let args: crate::cli::CliArgs =
+            serde_wasm_bindgen::from_value(cli_args).map_err(|e| JsError::new(e.to_string().as_str()))?;
+        HoprdConfig::from_cli_args(args, false).map_err(|e| JsError::new(e.to_string().as_str()))
     }
 }
 


### PR DESCRIPTION
The error was unreadable, so it needed to be passed properly, this will fix the error output to be readable.

## Info
The failed parsing is now properly displayed as:
```shell
➜   NODE_ENV=production NODE_OPTIONS="--experimental-wasm-modules" node packages/hoprd/lib/main.cjs --network anvil-localhost --configurationFilePath ~/hoprd.yaml
(node:31339) ExperimentalWarning: Import assertions are not a stable feature of the JavaScript language. Avoid relying on their current behavior and syntax as those might change in a future version of Node.js.
(Use `node --trace-warnings ...` to show where the warning was created)
(node:31339) ExperimentalWarning: Importing JSON modules is an experimental feature and might change at any time
(node:31339) ExperimentalWarning: Importing WebAssembly modules is an experimental feature and might change at any time
2023-10-17T10:14:43.431Z [DEBUG] hoprd_hoprd::config fetching configuration from file /Users/teebor/hoprd.yaml
Error: serialization failed: 'strategy.strategies[0]: missing field `new_channel_stake` at line 27 column 5'
    at __wbindgen_error_new (file:///Users/teebor/dev/hoprnet.org/hoprnet/packages/hoprd/lib/hoprd_hoprd_bg.js:11838:17)
    at wasm://wasm/0131d9ca:wasm-function[8316]:0x3b79a7
    at wasm://wasm/0131d9ca:wasm-function[8471]:0x3c3139
    at fetch_configuration (file:///Users/teebor/dev/hoprnet.org/hoprnet/packages/hoprd/lib/hoprd_hoprd_bg.js:361:14)
    at main (file:///Users/teebor/dev/hoprnet.org/hoprnet/packages/hoprd/lib/index.js:137:15)
```

## Test
Tested using damaged versions of this valid configuration:
```yaml
host:
  address: !IPv4 127.0.0.1
  port: 19091
identity:
  file: /tmp/local_0.id
  password: local
  private_key: null
db:
  data: /tmp/local_0
  initialize: true
  force_initialize: false
inbox:
  capacity: 512
  max_age: 900
  excluded_tags:
  - 0
api:
  enable: true
  auth: !Token ^^LOCAL-testing-123^^
  host:
    address: !IPv4 127.0.0.1
    port: 13301
strategy:
  on_fail_continue: true
  allow_recursive: false
  strategies:
  - !Promiscuous
    network_quality_threshold: 0.4
    new_channel_stake: '20 HOPR'
    minimum_node_balance: '5 HOPR'
    enforce_max_channels: true
    max_channels: 100
heartbeat:
  variance: 1000
  interval: 2500
  threshold: 2500
network_options:
  min_delay: 1
  max_delay: 300
  quality_bad_threshold: 0.2
  quality_offline_threshold: 0.3
  quality_step: 0.1
  ignore_timeframe: 600
  backoff_exponent: 1.5
  backoff_min: 2.0
  backoff_max: 300.0
healthcheck:
  enable: true
  host: 127.0.0.1
  port: 18081
protocol:
  ack:
    timeout: 15
  heartbeat:
    timeout: 15
  msg:
    timeout: 15
  ticket_aggregation:
    timeout: 15
network: anvil-localhost
chain:
  announce: true
  provider: null
  check_unrealized_balance: true
safe_module:
  safe_transaction_service_provider: null
  safe_address:
    addr:
    - 212
    - 107
    - 212
    - 144
    - 148
    - 72
    - 145
    - 208
    - 156
    - 154
    - 84
    - 116
    - 50
    - 209
    - 64
    - 66
    - 28
    - 111
    - 220
    - 72
  module_address:
    addr:
    - 155
    - 46
    - 63
    - 3
    - 221
    - 130
    - 81
    - 108
    - 137
    - 137
    - 210
    - 77
    - 194
    - 189
    - 234
    - 92
    - 140
    - 17
    - 211
    - 162
test:
  announce_local_addresses: true
  prefer_local_addresses: true
  use_weak_crypto: true
```

Fix #5633