### PR TITLE
Update bindings/Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,7 +800,6 @@ name = "bindings"
 version = "0.1.0"
 dependencies = [
  "ethers",
- "serde",
 ]
 
 [[package]]

--- a/ethereum/bindings/Cargo.toml
+++ b/ethereum/bindings/Cargo.toml
@@ -7,4 +7,3 @@ edition = "2021"
 
 [dependencies]
 ethers = { version = "2", default-features = false, features = ["abigen"] }
-serde = "1"


### PR DESCRIPTION
Removes obsolete `serde = "1"` from `bindings/Cargo.toml`

Seems that Foundry bindings use the serde functionality from `ethers-rs`