### PR TITLE
Optimizations to strategies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "core-strategy"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "async-std",
  "async-trait",

--- a/packages/core/crates/core-strategy/Cargo.toml
+++ b/packages/core/crates/core-strategy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-strategy"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Contains implementations of different HOPR strategies"
 edition = "2021"

--- a/packages/core/crates/core-strategy/README.md
+++ b/packages/core/crates/core-strategy/README.md
@@ -34,6 +34,9 @@ The constant `k` can be also set to a value > 1, which will make the strategy to
 but it would keep the same asymptotic properties.
 Per default `k` = 1.
 
+The strategy starts acting only after at least 10 network size samples were gathered, which means
+it does not start opening/closing channels earlier than 10 minutes after the node start.
+
 ### Default parameters
 
 - `network_quality_threshold`: 0.5

--- a/packages/core/crates/core-strategy/src/aggregating.rs
+++ b/packages/core/crates/core-strategy/src/aggregating.rs
@@ -115,7 +115,7 @@ impl<Db: HoprCoreEthereumDbActions + Clone, T, U> AggregatingStrategy<Db, T, U> 
 
 impl<Db: HoprCoreEthereumDbActions + 'static + Clone, T, U> AggregatingStrategy<Db, T, U> {
     async fn start_aggregation(&self, channel: ChannelEntry, redeem_if_failed: bool) -> crate::errors::Result<()> {
-        debug!("{self} strategy: starting aggregation in {channel}");
+        debug!("starting aggregation in {channel}");
         // Perform marking as aggregated ahead, to avoid concurrent aggregation races in spawn_local
         let tickets_to_agg = self
             .db
@@ -125,7 +125,7 @@ impl<Db: HoprCoreEthereumDbActions + 'static + Clone, T, U> AggregatingStrategy<
             .await?;
 
         info!(
-            "{self} strategy: will aggregate {} tickets in {channel}",
+            "will aggregate {} tickets in {channel}",
             tickets_to_agg.len()
         );
 
@@ -139,22 +139,21 @@ impl<Db: HoprCoreEthereumDbActions + 'static + Clone, T, U> AggregatingStrategy<
                 // Spawn waiting for the aggregation as a separate task
                 let agg_timeout = self.cfg.aggregation_timeout;
                 let actions_clone = self.chain_actions.clone();
-                let strategy_id = self.to_string();
 
                 spawn_local(async move {
                     match awaiter.consume_and_wait(agg_timeout).await {
                         Ok(_) => {
                             // The TicketAggregationActions will raise the on_acknowledged_ticket event,
                             // so the AutoRedeem strategy can take care of redeeming if needed
-                            info!("{strategy_id} strategy: has completed ticket aggregation");
+                            info!("completed ticket aggregation");
                         }
                         Err(e) => {
-                            warn!("{strategy_id} strategy: could not aggregate tickets: {e}");
+                            warn!("could not aggregate tickets: {e}");
                             if redeem_if_failed {
-                                info!("{strategy_id} strategy: initiating redemption of all tickets in {channel} after aggregation failure");
+                                info!("initiating redemption of all tickets in {channel} after aggregation failure");
 
                                 if let Err(e) = actions_clone.redeem_tickets_in_channel(&channel, false).await {
-                                    error!("{strategy_id} strategy: failed to issue redeeming of all tickets in {channel}: {e}");
+                                    error!("failed to issue redeeming of all tickets in {channel}: {e}");
                                 }
 
                                 // We do not need to await the redemption completion of all the tickets
@@ -166,7 +165,7 @@ impl<Db: HoprCoreEthereumDbActions + 'static + Clone, T, U> AggregatingStrategy<
                 Ok(())
             }
             Err(e) => {
-                warn!("{self} strategy: could not initiate aggregate tickets due to {e}");
+                warn!("could not initiate aggregate tickets due to {e}");
                 Err(crate::errors::StrategyError::Other("ticket aggregation failed".into()))
             }
         }
@@ -181,7 +180,7 @@ impl<Db: HoprCoreEthereumDbActions + 'static + Clone, T, U> SingularStrategy for
         let channel = match self.db.read().await.get_channel(&channel_id).await? {
             Some(channel) => channel,
             None => {
-                error!("{self} strategy: encountered {ack} in a non-existing channel!");
+                error!("encountered {ack} in a non-existing channel!");
                 return Err(ChannelDoesNotExist.into());
             }
         };
@@ -199,7 +198,7 @@ impl<Db: HoprCoreEthereumDbActions + 'static + Clone, T, U> SingularStrategy for
                 }
                 AcknowledgedTicketStatus::BeingAggregated { .. } => {
                     debug!(
-                        "{self} strategy: {channel} already has ticket aggregation in progress, not aggregating yet"
+                        "{channel} already has ticket aggregation in progress, not aggregating yet"
                     );
                     return Ok(());
                 }
@@ -212,10 +211,10 @@ impl<Db: HoprCoreEthereumDbActions + 'static + Clone, T, U> SingularStrategy for
         // Check the aggregation threshold
         if let Some(agg_threshold) = self.cfg.aggregation_threshold {
             if aggregatable_tickets >= agg_threshold {
-                info!("{self} strategy: {channel} has {aggregatable_tickets} >= {agg_threshold} ack tickets");
+                info!("{channel} has {aggregatable_tickets} >= {agg_threshold} ack tickets");
                 can_aggregate = true;
             } else {
-                debug!("{self} strategy: {channel} has {aggregatable_tickets} < {agg_threshold} ack tickets, not aggregating yet");
+                debug!("{channel} has {aggregatable_tickets} < {agg_threshold} ack tickets, not aggregating yet");
             }
         }
         if let Some(unrealized_threshold) = self.cfg.unrealized_balance_ratio {
@@ -225,14 +224,14 @@ impl<Db: HoprCoreEthereumDbActions + 'static + Clone, T, U> SingularStrategy for
             // and there are at least two tickets
             if unredeemed_value.gte(&diminished_balance) {
                 if aggregatable_tickets > 1 {
-                    info!("{self} strategy: {channel} has unrealized balance {unredeemed_value} >= {diminished_balance} in {aggregatable_tickets} tickets");
+                    info!("{channel} has unrealized balance {unredeemed_value} >= {diminished_balance} in {aggregatable_tickets} tickets");
                     can_aggregate = true;
                 } else {
-                    debug!("{self} strategy: {channel} has unrealized balance {unredeemed_value} >= {diminished_balance} but in just {aggregatable_tickets} tickets, not aggregating yet");
+                    debug!("{channel} has unrealized balance {unredeemed_value} >= {diminished_balance} but in just {aggregatable_tickets} tickets, not aggregating yet");
                 }
             } else {
                 debug!(
-                    "{self} strategy: {channel} has unrealized balance {unredeemed_value} < {diminished_balance} in {aggregatable_tickets} tickets, not aggregating yet"
+                    "{channel} has unrealized balance {unredeemed_value} < {diminished_balance} in {aggregatable_tickets} tickets, not aggregating yet"
                 );
             }
         }
@@ -241,7 +240,7 @@ impl<Db: HoprCoreEthereumDbActions + 'static + Clone, T, U> SingularStrategy for
         if can_aggregate {
             self.start_aggregation(channel, false).await
         } else {
-            debug!("{self} strategy: channel {channel_id} has not met the criteria for aggregation");
+            debug!("channel {channel_id} has not met the criteria for aggregation");
             Ok(())
         }
     }
@@ -258,7 +257,7 @@ impl<Db: HoprCoreEthereumDbActions + 'static + Clone, T, U> SingularStrategy for
 
         if let ChannelChange::Status { left: old, right: new } = change {
             if old != ChannelStatus::Open || new != ChannelStatus::PendingToClose {
-                debug!("{self} strategy: ignoring channel {channel} state change that's not in PendingToClose");
+                debug!("ignoring channel {channel} state change that's not in PendingToClose");
                 return Ok(());
             }
 
@@ -273,7 +272,7 @@ impl<Db: HoprCoreEthereumDbActions + 'static + Clone, T, U> SingularStrategy for
                     }
                     AcknowledgedTicketStatus::BeingAggregated { .. } => {
                         debug!(
-                        "{self} strategy: {channel} already has ticket aggregation in progress, not aggregating yet"
+                        "{channel} already has ticket aggregation in progress, not aggregating yet"
                     );
                         return Ok(());
                     }
@@ -282,10 +281,10 @@ impl<Db: HoprCoreEthereumDbActions + 'static + Clone, T, U> SingularStrategy for
             }
 
             if aggregatable_tickets > 1 {
-                debug!("{self} strategy: {channel} has {aggregatable_tickets} aggregatable tickets");
+                debug!("{channel} has {aggregatable_tickets} aggregatable tickets");
                 self.start_aggregation(*channel, true).await
             } else {
-                debug!("{self} strategy: closing {channel} does not have more than 1 tickets to aggregate");
+                debug!("closing {channel} does not have more than 1 tickets to aggregate");
                 Ok(())
             }
         } else {

--- a/packages/core/crates/core-strategy/src/aggregating.rs
+++ b/packages/core/crates/core-strategy/src/aggregating.rs
@@ -124,10 +124,7 @@ impl<Db: HoprCoreEthereumDbActions + 'static + Clone, T, U> AggregatingStrategy<
             .prepare_aggregatable_tickets(&channel.get_id(), channel.channel_epoch.as_u32(), 0u64, u64::MAX)
             .await?;
 
-        info!(
-            "will aggregate {} tickets in {channel}",
-            tickets_to_agg.len()
-        );
+        info!("will aggregate {} tickets in {channel}", tickets_to_agg.len());
 
         match self
             .ticket_aggregator
@@ -197,9 +194,7 @@ impl<Db: HoprCoreEthereumDbActions + 'static + Clone, T, U> SingularStrategy for
                     unredeemed_value = unredeemed_value.add(&ticket.ticket.amount);
                 }
                 AcknowledgedTicketStatus::BeingAggregated { .. } => {
-                    debug!(
-                        "{channel} already has ticket aggregation in progress, not aggregating yet"
-                    );
+                    debug!("{channel} already has ticket aggregation in progress, not aggregating yet");
                     return Ok(());
                 }
                 AcknowledgedTicketStatus::BeingRedeemed { .. } => {}
