### PR TITLE
Use SingleSumSMA in `PeerStatus`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6600,7 +6600,7 @@ dependencies = [
 
 [[package]]
 name = "utils-types"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/packages/core/crates/core-network/src/network.rs
+++ b/packages/core/crates/core-network/src/network.rs
@@ -13,7 +13,7 @@ use validator::Validate;
 use crate::constants::DEFAULT_NETWORK_QUALITY_THRESHOLD;
 use utils_log::{info, warn};
 use utils_metrics::metrics::{MultiGauge, SimpleGauge};
-use utils_types::sma::{NoSumSMA, SMA};
+use utils_types::sma::{SingleSumSMA, SMA};
 
 #[cfg_attr(feature = "wasm", wasm_bindgen::prelude::wasm_bindgen(getter_with_clone))]
 #[serde_as]
@@ -154,7 +154,7 @@ pub struct PeerStatus {
     pub heartbeats_sent: u64,
     pub heartbeats_succeeded: u64,
     pub backoff: f64,
-    quality_avg: NoSumSMA<f64>,
+    quality_avg: SingleSumSMA<f64>,
     metadata: HashMap<String, String>,
 }
 
@@ -170,13 +170,13 @@ impl PeerStatus {
             backoff,
             quality: 0.0,
             metadata: HashMap::new(),
-            quality_avg: NoSumSMA::new(quality_window),
+            quality_avg: SingleSumSMA::new(quality_window),
         }
     }
 
     pub fn update_quality(&mut self, new_value: f64) {
         self.quality = new_value;
-        self.quality_avg.add_sample(new_value);
+        self.quality_avg.push(new_value);
     }
 
     /// Gets metadata associated with the peer
@@ -186,7 +186,7 @@ impl PeerStatus {
 
     /// Gets the average quality of this peer
     pub fn get_average_quality(&self) -> f64 {
-        self.quality_avg.get_average()
+        self.quality_avg.average().unwrap_or_default()
     }
 
     /// Gets the immediate node quality
@@ -556,6 +556,7 @@ pub mod wasm {
     use js_sys::JsString;
     use std::str::FromStr;
     use utils_misc::utils::wasm::js_map_to_hash_map;
+    use utils_types::sma::SingleSumSMA;
     use wasm_bindgen::prelude::*;
 
     #[wasm_bindgen]
@@ -614,7 +615,7 @@ pub mod wasm {
                 heartbeats_succeeded,
                 backoff,
                 metadata: js_map_to_hash_map(peer_metadata).unwrap_or(HashMap::new()),
-                quality_avg: NoSumSMA::new_with_samples(quality_window, &[quality]),
+                quality_avg: SingleSumSMA::new_with_samples(quality_window, vec![quality]),
             }
         }
     }

