### PR TITLE
Disable redeem tickets from epoch other than the current channel epoch

### DIFF
--- a/packages/core-ethereum/crates/core-ethereum-actions/src/redeem.rs
+++ b/packages/core-ethereum/crates/core-ethereum-actions/src/redeem.rs
@@ -11,7 +11,7 @@ use std::ops::DerefMut;
 use std::sync::Arc;
 use utils_db::errors::DbError;
 use utils_log::{debug, error, info, warn};
-use utils_types::primitives::Address;
+use utils_types::primitives::{Address, U256};
 
 use crate::errors::CoreEthereumActionsError::ChannelDoesNotExist;
 use crate::errors::{
@@ -154,7 +154,7 @@ impl<Db: HoprCoreEthereumDbActions + Clone> TicketRedeemActions for CoreEthereum
             .get_acknowledged_tickets(Some(*channel))
             .await?
             .iter()
-            .filter(|t| t.status == Untouched && (!only_aggregated || t.ticket.is_aggregated()))
+            .filter(|t| t.status == Untouched && channel.channel_epoch == U256::from(t.ticket.channel_epoch) && (!only_aggregated || t.ticket.is_aggregated()))
             .count();
         info!(
             "there are {count_redeemable_tickets} acknowledged tickets in channel {channel_id} which can be redeemed"
@@ -174,7 +174,7 @@ impl<Db: HoprCoreEthereumDbActions + Clone> TicketRedeemActions for CoreEthereum
                 .get_acknowledged_tickets(Some(*channel))
                 .await?
                 .into_iter()
-                .filter(|t| Untouched == t.status && (!only_aggregated || t.ticket.is_aggregated()));
+                .filter(|t| Untouched == t.status && channel.channel_epoch == U256::from(t.ticket.channel_epoch) && (!only_aggregated || t.ticket.is_aggregated()));
 
             for mut avail_to_redeem in redeemable {
                 if let Err(e) = set_being_redeemed(&mut *db, &mut avail_to_redeem, *EMPTY_TX_HASH).await {
@@ -290,6 +290,7 @@ mod tests {
         rdb: RustyLevelDbShim,
         ticket_count: usize,
         counterparty: &ChainKeypair,
+        channel_epoch: U256,
     ) -> (ChannelEntry, Vec<AcknowledgedTicket>) {
         let mut inner_db = DB::new(rdb);
         let mut input_tickets = Vec::new();
@@ -310,7 +311,7 @@ mod tests {
             Balance::zero(BalanceType::HOPR),
             U256::zero(),
             ChannelStatus::Open,
-            U256::zero(),
+            channel_epoch,
             U256::zero(),
         );
         db.update_channel_and_snapshot(&channel.get_id(), &channel, &Default::default())
@@ -330,9 +331,10 @@ mod tests {
         let ticket_count = 5;
         let rdb = RustyLevelDbShim::new_in_memory();
 
-        let (channel_from_bob, bob_tickets) = create_channel_with_ack_tickets(rdb.clone(), ticket_count, &BOB).await;
+        // all the tickets can be redeemed, coz they are issued with the same epoch as channel
+        let (channel_from_bob, bob_tickets) = create_channel_with_ack_tickets(rdb.clone(), ticket_count, &BOB, U256::from(4u32)).await;
         let (channel_from_charlie, charlie_tickets) =
-            create_channel_with_ack_tickets(rdb.clone(), ticket_count, &CHARLIE).await;
+            create_channel_with_ack_tickets(rdb.clone(), ticket_count, &CHARLIE, U256::from(4u32)).await;
 
         let db = Arc::new(RwLock::new(CoreEthereumDb::new(
             DB::new(rdb.clone()),
@@ -419,8 +421,9 @@ mod tests {
         let ticket_count = 5;
         let rdb = RustyLevelDbShim::new_in_memory();
 
-        let (channel_from_bob, bob_tickets) = create_channel_with_ack_tickets(rdb.clone(), ticket_count, &BOB).await;
-        let (channel_from_charlie, _) = create_channel_with_ack_tickets(rdb.clone(), ticket_count, &CHARLIE).await;
+        // all the tickets can be redeemed, coz they are issued with the same epoch as channel
+        let (channel_from_bob, bob_tickets) = create_channel_with_ack_tickets(rdb.clone(), ticket_count, &BOB, U256::from(4u32)).await;
+        let (channel_from_charlie, _) = create_channel_with_ack_tickets(rdb.clone(), ticket_count, &CHARLIE, U256::from(4u32)).await;
 
         let db = Arc::new(RwLock::new(CoreEthereumDb::new(
             DB::new(rdb.clone()),
@@ -496,7 +499,7 @@ mod tests {
         let ticket_count = 3;
         let rdb = RustyLevelDbShim::new_in_memory();
 
-        let (channel_from_bob, mut tickets) = create_channel_with_ack_tickets(rdb.clone(), ticket_count, &BOB).await;
+        let (channel_from_bob, mut tickets) = create_channel_with_ack_tickets(rdb.clone(), ticket_count, &BOB, U256::from(4u32)).await;
 
         let db = Arc::new(RwLock::new(CoreEthereumDb::new(
             DB::new(rdb.clone()),
@@ -551,5 +554,119 @@ mod tests {
             actions.redeem_ticket(tickets[1].clone()).await.is_err(),
             "cannot redeem a ticket that's being redeemed"
         );
+    }
+
+    #[async_std::test]
+    async fn test_redeem_must_not_work_for_tickets_of_previous_epoch_being_aggregated_and_being_redeemed() {
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        let ticket_count = 3;
+        let ticket_from_previous_epoch_count = 1;
+        let rdb = RustyLevelDbShim::new_in_memory();
+
+        // Make the first ticket from the previous epoch
+        let (_, mut tickets_from_previous_epoch) = create_channel_with_ack_tickets(rdb.clone(), ticket_from_previous_epoch_count, &BOB, U256::from(3u32)).await;
+        // remaining tickets are from the current epoch
+        let (channel_from_bob, mut tickets_from_current_epoch) = create_channel_with_ack_tickets(rdb.clone(), ticket_count - ticket_from_previous_epoch_count, &BOB, U256::from(4u32)).await;
+
+        let db = Arc::new(RwLock::new(CoreEthereumDb::new(
+            DB::new(rdb.clone()),
+            ALICE.public().to_address(),
+        )));
+
+        // Expect only the redeemable tickets get redeemed
+        let mut tickets = tickets_from_previous_epoch.clone();
+        tickets.append(&mut tickets_from_current_epoch);
+
+        let tickets_clone = tickets.clone();
+        let mut tx_exec = MockTransactionExecutor::new();
+        tx_exec
+            .expect_redeem_ticket()
+            .times(ticket_count - ticket_from_previous_epoch_count)
+            .withf(move |t| tickets_clone[ticket_from_previous_epoch_count..].iter().find(|tk| tk.ticket.eq(&t.ticket)).is_some())
+            .returning(|_| TransactionResult::RedeemTicket {
+                tx_hash: Hash::default(),
+            });
+
+        // Start the TransactionQueue with the mock TransactionExecutor
+        let tx_queue = TransactionQueue::new(db.clone(), Box::new(tx_exec));
+        let tx_sender = tx_queue.new_sender();
+        async_std::task::spawn_local(async move {
+            tx_queue.transaction_loop().await;
+        });
+
+        let actions = CoreEthereumActions::new(ALICE.public().to_address(), db.clone(), tx_sender.clone());
+
+        futures::future::join_all(
+            actions
+                .redeem_tickets_in_channel(&channel_from_bob, false)
+                .await
+                .expect("redeem_tickets_in_channel should succeed")
+                .into_iter(),
+        )
+        .await;
+
+        assert!(
+            actions.redeem_ticket(tickets[0].clone()).await.is_err(),
+            "cannot redeem a ticket that's from the previous epoch"
+        );
+    }
+
+    #[async_std::test]
+    async fn test_redeem_must_not_work_for_tickets_of_next_epoch_being_redeemed() {
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        let ticket_count = 4;
+        let ticket_from_next_epoch_count = 2;
+        let rdb = RustyLevelDbShim::new_in_memory();
+
+        // Make the first few tickets from the next epoch
+        let (_, mut tickets_from_next_epoch) = create_channel_with_ack_tickets(rdb.clone(), ticket_from_next_epoch_count, &BOB, U256::from(5u32)).await;
+        // remaining tickets are from the current epoch
+        let (channel_from_bob, mut tickets_from_current_epoch) = create_channel_with_ack_tickets(rdb.clone(), ticket_count - ticket_from_next_epoch_count, &BOB, U256::from(4u32)).await;
+
+        let db = Arc::new(RwLock::new(CoreEthereumDb::new(
+            DB::new(rdb.clone()),
+            ALICE.public().to_address(),
+        )));
+
+        // Expect only the redeemable tickets get redeemed
+        let mut tickets = tickets_from_next_epoch.clone();
+        tickets.append(&mut tickets_from_current_epoch);
+
+        let tickets_clone = tickets.clone();
+        let mut tx_exec = MockTransactionExecutor::new();
+        tx_exec
+            .expect_redeem_ticket()
+            .times(ticket_count - ticket_from_next_epoch_count)
+            .withf(move |t| tickets_clone[ticket_from_next_epoch_count..].iter().find(|tk| tk.ticket.eq(&t.ticket)).is_some())
+            .returning(|_| TransactionResult::RedeemTicket {
+                tx_hash: Hash::default(),
+            });
+
+        // Start the TransactionQueue with the mock TransactionExecutor
+        let tx_queue = TransactionQueue::new(db.clone(), Box::new(tx_exec));
+        let tx_sender = tx_queue.new_sender();
+        async_std::task::spawn_local(async move {
+            tx_queue.transaction_loop().await;
+        });
+
+        let actions = CoreEthereumActions::new(ALICE.public().to_address(), db.clone(), tx_sender.clone());
+
+        futures::future::join_all(
+            actions
+                .redeem_tickets_in_channel(&channel_from_bob, false)
+                .await
+                .expect("redeem_tickets_in_channel should succeed")
+                .into_iter(),
+        )
+        .await;
+
+        for unredeemable_index  in 0..ticket_from_next_epoch_count {
+            assert!(
+                actions.redeem_ticket(tickets[unredeemable_index].clone()).await.is_err(),
+                "cannot redeem a ticket that's from the next epoch"
+            );
+        }
     }
 }

--- a/packages/core-ethereum/crates/core-ethereum-db/src/db.rs
+++ b/packages/core-ethereum/crates/core-ethereum-db/src/db.rs
@@ -649,7 +649,7 @@ impl<T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>> + Clone> HoprCoreEthe
 
     // core-ethereum only part
     async fn mark_acknowledged_tickets_neglected(&mut self, channel: ChannelEntry) -> Result<()> {
-        let acknowledged_tickets = self.get_acknowledged_tickets(Some(channel)).await?;
+        let acknowledged_tickets: Vec<AcknowledgedTicket> = self.get_acknowledged_tickets(Some(channel)).await?.into_iter().filter(|ack| U256::from(ack.ticket.channel_epoch) <= channel.channel_epoch).collect();
 
         let count_key = utils_db::db::Key::new_from_str(NEGLECTED_TICKETS_COUNT)?;
         let value_key = utils_db::db::Key::new_from_str(NEGLECTED_TICKETS_VALUE)?;
@@ -2113,6 +2113,56 @@ mod tests {
         }
 
         acked_tickets
+    }
+
+    #[async_std::test]
+    async fn test_mark_mark_acknowledged_tickets_neglected() {
+        let mut db = CoreEthereumDb::new(DB::new(RustyLevelDbShim::new_in_memory()), Address::random());
+
+        let start_index = 23u64;
+        let tickets_to_generate = 3u64;
+        let channel_epoch = 29u32;
+
+        // set channel to current epoch
+        let mut channel = ChannelEntry::new(
+            ALICE_KEYPAIR.public().to_address(),
+            BOB_KEYPAIR.public().to_address(),
+            Balance::zero(BalanceType::HOPR),
+            U256::zero(),
+            ChannelStatus::Open,
+            channel_epoch.into(),
+            0_u32.into(),
+        );
+
+        db.update_channel_and_snapshot(&channel.get_id(), &channel, &Snapshot::default())
+            .await
+            .unwrap();
+
+        // create acked tickets of channel_epoch
+        let acked_tickets = create_acknowledged_tickets(&mut db, tickets_to_generate, channel_epoch, start_index).await;
+
+        // assert channel id
+        let channel_id = generate_channel_id(&ALICE_KEYPAIR.public().to_address(), &BOB_KEYPAIR.public().to_address());
+        assert_eq!(channel_id, acked_tickets[0].ticket.channel_id);
+        assert_eq!(channel_id, channel.get_id());
+
+        // check acked ticket count
+        let acked_tickets_count = db.get_acknowledged_tickets_count(Some(channel.clone())).await.unwrap();
+
+        assert_eq!(acked_tickets_count, tickets_to_generate as usize);
+
+        // bump channel to next epoch
+        channel.channel_epoch = (channel_epoch + 1).into();
+        db.update_channel_and_snapshot(&channel.get_id(), &channel, &Snapshot::default())
+            .await
+            .unwrap();
+
+        // mark_acknowledged_tickets_neglected
+        assert!(db.mark_acknowledged_tickets_neglected(channel).await.is_ok());
+
+        // acked tickets should reduce to zero
+        let acked_tickets_count_after_mark = db.get_acknowledged_tickets_count(None).await.unwrap();
+        assert_eq!(acked_tickets_count_after_mark, 0usize);
     }
 
     #[async_std::test]


### PR DESCRIPTION
### Description
- Only tickets from the current epoch can be redeemed
- On channel closed event, db should mark all the tickets until the current epoch as neglected. 

### Note 
Partially fixes issues discovered in https://github.com/hoprnet/hoprnet/issues/5760, i.e.:
- [x] Nodes were not able to process properly the channel closure event, and invalidate tickets from previous channel epoch
- [x] Nodes kept trying to redeem single outdated tickets (from previous epoch)
- [ ] Nodes kept trying to redeem single outdated tickets (from previous epoch), while processing ticket from the current epoch.

RPCh nodes should remove the db and upgraded with the latest release. 