### PR TITLE
Update toolchain to Rust 1.75.0 and fix test workflow naming

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -72,7 +72,7 @@ jobs:
         run: nix develop -c make -j build
 
   unit-tests:
-    name: Test | Unit
+    name: Unit
     needs:
       - build
     runs-on: ubuntu-2-core
@@ -125,7 +125,7 @@ jobs:
           HOPR_NETWORK: anvil-localhost
 
   smoke-tests:
-    name: Test | Smoke
+    name: Smoke
     needs:
       - build
     strategy:

--- a/ethereum/bindings/Cargo.toml
+++ b/ethereum/bindings/Cargo.toml
@@ -8,6 +8,3 @@ edition = "2021"
 [dependencies]
 ethers = { version = "2", default-features = false, features = ["abigen"] }
 serde = "1"
-
-[lib]
-crate-type = ["rlib"]

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1701473968,
-        "narHash": "sha256-YcVE5emp1qQ8ieHUnxt1wCZCC3ZfAS+SRRWZ2TMda7E=",
+        "lastModified": 1704982712,
+        "narHash": "sha256-2Ptt+9h8dczgle2Oo6z5ni5rt/uLMG47UFTR1ry/wgg=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "34fed993f1674c8d06d58b37ce1e0fe5eebcb9f5",
+        "rev": "07f6395285469419cf9d078f59b5b49993198c00",
         "type": "github"
       },
       "original": {
@@ -38,11 +38,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1702151865,
-        "narHash": "sha256-9VAt19t6yQa7pHZLDbil/QctAgVsA66DLnzdRGqDisg=",
+        "lastModified": 1705240339,
+        "narHash": "sha256-QDPkF/x35n9Z1rd2BYRGfn7Yg+JjePk9V6XU9WpUDlA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "666fc80e7b2afb570462423cb0e1cf1a3a34fedd",
+        "rev": "06751d407cdb9b67faaf606aa6d281712ce4fb85",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1701253981,
-        "narHash": "sha256-ztaDIyZ7HrTAfEEUt9AtTDNoCYxUdSd6NrRHaYOIxtk=",
+        "lastModified": 1703961334,
+        "narHash": "sha256-M1mV/Cq+pgjk0rt6VxoyyD+O8cOUiai8t9Q6Yyq4noY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e92039b55bcd58469325ded85d4f58dd5a4eaf58",
+        "rev": "b0d36bd0a420ecee3bc916c91886caca87c894e9",
         "type": "github"
       },
       "original": {
@@ -85,11 +85,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1702088052,
-        "narHash": "sha256-FkwIBTAMsxyceQce0Mbm+/+cOjj2r5IHBK4R/ekPNaw=",
+        "lastModified": 1705198720,
+        "narHash": "sha256-/pzqqQQ1aU4llyaCDVjhPjQWIWpcRxFCsiDzl0lcAIk=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2cfb76b8e836a26efecd9f853bea78355a11c58a",
+        "rev": "71d1d01578272b2294f6993b1860dfb22e4baac3",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 channel = "1.75"
 profile = "default"
 components = [ "cargo", "clippy", "rust-src" ]
-targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin" ]
+targets = [ "x86_64-unknown-linux-gnu" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.74"
+channel = "1.75"
 profile = "default"
-components = [ "rust-src" ]
-targets = [ "wasm32-unknown-unknown" ]
+components = [ "cargo", "clippy", "rust-src" ]
+targets = ["x86_64-unknown-linux-gnu", "aarch64-apple-darwin" ]

--- a/scripts/toolchain/install-toolchain.sh
+++ b/scripts/toolchain/install-toolchain.sh
@@ -108,7 +108,7 @@ function install_cargo() {
         local rust_toolchain_toml_path="${mydir}/../../rust-toolchain.toml"
         local rust_version=$(sed -En 's/^channel = "([0-9a-z.]*)"$/\1/p' ${rust_toolchain_toml_path})
         echo "Installing Cargo, Rust compiler v${rust_version}"
-        local target=$(sed -En 's/^targets = \[ "([a-z0-9-]*)" \]$/\1/p' ${rust_toolchain_toml_path})
+        local target=$(sed -En 's/^targets = \[ "([a-z0-9_-]*)" \]$/\1/p' ${rust_toolchain_toml_path})
         local profile=$(sed -En 's/^profile = "([a-z]*)"$/\1/p' ${rust_toolchain_toml_path})
 
         # Always install the version specified in `rust-toolchain.toml`


### PR DESCRIPTION
Updates:
- nix environment update
- Rust 1.74.0 -> Rust 1.75

Fixes:
- `test` workflow naming update