### PR TITLE
Fix string formatting in Balance type

### DIFF
--- a/packages/utils/crates/utils-types/src/primitives.rs
+++ b/packages/utils/crates/utils-types/src/primitives.rs
@@ -363,7 +363,7 @@ impl Balance {
     pub const SIZE: usize = U256::SIZE;
 
     /// Number of digits in the base unit
-    pub const SCALE: usize = 18;
+    pub const SCALE: usize = 19;
 
     pub fn new(value: U256, balance_type: BalanceType) -> Self {
         Balance { value, balance_type }
@@ -894,10 +894,10 @@ mod tests {
         let b3 = Balance::new_from_str(&base[..Balance::SCALE - 3], BalanceType::HOPR);
         let b4 = Balance::new_from_str(&base[..Balance::SCALE - 1], BalanceType::HOPR);
 
-        assert_eq!("1.23000000000000000 HOPR", b1.to_formatted_string());
-        assert_eq!("123.000000000000000 HOPR", b2.to_formatted_string());
-        assert_eq!("0.00123000000000000 HOPR", b3.to_formatted_string());
-        assert_eq!("0.12300000000000000 HOPR", b4.to_formatted_string());
+        assert_eq!("1.230000000000000000 HOPR", b1.to_formatted_string());
+        assert_eq!("123.0000000000000000 HOPR", b2.to_formatted_string());
+        assert_eq!("0.001230000000000000 HOPR", b3.to_formatted_string());
+        assert_eq!("0.123000000000000000 HOPR", b4.to_formatted_string());
     }
 
     #[test]


### PR DESCRIPTION
## Description
HOPR balance conversion is off by 1 digit. E.g. HOPR balance of "1230000000000000000" should be converted to "1.23 HOPR" by `to_formatted_string`, as in `1230000000000000000/1e18 = 1.23`
