### PR TITLE
Prevent packet keys with `0xff` prefix to be generated

### DIFF
--- a/packages/core/crates/core-crypto/Cargo.toml
+++ b/packages/core/crates/core-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-crypto"
-version = "0.5.1"
+version = "0.5.2"
 description = "Core cryptographic primitives and functions used in the HOPR protocol"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"

--- a/packages/core/crates/core-crypto/src/keypairs.rs
+++ b/packages/core/crates/core-crypto/src/keypairs.rs
@@ -51,7 +51,12 @@ impl Keypair for OffchainKeypair {
     type Public = OffchainPublicKey;
 
     fn random() -> Self {
-        Self::from_secret(&random_bytes::<{ ed25519_dalek::SECRET_KEY_LENGTH }>()).unwrap()
+        let mut kp = Self::from_secret(&random_bytes::<{ ed25519_dalek::SECRET_KEY_LENGTH }>()).unwrap();
+        // TODO: remove this loop once https://github.com/hoprnet/hoprnet/pull/5665 is merged
+        while kp.1.to_bytes().as_ref()[0] == 0xff {
+            kp = Self::from_secret(&random_bytes::<{ ed25519_dalek::SECRET_KEY_LENGTH }>()).unwrap();
+        }
+        kp
     }
 
     fn from_secret(bytes: &[u8]) -> errors::Result<Self> {

--- a/packages/core/crates/core-strategy/src/strategy.rs
+++ b/packages/core/crates/core-strategy/src/strategy.rs
@@ -18,7 +18,6 @@ use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Debug, Display, Formatter};
 use std::sync::Arc;
-use strum::VariantNames;
 use utils_log::{debug, error, info, warn};
 use validator::Validate;
 
@@ -29,7 +28,10 @@ use utils_misc::time::native::current_timestamp;
 use utils_misc::time::wasm::current_timestamp;
 
 #[cfg(all(feature = "prometheus", not(test)))]
-use utils_metrics::metrics::{MultiGauge, SimpleCounter};
+use {
+    strum::VariantNames,
+    utils_metrics::metrics::{MultiGauge, SimpleCounter},
+};
 
 #[cfg(all(feature = "prometheus", not(test)))]
 lazy_static::lazy_static! {

--- a/packages/hoprd/src/index.ts
+++ b/packages/hoprd/src/index.ts
@@ -229,6 +229,12 @@ async function main() {
     log(`chain_key ${keypair.chain_key.public().to_hex(true)}`)
     log(`packet_key ${keypair.packet_key.public().to_peerid_str()}`)
 
+    if (keypair.packet_key.public().to_string().startsWith('0xff')) {
+      log(
+        `WARNING: this node uses invalid packet key type and won't be able to become an effective relay, please create a new identity!`
+      )
+    }
+
     // 2. Create node instance
     log('Creating HOPR Node')
     node = await createHoprNode(keypair.chain_key, keypair.packet_key, cfg, false)


### PR DESCRIPTION
Also issues a warning to the logs if such key is already in-use.

This is a temporary solution, until a backwards compatible fix is merged in #5665

Closes #5666
Closes #5667