### PR TITLE
Fix issue with non-deleting binding repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ clean: # Cleanup build directories (lib,build, ...etc.)
 	cargo clean
 	yarn clean
 	find packages -type f -name "*.js" -path "packages/*/src/*" ! -path "packages/*/crates/*" -delete
-	find packages/ethereum/crates/bindings/src -type f -delete
+	find packages/ethereum/crates/bindings/src -delete
 
 .PHONY: reset
 reset: # Performs cleanup & also deletes all "node_modules" directories


### PR DESCRIPTION
The `make clean` command removed the contents of the `bindings` directory, but not the directory structure itself. When followed by the `make build` command, it was not possible to build the project, because the existing empty directory structure forced skipping of the bindings generation.

