### PR TITLE
SMA improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1064,7 +1064,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-crypto"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "aes 0.8.3",
  "blake2",
@@ -1084,6 +1084,7 @@ dependencies = [
  "k256",
  "libp2p-identity",
  "parameterized",
+ "primitive-types",
  "rand 0.8.5",
  "serde",
  "sha2 0.10.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6264,7 +6264,7 @@ dependencies = [
 
 [[package]]
 name = "utils-types"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/packages/core/crates/core-crypto/Cargo.toml
+++ b/packages/core/crates/core-crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-crypto"
-version = "0.5.2"
+version = "0.5.3"
 description = "Core cryptographic primitives and functions used in the HOPR protocol"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
@@ -28,6 +28,7 @@ hkdf = "0.12"
 js-sys = { workspace = true, optional = true }
 k256 = { version = "0.13.0", features = ["arithmetic", "ecdh", "hash2curve", "serde"] }
 libp2p-identity = { workspace = true }
+primitive-types = "0.12"
 rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }
 sha2 = "0.10"

--- a/packages/core/crates/core-crypto/src/keypairs.rs
+++ b/packages/core/crates/core-crypto/src/keypairs.rs
@@ -1,4 +1,11 @@
+use digest::Digest;
+use generic_array::{ArrayLength, GenericArray};
+use sha2::Sha512;
 use std::fmt::Debug;
+use subtle::{Choice, ConstantTimeEq};
+use utils_types::traits::PeerIdLike;
+use utils_types::{primitives::Address, traits::BinarySerializable};
+use zeroize::ZeroizeOnDrop;
 
 use crate::errors;
 use crate::errors::CryptoError::InvalidInputValue;
@@ -6,12 +13,6 @@ use crate::random::{random_bytes, random_group_element};
 use crate::shared_keys::Scalar;
 use crate::types::{CompressedPublicKey, OffchainPublicKey, PublicKey};
 use crate::utils::SecretValue;
-use digest::Digest;
-use generic_array::{ArrayLength, GenericArray};
-use sha2::Sha512;
-use subtle::{Choice, ConstantTimeEq};
-use utils_types::{primitives::Address, traits::BinarySerializable};
-use zeroize::ZeroizeOnDrop;
 
 /// Represents a generic key pair
 /// The keypair contains a private key and public key.
@@ -109,6 +110,12 @@ impl From<&OffchainKeypair> for libp2p_identity::Keypair {
     }
 }
 
+impl From<&OffchainKeypair> for libp2p_identity::PeerId {
+    fn from(value: &OffchainKeypair) -> Self {
+        value.1.to_peerid()
+    }
+}
+
 /// Represents a keypair consisting of a secp256k1 private and public key
 #[derive(Clone, ZeroizeOnDrop)]
 #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
@@ -143,6 +150,7 @@ impl Keypair for ChainKeypair {
 
 impl Debug for ChainKeypair {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Do not expose the private key
         f.debug_tuple("ChainKeypair").field(&self.1).finish()
     }
 }

