### PR TITLE
Add token balance checks to open/fund channels

### DIFF
--- a/packages/core-ethereum/crates/core-ethereum-actions/src/errors.rs
+++ b/packages/core-ethereum/crates/core-ethereum-actions/src/errors.rs
@@ -25,6 +25,9 @@ pub enum CoreEthereumActionsError {
     #[error("ticket is not a win")]
     NotAWinningTicket,
 
+    #[error("balance is too low to perform the operation")]
+    BalanceTooLow,
+
     #[error("safe does not have enough allowance to fund channel")]
     NotEnoughAllowance,
 

--- a/packages/core-ethereum/crates/core-ethereum-actions/src/node.rs
+++ b/packages/core-ethereum/crates/core-ethereum-actions/src/node.rs
@@ -22,6 +22,8 @@ impl<Db: HoprCoreEthereumDbActions + Clone> NodeActions for CoreEthereumActions<
             return Err(InvalidArguments("cannot withdraw zero amount".into()).into());
         }
 
+        // TODO: should we check native/token balance here before withdrawing ?
+
         self.tx_sender.send(Transaction::Withdraw(recipient, amount)).await
     }
 }

--- a/packages/core/crates/core-strategy/src/auto_funding.rs
+++ b/packages/core/crates/core-strategy/src/auto_funding.rs
@@ -209,6 +209,12 @@ mod tests {
 
         db.write()
             .await
+            .set_hopr_balance(&Balance::new(5_000_000u64.into(), BalanceType::HOPR))
+            .await
+            .unwrap();
+
+        db.write()
+            .await
             .set_channels_domain_separator(&Hash::default(), &Snapshot::default())
             .await
             .unwrap();


### PR DESCRIPTION
The prior check for token balance before opening or funding channel was missing, which led to redundant TX which will clearly fail on-chain.