### PR TITLE
Skip aggregated tickets in unrealized balance criteria

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1467,7 +1467,7 @@ dependencies = [
 
 [[package]]
 name = "core-strategy"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "async-std",
  "async-trait",

--- a/packages/core/crates/core-strategy/Cargo.toml
+++ b/packages/core/crates/core-strategy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-strategy"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Contains implementations of different HOPR strategies"
 edition = "2021"

--- a/packages/core/crates/core-strategy/README.md
+++ b/packages/core/crates/core-strategy/README.md
@@ -79,7 +79,7 @@ This strategy listens for two distinct channel events and triggers the interacti
 
 This strategy listens to newly added acknowledged winning tickets and once the amount of tickets in a certain channel reaches
 an `aggregation_threshold`, the strategy will initiate ticket aggregation in that channel.
-The strategy can independently also check if the unrealized balance (current balance _minus_ unredeemed tickets value) in a certain channel
+The strategy can independently also check if the unrealized balance (current balance _minus_ total unredeemed unaggregated tickets value) in a certain channel
 has not gone over `unrelalized_balance_ratio` percent of the current balance in that channel. If that happens, the strategy will also initiate
 ticket aggregation.
 

--- a/packages/core/crates/core-strategy/src/aggregating.rs
+++ b/packages/core/crates/core-strategy/src/aggregating.rs
@@ -27,6 +27,7 @@ use async_std::task::spawn_local;
 #[cfg(all(feature = "wasm", not(test)))]
 use wasm_bindgen_futures::spawn_local;
 
+use crate::errors::StrategyError::CriteriaNotSatisfied;
 #[cfg(all(feature = "prometheus", not(test)))]
 use utils_metrics::metrics::SimpleCounter;
 
@@ -159,18 +160,14 @@ impl<Db: HoprCoreEthereumDbActions + 'static + Clone, T, U> AggregatingStrategy<
                             warn!("could not aggregate tickets: {e}");
                             if let Err(e) = list.rollback(db_clone).await {
                                 error!("could not rollback failed aggregation: {e}")
-                            } else {
-                                if redeem_if_failed {
-                                    info!(
-                                        "initiating redemption of all tickets in {channel} after aggregation failure"
-                                    );
+                            } else if redeem_if_failed {
+                                info!("initiating redemption of all tickets in {channel} after aggregation failure");
 
-                                    if let Err(e) = actions_clone.redeem_tickets_in_channel(&channel, false).await {
-                                        error!("failed to issue redeeming of all tickets in {channel}: {e}");
-                                    }
-
-                                    // We do not need to await the redemption completion of all the tickets
+                                if let Err(e) = actions_clone.redeem_tickets_in_channel(&channel, false).await {
+                                    error!("failed to issue redeeming of all tickets in {channel}: {e}");
                                 }
+
+                                // We do not need to await the redemption completion of all the tickets
                             }
                         }
                     }
@@ -255,7 +252,7 @@ impl<Db: HoprCoreEthereumDbActions + 'static + Clone, T, U> SingularStrategy for
             self.start_aggregation(channel, false).await
         } else {
             debug!("channel {channel_id} has not met the criteria for aggregation");
-            Ok(())
+            Err(CriteriaNotSatisfied)
         }
     }
 
@@ -652,6 +649,69 @@ mod tests {
             1,
             "there should be a single aggregated ticket"
         );
