### PR TITLE
api: Balances are shown as base values without unit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6434,7 +6434,7 @@ dependencies = [
 
 [[package]]
 name = "utils-types"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "bincode",
  "console_error_panic_hook",

--- a/packages/hoprd/src/api/v3/paths/account/balances.integration.spec.ts
+++ b/packages/hoprd/src/api/v3/paths/account/balances.integration.spec.ts
@@ -30,13 +30,22 @@ describe('GET /account/balances', () => {
     const res = await request(service).get('/api/v3/account/balances')
     expect(res.status).to.equal(200)
     expect(res).to.satisfyApiSpec
+
+    // ensure all values are present
     expect(res.body).to.deep.equal({
-      native: nativeBalance.to_string(),
-      hopr: balance.to_string(),
-      safeNative: nativeBalance.to_string(),
-      safeHopr: balance.to_string(),
-      safeHoprAllowance: balance.to_string()
+      native: nativeBalance.to_value_string(),
+      hopr: balance.to_value_string(),
+      safeNative: nativeBalance.to_value_string(),
+      safeHopr: balance.to_value_string(),
+      safeHoprAllowance: balance.to_value_string()
     })
+
+    // ensure the balances are numbers without units, we assume wei always
+    expect(!!Number(res.body.native)).to.be.true
+    expect(!!Number(res.body.hopr)).to.be.true
+    expect(!!Number(res.body.safeNative)).to.be.true
+    expect(!!Number(res.body.safeHopr)).to.be.true
+    expect(!!Number(res.body.safeHoprAllowance)).to.be.true
   })
 
   it('should return 422 when either of balances node calls fail', async () => {

--- a/packages/hoprd/src/api/v3/paths/account/balances.ts
+++ b/packages/hoprd/src/api/v3/paths/account/balances.ts
@@ -16,11 +16,11 @@ export const getBalances = async (node: Hopr) => {
   ])
 
   return {
-    native: nativeBalance.to_string(),
-    hopr: hoprBalance.to_string(),
-    safeNative: safeNativeBalance.to_string(),
-    safeHopr: safeHoprBalance.to_string(),
-    safeHoprAllowance: safeHoprAllowance.to_string()
+    native: nativeBalance.to_value_string(),
+    hopr: hoprBalance.to_value_string(),
+    safeNative: safeNativeBalance.to_value_string(),
+    safeHopr: safeHoprBalance.to_value_string(),
+    safeHoprAllowance: safeHoprAllowance.to_value_string()
   }
 }
 

--- a/packages/utils/crates/utils-types/Cargo.toml
+++ b/packages/utils/crates/utils-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "utils-types"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Generic types used through the entire code base"

--- a/packages/utils/crates/utils-types/src/primitives.rs
+++ b/packages/utils/crates/utils-types/src/primitives.rs
@@ -956,7 +956,7 @@ mod tests {
         let b4 = Balance::new_from_str(&base[..Balance::SCALE - 1], BalanceType::HOPR);
 
         assert_eq!("123000000000000000", b1.to_value_string());
-        assert_eq!("123000000000000000", b2.to_value_string());
+        assert_eq!("12300000000000000000", b2.to_value_string());
         assert_eq!("123000000000000", b3.to_value_string());
         assert_eq!("12300000000000000", b4.to_value_string());
     }

--- a/packages/utils/crates/utils-types/src/primitives.rs
+++ b/packages/utils/crates/utils-types/src/primitives.rs
@@ -332,6 +332,10 @@ impl Balance {
     pub fn to_formatted_string(&self) -> String {
         format!("{} {}", self.amount_base_units(), self.balance_type)
     }
+
+    pub fn to_value_string(&self) -> String {
+        self.value.to_string()
+    }
 }
 
 impl PartialEq for Balance {
@@ -937,6 +941,24 @@ mod tests {
         assert_eq!("123.000000000000000 HOPR", b2.to_formatted_string());
         assert_eq!("0.00123000000000000 HOPR", b3.to_formatted_string());
         assert_eq!("0.12300000000000000 HOPR", b4.to_formatted_string());
+    }
+
+    #[test]
+    fn balance_test_value_string() {
+        let mut base = "123".to_string();
+        for _ in 0..Balance::SCALE - 3 {
+            base += "0";
+        }
+
+        let b1 = Balance::new_from_str(&base, BalanceType::HOPR);
+        let b2 = b1.imul(100);
+        let b3 = Balance::new_from_str(&base[..Balance::SCALE - 3], BalanceType::HOPR);
+        let b4 = Balance::new_from_str(&base[..Balance::SCALE - 1], BalanceType::HOPR);
+
+        assert_eq!("123000000000000000", b1.to_value_string());
+        assert_eq!("123000000000000000", b2.to_value_string());
+        assert_eq!("123000000000000", b3.to_value_string());
+        assert_eq!("12300000000000000", b4.to_value_string());
     }
 
     #[test]


### PR DESCRIPTION
This fixes a regression within the API which would brake the SDKs for 2.1.x

Fixes #5732 