### PR TITLE
Fix iterator based operations in the critical path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1138,6 +1138,7 @@ dependencies = [
  "console_error_panic_hook",
  "core-crypto",
  "core-types",
+ "env_logger",
  "hex",
  "hex-literal",
  "js-sys",

--- a/packages/core-ethereum/crates/core-ethereum-db/Cargo.toml
+++ b/packages/core-ethereum/crates/core-ethereum-db/Cargo.toml
@@ -34,6 +34,7 @@ serde-wasm-bindgen = { workspace = true, optional = true }
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes"] }
 wasm-bindgen-test = "0.3.30"
+env_logger = "0.10.0"
 
 [target.'cfg(not(target_arch = "wasm32"))'.build-dependencies]
 wasm-pack = { workspace = true }

--- a/packages/core-ethereum/crates/core-ethereum-db/src/traits.rs
+++ b/packages/core-ethereum/crates/core-ethereum-db/src/traits.rs
@@ -18,6 +18,10 @@ pub trait HoprCoreEthereumDbActions {
 
     async fn get_tickets(&self, signer: Option<Address>) -> Result<Vec<Ticket>>;
 
+    async fn get_unrealized_balance(&self, channel: &Hash) -> Result<Balance>;
+
+    async fn get_channel_epoch(&self, channel: &Hash) -> Result<Option<U256>>;
+
     async fn cleanup_invalid_channel_tickets(&mut self, channel: &ChannelEntry) -> Result<()>;
 
     async fn mark_rejected(&mut self, ticket: &Ticket) -> Result<()>;

--- a/packages/core/crates/core-crypto/src/types.rs
+++ b/packages/core/crates/core-crypto/src/types.rs
@@ -432,7 +432,7 @@ impl From<HalfKey> for HalfKeyChallenge {
 
 /// Represents an Ethereum 256-bit hash value
 /// This implementation instantiates the hash via Keccak256 digest.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, PartialOrd, Ord, std::hash::Hash)]
 #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
 pub struct Hash {
     hash: [u8; Self::SIZE],

--- a/packages/core/crates/core-packet/src/validation.rs
+++ b/packages/core/crates/core-packet/src/validation.rs
@@ -6,7 +6,7 @@ use core_crypto::types::Hash;
 use core_ethereum_db::traits::HoprCoreEthereumDbActions;
 use core_types::channels::{ChannelEntry, ChannelStatus, Ticket};
 use utils_log::{debug, info};
-use utils_types::primitives::{Address, Balance, BalanceType};
+use utils_types::primitives::{Address, Balance};
 
 /// Performs validations of the given unacknowledged ticket and channel.
 pub async fn validate_unacknowledged_ticket<T: HoprCoreEthereumDbActions>(
@@ -63,28 +63,38 @@ pub async fn validate_unacknowledged_ticket<T: HoprCoreEthereumDbActions>(
     }
 
     if check_unrealized_balance {
-        info!("checking unrealized balances for channel {}", channel.get_id());
+        // ticket's channelEpoch MUST match the current DB channel's epoch
+        match db.get_channel_epoch(&ticket.channel_id).await? {
+            Some(epoch) => {
+                if !epoch.eq(&ticket.channel_epoch.into()) {
+                    return Err(TicketValidation(format!(
+                        "ticket was created for a different channel iteration than is present in the DB {} != {} of channel {}",
+                        ticket.channel_epoch,
+                        epoch,
+                        channel.get_id()
+                    )));
+                }
 
-        let unrealized_balance = db
-            .get_tickets(Some(*sender))
-            .await? // all tickets from sender
-            .into_iter()
-            .filter(|t| channel.channel_epoch.eq(&t.channel_epoch.into()))
-            .fold(Some(channel.balance), |result, t| {
-                result
-                    .and_then(|b| b.value().value().checked_sub(*t.amount.value().value()))
-                    .map(|u| Balance::new(u.into(), channel.balance.balance_type()))
-            });
+                info!("checking unrealized balances for channel {}", channel.get_id());
 
-        debug!(
-            "channel balance of {} after subtracting unrealized balance: {}",
-            channel.get_id(),
-            unrealized_balance.unwrap_or(Balance::zero(BalanceType::HOPR))
-        );
+                let unrealized_balance = db.get_unrealized_balance(&ticket.channel_id).await?;
 
-        // ensure sender has enough funds
-        if unrealized_balance.is_none() || ticket.amount.gt(&unrealized_balance.unwrap()) {
-            return Err(OutOfFunds(channel.get_id().to_string()));
+                debug!(
+                    "channel balance of {} after subtracting unrealized balance: {unrealized_balance}",
+                    channel.get_id()
+                );
+
+                // ensure sender has enough funds
+                if ticket.amount.gt(&unrealized_balance) {
+                    return Err(OutOfFunds(channel.get_id().to_string()));
+                }
+            }
+            None => {
+                return Err(TicketValidation(format!(
+                    "no such channel {} available in the database",
+                    ticket.channel_id,
+                )));
+            }
         }
     }
 
@@ -138,6 +148,8 @@ mod tests {
             async fn get_current_ticket_index(&self, channel_id: &Hash) -> core_ethereum_db::errors::Result<Option<U256>>;
             async fn set_current_ticket_index(&mut self, channel_id: &Hash, index: U256) -> core_ethereum_db::errors::Result<()>;
             async fn get_tickets(&self, signer: Option<Address>) -> core_ethereum_db::errors::Result<Vec<Ticket>>;
+            async fn get_unrealized_balance(&self, signer: &Hash) -> core_ethereum_db::errors::Result<Balance>;
+            async fn get_channel_epoch(&self, channel: &Hash) -> core_ethereum_db::errors::Result<Option<U256>>;
             async fn cleanup_invalid_channel_tickets(&mut self, channel: &ChannelEntry) -> core_ethereum_db::errors::Result<()>;
             async fn mark_rejected(&mut self, ticket: &Ticket) -> core_ethereum_db::errors::Result<()>;
             async fn get_pending_acknowledgement(
@@ -278,10 +290,16 @@ mod tests {
     #[async_std::test]
     async fn test_ticket_validation_should_pass_if_ticket_ok() {
         let mut db = MockDb::new();
-        db.expect_get_tickets().returning(|_| Ok(Vec::<Ticket>::new()));
 
         let ticket = create_valid_ticket();
         let channel = create_channel_entry();
+
+        let more_than_ticket_balance = ticket.amount.add(&Balance::new(U256::from(500u128), BalanceType::HOPR));
+        let channel_epoch = U256::from(ticket.channel_epoch);
+        db.expect_get_channel_epoch()
+            .returning(move |_| Ok(Some(channel_epoch)));
+        db.expect_get_unrealized_balance()
+            .returning(move |_| Ok(more_than_ticket_balance));
 
         let ret = validate_unacknowledged_ticket(
             &db,
@@ -440,66 +458,19 @@ mod tests {
     }
 
     #[async_std::test]
-    async fn test_ticket_validation_ok_if_ticket_index_smaller_than_channel_index() {
-        let mut db = MockDb::new();
-        db.expect_get_tickets().returning(|_| Ok(Vec::<Ticket>::new()));
-
-        let ticket = create_valid_ticket();
-        let mut channel = create_channel_entry();
-        channel.ticket_index = 2u32.into();
-
-        let ret = validate_unacknowledged_ticket(
-            &db,
-            &ticket,
-            &channel,
-            &SENDER_PRIV_KEY.public().to_address(),
-            Balance::new(1u64.into(), BalanceType::HOPR),
-            1.0f64,
-            true,
-            &Hash::default(),
-        )
-        .await;
-
-        assert!(ret.is_ok());
-    }
-
-    #[async_std::test]
-    async fn test_ticket_validation_ok_if_ticket_idx_smaller_than_channel_idx_unredeemed() {
-        let mut db_ticket = create_valid_ticket();
-        db_ticket.amount = Balance::new_from_str("100", BalanceType::HOPR);
-        db_ticket.index = 2u32.into();
-        db_ticket.sign(&SENDER_PRIV_KEY, &Hash::default());
-
-        let mut db = MockDb::new();
-        db.expect_get_tickets().returning(move |_| Ok(vec![db_ticket.clone()]));
-
-        let ticket = create_valid_ticket();
-        let mut channel = create_channel_entry();
-        channel.balance = Balance::new_from_str("200", BalanceType::HOPR);
-
-        let ret = validate_unacknowledged_ticket(
-            &db,
-            &ticket,
-            &channel,
-            &SENDER_PRIV_KEY.public().to_address(),
-            Balance::new(1u64.into(), BalanceType::HOPR),
-            1.0f64,
-            true,
-            &Hash::default(),
-        )
-        .await;
-
-        assert!(ret.is_ok());
-    }
-
-    #[async_std::test]
     async fn test_ticket_validation_fail_if_does_not_have_funds() {
         let mut db = MockDb::new();
-        db.expect_get_tickets().returning(|_| Ok(Vec::<Ticket>::new()));
 
         let ticket = create_valid_ticket();
         let mut channel = create_channel_entry();
         channel.balance = Balance::zero(BalanceType::HOPR);
+        channel.channel_epoch = U256::from(ticket.channel_epoch);
+
+        let channel_epoch = U256::from(ticket.channel_epoch);
+        db.expect_get_channel_epoch()
+            .returning(move |_| Ok(Some(channel_epoch)));
+        db.expect_get_unrealized_balance()
+            .returning(move |_| Ok(Balance::zero(BalanceType::HOPR)));
 
         let ret = validate_unacknowledged_ticket(
             &db,
@@ -514,68 +485,11 @@ mod tests {
         .await;
 
         assert!(ret.is_err());
+        // assert_eq!(ret.unwrap_err().to_string(), "");
         match ret.unwrap_err() {
             PacketError::OutOfFunds(_) => {}
             _ => panic!("invalid error type"),
         }
-    }
-
-    #[async_std::test]
-    async fn test_ticket_validation_fail_if_does_not_have_funds_including_unredeemed() {
-        let mut db_ticket = create_valid_ticket();
-        db_ticket.amount = Balance::new(200u64.into(), BalanceType::HOPR);
-        db_ticket.sign(&SENDER_PRIV_KEY, &Hash::default());
-
-        let mut db = MockDb::new();
-        db.expect_get_tickets().returning(move |_| Ok(vec![db_ticket.clone()]));
-
-        let ticket = create_valid_ticket();
-        let channel = create_channel_entry();
-
-        let ret = validate_unacknowledged_ticket(
-            &db,
-            &ticket,
-            &channel,
-            &SENDER_PRIV_KEY.public().to_address(),
-            Balance::new(1u64.into(), BalanceType::HOPR),
-            1.0f64,
-            true,
-            &Hash::default(),
-        )
-        .await;
-
-        assert!(ret.is_err());
-        match ret.unwrap_err() {
-            PacketError::OutOfFunds(_) => {}
-            _ => panic!("invalid error type"),
-        }
-    }
-
-    #[async_std::test]
-    async fn test_ticket_validation_ok_if_does_not_have_funds_including_unredeemed() {
-        let mut db_ticket = create_valid_ticket();
-        db_ticket.amount = Balance::new(200u64.into(), BalanceType::HOPR);
-        db_ticket.sign(&SENDER_PRIV_KEY, &Hash::default());
-
-        let mut db = MockDb::new();
-        db.expect_get_tickets().returning(move |_| Ok(vec![db_ticket.clone()]));
-
-        let ticket = create_valid_ticket();
-        let channel = create_channel_entry();
-
-        let ret = validate_unacknowledged_ticket(
-            &db,
-            &ticket,
-            &channel,
-            &SENDER_PRIV_KEY.public().to_address(),
-            Balance::new(1u64.into(), BalanceType::HOPR),
-            1.0f64,
-            false,
-            &Hash::default(),
-        )
-        .await;
-
-        assert!(ret.is_ok());
     }
 
     #[async_std::test]

--- a/packages/core/src/main.ts
+++ b/packages/core/src/main.ts
@@ -29,6 +29,8 @@ export async function createHoprNode(
     cfg.db.initialize = true
   }
   let db = new Database(dbPath.toString(), cfg.db.initialize, chainKeypair.public().to_address())
+  log(`Initializing DB caches...`)
+  await db.init_cache()
 
   // if safe address or module address is not provided, replace with values stored in the db
   let safeAddress = cfg.safe_module.safe_address

--- a/packages/utils/crates/utils-db/src/constants.rs
+++ b/packages/utils/crates/utils-db/src/constants.rs
@@ -16,7 +16,6 @@ pub const NEGLECTED_TICKETS_VALUE: &str = "statistics:neglected:value";
 pub const LOSING_TICKET_COUNT: &str = "statistics:losing:count";
 pub const LATEST_CONFIRMED_SNAPSHOT_KEY: &str = "latestConfirmedSnapshot";
 pub const PENDING_ACKNOWLEDGEMENTS_PREFIX: &str = "tickets:pending-acknowledgement-";
-pub const TICKETS_CHANNEL_UNREALIZED_BALANCE_PREFIX: &str = "tickets:channel-unrealized-balance-";
 pub const ACKNOWLEDGED_TICKETS_PREFIX: &str = "tickets:acknowledged-";
 pub const HOPR_BALANCE_KEY: &str = "hopr-balance";
 pub const TICKET_PRICE_KEY: &str = "ticket-price";

--- a/packages/utils/crates/utils-db/src/constants.rs
+++ b/packages/utils/crates/utils-db/src/constants.rs
@@ -16,6 +16,7 @@ pub const NEGLECTED_TICKETS_VALUE: &str = "statistics:neglected:value";
 pub const LOSING_TICKET_COUNT: &str = "statistics:losing:count";
 pub const LATEST_CONFIRMED_SNAPSHOT_KEY: &str = "latestConfirmedSnapshot";
 pub const PENDING_ACKNOWLEDGEMENTS_PREFIX: &str = "tickets:pending-acknowledgement-";
+pub const TICKETS_CHANNEL_UNREALIZED_BALANCE_PREFIX: &str = "tickets:channel-unrealized-balance-";
 pub const ACKNOWLEDGED_TICKETS_PREFIX: &str = "tickets:acknowledged-";
 pub const HOPR_BALANCE_KEY: &str = "hopr-balance";
 pub const TICKET_PRICE_KEY: &str = "ticket-price";


### PR DESCRIPTION
The critical path inside packet processing relied on an expensive DB call that would collect all Acknowledged and Pending tickets. In case of a large ticket collection this operation over the DB would take extremely long and block the critical path.

## Details
The unrealized balance value is now calculated internally in the DB on relevant DB operations and not on demand over the entire collection of tickets. This reduces the time to fetch the value, but complicates the logic of ticket handling by introducing the concept of channel life-time deeper into ticket handling. Ideally, these would be separated.

## Notes
Fixes #5720 