### PR TITLE
Refactor core-ethereum-actions to use traits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "core-strategy"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "core-ethereum-actions"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-lock",
  "async-std",

--- a/packages/core-ethereum/crates/core-ethereum-actions/Cargo.toml
+++ b/packages/core-ethereum/crates/core-ethereum-actions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-ethereum-actions"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "High-level Core-Ethereum functions that translate to on-chain transactions"

--- a/packages/core-ethereum/crates/core-ethereum-actions/README.md
+++ b/packages/core-ethereum/crates/core-ethereum-actions/README.md
@@ -1,6 +1,6 @@
 # core-ethereum-actions
 
-Contains high-level Core-Ethereum functions that translate to on-chain transactions
+Contains high-level Core-Ethereum traits that translate to on-chain transactions
 
 ## `transaction_queue`
 
@@ -14,7 +14,7 @@ wishes to await the transaction being confirmed.
 
 ## `redeem`
 
-There are 4 functions that can be used to redeem tickets:
+There are 4 functions that can be used to redeem tickets in the `TicketRedeemActions` trait:
 
 - `redeem_all_tickets`
 - `redeem_tickets_in_channel`
@@ -29,14 +29,19 @@ confirmation of each ticket redemption.
 
 ## `channels`
 
-This submodule adds 4 basic high-level on-chain functions:
+This submodule adds 4 basic high-level on-chain functions in the `ChannelActions` trait:
 
 - `open_channel`
 - `fund_channel`
 - `close_channel`
-- `withdraw`
 
 All the functions do the necessary validations using the DB and then post the corresponding transaction
 into the `TransactionQueue`.
 The functions return immediately, but provide futures that can be awaited in case the callers wishes to await the on-chain
 confirmation of the corresponding operation.
+
+## `node`
+
+Submodule containing high-level on-chain actions in the `NodeActions` trait, which related to HOPR node itself.
+
+- `withdraw`

--- a/packages/core-ethereum/crates/core-ethereum-actions/src/channels.rs
+++ b/packages/core-ethereum/crates/core-ethereum-actions/src/channels.rs
@@ -1,9 +1,8 @@
-use async_lock::RwLock;
 use core_crypto::types::Hash;
 use core_ethereum_db::traits::HoprCoreEthereumDbActions;
 use core_ethereum_misc::errors::CoreEthereumError::{InvalidArguments, InvalidState};
 use core_types::channels::{ChannelDirection, ChannelStatus};
-use std::sync::Arc;
+use async_trait::async_trait;
 use utils_log::{debug, error, info};
 use utils_types::primitives::{Address, Balance, BalanceType};
 
@@ -12,159 +11,151 @@ use crate::errors::{
     CoreEthereumActionsError::{ChannelAlreadyClosed, ChannelAlreadyExists, ChannelDoesNotExist},
     Result,
 };
-use crate::redeem::redeem_tickets_in_channel;
-use crate::transaction_queue::{Transaction, TransactionCompleted, TransactionSender};
+use crate::transaction_queue::{Transaction, TransactionCompleted};
 
 #[cfg(all(feature = "wasm", not(test)))]
 use utils_misc::time::wasm::current_timestamp;
 
 #[cfg(any(not(feature = "wasm"), test))]
 use utils_misc::time::native::current_timestamp;
+use crate::CoreEthereumActions;
+use crate::redeem::TicketRedeemActions;
 
