### PR TITLE
Lint the entire codebase with cargo clippy

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,7 +7,7 @@ directory = "vendor/cargo"
 [install]
 root = ".cargo"
 
-[build]
-rustflags = ["-Wunused-crate-dependencies"]
+# [build]
+# rustflags = ["-Wunused-crate-dependencies"]
 # Nightly only
 #rustflags = [ "-Zlocation-detail=none" ]

--- a/Makefile
+++ b/Makefile
@@ -177,6 +177,7 @@ lint-sol: ## run linter for Solidity
 .PHONY: lint-rust
 lint-rust: ## run linter for Rust
 	cargo fmt --check
+	#cargo clippy -- -Dwarnings			# cannot be used unless all deprecation notices are removed as well
 
 .PHONY: lint-python
 lint-python: ## run linter for Python

--- a/chain/actions/src/channels.rs
+++ b/chain/actions/src/channels.rs
@@ -538,7 +538,7 @@ mod tests {
         tx_exec
             .expect_fund_channel()
             .times(1)
-            .withf(move |dest, balance| channel.destination.eq(&dest) && stake.eq(balance))
+            .withf(move |dest, balance| channel.destination.eq(dest) && stake.eq(balance))
             .returning(move |_, _| Ok(random_hash));
 
         let mut indexer_action_tracker = MockActionState::new();

--- a/chain/actions/src/node.rs
+++ b/chain/actions/src/node.rs
@@ -111,7 +111,7 @@ mod tests {
             "must be withdraw action"
         );
         assert!(
-            matches!(tx_res.event, None),
+            tx_res.event.is_none(),
             "withdraw tx must not connect to any chain event"
         );
     }