--- a/packages/core/crates/core-strategy/src/promiscuous.rs
+++ b/packages/core/crates/core-strategy/src/promiscuous.rs
@@ -123,12 +123,12 @@ where
     }
 
     async fn sample_size_and_evaluate_avg(&self, sample: u32) -> Option<u32> {
-        self.sma.write().await.add_sample(sample);
+        self.sma.write().await.push(sample);
         info!("evaluated qualities of {sample} peers seen in the network");
 
         let sma = self.sma.read().await;
         if sma.len() >= sma.window_size() {
-            Some(sma.get_average())
+            sma.average()
         } else {
             info!(
                 "not yet enough samples ({} out of {}) of network size to perform a strategy tick, skipping.",

--- a/packages/utils/crates/utils-types/Cargo.toml
+++ b/packages/utils/crates/utils-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utils-types"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Generic types used through the entire code base"

--- a/packages/utils/crates/utils-types/src/errors.rs
+++ b/packages/utils/crates/utils-types/src/errors.rs
@@ -1,3 +1,4 @@
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 /// Type for any possible error, because the traits in this modules
@@ -5,7 +6,7 @@ use thiserror::Error;
 pub type AnyError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
 /// Listing of some general re-usable errors
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Serialize, Deserialize)]
 pub enum GeneralError {
     #[error("failed to parse/deserialize the data")]
     ParseError,

--- a/packages/utils/crates/utils-types/src/sma.rs
+++ b/packages/utils/crates/utils-types/src/sma.rs
@@ -1,18 +1,18 @@
 use ringbuffer::{AllocRingBuffer, RingBuffer};
 use std::fmt::{Display, Formatter};
-use std::ops::{Add, Div};
+use std::iter::Sum;
+use std::marker::PhantomData;
+use std::ops::{AddAssign, Div, SubAssign};
 
 /// Simple Moving Average trait.
 /// The second-most useful filter type, bested only by coffee filters.
-pub trait SMA<T>
-where
-    T: for<'a> Add<&'a T, Output = T> + Div<T, Output = T> + Clone + From<u32> + Display + Default,
-{
-    /// Adds a sample.
-    fn add_sample(&mut self, sample: T);
+pub trait SMA<T> {
+    /// Pushes a sample.
+    fn push(&mut self, sample: T);
 
     /// Calculates the moving average value.
-    fn get_average(&self) -> T;
+    /// Returns `None` if no samples were added.
+    fn average(&self) -> Option<T>;
 
     /// Returns the window size.
     fn window_size(&self) -> usize;
@@ -20,37 +20,42 @@ where
     /// Returns the number of elements in the window.
     /// This value is always between 0 and `window_size()`.
     fn len(&self) -> usize;
+
+    /// Indicates whether the window is fully occupied
+    /// with samples.
+    fn is_window_full(&self) -> bool {
+        self.len() == self.window_size()
+    }
+
+    /// Indicates whether there are no samples.
+    fn is_empty(&self) -> bool;
 }
 
 /// Basic implementation of Simple Moving Average (SMA).
 /// The maximum window size is bound by 2^32 - 1.
-/// Useful mainly for floating-point types, as it does not accumulate floating point error with each sample,
-/// but requires `O(N)` of memory and `O(N)` for average computation, `N` being window size.
+/// Useful mainly for floating-point types, as it does not accumulate floating point error with each sample.
+/// Requires `O(N)` of memory and `O(N)` for average computation, `N` being window size.
+/// The divisor argument `D` is used only for such types `T` that do not implement `From<u32>` (such as `Duration`,...).
 #[derive(Clone, Debug, PartialEq)]
-pub struct NoSumSMA<T>
-where
-    T: for<'a> Add<&'a T, Output = T> + Div<T, Output = T> + Clone + From<u32> + Display + Default,
-{
+pub struct NoSumSMA<T, D = T> {
     window: AllocRingBuffer<T>,
+    _div: PhantomData<D>,
 }
 
-impl<T> SMA<T> for NoSumSMA<T>
+impl<T, D> SMA<T> for NoSumSMA<T, D>
 where
-    T: for<'a> Add<&'a T, Output = T> + Div<T, Output = T> + Clone + From<u32> + Display + Default,
+    T: for<'a> Sum<&'a T> + Div<D, Output = T>,
+    D: From<u32>,
 {
-    fn add_sample(&mut self, sample: T) {
+    fn push(&mut self, sample: T) {
         self.window.push(sample);
     }
 
-    fn get_average(&self) -> T {
-        if !self.window.is_empty() {
-            let mut ret = T::default();
-            for v in self.window.iter() {
-                ret = ret + v;
-            }
-            ret / (self.window.len() as u32).into()
+    fn average(&self) -> Option<T> {
+        if !self.is_empty() {
+            Some(self.window.iter().sum::<T>() / D::from(self.window.len() as u32))
         } else {
-            Default::default()
+            None
         }
     }
 
@@ -61,11 +66,16 @@ where
     fn len(&self) -> usize {
         self.window.len()
     }
+
+    fn is_empty(&self) -> bool {
+        self.window.is_empty()
+    }
 }
 
-impl<T> NoSumSMA<T>
+impl<T, D> NoSumSMA<T, D>
 where
-    T: for<'a> Add<&'a T, Output = T> + Div<T, Output = T> + Clone + From<u32> + Display + Default,
+    T: for<'a> Sum<&'a T> + Div<D, Output = T>,
+    D: From<u32>,
 {
     /// Creates an empty SMA instance with the given window size.
     /// The maximum window size is u32::MAX and must be greater than 1.
@@ -73,46 +83,148 @@ where
         assert!(window_size > 1, "window size must be greater than 1");
         Self {
             window: AllocRingBuffer::new(window_size as usize),
+            _div: PhantomData,
         }
     }
 
     /// Creates SMA instance given window size and some initial samples.
-    pub fn new_with_samples(window_size: u32, initial_samples: &[T]) -> Self {
+    pub fn new_with_samples<I>(window_size: u32, initial_samples: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
         let mut ret = Self::new(window_size);
-        initial_samples.iter().for_each(|s| ret.add_sample(s.clone()));
+        initial_samples.into_iter().for_each(|s| ret.push(s));
         ret
     }
 }
 
-impl<T> Display for NoSumSMA<T>
+impl<T, D> Display for NoSumSMA<T, D>
 where
-    T: for<'a> Add<&'a T, Output = T> + Div<T, Output = T> + Clone + From<u32> + Display + Default,
+    T: for<'a> Sum<&'a T> + Div<D, Output = T> + Default + Display,
+    D: From<u32>,
 {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.get_average())
+        write!(f, "{}", self.average().unwrap_or_default())
+    }
+}
+
+/// Basic implementation of Simple Moving Average (SMA).
+/// The maximum window size is bound by 2^32 - 1.
+/// Useful mainly for integer types, as it does accumulate floating point error with each sample.
+/// Requires `O(N)` of memory and `O(1)` for average computation, `N` being window size.
+/// The divisor argument `D` is used only for such types `T` that do not implement `From<u32>` (such as `Duration`,...).
+#[derive(Clone, Debug, PartialEq)]
+pub struct SingleSumSMA<T, D = T> {
+    window: AllocRingBuffer<T>,
+    sum: T,
+    _div: PhantomData<D>,
+}
+
+impl<T, D> SMA<T> for SingleSumSMA<T, D>
+where
+    T: AddAssign + SubAssign + Div<D, Output = T> + Copy,
+    D: From<u32>,
+{
+    fn push(&mut self, sample: T) {
+        self.sum += sample;
+
+        if self.is_window_full() {
+            if let Some(shifted_sample) = self.window.dequeue() {
+                self.sum -= shifted_sample;
+            }
+        }
+
+        self.window.enqueue(sample);
+    }
+
+    fn average(&self) -> Option<T> {
+        if !self.is_empty() {
+            Some(self.sum / D::from(self.window.len() as u32))
+        } else {
+            None
+        }
+    }
+
+    fn window_size(&self) -> usize {
+        self.window.capacity()
+    }
+
+    fn len(&self) -> usize {
+        self.window.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.window.is_empty()
+    }
+}
+
+impl<T, D> SingleSumSMA<T, D>
+where
+    T: AddAssign + SubAssign + Div<D, Output = T> + Copy + Default,
+    D: From<u32>,
+{
+    /// Creates an empty SMA instance with the given window size.
+    /// The maximum window size is u32::MAX and must be greater than 1.
+    pub fn new(window_size: u32) -> Self {
+        assert!(window_size > 1, "window size must be greater than 1");
+        Self {
+            window: AllocRingBuffer::new(window_size as usize),
+            sum: T::default(),
+            _div: PhantomData,
+        }
+    }
+
+    /// Creates SMA instance given window size and some initial samples.
+    pub fn new_with_samples<I>(window_size: u32, initial_samples: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let mut ret = Self::new(window_size);
+        initial_samples.into_iter().for_each(|s| ret.push(s));
+        ret
+    }
+}
+
+impl<T, D> Display for SingleSumSMA<T, D>
+where
+    T: AddAssign + SubAssign + Div<D, Output = T> + Copy + Display + Default,
+    D: From<u32>,
+{
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.average().unwrap_or_default())
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::sma::{NoSumSMA, SMA};
+    use crate::sma::{NoSumSMA, SingleSumSMA, SMA};
 
-    #[test]
-    fn test_nosum_sma_empty() {
-        let sma = NoSumSMA::<u32>::new(3);
-        assert_eq!(3, sma.window_size(), "invalid windows size");
-        assert_eq!(0, sma.get_average(), "invalid empty average");
+    fn test_sma<T: SMA<u32>>(mut sma: T, window_size: usize) {
+        assert_eq!(window_size, sma.window_size(), "invalid windows size");
+        assert!(sma.average().is_none(), "invalid empty average");
+
+        assert!(sma.is_empty(), "should be empty");
+        assert_eq!(0, sma.len(), "len is invalid");
+
+        sma.push(0);
+        sma.push(1);
+        sma.push(2);
+        sma.push(3);
+
+        assert_eq!(Some(2), sma.average(), "invalid average");
+        assert_eq!(3, sma.window_size(), "window size is invalid");
+
+        assert!(!sma.is_empty(), "should not be empty");
+        assert_eq!(3, sma.len(), "len is invalid");
     }
 
     #[test]
     fn test_nosum_sma_should_calculate_avg_correctly() {
-        let mut sma = NoSumSMA::<u32>::new(3);
-        sma.add_sample(0);
-        sma.add_sample(1);
-        sma.add_sample(2);
-        sma.add_sample(3);
+        test_sma(NoSumSMA::<u32, u32>::new(3), 3);
+    }
 
-        assert_eq!(2, sma.get_average(), "invalid average");
-        assert_eq!(3, sma.window_size(), "window size is invalid");
+    #[test]
+    fn test_single_sum_sma_should_calculate_avg_correctly() {
+        test_sma(SingleSumSMA::<u32, u32>::new(3), 3);
     }
 }


### PR DESCRIPTION
This optimizes the retrieval of average value from SMA to be O(1) at the cost of accumulating floating point error, which should be less prominent when using `f64` to represent qualities.

This is a back-port from `master` branch, where this fix has been already applied.

Fixes #5752