+    }
+
+    #[async_std::test]
+    async fn test_strategy_aggregation_on_ack_should_not_agg_when_unrealized_balance_exceeded_via_aggregated_tickets() {
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        // db_0: Alice (channel source)
+        // db_1: Bob (channel destination)
+        let mut inner_dbs = (0..2)
+            .map(|_| DB::new(RustyLevelDbShim::new_in_memory()))
+            .collect::<Vec<_>>();
+
+        let mut acked_tickets = populate_db_with_ack_tickets(&mut inner_dbs[1], 4).await;
+
+        let dbs = init_dbs(inner_dbs).await;
+
+        // Make this ticket aggregated
+        acked_tickets[0].ticket.index_offset = 2;
+        dbs[1]
+            .write()
+            .await
+            .update_acknowledged_ticket(&acked_tickets[0])
+            .await
+            .unwrap();
+
+        let channel = ChannelEntry::new(
+            (&PEERS_CHAIN[0]).into(),
+            (&PEERS_CHAIN[1]).into(),
+            Balance::new(100u64.into(), BalanceType::HOPR),
+            6u64.into(),
+            ChannelStatus::Open,
+            1u32.into(),
+            0u64.into(),
+        );
+
+        dbs[1]
+            .write()
+            .await
+            .update_channel_and_snapshot(&channel.get_id(), &channel, &Snapshot::default())
+            .await
+            .unwrap();
+
+        let tx_sender = spawn_tx_queue(dbs[1].clone(), MockTxExec::new());
+        let (bob_aggregator, _) =
+            spawn_aggregation_interaction(dbs[0].clone(), dbs[1].clone(), &PEERS_CHAIN[0], &PEERS_CHAIN[1]);
+
+        let cfg = super::AggregatingStrategyConfig {
+            aggregation_threshold: None,
+            unrealized_balance_ratio: Some(0.75),
+            aggregation_timeout: Duration::from_secs(5),
+            aggregate_on_channel_close: false,
+        };
+
+        let actions = CoreEthereumActions::new(PEERS_CHAIN[1].public().to_address(), dbs[1].clone(), tx_sender.clone());
+
+        let aggregation_strategy = super::AggregatingStrategy::new(cfg, dbs[1].clone(), actions, bob_aggregator);
+
+        let threshold_ticket = acked_tickets.last().unwrap();
+
+        aggregation_strategy
+            .on_acknowledged_winning_ticket(&threshold_ticket)
+            .await
+            .expect_err("strategy call should not satisfy the criteria");
     }
 
     #[async_std::test]

--- a/packages/core/crates/core-strategy/src/auto_funding.rs
+++ b/packages/core/crates/core-strategy/src/auto_funding.rs
@@ -11,10 +11,10 @@ use utils_log::info;
 use utils_types::primitives::{Balance, BalanceType};
 use validator::Validate;
 
+use crate::errors::StrategyError::CriteriaNotSatisfied;
 use crate::strategy::SingularStrategy;
 use crate::Strategy;
 
-use crate::errors::StrategyError::CriteriaNotSatisfied;
 #[cfg(all(feature = "prometheus", not(test)))]
 use utils_metrics::metrics::SimpleCounter;
 

--- a/packages/core/crates/core-strategy/src/auto_funding.rs
+++ b/packages/core/crates/core-strategy/src/auto_funding.rs
@@ -14,6 +14,7 @@ use validator::Validate;
 use crate::strategy::SingularStrategy;
 use crate::Strategy;
 
+use crate::errors::StrategyError::CriteriaNotSatisfied;
 #[cfg(all(feature = "prometheus", not(test)))]
 use utils_metrics::metrics::SimpleCounter;
 
@@ -102,9 +103,10 @@ impl<Db: HoprCoreEthereumDbActions + Clone> SingularStrategy for AutoFundingStra
                 std::mem::drop(rx); // The Receiver is not intentionally awaited here and the oneshot Sender can fail safely
                 info!("issued re-staking of {channel} with {}", self.cfg.funding_amount);
             }
+            Ok(())
+        } else {
+            Err(CriteriaNotSatisfied)
         }
-
-        Ok(())
     }
 }
 

--- a/packages/core/crates/core-strategy/src/auto_redeeming.rs
+++ b/packages/core/crates/core-strategy/src/auto_redeeming.rs
@@ -8,10 +8,10 @@ use std::fmt::{Debug, Display, Formatter};
 use utils_log::info;
 use validator::Validate;
 
+use crate::errors::StrategyError::CriteriaNotSatisfied;
 use crate::strategy::SingularStrategy;
 use crate::Strategy;
 
-use crate::errors::StrategyError::CriteriaNotSatisfied;
 #[cfg(all(feature = "prometheus", not(test)))]
 use utils_metrics::metrics::SimpleCounter;
 

--- a/packages/core/crates/core-strategy/src/auto_redeeming.rs
+++ b/packages/core/crates/core-strategy/src/auto_redeeming.rs
@@ -11,6 +11,7 @@ use validator::Validate;
 use crate::strategy::SingularStrategy;
 use crate::Strategy;
 
