### PR TITLE
Using latest release of HOPR Admin on Dappnode build

### DIFF
--- a/.github/workflows/build-dappnode.yaml
+++ b/.github/workflows/build-dappnode.yaml
@@ -69,10 +69,13 @@ jobs:
           dappnode_patch_bumped_patch_version=$((dappnode_patch_version + 1))
           dappnode_version="${dappnode_minor_version}.${dappnode_patch_version}"
           dappnode_bumped_version="${dappnode_minor_version}.${dappnode_patch_bumped_patch_version}"
+          hopr_admin_latest_tag=$(curl -s "https://api.github.com/repos/hoprnet/hopr-admin/releases/latest" | jq -r '.tag_name')
 
           cat <<< $(jq --arg dappnode_bumped_version ${dappnode_bumped_version} ' . |= .+ { "version": $dappnode_bumped_version}' dappnode_package.json) > dappnode_package.json
           yq -i e ".services.node.image |= \"node.hopr.public.dappnode.eth:${dappnode_bumped_version}\"" docker-compose.yml
           yq -i e ".services.node.build.args.UPSTREAM_VERSION |= \"${docker_tag}\"" docker-compose.yml
+          yq -i e ".services.admin.image |= \"europe-west3-docker.pkg.dev/hoprassociation/docker-images/hopr-admin:{hopr_admin_latest_tag}\"" docker-compose.yml
+
         working-directory: "./DAppNodePackage-Hopr"
 
       - name: Create Pull Request

--- a/Makefile
+++ b/Makefile
@@ -570,7 +570,7 @@ run-docker-dev: ## start a local development Docker container
 		develop
 
 .PHONY: run-hopr-admin
-run-hopr-admin: version=07aec21b
+run-hopr-admin: version=latest
 run-hopr-admin: port=3000
 run-hopr-admin: ## launches HOPR Admin in a Docker container, supports port= and version=, use http://host.docker.internal to access the host machine
 	docker run -p $(port):3000 --add-host=host.docker.internal:host-gateway \


### PR DESCRIPTION
Until now, the HOPR Admin version used when building the Dappnode image was hardcoded -> not using latest.
Now, it fetches the latest release on Dappnode built.

Also, when building locally, the latest image built on hopr-admin repo is being used (could be different than the latest release). This allow to directly test new features from HOPR Admin. 

Fixes #5481 