### PR TITLE
Remove `surf` client middleware logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3265,6 +3265,7 @@ dependencies = [
  "core-path",
  "core-strategy",
  "core-transport",
+ "env_logger",
  "futures",
  "hopr-internal-types",
  "hopr-metrics",

--- a/chain/indexer/src/block.rs
+++ b/chain/indexer/src/block.rs
@@ -51,6 +51,7 @@ pub struct IndexerConfig {
     /// The number of blocks including and decreasing from the chain HEAD
     /// that the logs will be buffered for before being considered
     /// successfully joined to the chain.
+    /// Default is 8.
     pub finalization: u64,
     /// The block at which the indexer should start
     ///
@@ -59,10 +60,12 @@ pub struct IndexerConfig {
     /// relevant smart contracts were introduced into the chain.
     ///
     /// This value makes sure that indexing is relevant and as minimal as possible.
+    /// Default is 0.
     pub start_block_number: u64,
     /// Fetch token transactions
     ///
     /// Whether the token transaction topics should also be fetched.
+    /// Default is true.
     pub fetch_token_transactions: bool,
 }
 

--- a/chain/rpc/Cargo.toml
+++ b/chain/rpc/Cargo.toml
@@ -35,7 +35,7 @@ hopr-metrics = { workspace = true, optional = true }
 hopr-primitive-types = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-surf = { version = "2.3.2", default-features = false, features = ["h1-client-rustls", "encoding", "middleware-logger"] }
+surf = { version = "2.3.2", default-features = false, features = ["h1-client-rustls", "encoding"] }
 
 [dev-dependencies]
 async-std = { version = "1.12.0", features = ["attributes", "unstable"] }

--- a/chain/rpc/src/client.rs
+++ b/chain/rpc/src/client.rs
@@ -233,7 +233,7 @@ impl<Req: HttpPostRequestor, R: RetryPolicy<JsonRpcProviderClientError>> JsonRpc
         let body = self.requestor.http_post(self.url.as_ref(), payload).await?;
         let req_duration = start.elapsed();
 
-        trace!("rpc call {method} took {}ms", req_duration.as_millis());
+        debug!("rpc call {method} took {}ms", req_duration.as_millis());
 
         #[cfg(all(feature = "prometheus", not(test)))]
         METRIC_RPC_CALLS_TIMING.observe(&[method], req_duration.as_secs_f64());
@@ -471,7 +471,7 @@ pub fn create_rpc_client_to_anvil<R: HttpPostRequestor + Debug>(
     let wallet =
         ethers::signers::LocalWallet::from_bytes(signer.secret().as_ref()).expect("failed to construct wallet");
     let json_client = JsonRpcProviderClient::new(&anvil.endpoint(), backend, SimpleJsonRpcRetryPolicy::default());
-    let provider = ethers::providers::Provider::new(json_client).interval(Duration::from_millis(10u64));
+    let provider = ethers::providers::Provider::new(json_client).interval(Duration::from_millis(10_u64));
 
     std::sync::Arc::new(ethers::middleware::SignerMiddleware::new(
         provider,

--- a/chain/rpc/src/rpc.rs
+++ b/chain/rpc/src/rpc.rs
@@ -177,6 +177,7 @@ impl<P: JsonRpcClient + 'static> HoprRpcOperations for RpcOperations<P> {
     async fn send_transaction(&self, tx: TypedTransaction) -> Result<PendingTransaction> {
         // This only sets the nonce on the first TX, otherwise it is a no-op
         let _ = self.provider.initialize_nonce(None).await;
+        debug!("send outgoing tx: {:?}", tx);
 
         // Also fills the transaction including the EIP1559 fee estimates from the provider
         let sent_tx = self

--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -22,7 +22,7 @@ semver = "1.0"
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
-thiserror = "1.0"
+thiserror = { workspace = true }
 validator = { workspace = true }
 
 core-path = { workspace = true }
@@ -42,6 +42,7 @@ hopr-primitive-types = { workspace = true }
 
 [dev-dependencies]
 serde_yaml = { version = "0.9" }
+env_logger = { workspace = true }
 
 [features]
 default = ["prometheus"]


### PR DESCRIPTION
The `surf` middleware logger is not useful as we have more superior RPC logging in-place already.