### PR TITLE
WTF of the day: Revert "chore(cargo): updated vendored dependencies"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -654,6 +654,7 @@ name = "bindings"
 version = "0.1.0"
 dependencies = [
  "ethers",
+ "serde",
 ]
 
 [[package]]

--- a/packages/ethereum/crates/bindings/Cargo.toml
+++ b/packages/ethereum/crates/bindings/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 ethers = { version = "2", default-features = false, features = ["abigen"] }
+serde = "1"
 
 [lib] 
 crate-type = ["cdylib", "rlib"]


### PR DESCRIPTION
This reverts commit 28d7fcf75bcf3c226ab7c597b612868288fed088.

I have no idea how this got in. Maybe an issue with the vendor update workflow.