@@ -271,9 +266,7 @@ impl<Db: HoprCoreEthereumDbActions + 'static + Clone, T, U> SingularStrategy for
                         aggregatable_tickets += 1;
                     }
                     AcknowledgedTicketStatus::BeingAggregated { .. } => {
-                        debug!(
-                        "{channel} already has ticket aggregation in progress, not aggregating yet"
-                    );
+                        debug!("{channel} already has ticket aggregation in progress, not aggregating yet");
                         return Ok(());
                     }
                     AcknowledgedTicketStatus::BeingRedeemed { .. } => {}

--- a/packages/core/crates/core-strategy/src/auto_funding.rs
+++ b/packages/core/crates/core-strategy/src/auto_funding.rs
@@ -79,7 +79,7 @@ impl<Db: HoprCoreEthereumDbActions + Clone> SingularStrategy for AutoFundingStra
         if let ChannelChange::CurrentBalance { right: new, .. } = change {
             if new.lt(&self.cfg.min_stake_threshold) && channel.status == ChannelStatus::Open {
                 info!(
-                    "{self} strategy: stake on {channel} is below threshold {} < {}",
+                    "stake on {channel} is below threshold {} < {}",
                     channel.balance, self.cfg.min_stake_threshold
                 );
 
@@ -89,7 +89,7 @@ impl<Db: HoprCoreEthereumDbActions + Clone> SingularStrategy for AutoFundingStra
                     .await?;
                 std::mem::drop(rx); // The Receiver is not intentionally awaited here and the oneshot Sender can fail safely
                 info!(
-                    "{self} strategy: issued re-staking of {channel} with {}",
+                    "issued re-staking of {channel} with {}",
                     self.cfg.funding_amount
                 );
             }

--- a/packages/core/crates/core-strategy/src/auto_funding.rs
+++ b/packages/core/crates/core-strategy/src/auto_funding.rs
@@ -88,10 +88,7 @@ impl<Db: HoprCoreEthereumDbActions + Clone> SingularStrategy for AutoFundingStra
                     .fund_channel(channel.get_id(), self.cfg.funding_amount)
                     .await?;
                 std::mem::drop(rx); // The Receiver is not intentionally awaited here and the oneshot Sender can fail safely
-                info!(
-                    "issued re-staking of {channel} with {}",
-                    self.cfg.funding_amount
-                );
+                info!("issued re-staking of {channel} with {}", self.cfg.funding_amount);
             }
         }
 

