### PR TITLE
Throw an error and let hoprd restart when indexer fails to start

### DIFF
--- a/packages/core-ethereum/src/index.ts
+++ b/packages/core-ethereum/src/index.ts
@@ -176,6 +176,7 @@ export default class HoprCoreEthereum extends EventEmitter {
         log('Connector started')
       } catch (err) {
         log('error: failed to start the indexer', err)
+        throw Error(`Failed to start the indexer: ${err.toString()}`)
       }
       return this
     }


### PR DESCRIPTION
Closes https://github.com/hoprnet/hoprnet/issues/5850

Some v2.0.7 nodes still run into rejected tickets issues due to a diverged view on the network graph. Terminating hoprd and let the container to restart the daemon prevents nodes to operate on a stale view