### PR TITLE
Fix offchain ticket_index record out of sync

### DIFF
--- a/packages/core-ethereum/crates/core-ethereum-db/src/db.rs
+++ b/packages/core-ethereum/crates/core-ethereum-db/src/db.rs
@@ -70,7 +70,11 @@ impl<T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>> + Clone> HoprCoreEthe
     // combine the two function above to increase the current ticket index of a channel
     async fn increase_current_ticket_index(&mut self, channel_id: &Hash) -> Result<()> {
         let prefixed_key = utils_db::db::Key::new_with_prefix(channel_id, TICKET_INDEX_PREFIX)?;
-        let current_index = self.db.get_or_none::<U256>(prefixed_key.clone()).await?.unwrap_or(U256::zero());
+        let current_index = self
+            .db
+            .get_or_none::<U256>(prefixed_key.clone())
+            .await?
+            .unwrap_or(U256::zero());
         let _evicted = self.db.set(prefixed_key, &current_index.addn(1_u32)).await?;
         // Ignoring evicted value
         Ok(())
@@ -79,7 +83,11 @@ impl<T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>> + Clone> HoprCoreEthe
     // ensure the current ticket index is not smaller than the given value. If it's samller, set to the given value
     async fn ensure_current_ticket_index_gte(&mut self, channel_id: &Hash, index: U256) -> Result<()> {
         let prefixed_key = utils_db::db::Key::new_with_prefix(channel_id, TICKET_INDEX_PREFIX)?;
-        let current_index = self.db.get_or_none::<U256>(prefixed_key.clone()).await?.unwrap_or(U256::zero());
+        let current_index = self
+            .db
+            .get_or_none::<U256>(prefixed_key.clone())
+            .await?
+            .unwrap_or(U256::zero());
         // compare the current_index with index, if current_index is smaller than index, set to index
         if current_index < index {
             let _evicted = self.db.set(prefixed_key, &index).await?;

--- a/packages/core-ethereum/crates/core-ethereum-db/src/db.rs
+++ b/packages/core-ethereum/crates/core-ethereum-db/src/db.rs
@@ -124,6 +124,8 @@ impl<T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>> + Clone> HoprCoreEthe
         if current_index < index {
             let _evicted = self.db.set(prefixed_key, &index).await?;
             // Ignoring evicted value
+            // flush the db after setter
+            self.db.flush().await?;
         }
         Ok(())
     }

--- a/packages/core-ethereum/crates/core-ethereum-db/src/db.rs
+++ b/packages/core-ethereum/crates/core-ethereum-db/src/db.rs
@@ -67,6 +67,27 @@ impl<T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>> + Clone> HoprCoreEthe
         Ok(())
     }
 
+    // combine the two function above to increase the current ticket index of a channel
+    async fn increase_current_ticket_index(&mut self, channel_id: &Hash) -> Result<()> {
+        let prefixed_key = utils_db::db::Key::new_with_prefix(channel_id, TICKET_INDEX_PREFIX)?;
+        let current_index = self.db.get_or_none::<U256>(prefixed_key.clone()).await?.unwrap_or(U256::zero());
+        let _evicted = self.db.set(prefixed_key, &current_index.addn(1_u32)).await?;
+        // Ignoring evicted value
+        Ok(())
+    }
+
+    // ensure the current ticket index is not smaller than the given value. If it's samller, set to the given value
+    async fn ensure_current_ticket_index_gte(&mut self, channel_id: &Hash, index: U256) -> Result<()> {
+        let prefixed_key = utils_db::db::Key::new_with_prefix(channel_id, TICKET_INDEX_PREFIX)?;
+        let current_index = self.db.get_or_none::<U256>(prefixed_key.clone()).await?.unwrap_or(U256::zero());
+        // compare the current_index with index, if current_index is smaller than index, set to index
+        if current_index < index {
+            let _evicted = self.db.set(prefixed_key, &index).await?;
+            // Ignoring evicted value
+        }
+        Ok(())
+    }
+
     async fn get_tickets(&self, maybe_signer: Option<Address>) -> Result<Vec<Ticket>> {
         let mut acked_tickets = self
             .db

--- a/packages/core-ethereum/crates/core-ethereum-db/src/traits.rs
+++ b/packages/core-ethereum/crates/core-ethereum-db/src/traits.rs
@@ -15,6 +15,8 @@ pub trait HoprCoreEthereumDbActions {
     // core only part
     async fn get_current_ticket_index(&self, channel_id: &Hash) -> Result<Option<U256>>;
     async fn set_current_ticket_index(&mut self, channel_id: &Hash, index: U256) -> Result<()>;
+    async fn increase_current_ticket_index(&mut self, channel_id: &Hash) -> Result<()>;
+    async fn ensure_current_ticket_index_gte(&mut self, channel_id: &Hash, index: U256) -> Result<()>;
 
     async fn get_tickets(&self, signer: Option<Address>) -> Result<Vec<Ticket>>;
 

--- a/packages/core-ethereum/crates/core-ethereum-indexer/src/handlers.rs
+++ b/packages/core-ethereum/crates/core-ethereum-indexer/src/handlers.rs
@@ -292,11 +292,10 @@ where
 
                     db.update_channel_and_snapshot(&channel_closed.channel_id.try_into()?, &channel, snapshot)
                         .await?;
-
-                    // Reset the current_ticket_index to zero
-                    db.set_current_ticket_index(&channel_closed.channel_id.try_into()?, U256::zero()).await?;
-
+                    
                     if channel.source.eq(&self.chain_key) || channel.destination.eq(&self.chain_key) {
+                        // Reset the current_ticket_index to zero
+                        db.set_current_ticket_index(&channel_closed.channel_id.try_into()?, U256::zero()).await?;
                         self.cbs.own_channel_updated(&channel);
                     }
                 } else {
@@ -317,9 +316,6 @@ where
                     channel_id.to_string(),
                     maybe_channel.is_some()
                 );
-
-                // Reset the current_ticket_index to zero
-                db.set_current_ticket_index(&channel_id, U256::zero()).await?;
 
                 if let Some(mut channel) = maybe_channel {
                     // set all channel fields like we do on-chain on close
@@ -347,6 +343,8 @@ where
                         .await?;
 
                     if source.eq(&self.chain_key) || destination.eq(&self.chain_key) {
+                        // Reset the current_ticket_index to zero
+                        db.set_current_ticket_index(&channel_id, U256::zero()).await?;
                         self.cbs.own_channel_updated(&new_channel);
                     }
                 }

--- a/packages/core-ethereum/crates/core-ethereum-indexer/src/handlers.rs
+++ b/packages/core-ethereum/crates/core-ethereum-indexer/src/handlers.rs
@@ -326,6 +326,8 @@ where
                     db.update_channel_and_snapshot(&channel_id, &channel, snapshot).await?;
 
                     if source.eq(&self.chain_key) || destination.eq(&self.chain_key) {
+                        // Reset the current_ticket_index to zero
+                        db.set_current_ticket_index(&channel_id, U256::zero()).await?;
                         self.cbs.own_channel_updated(&channel);
                     }
                 } else {

--- a/packages/core-ethereum/crates/core-ethereum-indexer/src/handlers.rs
+++ b/packages/core-ethereum/crates/core-ethereum-indexer/src/handlers.rs
@@ -292,10 +292,11 @@ where
 
                     db.update_channel_and_snapshot(&channel_closed.channel_id.try_into()?, &channel, snapshot)
                         .await?;
-                    
+
                     if channel.source.eq(&self.chain_key) || channel.destination.eq(&self.chain_key) {
                         // Reset the current_ticket_index to zero
-                        db.set_current_ticket_index(&channel_closed.channel_id.try_into()?, U256::zero()).await?;
+                        db.set_current_ticket_index(&channel_closed.channel_id.try_into()?, U256::zero())
+                            .await?;
                         self.cbs.own_channel_updated(&channel);
                     }
                 } else {
@@ -360,7 +361,8 @@ where
                     db.update_channel_and_snapshot(&ticket_redeemed.channel_id.try_into()?, &channel, snapshot)
                         .await?;
                     // compare the ticket index from the redeemed ticket with the current_ticket_index. Ensure that the current_ticket_index is not smaller than the value from redeemed ticket.
-                    db.ensure_current_ticket_index_gte(&ticket_redeemed.channel_id.try_into()?, channel.ticket_index).await?;
+                    db.ensure_current_ticket_index_gte(&ticket_redeemed.channel_id.try_into()?, channel.ticket_index)
+                        .await?;
 
                     if channel.source.eq(&self.chain_key) || channel.destination.eq(&self.chain_key) {
                         self.cbs.own_channel_updated(&channel);

--- a/packages/core/crates/core-packet/src/validation.rs
+++ b/packages/core/crates/core-packet/src/validation.rs
@@ -137,6 +137,8 @@ mod tests {
         impl HoprCoreEthereumDbActions for Db {
             async fn get_current_ticket_index(&self, channel_id: &Hash) -> core_ethereum_db::errors::Result<Option<U256>>;
             async fn set_current_ticket_index(&mut self, channel_id: &Hash, index: U256) -> core_ethereum_db::errors::Result<()>;
+            async fn increase_current_ticket_index(&mut self, channel_id: &Hash) -> core_ethereum_db::errors::Result<()>;
+            async fn ensure_current_ticket_index_gte(&mut self, channel_id: &Hash, index: U256) -> core_ethereum_db::errors::Result<()>;
             async fn get_tickets(&self, signer: Option<Address>) -> core_ethereum_db::errors::Result<Vec<Ticket>>;
             async fn cleanup_invalid_channel_tickets(&mut self, channel: &ChannelEntry) -> core_ethereum_db::errors::Result<()>;
             async fn mark_rejected(&mut self, ticket: &Ticket) -> core_ethereum_db::errors::Result<()>;
@@ -639,5 +641,53 @@ mod tests {
             .expect("db must contain ticket index");
 
         assert_eq!(dummy_index, idx, "ticket index mismatch");
+    }
+
+    #[async_std::test]
+    async fn test_db_should_increase_ticket_index() {
+        let mut db = CoreEthereumDb::new(
+            DB::new(RustyLevelDbShim::new_in_memory()),
+            SENDER_PRIV_KEY.public().to_address(),
+        );
+
+        let dummy_channel = Hash::new(&[0xffu8; Hash::SIZE]);
+
+        // increase current ticket index of a non-existing channel, the result should be 1
+        db.increase_current_ticket_index(&dummy_channel).await.unwrap();
+        let idx = db
+            .get_current_ticket_index(&dummy_channel)
+            .await
+            .unwrap()
+            .expect("db must contain ticket index");
+        assert_eq!(idx,  U256::one(), "ticket index mismatch. Expecting 1");
+    
+        // increase current ticket index of an existing channel where previous value is 1, the result should be 2
+        db.increase_current_ticket_index(&dummy_channel).await.unwrap();
+        let idx = db
+            .get_current_ticket_index(&dummy_channel)
+            .await
+            .unwrap()
+            .expect("db must contain ticket index");
+        assert_eq!(idx,  U256::new("2"), "ticket index mismatch. Expecting 2");
+    }
+
+    #[async_std::test]
+    async fn test_db_should_ensure_ticket_index_not_smaller_than_given_index() {
+        let mut db = CoreEthereumDb::new(
+            DB::new(RustyLevelDbShim::new_in_memory()),
+            SENDER_PRIV_KEY.public().to_address(),
+        );
+
+        let dummy_channel = Hash::new(&[0xffu8; Hash::SIZE]);
+        let dummy_index = U256::new("123");
+    
+        // the ticket index should be equal or greater than the given dummy index
+        db.ensure_current_ticket_index_gte(&dummy_channel, dummy_index).await.unwrap();
+        let idx = db
+            .get_current_ticket_index(&dummy_channel)
+            .await
+            .unwrap()
+            .expect("db must contain ticket index");
+        assert_eq!(idx,  dummy_index, "ticket index mismatch. Expecting 2");
     }
 }

--- a/packages/core/crates/core-packet/src/validation.rs
+++ b/packages/core/crates/core-packet/src/validation.rs
@@ -659,8 +659,8 @@ mod tests {
             .await
             .unwrap()
             .expect("db must contain ticket index");
-        assert_eq!(idx,  U256::one(), "ticket index mismatch. Expecting 1");
-    
+        assert_eq!(idx, U256::one(), "ticket index mismatch. Expecting 1");
+
         // increase current ticket index of an existing channel where previous value is 1, the result should be 2
         db.increase_current_ticket_index(&dummy_channel).await.unwrap();
         let idx = db
@@ -668,7 +668,7 @@ mod tests {
             .await
             .unwrap()
             .expect("db must contain ticket index");
-        assert_eq!(idx,  U256::new("2"), "ticket index mismatch. Expecting 2");
+        assert_eq!(idx, U256::new("2"), "ticket index mismatch. Expecting 2");
     }
 
     #[async_std::test]
@@ -680,14 +680,16 @@ mod tests {
 
         let dummy_channel = Hash::new(&[0xffu8; Hash::SIZE]);
         let dummy_index = U256::new("123");
-    
+
         // the ticket index should be equal or greater than the given dummy index
-        db.ensure_current_ticket_index_gte(&dummy_channel, dummy_index).await.unwrap();
+        db.ensure_current_ticket_index_gte(&dummy_channel, dummy_index)
+            .await
+            .unwrap();
         let idx = db
             .get_current_ticket_index(&dummy_channel)
             .await
             .unwrap()
             .expect("db must contain ticket index");
-        assert_eq!(idx,  dummy_index, "ticket index mismatch. Expecting 2");
+        assert_eq!(idx, dummy_index, "ticket index mismatch. Expecting 2");
     }
 }

--- a/packages/core/crates/core-protocol/src/ticket_aggregation/processor.rs
+++ b/packages/core/crates/core-protocol/src/ticket_aggregation/processor.rs
@@ -345,7 +345,11 @@ impl<Db: HoprCoreEthereumDbActions> TicketAggregationProcessor<Db> {
         // calculate the minimum current ticket index as the larger value from the acked ticket index and on-chain ticket_index from channel_entry
         let current_ticket_index_from_acked_tickets = U256::from(last_acked_ticket.ticket.index).addn(1);
         let current_ticket_index_gte = current_ticket_index_from_acked_tickets.max(channel_entry.ticket_index);
-        self.db.write().await.ensure_current_ticket_index_gte(&channel_id, current_ticket_index_gte).await?;
+        self.db
+            .write()
+            .await
+            .ensure_current_ticket_index_gte(&channel_id, current_ticket_index_gte)
+            .await?;
 
         Ticket::new(
             &destination,
@@ -426,8 +430,9 @@ impl<Db: HoprCoreEthereumDbActions> TicketAggregationProcessor<Db> {
             })?;
 
         // calculate the new current ticket index
-        let current_ticket_index_from_aggregated_ticket = U256::from(aggregated_ticket.index).addn(aggregated_ticket.index_offset);
-        
+        let current_ticket_index_from_aggregated_ticket =
+            U256::from(aggregated_ticket.index).addn(aggregated_ticket.index_offset);
+
         let acked_aggregated_ticket = AcknowledgedTicket::new(
             aggregated_ticket,
             first_stored_ticket.response.clone(),
@@ -466,8 +471,12 @@ impl<Db: HoprCoreEthereumDbActions> TicketAggregationProcessor<Db> {
             .await?;
 
         info!("ensure the current ticket index is not smaller than the the aggregated ticket index + offset");
-        self.db.write().await.ensure_current_ticket_index_gte(&channel_id, current_ticket_index_from_aggregated_ticket).await?;
-    
+        self.db
+            .write()
+            .await
+            .ensure_current_ticket_index_gte(&channel_id, current_ticket_index_from_aggregated_ticket)
+            .await?;
+
         Ok(acked_aggregated_ticket)
     }
 

--- a/packages/core/crates/core-protocol/src/ticket_aggregation/processor.rs
+++ b/packages/core/crates/core-protocol/src/ticket_aggregation/processor.rs
@@ -285,7 +285,7 @@ impl<Db: HoprCoreEthereumDbActions> TicketAggregationProcessor<Db> {
         acked_tickets.sort();
         acked_tickets.dedup();
 
-        let channel_epoch = acked_tickets[0].ticket.channel_epoch;
+        let channel_epoch = channel_entry.channel_epoch;
 
         let mut final_value = Balance::zero(BalanceType::HOPR);
 
@@ -297,7 +297,7 @@ impl<Db: HoprCoreEthereumDbActions> TicketAggregationProcessor<Db> {
                 )));
             }
 
-            if acked_ticket.ticket.channel_epoch != channel_epoch {
+            if U256::from(acked_ticket.ticket.channel_epoch) != channel_epoch {
                 return Err(ProtocolTicketAggregation("Channel epochs do not match".to_owned()));
             }
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -81,7 +81,12 @@ async def check_channel_status(src, dest, status):
     while True:
         channel = await get_channel(src, dest, include_closed=False)
         channel_seen_from_dst = await get_channel_seen_from_dst(src, dest, include_closed=False)
-        if channel is not None and channel.status == status and channel_seen_from_dst is not None and channel_seen_from_dst.status == status:
+        if (
+            channel is not None
+            and channel.status == status
+            and channel_seen_from_dst is not None
+            and channel_seen_from_dst.status == status
+        ):
             break
         else:
             await asyncio.sleep(CHECK_RETRY_INTERVAL)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -65,11 +65,23 @@ async def get_channel(src, dest, include_closed=False):
     return channels[0] if len(channels) > 0 else None
 
 
+async def get_channel_seen_from_dst(src, dest, include_closed=False):
+    open_channels = await dest["api"].all_channels(include_closed=include_closed)
+    channels = [
+        oc
+        for oc in open_channels.all
+        if oc.source_address == src["address"] and oc.destination_address == dest["address"]
+    ]
+
+    return channels[0] if len(channels) > 0 else None
+
+
 async def check_channel_status(src, dest, status):
     assert status in ["Open", "PendingToClose", "Closed"]
     while True:
         channel = await get_channel(src, dest, include_closed=False)
-        if channel is not None and channel.status == status:
+        channel_seen_from_dst = await get_channel_seen_from_dst(src, dest, include_closed=False)
+        if channel is not None and channel.status == status and channel_seen_from_dst is not None and channel_seen_from_dst.status == status:
             break
         else:
             await asyncio.sleep(CHECK_RETRY_INTERVAL)


### PR DESCRIPTION
Nodes keep "current_ticket_index" in the DB for all the incoming and outgoing channels. This value can be greater or equal to its on-chain counterpart (channel_entry.ticket_index). The offchain record increases by 1 for each issuance of ticket and gets reset to zero when the channel is closed and re-opened. When the this value gets reset incorrectly, e.g. in an event of DB removal, indexer should be able to bring it back to the on-chain state. 

## Details
- Add db operation 
   - `ensure_current_ticket_index_gte` to set the "current ticket index" to a larger value
   -  `increase_current_ticket_index` to increase the "current ticket index" by 1 (unused)
- Indexer update the "current ticket index" in ChannelOpened, ChannelClosed and TicketRedeemed
- During ticket aggregation, add checks on the "current ticket index".
 
## Miscellaneous
- Modifier e2e test so that create_channel ensures channel creation is indexed by both src and dst nodes.

## Notes

Fixes https://github.com/hoprnet/hoprnet/issues/5723