### PR TITLE
Fix usage of Address type in TS

### DIFF
--- a/packages/core-ethereum/crates/core-ethereum-actions/src/transaction_queue.rs
+++ b/packages/core-ethereum/crates/core-ethereum-actions/src/transaction_queue.rs
@@ -164,7 +164,7 @@ impl<Db: HoprCoreEthereumDbActions + 'static> TransactionQueue<Db> {
                         Failure(e) => {
                             // TODO: once we can distinguish EVM execution failure from `e`, we can mark ticket as losing instead
 
-                            error!("marking the acknowledged ticket as untouched - edeem tx failed: {e}");
+                            error!("marking the acknowledged ticket as untouched - redeem tx failed: {e}");
                             ack.status = AcknowledgedTicketStatus::Untouched;
                             if let Err(e) = db.write().await.update_acknowledged_ticket(&ack).await {
                                 error!("cannot mark {ack} as untouched: {e}");

--- a/packages/core-ethereum/src/index.ts
+++ b/packages/core-ethereum/src/index.ts
@@ -238,9 +238,14 @@ export default class HoprCoreEthereum extends EventEmitter {
    * @returns HOPR balance
    */
   public async getBalance(useIndexer: boolean = false): Promise<Balance> {
-    return useIndexer
-      ? Balance.deserialize((await this.db.get_hopr_balance()).serialize_value(), BalanceType.HOPR)
-      : this.chain.getBalance(this.chainKeypair.to_address())
+    let ret
+    if (useIndexer) {
+      ret = await this.db.get_hopr_balance()
+    } else {
+      let selfAddr = this.chainKeypair.to_address()
+      ret = this.chain.getBalance(selfAddr)
+    }
+    return ret
   }
 
   public getPublicKey(): PublicKey {
@@ -310,7 +315,8 @@ export default class HoprCoreEthereum extends EventEmitter {
   async openChannel(dest: Address, amount: Balance): Promise<{ channel_id: string; receipt: string }> {
     log(`opening channel to ${dest.to_hex()} with amount ${amount.to_formatted_string()}`)
     const receipt = await this.fundChannel(dest, amount)
-    return { channel_id: generate_channel_id(this.chainKeypair.to_address(), dest).to_hex(), receipt }
+    let selfAddr = this.chainKeypair.to_address()
+    return { channel_id: generate_channel_id(selfAddr, dest).to_hex(), receipt }
   }
 
   // This operation works on open and closed channels. More assertions must be

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -442,7 +442,8 @@ export class Hopr extends EventEmitter {
   private async onTicketRedeemed(channel: ChannelEntry, ticketAmount: Balance): Promise<void> {
     // We are only interested in channels where we are the source, since only
     // then we track the pending balance.
-    if (channel.source.eq(this.getEthereumAddress())) {
+    let selfAddr = this.getEthereumAddress()
+    if (channel.source.eq(selfAddr)) {
       await this.db.resolve_pending(channel.destination, ticketAmount)
     }
   }
@@ -704,9 +705,8 @@ export class Hopr extends EventEmitter {
 
     metric_pathLength.observe(path.length())
 
-    return (
-      await this.tools.send_message(new ApplicationData(applicationTag, msg), path, PACKET_QUEUE_TIMEOUT_MILLISECONDS)
-    ).to_hex()
+    let appData = new ApplicationData(applicationTag, msg)
+    return (await this.tools.send_message(appData, path, PACKET_QUEUE_TIMEOUT_MILLISECONDS)).to_hex()
   }
 
   /**
@@ -884,7 +884,8 @@ export class Hopr extends EventEmitter {
     }
 
     // Check if there was a previous announcement from us
-    const ownAccount = await connector.getAccount(this.getEthereumAddress())
+    let selfAddr = this.getEthereumAddress()
+    const ownAccount = await connector.getAccount(selfAddr)
 
     // Do not announce if our last is equal to what we intend to announce
     log('known own multiaddr from previous announcement %s', ownAccount?.get_multiaddr_str())
@@ -943,7 +944,8 @@ export class Hopr extends EventEmitter {
 
   public async getNativeBalance(): Promise<Balance> {
     verbose('Requesting native balance for node')
-    return await HoprCoreEthereum.getInstance().getNativeBalance(this.getEthereumAddress().to_string(), true)
+    let selfAddr = this.getEthereumAddress()
+    return await HoprCoreEthereum.getInstance().getNativeBalance(selfAddr.to_string(), true)
   }
 
   public async getSafeBalance(): Promise<Balance> {
@@ -1058,7 +1060,8 @@ export class Hopr extends EventEmitter {
     log(`looking for tickets in channel ${channelId.to_hex()}`)
     const channel = await this.db.get_channel(channelId)
     // return no tickets if channel does not exist or is not an incoming channel
-    if (!channel || !channel.destination.eq(this.getEthereumAddress())) {
+    let selfAddr = this.getEthereumAddress()
+    if (!channel || !channel.destination.eq(selfAddr)) {
       return []
     }
 
@@ -1125,7 +1128,8 @@ export class Hopr extends EventEmitter {
       log(`trying to redeem tickets in channel ${channelId.to_hex()}`)
       const channel = await this.db.get_channel(channelId)
       let actions = this.tools.chain_actions()
-      if (channel?.destination.eq(this.getEthereumAddress())) {
+      let selfAddr = this.getEthereumAddress()
+      if (channel?.destination.eq(selfAddr)) {
         await actions.redeem_tickets_in_channel(channel, onlyAggregated)
       } else {
         log(`cannot redeem tickets in channel ${channelId.to_hex()}`)
@@ -1213,7 +1217,6 @@ export class Hopr extends EventEmitter {
 
   /**
    * Withdraw on-chain assets to a given address
-   * @param currency either native currency or HOPR tokens
    * @param recipient the account where the assets should be transferred to
    * @param amount how many tokens to be transferred
    * @returns
@@ -1243,8 +1246,9 @@ export class Hopr extends EventEmitter {
    */
   public async isAllowedAccessToNetwork(id: PeerId): Promise<boolean> {
     // Don't wait for key binding and local linking if identity is the local node
+    let selfAddr = this.getEthereumAddress()
     if (this.id.equals(id)) {
-      return await this.db.is_allowed_to_access_network(this.getEthereumAddress())
+      return await this.db.is_allowed_to_access_network(selfAddr)
     }
     let chain_key: Address = await this.peerIdToChainKey(id)
     // Only check if we found a chain key, otherwise peer is not allowed


### PR DESCRIPTION
The possible root cause of #5650 is immediate usage of the `Address` type in Rust function calls. Whenever possible, Rust types need to be put into temporary variable before being passed to WASM-bound functions.

Refs #5650 