### PR TITLE
libp2p: Adjust mplex configuration to allow more sub-streams

### DIFF
--- a/packages/core/crates/core-p2p/src/lib.rs
+++ b/packages/core/crates/core-p2p/src/lib.rs
@@ -221,10 +221,28 @@ pub fn build_p2p_network(
     msg_proto_cfg: MsgProtocolConfig,
     ticket_aggregation_proto_cfg: TicketAggregationProtocolConfig,
 ) -> libp2p_swarm::Swarm<HoprNetworkBehavior> {
+    let mut mplex_config = libp2p_mplex::MplexConfig::new();
+
+    // libp2p default is 128
+    // we use more to accomodate many concurrent messages
+    // FIXME: make value configurable
+    mplex_config.set_max_num_streams(512);
+
+    // libp2p default is 32 Bytes
+    // we use 2MB, just above the uniform hopr message size, trade off memory for less scheduler
+    // switching
+    // FIXME: benchmark and find appropriate values
+    mplex_config.set_max_buffer_size(2 * 1024 * 1024);
+
+    // libp2p default is 8 KBytes
+    // we use the allowed max 1MB, trade off memory for less scheduler
+    // FIXME: benchmark and find appropriate values
+    mplex_config.set_split_send_size(1 * 1024 * 1024);
+
     let transport = build_basic_transport()
         .upgrade(upgrade::Version::V1)
         .authenticate(libp2p_noise::Config::new(&me).expect("signing libp2p-noise static keypair"))
-        .multiplex(libp2p_mplex::MplexConfig::default())
+        .multiplex(mplex_config.clone())
         .timeout(std::time::Duration::from_secs(60))
         .boxed();
 

--- a/packages/core/crates/core-p2p/src/lib.rs
+++ b/packages/core/crates/core-p2p/src/lib.rs
@@ -229,10 +229,10 @@ pub fn build_p2p_network(
     mplex_config.set_max_num_streams(512);
 
     // libp2p default is 32 Bytes
-    // we use 2MB, just above the uniform hopr message size, trade off memory for less scheduler
+    // we use 2KB, just above the uniform hopr message size, trade off memory for less scheduler
     // switching
     // FIXME: benchmark and find appropriate values
-    mplex_config.set_max_buffer_size(2 * 1024 * 1024);
+    mplex_config.set_max_buffer_size(2 * 1024);
 
     // libp2p default is 8 KBytes
     // we use the allowed max 1MB, trade off memory for less scheduler
@@ -242,7 +242,7 @@ pub fn build_p2p_network(
     let transport = build_basic_transport()
         .upgrade(upgrade::Version::V1)
         .authenticate(libp2p_noise::Config::new(&me).expect("signing libp2p-noise static keypair"))
-        .multiplex(mplex_config.clone())
+        .multiplex(mplex_config)
         .timeout(std::time::Duration::from_secs(60))
         .boxed();
 


### PR DESCRIPTION
Refs #5769 

The values were adjusted to allow use of more buffer memory which should incur less scheduler overhead, which is our most scarce resource at the moment. This can/should be re-adjusted later again based on proper benchmarks when the system is Rust-native.