### PR TITLE
Fix docker labeling on merge

### DIFF
--- a/.github/workflows/build-anvil.yaml
+++ b/.github/workflows/build-anvil.yaml
@@ -49,7 +49,7 @@ jobs:
         id: update
         run: |
           if ${{ contains(github.event.pull_request.labels.*.name, 'release') }}; then
-            docker_tag=$(jq -r '.version' packages/hoprd/package.json | sed 's/+/-/')
+            docker_tag=$(./scripts/get-current-version.sh docker)
             echo "DOCKER_TAG=${docker_tag}" >> $GITHUB_OUTPUT
           else
             next_version=$(./scripts/get-next-version.sh Build ${{ github.event.pull_request.number }})

--- a/.github/workflows/build-dappnode.yaml
+++ b/.github/workflows/build-dappnode.yaml
@@ -58,7 +58,7 @@ jobs:
       - name: Setup variables
         id: setup
         run: |
-          current_version=$(jq -r '.version' packages/hoprd/package.json)
+          current_version=$(./scripts/get-current-version.sh docker)
           echo "current_version=${current_version}" >> $GITHUB_OUTPUT
 
       - name: Bump version

--- a/.github/workflows/build-hopli.yaml
+++ b/.github/workflows/build-hopli.yaml
@@ -48,7 +48,7 @@ jobs:
         id: update
         run: |
           if ${{ contains(github.event.pull_request.labels.*.name, 'release') }}; then
-            docker_tag=$(jq -r '.version' packages/hoprd/package.json | sed 's/+/-/')
+            docker_tag=$(./scripts/get-current-version.sh docker)
             echo "DOCKER_TAG=${docker_tag}" >> $GITHUB_OUTPUT
           else
             next_version=$(./scripts/get-next-version.sh Build ${{ github.event.pull_request.number }})

--- a/.github/workflows/build-hoprd.yaml
+++ b/.github/workflows/build-hoprd.yaml
@@ -47,7 +47,7 @@ jobs:
         id: update
         run: |
           if ${{ contains(github.event.pull_request.labels.*.name, 'release') }}; then
-            docker_tag=$(jq -r '.version' packages/hoprd/package.json | sed 's/+/-/')
+            docker_tag=$(./scripts/get-current-version.sh docker)
             echo "DOCKER_TAG=${docker_tag}" >> $GITHUB_OUTPUT
           else
             next_version=$(./scripts/get-next-version.sh Build ${{ github.event.pull_request.number }})

--- a/.github/workflows/build-pluto.yaml
+++ b/.github/workflows/build-pluto.yaml
@@ -49,7 +49,7 @@ jobs:
         id: update
         run: |
           if ${{ contains(github.event.pull_request.labels.*.name, 'release') }}; then
-            docker_tag=$(jq -r '.version' packages/hoprd/package.json | sed 's/+/-/')
+            docker_tag=$(./scripts/get-current-version.sh docker)
             echo "DOCKER_TAG=${docker_tag}" >> $GITHUB_OUTPUT
           else
             next_version=$(./scripts/get-next-version.sh Build ${{ github.event.pull_request.number }})

--- a/.github/workflows/build-toolchain.yaml
+++ b/.github/workflows/build-toolchain.yaml
@@ -47,7 +47,7 @@ jobs:
         id: update
         run: |
           if ${{ contains(github.event.pull_request.labels.*.name, 'release') }}; then
-            docker_tag=$(jq -r '.version' packages/hoprd/package.json | sed 's/+/-/')
+            docker_tag=$(./scripts/get-current-version.sh docker)
             echo "DOCKER_TAG=${docker_tag}" >> $GITHUB_OUTPUT
           else
             next_version=$(./scripts/get-next-version.sh Build ${{ github.event.pull_request.number }})

--- a/.github/workflows/close-release.yaml
+++ b/.github/workflows/close-release.yaml
@@ -92,7 +92,7 @@ jobs:
       - name: Generate Changelog
         id: template
         run: |
-          current_version=$(jq -r '.version' packages/hoprd/package.json)
+          current_version=$(./scripts/get-current-version.sh semver)
           echo "current_version=${current_version}" >> $GITHUB_OUTPUT
           # Choose the template file
           if [[ "${{ github.ref_name }}" = "master" ]] && [[ ${current_version} == *"-rc.1" ]]

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -15,6 +15,7 @@ on:
       - closed
       - synchronize
 
+
 concurrency:
   group: merge
   cancel-in-progress: false

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -164,7 +164,7 @@ jobs:
       - name: Setup variables
         id: setup
         run: |
