### PR TITLE
Pin the hoprd-sdk-python to a specific version

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 black==23.3.0
-hoprd-sdk @ git+https://github.com/hoprnet/hoprd-sdk-python@main
+hoprd-sdk @ git+https://github.com/hoprnet/hoprd-sdk-python@v2.0.5
 pytest==7.2.1
 pytest-asyncio==0.21.0
 requests==2.28.2


### PR DESCRIPTION
the 2.1 hoprd-sdk-python will be breaking, this change needs to get into the `master` as well as `release/providence` to not follow the tip of the `hoprd-sdk-python` repository, but a specific tag.