### PR TITLE
db: Fsync on every write

### DIFF
--- a/packages/core-ethereum/crates/core-ethereum-db/src/db.rs
+++ b/packages/core-ethereum/crates/core-ethereum-db/src/db.rs
@@ -162,9 +162,6 @@ impl<T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>> + Clone> HoprCoreEthe
         // compare the current_index with index, if current_index is smaller than index, set to index
         if current_index < index {
             let _evicted = self.db.set(prefixed_key, &index).await?;
-            // Ignoring evicted value
-            // flush the db after setter
-            self.db.flush().await?;
         }
         Ok(())
     }
@@ -345,8 +342,6 @@ impl<T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>> + Clone> HoprCoreEthe
         //     self.cached_unrealized_value
         //         .insert(v.ticket.channel_id, current_unrealized_value.add(&v.ticket.amount));
         // }
-
-        self.db.flush().await?;
 
         Ok(())
     }
@@ -585,8 +580,7 @@ impl<T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>> + Clone> HoprCoreEthe
     async fn update_acknowledged_ticket(&mut self, ticket: &AcknowledgedTicket) -> Result<()> {
         let key = get_acknowledged_ticket_key(ticket)?;
         if self.db.contains(key.clone()).await {
-            self.db.set(key, ticket).await.map(|_| ())?;
-            self.db.flush().await
+            self.db.set(key, ticket).await.map(|_| ())
         } else {
             Err(DbError::NotFound)
         }

--- a/packages/utils/crates/utils-db/src/rusty.rs
+++ b/packages/utils/crates/utils-db/src/rusty.rs
@@ -678,7 +678,10 @@ pub mod wasm {
                 .map_err(|_| io::Error::from(io::ErrorKind::Other))?;
 
             if written >= 0 {
-                Ok(written as usize)
+                // we flush after every successful write to ensure consistency
+                fsync_sync(self.0)
+                    .map(|_| written as usize)
+                    .map_err(|_| io::Error::from(io::ErrorKind::Other))
             } else {
                 Err(io::ErrorKind::Other.into())
             }


### PR DESCRIPTION
Refs #5829 

The observation was that during write-heavy operations, namely the initial indexing phase, the database gets into an inconsistent states. It seems no writes get through and the node crashes multiple times, eventually all data is lost (possibly the db is corrupted and re-created) and the nodes starts synching from scratch until possible completion. Another side-effect is that data is only synched to disk in irregular intervals, sometimes 10 seconds. 

Ensuring data is synched to disk after every write improves consistency guarantees. While it does present an overhead, its currently more essential to have a consistent database. We can improve performance later as we go forward.

This changes was tested on bare metal servers and dappnodes. The aforementioned sync problems did not occur again.