### PR TITLE
docker: Reduce max memory limit for Node.js to 1.5GB

### DIFF
--- a/packages/hoprd/Dockerfile
+++ b/packages/hoprd/Dockerfile
@@ -78,7 +78,11 @@ WORKDIR /app/hoprnet/packages/hoprd
 ENV NODE_ENV production
 ENV NEXT_TELEMETRY_DISABLED 1
 ENV DEBUG 'hopr*'
-ENV NODE_OPTIONS="--max_old_space_size=4096 --experimental-wasm-modules"
+# Set max memory to 1.5GB, assuming Docker will be set to `-m 2g`.
+# This makes Node.js run GC more frequently as it approaches the memory bounds
+# so it won't reach the maximum memory given by Docker.
+# Can be configured differently by the user if needed.
+ENV NODE_OPTIONS="--max_old_space_size=1542 --experimental-wasm-modules"
 
 # Admin web server
 EXPOSE 3000


### PR DESCRIPTION
Before the limit was set to 4GB while Docker's limit was set to 2GB. This meant Node.js would run very little GC and rather try to get more memory allocated since it was far away from reaching 4GB. However, then Docker would kill the container. This could occur during initial indexing where lots of objects are allocated in short periods of time.

This change lowers the limit for Node.js 1.5GB which is well below the Docker limit and should be enough for the current `hoprd`.