--- a/packages/core/crates/core-crypto/src/types.rs
+++ b/packages/core/crates/core-crypto/src/types.rs
@@ -25,6 +25,7 @@ use k256::{
 
 use libp2p_identity::PeerId;
 use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
 use std::{
     fmt::{Display, Formatter},
     ops::Add,
@@ -432,7 +433,7 @@ impl From<HalfKey> for HalfKeyChallenge {
 
 /// Represents an Ethereum 256-bit hash value
 /// This implementation instantiates the hash via Keccak256 digest.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, PartialOrd, Ord)]
+#[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize, PartialOrd, Ord)]
 #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
 pub struct Hash {
     hash: [u8; Self::SIZE],
@@ -446,7 +447,14 @@ impl Default for Hash {
     }
 }
 
-impl std::fmt::Display for Hash {
+impl Debug for Hash {
+    // Intentionally same as Display
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.to_hex().as_str())
+    }
+}
+
+impl Display for Hash {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.to_hex().as_str())
     }
@@ -511,6 +519,18 @@ impl From<[u8; Self::SIZE]> for Hash {
 impl From<Hash> for [u8; Hash::SIZE] {
     fn from(value: Hash) -> Self {
         value.hash
+    }
+}
+
+impl From<Hash> for primitive_types::H256 {
+    fn from(value: Hash) -> Self {
+        value.hash.into()
+    }
+}
+
+impl From<primitive_types::H256> for Hash {
+    fn from(value: primitive_types::H256) -> Self {
+        Self { hash: value.0 }
     }
 }
 

--- a/packages/core/crates/core-network/src/network.rs
+++ b/packages/core/crates/core-network/src/network.rs
@@ -12,7 +12,7 @@ use validator::Validate;
 
 use crate::constants::DEFAULT_NETWORK_QUALITY_THRESHOLD;
 use utils_log::{info, warn};
-use utils_types::sma::{NoSumSMA, SMA};
+use utils_types::sma::{SingleSumSMA, SMA};
 
 #[cfg(all(feature = "prometheus", not(test), not(feature = "wasm")))]
 use utils_misc::time::native::current_timestamp;
@@ -180,7 +180,7 @@ pub struct PeerStatus {
     pub heartbeats_sent: u64,
     pub heartbeats_succeeded: u64,
     pub backoff: f64,
-    quality_avg: NoSumSMA<f64>,
+    quality_avg: SingleSumSMA<f64>,
     metadata: HashMap<String, String>,
 }
 
@@ -197,13 +197,13 @@ impl PeerStatus {
             backoff,
             quality: 0.0,
             metadata: HashMap::new(),
-            quality_avg: NoSumSMA::new(quality_window),
+            quality_avg: SingleSumSMA::new(quality_window),
         }
     }
 
     pub fn update_quality(&mut self, new_value: f64) {
         self.quality = new_value;
-        self.quality_avg.add_sample(new_value);
+        self.quality_avg.push(new_value);
     }
 
     /// Gets metadata associated with the peer
@@ -213,7 +213,7 @@ impl PeerStatus {
 
     /// Gets the average quality of this peer
     pub fn get_average_quality(&self) -> f64 {
-        self.quality_avg.get_average()
+        self.quality_avg.average().unwrap_or_default()
     }
 
     /// Gets the immediate node quality
@@ -640,7 +640,7 @@ pub mod wasm {
                 heartbeats_succeeded,
                 backoff,
                 metadata: js_map_to_hash_map(peer_metadata).unwrap_or(HashMap::new()),
-                quality_avg: NoSumSMA::new_with_samples(quality_window, &[quality]),
+                quality_avg: SingleSumSMA::new_with_samples(quality_window, vec![quality]),
             }
         }
     }

