### PR TITLE
Fix stress tests to run with the refactored hoprd-api and fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import subprocess
 from time import sleep
 
 import pytest
-from hopr import HoprdAPI
+from .hopr import HoprdAPI
 
 random_data = os.urandom(8)
 SEED = int.from_bytes(random_data, byteorder="big")
@@ -27,7 +27,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--stress-seq-request-count",
         action="store",
-        default=200,
+        default=500,
         help="Number of sequential requests in the stress test",
     )
     parser.addoption(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,7 +5,7 @@ from contextlib import AsyncExitStack, asynccontextmanager
 
 import pytest
 import requests
-from conftest import (
+from .conftest import (
     default_nodes,
     default_nodes_with_auth,
     random_distinct_pairs_from,

--- a/tests/test_stress.py
+++ b/tests/test_stress.py
@@ -1,75 +1,90 @@
 import asyncio
-import logging
 import os
 import pytest
 import random
 
-from hopr import HoprdAPI
+from .conftest import TICKET_PRICE_PER_HOP, default_nodes
+from .hopr import HoprdAPI
+from .test_integration import create_channel, passive_node, send_and_receive_packets_with_pop
 
-HTTP_STATUS_CODE_OK = 200
-HTTP_STATUS_CODE_SEND_MESSAGE_OK = 202
+
+async def check_connected_peer_count(me, count):
+    while True:
+        if len([x["peer_id"] for x in await me.peers()]) >= count:
+            break
+        else:
+            await asyncio.sleep(0.5)
 
 
 @pytest.mark.asyncio
-@pytest.mark.skipif(os.getenv("CI", "false") == "true", reason="stress tests fail randomly on CI due to resources")
+@pytest.mark.skipif(
+    os.getenv("CI", "false") == "true", reason="stress tests fail randomly on CI due to resource constraints"
+)
+@pytest.mark.parametrize("src,dest", [(random.choice(default_nodes()), passive_node())])
+async def test_hoprd_stress_1_hop_to_self(src, dest, swarm7, cmd_line_args):
+    STRESS_1_HOP_TO_SELF_MESSAGE_COUNT = cmd_line_args["stress_seq_request_count"]
+
+    async with create_channel(
+        swarm7[src],
+        swarm7[dest],
+        funding=STRESS_1_HOP_TO_SELF_MESSAGE_COUNT * TICKET_PRICE_PER_HOP,
+        close_from_dest=False,
+    ) as _channel_id:
+        packets = [
+            f"1 hop stress msg to self: {src} - {dest} - {src} #{i+1:08d}/{STRESS_1_HOP_TO_SELF_MESSAGE_COUNT:08d}"
+            for i in range(STRESS_1_HOP_TO_SELF_MESSAGE_COUNT)
+        ]
+
+        await send_and_receive_packets_with_pop(
+            packets, src=swarm7[src], dest=swarm7[src], path=[swarm7[dest]["peer_id"]], timeout=60.0
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(
+    os.getenv("CI", "false") == "true", reason="stress tests fail randomly on CI due to resource constraints"
+)
 async def test_stress_hoprd_send_message_should_send_sequential_messages_without_errors(request, cmd_line_args):
     if "127.0.0.1" in cmd_line_args["stress_tested_api"] or "localhost" in cmd_line_args["stress_tested_api"]:
-        request.getfixturevalue("setup_7_nodes")
+        request.getfixturevalue("swarm7")
 
     STRESS_SEQUENTIAL_MESSAGE_COUNT = cmd_line_args["stress_seq_request_count"]
 
-    alice = HoprdAPI(cmd_line_args["stress_tested_api"], cmd_line_args["stress_tested_api_token"])
-    hops = []  # zero hop
+    stressor = HoprdAPI(cmd_line_args["stress_tested_api"], cmd_line_args["stress_tested_api_token"])
+    await asyncio.wait_for(check_connected_peer_count(stressor, count=cmd_line_args["stress_minimum_peer_count"]), 20.0)
 
-    # wait for peers to be connected
-    for _ in range(60):
-        alices_peers = await alice.peers()
-        if len(alices_peers) >= cmd_line_args["stress_minimum_peer_count"]:
-            logging.info(f"peers ready {alices_peers}")
-            break
-        else:
-            await asyncio.sleep(1)
+    connected_peers = [x["peer_id"] for x in await stressor.peers()]
 
-    connected_peers = await alice.peers()
     assert len(connected_peers) >= cmd_line_args["stress_minimum_peer_count"]
 
-    expected = [True] * STRESS_SEQUENTIAL_MESSAGE_COUNT
-    actual = [
-        (await alice.send_message(random.choice(connected_peers), f"message #{i}", hops)).status_code
-        for i in range(STRESS_SEQUENTIAL_MESSAGE_COUNT)
-    ]
-    assert expected == actual
+    assert all(
+        [
+            (await stressor.send_message(random.choice(connected_peers), f"message #{i}", []))
+            for i in range(STRESS_SEQUENTIAL_MESSAGE_COUNT)
+        ]
+    )
 
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(os.getenv("CI", "false") == "true", reason="stress tests fail randomly on CI due to resources")
 async def test_stress_hoprd_send_message_should_send_parallel_messages_without_errors(request, cmd_line_args):
     if "127.0.0.1" in cmd_line_args["stress_tested_api"] or "localhost" in cmd_line_args["stress_tested_api"]:
-        request.getfixturevalue("setup_7_nodes")
+        request.getfixturevalue("swarm7")
 
-    STRESS_PARALLEL_MESSAGE_COUNT = cmd_line_args["stress_par_request_count"]
+    STRESS_PARALLEL_MESSAGE_COUNT = cmd_line_args["stress_seq_request_count"]
 
-    alice = HoprdAPI(cmd_line_args["stress_tested_api"], cmd_line_args["stress_tested_api_token"])
-    hops = []  # zero hop
+    stressor = HoprdAPI(cmd_line_args["stress_tested_api"], cmd_line_args["stress_tested_api_token"])
+    await asyncio.wait_for(check_connected_peer_count(stressor, count=cmd_line_args["stress_minimum_peer_count"]), 20.0)
 
-    # wait for peers to be connected
-    for _ in range(60):
-        alices_peers = await alice.peers()
-        if len(alices_peers) >= cmd_line_args["stress_minimum_peer_count"]:
-            logging.info(f"peers ready {alices_peers}")
-            break
-        else:
-            await asyncio.sleep(1)
+    connected_peers = [x["peer_id"] for x in await stressor.peers()]
 
-    connected_peers = await alice.peers()
     assert len(connected_peers) >= cmd_line_args["stress_minimum_peer_count"]
 
-    expected = [True] * STRESS_PARALLEL_MESSAGE_COUNT
-    actual = await asyncio.gather(
-        *[
-            alice.send_message(random.choice(connected_peers), f"message #{i}", hops)
-            for i in range(STRESS_PARALLEL_MESSAGE_COUNT)
-        ]
+    assert all(
+        await asyncio.gather(
+            *[
+                stressor.send_message(random.choice(connected_peers), f"message #{i}", [])
+                for i in range(STRESS_PARALLEL_MESSAGE_COUNT)
+            ]
+        )
     )
-
-    assert expected == actual

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -7,7 +7,7 @@ import re
 
 import websocket
 import websockets
-from tests.conftest import DEFAULT_API_TOKEN, default_nodes_with_auth, random_distinct_pairs_from
+from .conftest import DEFAULT_API_TOKEN, default_nodes_with_auth, random_distinct_pairs_from
 
 
 def url(host, port):


### PR DESCRIPTION
The stress tests are run locally at the maximum inbox size of 500 messages.