### PR TITLE
Update the development environment

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1693611461,
-        "narHash": "sha256-aPODl8vAgGQ0ZYFIRisxYG5MOGSkIczvu2Cd8Gb9+1Y=",
+        "lastModified": 1698882062,
+        "narHash": "sha256-HkhafUayIqxXyHH1X8d9RDl1M2CkFgZLjKD3MzabiEo=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "7f53fdb7bdc5bb237da7fefef12d099e4fd611ca",
+        "rev": "8c9fa2545007b49a5db5f650ae91f227672c3877",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1695675437,
-        "narHash": "sha256-4dBT8mbbmederQ1ENGSgph0n5GMMr6zgWIaVftDolL8=",
+        "lastModified": 1699433547,
+        "narHash": "sha256-HhcLzNYq0orOvDI7Vkz0qfqlnepXiF/KKPKZnTNqI9o=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0dd560f0abbe9e0b09bd1626ab44f05c80a68b26",
+        "rev": "923abd6420e9eb12caaafc701f98d4ad4a6aecc9",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1693471703,
-        "narHash": "sha256-0l03ZBL8P1P6z8MaSDS/MvuU8E75rVxe5eE1N6gxeTo=",
+        "lastModified": 1698611440,
+        "narHash": "sha256-jPjHjrerhYDy3q9+s5EAsuhyhuknNfowY6yt6pjn9pc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "3e52e76b70d5508f3cec70b882a29199f4d1ee85",
+        "rev": "0cbe9f69c234a7700596e943bfae7ef27a31b735",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1695607919,
-        "narHash": "sha256-PU6yIbHXdm3W8bBlhO6aL+VIjK5UQCRnOvCqa1lYQ6M=",
+        "lastModified": 1699409596,
+        "narHash": "sha256-L3g1smIol3dGTxkUQOlNShJtZLvjLzvtbaeTRizwZBU=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "014e0035c262e5506f904829e6b925ee3cfdb55e",
+        "rev": "58240e1ac627cef3ea30c7732fedfb4f51afd8e7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Basic `nix flake update` for 2.1.0 branch.

```shell
• Updated input 'flake-parts':
    'github:hercules-ci/flake-parts/7f53fdb7bdc5bb237da7fefef12d099e4fd611ca' (2023-09-01)
  → 'github:hercules-ci/flake-parts/8c9fa2545007b49a5db5f650ae91f227672c3877' (2023-11-01)
• Updated input 'flake-parts/nixpkgs-lib':
    'github:NixOS/nixpkgs/3e52e76b70d5508f3cec70b882a29199f4d1ee85?dir=lib' (2023-08-31)
  → 'github:NixOS/nixpkgs/0cbe9f69c234a7700596e943bfae7ef27a31b735?dir=lib' (2023-10-29)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/0dd560f0abbe9e0b09bd1626ab44f05c80a68b26' (2023-09-25)
  → 'github:NixOS/nixpkgs/923abd6420e9eb12caaafc701f98d4ad4a6aecc9' (2023-11-08)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/014e0035c262e5506f904829e6b925ee3cfdb55e' (2023-09-25)
  → 'github:oxalica/rust-overlay/58240e1ac627cef3ea30c7732fedfb4f51afd8e7' (2023-11-08)
```