--- a/packages/core/crates/core-strategy/src/promiscuous.rs
+++ b/packages/core/crates/core-strategy/src/promiscuous.rs
@@ -128,7 +128,7 @@ where
 
         let sma = self.sma.read().await;
         if sma.len() >= sma.window_size() {
-            Some(sma.average().unwrap())
+            sma.average()
         } else {
             info!(
                 "not yet enough samples ({} out of {}) of network size to perform a strategy tick, skipping.",

--- a/packages/core/crates/core-strategy/src/promiscuous.rs
+++ b/packages/core/crates/core-strategy/src/promiscuous.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use std::fmt::{Debug, Display, Formatter};
 use std::sync::Arc;
-use utils_types::sma::{NoSumSMA, SMA};
+use utils_types::sma::{SingleSumSMA, SMA};
 use utils_types::traits::PeerIdLike;
 use validator::Validate;
 
@@ -98,7 +98,7 @@ where
     network: Arc<RwLock<Network<Net>>>,
     chain_actions: A,
     cfg: PromiscuousStrategyConfig,
-    sma: RwLock<NoSumSMA<u32>>,
+    sma: RwLock<SingleSumSMA<u32>>,
 }
 
 impl<Db, Net, A> PromiscuousStrategy<Db, Net, A>
@@ -117,18 +117,18 @@ where
             db,
             network,
             chain_actions,
-            sma: RwLock::new(NoSumSMA::new(cfg.min_network_size_samples)),
+            sma: RwLock::new(SingleSumSMA::new(cfg.min_network_size_samples)),
             cfg,
         }
     }
 
     async fn sample_size_and_evaluate_avg(&self, sample: u32) -> Option<u32> {
-        self.sma.write().await.add_sample(sample);
+        self.sma.write().await.push(sample);
         info!("evaluated qualities of {sample} peers seen in the network");
 
         let sma = self.sma.read().await;
         if sma.len() >= sma.window_size() {
-            Some(sma.get_average())
+            Some(sma.average().unwrap())
         } else {
             info!(
                 "not yet enough samples ({} out of {}) of network size to perform a strategy tick, skipping.",

--- a/packages/utils/crates/utils-types/Cargo.toml
+++ b/packages/utils/crates/utils-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utils-types"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Generic types used through the entire code base"

--- a/packages/utils/crates/utils-types/src/primitives.rs
+++ b/packages/utils/crates/utils-types/src/primitives.rs
@@ -1,6 +1,5 @@
 use ethnum::{u256, AsU256};
 use getrandom::getrandom;
-use primitive_types::{H160, U256 as EthereumU256};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
@@ -13,10 +12,17 @@ use crate::errors::{GeneralError, GeneralError::InvalidInput, GeneralError::Pars
 use crate::traits::{AutoBinarySerializable, BinarySerializable, ToHex};
 
 /// Represents an Ethereum address
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash, PartialOrd, Ord)]
+#[derive(Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash, PartialOrd, Ord)]
 #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen)]
 pub struct Address {
     addr: [u8; Self::SIZE],
+}
+
+impl Debug for Address {
+    // Intentionally same as Display
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.to_hex())
+    }
 }
 
 impl Display for Address {
@@ -26,6 +32,7 @@ impl Display for Address {
 }
 
 impl Default for Address {
+    /// Defaults to all zeroes.
     fn default() -> Self {
         Self {
             addr: [0u8; Self::SIZE],
@@ -43,10 +50,6 @@ impl Address {
         ret
     }
 
-    pub fn is_null(&self) -> bool {
-        self.addr == [0u8; Self::SIZE]
-    }
-
     pub fn to_bytes32(&self) -> Box<[u8]> {
         let mut ret = Vec::with_capacity(12 + Self::SIZE);
         ret.extend_from_slice(&[0u8; 12]);
@@ -56,10 +59,16 @@ impl Address {
 
     /// Creates a random Ethereum address, mostly used for testing
     pub fn random() -> Self {
+        // Uses getrandom, because it cannot bring in dependency on core-crypto
         let mut addr = [0u8; Self::SIZE];
         getrandom(&mut addr[..]).unwrap();
 
         Self { addr }
+    }
+
+    /// Checks if the address is all zeroes.
+    pub fn is_zero(&self) -> bool {
+        self.addr.iter().all(|e| 0_u8.eq(e))
     }
 }
 
@@ -89,15 +98,15 @@ impl From<[u8; Address::SIZE]> for Address {
     }
 }
 
-impl From<H160> for Address {
-    fn from(value: H160) -> Self {
+impl From<primitive_types::H160> for Address {
+    fn from(value: primitive_types::H160) -> Self {
         Address { addr: value.0 }
     }
 }
 
-impl From<Address> for H160 {
+impl From<Address> for primitive_types::H160 {
     fn from(value: Address) -> Self {
-        H160::from_slice(&value.to_bytes())
+        primitive_types::H160::from_slice(&value.addr)
     }
 }
 
@@ -736,14 +745,14 @@ impl From<u8> for U256 {
     }
 }
 
-impl From<EthereumU256> for U256 {
-    fn from(value: EthereumU256) -> Self {
+impl From<primitive_types::U256> for U256 {
+    fn from(value: primitive_types::U256) -> Self {
         U256::from(&value)
     }
 }
 
-impl From<&EthereumU256> for U256 {
-    fn from(value: &EthereumU256) -> Self {
+impl From<&primitive_types::U256> for U256 {
+    fn from(value: &primitive_types::U256) -> Self {
         let mut tmp = [0u8; 32];
         value.to_big_endian(&mut tmp);
 
@@ -753,15 +762,15 @@ impl From<&EthereumU256> for U256 {
     }
 }
 
-impl From<U256> for EthereumU256 {
+impl From<U256> for primitive_types::U256 {
     fn from(value: U256) -> Self {
-        EthereumU256::from(&value)
+        primitive_types::U256::from(&value)
     }
 }
 
-impl From<&U256> for EthereumU256 {
+impl From<&U256> for primitive_types::U256 {
     fn from(value: &U256) -> Self {
-        EthereumU256::from_big_endian(&value.value.to_be_bytes())
+        primitive_types::U256::from_big_endian(&value.value.to_be_bytes())
     }
 }
 
@@ -826,7 +835,6 @@ impl AuthorizationToken {
 mod tests {
     use super::*;
     use hex_literal::hex;
-    use primitive_types::U256 as EthereumU256;
     use std::cmp::Ordering;
     use std::str::FromStr;
 
@@ -985,7 +993,8 @@ mod tests {
     #[test]
     fn u256_conversions() {
         let u256_ethereum =
-            EthereumU256::from_str("ef35a3f4fda07a4719ed5960b40ac51e67f013c1c444662eaff3b3d217492957").unwrap();
+            primitive_types::U256::from_str("ef35a3f4fda07a4719ed5960b40ac51e67f013c1c444662eaff3b3d217492957")
+                .unwrap();
 
         assert_eq!(
             U256::from(u256_ethereum),
@@ -995,8 +1004,9 @@ mod tests {
         let u256 = U256::from_hex("ef35a3f4fda07a4719ed5960b40ac51e67f013c1c444662eaff3b3d217492957").unwrap();
 
         assert_eq!(
-            EthereumU256::from(u256),
-            EthereumU256::from_str("ef35a3f4fda07a4719ed5960b40ac51e67f013c1c444662eaff3b3d217492957").unwrap()
+            primitive_types::U256::from(u256),
+            primitive_types::U256::from_str("ef35a3f4fda07a4719ed5960b40ac51e67f013c1c444662eaff3b3d217492957")
+                .unwrap()
         );
     }
 }
@@ -1073,7 +1083,7 @@ pub mod wasm {
 
         #[wasm_bindgen(js_name = "to_string")]
         pub fn _to_string(&self) -> String {
-            format!("{} {}", self.value.to_string(), self.balance_type)
+            format!("{} {}", self.value, self.balance_type)
         }
 
         #[wasm_bindgen]

--- a/packages/utils/crates/utils-types/src/sma.rs
+++ b/packages/utils/crates/utils-types/src/sma.rs
@@ -1,18 +1,18 @@
 use ringbuffer::{AllocRingBuffer, RingBuffer};
 use std::fmt::{Display, Formatter};
-use std::ops::{Add, Div};
+use std::iter::Sum;
+use std::marker::PhantomData;
+use std::ops::{AddAssign, Div, SubAssign};
 
 /// Simple Moving Average trait.
 /// The second-most useful filter type, bested only by coffee filters.
-pub trait SMA<T>
-where
-    T: for<'a> Add<&'a T, Output = T> + Div<T, Output = T> + Clone + From<u32> + Display + Default,
-{
-    /// Adds a sample.
-    fn add_sample(&mut self, sample: T);
+pub trait SMA<T> {
+    /// Pushes a sample.
+    fn push(&mut self, sample: T);
 
     /// Calculates the moving average value.
-    fn get_average(&self) -> T;
+    /// Returns `None` if no samples were added.
+    fn average(&self) -> Option<T>;
 
     /// Returns the window size.
     fn window_size(&self) -> usize;
@@ -20,37 +20,42 @@ where
     /// Returns the number of elements in the window.
     /// This value is always between 0 and `window_size()`.
     fn len(&self) -> usize;
+
+    /// Indicates whether the window is fully occupied
+    /// with samples.
+    fn is_window_full(&self) -> bool {
+        self.len() == self.window_size()
+    }
+
+    /// Indicates whether there are no samples.
+    fn is_empty(&self) -> bool;
 }
 
 /// Basic implementation of Simple Moving Average (SMA).
 /// The maximum window size is bound by 2^32 - 1.
-/// Useful mainly for floating-point types, as it does not accumulate floating point error with each sample,
-/// but requires `O(N)` of memory and `O(N)` for average computation, `N` being window size.
+/// Useful mainly for floating-point types, as it does not accumulate floating point error with each sample.
+/// Requires `O(N)` of memory and `O(N)` for average computation, `N` being window size.
+/// The divisor argument `D` is used only for such types `T` that do not implement `From<u32>` (such as `Duration`,...).
 #[derive(Clone, Debug, PartialEq)]
-pub struct NoSumSMA<T>
-where
-    T: for<'a> Add<&'a T, Output = T> + Div<T, Output = T> + Clone + From<u32> + Display + Default,
-{
+pub struct NoSumSMA<T, D = T> {
     window: AllocRingBuffer<T>,
+    _div: PhantomData<D>,
 }
 
-impl<T> SMA<T> for NoSumSMA<T>
+impl<T, D> SMA<T> for NoSumSMA<T, D>
 where
-    T: for<'a> Add<&'a T, Output = T> + Div<T, Output = T> + Clone + From<u32> + Display + Default,
+    T: for<'a> Sum<&'a T> + Div<D, Output = T>,
+    D: From<u32>,
 {
-    fn add_sample(&mut self, sample: T) {
+    fn push(&mut self, sample: T) {
         self.window.push(sample);
     }
 
-    fn get_average(&self) -> T {
-        if !self.window.is_empty() {
-            let mut ret = T::default();
-            for v in self.window.iter() {
-                ret = ret + v;
-            }
-            ret / (self.window.len() as u32).into()
+    fn average(&self) -> Option<T> {
+        if !self.is_empty() {
+            Some(self.window.iter().sum::<T>() / D::from(self.window.len() as u32))
         } else {
-            Default::default()
+            None
         }
     }
 
@@ -61,11 +66,16 @@ where
     fn len(&self) -> usize {
         self.window.len()
     }
+
+    fn is_empty(&self) -> bool {
+        self.window.is_empty()
+    }
 }
 
-impl<T> NoSumSMA<T>
+impl<T, D> NoSumSMA<T, D>
 where
-    T: for<'a> Add<&'a T, Output = T> + Div<T, Output = T> + Clone + From<u32> + Display + Default,
+    T: for <'a> Sum<&'a T> + Div<D, Output = T>,
+    D: From<u32>,
 {
     /// Creates an empty SMA instance with the given window size.
     /// The maximum window size is u32::MAX and must be greater than 1.
@@ -73,46 +83,143 @@ where
         assert!(window_size > 1, "window size must be greater than 1");
         Self {
             window: AllocRingBuffer::new(window_size as usize),
+            _div: PhantomData,
         }
     }
 
     /// Creates SMA instance given window size and some initial samples.
-    pub fn new_with_samples(window_size: u32, initial_samples: &[T]) -> Self {
+    pub fn new_with_samples(window_size: u32, initial_samples: Vec<T>) -> Self {
         let mut ret = Self::new(window_size);
-        initial_samples.iter().for_each(|s| ret.add_sample(s.clone()));
+        initial_samples.into_iter().for_each(|s| ret.push(s));
         ret
     }
 }
 
-impl<T> Display for NoSumSMA<T>
+impl<T, D> Display for NoSumSMA<T, D>
 where
-    T: for<'a> Add<&'a T, Output = T> + Div<T, Output = T> + Clone + From<u32> + Display + Default,
+    T: for <'a> Sum<&'a T> + Div<D, Output = T> + Default + Display,
+    D: From<u32>,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.get_average())
+        write!(f, "{}", self.average().unwrap_or_default())
     }
 }
 
+/// Basic implementation of Simple Moving Average (SMA).
+/// The maximum window size is bound by 2^32 - 1.
+/// Useful mainly for integer types, as it does accumulate floating point error with each sample.
+/// Requires `O(N)` of memory and `O(1)` for average computation, `N` being window size.
+/// The divisor argument `D` is used only for such types `T` that do not implement `From<u32>` (such as `Duration`,...).
+#[derive(Clone, Debug, PartialEq)]
+pub struct SingleSumSMA<T, D = T> {
+    window: AllocRingBuffer<T>,
+    sum: T,
+    _div: PhantomData<D>,
+}
+
+impl<T, D> SMA<T> for SingleSumSMA<T, D>
+where
+    T: AddAssign + SubAssign + Div<D, Output = T> + Copy,
+    D: From<u32>,
+{
+    fn push(&mut self, sample: T) {
+        self.sum += sample;
+
+        if self.is_window_full() {
+            if let Some(shifted_sample) = self.window.dequeue() {
+                self.sum -= shifted_sample;
+            }
+        }
+
+        self.window.enqueue(sample);
+    }
+
+    fn average(&self) -> Option<T> {
+        if !self.is_empty() {
+            Some(self.sum / D::from(self.window.len() as u32))
+        } else {
+            None
+        }
+    }
+
+    fn window_size(&self) -> usize {
+        self.window.capacity()
+    }
+
+    fn len(&self) -> usize {
+        self.window.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.window.is_empty()
+    }
+}
+
+impl<T, D> SingleSumSMA<T, D>
+where
+    T: AddAssign + SubAssign + Div<D, Output = T> + Copy + Default,
+    D: From<u32>,
+{
+    /// Creates an empty SMA instance with the given window size.
+    /// The maximum window size is u32::MAX and must be greater than 1.
+    pub fn new(window_size: u32) -> Self {
+        assert!(window_size > 1, "window size must be greater than 1");
+        Self {
+            window: AllocRingBuffer::new(window_size as usize),
+            sum: T::default(),
+            _div: PhantomData,
+        }
+    }
+
+    /// Creates SMA instance given window size and some initial samples.
+    pub fn new_with_samples(window_size: u32, initial_samples: Vec<T>) -> Self {
+        let mut ret = Self::new(window_size);
+        initial_samples.into_iter().for_each(|s| ret.push(s));
+        ret
+    }
+}
+
+impl<T, D> Display for SingleSumSMA<T, D>
+where
+    T: AddAssign + SubAssign + Div<D, Output = T> + Copy + Display + Default,
+    D: From<u32>,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.average().unwrap_or_default())
+    }
+}
+
+
 #[cfg(test)]
 mod tests {
-    use crate::sma::{NoSumSMA, SMA};
+    use crate::sma::{NoSumSMA, SingleSumSMA, SMA};
 
-    #[test]
-    fn test_nosum_sma_empty() {
-        let sma = NoSumSMA::<u32>::new(3);
-        assert_eq!(3, sma.window_size(), "invalid windows size");
-        assert_eq!(0, sma.get_average(), "invalid empty average");
+    fn test_sma<T: SMA<u32>>(mut sma: T, window_size: usize) {
+        assert_eq!(window_size, sma.window_size(), "invalid windows size");
+        assert!(sma.average().is_none(), "invalid empty average");
+
+        assert!(sma.is_empty(), "should be empty");
+        assert_eq!(0, sma.len(), "len is invalid");
+
+        sma.push(0);
+        sma.push(1);
+        sma.push(2);
+        sma.push(3);
+
+        assert_eq!(Some(2), sma.average(), "invalid average");
+        assert_eq!(3, sma.window_size(), "window size is invalid");
+
+        assert!(!sma.is_empty(), "should not be empty");
+        assert_eq!(3, sma.len(), "len is invalid");
     }
 
     #[test]
     fn test_nosum_sma_should_calculate_avg_correctly() {
-        let mut sma = NoSumSMA::<u32>::new(3);
-        sma.add_sample(0);
-        sma.add_sample(1);
-        sma.add_sample(2);
-        sma.add_sample(3);
+        test_sma(NoSumSMA::<u32, u32>::new(3), 3);
+    }
 
-        assert_eq!(2, sma.get_average(), "invalid average");
-        assert_eq!(3, sma.window_size(), "window size is invalid");
+    #[test]
+    fn test_single_sum_sma_should_calculate_avg_correctly() {
+        test_sma(SingleSumSMA::<u32, u32>::new(3), 3);
     }
 }

--- a/packages/utils/crates/utils-types/src/sma.rs
+++ b/packages/utils/crates/utils-types/src/sma.rs
@@ -74,7 +74,7 @@ where
 
 impl<T, D> NoSumSMA<T, D>
 where
-    T: for <'a> Sum<&'a T> + Div<D, Output = T>,
+    T: for<'a> Sum<&'a T> + Div<D, Output = T>,
     D: From<u32>,
 {
     /// Creates an empty SMA instance with the given window size.
@@ -97,7 +97,7 @@ where
 
 impl<T, D> Display for NoSumSMA<T, D>
 where
-    T: for <'a> Sum<&'a T> + Div<D, Output = T> + Default + Display,
+    T: for<'a> Sum<&'a T> + Div<D, Output = T> + Default + Display,
     D: From<u32>,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
@@ -188,7 +188,6 @@ where
         write!(f, "{}", self.average().unwrap_or_default())
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/packages/utils/crates/utils-types/src/sma.rs
+++ b/packages/utils/crates/utils-types/src/sma.rs
@@ -88,7 +88,10 @@ where
     }
 
     /// Creates SMA instance given window size and some initial samples.
-    pub fn new_with_samples(window_size: u32, initial_samples: Vec<T>) -> Self {
+    pub fn new_with_samples<I>(window_size: u32, initial_samples: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
         let mut ret = Self::new(window_size);
         initial_samples.into_iter().for_each(|s| ret.push(s));
         ret
@@ -172,7 +175,10 @@ where
     }
 
     /// Creates SMA instance given window size and some initial samples.
-    pub fn new_with_samples(window_size: u32, initial_samples: Vec<T>) -> Self {
+    pub fn new_with_samples<I>(window_size: u32, initial_samples: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
         let mut ret = Self::new(window_size);
         initial_samples.into_iter().for_each(|s| ret.push(s));
         ret


### PR DESCRIPTION
This PR introduces new Simple Moving Average implementation (SingleSumSMA), which accumulates floating point error, but has O(1) for sample insertion and average calculation.

This SMA implementation is then used in Promiscuous strategy and in `PeerStatus`. The original NoSumSMA implementation is kept back, if the accumulating floating point error shows to be problematic.

Several minor improvements were added into `utils-types` crates.

Also some minor improvements of ergonomy of certain `core-crypto` types.