### PR TITLE
Improve ticket aggregation interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,7 +1424,7 @@ dependencies = [
 
 [[package]]
 name = "core-protocol"
-version = "0.2.2"
+version = "0.2.3"
 dependencies = [
  "async-lock",
  "async-std",
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "core-strategy"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-std",
  "async-trait",

--- a/packages/core-ethereum/crates/core-ethereum-db/src/db.rs
+++ b/packages/core-ethereum/crates/core-ethereum-db/src/db.rs
@@ -255,7 +255,7 @@ impl<T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>> + Clone> HoprCoreEthe
         index_start: u64,
         index_end: u64,
     ) -> Result<Vec<AcknowledgedTicket>> {
-        let mut tickets = self.get_acknowledged_tickets_range(channel_id, epoch, index_start, index_end)?;
+        let mut tickets = self.get_acknowledged_tickets_range(channel_id, epoch, index_start, index_end).await?;
 
         let mut batch_ops = utils_db::db::Batch::default();
 

--- a/packages/core-ethereum/crates/core-ethereum-db/src/db.rs
+++ b/packages/core-ethereum/crates/core-ethereum-db/src/db.rs
@@ -255,7 +255,9 @@ impl<T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>> + Clone> HoprCoreEthe
         index_start: u64,
         index_end: u64,
     ) -> Result<Vec<AcknowledgedTicket>> {
-        let mut tickets = self.get_acknowledged_tickets_range(channel_id, epoch, index_start, index_end).await?;
+        let mut tickets = self
+            .get_acknowledged_tickets_range(channel_id, epoch, index_start, index_end)
+            .await?;
 
         let mut batch_ops = utils_db::db::Batch::default();
 

--- a/packages/core/crates/core-hopr/src/lib.rs
+++ b/packages/core/crates/core-hopr/src/lib.rs
@@ -112,6 +112,7 @@ pub mod wasm_impls {
     use core_path::channel_graph::ChannelGraph;
     use core_path::path::TransportPath;
     use core_path::DbPeerAddressResolver;
+    use core_protocol::ticket_aggregation::processor::AggregationList;
     use core_strategy::strategy::MultiStrategyConfig;
     use core_types::channels::{ChannelChange, ChannelStatus};
     use core_types::protocol::ApplicationData;
@@ -204,9 +205,11 @@ pub mod wasm_impls {
             timeout_in_millis: u64,
         ) -> Result<(), JsValue> {
             ok_or_jserr!(
-                ok_or_jserr!(self.ticket_aggregate_actions.aggregate_tickets(channel))?
-                    .consume_and_wait(std::time::Duration::from_millis(timeout_in_millis))
-                    .await
+                ok_or_jserr!(self
+                    .ticket_aggregate_actions
+                    .aggregate_tickets(AggregationList::WholeChannel(channel.clone())))?
+                .consume_and_wait(std::time::Duration::from_millis(timeout_in_millis))
+                .await
             )
         }
 

--- a/packages/core/crates/core-protocol/Cargo.toml
+++ b/packages/core/crates/core-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-protocol"
-version = "0.2.2"
+version = "0.2.3"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 license = "GPL-3.0-only"

--- a/packages/core/crates/core-protocol/src/ticket_aggregation/processor.rs
+++ b/packages/core/crates/core-protocol/src/ticket_aggregation/processor.rs
@@ -7,7 +7,7 @@ use core_crypto::{keypairs::ChainKeypair, types::OffchainPublicKey};
 use core_ethereum_db::traits::HoprCoreEthereumDbActions;
 use core_types::{
     acknowledgement::AcknowledgedTicket,
-    channels::{generate_channel_id, Ticket},
+    channels::{generate_channel_id, ChannelEntry, Ticket},
 };
 use futures::{
     channel::{
@@ -18,6 +18,7 @@ use futures::{
     pin_mut,
 };
 use futures_lite::stream::{Stream, StreamExt};
+use libp2p::request_response::{RequestId, ResponseChannel};
 use libp2p_identity::PeerId;
 use rust_stream_ext_concurrent::then_concurrent::StreamThenConcurrentExt;
 use std::{pin::Pin, sync::Arc, task::Poll};
@@ -28,8 +29,15 @@ use utils_types::{
 };
 
 #[cfg(any(not(feature = "wasm"), test))]
+use async_std::task::sleep;
+
+#[cfg(all(feature = "wasm", not(test)))]
+use gloo_timers::future::sleep;
+
+#[cfg(any(not(feature = "wasm"), test))]
 use async_std::task::spawn_local;
 
+use core_crypto::types::Hash;
 #[cfg(all(feature = "wasm", not(test)))]
 use wasm_bindgen_futures::spawn_local;
 
@@ -54,12 +62,35 @@ lazy_static::lazy_static! {
 pub const TICKET_AGGREGATION_TX_QUEUE_SIZE: usize = 2048;
 pub const TICKET_AGGREGATION_RX_QUEUE_SIZE: usize = 2048;
 
+/// Variants of lists of acknowledged tickets for aggregation
+#[derive(Clone, Debug)]
+pub enum AggregationList {
+    /// Aggregate all acknowledged tickets in the given channel
+    WholeChannel(ChannelEntry),
+
+    /// Aggregate the given range of acknowledged tickets in a channel
+    ChannelRange {
+        /// ID of the channel
+        channel_id: Hash,
+        /// Channel epoch
+        epoch: u32,
+        /// Starting ticket index
+        index_start: u64,
+        /// The last ticket index (inclusive)
+        index_end: u64,
+    },
+
+    /// Aggregate the given list of acknowledged tickets.
+    /// The tickets must belong to the same channel.
+    TicketList(Vec<AcknowledgedTicket>),
+}
+
 /// The input to the processor background pipeline
 #[derive(Debug)]
 pub enum TicketAggregationToProcess<T, U> {
     ToReceive(PeerId, std::result::Result<Ticket, String>, U),
     ToProcess(PeerId, Vec<AcknowledgedTicket>, T),
-    ToSend(ChannelEntry, TicketAggregationFinalizer),
+    ToSend(AggregationList, TicketAggregationFinalizer),
 }
 
 /// Emitted by the processor background pipeline once processed
@@ -305,35 +336,56 @@ impl<Db: HoprCoreEthereumDbActions> TicketAggregationProcessor<Db> {
         Ok(acked_aggregated_ticket)
     }
 
-    pub async fn prepare_aggregatable_tickets(
+    pub async fn validate_tickets_to_aggregate(
         &self,
-        channel: &ChannelEntry,
+        ticket_list: AggregationList,
     ) -> Result<(PeerId, Vec<AcknowledgedTicket>)> {
-        // get aggregatable tickets and them as being aggregated
-        let tickets_to_aggregate = self
-            .db
-            .write()
-            .await
-            .prepare_aggregatable_tickets(&channel.get_id(), channel.channel_epoch.as_u32(), 0u64, u64::MAX)
-            .await?;
+        let tickets_to_aggregate = match ticket_list {
+            AggregationList::WholeChannel(channel) => {
+                self.db
+                    .write()
+                    .await
+                    .prepare_aggregatable_tickets(&channel.get_id(), channel.channel_epoch.as_u32(), 0u64, u64::MAX)
+                    .await?
+            }
+            AggregationList::ChannelRange {
+                channel_id,
+                epoch,
+                index_start,
+                index_end,
+            } => {
+                self.db
+                    .write()
+                    .await
+                    .prepare_aggregatable_tickets(&channel_id, epoch, index_start, index_end)
+                    .await?
+            }
+            AggregationList::TicketList(list) => list,
+        };
 
         if tickets_to_aggregate.is_empty() {
-            debug!("No tickets to aggregate in {channel}, dropping request");
-            return Err(ProtocolTicketAggregation("No tickets to aggregate".into()));
+            debug!("got empty list of tickets to aggregate");
+            return Err(ProtocolTicketAggregation("no tickets to aggregate".into()));
         }
 
-        let source_peer_id = self
-            .db
-            .read()
-            .await
-            .get_packet_key(&tickets_to_aggregate[0].signer)
-            .await?
-            .ok_or_else(|| {
-                ProtocolTicketAggregation(format!(
-                    "Cannot aggregate tickets because we do not know the peerId for node {}",
-                    tickets_to_aggregate[0].signer
-                ))
-            })?;
+        let signer = tickets_to_aggregate[0].signer;
+        let channel_id = tickets_to_aggregate[0].ticket.channel_id;
+
+        if !tickets_to_aggregate
+            .iter()
+            .all(|tkt| tkt.signer == signer || tkt.ticket.channel_id == channel_id)
+        {
+            error!("some tickets to aggregate in the given list do not come from the same signer or channel id");
+            return Err(ProtocolTicketAggregation(
+                "invalid list of tickets to aggregate given".into(),
+            ));
+        }
+
+        let source_peer_id = self.db.read().await.get_packet_key(&signer).await?.ok_or_else(|| {
+            ProtocolTicketAggregation(format!(
+                "cannot aggregate tickets because we do not know the peer id for {signer}",
+            ))
+        })?;
 
         Ok((source_peer_id.to_peerid(), tickets_to_aggregate))
     }
@@ -349,13 +401,6 @@ impl From<oneshot::Receiver<()>> for TicketAggregationAwaiter {
         Self { rx: Some(value) }
     }
 }
-
-#[cfg(any(not(feature = "wasm"), test))]
-use async_std::task::sleep;
-use core_types::channels::ChannelEntry;
-#[cfg(all(feature = "wasm", not(test)))]
-use gloo_timers::future::sleep;
-use libp2p::request_response::{RequestId, ResponseChannel};
 
 impl TicketAggregationAwaiter {
     pub async fn consume_and_wait(&mut self, until_timeout: std::time::Duration) -> Result<()> {
@@ -436,11 +481,11 @@ impl<T, U> TicketAggregationActions<T, U> {
     }
 
     /// Pushes a new collection of tickets into the processing.
-    pub fn aggregate_tickets(&mut self, channel: &ChannelEntry) -> Result<TicketAggregationAwaiter> {
+    pub fn aggregate_tickets(&mut self, ack_tickets: AggregationList) -> Result<TicketAggregationAwaiter> {
         let (tx, rx) = oneshot::channel::<()>();
 
         self.process(TicketAggregationToProcess::ToSend(
-            *channel,
+            ack_tickets,
             TicketAggregationFinalizer::new(tx),
         ))?;
 
@@ -516,8 +561,8 @@ impl<T: 'static, U: 'static> TicketAggregationInteraction<T, U> {
                             }
                         }
                     }
-                    TicketAggregationToProcess::ToSend(channel, finalizer) => {
-                        match processor.prepare_aggregatable_tickets(&channel).await {
+                    TicketAggregationToProcess::ToSend(tickets_to_agg, finalizer) => {
+                        match processor.validate_tickets_to_aggregate(tickets_to_agg).await {
                             Ok((source, tickets)) => Some(TicketAggregationProcessed::Send(source, tickets, finalizer)),
                             Err(_) => None,
                         }
@@ -587,7 +632,7 @@ mod tests {
         traits::{BinarySerializable, PeerIdLike},
     };
 
-    use super::TicketAggregationProcessed;
+    use super::{AggregationList, TicketAggregationProcessed};
 
     lazy_static! {
         static ref PEERS: Vec<OffchainKeypair> = vec![
@@ -734,7 +779,10 @@ mod tests {
         let mut alice = super::TicketAggregationInteraction::<(), ()>::new(dbs[0].clone(), &PEERS_CHAIN[0]);
         let mut bob = super::TicketAggregationInteraction::<(), ()>::new(dbs[1].clone(), &PEERS_CHAIN[1]);
 
-        let mut awaiter = bob.writer().aggregate_tickets(&channel_alice_bob).unwrap();
+        let mut awaiter = bob
+            .writer()
+            .aggregate_tickets(AggregationList::WholeChannel(channel_alice_bob))
+            .unwrap();
         let mut finalizer = None;
         match bob.next().await {
             Some(TicketAggregationProcessed::Send(_, acked_tickets, request_finalizer)) => {

--- a/packages/core/crates/core-protocol/src/ticket_aggregation/processor.rs
+++ b/packages/core/crates/core-protocol/src/ticket_aggregation/processor.rs
@@ -3,7 +3,7 @@ use crate::errors::{
     Result,
 };
 use async_lock::RwLock;
-use core_crypto::{keypairs::ChainKeypair, types::OffchainPublicKey};
+use core_crypto::{keypairs::ChainKeypair, types::Hash, types::OffchainPublicKey};
 use core_ethereum_db::traits::HoprCoreEthereumDbActions;
 use core_types::{
     acknowledgement::AcknowledgedTicket,
@@ -37,7 +37,6 @@ use gloo_timers::future::sleep;
 #[cfg(any(not(feature = "wasm"), test))]
 use async_std::task::spawn_local;
 
-use core_crypto::types::Hash;
 #[cfg(all(feature = "wasm", not(test)))]
 use wasm_bindgen_futures::spawn_local;
 

--- a/packages/core/crates/core-strategy/Cargo.toml
+++ b/packages/core/crates/core-strategy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-strategy"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Contains implementations of different HOPR strategies"
 edition = "2021"

--- a/packages/core/crates/core-strategy/src/aggregating.rs
+++ b/packages/core/crates/core-strategy/src/aggregating.rs
@@ -116,6 +116,7 @@ impl<Db: HoprCoreEthereumDbActions + Clone, T, U> AggregatingStrategy<Db, T, U> 
 impl<Db: HoprCoreEthereumDbActions + 'static + Clone, T, U> AggregatingStrategy<Db, T, U> {
     async fn start_aggregation(&self, channel: ChannelEntry, redeem_if_failed: bool) -> crate::errors::Result<()> {
         debug!("{self} strategy: starting aggregation in {channel}");
+        // Perform marking as redeem ahead, to avoid concurrent aggregation race here
         let tickets_to_agg = self
             .db
             .write()

--- a/packages/core/crates/core-strategy/src/aggregating.rs
+++ b/packages/core/crates/core-strategy/src/aggregating.rs
@@ -116,7 +116,7 @@ impl<Db: HoprCoreEthereumDbActions + Clone, T, U> AggregatingStrategy<Db, T, U> 
 impl<Db: HoprCoreEthereumDbActions + 'static + Clone, T, U> AggregatingStrategy<Db, T, U> {
     async fn start_aggregation(&self, channel: ChannelEntry, redeem_if_failed: bool) -> crate::errors::Result<()> {
         debug!("{self} strategy: starting aggregation in {channel}");
-        // Perform marking as redeem ahead, to avoid concurrent aggregation race here
+        // Perform marking as aggregated ahead, to avoid concurrent aggregation races in spawn_local
         let tickets_to_agg = self
             .db
             .write()

--- a/packages/core/crates/core-types/src/acknowledgement.rs
+++ b/packages/core/crates/core-types/src/acknowledgement.rs
@@ -82,17 +82,42 @@ impl BinarySerializable for Acknowledgement {
     }
 }
 
+/// Status of the acknowledged ticket.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub enum AcknowledgedTicketStatus {
+    /// The ticket is available for redeeming or aggregating
     #[default]
     Untouched,
-    BeingRedeemed {
-        tx_hash: Hash,
-    },
-    BeingAggregated {
-        start: u64,
-        end: u64,
-    },
+    /// Ticket is currently being redeemed in and on-going redemption process
+    BeingRedeemed { tx_hash: Hash },
+    /// Ticket is currently being aggregated in and on-going aggregation process
+    BeingAggregated { start: u64, end: u64 },
+}
+
+impl AcknowledgedTicketStatus {
+    /// Short-hand to check if the ticket is `BeingAggregated`
+    pub fn is_being_redeemed(&self) -> bool {
+        match self {
+            AcknowledgedTicketStatus::BeingRedeemed { .. } => true,
+            _ => false,
+        }
+    }
+
+    /// Short-hand to check if the ticket is `BeingRedeemed`
+    pub fn is_being_aggregated(&self) -> bool {
+        match self {
+            AcknowledgedTicketStatus::BeingAggregated { .. } => true,
+            _ => false,
+        }
+    }
+
+    /// Short-hand to check if the ticket is `Untouched`
+    pub fn is_untouched(&self) -> bool {
+        match self {
+            AcknowledgedTicketStatus::Untouched { .. } => true,
+            _ => false,
+        }
+    }
 }
 
 impl Display for AcknowledgedTicketStatus {


### PR DESCRIPTION
This PR splits ticket aggregation API interface into 3 different possible calls:

- aggregate all tickets in the given channel (this was the existing functionality)
- aggregate the given range of tickets in the given channel (new)
- aggregate the give list of acknowledged tickets (new)

This separation is important for the aggregation strategy, which must manually first gather the aggregatable tickets in a channel (and mark them as being aggregated) and only then proceed with the aggregation. 
Without this separation, it was possible that the aggregation requests from the strategy could interleave, resulting in doubling the aggregation request.

Fixes #5638