-pub async fn open_channel<Db>(
-    db: Arc<RwLock<Db>>,
-    tx_sender: TransactionSender,
-    destination: Address,
-    self_addr: Address,
-    amount: Balance,
-) -> Result<TransactionCompleted>
-where
-    Db: HoprCoreEthereumDbActions,
-{
-    if self_addr == destination {
-        return Err(InvalidArguments("cannot open channel to self".into()).into());
-    }
+/// Gathers all channel related on-chain actions.
+#[async_trait(? Send)]
+pub trait ChannelActions {
+    /// Opens a channel to the given `destination` with the given `amount` staked.
+    async fn open_channel(&self, destination: Address, amount: Balance) -> Result<TransactionCompleted>;
 
-    if amount.eq(&amount.of_same("0")) || amount.balance_type() != BalanceType::HOPR {
-        return Err(InvalidArguments("invalid balance or balance type given".into()).into());
-    }
+    /// Funds the given channel with the given `amount`
+    async fn fund_channel(&self, channel_id: Hash, amount: Balance) -> Result<TransactionCompleted>;
 
-    let allowance = db.read().await.get_staking_safe_allowance().await?;
-    debug!("current staking safe allowance is {allowance}");
-    if allowance.lt(&amount) {
-        return Err(NotEnoughAllowance);
-    }
+    /// Closes the channel to counterparty in the given direction. Optionally can issue redeeming of all tickets in that channel.
+    async fn close_channel(&self, counterparty: Address, direction: ChannelDirection, redeem_before_close: bool) -> Result<TransactionCompleted>;
 
-    if db.read().await.is_network_registry_enabled().await?
-        && !db.read().await.is_allowed_to_access_network(&destination).await?
-    {
-        return Err(PeerAccessDenied);
-    }
-
-    let maybe_channel = db.read().await.get_channel_x(&self_addr, &destination).await?;
-    if let Some(channel) = maybe_channel {
-        debug!("already found existing {channel}");
-        if channel.status != ChannelStatus::Closed {
-            error!("channel to {destination} is already opened or pending to close");
-            return Err(ChannelAlreadyExists);
-        }
-    }
-
-    tx_sender.send(Transaction::OpenChannel(destination, amount)).await
 }
 
-pub async fn fund_channel<Db>(
-    db: Arc<RwLock<Db>>,
-    tx_sender: TransactionSender,
-    channel_id: Hash,
-    amount: Balance,
-) -> Result<TransactionCompleted>
-where
-    Db: HoprCoreEthereumDbActions,
-{
-    if amount.eq(&amount.of_same("0")) || amount.balance_type() != BalanceType::HOPR {
-        return Err(InvalidArguments("invalid balance or balance type given".into()).into());
-    }
+#[async_trait(? Send)]
+impl<Db: HoprCoreEthereumDbActions> ChannelActions for CoreEthereumActions<Db> {
+    async fn open_channel(
+        &self,
+        destination: Address,
+        amount: Balance,
+    ) -> Result<TransactionCompleted>
+    {
+        if self.me == destination {
+            return Err(InvalidArguments("cannot open channel to self".into()).into());
+        }
 
-    let allowance = db.read().await.get_staking_safe_allowance().await?;
-    debug!("current staking safe allowance is {allowance}");
-    if allowance.lt(&amount) {
-        return Err(NotEnoughAllowance);
-    }
+        if amount.eq(&amount.of_same("0")) || amount.balance_type() != BalanceType::HOPR {
+            return Err(InvalidArguments("invalid balance or balance type given".into()).into());
+        }
 
-    let maybe_channel = db.read().await.get_channel(&channel_id).await?;
-    match maybe_channel {
-        Some(channel) => {
-            if channel.status == ChannelStatus::Open {
-                tx_sender.send(Transaction::FundChannel(channel, amount)).await
-            } else {
-                Err(InvalidState(format!("channel {channel_id} is not opened")).into())
+        let allowance = self.db.read().await.get_staking_safe_allowance().await?;
+        debug!("current staking safe allowance is {allowance}");
+        if allowance.lt(&amount) {
+            return Err(NotEnoughAllowance);
+        }
+
+        if self.db.read().await.is_network_registry_enabled().await?
+            && !self.db.read().await.is_allowed_to_access_network(&destination).await?
+        {
+            return Err(PeerAccessDenied);
+        }
+
+        let maybe_channel = self.db.read().await.get_channel_x(&self.me, &destination).await?;
+        if let Some(channel) = maybe_channel {
+            debug!("already found existing {channel}");
+            if channel.status != ChannelStatus::Closed {
+                error!("channel to {destination} is already opened or pending to close");
+                return Err(ChannelAlreadyExists);
             }
         }
-        None => Err(ChannelDoesNotExist),
+
+        self.tx_sender.send(Transaction::OpenChannel(destination, amount)).await
     }
-}
 
-pub async fn close_channel<Db>(
-    db: Arc<RwLock<Db>>,
-    tx_sender: TransactionSender,
-    counterparty: Address,
-    self_address: Address,
-    direction: ChannelDirection,
-    redeem_before_close: bool,
-) -> Result<TransactionCompleted>
-where
-    Db: HoprCoreEthereumDbActions,
-{
-    let maybe_channel = match direction {
-        ChannelDirection::Incoming => db.read().await.get_channel_x(&counterparty, &self_address).await?,
-        ChannelDirection::Outgoing => db.read().await.get_channel_x(&self_address, &counterparty).await?,
-    };
+    async fn fund_channel(
+        &self,
+        channel_id: Hash,
+        amount: Balance,
+    ) -> Result<TransactionCompleted> {
+        if amount.eq(&amount.of_same("0")) || amount.balance_type() != BalanceType::HOPR {
+            return Err(InvalidArguments("invalid balance or balance type given".into()).into());
+        }
 
-    match maybe_channel {
-        Some(channel) => {
-            match channel.status {
-                ChannelStatus::Closed => Err(ChannelAlreadyClosed),
-                ChannelStatus::PendingToClose => {
-                    info!(
+        let allowance = self.db.read().await.get_staking_safe_allowance().await?;
+        debug!("current staking safe allowance is {allowance}");
+        if allowance.lt(&amount) {
+            return Err(NotEnoughAllowance);
+        }
+
+        let maybe_channel = self.db.read().await.get_channel(&channel_id).await?;
+        match maybe_channel {
+            Some(channel) => {
+                if channel.status == ChannelStatus::Open {
+                    self.tx_sender.send(Transaction::FundChannel(channel, amount)).await
+                } else {
+                    Err(InvalidState(format!("channel {channel_id} is not opened")).into())
+                }
+            }
+            None => Err(ChannelDoesNotExist),
+        }
+    }
+
+    async fn close_channel(
+        &self,
+        counterparty: Address,
+        direction: ChannelDirection,
+        redeem_before_close: bool,
+    ) -> Result<TransactionCompleted> {
+        let maybe_channel = match direction {
+            ChannelDirection::Incoming => self.db.read().await.get_channel_x(&counterparty, &self.me).await?,
+            ChannelDirection::Outgoing => self.db.read().await.get_channel_x(&self.me, &counterparty).await?,
+        };
+
+        match maybe_channel {
+            Some(channel) => {
+                match channel.status {
+                    ChannelStatus::Closed => Err(ChannelAlreadyClosed),
+                    ChannelStatus::PendingToClose => {
+                        info!(
                         "{channel} - remaining closure time is {:?}",
                         channel.remaining_closure_time(current_timestamp())
                     );
-                    if channel.closure_time_passed(current_timestamp()).unwrap_or(false) {
-                        // TODO: emit "channel state change" event
-                        tx_sender.send(Transaction::CloseChannel(channel)).await
-                    } else {
-                        Err(ClosureTimeHasNotElapsed(
-                            channel
-                                .remaining_closure_time(current_timestamp())
-                                .unwrap_or(u32::MAX as u64),
-                        ))
+                        if channel.closure_time_passed(current_timestamp()).unwrap_or(false) {
+                            // TODO: emit "channel state change" event
+                            self.tx_sender.send(Transaction::CloseChannel(channel)).await
+                        } else {
+                            Err(ClosureTimeHasNotElapsed(
+                                channel
+                                    .remaining_closure_time(current_timestamp())
+                                    .unwrap_or(u32::MAX as u64),
+                            ))
+                        }
                     }
-                }
-                ChannelStatus::Open => {
-                    if redeem_before_close {
-                        // TODO: trigger aggregation
-                        // Do not await the redemption, just submit it to the queue
-                        let redeemed = redeem_tickets_in_channel(db.clone(), &channel, false, tx_sender.clone())
-                            .await?
-                            .len();
-                        info!("{redeemed} tickets will be redeemed before closing {channel}");
-                    }
+                    ChannelStatus::Open => {
+                        if redeem_before_close {
+                            // TODO: trigger aggregation
+                            // Do not await the redemption, just submit it to the queue
+                            let redeemed = self.redeem_tickets_in_channel(&channel, false)
+                                .await?
+                                .len();
+                            info!("{redeemed} tickets will be redeemed before closing {channel}");
+                        }
 
-                    tx_sender.send(Transaction::CloseChannel(channel)).await
-                    // TODO: emit "channel state change" event
+                        self.tx_sender.send(Transaction::CloseChannel(channel)).await
+                        // TODO: emit "channel state change" event
+                    }
                 }
             }
+            None => Err(ChannelDoesNotExist),
         }
-        None => Err(ChannelDoesNotExist),
     }
 }
-
-pub async fn withdraw(
-    tx_sender: TransactionSender,
-    recipient: Address,
-    amount: Balance,
-) -> Result<TransactionCompleted> {
-    if amount.eq(&amount.of_same("0")) {
-        return Err(InvalidArguments("cannot withdraw zero amount".into()).into());
-    }
-
-    tx_sender.send(Transaction::Withdraw(recipient, amount)).await
-}
-
 #[cfg(test)]
 mod tests {
-    use crate::channels::{close_channel, fund_channel, open_channel, withdraw};
+    use crate::channels::ChannelActions;
     use crate::errors::CoreEthereumActionsError;
     use crate::transaction_queue::{MockTransactionExecutor, TransactionQueue, TransactionResult};
     use async_lock::RwLock;
@@ -181,6 +172,7 @@ mod tests {
     use utils_db::rusty::RustyLevelDbShim;
     use utils_types::primitives::{Address, Balance, BalanceType, Snapshot, U256};
     use utils_types::traits::BinarySerializable;
+    use crate::CoreEthereumActions;
 
     #[async_std::test]
     async fn test_open_channel() {
@@ -226,7 +218,9 @@ mod tests {
             tx_queue.transaction_loop().await;
         });
 
-        let tx_res = open_channel(db.clone(), tx_sender.clone(), bob, self_addr, stake)
+        let actions = CoreEthereumActions::new(self_addr, db.clone(), tx_sender.clone());
+
+        let tx_res = actions.open_channel(bob, stake)
             .await
             .unwrap()
             .await
@@ -285,9 +279,11 @@ mod tests {
             .await
             .unwrap();
 
+        let actions = CoreEthereumActions::new(self_addr, db.clone(), tx_queue.new_sender());
+
         assert!(
             matches!(
-                open_channel(db.clone(), tx_queue.new_sender(), bob, self_addr, stake)
+                actions.open_channel(bob, stake)
                     .await
                     .err()
                     .unwrap(),
@@ -319,9 +315,11 @@ mod tests {
             .await
             .unwrap();
 
+        let actions = CoreEthereumActions::new(self_addr, db.clone(), tx_queue.new_sender());
+
         assert!(
             matches!(
-                open_channel(db.clone(), tx_queue.new_sender(), self_addr, self_addr, stake)
+                actions.open_channel(self_addr, stake)
                     .await
                     .err()
                     .unwrap(),
@@ -353,10 +351,11 @@ mod tests {
             .await
             .unwrap();
 
+        let actions = CoreEthereumActions::new(self_addr, db.clone(), tx_queue.new_sender());
         let stake = Balance::new(10_u32.into(), BalanceType::Native);
         assert!(
             matches!(
-                open_channel(db.clone(), tx_queue.new_sender(), self_addr, bob, stake)
+                actions.open_channel(bob, stake)
                     .await
                     .err()
                     .unwrap(),
@@ -366,9 +365,10 @@ mod tests {
         );
 
         let stake = Balance::new(0_u32.into(), BalanceType::HOPR);
+
         assert!(
             matches!(
-                open_channel(db.clone(), tx_queue.new_sender(), self_addr, bob, stake)
+                actions.open_channel(bob, stake)
                     .await
                     .err()
                     .unwrap(),
@@ -398,9 +398,11 @@ mod tests {
             .await
             .unwrap();
 
+        let actions = CoreEthereumActions::new(self_addr, db.clone(), tx_queue.new_sender());
+
         assert!(
             matches!(
-                open_channel(db.clone(), tx_queue.new_sender(), bob, self_addr, stake)
+                actions.open_channel(bob, stake)
                     .await
                     .err()
                     .unwrap(),
@@ -460,7 +462,9 @@ mod tests {
             tx_queue.transaction_loop().await;
         });
 
-        let tx_res = fund_channel(db.clone(), tx_sender.clone(), channel.get_id(), stake)
+        let actions = CoreEthereumActions::new(self_addr, db.clone(), tx_sender.clone());
+
+        let tx_res = actions.fund_channel(channel.get_id(), stake)
             .await
             .unwrap()
             .await
@@ -497,10 +501,11 @@ mod tests {
             .await
             .unwrap();
 
+        let actions = CoreEthereumActions::new(self_addr, db.clone(), tx_queue.new_sender());
         let stake = Balance::new(10_u32.into(), BalanceType::HOPR);
         assert!(
             matches!(
-                fund_channel(db.clone(), tx_queue.new_sender(), channel_id, stake)
+                actions.fund_channel(channel_id, stake)
                     .await
                     .err()
                     .unwrap(),
@@ -533,10 +538,11 @@ mod tests {
             .await
             .unwrap();
 
+        let actions = CoreEthereumActions::new(self_addr, db.clone(), tx_queue.new_sender());
         let stake = Balance::new(10_u32.into(), BalanceType::Native);
         assert!(
             matches!(
-                open_channel(db.clone(), tx_queue.new_sender(), self_addr, bob, stake)
+                actions.open_channel(bob, stake)
                     .await
                     .err()
                     .unwrap(),
@@ -548,7 +554,7 @@ mod tests {
         let stake = Balance::new(0_u32.into(), BalanceType::HOPR);
         assert!(
             matches!(
-                fund_channel(db.clone(), tx_queue.new_sender(), channel_id, stake)
+                actions.fund_channel(channel_id, stake)
                     .await
                     .err()
                     .unwrap(),
@@ -578,10 +584,11 @@ mod tests {
             .await
             .unwrap();
 
+        let actions = CoreEthereumActions::new(self_addr, db.clone(), tx_queue.new_sender());
         let stake = Balance::new(10_000_u32.into(), BalanceType::HOPR);
         assert!(
             matches!(
-                fund_channel(db.clone(), tx_queue.new_sender(), channel_id, stake)
+                actions.fund_channel(channel_id, stake)
                     .await
                     .err()
                     .unwrap(),
@@ -663,7 +670,9 @@ mod tests {
             tx_queue.transaction_loop().await;
         });
 
-        let tx_res = close_channel(db.clone(), tx_sender.clone(), bob, self_addr, direction, false)
+        let actions = CoreEthereumActions::new(self_addr, db.clone(), tx_sender.clone());
+
+        let tx_res = actions.close_channel(bob, direction, false)
             .await
             .unwrap()
             .await
@@ -692,7 +701,7 @@ mod tests {
             .await
             .unwrap();
 
-        let tx_res = close_channel(db.clone(), tx_sender.clone(), bob, self_addr, direction, false)
+        let tx_res = actions.close_channel(bob, direction, false)
             .await
             .unwrap()
             .await
@@ -753,13 +762,12 @@ mod tests {
 
         let tx_queue = TransactionQueue::new(db.clone(), Box::new(MockTransactionExecutor::new()));
 
+        let actions = CoreEthereumActions::new(self_addr, db.clone(), tx_queue.new_sender());
+
         assert!(
             matches!(
-                close_channel(
-                    db.clone(),
-                    tx_queue.new_sender(),
+                actions.close_channel(
                     bob,
-                    self_addr,
                     ChannelDirection::Outgoing,
                     false
                 )
@@ -784,14 +792,12 @@ mod tests {
             self_addr,
         )));
         let tx_queue = TransactionQueue::new(db.clone(), Box::new(MockTransactionExecutor::new()));
+        let actions = CoreEthereumActions::new(self_addr, db.clone(), tx_queue.new_sender());
 
         assert!(
             matches!(
-                close_channel(
-                    db.clone(),
-                    tx_queue.new_sender(),
+                actions.close_channel(
                     bob,
-                    self_addr,
                     ChannelDirection::Outgoing,
                     false
                 )
@@ -817,6 +823,7 @@ mod tests {
             self_addr,
         )));
         let tx_queue = TransactionQueue::new(db.clone(), Box::new(MockTransactionExecutor::new()));
+        let actions = CoreEthereumActions::new(self_addr, db.clone(), tx_queue.new_sender());
 
         let channel = ChannelEntry::new(
             self_addr,
@@ -835,11 +842,8 @@ mod tests {
 
         assert!(
             matches!(
-                close_channel(
-                    db.clone(),
-                    tx_queue.new_sender(),
+                actions.close_channel(
                     bob,
-                    self_addr,
                     ChannelDirection::Outgoing,
                     false
                 )
@@ -850,177 +854,5 @@ mod tests {
             ),
             "should fail when channel is already closed"
         );
-    }
-
-    #[async_std::test]
-    async fn test_withdraw() {
-        let _ = env_logger::builder().is_test(true).try_init();
-
-        let self_addr = Address::random();
-        let bob = Address::random();
-        let stake = Balance::new(10_u32.into(), BalanceType::HOPR);
-        let random_hash = Hash::new(&random_bytes::<{ Hash::SIZE }>());
-
-        let db = Arc::new(RwLock::new(CoreEthereumDb::new(
-            DB::new(RustyLevelDbShim::new_in_memory()),
-            self_addr,
-        )));
-
-        let mut tx_exec = MockTransactionExecutor::new();
-        tx_exec
-            .expect_withdraw()
-            .times(1)
-            .withf(move |dst, balance| bob.eq(dst) && stake.eq(balance))
-            .returning(move |_, _| TransactionResult::Withdraw { tx_hash: random_hash });
-
-        let tx_queue = TransactionQueue::new(db.clone(), Box::new(tx_exec));
-        let tx_sender = tx_queue.new_sender();
-        async_std::task::spawn_local(async move {
-            tx_queue.transaction_loop().await;
-        });
-
-        let tx_res = withdraw(tx_sender.clone(), bob, stake).await.unwrap().await.unwrap();
-
-        match tx_res {
-            TransactionResult::Withdraw { tx_hash } => {
-                assert_eq!(random_hash, tx_hash, "tx hash must be equal");
-            }
-            _ => panic!("invalid or failed tx result"),
-        }
-    }
-
-    #[async_std::test]
-    async fn test_should_not_withdraw_zero_amount() {
-        let _ = env_logger::builder().is_test(true).try_init();
-
-        let self_addr = Address::random();
-        let bob = Address::random();
-
-        let db = Arc::new(RwLock::new(CoreEthereumDb::new(
-            DB::new(RustyLevelDbShim::new_in_memory()),
-            self_addr,
-        )));
-        let tx_queue = TransactionQueue::new(db.clone(), Box::new(MockTransactionExecutor::new()));
-
-        assert!(
-            matches!(
-                withdraw(tx_queue.new_sender(), bob, Balance::zero(BalanceType::HOPR))
-                    .await
-                    .err()
-                    .unwrap(),
-                CoreEthereumActionsError::OtherError(_)
-            ),
-            "should not allow to withdraw 0"
-        );
-    }
-}
-
-#[cfg(feature = "wasm")]
-pub mod wasm {
-    use crate::transaction_queue::{TransactionResult, TransactionSender};
-    use core_crypto::types::Hash;
-    use core_ethereum_db::db::wasm::Database;
-    use core_types::channels::{ChannelDirection, ChannelStatus};
-    use utils_misc::utils::wasm::JsResult;
-    use utils_types::primitives::{Address, Balance};
-    use wasm_bindgen::prelude::wasm_bindgen;
-    use wasm_bindgen::JsValue;
-
-    #[wasm_bindgen(getter_with_clone)]
-    pub struct OpenChannelResult {
-        pub tx_hash: Hash,
-        pub channel_id: Hash,
-    }
-
-    #[wasm_bindgen(getter_with_clone)]
-    pub struct CloseChannelResult {
-        pub tx_hash: Hash,
-        pub status: ChannelStatus,
-    }
-
-    #[wasm_bindgen]
-    pub async fn open_channel(
-        db: &Database,
-        destination: &Address,
-        self_addr: &Address,
-        amount: &Balance,
-        on_chain_tx_sender: &TransactionSender,
-    ) -> JsResult<OpenChannelResult> {
-        let awaiter = super::open_channel(
-            db.as_ref_counted(),
-            on_chain_tx_sender.clone(),
-            *destination,
-            *self_addr,
-            *amount,
-        )
-        .await?;
-        match awaiter
-            .await
-            .map_err(|_| JsValue::from("transaction has been cancelled".to_string()))?
-        {
-            TransactionResult::OpenChannel { tx_hash, channel_id } => Ok(OpenChannelResult { tx_hash, channel_id }),
-            _ => Err(JsValue::from("open channel transaction failed".to_string())),
-        }
-    }
-
-    #[wasm_bindgen]
-    pub async fn fund_channel(
-        db: &Database,
-        channel_id: &Hash,
-        amount: &Balance,
-        on_chain_tx_sender: &TransactionSender,
-    ) -> JsResult<Hash> {
-        let awaiter =
-            super::fund_channel(db.as_ref_counted(), on_chain_tx_sender.clone(), *channel_id, *amount).await?;
-        match awaiter
-            .await
-            .map_err(|_| JsValue::from("transaction has been cancelled".to_string()))?
-        {
-            TransactionResult::FundChannel { tx_hash } => Ok(tx_hash),
-            _ => Err(JsValue::from("fund channel transaction failed".to_string())),
-        }
-    }
-
-    #[wasm_bindgen]
-    pub async fn close_channel(
-        db: &Database,
-        counterparty: &Address,
-        self_addr: &Address,
-        direction: ChannelDirection,
-        redeem_before_close: bool,
-        on_chain_tx_sender: &TransactionSender,
-    ) -> JsResult<CloseChannelResult> {
-        let awaiter = super::close_channel(
-            db.as_ref_counted(),
-            on_chain_tx_sender.clone(),
-            *counterparty,
-            *self_addr,
-            direction,
-            redeem_before_close,
-        )
-        .await?;
-        match awaiter
-            .await
-            .map_err(|_| JsValue::from("transaction has been cancelled".to_string()))?
-        {
-            TransactionResult::CloseChannel { tx_hash, status } => Ok(CloseChannelResult { tx_hash, status }),
-            _ => Err(JsValue::from("close channel transaction failed".to_string())),
-        }
-    }
-
-    #[wasm_bindgen]
-    pub async fn withdraw(
-        recipient: &Address,
-        amount: &Balance,
-        on_chain_tx_sender: &TransactionSender,
-    ) -> JsResult<Hash> {
-        let awaiter = super::withdraw(on_chain_tx_sender.clone(), *recipient, *amount).await?;
-        match awaiter
-            .await
-            .map_err(|_| JsValue::from("transaction has been cancelled".to_string()))?
-        {
-            TransactionResult::Withdraw { tx_hash } => Ok(tx_hash),
-            _ => Err(JsValue::from("withdraw transaction failed".to_string())),
-        }
     }
 }

--- a/packages/core-ethereum/crates/core-ethereum-actions/src/lib.rs
+++ b/packages/core-ethereum/crates/core-ethereum-actions/src/lib.rs
@@ -44,9 +44,11 @@ pub mod wasm {
     use utils_types::primitives::{Address, Balance};
     use crate::channels::ChannelActions;
     use crate::CoreEthereumActions;
+    use crate::node::NodeActions;
     use crate::redeem::TicketRedeemActions;
     use crate::transaction_queue::{TransactionResult, TransactionSender};
 
+    #[derive(Clone)]
     #[wasm_bindgen]
     pub struct WasmCoreEthereumActions {
         w: CoreEthereumActions<CoreEthereumDb<RustyLevelDbShim>>
@@ -55,6 +57,10 @@ pub mod wasm {
     impl WasmCoreEthereumActions {
         pub fn inner_ref(&self) -> &CoreEthereumActions<CoreEthereumDb<RustyLevelDbShim>> {
             &self.w
+        }
+
+        pub fn new_from_actions(actions: CoreEthereumActions<CoreEthereumDb<RustyLevelDbShim>>) -> Self {
+            Self { w: actions }
         }
     }
 

--- a/packages/core-ethereum/crates/core-ethereum-actions/src/lib.rs
+++ b/packages/core-ethereum/crates/core-ethereum-actions/src/lib.rs
@@ -1,4 +1,198 @@
 pub mod channels;
 pub mod errors;
+pub mod node;
 pub mod redeem;
 pub mod transaction_queue;
+
+use std::sync::Arc;
+use async_lock::RwLock;
+use core_ethereum_db::traits::HoprCoreEthereumDbActions;
+use utils_types::primitives::Address;
+use crate::transaction_queue::TransactionSender;
+
+/// Contains all actions that a node can execute on-chain.
+#[derive(Clone)]
+pub struct CoreEthereumActions<Db: HoprCoreEthereumDbActions> {
+    me: Address,
+    db: Arc<RwLock<Db>>,
+    tx_sender: TransactionSender
+}
+
+impl<Db: HoprCoreEthereumDbActions> CoreEthereumActions<Db> {
+    /// Creates new instance.
+    pub fn new(me: Address, db: Arc<RwLock<Db>>, tx_sender: TransactionSender) -> Self {
+        Self { me, db, tx_sender }
+    }
+
+    /// On-chain address of this node
+    pub fn self_address(&self) -> Address {
+        self.me
+    }
+}
+
+#[cfg(feature = "wasm")]
+pub mod wasm {
+    use wasm_bindgen::JsValue;
+    use wasm_bindgen::prelude::wasm_bindgen;
+    use core_crypto::types::Hash;
+    use core_ethereum_db::db::CoreEthereumDb;
+    use core_ethereum_db::db::wasm::Database;
+    use core_types::acknowledgement::wasm::AcknowledgedTicket;
+    use core_types::channels::{ChannelDirection, ChannelEntry, ChannelStatus};
+    use utils_db::rusty::RustyLevelDbShim;
+    use utils_misc::utils::wasm::JsResult;
+    use utils_types::primitives::{Address, Balance};
+    use crate::channels::ChannelActions;
+    use crate::CoreEthereumActions;
+    use crate::redeem::TicketRedeemActions;
+    use crate::transaction_queue::{TransactionResult, TransactionSender};
+
+    #[wasm_bindgen]
+    pub struct WasmCoreEthereumActions {
+        w: CoreEthereumActions<CoreEthereumDb<RustyLevelDbShim>>
+    }
+
+    impl WasmCoreEthereumActions {
+        pub fn inner_ref(&self) -> &CoreEthereumActions<CoreEthereumDb<RustyLevelDbShim>> {
+            &self.w
+        }
+    }
+
+    #[wasm_bindgen(getter_with_clone)]
+    pub struct OpenChannelResult {
+        pub tx_hash: Hash,
+        pub channel_id: Hash,
+    }
+
+    #[wasm_bindgen(getter_with_clone)]
+    pub struct CloseChannelResult {
+        pub tx_hash: Hash,
+        pub status: ChannelStatus,
+    }
+
+    #[wasm_bindgen]
+    impl WasmCoreEthereumActions {
+        #[wasm_bindgen(constructor)]
+        pub fn new(me: Address, db: &Database, tx_sender: &TransactionSender) -> Self {
+            Self {
+                w: CoreEthereumActions::new(me, db.as_ref_counted(), tx_sender.clone())
+            }
+        }
+
+        pub async fn open_channel(
+            &self,
+            destination: &Address,
+            amount: &Balance,
+        ) -> JsResult<OpenChannelResult> {
+            let awaiter = self.w.open_channel(
+                *destination,
+                *amount,
+            )
+                .await?;
+            match awaiter
+                .await
+                .map_err(|_| JsValue::from("transaction has been cancelled".to_string()))?
+            {
+                TransactionResult::OpenChannel { tx_hash, channel_id } => Ok(OpenChannelResult { tx_hash, channel_id }),
+                _ => Err(JsValue::from("open channel transaction failed".to_string())),
+            }
+        }
+
+        pub async fn fund_channel(
+            &self,
+            channel_id: &Hash,
+            amount: &Balance,
+        ) -> JsResult<Hash> {
+            let awaiter =
+                self.w.fund_channel(*channel_id, *amount).await?;
+            match awaiter
+                .await
+                .map_err(|_| JsValue::from("transaction has been cancelled".to_string()))?
+            {
+                TransactionResult::FundChannel { tx_hash } => Ok(tx_hash),
+                _ => Err(JsValue::from("fund channel transaction failed".to_string())),
+            }
+        }
+
+        pub async fn close_channel(
+            &self,
+            counterparty: &Address,
+            direction: ChannelDirection,
+            redeem_before_close: bool,
+        ) -> JsResult<CloseChannelResult> {
+            let awaiter = self.w.close_channel(
+                *counterparty,
+                direction,
+                redeem_before_close,
+            )
+                .await?;
+            match awaiter
+                .await
+                .map_err(|_| JsValue::from("transaction has been cancelled".to_string()))?
+            {
+                TransactionResult::CloseChannel { tx_hash, status } => Ok(CloseChannelResult { tx_hash, status }),
+                _ => Err(JsValue::from("close channel transaction failed".to_string())),
+            }
+        }
+
+        pub async fn withdraw(
+            &self,
+            recipient: &Address,
+            amount: &Balance,
+        ) -> JsResult<Hash> {
+            let awaiter = self.w.withdraw(*recipient, *amount).await?;
+            match awaiter
+                .await
+                .map_err(|_| JsValue::from("transaction has been cancelled".to_string()))?
+            {
+                TransactionResult::Withdraw { tx_hash } => Ok(tx_hash),
+                _ => Err(JsValue::from("withdraw transaction failed".to_string())),
+            }
+        }
+
+        pub async fn redeem_all_tickets(
+            &self,
+            only_aggregated: bool,
+        ) -> JsResult<()> {
+            // We do not await the on-chain confirmation
+            self.w.redeem_all_tickets(only_aggregated).await?;
+            Ok(())
+        }
+
+        pub async fn redeem_tickets_with_counterparty(
+            &self,
+            counterparty: &Address,
+            only_aggregated: bool,
+        ) -> JsResult<()> {
+            // We do not await the on-chain confirmation
+            self.w.redeem_tickets_with_counterparty(
+                counterparty,
+                only_aggregated,
+            ).await?;
+            Ok(())
+        }
+
+        pub async fn redeem_tickets_in_channel(
+            &self,
+            channel: &ChannelEntry,
+            only_aggregated: bool,
+        ) -> JsResult<()> {
+            // We do not await the on-chain confirmation
+            self.w.redeem_tickets_in_channel(
+                channel,
+                only_aggregated,
+            )
+            .await?;
+            Ok(())
+        }
+
+        pub async fn redeem_ticket(
+            &self,
+            ack_ticket: &AcknowledgedTicket,
+        ) -> JsResult<()> {
+            // We do not await the on-chain confirmation
+            let _ = self.w.redeem_ticket(ack_ticket.into()).await?;
+            Ok(())
+        }
+    }
+}

--- a/packages/core-ethereum/crates/core-ethereum-actions/src/node.rs
+++ b/packages/core-ethereum/crates/core-ethereum-actions/src/node.rs
@@ -1,0 +1,113 @@
+use async_trait::async_trait;
+use core_ethereum_db::traits::HoprCoreEthereumDbActions;
+use core_ethereum_misc::errors::CoreEthereumError::InvalidArguments;
+use utils_types::primitives::{Address, Balance};
+use crate::CoreEthereumActions;
+use crate::transaction_queue::{Transaction, TransactionCompleted};
+use crate::errors::Result;
+
+/// Contains all on-chain calls specific to HOPR node itself.
+#[async_trait(? Send)]
+pub trait NodeActions {
+    /// Withdraws the specified `amount` of tokens to the given `recipient`.
+    async fn withdraw(&self, recipient: Address, amount: Balance) -> Result<TransactionCompleted>;
+
+    // TODO: add announce and register safe actions in this trait
+}
+
+#[async_trait(? Send)]
+impl <Db: HoprCoreEthereumDbActions> NodeActions for CoreEthereumActions<Db> {
+    async fn withdraw(
+        &self,
+        recipient: Address,
+        amount: Balance,
+    ) -> Result<TransactionCompleted> {
+        if amount.eq(&amount.of_same("0")) {
+            return Err(InvalidArguments("cannot withdraw zero amount".into()).into());
+        }
+
+        self.tx_sender.send(Transaction::Withdraw(recipient, amount)).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use async_lock::RwLock;
+    use core_crypto::random::random_bytes;
+    use core_crypto::types::Hash;
+    use core_ethereum_db::db::CoreEthereumDb;
+    use utils_db::db::DB;
+    use utils_db::rusty::RustyLevelDbShim;
+    use utils_types::primitives::{Address, Balance, BalanceType};
+    use utils_types::traits::BinarySerializable;
+    use crate::CoreEthereumActions;
+    use crate::node::NodeActions;
+    use crate::transaction_queue::{MockTransactionExecutor, TransactionQueue, TransactionResult};
+    use crate::errors::CoreEthereumActionsError;
+
+    #[async_std::test]
+    async fn test_withdraw() {
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        let self_addr = Address::random();
+        let bob = Address::random();
+        let stake = Balance::new(10_u32.into(), BalanceType::HOPR);
+        let random_hash = Hash::new(&random_bytes::<{ Hash::SIZE }>());
+
+        let db = Arc::new(RwLock::new(CoreEthereumDb::new(
+            DB::new(RustyLevelDbShim::new_in_memory()),
+            self_addr,
+        )));
+
+        let mut tx_exec = MockTransactionExecutor::new();
+        tx_exec
+            .expect_withdraw()
+            .times(1)
+            .withf(move |dst, balance| bob.eq(dst) && stake.eq(balance))
+            .returning(move |_, _| TransactionResult::Withdraw { tx_hash: random_hash });
+
+        let tx_queue = TransactionQueue::new(db.clone(), Box::new(tx_exec));
+        let tx_sender = tx_queue.new_sender();
+        async_std::task::spawn_local(async move {
+            tx_queue.transaction_loop().await;
+        });
+
+        let actions = CoreEthereumActions::new(self_addr, db.clone(), tx_sender.clone());
+
+        let tx_res = actions.withdraw(bob, stake).await.unwrap().await.unwrap();
+
+        match tx_res {
+            TransactionResult::Withdraw { tx_hash } => {
+                assert_eq!(random_hash, tx_hash, "tx hash must be equal");
+            }
+            _ => panic!("invalid or failed tx result"),
+        }
+    }
+
+    #[async_std::test]
+    async fn test_should_not_withdraw_zero_amount() {
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        let self_addr = Address::random();
+        let bob = Address::random();
+
+        let db = Arc::new(RwLock::new(CoreEthereumDb::new(
+            DB::new(RustyLevelDbShim::new_in_memory()),
+            self_addr,
+        )));
+        let tx_queue = TransactionQueue::new(db.clone(), Box::new(MockTransactionExecutor::new()));
+        let actions = CoreEthereumActions::new(self_addr, db.clone(), tx_queue.new_sender());
+
+        assert!(
+            matches!(
+                actions.withdraw(bob, Balance::zero(BalanceType::HOPR))
+                    .await
+                    .err()
+                    .unwrap(),
+                CoreEthereumActionsError::OtherError(_)
+            ),
+            "should not allow to withdraw 0"
+        );
+    }
+}

--- a/packages/core-ethereum/crates/core-ethereum-db/src/db.rs
+++ b/packages/core-ethereum/crates/core-ethereum-db/src/db.rs
@@ -36,22 +36,23 @@ fn get_acknowledged_ticket_key(ack: &AcknowledgedTicket) -> Result<utils_db::db:
     to_acknowledged_ticket_key(&ack.ticket.channel_id, ack.ticket.channel_epoch, ack.ticket.index)
 }
 
+#[derive(Clone)]
 pub struct CoreEthereumDb<T>
 where
-    T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>>,
+    T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>> + Clone,
 {
     pub db: DB<T>,
     pub me: Address,
 }
 
-impl<T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>>> CoreEthereumDb<T> {
+impl<T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>> + Clone> CoreEthereumDb<T> {
     pub fn new(db: DB<T>, me: Address) -> Self {
         Self { db, me }
     }
 }
 
 #[async_trait(? Send)] // not placing the `Send` trait limitations on the trait
-impl<T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>>> HoprCoreEthereumDbActions for CoreEthereumDb<T> {
+impl<T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>> + Clone> HoprCoreEthereumDbActions for CoreEthereumDb<T> {
     // core only part
     async fn get_current_ticket_index(&self, channel_id: &Hash) -> Result<Option<U256>> {
         let prefixed_key = utils_db::db::Key::new_with_prefix(channel_id, TICKET_INDEX_PREFIX)?;

--- a/packages/core-ethereum/crates/core-ethereum-db/src/traits.rs
+++ b/packages/core-ethereum/crates/core-ethereum-db/src/traits.rs
@@ -11,7 +11,7 @@ use core_types::{
 use utils_types::primitives::{Address, AuthorizationToken, Balance, Snapshot, U256};
 
 #[async_trait(? Send)] // not placing the `Send` trait limitations on the trait
-pub trait HoprCoreEthereumDbActions {
+pub trait HoprCoreEthereumDbActions: Clone {
     // core only part
     async fn get_current_ticket_index(&self, channel_id: &Hash) -> Result<Option<U256>>;
     async fn set_current_ticket_index(&mut self, channel_id: &Hash, index: U256) -> Result<()>;

--- a/packages/core/crates/core-hopr/src/lib.rs
+++ b/packages/core/crates/core-hopr/src/lib.rs
@@ -105,6 +105,7 @@ pub mod wasm_impls {
     use core_crypto::keypairs::Keypair;
     use core_crypto::{keypairs::OffchainKeypair, types::HalfKeyChallenge};
     use core_ethereum_actions::transaction_queue::wasm::WasmTxExecutor;
+    use core_ethereum_actions::CoreEthereumActions;
     use core_ethereum_db::db::wasm::Database;
     use core_ethereum_db::traits::HoprCoreEthereumDbActions;
     use core_network::network::NetworkConfig;
@@ -117,7 +118,6 @@ pub mod wasm_impls {
     use utils_db::rusty::RustyLevelDbShim;
     use utils_misc::ok_or_jserr;
     use wasm_bindgen::prelude::*;
-    use core_ethereum_actions::CoreEthereumActions;
 
     #[wasm_bindgen]
     #[derive(Clone)]
@@ -261,7 +261,8 @@ pub mod wasm_impls {
 
         let tx_queue = TransactionQueue::new(db.clone(), Box::new(tx_executor));
 
-        let chain_actions = CoreEthereumActions::new(me_onchain.public().to_address(), db.clone(), tx_queue.new_sender());
+        let chain_actions =
+            CoreEthereumActions::new(me_onchain.public().to_address(), db.clone(), tx_queue.new_sender());
 
         let multi_strategy = Arc::new(MultiStrategy::new(
             strategy_cfg,

--- a/packages/core/crates/core-hopr/src/lib.rs
+++ b/packages/core/crates/core-hopr/src/lib.rs
@@ -40,7 +40,7 @@ use std::{sync::Arc, time::Duration};
 use utils_log::{error, info};
 use utils_types::traits::BinarySerializable;
 
-use core_ethereum_actions::transaction_queue::{TransactionQueue, TransactionSender};
+use core_ethereum_actions::transaction_queue::TransactionQueue;
 
 use core_strategy::{
     strategy::{MultiStrategy, SingularStrategy},
@@ -117,6 +117,7 @@ pub mod wasm_impls {
     use utils_db::rusty::RustyLevelDbShim;
     use utils_misc::ok_or_jserr;
     use wasm_bindgen::prelude::*;
+    use core_ethereum_actions::CoreEthereumActions;
 
     #[wasm_bindgen]
     #[derive(Clone)]
@@ -125,7 +126,7 @@ pub mod wasm_impls {
         network: adaptors::network::wasm::WasmNetwork,
         indexer: adaptors::indexer::WasmIndexerInteractions,
         pkt_sender: PacketActions,
-        tx_sender: TransactionSender,
+        chain_actions: core_ethereum_actions::wasm::WasmCoreEthereumActions,
         ticket_aggregate_actions: TicketAggregationActions<ResponseChannel<Result<Ticket, String>>, RequestId>,
         channel_events: ChannelEventEmitter,
         channel_graph: core_path::channel_graph::wasm::ChannelGraph,
@@ -138,7 +139,7 @@ pub mod wasm_impls {
             change_notifier: Sender<NetworkEvent>,
             indexer: adaptors::indexer::WasmIndexerInteractions,
             pkt_sender: PacketActions,
-            tx_sender: TransactionSender,
+            chain_actions: core_ethereum_actions::wasm::WasmCoreEthereumActions,
             ticket_aggregate_actions: TicketAggregationActions<ResponseChannel<Result<Ticket, String>>, RequestId>,
             channel_events: ChannelEventEmitter,
             channel_graph: core_path::channel_graph::wasm::ChannelGraph,
@@ -149,7 +150,7 @@ pub mod wasm_impls {
                 indexer,
                 pkt_sender,
                 ticket_aggregate_actions,
-                tx_sender,
+                chain_actions,
                 channel_events,
                 channel_graph,
             }
@@ -209,8 +210,8 @@ pub mod wasm_impls {
             )
         }
 
-        pub fn get_tx_sender(&self) -> TransactionSender {
-            self.tx_sender.clone()
+        pub fn chain_actions(&self) -> core_ethereum_actions::wasm::WasmCoreEthereumActions {
+            self.chain_actions.clone()
         }
     }
 
@@ -260,11 +261,13 @@ pub mod wasm_impls {
 
         let tx_queue = TransactionQueue::new(db.clone(), Box::new(tx_executor));
 
+        let chain_actions = CoreEthereumActions::new(me_onchain.public().to_address(), db.clone(), tx_queue.new_sender());
+
         let multi_strategy = Arc::new(MultiStrategy::new(
             strategy_cfg,
             db.clone(),
             network.clone(),
-            tx_queue.new_sender(),
+            chain_actions.clone(),
             ticket_aggregation.writer(),
         ));
         info!("initialized strategies: {multi_strategy:?}");
@@ -357,7 +360,7 @@ pub mod wasm_impls {
             network_events_tx,
             indexer_updater,
             packet_actions.writer(),
-            tx_queue.new_sender(),
+            core_ethereum_actions::wasm::WasmCoreEthereumActions::new_from_actions(chain_actions),
             ticket_aggregation.writer(),
             ChannelEventEmitter {
                 tx: on_channel_event_tx,

--- a/packages/core/crates/core-packet/src/validation.rs
+++ b/packages/core/crates/core-packet/src/validation.rs
@@ -132,6 +132,7 @@ mod tests {
 
     mock! {
         pub Db { }
+
         #[async_trait(? Send)]
         impl HoprCoreEthereumDbActions for Db {
             async fn get_current_ticket_index(&self, channel_id: &Hash) -> core_ethereum_db::errors::Result<Option<U256>>;
@@ -243,6 +244,12 @@ mod tests {
             async fn set_allowed_to_access_network(&mut self, node: &Address, allowed: bool, snapshot: &Snapshot) -> core_ethereum_db::errors::Result<()>;
             async fn get_from_network_registry(&self, stake_account: &Address) -> core_ethereum_db::errors::Result<Vec<Address>>;
             async fn set_eligible(&mut self, account: &Address, eligible: bool, snapshot: &Snapshot) -> core_ethereum_db::errors::Result<Vec<Address>>;
+        }
+    }
+
+    impl Clone for MockDb {
+        fn clone(&self) -> Self {
+            MockDb::new()
         }
     }
 

--- a/packages/core/crates/core-strategy/Cargo.toml
+++ b/packages/core/crates/core-strategy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-strategy"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Contains implementations of different HOPR strategies"
 edition = "2021"

--- a/packages/core/crates/core-strategy/src/aggregating.rs
+++ b/packages/core/crates/core-strategy/src/aggregating.rs
@@ -5,6 +5,7 @@ use core_ethereum_actions::errors::CoreEthereumActionsError::ChannelDoesNotExist
 use core_ethereum_db::traits::HoprCoreEthereumDbActions;
 use core_protocol::ticket_aggregation::processor::TicketAggregationActions;
 use core_types::acknowledgement::{AcknowledgedTicket, AcknowledgedTicketStatus};
+use core_types::channels::ChannelDirection::Incoming;
 use core_types::channels::{ChannelChange, ChannelDirection, ChannelEntry, ChannelStatus};
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DurationSeconds};
@@ -15,18 +16,16 @@ use std::{
     time::Duration,
 };
 use utils_log::{debug, error, info, warn};
-use validator::Validate;
-use core_types::channels::ChannelDirection::Incoming;
 use utils_types::primitives::{Balance, BalanceType};
+use validator::Validate;
 
 #[cfg(any(not(feature = "wasm"), test))]
 use async_std::task::spawn_local;
 
+use core_ethereum_actions::redeem::TicketRedeemActions;
+use core_ethereum_actions::CoreEthereumActions;
 #[cfg(all(feature = "wasm", not(test)))]
 use wasm_bindgen_futures::spawn_local;
-use core_ethereum_actions::CoreEthereumActions;
-use core_ethereum_actions::redeem::TicketRedeemActions;
-
 
 /// Configuration object for the `AggregatingStrategy`
 #[serde_as]
@@ -289,6 +288,7 @@ mod tests {
     use core_ethereum_actions::transaction_queue::{
         TransactionExecutor, TransactionQueue, TransactionResult, TransactionSender,
     };
+    use core_ethereum_actions::CoreEthereumActions;
     use core_ethereum_db::{db::CoreEthereumDb, traits::HoprCoreEthereumDbActions};
     use core_protocol::ticket_aggregation::processor::{
         TicketAggregationActions, TicketAggregationInteraction, TicketAggregationProcessed,
@@ -307,7 +307,6 @@ mod tests {
     use std::pin::pin;
     use std::sync::Arc;
     use std::time::Duration;
-    use core_ethereum_actions::CoreEthereumActions;
     use utils_db::{constants::ACKNOWLEDGED_TICKETS_PREFIX, db::DB, rusty::RustyLevelDbShim};
     use utils_types::{
         primitives::{Address, Balance, BalanceType, Snapshot, U256},
@@ -529,8 +528,7 @@ mod tests {
 
         let actions = CoreEthereumActions::new(PEERS_CHAIN[1].public().to_address(), dbs[1].clone(), tx_sender.clone());
 
-        let aggregation_strategy =
-            super::AggregatingStrategy::new(cfg, dbs[1].clone(), actions, bob_aggregator);
+        let aggregation_strategy = super::AggregatingStrategy::new(cfg, dbs[1].clone(), actions, bob_aggregator);
 
         let threshold_ticket = acked_tickets.last().unwrap();
         aggregation_strategy
@@ -600,8 +598,7 @@ mod tests {
 
         let actions = CoreEthereumActions::new(PEERS_CHAIN[1].public().to_address(), dbs[1].clone(), tx_sender.clone());
 
-        let aggregation_strategy =
-            super::AggregatingStrategy::new(cfg, dbs[1].clone(), actions, bob_aggregator);
+        let aggregation_strategy = super::AggregatingStrategy::new(cfg, dbs[1].clone(), actions, bob_aggregator);
 
         let threshold_ticket = acked_tickets.last().unwrap();
 
@@ -672,8 +669,7 @@ mod tests {
 
         let actions = CoreEthereumActions::new(PEERS_CHAIN[1].public().to_address(), dbs[1].clone(), tx_sender.clone());
 
-        let aggregation_strategy =
-            super::AggregatingStrategy::new(cfg, dbs[1].clone(), actions, bob_aggregator);
+        let aggregation_strategy = super::AggregatingStrategy::new(cfg, dbs[1].clone(), actions, bob_aggregator);
 
         channel.status = ChannelStatus::PendingToClose;
         dbs[1]

--- a/packages/core/crates/core-strategy/src/auto_funding.rs
+++ b/packages/core/crates/core-strategy/src/auto_funding.rs
@@ -1,4 +1,6 @@
 use async_trait::async_trait;
+use core_ethereum_actions::channels::ChannelActions;
+use core_ethereum_actions::CoreEthereumActions;
 use core_ethereum_db::traits::HoprCoreEthereumDbActions;
 use core_types::channels::ChannelDirection::Outgoing;
 use core_types::channels::{ChannelChange, ChannelDirection, ChannelEntry, ChannelStatus};
@@ -8,8 +10,6 @@ use std::fmt::{Debug, Display, Formatter};
 use utils_log::info;
 use utils_types::primitives::{Balance, BalanceType};
 use validator::Validate;
-use core_ethereum_actions::channels::ChannelActions;
-use core_ethereum_actions::CoreEthereumActions;
 
 use crate::strategy::SingularStrategy;
 use crate::Strategy;
@@ -83,11 +83,10 @@ impl<Db: HoprCoreEthereumDbActions> SingularStrategy for AutoFundingStrategy<Db>
                     channel.balance, self.cfg.min_stake_threshold
                 );
 
-                let rx = self.chain_actions.fund_channel(
-                    channel.get_id(),
-                    self.cfg.funding_amount,
-                )
-                .await?;
+                let rx = self
+                    .chain_actions
+                    .fund_channel(channel.get_id(), self.cfg.funding_amount)
+                    .await?;
                 std::mem::drop(rx); // The Receiver is not intentionally awaited here and the oneshot Sender can fail safely
                 info!(
                     "{self} strategy: issued re-staking of {channel} with {}",
@@ -108,6 +107,7 @@ mod tests {
     use async_trait::async_trait;
     use core_crypto::types::Hash;
     use core_ethereum_actions::transaction_queue::{TransactionExecutor, TransactionQueue, TransactionResult};
+    use core_ethereum_actions::CoreEthereumActions;
     use core_ethereum_db::db::CoreEthereumDb;
     use core_ethereum_db::traits::HoprCoreEthereumDbActions;
     use core_types::acknowledgement::AcknowledgedTicket;
@@ -116,7 +116,6 @@ mod tests {
     use core_types::channels::{ChannelEntry, ChannelStatus};
     use mockall::mock;
     use std::sync::Arc;
-    use core_ethereum_actions::CoreEthereumActions;
     use utils_db::db::DB;
     use utils_db::rusty::RustyLevelDbShim;
     use utils_types::primitives::{Address, Balance, BalanceType, Snapshot};

--- a/packages/core/crates/core-strategy/src/auto_redeeming.rs
+++ b/packages/core/crates/core-strategy/src/auto_redeeming.rs
@@ -1,12 +1,12 @@
 use async_trait::async_trait;
+use core_ethereum_actions::redeem::TicketRedeemActions;
+use core_ethereum_actions::CoreEthereumActions;
 use core_ethereum_db::traits::HoprCoreEthereumDbActions;
 use core_types::acknowledgement::AcknowledgedTicket;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
 use utils_log::info;
 use validator::Validate;
-use core_ethereum_actions::CoreEthereumActions;
-use core_ethereum_actions::redeem::TicketRedeemActions;
 
 use crate::strategy::SingularStrategy;
 use crate::Strategy;
@@ -74,6 +74,7 @@ mod tests {
     use core_crypto::keypairs::{ChainKeypair, Keypair};
     use core_crypto::types::{Challenge, CurvePoint, HalfKey, Hash};
     use core_ethereum_actions::transaction_queue::{TransactionExecutor, TransactionQueue, TransactionResult};
+    use core_ethereum_actions::CoreEthereumActions;
     use core_ethereum_db::db::CoreEthereumDb;
     use core_ethereum_db::traits::HoprCoreEthereumDbActions;
     use core_types::acknowledgement::{AcknowledgedTicket, UnacknowledgedTicket};
@@ -81,7 +82,6 @@ mod tests {
     use hex_literal::hex;
     use mockall::mock;
     use std::sync::Arc;
-    use core_ethereum_actions::CoreEthereumActions;
     use utils_db::constants::ACKNOWLEDGED_TICKETS_PREFIX;
     use utils_db::db::DB;
     use utils_db::rusty::RustyLevelDbShim;

--- a/packages/core/crates/core-strategy/src/auto_redeeming.rs
+++ b/packages/core/crates/core-strategy/src/auto_redeeming.rs
@@ -1,16 +1,15 @@
-use crate::strategy::SingularStrategy;
-use crate::Strategy;
-use async_std::sync::RwLock;
 use async_trait::async_trait;
-use core_ethereum_actions::redeem::redeem_ticket;
-use core_ethereum_actions::transaction_queue::TransactionSender;
 use core_ethereum_db::traits::HoprCoreEthereumDbActions;
 use core_types::acknowledgement::AcknowledgedTicket;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
-use std::sync::Arc;
 use utils_log::info;
 use validator::Validate;
+use core_ethereum_actions::CoreEthereumActions;
+use core_ethereum_actions::redeem::TicketRedeemActions;
+
+use crate::strategy::SingularStrategy;
+use crate::Strategy;
 
 /// Configuration object for the `AutoRedeemingStrategy`
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Validate, Serialize, Deserialize)]
@@ -32,8 +31,7 @@ impl Default for AutoRedeemingStrategyConfig {
 /// for redemption once encountered.
 /// The strategy does not await the result of the redemption.
 pub struct AutoRedeemingStrategy<Db: HoprCoreEthereumDbActions> {
-    db: Arc<RwLock<Db>>,
-    tx_sender: TransactionSender,
+    chain_actions: CoreEthereumActions<Db>,
     cfg: AutoRedeemingStrategyConfig,
 }
 
@@ -50,8 +48,8 @@ impl<Db: HoprCoreEthereumDbActions> Display for AutoRedeemingStrategy<Db> {
 }
 
 impl<Db: HoprCoreEthereumDbActions> AutoRedeemingStrategy<Db> {
-    pub fn new(cfg: AutoRedeemingStrategyConfig, db: Arc<RwLock<Db>>, tx_sender: TransactionSender) -> Self {
-        Self { cfg, db, tx_sender }
+    pub fn new(cfg: AutoRedeemingStrategyConfig, chain_actions: CoreEthereumActions<Db>) -> Self {
+        Self { cfg, chain_actions }
     }
 }
 
@@ -60,7 +58,7 @@ impl<Db: HoprCoreEthereumDbActions + 'static> SingularStrategy for AutoRedeeming
     async fn on_acknowledged_winning_ticket(&self, ack: &AcknowledgedTicket) -> crate::errors::Result<()> {
         if !self.cfg.redeem_only_aggregated || ack.ticket.is_aggregated() {
             info!("{self} strategy: auto-redeeming {ack}");
-            let rx = redeem_ticket(self.db.clone(), ack.clone(), self.tx_sender.clone()).await?;
+            let rx = self.chain_actions.redeem_ticket(ack.clone()).await?;
             std::mem::drop(rx); // The Receiver is not intentionally awaited here and the oneshot Sender can fail safely
         }
         Ok(())
@@ -83,6 +81,7 @@ mod tests {
     use hex_literal::hex;
     use mockall::mock;
     use std::sync::Arc;
+    use core_ethereum_actions::CoreEthereumActions;
     use utils_db::constants::ACKNOWLEDGED_TICKETS_PREFIX;
     use utils_db::db::DB;
     use utils_db::rusty::RustyLevelDbShim;
@@ -189,7 +188,9 @@ mod tests {
             redeem_only_aggregated: false,
         };
 
-        let ars = AutoRedeemingStrategy::new(cfg, db.clone(), tx_sender);
+        let actions = CoreEthereumActions::new(ALICE.public().to_address(), db.clone(), tx_sender);
+
+        let ars = AutoRedeemingStrategy::new(cfg, actions);
         ars.on_acknowledged_winning_ticket(&ack_ticket).await.unwrap();
 
         awaiter.await.unwrap();
@@ -244,7 +245,9 @@ mod tests {
             redeem_only_aggregated: true,
         };
 
-        let ars = AutoRedeemingStrategy::new(cfg, db.clone(), tx_sender);
+        let actions = CoreEthereumActions::new(ALICE.public().to_address(), db.clone(), tx_sender);
+
+        let ars = AutoRedeemingStrategy::new(cfg, actions);
         ars.on_acknowledged_winning_ticket(&ack_ticket_unagg).await.unwrap();
         ars.on_acknowledged_winning_ticket(&ack_ticket_agg).await.unwrap();
 

--- a/packages/core/crates/core-strategy/src/promiscuous.rs
+++ b/packages/core/crates/core-strategy/src/promiscuous.rs
@@ -12,6 +12,7 @@ use utils_types::primitives::{Address, Balance, BalanceType};
 
 use async_std::sync::RwLock;
 use async_trait::async_trait;
+use core_ethereum_actions::channels::ChannelActions;
 use core_ethereum_actions::CoreEthereumActions;
 use core_ethereum_db::traits::HoprCoreEthereumDbActions;
 use core_network::network::{Network, NetworkExternalActions};
@@ -20,7 +21,6 @@ use serde_with::{serde_as, DisplayFromStr};
 use std::fmt::{Debug, Display, Formatter};
 use std::sync::Arc;
 use validator::Validate;
-use core_ethereum_actions::channels::ChannelActions;
 
 use crate::errors::Result;
 use crate::strategy::SingularStrategy;
@@ -306,12 +306,14 @@ where
         // close all the channels, need to be synchronous because Ethereum transactions
         // are synchronous, especially due nonces
         for channel_to_close in tick_decision.get_to_close() {
-            match self.chain_actions.close_channel(
-                channel_to_close.destination,
-                ChannelDirection::Outgoing,
-                false, // TODO: get this value from config
-            )
-            .await
+            match self
+                .chain_actions
+                .close_channel(
+                    channel_to_close.destination,
+                    ChannelDirection::Outgoing,
+                    false, // TODO: get this value from config
+                )
+                .await
             {
                 Ok(_) => {
                     // Intentionally do not await result of the channel transaction
@@ -327,11 +329,10 @@ where
         // open all the channels, need to be synchronous because Ethereum
         // transactions are synchronous, especially due to nonces
         for channel_to_open in tick_decision.get_to_open() {
-            match self.chain_actions.open_channel(
-                channel_to_open.0,
-                channel_to_open.1,
-            )
-            .await
+            match self
+                .chain_actions
+                .open_channel(channel_to_open.0, channel_to_open.1)
+                .await
             {
                 Ok(_) => {
                     // Intentionally do not await result of the channel transaction

--- a/packages/core/crates/core-strategy/src/strategy.rs
+++ b/packages/core/crates/core-strategy/src/strategy.rs
@@ -6,6 +6,7 @@ use crate::promiscuous::PromiscuousStrategy;
 use crate::Strategy;
 use async_std::sync::RwLock;
 use async_trait::async_trait;
+use core_ethereum_actions::CoreEthereumActions;
 use core_ethereum_db::traits::HoprCoreEthereumDbActions;
 use core_network::network::{Network, NetworkExternalActions};
 use core_protocol::ticket_aggregation::processor::BasicTicketAggregationActions;
@@ -16,7 +17,6 @@ use std::fmt::{Debug, Display, Formatter};
 use std::sync::Arc;
 use utils_log::{error, warn};
 use validator::Validate;
-use core_ethereum_actions::CoreEthereumActions;
 
 /// Basic single strategy.
 #[cfg_attr(test, mockall::automock)]

--- a/packages/hoprd/crates/hoprd-hoprd/src/lib.rs
+++ b/packages/hoprd/crates/hoprd-hoprd/src/lib.rs
@@ -12,12 +12,6 @@ pub mod wasm {
     use core_network::network::wasm::*;
 
     #[allow(unused_imports)]
-    use core_ethereum_actions::channels::wasm::*;
-
-    #[allow(unused_imports)]
-    use core_ethereum_actions::redeem::wasm::*;
-
-    #[allow(unused_imports)]
     use core_ethereum_db::db::wasm::*;
 
     #[allow(unused_imports)]

--- a/packages/utils/crates/utils-db/src/db.rs
+++ b/packages/utils/crates/utils-db/src/db.rs
@@ -121,11 +121,12 @@ impl Deref for Key {
     }
 }
 
-pub struct DB<T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>>> {
+#[derive(Clone)]
+pub struct DB<T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>> + Clone> {
     backend: T,
 }
 
-impl<T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>>> DB<T> {
+impl<T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>> + Clone> DB<T> {
     pub fn new(backend: T) -> Self {
         Self { backend }
     }
@@ -249,6 +250,12 @@ mod tests {
     use mockall::predicate;
     use serde::Deserialize;
     use utils_types::traits::BinarySerializable;
+
+    impl Clone for MockAsyncKVStorage {
+        fn clone(&self) -> Self {
+            Self::default()
+        }
+    }
 
     #[test]
     fn test_key_to_string() {

--- a/packages/utils/src/types.ts
+++ b/packages/utils/src/types.ts
@@ -31,7 +31,6 @@ export {
   ChannelStatus,
   channel_status_to_number,
   channel_status_to_string,
-  close_channel,
   ChannelDirection,
   OpenChannelResult,
   CloseChannelResult,
@@ -54,7 +53,6 @@ export {
   derive_mac_key,
   derive_packet_tag,
   EthereumChallenge,
-  fund_channel,
   gather_all_metrics,
   generate_channel_id,
   get_package_version,
@@ -83,7 +81,6 @@ export {
   OffchainKeypair,
   OffchainPublicKey,
   OffchainSignature,
-  open_channel,
   PacketInteractionConfig,
   TransportPath,
   PeerOrigin,
@@ -94,10 +91,6 @@ export {
   random_fill,
   random_float,
   random_integer,
-  redeem_ticket,
-  redeem_all_tickets,
-  redeem_tickets_in_channel,
-  redeem_tickets_with_counterparty,
   Response,
   Signature,
   SimpleCounter,
@@ -118,6 +111,6 @@ export {
   WasmPing,
   WasmIndexerInteractions,
   PingConfig,
-  WasmTxExecutor,
-  withdraw
+  WasmCoreEthereumActions,
+  WasmTxExecutor
 } from '../../hoprd/lib/hoprd_hoprd.js'


### PR DESCRIPTION
This PR refactors the `core-ethereum-action` crate so it uses a different trait per module.

All free functions were moved under traits in the respective modules:

- `TicketRedeemActions` in the `redeem` module
- `ChannelActions` in the `channels` module
- `NodeActions` in the `node` module

There is a single type `CoreEthereumActions` type which implements all those traits and represents the main front-end of the crate.