### PR TITLE
Allow hopli faucet to accept multiple addresses

### DIFF
--- a/packages/hopli/README.md
+++ b/packages/hopli/README.md
@@ -79,7 +79,7 @@ PRIVATE_KEY=<bank_private_key> \
 hopli faucet \
     --network anvil-localhost \
     --use-local-identities --identity-directory "/app/.hoprd-db" \
-    --address 0x0aa7420c43b8c1a7b165d216948870c8ecfe1ee1 \
+    --address 0x0aa7420c43b8c1a7b165d216948870c8ecfe1ee1,0xd057604a14982fe8d88c5fc25aac3267ea142a08 \
     --contracts-root "../ethereum/contracts" \
     --hopr-amount 10 --native-amount 0.1
 ```
@@ -204,7 +204,7 @@ PRIVATE_KEY=<bank_private_key> \
 IDENTITY_PASSWORD=local \
     cargo run -- faucet --network anvil-localhost \
     --use-local-identities --identity-directory "/tmp" \
-    --address 0x0aa7420c43b8c1a7b165d216948870c8ecfe1ee1 \
+    --address 0x0aa7420c43b8c1a7b165d216948870c8ecfe1ee1,0xd057604a14982fe8d88c5fc25aac3267ea142a08 \
     --contracts-root "../ethereum/contracts"  \
     --hopr-amount 10 --native-amount 0.1
 ```

--- a/packages/hopli/src/faucet.rs
+++ b/packages/hopli/src/faucet.rs
@@ -23,7 +23,7 @@ pub struct FaucetArgs {
     network: String,
 
     #[clap(
-        help = "Ethereum address of node that will receive funds",
+        help = "Comma-separated Ethereum addresses of nodes that will receive funds",
         long,
         short,
         default_value = None
@@ -84,20 +84,11 @@ impl FaucetArgs {
 
         // Include provided address
         let mut addresses_all = Vec::new();
-        if let Some(addr) = address {
-            // parse provided address string into `Address` type
-            let parsed_addr = if addr.starts_with("0x") {
-                addr.strip_prefix("0x").unwrap_or(&addr)
-            } else {
-                &addr
-            };
 
-            match Address::from_str(parsed_addr) {
-                // match addr.parse::<Address>() {
-                Ok(checksumed_addr) => addresses_all.push(checksumed_addr.to_checksum()),
-                // TODO: Consider accept peer id here
-                Err(_) => return Err(HelperErrors::UnableToParseAddress(addr.to_string())),
-            }
+        // validate and arrayfy provided list of addresses
+        if let Some(addresses) = address {
+            let provided_addresses: Vec<String> = addresses.split(',').map(|addr| Address::from_str(addr).unwrap().to_checksum()).collect();
+            addresses_all.extend(provided_addresses);
         }
 
         // if local identity dirs/path is provided, read files

--- a/packages/hopli/src/network_registry.rs
+++ b/packages/hopli/src/network_registry.rs
@@ -17,7 +17,7 @@ pub struct RegisterInNetworkRegistryArgs {
     network: String,
 
     #[clap(
-        help = "Comma sperated node peer ids",
+        help = "Comma separated node peer ids",
         long,
         short,
         default_value = None


### PR DESCRIPTION
## Description
`hopli faucet` accepts comma-separated addresses in `--address` so nodes can be funded by supplying a list of addresses.

## Note
Closes https://github.com/hoprnet/hoprnet/issues/5750