--- a/packages/core/crates/core-strategy/src/auto_redeeming.rs
+++ b/packages/core/crates/core-strategy/src/auto_redeeming.rs
@@ -57,7 +57,7 @@ impl<Db: HoprCoreEthereumDbActions + Clone> AutoRedeemingStrategy<Db> {
 impl<Db: HoprCoreEthereumDbActions + 'static + Clone> SingularStrategy for AutoRedeemingStrategy<Db> {
     async fn on_acknowledged_winning_ticket(&self, ack: &AcknowledgedTicket) -> crate::errors::Result<()> {
         if !self.cfg.redeem_only_aggregated || ack.ticket.is_aggregated() {
-            info!("{self} strategy: auto-redeeming {ack}");
+            info!("redeeming {ack}");
             let rx = self.chain_actions.redeem_ticket(ack.clone()).await?;
             std::mem::drop(rx); // The Receiver is not intentionally awaited here and the oneshot Sender can fail safely
         }

--- a/packages/core/crates/core-strategy/src/promiscuous.rs
+++ b/packages/core/crates/core-strategy/src/promiscuous.rs
@@ -27,7 +27,7 @@ use crate::{decision::ChannelDecision, Strategy};
 use utils_types::traits::PeerIdLike;
 
 /// Size of the simple moving average window used to smoothen the number of registered peers.
-pub const SMA_WINDOW_SIZE: usize = 3;
+pub const SMA_WINDOW_SIZE: usize = 10;
 
 type SimpleMovingAvg = SumTreeSMA<usize, usize, SMA_WINDOW_SIZE>;
 
@@ -174,6 +174,7 @@ where
             .into_iter()
             .filter(|channel| channel.status == ChannelStatus::Open)
             .collect::<Vec<_>>();
+        debug!("tracking {} open outgoing channels", outgoing_open_channels.len());
 
         // Check if we have enough network size samples before proceeding quality-based evaluation
         let peers_with_quality = self.get_peers_with_quality().await;
@@ -217,7 +218,7 @@ where
         // lowest-quality ones which passed the threshold
         if occupied > max_auto_channels && self.cfg.enforce_max_channels {
             warn!(
-                "{self} strategy: there are {occupied} effectively opened channels, but the strategy allows only {max_auto_channels}"
+                "there are {occupied} effectively opened channels, but the strategy allows only {max_auto_channels}"
             );
 
             // Get all open channels which are not planned to be closed
@@ -249,8 +250,9 @@ where
             sorted_channels
                 .into_iter()
                 .take(occupied - max_auto_channels)
-                .for_each(|c| {
-                    tick_decision.add_to_close(c.clone());
+                .for_each(|channel| {
+                    debug!("enforcing channel closure of {channel}");
+                    tick_decision.add_to_close(*channel);
                 });
         } else if max_auto_channels > occupied {
             // Sort the new channel candidates by best quality first, then truncate to the number of available slots
@@ -267,7 +269,7 @@ where
             for (address, _) in new_channel_candidates {
                 // Stop if we ran out of balance
                 if remaining_balance.lte(&self.cfg.minimum_node_balance) {
-                    warn!("{self} strategy: ran out of allowed node balance - balance is {remaining_balance}");
+                    warn!("ran out of allowed node balance - balance is {remaining_balance}");
                     break;
                 }
 
@@ -280,7 +282,7 @@ where
             }
         } else {
             // max_channels == occupied
-            info!("{self} strategy: not going to allocate new channels, maximum number of effective channels is reached ({occupied})")
+            info!("not going to allocate new channels, maximum number of effective channels is reached ({occupied})")
         }
 
         Ok(tick_decision)
@@ -316,7 +318,7 @@ where
     async fn on_tick(&self) -> Result<()> {
         let tick_decision = self.collect_tick_decision().await?;
 
-        debug!("{self} strategy: on tick executing {tick_decision}");
+        debug!("on tick executing {tick_decision}");
 
         for channel_to_close in tick_decision.get_to_close() {
             match self
@@ -330,10 +332,10 @@ where
             {
                 Ok(_) => {
                     // Intentionally do not await result of the channel transaction
-                    debug!("{self} strategy: issued channel closing tx: {}", channel_to_close);
+                    debug!("issued channel closing tx: {}", channel_to_close);
                 }
                 Err(e) => {
-                    error!("{self} strategy: error while closing channel: {e}");
+                    error!("error while closing channel: {e}");
                 }
             }
         }
@@ -346,18 +348,18 @@ where
             {
                 Ok(_) => {
                     // Intentionally do not await result of the channel transaction
-                    debug!("{self} strategy: issued channel opening tx: {}", channel_to_open.0);
+                    debug!("issued channel opening tx: {}", channel_to_open.0);
                 }
                 Err(e) => {
                     error!(
-                        "{self} strategy: error while issuing channel opening to {}: {e}",
+                        "error while issuing channel opening to {}: {e}",
                         channel_to_open.0
                     );
                 }
             }
         }
 
-        info!("{self} strategy: on tick executed {tick_decision}");
+        info!("on tick executed {tick_decision}");
         Ok(())
     }
 }
@@ -557,8 +559,9 @@ mod tests {
             .unwrap();
 
         // Add fake samples to allow the test to run
-        strat.sma.write().await.add_sample(peers.len());
-        strat.sma.write().await.add_sample(peers.len());
+        for _ in 0..SMA_WINDOW_SIZE - 1 {
+            strat.sma.write().await.add_sample(peers.len());
+        }
         (strat, address_peer_id_pairs)
     }
 

--- a/packages/core/crates/core-strategy/src/promiscuous.rs
+++ b/packages/core/crates/core-strategy/src/promiscuous.rs
@@ -217,9 +217,7 @@ where
         // If there is still more channels opened than we allow, close some
         // lowest-quality ones which passed the threshold
         if occupied > max_auto_channels && self.cfg.enforce_max_channels {
-            warn!(
-                "there are {occupied} effectively opened channels, but the strategy allows only {max_auto_channels}"
-            );
+            warn!("there are {occupied} effectively opened channels, but the strategy allows only {max_auto_channels}");
 
             // Get all open channels which are not planned to be closed
             let mut sorted_channels = outgoing_open_channels
@@ -351,10 +349,7 @@ where
                     debug!("issued channel opening tx: {}", channel_to_open.0);
                 }
                 Err(e) => {
-                    error!(
-                        "error while issuing channel opening to {}: {e}",
-                        channel_to_open.0
-                    );
+                    error!("error while issuing channel opening to {}: {e}", channel_to_open.0);
                 }
             }
         }


### PR DESCRIPTION
Smaller strategies improvements:

- increase SMA windows size in promiscuous mode to 10 (= the strategy starts to act not earlier than after 10 minutes since Node startup)
- cleaned up logging in strategies