### PR TITLE
Fix aggregated ticket index and deadlock on ticket rejection

### DIFF
--- a/packages/core/crates/core-protocol/src/msg/processor.rs
+++ b/packages/core/crates/core-protocol/src/msg/processor.rs
@@ -287,7 +287,7 @@ where
 
                 debug!("price per packet is {price_per_packet}");
 
-                if let Err(e) = validate_unacknowledged_ticket::<Db>(
+                let validation_res = validate_unacknowledged_ticket::<Db>(
                     &*self.db.read().await,
                     &ticket,
                     &channel,
@@ -297,8 +297,9 @@ where
                     self.cfg.check_unrealized_balance,
                     &domain_separator,
                 )
-                .await
-                {
+                .await;
+
+                if let Err(e) = validation_res {
                     // Mark as reject and passthrough the error
                     self.db.write().await.mark_rejected(&ticket).await?;
                     return Err(e);

--- a/packages/core/crates/core-protocol/src/ticket_aggregation/processor.rs
+++ b/packages/core/crates/core-protocol/src/ticket_aggregation/processor.rs
@@ -315,7 +315,7 @@ impl<Db: HoprCoreEthereumDbActions> TicketAggregationProcessor<Db> {
             &destination,
             &Balance::new(final_value, BalanceType::HOPR),
             first_acked_ticket.ticket.index.into(),
-            (last_acked_ticket.ticket.index - first_acked_ticket.ticket.index).into(),
+            (last_acked_ticket.ticket.index - first_acked_ticket.ticket.index + 1).into(),
             1.0,
             channel_epoch.into(),
             first_acked_ticket.ticket.challenge.clone(),

--- a/packages/core/crates/core-strategy/src/auto_redeeming.rs
+++ b/packages/core/crates/core-strategy/src/auto_redeeming.rs
@@ -95,12 +95,10 @@ mod tests {
     use core_ethereum_db::traits::HoprCoreEthereumDbActions;
     use core_types::acknowledgement::{AcknowledgedTicket, UnacknowledgedTicket};
     use core_types::channels::Ticket;
-    use futures::channel::oneshot::{Canceled, Receiver};
     use futures::future::Either;
     use hex_literal::hex;
     use mockall::mock;
-    use std::future::Future;
-    use std::pin::{pin, Pin};
+    use std::pin::pin;
     use std::sync::Arc;
     use utils_db::constants::ACKNOWLEDGED_TICKETS_PREFIX;
     use utils_db::db::DB;

--- a/packages/core/crates/core-types/src/channels.rs
+++ b/packages/core/crates/core-types/src/channels.rs
@@ -392,8 +392,8 @@ impl Display for Ticket {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "ticket #{}, epoch {} in channel {}",
-            self.index, self.channel_epoch, self.channel_id
+            "ticket #{}, offset {}, epoch {} in channel {}",
+            self.index, self.index_offset, self.channel_epoch, self.channel_id
         )
     }
 }


### PR DESCRIPTION
- the index on the aggregated ticket was off-by-one - refs #5673

- when ticket validation at the relayer found the ticket invalid, the read lock was still held and deadlocked the database when the ticket was subsequently tried to be marked as rejected.