+use crate::errors::StrategyError::CriteriaNotSatisfied;
 #[cfg(all(feature = "prometheus", not(test)))]
 use utils_metrics::metrics::SimpleCounter;
 
@@ -73,8 +74,10 @@ impl<Db: HoprCoreEthereumDbActions + 'static + Clone> SingularStrategy for AutoR
 
             let rx = self.chain_actions.redeem_ticket(ack.clone()).await?;
             std::mem::drop(rx); // The Receiver is not intentionally awaited here and the oneshot Sender can fail safely
+            Ok(())
+        } else {
+            Err(CriteriaNotSatisfied)
         }
-        Ok(())
     }
 }
 

--- a/packages/core/crates/core-strategy/src/errors.rs
+++ b/packages/core/crates/core-strategy/src/errors.rs
@@ -5,6 +5,9 @@ use utils_types::errors::GeneralError;
 
 #[derive(Debug, Error)]
 pub enum StrategyError {
+    #[error("criteria to trigger the strategy were not satisfied")]
+    CriteriaNotSatisfied,
+
     #[error("non-specific strategy error: {0}")]
     Other(String),
 

--- a/packages/core/crates/core-strategy/src/promiscuous.rs
+++ b/packages/core/crates/core-strategy/src/promiscuous.rs
@@ -19,14 +19,14 @@ use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use std::fmt::{Debug, Display, Formatter};
 use std::sync::Arc;
+use utils_types::traits::PeerIdLike;
 use validator::Validate;
 
 use crate::errors::Result;
+use crate::errors::StrategyError::CriteriaNotSatisfied;
 use crate::strategy::SingularStrategy;
 use crate::{decision::ChannelDecision, Strategy};
-use utils_types::traits::PeerIdLike;
 
-use crate::errors::StrategyError::CriteriaNotSatisfied;
 #[cfg(all(feature = "prometheus", not(test)))]
 use utils_metrics::metrics::SimpleCounter;
 

--- a/packages/core/crates/core-strategy/src/strategy.rs
+++ b/packages/core/crates/core-strategy/src/strategy.rs
@@ -221,25 +221,23 @@ impl MultiStrategy {
         for strategy in cfg.strategies.iter() {
             match strategy {
                 Strategy::Promiscuous(sub_cfg) => strategies.push(Box::new(PromiscuousStrategy::new(
-                    sub_cfg.clone(),
+                    *sub_cfg,
                     db.clone(),
                     network.clone(),
                     chain_actions.clone(),
                 ))),
                 Strategy::Aggregating(sub_cfg) => strategies.push(Box::new(AggregatingStrategy::new(
-                    sub_cfg.clone(),
+                    *sub_cfg,
                     db.clone(),
                     chain_actions.clone(),
                     ticket_aggregator.clone(),
                 ))),
-                Strategy::AutoRedeeming(sub_cfg) => strategies.push(Box::new(AutoRedeemingStrategy::new(
-                    sub_cfg.clone(),
-                    chain_actions.clone(),
-                ))),
-                Strategy::AutoFunding(sub_cfg) => strategies.push(Box::new(AutoFundingStrategy::new(
-                    sub_cfg.clone(),
-                    chain_actions.clone(),
-                ))),
+                Strategy::AutoRedeeming(sub_cfg) => {
+                    strategies.push(Box::new(AutoRedeemingStrategy::new(*sub_cfg, chain_actions.clone())))
+                }
+                Strategy::AutoFunding(sub_cfg) => {
+                    strategies.push(Box::new(AutoFundingStrategy::new(*sub_cfg, chain_actions.clone())))
+                }
                 Strategy::Multi(sub_cfg) => {
                     if cfg.allow_recursive {
                         let mut cfg_clone = sub_cfg.clone();


### PR DESCRIPTION
The unrealized balance percentage threshold in the Aggregating strategy must not take unredeemed aggregated tickets into the account, as this could cause recursive aggregation.

Successive aggregations that have the same starting tickets, result in creation of aggregated tickets with the same index (but different offset) and subsequent redemption fails if the first aggregated one has been already redeemed in the meantime.

Closes #5673 