--- a/chain/actions/src/payload.rs
+++ b/chain/actions/src/payload.rs
@@ -102,7 +102,7 @@ fn transfer_tx(destination: Address, amount: Balance) -> TypedTransaction {
             tx.set_data(
                 TransferCall {
                     recipient: destination.into(),
-                    amount: amount.amount().into(),
+                    amount: amount.amount(),
                 }
                 .encode()
                 .into(),
@@ -596,7 +596,7 @@ pub mod tests {
         hopr_token: &U256,
         hopr_token_contract: HoprToken<M>,
         client: Arc<M>,
-    ) -> () {
+    ) {
         let node_address = H160::from_slice(&node.to_bytes());
         let native_transfer_tx = Eip1559TransactionRequest::new().to(node_address).value(native_token);
         client
@@ -607,7 +607,7 @@ pub mod tests {
             .unwrap();
 
         hopr_token_contract
-            .transfer(node_address, hopr_token.clone())
+            .transfer(node_address, *hopr_token)
             .send()
             .await
             .unwrap()

--- a/chain/actions/src/redeem.rs
+++ b/chain/actions/src/redeem.rs
@@ -391,7 +391,7 @@ mod tests {
             .expect_redeem_ticket()
             .times(ticket_count)
             .in_sequence(&mut seq)
-            .withf(move |t| bob_tickets.iter().find(|tk| tk.ticket.eq(&t.ticket)).is_some())
+            .withf(move |t| bob_tickets.iter().any(|tk| tk.ticket.eq(&t.ticket)))
             .returning(move |_| Ok(random_hash));
 
         // and then all Charlie's tickets get redeemed
@@ -399,7 +399,7 @@ mod tests {
             .expect_redeem_ticket()
             .times(ticket_count)
             .in_sequence(&mut seq)
-            .withf(move |t| charlie_tickets.iter().find(|tk| tk.ticket.eq(&t.ticket)).is_some())
+            .withf(move |t| charlie_tickets.iter().any(|tk| tk.ticket.eq(&t.ticket)))
             .returning(move |_| Ok(random_hash));
 
         // Start the ActionQueue with the mock TransactionExecutor
@@ -492,7 +492,7 @@ mod tests {
         tx_exec
             .expect_redeem_ticket()
             .times(ticket_count)
-            .withf(move |t| bob_tickets.iter().find(|tk| tk.ticket.eq(&t.ticket)).is_some())
+            .withf(move |t| bob_tickets.iter().any(|tk| tk.ticket.eq(&t.ticket)))
             .returning(move |_| Ok(random_hash));
 
         // Start the ActionQueue with the mock TransactionExecutor
@@ -576,11 +576,11 @@ mod tests {
         tx_exec
             .expect_redeem_ticket()
             .times(ticket_count - 2)
-            .withf(move |t| tickets_clone[2..].iter().find(|tk| tk.ticket.eq(&t.ticket)).is_some())
+            .withf(move |t| tickets_clone[2..].iter().any(|tk| tk.ticket.eq(&t.ticket)))
             .returning(move |_| Ok(random_hash));
 
         let mut indexer_action_tracker = MockActionState::new();
-        for tkt in tickets.iter().cloned().skip(2) {
+        for tkt in tickets.iter().skip(2).cloned() {
             indexer_action_tracker
                 .expect_register_expectation()
                 .once()
@@ -668,13 +668,12 @@ mod tests {
             .withf(move |t| {
                 tickets_clone[ticket_from_previous_epoch_count..]
                     .iter()
-                    .find(|tk| tk.ticket.eq(&t.ticket))
-                    .is_some()
+                    .any(|tk| tk.ticket.eq(&t.ticket))
             })
             .returning(move |_| Ok(random_hash));
 
         let mut indexer_action_tracker = MockActionState::new();
-        for tkt in tickets.iter().cloned().skip(ticket_from_previous_epoch_count) {
+        for tkt in tickets.iter().skip(ticket_from_previous_epoch_count).cloned() {
             indexer_action_tracker
                 .expect_register_expectation()
                 .once()
@@ -749,13 +748,12 @@ mod tests {
             .withf(move |t| {
                 tickets_clone[ticket_from_next_epoch_count..]
                     .iter()
-                    .find(|tk| tk.ticket.eq(&t.ticket))
-                    .is_some()
+                    .any(|tk| tk.ticket.eq(&t.ticket))
             })
             .returning(move |_| Ok(random_hash));
 
         let mut indexer_action_tracker = MockActionState::new();
-        for tkt in tickets.iter().cloned().skip(ticket_from_next_epoch_count) {
+        for tkt in tickets.iter().skip(ticket_from_next_epoch_count).cloned() {
             indexer_action_tracker
                 .expect_register_expectation()
                 .once()

--- a/chain/api/src/lib.rs
+++ b/chain/api/src/lib.rs
@@ -111,6 +111,7 @@ pub struct HoprChain {
 }
 
 impl HoprChain {
+    #[allow(clippy::too_many_arguments)]        // TODO: refactor this function into a reasonable group of components once fully rearchitected
     pub fn new(
         me_onchain: ChainKeypair,
         db: Arc<RwLock<CoreEthereumDb<CurrentDbShim>>>,

--- a/chain/db/src/db.rs
+++ b/chain/db/src/db.rs
@@ -1337,9 +1337,9 @@ impl<T: AsyncKVStorage<Key = Box<[u8]>, Value = Box<[u8]>> + Clone + Send + Sync
 mod tests {
     use super::*;
     use hex_literal::hex;
-    use hopr_crypto_types::prelude::*;
+    
     use hopr_internal_types::channels::ChannelEntry;
-    use hopr_primitive_types::prelude::*;
+    
     use lazy_static::lazy_static;
     use std::ops::Mul;
     use std::str::FromStr;
@@ -1464,19 +1464,19 @@ mod tests {
 
         let test_address = Address::from_str("0xa6416794a09d1c8c4c6110f83f42cf6f1ed9c416").unwrap();
 
-        assert_eq!(db.is_allowed_to_access_network(&test_address).await.unwrap(), false);
+        assert!(!db.is_allowed_to_access_network(&test_address).await.unwrap());
 
         db.set_allowed_to_access_network(&test_address, true, &Snapshot::default())
             .await
             .unwrap();
 
-        assert_eq!(db.is_allowed_to_access_network(&test_address).await.unwrap(), true);
+        assert!(db.is_allowed_to_access_network(&test_address).await.unwrap());
 
         db.set_allowed_to_access_network(&test_address, false, &Snapshot::default())
             .await
             .unwrap();
 
-        assert_eq!(db.is_allowed_to_access_network(&test_address).await.unwrap(), false);
+        assert!(!db.is_allowed_to_access_network(&test_address).await.unwrap());
     }
 
     #[async_std::test]
@@ -1601,7 +1601,7 @@ mod tests {
         assert_eq!(channel_id, channel.get_id());
 
         // check acked ticket count
-        let acked_tickets_count = db.get_acknowledged_tickets_count(Some(channel.clone())).await.unwrap();
+        let acked_tickets_count = db.get_acknowledged_tickets_count(Some(channel)).await.unwrap();
 
         assert_eq!(acked_tickets_count, tickets_to_generate as usize);
 

--- a/chain/indexer/src/block.rs
+++ b/chain/indexer/src/block.rs
@@ -221,8 +221,8 @@ where
                     }
                 }
 
-                while let Some(logs) = unconfirmed_events.get(0) {
-                    if let Some(log) = logs.get(0) {
+                while let Some(logs) = unconfirmed_events.front() {
+                    if let Some(log) = logs.first() {
                         if log.block_number + finalization <= current_block {
                             if let Err(error) = db
                                 .write()
@@ -576,7 +576,7 @@ pub mod tests {
         assert!(tx.start_send(head_allowing_finalization.clone()).is_ok());
 
         let (tx_events, rx_events) = futures::channel::mpsc::unbounded();
-        let mut indexer = Indexer::new(rpc, handlers, db.clone(), cfg, tx_events.into());
+        let mut indexer = Indexer::new(rpc, handlers, db.clone(), cfg, tx_events);
         assert!(indexer.start().await.is_ok());
 
         tx.close_channel();

--- a/chain/indexer/src/handlers.rs
+++ b/chain/indexer/src/handlers.rs
@@ -513,7 +513,7 @@ impl<U: HoprCoreEthereumDbActions> ContractEventHandlers<U> {
                     update.1.to_string()
                 );
 
-                db.set_ticket_price(&update.1.into()).await?;
+                db.set_ticket_price(&update.1).await?;
             }
             HoprTicketPriceOracleEvents::OwnershipTransferredFilter(_event) => {
                 // ignore ownership transfer event
@@ -686,14 +686,14 @@ pub mod tests {
         };
 
         let account_entry = AccountEntry::new(
-            SELF_PRIV_KEY.public().clone(),
+            *SELF_PRIV_KEY.public(),
             *SELF_CHAIN_ADDRESS,
             AccountType::NotAnnounced,
         );
 
         handlers
             .on_event(
-                handlers.addresses.announcements.clone(),
+                handlers.addresses.announcements,
                 0u32,
                 keybinding_log,
                 Snapshot::default(),
@@ -715,7 +715,7 @@ pub mod tests {
 
         // Assume that there is a keybinding
         let account_entry = AccountEntry::new(
-            SELF_PRIV_KEY.public().clone(),
+            *SELF_PRIV_KEY.public(),
             *SELF_CHAIN_ADDRESS,
             AccountType::NotAnnounced,
         );
@@ -738,7 +738,7 @@ pub mod tests {
 
         let _error = handlers
             .on_event(
-                handlers.addresses.announcements.clone(),
+                handlers.addresses.announcements,
                 0u32,
                 address_announcement_empty_log,
                 Snapshot::default(),
@@ -762,7 +762,7 @@ pub mod tests {
         };
 
         let announced_account_entry = AccountEntry::new(
-            SELF_PRIV_KEY.public().clone(),
+            *SELF_PRIV_KEY.public(),
             *SELF_CHAIN_ADDRESS,
             AccountType::Announced {
                 multiaddr: test_multiaddr,
@@ -772,7 +772,7 @@ pub mod tests {
 
         handlers
             .on_event(
-                handlers.addresses.announcements.clone(),
+                handlers.addresses.announcements,
                 0u32,
                 address_announcement_log,
                 Snapshot::default(),
@@ -796,7 +796,7 @@ pub mod tests {
         };
 
         let announced_dns_account_entry = AccountEntry::new(
-            SELF_PRIV_KEY.public().clone(),
+            *SELF_PRIV_KEY.public(),
             *SELF_CHAIN_ADDRESS,
             AccountType::Announced {
                 multiaddr: test_multiaddr_dns,
@@ -806,7 +806,7 @@ pub mod tests {
 
         handlers
             .on_event(
-                handlers.addresses.announcements.clone(),
+                handlers.addresses.announcements,
                 0u32,
                 address_announcement_dns_log,
                 Snapshot::default(),
@@ -829,7 +829,7 @@ pub mod tests {
 
         // Assume that there is a keybinding and an address announcement
         let announced_account_entry = AccountEntry::new(
-            SELF_PRIV_KEY.public().clone(),
+            *SELF_PRIV_KEY.public(),
             *SELF_CHAIN_ADDRESS,
             AccountType::Announced {
                 multiaddr: test_multiaddr,
@@ -851,14 +851,14 @@ pub mod tests {
         };
 
         let account_entry = AccountEntry::new(
-            SELF_PRIV_KEY.public().clone(),
+            *SELF_PRIV_KEY.public(),
             *SELF_CHAIN_ADDRESS,
             AccountType::NotAnnounced,
         );
 
         handlers
             .on_event(
-                handlers.addresses.announcements.clone(),
+                handlers.addresses.announcements,
                 0u32,
                 revoke_announcement_log,
                 Snapshot::default(),
@@ -891,7 +891,7 @@ pub mod tests {
 
         handlers
             .on_event(
-                handlers.addresses.token.clone(),
+                handlers.addresses.token,
                 0u32,
                 transferred_log,
                 Snapshot::default(),
@@ -932,7 +932,7 @@ pub mod tests {
 
         handlers
             .on_event(
-                handlers.addresses.token.clone(),
+                handlers.addresses.token,
                 0u32,
                 transferred_log,
                 Snapshot::default(),
@@ -968,7 +968,7 @@ pub mod tests {
         );
 
         handlers
-            .on_event(handlers.addresses.token.clone(), 0u32, log.clone(), Snapshot::default())
+            .on_event(handlers.addresses.token, 0u32, log.clone(), Snapshot::default())
             .await
             .unwrap();
 
@@ -992,7 +992,7 @@ pub mod tests {
         );
 
         handlers
-            .on_event(handlers.addresses.token.clone(), 0u32, log, Snapshot::default())
+            .on_event(handlers.addresses.token, 0u32, log, Snapshot::default())
             .await
             .unwrap();
 
@@ -1026,7 +1026,7 @@ pub mod tests {
 
         handlers
             .on_event(
-                handlers.addresses.network_registry.clone(),
+                handlers.addresses.network_registry,
                 0u32,
                 registered_log,
                 Snapshot::default(),
@@ -1066,7 +1066,7 @@ pub mod tests {
 
         handlers
             .on_event(
-                handlers.addresses.network_registry.clone(),
+                handlers.addresses.network_registry,
                 0u32,
                 registered_log,
                 Snapshot::default(),
@@ -1112,7 +1112,7 @@ pub mod tests {
 
         handlers
             .on_event(
-                handlers.addresses.network_registry.clone(),
+                handlers.addresses.network_registry,
                 0u32,
                 registered_log,
                 Snapshot::default(),
@@ -1158,7 +1158,7 @@ pub mod tests {
 
         handlers
             .on_event(
-                handlers.addresses.network_registry.clone(),
+                handlers.addresses.network_registry,
                 0u32,
                 registered_log,
                 Snapshot::default(),
@@ -1190,7 +1190,7 @@ pub mod tests {
 
         handlers
             .on_event(
-                handlers.addresses.network_registry.clone(),
+                handlers.addresses.network_registry,
                 0u32,
                 nr_enabled,
                 Snapshot::default(),
@@ -1223,7 +1223,7 @@ pub mod tests {
 
         handlers
             .on_event(
-                handlers.addresses.network_registry.clone(),
+                handlers.addresses.network_registry,
                 0u32,
                 nr_disabled,
                 Snapshot::default(),
@@ -1251,7 +1251,7 @@ pub mod tests {
 
         handlers
             .on_event(
-                handlers.addresses.network_registry.clone(),
+                handlers.addresses.network_registry,
                 0u32,
                 set_eligible,
                 Snapshot::default(),
@@ -1285,7 +1285,7 @@ pub mod tests {
 
         handlers
             .on_event(
-                handlers.addresses.network_registry.clone(),
+                handlers.addresses.network_registry,
                 0u32,
                 set_eligible,
                 Snapshot::default(),
@@ -1334,7 +1334,7 @@ pub mod tests {
 
         handlers
             .on_event(
-                handlers.addresses.channels.clone(),
+                handlers.addresses.channels,
                 0u32,
                 balance_increased_log,
                 Snapshot::default(),
@@ -1374,7 +1374,7 @@ pub mod tests {
         assert!(db.read().await.get_channels_domain_separator().await.unwrap().is_none());
 
         handlers
-            .on_event(handlers.addresses.channels.clone(), 0u32, log, Snapshot::default())
+            .on_event(handlers.addresses.channels, 0u32, log, Snapshot::default())
             .await
             .unwrap();
 
@@ -1422,7 +1422,7 @@ pub mod tests {
 
         handlers
             .on_event(
-                handlers.addresses.channels.clone(),
+                handlers.addresses.channels,
                 0u32,
                 balance_increased_log,
                 Snapshot::default(),
@@ -1480,7 +1480,7 @@ pub mod tests {
 
         handlers
             .on_event(
-                handlers.addresses.channels.clone(),
+                handlers.addresses.channels,
                 0u32,
                 channel_closed_log,
                 Snapshot::default(),
@@ -1523,7 +1523,7 @@ pub mod tests {
 
         handlers
             .on_event(
-                handlers.addresses.channels.clone(),
+                handlers.addresses.channels,
                 0u32,
                 channel_opened_log,
                 Snapshot::default(),
@@ -1584,7 +1584,7 @@ pub mod tests {
 
         handlers
             .on_event(
-                handlers.addresses.channels.clone(),
+                handlers.addresses.channels,
                 0u32,
                 channel_opened_log,
                 Snapshot::default(),
@@ -1647,7 +1647,7 @@ pub mod tests {
 
         handlers
             .on_event(
-                handlers.addresses.channels.clone(),
+                handlers.addresses.channels,
                 0u32,
                 ticket_redeemed_log,
                 Snapshot::default(),
@@ -1708,7 +1708,7 @@ pub mod tests {
 
         handlers
             .on_event(
-                handlers.addresses.channels.clone(),
+                handlers.addresses.channels,
                 0u32,
                 closure_initiated_log,
                 Snapshot::default(),
@@ -1741,7 +1741,7 @@ pub mod tests {
 
         handlers
             .on_event(
-                handlers.addresses.safe_registry.clone(),
+                handlers.addresses.safe_registry,
                 0u32,
                 safe_registered_log,
                 Snapshot::default(),
@@ -1780,7 +1780,7 @@ pub mod tests {
 
         handlers
             .on_event(
-                handlers.addresses.safe_registry.clone(),
+                handlers.addresses.safe_registry,
                 0u32,
                 safe_registered_log,
                 Snapshot::default(),
@@ -1807,7 +1807,7 @@ pub mod tests {
         assert_eq!(db.read().await.get_ticket_price().await.unwrap(), None);
 
         handlers
-            .on_event(handlers.addresses.price_oracle.clone(), 0u32, log, Snapshot::default())
+            .on_event(handlers.addresses.price_oracle, 0u32, log, Snapshot::default())
             .await
             .unwrap();
 

--- a/chain/rpc/src/client.rs
+++ b/chain/rpc/src/client.rs
@@ -453,18 +453,19 @@ pub mod native {
     }
 }
 
+type AnvilRpcClient<R> = std::sync::Arc<
+ethers::middleware::SignerMiddleware<
+    ethers::providers::Provider<JsonRpcProviderClient<R, SimpleJsonRpcRetryPolicy>>,
+    ethers::signers::Wallet<ethers::core::k256::ecdsa::SigningKey>,
+>>;
+
 /// Used for testing. Creates Ethers RPC client to the local Anvil instance.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn create_rpc_client_to_anvil<R: HttpPostRequestor + Debug>(
     backend: R,
     anvil: &ethers::utils::AnvilInstance,
     signer: &hopr_crypto_types::keypairs::ChainKeypair,
-) -> std::sync::Arc<
-    ethers::middleware::SignerMiddleware<
-        ethers::providers::Provider<JsonRpcProviderClient<R, SimpleJsonRpcRetryPolicy>>,
-        ethers::signers::Wallet<ethers::core::k256::ecdsa::SigningKey>,
-    >,
-> {
+) -> AnvilRpcClient<R> {
     use ethers::signers::Signer;
     use hopr_crypto_types::keypairs::Keypair;
 

--- a/chain/rpc/src/indexer.rs
+++ b/chain/rpc/src/indexer.rs
@@ -191,7 +191,7 @@ mod test {
 
         let cfg = RpcOperationsConfig {
             tx_polling_interval: Duration::from_millis(10),
-            contract_addrs: contract_addrs.clone(),
+            contract_addrs: contract_addrs,
             expected_block_time: block_time,
             ..RpcOperationsConfig::default()
         };
@@ -296,7 +296,7 @@ mod test {
 
         let cfg = RpcOperationsConfig {
             tx_polling_interval: Duration::from_millis(10),
-            contract_addrs: contract_addrs.clone(),
+            contract_addrs: contract_addrs,
             expected_block_time: block_time,
             ..RpcOperationsConfig::default()
         };

--- a/chain/rpc/src/lib.rs
+++ b/chain/rpc/src/lib.rs
@@ -62,7 +62,7 @@ impl From<ethers::types::Log> for Log {
             data: Box::from(value.data.as_ref()),
             tx_index: value.transaction_index.expect("tx index must be present").as_u64(),
             block_number: value.block_number.expect("block id must be present").as_u64(),
-            log_index: value.log_index.expect("log index must be present").into(),
+            log_index: value.log_index.expect("log index must be present"),
             tx_hash: value.transaction_hash.expect("tx hash must be present").into(),
         }
     }

--- a/chain/rpc/src/rpc.rs
+++ b/chain/rpc/src/rpc.rs
@@ -143,7 +143,7 @@ impl<P: JsonRpcClient + 'static> HoprRpcOperations for RpcOperations<P> {
     async fn get_node_management_module_target_info(&self, target: Address) -> Result<Option<U256>> {
         let (exists, target) = self.node_module.try_get_target(target.into()).call().await?;
 
-        Ok(exists.then_some(target.into()))
+        Ok(exists.then_some(target))
     }
 
     async fn get_safe_from_node_safe_registry(&self, node_address: Address) -> Result<Address> {
@@ -243,17 +243,15 @@ pub mod tests {
     fn transfer_eth_tx(to: Address, amount: U256) -> TypedTransaction {
         let mut tx = TypedTransaction::Eip1559(Eip1559TransactionRequest::new());
         tx.set_to(H160::from(to));
-        tx.set_value(ethers::types::U256(primitive_types::U256::from(amount).0));
+        tx.set_value(ethers::types::U256(amount.0));
         tx
     }
 
     pub async fn wait_until_tx(pending: PendingTransaction<'_>, timeout: Duration) {
         let tx_hash = pending.tx_hash();
         sleep(timeout).await;
-        pending.await.expect(&format!(
-            "timeout awaiting tx hash {tx_hash} after {} seconds",
-            timeout.as_secs()
-        ));
+        pending.await.unwrap_or_else(|_| panic!("timeout awaiting tx hash {tx_hash} after {} seconds",
+            timeout.as_secs()));
     }
 
     #[async_std::test]
@@ -325,7 +323,7 @@ pub mod tests {
         let send_amount = 1000000_u64;
 
         // Send 1 ETH to some random address
-        futures::future::join_all((0..txs_count).into_iter().map(|_| async {
+        futures::future::join_all((0..txs_count).map(|_| async {
             rpc.send_transaction(transfer_eth_tx(Address::random(), send_amount.into()))
                 .await
                 .expect("tx should be sent")

--- a/chain/types/src/actions.rs
+++ b/chain/types/src/actions.rs
@@ -3,6 +3,7 @@ use hopr_primitive_types::prelude::*;
 use std::fmt::{Display, Formatter};
 
 /// Enumerates all possible on-chain state change requests
+#[allow(clippy::large_enum_variant)]     // TODO: Refactor the large enum variant
 #[derive(Clone, PartialEq, Debug, strum::EnumVariantNames, strum::IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum Action {

--- a/chain/types/src/chain_events.rs
+++ b/chain/types/src/chain_events.rs
@@ -24,6 +24,7 @@ pub enum NetworkRegistryStatus {
 }
 
 /// Enumeration of HOPR chain events.
+#[allow(clippy::large_enum_variant)]     // TODO: Refactor the large enum variant
 #[derive(Debug, Clone, PartialEq)]
 pub enum ChainEventType {
     /// Peer on-chain announcement event.

--- a/common/internal-types/src/acknowledgement.rs
+++ b/common/internal-types/src/acknowledgement.rs
@@ -368,7 +368,9 @@ impl BinarySerializable for UnacknowledgedTicket {
 
 /// Contains either unacknowledged ticket if we're waiting for the acknowledgement as a relayer
 /// or information if we wait for the acknowledgement as a sender.
+#[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+
 pub enum PendingAcknowledgement {
     /// We're waiting for acknowledgement as a sender
     WaitingAsSender,

--- a/common/internal-types/src/announcement.rs
+++ b/common/internal-types/src/announcement.rs
@@ -32,7 +32,7 @@ impl KeyBinding {
         let to_sign = Self::prepare_for_signing(&chain_key, packet_key.public());
         Self {
             chain_key,
-            packet_key: packet_key.public().clone(),
+            packet_key: *packet_key.public(),
             signature: OffchainSignature::sign_message(&to_sign, packet_key),
         }
     }
@@ -157,7 +157,7 @@ mod tests {
     #[test]
     fn test_key_binding() {
         let kb_1 = KeyBinding::new(*CHAIN_ADDR, &KEY_PAIR);
-        let kb_2 = KeyBinding::from_parts(kb_1.chain_key.clone(), kb_1.packet_key.clone(), kb_1.signature.clone())
+        let kb_2 = KeyBinding::from_parts(kb_1.chain_key, kb_1.packet_key, kb_1.signature.clone())
             .expect("should verify correctly");
 
         assert_eq!(kb_1, kb_2, "must be equal");
@@ -171,23 +171,23 @@ mod tests {
         for (ma_str, decapsulated_ma_str) in vec![
             (
                 format!("/ip4/127.0.0.1/tcp/10000/p2p/{peer_id}"),
-                format!("/ip4/127.0.0.1/tcp/10000"),
+                "/ip4/127.0.0.1/tcp/10000".to_string(),
             ),
             (
                 format!("/ip6/::1/tcp/10000/p2p/{peer_id}"),
-                format!("/ip6/::1/tcp/10000"),
+                "/ip6/::1/tcp/10000".to_string(),
             ),
             (
                 format!("/dns4/hoprnet.org/tcp/10000/p2p/{peer_id}"),
-                format!("/dns4/hoprnet.org/tcp/10000"),
+                "/dns4/hoprnet.org/tcp/10000".to_string(),
             ),
             (
                 format!("/dns6/hoprnet.org/tcp/10000/p2p/{peer_id}"),
-                format!("/dns6/hoprnet.org/tcp/10000"),
+                "/dns6/hoprnet.org/tcp/10000".to_string(),
             ),
             (
                 format!("/ip4/127.0.0.1/udp/10000/quic/p2p/{peer_id}"),
-                format!("/ip4/127.0.0.1/udp/10000/quic"),
+                "/ip4/127.0.0.1/udp/10000/quic".to_string(),
             ),
         ] {
             let maddr: Multiaddr = ma_str.parse().unwrap();
@@ -201,7 +201,7 @@ mod tests {
 
     #[test]
     fn test_announcement_no_keybinding() {
-        let maddr: Multiaddr = format!("/ip4/127.0.0.1/tcp/10000").parse().unwrap();
+        let maddr: Multiaddr = "/ip4/127.0.0.1/tcp/10000".to_string().parse().unwrap();
 
         let ad = AnnouncementData::new(&maddr, None).expect("construction of announcement data should work");
 
@@ -211,7 +211,7 @@ mod tests {
     #[test]
     fn test_announcement_decapsulated_ma() {
         let key_binding = KeyBinding::new(*CHAIN_ADDR, &KEY_PAIR);
-        let maddr: Multiaddr = format!("/ip4/127.0.0.1/tcp/10000").parse().unwrap();
+        let maddr: Multiaddr = "/ip4/127.0.0.1/tcp/10000".to_string().parse().unwrap();
 
         let ad = AnnouncementData::new(&maddr, Some(key_binding.clone()))
             .expect("construction of announcement data should work");

--- a/common/internal-types/src/channels.rs
+++ b/common/internal-types/src/channels.rs
@@ -437,7 +437,7 @@ impl Ticket {
     }
 
     /// Creates a ticket with signature attached.
-    #[warn(clippy::too_many_arguments)]         // TODO: Refactor the function to take either less arguments or is more straigtforward
+    #[allow(clippy::too_many_arguments)]         // TODO: Refactor the function to take either less arguments or is more straigtforward
     pub fn new_with_signature(
         own_address: &Address,
         counterparty: &Address,

--- a/common/internal-types/src/channels.rs
+++ b/common/internal-types/src/channels.rs
@@ -395,6 +395,7 @@ impl std::fmt::Debug for Ticket {
 
 impl Ticket {
     /// Creates a new Ticket given the raw Challenge and signs it using the given chain keypair.
+    #[allow(clippy::too_many_arguments)]        // TODO: Refactor to use less inputs
     pub fn new(
         counterparty: &Address,
         amount: &Balance,
@@ -436,6 +437,7 @@ impl Ticket {
     }
 
     /// Creates a ticket with signature attached.
+    #[warn(clippy::too_many_arguments)]         // TODO: Refactor the function to take either less arguments or is more straigtforward
     pub fn new_with_signature(
         own_address: &Address,
         counterparty: &Address,

--- a/common/internal-types/src/protocol.rs
+++ b/common/internal-types/src/protocol.rs
@@ -189,7 +189,6 @@ mod tests {
         let mut filter1 = TagBloomFilter::default();
 
         let items = (0..10_000)
-            .into_iter()
             .map(|i| {
                 let mut ret = random_bytes::<{ hopr_crypto_types::types::PACKET_TAG_LENGTH }>();
                 ret[i % hopr_crypto_types::types::PACKET_TAG_LENGTH] = 0xaa; // ensure it is not completely just zeroes

--- a/crypto/sphinx/src/prg.rs
+++ b/crypto/sphinx/src/prg.rs
@@ -47,6 +47,7 @@ impl PRGParameters {
 /// using AES-128 block cipher in Counter mode (with 32-bit counter).
 /// It forms an infinite sequence of pseudo-random bytes (generated deterministically from the parameters)
 /// and can be queried by chunks using the `digest` function.
+#[allow(clippy::upper_case_acronyms)]
 #[derive(ZeroizeOnDrop)]
 pub struct PRG {
     params: PRGParameters,

--- a/crypto/sphinx/src/prp.rs
+++ b/crypto/sphinx/src/prp.rs
@@ -200,7 +200,7 @@ mod tests {
     fn test_prp_random_inplace() {
         let prp = PRP::new(random_bytes(), random_bytes());
         let mut data: [u8; 278] = random_bytes();
-        let data_old = data.clone();
+        let data_old = data;
 
         prp.forward_inplace(&mut data).unwrap();
         assert_ne!(&data_old, data.as_ref(), "buffer must be encrypted in-place");

--- a/crypto/types/src/utils.rs
+++ b/crypto/types/src/utils.rs
@@ -49,7 +49,7 @@ pub fn x25519_scalar_from_bytes(bytes: &[u8]) -> crate::errors::Result<curve2551
 /// Creates secp256k1 secret scalar from the given bytes.
 /// Note that this function allows zero scalars.
 pub fn k256_scalar_from_bytes(bytes: &[u8]) -> crate::errors::Result<k256::Scalar> {
-    Ok(Option::from(k256::Scalar::from_repr(*k256::FieldBytes::from_slice(bytes))).ok_or(InvalidInputValue)?)
+    Option::from(k256::Scalar::from_repr(*k256::FieldBytes::from_slice(bytes))).ok_or(InvalidInputValue)
 }
 
 /// Represents a secret value of a fixed length that is zeroized on drop.

--- a/hopli/src/create_safe_module.rs
+++ b/hopli/src/create_safe_module.rs
@@ -73,28 +73,16 @@ impl CreateSafeModuleArgs {
         }
 
         // 2. Calculate addresses from the identity file
-        // collect all the peer ids
-        let all_node_addresses: Vec<String>;
-        // check if password is provided
-        let pwd = match password.read_password() {
-            Ok(read_pwd) => read_pwd,
-            Err(e) => return Err(e),
-        };
+        
+        let pwd = password.read_password()?;
 
         // read all the identities from the directory
         let files = local_identity.get_files();
-        match read_identities(files, &pwd) {
-            Ok(node_identities) => {
-                all_node_addresses = node_identities
-                    .values()
-                    .map(|ni| ni.chain_key.public().to_address().to_string())
-                    .collect();
-            }
-            Err(e) => {
-                println!("error {:?}", e);
-                return Err(e);
-            }
-        }
+        let all_node_addresses: Vec<String> = read_identities(files, &pwd)?
+            .values()
+            .map(|ni| ni.chain_key.public().to_address().to_string())
+            .collect();
+
         log!(target: "create_safe_module", Level::Info, "NodeAddresses {:?}", all_node_addresses.join(","));
 
         // set directory and environment variables

--- a/hopli/src/create_safe_module.rs
+++ b/hopli/src/create_safe_module.rs
@@ -68,7 +68,7 @@ impl CreateSafeModuleArgs {
         } = self;
 
         // 1. `PRIVATE_KEY` - Private key is required to send on-chain transactions
-        if let Err(_) = env::var("PRIVATE_KEY") {
+        if env::var("PRIVATE_KEY").is_err() {
             return Err(HelperErrors::UnableToReadPrivateKey);
         }
 
@@ -98,9 +98,7 @@ impl CreateSafeModuleArgs {
         log!(target: "create_safe_module", Level::Info, "NodeAddresses {:?}", all_node_addresses.join(","));
 
         // set directory and environment variables
-        if let Err(e) = set_process_path_env(&contracts_root, &network) {
-            return Err(e);
-        }
+        set_process_path_env(&contracts_root, &network)?;
 
         // convert hopr_amount and native_amount from f64 to uint256 string
         let hopr_amount_uint256 = parse_units(hopr_amount, "ether").unwrap();

--- a/hopli/src/environment_config.rs
+++ b/hopli/src/environment_config.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, fmt, path::PathBuf};
+use std::{collections::HashMap, fmt, path::Path};
 
 /// Type of environment that HOPR node is running in
 #[derive(Debug, Deserialize, Serialize, Clone, Copy, PartialEq)]
@@ -71,7 +71,7 @@ pub struct NetworkConfig {
 /// ensures that the network and environment_type exist
 /// in `contracts-addresses.json` and are matched
 pub fn ensure_environment_and_network_are_set(
-    make_root_dir_path: &PathBuf,
+    make_root_dir_path: &Path,
     network: &str,
     environment_type: &str,
 ) -> Result<bool, String> {
@@ -98,7 +98,7 @@ pub fn ensure_environment_and_network_are_set(
 
 /// Returns the environment type from the network name
 /// according to `contracts-addresses.json`
-pub fn get_environment_type_from_name(make_root_dir_path: &PathBuf, network: &str) -> Result<EnvironmentType, String> {
+pub fn get_environment_type_from_name(make_root_dir_path: &Path, network: &str) -> Result<EnvironmentType, String> {
     // read `contracts-addresses.json` at make_root_dir_path
     let contract_environment_config_path = make_root_dir_path.join("contracts-addresses.json");
 

--- a/hopli/src/environment_config.rs
+++ b/hopli/src/environment_config.rs
@@ -113,7 +113,7 @@ pub fn get_environment_type_from_name(make_root_dir_path: &PathBuf, network: &st
         .get(network)
         .expect("Unable to find environment details");
 
-    return Ok(env_detail.environment_type);
+    Ok(env_detail.environment_type)
 }
 
 #[cfg(test)]
@@ -132,7 +132,7 @@ mod tests {
         let network = "anvil-localhost";
         let environment_type = "local";
         match ensure_environment_and_network_are_set(correct_dir, network, environment_type) {
-            Ok(result) => assert_eq!(result, true),
+            Ok(result) => assert!(result),
             _ => assert!(false),
         }
     }
@@ -173,7 +173,7 @@ mod tests {
         let network = "anvil-localhost";
         let environment_type = "production";
         match ensure_environment_and_network_are_set(correct_dir, network, environment_type) {
-            Ok(result) => assert_eq!(result, false),
+            Ok(result) => assert!(!result),
             _ => assert!(false),
         }
     }

--- a/hopli/src/identity.rs
+++ b/hopli/src/identity.rs
@@ -82,10 +82,7 @@ impl IdentityArgs {
                 let id_dir = local_id.identity_directory.unwrap();
                 for index in 0..=number - 1 {
                     // build file name
-                    let file_prefix = match &local_id.identity_prefix {
-                        Some(ref provided_name) => Some(provided_name.to_owned() + &index.to_string()),
-                        None => None,
-                    };
+                    let file_prefix = local_id.identity_prefix.as_ref().map(|provided_name| provided_name.to_owned() + &index.to_string());
 
                     match create_identity(&id_dir, &pwd, &file_prefix) {
                         Ok((id_filename, identity)) => _ = node_identities.insert(id_filename, identity),

--- a/hopli/src/identity_input.rs
+++ b/hopli/src/identity_input.rs
@@ -7,6 +7,7 @@ use std::{
 };
 
 #[derive(Debug, Clone, Parser)]
+#[derive(Default)]
 pub struct LocalIdentityFromDirectoryArgs {
     #[clap(
         help = "Path to the directory that stores identity files",
@@ -26,6 +27,7 @@ pub struct LocalIdentityFromDirectoryArgs {
 }
 
 #[derive(Debug, Clone, Parser)]
+#[derive(Default)]
 pub struct LocalIdentityArgs {
     #[clap(help = "Get identity file(s) from a directory", flatten)]
     pub identity_from_directory: Option<LocalIdentityFromDirectoryArgs>,
@@ -39,14 +41,7 @@ pub struct LocalIdentityArgs {
     pub identity_from_path: Option<PathBuf>,
 }
 
-impl Default for LocalIdentityFromDirectoryArgs {
-    fn default() -> Self {
-        LocalIdentityFromDirectoryArgs {
-            identity_directory: None,
-            identity_prefix: None,
-        }
-    }
-}
+
 
 impl LocalIdentityFromDirectoryArgs {
     /// read files from given directory or file path
@@ -80,14 +75,7 @@ impl LocalIdentityFromDirectoryArgs {
     }
 }
 
-impl Default for LocalIdentityArgs {
-    fn default() -> Self {
-        LocalIdentityArgs {
-            identity_from_directory: None,
-            identity_from_path: None,
-        }
-    }
-}
+
 
 impl LocalIdentityArgs {
     /// read files from given directory or file path

--- a/hopli/src/initialize_node.rs
+++ b/hopli/src/initialize_node.rs
@@ -72,7 +72,7 @@ impl InitializeNodeArgs {
         } = self;
 
         // 1. `PRIVATE_KEY` - Private key is required to send on-chain transactions
-        if let Err(_) = env::var("PRIVATE_KEY") {
+        if env::var("PRIVATE_KEY").is_err() {
             return Err(HelperErrors::UnableToReadPrivateKey);
         }
 
@@ -102,9 +102,7 @@ impl InitializeNodeArgs {
         log!(target: "initialize_node", Level::Info, "NodeAddresses {:?}", all_node_addresses.join(","));
 
         // set directory and environment variables
-        if let Err(e) = set_process_path_env(&contracts_root, &network) {
-            return Err(e);
-        }
+        set_process_path_env(&contracts_root, &network)?;
 
         // convert hopr_amount and native_amount from f64 to uint256 string
         let hopr_amount_uint256 = parse_units(hopr_amount, "ether").unwrap();

--- a/hopli/src/initialize_node.rs
+++ b/hopli/src/initialize_node.rs
@@ -77,28 +77,15 @@ impl InitializeNodeArgs {
         }
 
         // 2. Calculate the peerID and addresses from the identity file
-        // collect all the peer ids
-        let all_node_addresses: Vec<String>;
-        // check if password is provided
-        let pwd = match password.read_password() {
-            Ok(read_pwd) => read_pwd,
-            Err(e) => return Err(e),
-        };
+        let pwd = password.read_password()?;
 
         // read all the identities from the directory
         let files = local_identity.get_files();
-        match read_identities(files, &pwd) {
-            Ok(node_identities) => {
-                all_node_addresses = node_identities
-                    .values()
-                    .map(|ni| ni.chain_key.public().0.to_address().to_string())
-                    .collect();
-            }
-            Err(e) => {
-                println!("error {:?}", e);
-                return Err(e);
-            }
-        }
+        let all_node_addresses: Vec<String> = read_identities(files, &pwd)?
+            .values()
+            .map(|ni| ni.chain_key.public().0.to_address().to_string())
+            .collect();
+        
         log!(target: "initialize_node", Level::Info, "NodeAddresses {:?}", all_node_addresses.join(","));
 
         // set directory and environment variables

--- a/hopli/src/key_pair.rs
+++ b/hopli/src/key_pair.rs
@@ -116,13 +116,13 @@ mod tests {
         let read_id = read_identities(files, &pwd.to_string()).unwrap();
         assert_eq!(read_id.len(), 1);
         assert_eq!(
-            read_id.values().nth(0).unwrap().chain_key.public().0.to_address(),
+            read_id.values().next().unwrap().chain_key.public().0.to_address(),
             created_id.chain_key.public().0.to_address()
         );
 
         // print the read id
         println!("Debug {:#?}", read_id);
-        println!("Display {}", read_id.values().nth(0).unwrap());
+        println!("Display {}", read_id.values().next().unwrap());
 
         remove_json_keystore(path).map_err(|err| println!("{:?}", err)).ok();
     }
@@ -231,14 +231,13 @@ mod tests {
         // create dir if not exist.
         fs::create_dir_all(path).unwrap();
         // save the keystore as file
-        fs::write(PathBuf::from(path).join(&name), weak_crypto_alice_keystore.as_bytes()).unwrap();
+        fs::write(PathBuf::from(path).join(name), weak_crypto_alice_keystore.as_bytes()).unwrap();
 
         let files = get_files(path, &None);
         let val = read_identities(files, &pwd.to_string()).unwrap();
         assert_eq!(val.len(), 1);
         assert_eq!(
-            val.values()
-                .nth(0)
+            val.values().next()
                 .unwrap()
                 .chain_key
                 .public()

--- a/hopli/src/key_pair.rs
+++ b/hopli/src/key_pair.rs
@@ -14,7 +14,7 @@ use std::{
 /// * `identity_directory` - Directory to all the identity files
 /// * `password` - Password to unlock all the identity files
 /// * `identity_prefix` - Prefix of identity files. Only identity files with the provided are decrypted with the password
-pub fn read_identities(files: Vec<PathBuf>, password: &String) -> Result<HashMap<String, HoprKeys>, HelperErrors> {
+pub fn read_identities(files: Vec<PathBuf>, password: &str) -> Result<HashMap<String, HoprKeys>, HelperErrors> {
     let mut results = HashMap::with_capacity(files.len());
 
     for file in files.iter() {

--- a/hopli/src/migrate_safe_module.rs
+++ b/hopli/src/migrate_safe_module.rs
@@ -59,28 +59,17 @@ impl MigrateSafeModuleArgs {
         }
 
         // 2. Calculate addresses from the identity file
-        // collect all the peer ids
-        let all_node_addresses: Vec<String>;
-        // check if password is provided
-        let pwd = match password.read_password() {
-            Ok(read_pwd) => read_pwd,
-            Err(e) => return Err(e),
-        };
+        let pwd = password.read_password()?;
+        
+
 
         // read all the identities from the directory
         let files = local_identity.get_files();
-        match read_identities(files, &pwd) {
-            Ok(node_identities) => {
-                all_node_addresses = node_identities
-                    .values()
-                    .map(|ni| ni.chain_key.public().to_address().to_string())
-                    .collect();
-            }
-            Err(e) => {
-                println!("error {:?}", e);
-                return Err(e);
-            }
-        }
+        let all_node_addresses: Vec<String> = read_identities(files, &pwd)?
+            .values()
+            .map(|ni| ni.chain_key.public().to_address().to_string())
+            .collect();
+        
         log!(target: "migrate_safe_module", Level::Info, "NodeAddresses {:?}", all_node_addresses.join(","));
 
         // 3. parse safe and module address

--- a/hopli/src/migrate_safe_module.rs
+++ b/hopli/src/migrate_safe_module.rs
@@ -54,7 +54,7 @@ impl MigrateSafeModuleArgs {
         } = self;
 
         // 1. `PRIVATE_KEY` - Private key is required to send on-chain transactions
-        if let Err(_) = env::var("PRIVATE_KEY") {
+        if env::var("PRIVATE_KEY").is_err() {
             return Err(HelperErrors::UnableToReadPrivateKey);
         }
 
@@ -98,9 +98,7 @@ impl MigrateSafeModuleArgs {
         let checksumed_module_addr = Address::from_str(parsed_module_addr).unwrap().to_checksum();
 
         // set directory and environment variables
-        if let Err(e) = set_process_path_env(&contracts_root, &network) {
-            return Err(e);
-        }
+        set_process_path_env(&contracts_root, &network)?;
 
         log!(target: "migrate_safe_module", Level::Debug, "Calling foundry...");
         // iterate and collect execution result. If error occurs, the entire operation failes.

--- a/hopli/src/migrate_safe_module.rs
+++ b/hopli/src/migrate_safe_module.rs
@@ -60,8 +60,6 @@ impl MigrateSafeModuleArgs {
 
         // 2. Calculate addresses from the identity file
         let pwd = password.read_password()?;
-        
-
 
         // read all the identities from the directory
         let files = local_identity.get_files();

--- a/hopli/src/move_node_to_safe_module.rs
+++ b/hopli/src/move_node_to_safe_module.rs
@@ -61,28 +61,15 @@ impl MoveNodeToSafeModuleArgs {
         }
 
         // 2. Calculate addresses from the identity file
-        // collect all the peer ids
-        let all_node_addresses: Vec<String>;
-        // check if password is provided
-        let pwd = match password.read_password() {
-            Ok(read_pwd) => read_pwd,
-            Err(e) => return Err(e),
-        };
+        let pwd = password.read_password()?;
 
         // read all the identities from the directory
         let files = local_identity.get_files();
-        match read_identities(files, &pwd) {
-            Ok(node_identities) => {
-                all_node_addresses = node_identities
-                    .values()
-                    .map(|ni| ni.chain_key.public().to_address().to_string())
-                    .collect();
-            }
-            Err(e) => {
-                println!("error {:?}", e);
-                return Err(e);
-            }
-        }
+        let all_node_addresses: Vec<String> = read_identities(files, &pwd)?
+            .values()
+            .map(|ni| ni.chain_key.public().to_address().to_string())
+            .collect();
+
         log!(target: "move_node_to_safe_module", Level::Info, "NodeAddresses {:?}", all_node_addresses.join(","));
 
         // 3. parse safe and module address

--- a/hopli/src/move_node_to_safe_module.rs
+++ b/hopli/src/move_node_to_safe_module.rs
@@ -56,7 +56,7 @@ impl MoveNodeToSafeModuleArgs {
         } = self;
 
         // 1. `PRIVATE_KEY` - Private key is required to send on-chain transactions
-        if let Err(_) = env::var("PRIVATE_KEY") {
+        if env::var("PRIVATE_KEY").is_err() {
             return Err(HelperErrors::UnableToReadPrivateKey);
         }
 

--- a/hopli/src/network_registry.rs
+++ b/hopli/src/network_registry.rs
@@ -92,9 +92,7 @@ impl RegisterInNetworkRegistryArgs {
         log!(target: "network_registry", Level::Info, "merged peer_ids {:?}", all_chain_addrs.join(","));
 
         // set directory and environment variables
-        if let Err(e) = set_process_path_env(&contracts_root, &network) {
-            return Err(e);
-        }
+        set_process_path_env(&contracts_root, &network)?;
 
         // iterate and collect execution result. If error occurs, the entire operation failes.
         child_process_call_foundry_self_register(&network, &all_chain_addrs.join(","))

--- a/hopli/src/password.rs
+++ b/hopli/src/password.rs
@@ -4,6 +4,7 @@ use std::{env, fs::read_to_string, path::PathBuf};
 
 /// Verification provider arguments
 #[derive(Debug, Clone, Parser)]
+#[derive(Default)]
 pub struct PasswordArgs {
     #[clap(
         long,
@@ -16,11 +17,7 @@ pub struct PasswordArgs {
     password_path: Option<PathBuf>,
 }
 
-impl Default for PasswordArgs {
-    fn default() -> Self {
-        PasswordArgs { password_path: None }
-    }
-}
+
 
 impl PasswordArgs {
     pub fn read_password(self) -> Result<String, HelperErrors> {

--- a/hopli/src/process.rs
+++ b/hopli/src/process.rs
@@ -31,7 +31,7 @@ pub fn set_process_path_env(contracts_root: &Option<String>, network: &String) -
     // run in the repo where the make target is saved
     if let Some(new_root) = contracts_root {
         let root = Path::new(OsStr::new(&new_root));
-        match env::set_current_dir(&root) {
+        match env::set_current_dir(root) {
             Ok(_) => println!("Successfully changed working directory to {}!", root.display()),
             Err(_) => return Err(HelperErrors::UnableToSetFoundryRoot),
         }
@@ -98,7 +98,7 @@ pub fn child_process_call_foundry_express_initialization(
     chain_keys: &String,
 ) -> Result<(), HelperErrors> {
     // add brackets to around the string
-    let chain_addresses_str = vec!["[", &chain_keys, "]"].concat();
+    let chain_addresses_str = ["[", &chain_keys, "]"].concat();
     let self_register_args = vec![
         "script",
         "script/SingleAction.s.sol:SingleActionFromPrivateKeyScript",

--- a/hopr/hopr-lib/src/chain.rs
+++ b/hopr/hopr-lib/src/chain.rs
@@ -383,6 +383,7 @@ where
     (tx_queue, chain_actions, rpc_operations)
 }
 
+#[allow(clippy::too_many_arguments)]    // TODO: refactor this function into a reasonable group of components once fully rearchitected
 pub fn build_chain_api(
     me_onchain: ChainKeypair,
     db: Arc<RwLock<CoreEthereumDb<CurrentDbShim>>>,

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -51,10 +51,7 @@ use core_transport::{
 };
 use core_transport::{ChainKeypair, Hash, HoprTransport, OffchainKeypair};
 use core_transport::{ExternalNetworkInteractions, IndexerToProcess, Network, PeerEligibility, PeerOrigin};
-use hopr_internal_types::prelude::*;
 use hopr_platform::file::native::{join, read_file, remove_dir_all, write};
-use hopr_primitive_types::prelude::*;
-use hopr_primitive_types::traits::BinarySerializable;
 use log::debug;
 use log::{error, info};
 use utils_db::db::DB;
@@ -154,6 +151,8 @@ impl std::fmt::Display for HoprLoopComponents {
     }
 }
 
+/// 
+#[allow(clippy::too_many_arguments)]        // TODO: refactor this function into a reasonable group of components once fully rearchitected
 pub fn to_chain_events_refresh_process<Db, S>(
     me: PeerId,
     me_onchain: Address,
@@ -287,6 +286,8 @@ where
 }
 
 /// Main builder of the hopr lib components
+#[allow(clippy::type_complexity)]       // TODO: refactor this function into a reasonable group of components once fully rearchitected
+#[allow(clippy::too_many_arguments)]    // TODO: refactor this function into a reasonable group of components once fully rearchitected
 pub fn build_components<FSaveTbf>(
     cfg: HoprLibConfig,
     chain_config: ChainNetworkConfig,

--- a/hoprd/hoprd/src/bin/hoprd-cfg.rs
+++ b/hoprd/hoprd/src/bin/hoprd-cfg.rs
@@ -68,7 +68,7 @@ fn main() -> Result<(), hoprd::errors::HoprdError> {
         );
     } else if let Some(cfg_path) = args.validate {
         let cfg_path = cfg_path.into_os_string().into_string()
-            .map_err(|e| hoprd::errors::HoprdError::ConfigError("file path not convertible".into()))?;
+            .map_err(|_| hoprd::errors::HoprdError::ConfigError("file path not convertible".into()))?;
 
         let yaml_configuration = hopr_platform::file::native::read_to_string(&cfg_path)
             .map_err(|e| hoprd::errors::HoprdError::ConfigError(e.to_string()))?;

--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -360,8 +360,8 @@ pub async fn run_hopr_api(
 
                 async move {
                     let mut queue = (
-                        ws_con.clone().map(|v| WebSocketInput::WsInput(v)),
-                        ws_rx.map(|v| WebSocketInput::Network(v)),
+                        ws_con.clone().map(WebSocketInput::WsInput),
+                        ws_rx.map(WebSocketInput::Network),
                     )
                         .merge();
 
@@ -1563,6 +1563,7 @@ mod messages {
     /// Authentication (if enabled) is done by cookie `X-Auth-Token`.
     ///
     /// Connect to the endpoint by using a WS client. No preview available. Example: `ws://127.0.0.1:3001/api/v3/messages/websocket
+    #[allow(dead_code)]     // not dead code, just for documentation
     #[utoipa::path(
         get,
         path = const_format::formatcp!("{BASE_PATH}/messages/websocket"),
@@ -1577,10 +1578,10 @@ mod messages {
         tag = "Messages",
     )]
     pub async fn websocket(_req: Request<InternalState>) -> tide::Result<Response> {
-        // Dummy implementation for utoipa, the websocket is created in place inside the tide server
-        return Ok(Response::builder(422)
+        // Dummy implementation for utoipa, the websocket is created in-place inside the tide server
+        Ok(Response::builder(422)
             .body(ApiErrorStatus::UnknownFailure("unimplemented".into()))
-            .build());
+            .build())
     }
 
     /// Delete messages from nodes message inbox.

--- a/logic/path/src/channel_graph.rs
+++ b/logic/path/src/channel_graph.rs
@@ -255,7 +255,7 @@ mod tests {
         let mut cg = ChannelGraph::new(ADDRESSES[0]);
 
         let c = dummy_channel(ADDRESSES[0], ADDRESSES[1], ChannelStatus::Open);
-        cg.update_channel(c.clone());
+        cg.update_channel(c);
 
         assert!(cg.contains_channel(&c), "must contain channel");
         assert!(cg.has_path(ADDRESSES[0], ADDRESSES[1]), "must have simple path");
@@ -270,7 +270,7 @@ mod tests {
         let mut cg = ChannelGraph::new(ADDRESSES[0]);
 
         let c = dummy_channel(ADDRESSES[0], ADDRESSES[1], ChannelStatus::Open);
-        cg.update_channel(c.clone());
+        cg.update_channel(c);
 
         assert!(cg.contains_channel(&c), "must contain channel");
         assert!(
@@ -292,8 +292,8 @@ mod tests {
 
         let c1 = dummy_channel(ADDRESSES[0], ADDRESSES[1], ChannelStatus::Open);
         let c2 = dummy_channel(ADDRESSES[1], ADDRESSES[2], ChannelStatus::Open);
-        cg.update_channel(c1.clone());
-        cg.update_channel(c2.clone());
+        cg.update_channel(c1);
+        cg.update_channel(c2);
 
         assert!(cg.is_own_channel(&c1), "must detect as own channel");
         assert!(!cg.is_own_channel(&c2), "must not detect as own channel");
@@ -305,7 +305,7 @@ mod tests {
 
         let mut c = dummy_channel(ADDRESSES[0], ADDRESSES[1], ChannelStatus::Open);
 
-        let changes = cg.update_channel(c.clone());
+        let changes = cg.update_channel(c);
         assert!(changes.is_none(), "must not produce changes for a new channel");
 
         let cr = cg
@@ -315,7 +315,7 @@ mod tests {
 
         c.balance = Balance::zero(BalanceType::HOPR);
         c.status = ChannelStatus::PendingToClose;
-        let changes = cg.update_channel(c.clone()).expect("must contain changes");
+        let changes = cg.update_channel(c).expect("must contain changes");
         assert_eq!(2, changes.len(), "must contain 2 changes");
 
         for change in changes {
@@ -348,7 +348,7 @@ mod tests {
 
         let mut c = dummy_channel(ADDRESSES[0], ADDRESSES[1], ChannelStatus::PendingToClose);
 
-        let changes = cg.update_channel(c.clone());
+        let changes = cg.update_channel(c);
         assert!(changes.is_none(), "must not produce changes for a new channel");
 
         let cr = cg
@@ -358,7 +358,7 @@ mod tests {
 
         c.balance = Balance::zero(BalanceType::HOPR);
         c.status = ChannelStatus::Closed;
-        let changes = cg.update_channel(c.clone()).expect("must contain changes");
+        let changes = cg.update_channel(c).expect("must contain changes");
         assert_eq!(2, changes.len(), "must contain 2 changes");
 
         for change in changes {

--- a/logic/path/src/path.rs
+++ b/logic/path/src/path.rs
@@ -108,7 +108,7 @@ impl ChannelPath {
             .iter()
             .map(|addr| {
                 resolver.resolve_packet_key(addr).map(move |opt| {
-                    opt.map(|k| PeerId::from(k.clone()))
+                    opt.map(PeerId::from)
                         .ok_or(InvalidPeer(addr.to_string()))
                 })
             })
@@ -400,7 +400,7 @@ mod tests {
             self.0
                 .iter()
                 .find(|(_, addr)| addr.eq(onchain_key))
-                .map(|(pk, _)| pk.clone())
+                .map(|(pk, _)| *pk)
         }
 
         async fn resolve_chain_key(&self, offchain_key: &OffchainPublicKey) -> Option<Address> {

--- a/logic/path/src/selectors/legacy.rs
+++ b/logic/path/src/selectors/legacy.rs
@@ -329,7 +329,7 @@ mod tests {
             ADDRESSES[1],
             |_, b| {
                 Balance::new(
-                    (ADDRESSES.iter().position(|a| b.eq(a)).unwrap() as u32 + 1),
+                    ADDRESSES.iter().position(|a| b.eq(a)).unwrap() as u32 + 1,
                     BalanceType::HOPR,
                 )
             },

--- a/misc/metrics/src/lib.rs
+++ b/misc/metrics/src/lib.rs
@@ -42,41 +42,39 @@
 //! ```rust
 //! use hopr_metrics::metrics::*;
 //!
-//! fn main() {
-//!     let metric_counter = SimpleCounter::new("test_counter", "Some testing counter").unwrap();
+//! let metric_counter = SimpleCounter::new("test_counter", "Some testing counter").unwrap();
 //!
-//!     // Counter can be only incremented by integers only
-//!     metric_counter.increment_by(10);
+//! // Counter can be only incremented by integers only
+//! metric_counter.increment_by(10);
 //!
-//!     let metric_gauge = SimpleGauge::new("test_gauge", "Some testing gauge").unwrap();
+//! let metric_gauge = SimpleGauge::new("test_gauge", "Some testing gauge").unwrap();
 //!
-//!     // Gauges can be incremented and decrements and support floats
-//!     metric_gauge.increment(5.0);
-//!     metric_gauge.decrement(3.2);
+//! // Gauges can be incremented and decrements and support floats
+//! metric_gauge.increment(5.0);
+//! metric_gauge.decrement(3.2);
 //!
-//!     let metric_histogram = SimpleHistogram::new("test_histogram", "Some testing histogram", vec![1.0, 2.0]).unwrap();
+//! let metric_histogram = SimpleHistogram::new("test_histogram", "Some testing histogram", vec![1.0, 2.0]).unwrap();
 //!
-//!     // Histograms can observe floating point values
-//!     metric_histogram.observe(10.1);
+//! // Histograms can observe floating point values
+//! metric_histogram.observe(10.1);
 //!
-//!     // ... and also can be used to measure time durations in seconds
-//!     let timer = metric_histogram.start_measure();
-//!     std::thread::sleep(std::time::Duration::from_secs(1));
-//!     metric_histogram.record_measure(timer);
+//! // ... and also can be used to measure time durations in seconds
+//! let timer = metric_histogram.start_measure();
+//! std::thread::sleep(std::time::Duration::from_secs(1));
+//! metric_histogram.record_measure(timer);
 //!
-//!     // Multi-metrics are labeled extensions
-//!     let metric_counts_per_version = MultiCounter::new("test_multi_counter", "Testing labeled counter", &["version"]).unwrap();
+//! // Multi-metrics are labeled extensions
+//! let metric_counts_per_version = MultiCounter::new("test_multi_counter", "Testing labeled counter", &["version"]).unwrap();
 //!
-//!     // Tracks counters per different versions
-//!     metric_counts_per_version.increment_by(&["1.0.0"], 2);
-//!     metric_counts_per_version.increment_by(&["1.0.1"], 1);
+//! // Tracks counters per different versions
+//! metric_counts_per_version.increment_by(&["1.0.0"], 2);
+//! metric_counts_per_version.increment_by(&["1.0.1"], 1);
 //!
-//!     // All metrics live in a global state and can be serialized at any time
-//!     let gathered_metrics = gather_all_metrics();
+//! // All metrics live in a global state and can be serialized at any time
+//! let gathered_metrics = gather_all_metrics();
 //!
-//!     // Metrics are in text format and can be exposed using an HTTP API endpoint
-//!     println!("{:?}", gathered_metrics);
-//! }
+//! // Metrics are in text format and can be exposed using an HTTP API endpoint
+//! println!("{:?}", gathered_metrics);
 //! ```
 //!
 //! ### Usage in JS/TS

--- a/misc/utils-db/src/db.rs
+++ b/misc/utils-db/src/db.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 pub struct Batch {
-    #[warn(clippy::type_complexity)]
+    #[allow(clippy::type_complexity)]
     pub ops: Vec<crate::traits::BatchOperation<Box<[u8]>, Box<[u8]>>>,
 }
 

--- a/misc/utils-db/src/db.rs
+++ b/misc/utils-db/src/db.rs
@@ -10,6 +10,7 @@ use std::{
 };
 
 pub struct Batch {
+    #[warn(clippy::type_complexity)]
     pub ops: Vec<crate::traits::BatchOperation<Box<[u8]>, Box<[u8]>>>,
 }
 

--- a/misc/utils-db/src/sqlite.rs
+++ b/misc/utils-db/src/sqlite.rs
@@ -301,7 +301,7 @@ mod tests {
             .await
             .unwrap();
 
-        while let Some(value) = data_stream.next() {
+        for value in data_stream {
             let v = value.unwrap();
 
             if v.as_ref() != value_2.as_bytes() {

--- a/transport/api/src/p2p.rs
+++ b/transport/api/src/p2p.rs
@@ -29,6 +29,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::TransportOutput;
 
+#[allow(clippy::large_enum_variant)]        // TODO: refactor the large types used in the enum
 #[derive(Debug)]
 pub enum Inputs {
     Heartbeat(api::HeartbeatChallenge),
@@ -113,6 +114,7 @@ fn alter_multiaddress_to_allow_listening(ma: &multiaddr::Multiaddr) -> crate::er
 /// The function represents the entirety of the business logic of the hopr daemon related to core operations.
 ///
 /// This future can only be resolved by an unrecoverable error or a panic.
+#[allow(clippy::too_many_arguments)]        // TODO: refactor this function into a reasonable group of components once fully rearchitected
 pub async fn p2p_loop(
     version: String,
     me: libp2p_identity::Keypair,

--- a/transport/network/src/network.rs
+++ b/transport/network/src/network.rs
@@ -587,7 +587,7 @@ mod tests {
     fn basic_network(my_id: &PeerId) -> Network<DummyNetworkAction> {
         let mut cfg = NetworkConfig::default();
         cfg.quality_offline_threshold = 0.6;
-        Network::new(my_id.clone(), cfg, DummyNetworkAction {})
+        Network::new(*my_id, cfg, DummyNetworkAction {})
     }
 
     #[test]
@@ -681,7 +681,7 @@ mod tests {
 
         let ts = peers.network_actions_api.create_timestamp();
 
-        peers.update(&peer, Ok(ts.clone()));
+        peers.update(&peer, Ok(ts));
 
         std::thread::sleep(std::time::Duration::from_millis(100));
 
@@ -725,7 +725,7 @@ mod tests {
 
             peers.update_with_metadata(
                 &peer,
-                Ok(ts.clone()),
+                Ok(ts),
                 Some([proto_version.clone(), other_metadata_2.clone()].into()),
             );
 
@@ -851,7 +851,7 @@ mod tests {
     #[test]
     fn test_network_should_be_healthy_when_a_public_peer_is_pingable_with_low_quality() {
         let peer = PeerId::random();
-        let public = peer.clone();
+        let public = peer;
 
         let mut cfg = NetworkConfig::default();
         cfg.quality_offline_threshold = 0.6;
@@ -872,7 +872,7 @@ mod tests {
     #[test]
     fn test_network_should_remove_the_peer_once_it_reaches_the_lowest_possible_quality() {
         let peer = PeerId::random();
-        let public = peer.clone();
+        let public = peer;
 
         let mut cfg = NetworkConfig::default();
         cfg.quality_offline_threshold = 0.6;
@@ -880,7 +880,7 @@ mod tests {
         let mut mock = MockNetworkExternalActions::new();
         mock.expect_is_public().times(3).returning(move |x| x == &public);
         mock.expect_emit()
-            .with(mockall::predicate::eq(NetworkEvent::CloseConnection(peer.clone())))
+            .with(mockall::predicate::eq(NetworkEvent::CloseConnection(peer)))
             .return_const(());
         mock.expect_create_timestamp()
             .returning(|| current_timestamp().as_millis() as u64);
@@ -898,13 +898,13 @@ mod tests {
     fn test_network_should_be_healthy_when_a_public_peer_is_pingable_with_high_quality_and_i_am_public() {
         let me = PeerId::random();
         let peer = PeerId::random();
-        let public = vec![peer.clone(), me.clone()];
+        let public = [peer, me];
 
         let mut cfg = NetworkConfig::default();
         cfg.quality_offline_threshold = 0.3;
 
         let mut mock = MockNetworkExternalActions::new();
-        mock.expect_is_public().times(5).returning(move |x| public.contains(&x));
+        mock.expect_is_public().times(5).returning(move |x| public.contains(x));
         mock.expect_create_timestamp()
             .returning(|| current_timestamp().as_millis() as u64);
         let mut peers = Network::new(me, cfg, mock);
@@ -923,13 +923,13 @@ mod tests {
     ) {
         let peer = PeerId::random();
         let peer2 = PeerId::random();
-        let public = vec![peer.clone()];
+        let public = [peer];
 
         let mut cfg = NetworkConfig::default();
         cfg.quality_offline_threshold = 0.3;
 
         let mut mock = MockNetworkExternalActions::new();
-        mock.expect_is_public().times(8).returning(move |x| public.contains(&x));
+        mock.expect_is_public().times(8).returning(move |x| public.contains(x));
         mock.expect_create_timestamp()
             .returning(|| current_timestamp().as_millis() as u64);
         let mut peers = Network::new(PeerId::random(), cfg, mock);

--- a/transport/network/src/ping.rs
+++ b/transport/network/src/ping.rs
@@ -255,7 +255,7 @@ mod tests {
         };
 
         let mut pinger = Ping::new(simple_ping_config(), tx, rx, mock);
-        futures::join!(pinger.ping(vec![peer.clone()]), ideal_single_use_channel);
+        futures::join!(pinger.ping(vec![peer]), ideal_single_use_channel);
     }
 
     #[async_std::test]
@@ -269,7 +269,7 @@ mod tests {
         let mut mock = MockPingExternalAPI::new();
         mock.expect_on_finished_ping()
             .with(
-                predicate::eq(peer.clone()),
+                predicate::eq(peer),
                 predicate::function(|x: &crate::types::Result| x.is_err()),
                 predicate::eq("version".to_owned()),
             )
@@ -282,7 +282,7 @@ mod tests {
         };
 
         let mut pinger = Ping::new(simple_ping_config(), tx, rx, mock);
-        futures::join!(pinger.ping(vec![peer.clone()]), bad_pong_single_use_channel);
+        futures::join!(pinger.ping(vec![peer]), bad_pong_single_use_channel);
     }
 
     #[async_std::test]
@@ -315,7 +315,7 @@ mod tests {
         };
 
         let mut pinger = Ping::new(ping_config, tx, rx, mock);
-        futures::join!(pinger.ping(vec![peer.clone()]), timeout_single_use_channel);
+        futures::join!(pinger.ping(vec![peer]), timeout_single_use_channel);
     }
 
     #[async_std::test]
@@ -329,14 +329,14 @@ mod tests {
         let mut mock = MockPingExternalAPI::new();
         mock.expect_on_finished_ping()
             .with(
-                predicate::eq(peers[0].clone()),
+                predicate::eq(peers[0]),
                 predicate::function(|x: &crate::types::Result| x.is_ok()),
                 predicate::eq("version".to_owned()),
             )
             .return_const(());
         mock.expect_on_finished_ping()
             .with(
-                predicate::eq(peers[1].clone()),
+                predicate::eq(peers[1]),
                 predicate::function(|x: &crate::types::Result| x.is_ok()),
                 predicate::eq("version".to_owned()),
             )
@@ -376,14 +376,14 @@ mod tests {
         let mut mock = MockPingExternalAPI::new();
         mock.expect_on_finished_ping()
             .with(
-                predicate::eq(peers[0].clone()),
+                predicate::eq(peers[0]),
                 predicate::function(|x: &crate::types::Result| x.is_ok()),
                 predicate::eq("version".to_owned()),
             )
             .return_const(());
         mock.expect_on_finished_ping()
             .with(
-                predicate::eq(peers[1].clone()),
+                predicate::eq(peers[1]),
                 predicate::function(|x: &crate::types::Result| x.is_ok()),
                 predicate::eq("version".to_owned()),
             )

--- a/transport/packet/src/packet.rs
+++ b/transport/packet/src/packet.rs
@@ -292,7 +292,7 @@ mod tests {
         for (i, pair) in keypairs.iter().enumerate() {
             let fwd = mp
                 .forward(pair, INTERMEDIATE_HOPS + 1, POR_SECRET_LENGTH, 0)
-                .expect(&format!("failed to unwrap at {i}"));
+                .unwrap_or_else(|_| panic!("failed to unwrap at {i}"));
 
             match fwd {
                 ForwardedMetaPacket::RelayedPacket { packet, .. } => {

--- a/transport/packet/src/validation.rs
+++ b/transport/packet/src/validation.rs
@@ -9,6 +9,7 @@ use hopr_primitive_types::prelude::*;
 use log::{debug, info};
 
 /// Performs validations of the given unacknowledged ticket and channel.
+#[allow(clippy::too_many_arguments)]        // TODO: The number of arguments and the logic needs to be refactored
 pub async fn validate_unacknowledged_ticket<T: HoprCoreEthereumDbActions>(
     db: &T,
     ticket: &Ticket,

--- a/transport/packet/src/validation.rs
+++ b/transport/packet/src/validation.rs
@@ -420,7 +420,7 @@ mod tests {
         db.expect_get_tickets().returning(|_| Ok(Vec::<Ticket>::new()));
 
         let mut ticket = create_valid_ticket();
-        ticket.channel_epoch = 2u32.into();
+        ticket.channel_epoch = 2u32;
         ticket.sign(&SENDER_PRIV_KEY, &Hash::default());
 
         let channel = create_channel_entry();
@@ -493,7 +493,7 @@ mod tests {
             SENDER_PRIV_KEY.public().to_address(),
         );
 
-        db.store_pending_acknowledgment(hkc.clone(), PendingAcknowledgement::WaitingAsRelayer(unack))
+        db.store_pending_acknowledgment(hkc, PendingAcknowledgement::WaitingAsRelayer(unack))
             .await
             .unwrap();
         let num_tickets = db.get_tickets(None).await.unwrap();

--- a/transport/protocol/src/ack/processor.rs
+++ b/transport/protocol/src/ack/processor.rs
@@ -40,6 +40,7 @@ lazy_static::lazy_static! {
 pub const ACK_TX_QUEUE_SIZE: usize = 2048;
 pub const ACK_RX_QUEUE_SIZE: usize = 2048;
 
+#[allow(clippy::large_enum_variant)]     // TODO: Uses too large objects
 #[derive(Debug)]
 pub enum Reply {
     Sender(HalfKeyChallenge),
@@ -53,6 +54,7 @@ pub enum AckToProcess {
     ToSend(PeerId, Acknowledgement),
 }
 
+#[allow(clippy::large_enum_variant)]     // TODO: Uses too large objects
 #[derive(Debug)]
 pub enum AckProcessed {
     Receive(PeerId, Result<Reply>),

--- a/transport/protocol/src/msg/chain.rs
+++ b/transport/protocol/src/msg/chain.rs
@@ -282,7 +282,7 @@ mod tests {
                 self.0
                     .iter()
                     .find(|(_, addr)| addr.eq(onchain_key))
-                    .map(|(pk, _)| pk.clone())
+                    .map(|(pk, _)| *pk)
             }
 
             async fn resolve_chain_key(&self, offchain_key: &OffchainPublicKey) -> Option<Address> {

--- a/transport/protocol/src/msg/packet.rs
+++ b/transport/protocol/src/msg/packet.rs
@@ -30,13 +30,14 @@ pub enum TransportPacket {
 }
 
 #[async_trait::async_trait]
+#[allow(clippy::wrong_self_convention)]      // TODO: The `from_*` and `into_*` should take self, not a reference
 pub trait PacketConstructing {
     type Input;
 
     #[allow(clippy::wrong_self_convention)]
     async fn into_outgoing(&self, data: Self::Input, path: &TransportPath) -> Result<TransportPacket>;
 
-    #[warn(clippy::wrong_self_convention)]
+    #[allow(clippy::wrong_self_convention)]
     async fn from_incoming(
         &self,
         data: Box<[u8]>,

--- a/transport/protocol/src/msg/processor.rs
+++ b/transport/protocol/src/msg/processor.rs
@@ -628,11 +628,8 @@ impl PacketInteraction {
                     };
 
                     #[cfg(all(feature = "prometheus", not(test)))]
-                    match &packet {
-                        Ok(TransportPacket::Forwarded { .. }) => {
-                            metadata.start_time = hopr_platform::time::native::current_timestamp();
-                        }
-                        _ => {}
+                    if let Ok(TransportPacket::Forwarded { .. }) = &packet {
+                        metadata.start_time = hopr_platform::time::native::current_timestamp();
                     }
 
                     (packet, metadata)

--- a/transport/protocol/src/msg/processor.rs
+++ b/transport/protocol/src/msg/processor.rs
@@ -840,26 +840,22 @@ mod tests {
     use utils_db::{db::DB, CurrentDbShim};
 
     lazy_static! {
-        static ref PEERS: Vec<OffchainKeypair> = vec![
-            hex!("492057cf93e99b31d2a85bc5e98a9c3aa0021feec52c227cc8170e8f7d047775"),
+        static ref PEERS: Vec<OffchainKeypair> = [hex!("492057cf93e99b31d2a85bc5e98a9c3aa0021feec52c227cc8170e8f7d047775"),
             hex!("5bf21ea8cccd69aa784346b07bf79c84dac606e00eecaa68bf8c31aff397b1ca"),
             hex!("3477d7de923ba3a7d5d72a7d6c43fd78395453532d03b2a1e2b9a7cc9b61bafa"),
             hex!("db7e3e8fcac4c817aa4cecee1d6e2b4d53da51f9881592c0e1cc303d8a012b92"),
-            hex!("0726a9704d56a013980a9077d195520a61b5aed28f92d89c50bca6e0e0c48cfc"),
-        ]
+            hex!("0726a9704d56a013980a9077d195520a61b5aed28f92d89c50bca6e0e0c48cfc")]
         .iter()
         .map(|private| OffchainKeypair::from_secret(private).unwrap())
         .collect();
     }
 
     lazy_static! {
-        static ref PEERS_CHAIN: Vec<ChainKeypair> = vec![
-            hex!("4db3ac225fdcc7e20bf887cd90bbd62dc6bd41ce8ba5c23cc9ae0bf56e20d056"),
+        static ref PEERS_CHAIN: Vec<ChainKeypair> = [hex!("4db3ac225fdcc7e20bf887cd90bbd62dc6bd41ce8ba5c23cc9ae0bf56e20d056"),
             hex!("1d40c69c179528bbdf49c2254e93400b485f47d7d2fa84aae280af5a31c1918b"),
             hex!("99facd2cd33664d65826ad220920a6b356e31d18c1ce1734303b70a962664d71"),
             hex!("62b362fd3295caf8657b8cf4f65d6e2cbb1ef81754f7bdff65e510220611afc2"),
-            hex!("40ed717eb285dea3921a8346155d988b7ed5bf751bc4eee3cd3a64f4c692396f"),
-        ]
+            hex!("40ed717eb285dea3921a8346155d988b7ed5bf751bc4eee3cd3a64f4c692396f")]
         .iter()
         .map(|private| ChainKeypair::from_secret(private).unwrap())
         .collect();
@@ -924,8 +920,8 @@ mod tests {
                 );
 
                 db.update_channel_and_snapshot(
-                    &channel.clone().unwrap().get_id(),
-                    &channel.clone().unwrap(),
+                    &channel.unwrap().get_id(),
+                    &channel.unwrap(),
                     &testing_snapshot,
                 )
                 .await?;
@@ -933,8 +929,8 @@ mod tests {
 
             if index > 0 {
                 db.update_channel_and_snapshot(
-                    &previous_channel.clone().unwrap().get_id(),
-                    &previous_channel.clone().unwrap(),
+                    &previous_channel.unwrap().get_id(),
+                    &previous_channel.unwrap(),
                     &testing_snapshot,
                 )
                 .await?;
@@ -954,7 +950,7 @@ mod tests {
         let challenge = HalfKeyChallenge::default();
         let mut awaiter: super::PacketSendAwaiter = rx.into();
 
-        finalizer.finalize(challenge.clone());
+        finalizer.finalize(challenge);
 
         let result = awaiter.consume_and_wait(Duration::from_millis(20)).await;
 
@@ -984,14 +980,14 @@ mod tests {
         const PENDING_ACKS: usize = 5;
         let mut sent_challenges = Vec::with_capacity(PENDING_ACKS);
         for _ in 0..PENDING_ACKS {
-            let secrets = (0..2).into_iter().map(|_| SharedSecret::random()).collect::<Vec<_>>();
+            let secrets = (0..2).map(|_| SharedSecret::random()).collect::<Vec<_>>();
             let porv = ProofOfRelayValues::new(&secrets[0], Some(&secrets[1]));
 
             // Mimics that the packet sender has sent a packet and now it has a pending acknowledgement in it's DB
             core_dbs[0]
                 .write()
                 .await
-                .store_pending_acknowledgment(porv.ack_challenge.clone(), PendingAcknowledgement::WaitingAsSender)
+                .store_pending_acknowledgment(porv.ack_challenge, PendingAcknowledgement::WaitingAsSender)
                 .await
                 .expect("failed to store pending ack");
 
@@ -1034,7 +1030,7 @@ mod tests {
                         AckProcessed::Receive(_, Ok(Reply::Sender(ack))) => {
                             debug!("sender has received acknowledgement {i}: {ack}");
                             assert!(
-                                sent_challenges.iter().find(|(_, c)| ack.eq(c)).is_some(),
+                                sent_challenges.iter().any(|(_, c)| ack.eq(c)),
                                 "received invalid challenge {ack}"
                             );
                         }
@@ -1242,7 +1238,7 @@ mod tests {
                 self.0
                     .iter()
                     .find(|(_, addr)| addr.eq(onchain_key))
-                    .map(|(pk, _)| pk.clone())
+                    .map(|(pk, _)| *pk)
             }
 
             async fn resolve_chain_key(&self, offchain_key: &OffchainPublicKey) -> Option<Address> {

--- a/transport/protocol/src/ticket_aggregation/processor.rs
+++ b/transport/protocol/src/ticket_aggregation/processor.rs
@@ -181,6 +181,7 @@ impl AggregationList {
 }
 
 /// The input to the processor background pipeline
+#[allow(clippy::type_complexity)]       // TODO: The type needs to be significantly refactored to easily move around
 #[derive(Debug)]
 pub enum TicketAggregationToProcess<T, U> {
     ToReceive(PeerId, std::result::Result<Ticket, String>, U),
@@ -189,6 +190,7 @@ pub enum TicketAggregationToProcess<T, U> {
 }
 
 /// Emitted by the processor background pipeline once processed
+#[allow(clippy::large_enum_variant)]        // TODO: refactor the large types used in the enum
 #[derive(Debug)]
 pub enum TicketAggregationProcessed<T, U> {
     Receive(PeerId, AcknowledgedTicket, U),
@@ -599,16 +601,18 @@ impl<T, U> TicketAggregationActions<T, U> {
     }
 }
 
+type AckEventQueue<T, U> = (
+    Sender<TicketAggregationToProcess<T, U>>,
+    Receiver<TicketAggregationProcessed<T, U>>,
+);
+
 /// Sets up processing of ticket aggregation interactions and returns relevant read and write mechanism.
 pub struct TicketAggregationInteraction<T, U>
 where
     T: Send,
     U: Send,
 {
-    ack_event_queue: (
-        Sender<TicketAggregationToProcess<T, U>>,
-        Receiver<TicketAggregationProcessed<T, U>>,
-    ),
+    ack_event_queue: AckEventQueue<T, U>,
 }
 
 impl<T: 'static, U: 'static> TicketAggregationInteraction<T, U>

--- a/transport/protocol/src/ticket_aggregation/processor.rs
+++ b/transport/protocol/src/ticket_aggregation/processor.rs
@@ -738,17 +738,13 @@ mod tests {
     use super::{AggregationList, TicketAggregationProcessed};
 
     lazy_static! {
-        static ref PEERS: Vec<OffchainKeypair> = vec![
-            hex!("b91a28ff9840e9c93e5fafd581131f0b9f33f3e61b02bf5dd83458aa0221f572"),
-            hex!("82283757872f99541ce33a47b90c2ce9f64875abf08b5119a8a434b2fa83ea98")
-        ]
+        static ref PEERS: Vec<OffchainKeypair> = [hex!("b91a28ff9840e9c93e5fafd581131f0b9f33f3e61b02bf5dd83458aa0221f572"),
+            hex!("82283757872f99541ce33a47b90c2ce9f64875abf08b5119a8a434b2fa83ea98")]
         .iter()
         .map(|private| OffchainKeypair::from_secret(private).unwrap())
         .collect();
-        static ref PEERS_CHAIN: Vec<ChainKeypair> = vec![
-            hex!("51d3003d908045a4d76d0bfc0d84f6ff946b5934b7ea6a2958faf02fead4567a"),
-            hex!("e1f89073a01831d0eed9fe2c67e7d65c144b9d9945320f6d325b1cccc2d124e9"),
-        ]
+        static ref PEERS_CHAIN: Vec<ChainKeypair> = [hex!("51d3003d908045a4d76d0bfc0d84f6ff946b5934b7ea6a2958faf02fead4567a"),
+            hex!("e1f89073a01831d0eed9fe2c67e7d65c144b9d9945320f6d325b1cccc2d124e9")]
         .iter()
         .map(|private| ChainKeypair::from_secret(private).unwrap())
         .collect();


### PR DESCRIPTION
Fix all `cargo clippy` issues apart from the ones which cannot be solved without rearchitecting the code, where instead an exception for clippy was introduced along with a TODO comment. 