-          current_version=$(docker_pr_tag=$(./scripts/get-current-version.sh semver)
+          current_version=$(./scripts/get-current-version.sh semver)
           echo "current_version=${current_version}" >> $GITHUB_OUTPUT
           if [[ $current_version == *"-rc."* ]]; then
             echo "prerelease=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -54,7 +54,7 @@ jobs:
   tag:
     name: Tag images
     runs-on: ubuntu-2-core
-    if: github.event.pull_request.merged == true && (github.event.pull_request.base.ref == 'master' || contains(github.event.pull_request.base.ref,'release/'))
+    # if: github.event.pull_request.merged == true && (github.event.pull_request.base.ref == 'master' || contains(github.event.pull_request.base.ref,'release/'))
     steps:
       - name: Checkout hoprnet repository
         uses: actions/checkout@v4

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -13,7 +13,7 @@ on:
   pull_request:
     types:
       - closed
-      # - synchronize
+      - synchronize
 
 concurrency:
   group: merge
@@ -23,32 +23,32 @@ permissions:
   contents: write
 
 jobs:
-  cleanup-actions:
-    name: Cleanup Actions
-    runs-on: ubuntu-2-core
-    steps:
-      - name: Checkout hoprnet repository
-        uses: actions/checkout@v4
-      - name: Cleanup
-        run: |
-          gh extension install actions/gh-actions-cache
+  # cleanup-actions:
+  #   name: Cleanup Actions
+  #   runs-on: ubuntu-2-core
+  #   steps:
+  #     - name: Checkout hoprnet repository
+  #       uses: actions/checkout@v4
+  #     - name: Cleanup
+  #       run: |
+  #         gh extension install actions/gh-actions-cache
 
-          REPO=${{ github.repository }}
-          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+  #         REPO=${{ github.repository }}
+  #         BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
 
-          echo "Fetching list of cache key"
-          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
+  #         echo "Fetching list of cache key"
+  #         cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
 
-          ## Setting this to not fail the workflow while deleting cache keys.
-          set +e
-          echo "Deleting caches..."
-          for cacheKey in $cacheKeysForPR
-          do
-            gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
-          done
-          echo "Done"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         ## Setting this to not fail the workflow while deleting cache keys.
+  #         set +e
+  #         echo "Deleting caches..."
+  #         for cacheKey in $cacheKeysForPR
+  #         do
+  #           gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+  #         done
+  #         echo "Done"
+  #       env:
+  #         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   tag:
     name: Tag images
@@ -82,175 +82,176 @@ jobs:
 
       - name: Tag docker images
         run: |
+          set -x
           docker_registry="europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/docker-images"
           # Set docker PR tag
           if ${{ contains(github.event.pull_request.labels.*.name, 'release') }}; then
-            docker_pr_tag=$(jq -r '.version' packages/hoprd/package.json | sed 's/+/-/')
+            docker_pr_tag=$(./scripts/get-current-version.sh docker)
           else
             docker_pr_tag=$(./scripts/get-next-version.sh Build ${{ github.event.pull_request.number }} | sed 's/+/-/')
           fi
-          # Set docker stable tag
+          # Set docker release latest tag
           declare base_branch=${{ github.event.pull_request.base.ref }}
           if [ "${base_branch}" == "master" ]; then
-            docker_stable_tag=latest
+            docker_release_latest_tag=${{ vars.BRANCH_MASTER_RELEASE_NAME }}-latest
           else
-            docker_stable_tag=${base_branch/release\//}
+            docker_release_latest_tag=${base_branch/release\//}-latest
           fi
 
           # Tag images
           images=(hopr-toolchain hopli hoprd hopr-anvil hopr-pluto)
           for image in ${images[@]}; 
           do
-            echo "Tagging ${image}:${docker_stable_tag}"
-            gcloud artifacts docker tags add ${docker_registry}/${image}:${docker_pr_tag} ${docker_registry}/${image}:${docker_stable_tag}
+            echo "Tagging ${image}:${docker_release_latest_tag}"
+            gcloud artifacts docker tags add ${docker_registry}/${image}:${docker_pr_tag} ${docker_registry}/${image}:${docker_release_latest_tag}
+            if [ "${base_branch}" == "master" ]; then
+              echo "Tagging ${image}:latest"
+              # gcloud artifacts docker tags add ${docker_registry}/${image}:${docker_pr_tag} ${docker_registry}/${image}:latest
+            fi
           done
 
-  deploy_nodes:
-    name: Deploy nodes
-    runs-on: ubuntu-2-core
-    if: needs.tag.result == 'success'
-    needs:
-      - tag
-    steps:
-      - name: Checkout hoprnet repository
-        uses: actions/checkout@v4
+  # deploy_nodes:
+  #   name: Deploy nodes
+  #   runs-on: ubuntu-2-core
+  #   if: needs.tag.result == 'success'
+  #   needs:
+  #     - tag
+  #   steps:
+  #     - name: "Restart deployments"
+  #       run: |
+  #         base_branch="${{ github.event.pull_request.base.ref }}"
+  #         # Identify parameters depending on branch
+  #         if [[ "${base_branch}" == "master" ]]; then
+  #           namespace=rotsee
+  #           identity_pool=core-staging
+  #         elif [[ "${base_branch}" =~ ^"release" ]]; then
+  #           namespace=dufour
+  #           identity_pool="core-dufour-${base_branch/release\/}"
+  #         else
+  #           echo "Skipping deployment"
+  #           exit 0
+  #         fi
+  #         echo "[INFO] Restarting deployments on ${namespace} from pr-${{ github.event.pull_request.number }}"
+  #         # Get list of deployments to restart
+  #         export deployments=($(kubectl get deployments -n ${namespace/-.*} -l app.kubernetes.io/name=hoprd-operator,hoprds.hoprnet.org/identitypool=${identity_pool} -o jsonpath="{.items[*].metadata.name}"))
+  #         for deployment in "${deployments[@]}"; do
+  #           echo "[INFO] Restarting hoprd node ${namespace}/${deployments}"
+  #           kubectl rollout restart deployments -n ${namespace} $deployment;
+  #         done
 
-      - name: "Restart deployments"
-        run: |
-          set -x
-          base_branch="${{ github.event.pull_request.base.ref }}"
-          # Identify parameters depending on branch
-          if [[ "${base_branch}" == "master" ]]; then
-            namespace=rotsee
-            identity_pool=core-staging
-          elif [[ "${base_branch}" =~ ^"release" ]]; then
-            namespace=dufour
-            identity_pool="core-dufour-${base_branch/release\/}"
-          else
-            echo "Skipping deployment"
-            exit 0
-          fi
-          echo "[INFO] Restarting deployments on ${namespace} from pr-${{ github.event.pull_request.number }}"
-          # Get list of deployments to restart
-          export deployments=($(kubectl get deployments -n ${namespace/-.*} -l app.kubernetes.io/name=hoprd-operator,hoprds.hoprnet.org/identitypool=${identity_pool} -o jsonpath="{.items[*].metadata.name}"))
-          for deployment in "${deployments[@]}"; do
-            echo "[INFO] Restarting hoprd node ${namespace}/${deployments}"
-            kubectl rollout restart deployments -n ${namespace} $deployment;
-          done
+  # create_release:
+  #   name: Create Release
+  #   runs-on: ubuntu-2-core
+  #   if: contains(github.event.pull_request.labels.*.name, 'release')
+  #   needs:
+  #     - tag
+  #   steps:
+  #     - name: Checkout hoprnet repository
+  #       uses: actions/checkout@v4
 
-  create_release:
-    name: Create Release
-    runs-on: ubuntu-2-core
-    if: contains(github.event.pull_request.labels.*.name, 'release')
-    needs:
-      - tag
-    steps:
-      - name: Checkout hoprnet repository
-        uses: actions/checkout@v4
+  #     - name: Set up Google Cloud Credentials
+  #       id: auth
+  #       uses: google-github-actions/auth@v1
+  #       with:
+  #         credentials_json: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
 
-      - name: Set up Google Cloud Credentials
-        id: auth
-        uses: google-github-actions/auth@v1
-        with:
-          credentials_json: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
+  #     - name: Set up Google Cloud SDK
+  #       uses: google-github-actions/setup-gcloud@v1
+  #       with:
+  #         project_id: ${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}
+  #         install_components: beta
 
-      - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
-        with:
-          project_id: ${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}
-          install_components: beta
+  #     - name: Setup variables
+  #       id: setup
+  #       run: |
+  #         current_version=$(docker_pr_tag=$(./scripts/get-current-version.sh semver)
+  #         echo "current_version=${current_version}" >> $GITHUB_OUTPUT
+  #         if [[ $current_version == *"-rc."* ]]; then
+  #           echo "prerelease=true" >> $GITHUB_OUTPUT
+  #         else
+  #           echo "prerelease=false" >> $GITHUB_OUTPUT
+  #         fi
 
-      - name: Setup variables
-        id: setup
-        run: |
-          current_version=$(jq -r '.version' packages/hoprd/package.json)
-          echo "current_version=${current_version}" >> $GITHUB_OUTPUT
-          if [[ $current_version == *"-rc."* ]]; then
-            echo "prerelease=true" >> $GITHUB_OUTPUT
-          else
-            echo "prerelease=false" >> $GITHUB_OUTPUT
-          fi
+  #     - name: Tag repository
+  #       id: tag
+  #       run: |
+  #         # Tag semver
+  #         git tag v${{ steps.setup.outputs.current_version }}
+  #         git push origin v${{ steps.setup.outputs.current_version }}
 
-      - name: Tag repository
-        id: tag
-        run: |
-          # Tag semver
-          git tag v${{ steps.setup.outputs.current_version }}
-          git push origin v${{ steps.setup.outputs.current_version }}
+  #         declare base_branch=${{ github.event.pull_request.base.ref }}
+  #         # Tag release name
+  #         if [[ "${base_branch}" == "master" ]]; then
+  #           release_name=${{ vars.BRANCH_MASTER_RELEASE_NAME }}
+  #         elif [[ "${base_branch}" =~ ^"release" ]]; then
+  #           release_name=${{ vars.BRANCH_RELEASE_RELEASE_NAME }}
+  #         fi
+  #         git tag --force ${release_name}
+  #         git push --force origin ${release_name}
+  #         echo "release_name=${release_name}" >> $GITHUB_OUTPUT
 
-          declare base_branch=${{ github.event.pull_request.base.ref }}
-          # Tag release name
-          if [[ "${base_branch}" == "master" ]]; then
-            release_name=${{ vars.BRANCH_MASTER_RELEASE_NAME }}
-          elif [[ "${base_branch}" =~ ^"release" ]]; then
-            release_name=${{ vars.BRANCH_RELEASE_RELEASE_NAME }}
-          fi
-          git tag --force ${release_name}
-          git push --force origin ${release_name}
-          echo "release_name=${release_name}" >> $GITHUB_OUTPUT
+  #     - name: Generate Changelog
+  #       id: changelog
+  #       run: |
+  #         milestone_number=$(gh api repos/${{ github.repository }}/milestones | jq -r --arg version "${{ steps.setup.outputs.current_version }}"  ' to_entries[] | select(.value.title | test($version)).value.number')
+  #         ./scripts/generate-changelog.sh ${milestone_number} | tee docs/changelog/changelog.md
+  #         echo "milestone_number=${milestone_number}" >> $GITHUB_OUTPUT
+  #       env:
+  #         GH_TOKEN: ${{ github.token }}
 
-      - name: Generate Changelog
-        id: changelog
-        run: |
-          milestone_number=$(gh api repos/${{ github.repository }}/milestones | jq -r --arg version "${{ steps.setup.outputs.current_version }}"  ' to_entries[] | select(.value.title | test($version)).value.number')
-          ./scripts/generate-changelog.sh ${milestone_number} | tee docs/changelog/changelog.md
-          echo "milestone_number=${milestone_number}" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ github.token }}
+  #     - name: Tag docker images with release name
+  #       run: |
+  #         docker_registry="europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/docker-images"
+  #         images=(hopr-toolchain hopli hoprd hopr-anvil hopr-pluto)
+  #         for image in ${images[@]};
+  #         do
+  #           echo "Tagging ${image}:${{ steps.tag.outputs.release_name }}"
+  #           gcloud artifacts docker tags add ${docker_registry}/${image}:${{ steps.setup.outputs.current_version }} ${docker_registry}/${image}:${{ steps.tag.outputs.release_name }}
+  #         done
 
-      - name: Tag docker images with release name
-        run: |
-          docker_registry="europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/docker-images"
-          images=(hopr-toolchain hopli hoprd hopr-anvil hopr-pluto)
-          for image in ${images[@]};
-          do
-            echo "Tagging ${image}:${{ steps.tag.outputs.release_name }}"
-            gcloud artifacts docker tags add ${docker_registry}/${image}:${{ steps.setup.outputs.current_version }} ${docker_registry}/${image}:${{ steps.tag.outputs.release_name }}
-          done
+  #     - name: Create Release
+  #       uses: softprops/action-gh-release@v1
+  #       with:
+  #         body_path: docs/changelog/changelog.md
+  #         prerelease: ${{ steps.setup.outputs.prerelease }}
+  #         name: HOPR - v${{ steps.setup.outputs.current_version }}
+  #         tag_name: v${{ steps.setup.outputs.current_version }}
 
-      - name: Create Release
-        uses: softprops/action-gh-release@v1
-        with:
-          body_path: docs/changelog/changelog.md
-          prerelease: ${{ steps.setup.outputs.prerelease }}
-          name: HOPR - v${{ steps.setup.outputs.current_version }}
-          tag_name: v${{ steps.setup.outputs.current_version }}
+  #     - name: Close Milestone
+  #       run: | 
+  #         gh api --method PATCH -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${{ github.repository }}/milestones/${{ steps.changelog.outputs.milestone_number }} -f state='closed'
+  #       env:
+  #         GH_TOKEN: ${{ secrets.GH_RUNNER_TOKEN }}
 
-      - name: Close Milestone
-        run: | 
-          gh api --method PATCH -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${{ github.repository }}/milestones/${{ steps.changelog.outputs.milestone_number }} -f state='closed'
-        env:
-          GH_TOKEN: ${{ secrets.GH_RUNNER_TOKEN }}
+  #     - name: Notify release on Element channel
+  #       run: |
+  #         messageHeader="<h3>&#9889; New Hoprd Release</h3><br><p>A new hoprd release has been launched. The tag <b>${{ steps.setup.outputs.current_version }}</b> is now available to be downloaded and use it</p>"
+  #         messageTagNumber="<code>docker pull europe-west3-docker.pkg.dev/hoprassociation/docker-images/hoprd:${{ steps.setup.outputs.current_version }}</code>"
+  #         messageTagName="<code>docker pull europe-west3-docker.pkg.dev/hoprassociation/docker-images/hoprd:${{ steps.tag.outputs.release_name }}</code>"
+  #         messageChangeLog="<p>Have a look at the <a href='https://github.com/hoprnet/hoprnet/releases/tag/v${{ steps.setup.outputs.current_version }}'>Changelog</a> to see what you are missing</p>"
+  #         message="${messageHeader}${messageTagNumber}<br>${messageTagName}<br><br>${messageChangeLog}<br>"
+  #         ./scripts/notify-matrix.sh "${{ secrets.MATRIX_ROOM_RELEASES }}" "${message}"
+  #       env:
+  #         MATRIX_SERVER: ${{ secrets.MATRIX_SERVER }}
+  #         MATRIX_ACCESS_TOKEN: ${{ secrets.MATRIX_ACCESS_TOKEN }}
 
-      - name: Notify release on Element channel
-        run: |
-          messageHeader="<h3>&#9889; New Hoprd Release</h3><br><p>A new hoprd release has been launched. The tag <b>${{ steps.setup.outputs.current_version }}</b> is now available to be downloaded and use it</p>"
-          messageTagNumber="<code>docker pull europe-west3-docker.pkg.dev/hoprassociation/docker-images/hoprd:${{ steps.setup.outputs.current_version }}</code>"
-          messageTagName="<code>docker pull europe-west3-docker.pkg.dev/hoprassociation/docker-images/hoprd:${{ steps.tag.outputs.release_name }}</code>"
-          messageChangeLog="<p>Have a look at the <a href='https://github.com/hoprnet/hoprnet/releases/tag/v${{ steps.setup.outputs.current_version }}'>Changelog</a> to see what you are missing</p>"
-          message="${messageHeader}${messageTagNumber}<br>${messageTagName}<br><br>${messageChangeLog}<br>"
-          ./scripts/notify-matrix.sh "${{ secrets.MATRIX_ROOM_RELEASES }}" "${message}"
-        env:
-          MATRIX_SERVER: ${{ secrets.MATRIX_SERVER }}
-          MATRIX_ACCESS_TOKEN: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+  # new_release:
+  #   name: Open new release
+  #   if: contains(github.event.pull_request.labels.*.name, 'release')
+  #   needs: 
+  #     - create_release
+  #   uses: ./.github/workflows/open-release.yaml
+  #   with:
+  #     release_type: ${{ vars.NEXT_RELEASE_TYPE }}
+  #     base_branch: ${{ github.event.pull_request.base.ref }}
+  #   secrets: inherit
 
-  new_release:
-    name: Open new release
-    if: contains(github.event.pull_request.labels.*.name, 'release')
-    needs: 
-      - create_release
-    uses: ./.github/workflows/open-release.yaml
-    with:
-      release_type: ${{ vars.NEXT_RELEASE_TYPE }}
-      base_branch: ${{ github.event.pull_request.base.ref }}
-    secrets: inherit
-
-  build_dappnode:
-    name: Build dappNode
-    if: contains(github.event.pull_request.labels.*.name, 'release')
-    needs: 
-      - create_release
-    uses: ./.github/workflows/build-dappnode.yaml
-    with:
-      base_branch: ${{ github.event.pull_request.base.ref }}
-    secrets: inherit
+  # build_dappnode:
+  #   name: Build dappNode
+  #   if: contains(github.event.pull_request.labels.*.name, 'release')
+  #   needs: 
+  #     - create_release
+  #   uses: ./.github/workflows/build-dappnode.yaml
+  #   with:
+  #     base_branch: ${{ github.event.pull_request.base.ref }}
+  #   secrets: inherit

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -13,7 +13,7 @@ on:
   pull_request:
     types:
       - closed
-      - synchronize
+      # - synchronize
 
 
 concurrency:
@@ -24,37 +24,37 @@ permissions:
   contents: write
 
 jobs:
-  # cleanup-actions:
-  #   name: Cleanup Actions
-  #   runs-on: ubuntu-2-core
-  #   steps:
-  #     - name: Checkout hoprnet repository
-  #       uses: actions/checkout@v4
-  #     - name: Cleanup
-  #       run: |
-  #         gh extension install actions/gh-actions-cache
+  cleanup-actions:
+    name: Cleanup Actions
+    runs-on: ubuntu-2-core
+    steps:
+      - name: Checkout hoprnet repository
+        uses: actions/checkout@v4
+      - name: Cleanup
+        run: |
+          gh extension install actions/gh-actions-cache
 
-  #         REPO=${{ github.repository }}
-  #         BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
+          REPO=${{ github.repository }}
+          BRANCH="refs/pull/${{ github.event.pull_request.number }}/merge"
 
-  #         echo "Fetching list of cache key"
-  #         cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
+          echo "Fetching list of cache key"
+          cacheKeysForPR=$(gh actions-cache list -R $REPO -B $BRANCH | cut -f 1 )
 
-  #         ## Setting this to not fail the workflow while deleting cache keys.
-  #         set +e
-  #         echo "Deleting caches..."
-  #         for cacheKey in $cacheKeysForPR
-  #         do
-  #           gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
-  #         done
-  #         echo "Done"
-  #       env:
-  #         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ## Setting this to not fail the workflow while deleting cache keys.
+          set +e
+          echo "Deleting caches..."
+          for cacheKey in $cacheKeysForPR
+          do
+            gh actions-cache delete $cacheKey -R $REPO -B $BRANCH --confirm
+          done
+          echo "Done"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   tag:
     name: Tag images
     runs-on: ubuntu-2-core
-    # if: github.event.pull_request.merged == true && (github.event.pull_request.base.ref == 'master' || contains(github.event.pull_request.base.ref,'release/'))
+    if: github.event.pull_request.merged == true && (github.event.pull_request.base.ref == 'master' || contains(github.event.pull_request.base.ref,'release/'))
     steps:
       - name: Checkout hoprnet repository
         uses: actions/checkout@v4
@@ -83,7 +83,6 @@ jobs:
 
       - name: Tag docker images
         run: |
-          set -x
           docker_registry="europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/docker-images"
           # Set docker PR tag
           if ${{ contains(github.event.pull_request.labels.*.name, 'release') }}; then
@@ -111,148 +110,148 @@ jobs:
             fi
           done
 
-  # deploy_nodes:
-  #   name: Deploy nodes
-  #   runs-on: ubuntu-2-core
-  #   if: needs.tag.result == 'success'
-  #   needs:
-  #     - tag
-  #   steps:
-  #     - name: "Restart deployments"
-  #       run: |
-  #         base_branch="${{ github.event.pull_request.base.ref }}"
-  #         # Identify parameters depending on branch
-  #         if [[ "${base_branch}" == "master" ]]; then
-  #           namespace=rotsee
-  #           identity_pool=core-staging
-  #         elif [[ "${base_branch}" =~ ^"release" ]]; then
-  #           namespace=dufour
-  #           identity_pool="core-dufour-${base_branch/release\/}"
-  #         else
-  #           echo "Skipping deployment"
-  #           exit 0
-  #         fi
-  #         echo "[INFO] Restarting deployments on ${namespace} from pr-${{ github.event.pull_request.number }}"
-  #         # Get list of deployments to restart
-  #         export deployments=($(kubectl get deployments -n ${namespace/-.*} -l app.kubernetes.io/name=hoprd-operator,hoprds.hoprnet.org/identitypool=${identity_pool} -o jsonpath="{.items[*].metadata.name}"))
-  #         for deployment in "${deployments[@]}"; do
-  #           echo "[INFO] Restarting hoprd node ${namespace}/${deployments}"
-  #           kubectl rollout restart deployments -n ${namespace} $deployment;
-  #         done
+  deploy_nodes:
+    name: Deploy nodes
+    runs-on: ubuntu-2-core
+    if: needs.tag.result == 'success'
+    needs:
+      - tag
+    steps:
+      - name: "Restart deployments"
+        run: |
+          base_branch="${{ github.event.pull_request.base.ref }}"
+          # Identify parameters depending on branch
+          if [[ "${base_branch}" == "master" ]]; then
+            namespace=rotsee
+            identity_pool=core-staging
+          elif [[ "${base_branch}" =~ ^"release" ]]; then
+            namespace=dufour
+            identity_pool="core-dufour-${base_branch/release\/}"
+          else
+            echo "Skipping deployment"
+            exit 0
+          fi
+          echo "[INFO] Restarting deployments on ${namespace} from pr-${{ github.event.pull_request.number }}"
+          # Get list of deployments to restart
+          export deployments=($(kubectl get deployments -n ${namespace/-.*} -l app.kubernetes.io/name=hoprd-operator,hoprds.hoprnet.org/identitypool=${identity_pool} -o jsonpath="{.items[*].metadata.name}"))
+          for deployment in "${deployments[@]}"; do
+            echo "[INFO] Restarting hoprd node ${namespace}/${deployments}"
+            kubectl rollout restart deployments -n ${namespace} $deployment;
+          done
 
-  # create_release:
-  #   name: Create Release
-  #   runs-on: ubuntu-2-core
-  #   if: contains(github.event.pull_request.labels.*.name, 'release')
-  #   needs:
-  #     - tag
-  #   steps:
-  #     - name: Checkout hoprnet repository
-  #       uses: actions/checkout@v4
+  create_release:
+    name: Create Release
+    runs-on: ubuntu-2-core
+    if: contains(github.event.pull_request.labels.*.name, 'release')
+    needs:
+      - tag
+    steps:
+      - name: Checkout hoprnet repository
+        uses: actions/checkout@v4
 
-  #     - name: Set up Google Cloud Credentials
-  #       id: auth
-  #       uses: google-github-actions/auth@v1
-  #       with:
-  #         credentials_json: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
+      - name: Set up Google Cloud Credentials
+        id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
 
-  #     - name: Set up Google Cloud SDK
-  #       uses: google-github-actions/setup-gcloud@v1
-  #       with:
-  #         project_id: ${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}
-  #         install_components: beta
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: ${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}
+          install_components: beta
 
-  #     - name: Setup variables
-  #       id: setup
-  #       run: |
-  #         current_version=$(docker_pr_tag=$(./scripts/get-current-version.sh semver)
-  #         echo "current_version=${current_version}" >> $GITHUB_OUTPUT
-  #         if [[ $current_version == *"-rc."* ]]; then
-  #           echo "prerelease=true" >> $GITHUB_OUTPUT
-  #         else
-  #           echo "prerelease=false" >> $GITHUB_OUTPUT
-  #         fi
+      - name: Setup variables
+        id: setup
+        run: |
+          current_version=$(docker_pr_tag=$(./scripts/get-current-version.sh semver)
+          echo "current_version=${current_version}" >> $GITHUB_OUTPUT
+          if [[ $current_version == *"-rc."* ]]; then
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+          else
+            echo "prerelease=false" >> $GITHUB_OUTPUT
+          fi
 
-  #     - name: Tag repository
-  #       id: tag
-  #       run: |
-  #         # Tag semver
-  #         git tag v${{ steps.setup.outputs.current_version }}
-  #         git push origin v${{ steps.setup.outputs.current_version }}
+      - name: Tag repository
+        id: tag
+        run: |
+          # Tag semver
+          git tag v${{ steps.setup.outputs.current_version }}
+          git push origin v${{ steps.setup.outputs.current_version }}
 
-  #         declare base_branch=${{ github.event.pull_request.base.ref }}
-  #         # Tag release name
-  #         if [[ "${base_branch}" == "master" ]]; then
-  #           release_name=${{ vars.BRANCH_MASTER_RELEASE_NAME }}
-  #         elif [[ "${base_branch}" =~ ^"release" ]]; then
-  #           release_name=${{ vars.BRANCH_RELEASE_RELEASE_NAME }}
-  #         fi
-  #         git tag --force ${release_name}
-  #         git push --force origin ${release_name}
-  #         echo "release_name=${release_name}" >> $GITHUB_OUTPUT
+          declare base_branch=${{ github.event.pull_request.base.ref }}
+          # Tag release name
+          if [[ "${base_branch}" == "master" ]]; then
+            release_name=${{ vars.BRANCH_MASTER_RELEASE_NAME }}
+          elif [[ "${base_branch}" =~ ^"release" ]]; then
+            release_name=${{ vars.BRANCH_RELEASE_RELEASE_NAME }}
+          fi
+          git tag --force ${release_name}
+          git push --force origin ${release_name}
+          echo "release_name=${release_name}" >> $GITHUB_OUTPUT
 
-  #     - name: Generate Changelog
-  #       id: changelog
-  #       run: |
-  #         milestone_number=$(gh api repos/${{ github.repository }}/milestones | jq -r --arg version "${{ steps.setup.outputs.current_version }}"  ' to_entries[] | select(.value.title | test($version)).value.number')
-  #         ./scripts/generate-changelog.sh ${milestone_number} | tee docs/changelog/changelog.md
-  #         echo "milestone_number=${milestone_number}" >> $GITHUB_OUTPUT
-  #       env:
-  #         GH_TOKEN: ${{ github.token }}
+      - name: Generate Changelog
+        id: changelog
+        run: |
+          milestone_number=$(gh api repos/${{ github.repository }}/milestones | jq -r --arg version "${{ steps.setup.outputs.current_version }}"  ' to_entries[] | select(.value.title | test($version)).value.number')
+          ./scripts/generate-changelog.sh ${milestone_number} | tee docs/changelog/changelog.md
+          echo "milestone_number=${milestone_number}" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
 
-  #     - name: Tag docker images with release name
-  #       run: |
-  #         docker_registry="europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/docker-images"
-  #         images=(hopr-toolchain hopli hoprd hopr-anvil hopr-pluto)
-  #         for image in ${images[@]};
-  #         do
-  #           echo "Tagging ${image}:${{ steps.tag.outputs.release_name }}"
-  #           gcloud artifacts docker tags add ${docker_registry}/${image}:${{ steps.setup.outputs.current_version }} ${docker_registry}/${image}:${{ steps.tag.outputs.release_name }}
-  #         done
+      - name: Tag docker images with release name
+        run: |
+          docker_registry="europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/docker-images"
+          images=(hopr-toolchain hopli hoprd hopr-anvil hopr-pluto)
+          for image in ${images[@]};
+          do
+            echo "Tagging ${image}:${{ steps.tag.outputs.release_name }}"
+            gcloud artifacts docker tags add ${docker_registry}/${image}:${{ steps.setup.outputs.current_version }} ${docker_registry}/${image}:${{ steps.tag.outputs.release_name }}
+          done
 
-  #     - name: Create Release
-  #       uses: softprops/action-gh-release@v1
-  #       with:
-  #         body_path: docs/changelog/changelog.md
-  #         prerelease: ${{ steps.setup.outputs.prerelease }}
-  #         name: HOPR - v${{ steps.setup.outputs.current_version }}
-  #         tag_name: v${{ steps.setup.outputs.current_version }}
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        with:
+          body_path: docs/changelog/changelog.md
+          prerelease: ${{ steps.setup.outputs.prerelease }}
+          name: HOPR - v${{ steps.setup.outputs.current_version }}
+          tag_name: v${{ steps.setup.outputs.current_version }}
 
-  #     - name: Close Milestone
-  #       run: | 
-  #         gh api --method PATCH -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${{ github.repository }}/milestones/${{ steps.changelog.outputs.milestone_number }} -f state='closed'
-  #       env:
-  #         GH_TOKEN: ${{ secrets.GH_RUNNER_TOKEN }}
+      - name: Close Milestone
+        run: | 
+          gh api --method PATCH -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${{ github.repository }}/milestones/${{ steps.changelog.outputs.milestone_number }} -f state='closed'
+        env:
+          GH_TOKEN: ${{ secrets.GH_RUNNER_TOKEN }}
 
-  #     - name: Notify release on Element channel
-  #       run: |
-  #         messageHeader="<h3>&#9889; New Hoprd Release</h3><br><p>A new hoprd release has been launched. The tag <b>${{ steps.setup.outputs.current_version }}</b> is now available to be downloaded and use it</p>"
-  #         messageTagNumber="<code>docker pull europe-west3-docker.pkg.dev/hoprassociation/docker-images/hoprd:${{ steps.setup.outputs.current_version }}</code>"
-  #         messageTagName="<code>docker pull europe-west3-docker.pkg.dev/hoprassociation/docker-images/hoprd:${{ steps.tag.outputs.release_name }}</code>"
-  #         messageChangeLog="<p>Have a look at the <a href='https://github.com/hoprnet/hoprnet/releases/tag/v${{ steps.setup.outputs.current_version }}'>Changelog</a> to see what you are missing</p>"
-  #         message="${messageHeader}${messageTagNumber}<br>${messageTagName}<br><br>${messageChangeLog}<br>"
-  #         ./scripts/notify-matrix.sh "${{ secrets.MATRIX_ROOM_RELEASES }}" "${message}"
-  #       env:
-  #         MATRIX_SERVER: ${{ secrets.MATRIX_SERVER }}
-  #         MATRIX_ACCESS_TOKEN: ${{ secrets.MATRIX_ACCESS_TOKEN }}
+      - name: Notify release on Element channel
+        run: |
+          messageHeader="<h3>&#9889; New Hoprd Release</h3><br><p>A new hoprd release has been launched. The tag <b>${{ steps.setup.outputs.current_version }}</b> is now available to be downloaded and use it</p>"
+          messageTagNumber="<code>docker pull europe-west3-docker.pkg.dev/hoprassociation/docker-images/hoprd:${{ steps.setup.outputs.current_version }}</code>"
+          messageTagName="<code>docker pull europe-west3-docker.pkg.dev/hoprassociation/docker-images/hoprd:${{ steps.tag.outputs.release_name }}</code>"
+          messageChangeLog="<p>Have a look at the <a href='https://github.com/hoprnet/hoprnet/releases/tag/v${{ steps.setup.outputs.current_version }}'>Changelog</a> to see what you are missing</p>"
+          message="${messageHeader}${messageTagNumber}<br>${messageTagName}<br><br>${messageChangeLog}<br>"
+          ./scripts/notify-matrix.sh "${{ secrets.MATRIX_ROOM_RELEASES }}" "${message}"
+        env:
+          MATRIX_SERVER: ${{ secrets.MATRIX_SERVER }}
+          MATRIX_ACCESS_TOKEN: ${{ secrets.MATRIX_ACCESS_TOKEN }}
 
-  # new_release:
-  #   name: Open new release
-  #   if: contains(github.event.pull_request.labels.*.name, 'release')
-  #   needs: 
-  #     - create_release
-  #   uses: ./.github/workflows/open-release.yaml
-  #   with:
-  #     release_type: ${{ vars.NEXT_RELEASE_TYPE }}
-  #     base_branch: ${{ github.event.pull_request.base.ref }}
-  #   secrets: inherit
+  new_release:
+    name: Open new release
+    if: contains(github.event.pull_request.labels.*.name, 'release')
+    needs: 
+      - create_release
+    uses: ./.github/workflows/open-release.yaml
+    with:
+      release_type: ${{ vars.NEXT_RELEASE_TYPE }}
+      base_branch: ${{ github.event.pull_request.base.ref }}
+    secrets: inherit
 
-  # build_dappnode:
-  #   name: Build dappNode
-  #   if: contains(github.event.pull_request.labels.*.name, 'release')
-  #   needs: 
-  #     - create_release
-  #   uses: ./.github/workflows/build-dappnode.yaml
-  #   with:
-  #     base_branch: ${{ github.event.pull_request.base.ref }}
-  #   secrets: inherit
+  build_dappnode:
+    name: Build dappNode
+    if: contains(github.event.pull_request.labels.*.name, 'release')
+    needs: 
+      - create_release
+    uses: ./.github/workflows/build-dappnode.yaml
+    with:
+      base_branch: ${{ github.event.pull_request.base.ref }}
+    secrets: inherit

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -20,7 +20,6 @@ mydir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
 
 new_version="${1}"
 
-
 # define packages for versioning
 # does not include ethereum, which isn't a real package anymore, just a folder
 declare -a versioned_packages=( utils core-ethereum core real hoprd )

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -35,4 +35,5 @@ for package in "${versioned_packages[@]}"; do
 done
 
 # Update hopr-lib Rust manifest
-sed -i 's/^version = ".*"$/version = : \&str = "'${new_version}'";/' ${mydir}/../packages/hoprd/crates/hopr-lib/Cargo.toml 
+sed -i'.original' 's/^version = ".*"$/version = "'${new_version}'"/' ${mydir}/../packages/hoprd/crates/hopr-lib/Cargo.toml
+rm ${mydir}/../packages/core/crates/core-hopr/src/constants.rs.original

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -36,4 +36,4 @@ done
 
 # Update hopr-lib Rust manifest
 sed -i'.original' 's/^version = ".*"$/version = "'${new_version}'"/' ${mydir}/../packages/hoprd/crates/hopr-lib/Cargo.toml
-rm ${mydir}/../packages/core/crates/core-hopr/src/constants.rs.original
+rm ${mydir}/../packages/hoprd/crates/hopr-lib/Cargo.toml.original

--- a/scripts/get-current-version.sh
+++ b/scripts/get-current-version.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# exit on errors, undefined variables, ensure errors in pipes are not hidden
+set -Eeuo pipefail
+
+usage() {
+  echo ""
+  echo "Usage: $0 <version_type[semver|docker]>"
+  echo ""
+  echo "$0 semver"
+  echo "$0 docker"
+  echo
+}
+
+# return early with help info when requested
+{ [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; } && { usage; exit 0; }
+
+# set mydir
+declare mydir
+mydir=$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd -P)
+
+version_type=${1} # Can be any of these values Build | ReleaseCandidate | Patch | Minor | Major
+current_version=$(sed -n "s/^version = //p" ${mydir}/../packages/hoprd/crates/hopr-lib/Cargo.toml | tr -d '"')
+
+if [ "${version_type}" == "docker" ] 
+then
+  echo ${current_version}
+else
+  echo $(echo ${current_version} | sed 's/+/-/')
+fi


### PR DESCRIPTION
When a PR is merged against branch `release/providence` the docker tag `providence` is updated independently if it's part of a release or a simple PR.

This PR provides these new tags:
- `saint-louis-latest`: This tag will contain the same value than `latest` while `saint-louis` is being developed in `master` branch.
- `providence-latest`: This tag will contain the latest change applied in branch `release/providence`