### PR TITLE
Remove the build step from the unit test job

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -81,9 +81,6 @@ jobs:
       - name: Install dependencies
         run: nix develop -c make -j deps-ci
 
-      - name: Build
-        run: nix develop -c make -j build
-
       - name: Test
         run: nix develop -c make -j test
         env:


### PR DESCRIPTION
The build step is not needed.