### PR TITLE
Improve Ticket related structures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3276,6 +3276,7 @@ dependencies = [
  "log",
  "primitive-types",
  "serde",
+ "serde_bytes",
  "sha2 0.10.8",
  "sha3",
  "subtle",

--- a/chain/actions/src/errors.rs
+++ b/chain/actions/src/errors.rs
@@ -47,6 +47,9 @@ pub enum CoreEthereumActionsError {
     #[error("indexer expectation has been unregistered")]
     ExpectationUnregistered,
 
+    #[error("no channel domain_separator tag found")]
+    MissingDomainSeparator,
+
     #[error(transparent)]
     DbError(#[from] DbError),
 

--- a/chain/actions/src/payload.rs
+++ b/chain/actions/src/payload.rs
@@ -61,7 +61,7 @@ pub trait PayloadGenerator<T: Into<TypedTransaction>> {
     fn finalize_outgoing_channel_closure(&self, destination: Address) -> Result<T>;
 
     /// Used to create the payload to claim incentives for relaying a mixnet packet.
-    fn redeem_ticket(&self, acked_ticket: AcknowledgedTicket) -> Result<T>;
+    fn redeem_ticket(&self, acked_ticket: AcknowledgedTicket, domain_separator: Hash) -> Result<T>;
 
     /// Creates a transaction payload to register a Safe instance which is used
     /// to manage the node's funds
@@ -263,10 +263,12 @@ impl PayloadGenerator<TypedTransaction> for BasicPayloadGenerator {
         Ok(tx)
     }
 
-    fn redeem_ticket(&self, acked_ticket: AcknowledgedTicket) -> Result<TypedTransaction> {
+    fn redeem_ticket(&self, acked_ticket: AcknowledgedTicket, domain_separator: Hash) -> Result<TypedTransaction> {
         let redeemable = convert_acknowledged_ticket(&acked_ticket)?;
-        let params = convert_vrf_parameters(&acked_ticket.vrf_params);
 
+        let ticket_hash = acked_ticket.ticket.get_hash(&domain_separator);
+
+        let params = convert_vrf_parameters(&acked_ticket.vrf_params, &self.me, ticket_hash, domain_separator);
         let mut tx = create_eip1559_transaction();
         tx.set_data(RedeemTicketCall { redeemable, params }.encode().into());
         tx.set_to(NameOrAddress::Address(self.contract_addrs.channels.into()));
@@ -459,9 +461,12 @@ impl PayloadGenerator<TypedTransaction> for SafePayloadGenerator {
         Ok(tx)
     }
 
-    fn redeem_ticket(&self, acked_ticket: AcknowledgedTicket) -> Result<TypedTransaction> {
+    fn redeem_ticket(&self, acked_ticket: AcknowledgedTicket, domain_separator: Hash) -> Result<TypedTransaction> {
         let redeemable = convert_acknowledged_ticket(&acked_ticket)?;
-        let params = convert_vrf_parameters(&acked_ticket.vrf_params);
+
+        let ticket_hash = acked_ticket.ticket.get_hash(&domain_separator);
+
+        let params = convert_vrf_parameters(&acked_ticket.vrf_params, &self.me, ticket_hash, domain_separator);
 
         let call_data = RedeemTicketSafeCall {
             self_: self.me.into(),
@@ -502,15 +507,23 @@ impl PayloadGenerator<TypedTransaction> for SafePayloadGenerator {
     }
 }
 
-/// Convert off-chain representation of VRF parameters to representation
+/// Converts off-chain representation of VRF parameters into a representation
 /// that the smart contract understands
 ///
 /// Not implemented using From trait because logic fits better here
-pub fn convert_vrf_parameters(off_chain: &VrfParameters) -> Vrfparameters {
+pub fn convert_vrf_parameters(
+    off_chain: &VrfParameters,
+    signer: &Address,
+    ticket_hash: Hash,
+    domain_separator: Hash,
+) -> Vrfparameters {
     // skip the secp256k1 curvepoint prefix
-    let v = off_chain.get_decompressed_v().to_bytes();
-    let s_b = off_chain.s_b.to_bytes();
-    let h_v = off_chain.h_v.to_bytes();
+    let v = off_chain.get_decompressed_v().unwrap().to_bytes();
+    let s_b = off_chain
+        .get_s_b_witness(signer, &(ticket_hash).into(), &domain_separator.to_bytes())
+        .to_bytes();
+
+    let h_v = off_chain.get_h_v_witness().to_bytes();
 
     Vrfparameters {
         vx: U256::from_big_endian(&v[1..33]),

--- a/chain/actions/src/payload.rs
+++ b/chain/actions/src/payload.rs
@@ -508,7 +508,7 @@ impl PayloadGenerator<TypedTransaction> for SafePayloadGenerator {
 /// Not implemented using From trait because logic fits better here
 pub fn convert_vrf_parameters(off_chain: &VrfParameters) -> Vrfparameters {
     // skip the secp256k1 curvepoint prefix
-    let v = off_chain.v.to_bytes();
+    let v = off_chain.get_decompressed_v().to_bytes();
     let s_b = off_chain.s_b.to_bytes();
     let h_v = off_chain.h_v.to_bytes();
 

--- a/chain/actions/src/payload.rs
+++ b/chain/actions/src/payload.rs
@@ -767,7 +767,7 @@ pub mod tests {
 
         // Bob redeems the ticket
         let generator = BasicPayloadGenerator::new((&chain_key_bob).into(), (&contract_instances).into());
-        let redeem_ticket_tx = generator.redeem_ticket(acked_ticket).expect("should create tx");
+        let redeem_ticket_tx = generator.redeem_ticket(acked_ticket, domain_separator).expect("should create tx");
         let client = create_rpc_client_to_anvil(SurfRequestor::default(), &anvil, &chain_key_bob);
         println!(
             "{:?}",

--- a/chain/actions/src/redeem.rs
+++ b/chain/actions/src/redeem.rs
@@ -64,16 +64,11 @@ where
                 return Err(NotAWinningTicket);
             }
         }
-        AcknowledgedTicketStatus::BeingAggregated { .. } => return Err(WrongTicketState(ack_ticket.to_string())),
-        AcknowledgedTicketStatus::BeingRedeemed { tx_hash: txh } => {
-            // If there's already some hash set for this ticket, do not allow unsetting it
-            if txh != Hash::default() && tx_hash == Hash::default() {
-                return Err(InvalidArguments(format!("cannot unset tx hash of {ack_ticket}")));
-            }
-        }
+        AcknowledgedTicketStatus::BeingAggregated => return Err(WrongTicketState(ack_ticket.to_string())),
+        AcknowledgedTicketStatus::BeingRedeemed  => {}
     }
 
-    ack_ticket.status = AcknowledgedTicketStatus::BeingRedeemed { tx_hash };
+    ack_ticket.status = AcknowledgedTicketStatus::BeingRedeemed;
     debug!(
         "setting a winning {} as being redeemed with TX hash {tx_hash}",
         ack_ticket.ticket

--- a/chain/api/src/executors.rs
+++ b/chain/api/src/executors.rs
@@ -118,8 +118,8 @@ where
     C: EthereumClient<T> + Clone + Sync + Send,
     PGen: PayloadGenerator<T> + Clone + Sync + Send,
 {
-    async fn redeem_ticket(&self, acked_ticket: AcknowledgedTicket) -> chain_actions::errors::Result<Hash> {
-        let payload = self.payload_generator.redeem_ticket(acked_ticket)?;
+    async fn redeem_ticket(&self, acked_ticket: AcknowledgedTicket, domain_separator: Hash) -> chain_actions::errors::Result<Hash> {
+        let payload = self.payload_generator.redeem_ticket(acked_ticket, domain_separator)?;
         Ok(self.client.post_transaction(payload).await?)
     }
 

--- a/chain/api/src/executors.rs
+++ b/chain/api/src/executors.rs
@@ -118,7 +118,11 @@ where
     C: EthereumClient<T> + Clone + Sync + Send,
     PGen: PayloadGenerator<T> + Clone + Sync + Send,
 {
-    async fn redeem_ticket(&self, acked_ticket: AcknowledgedTicket, domain_separator: Hash) -> chain_actions::errors::Result<Hash> {
+    async fn redeem_ticket(
+        &self,
+        acked_ticket: AcknowledgedTicket,
+        domain_separator: Hash,
+    ) -> chain_actions::errors::Result<Hash> {
         let payload = self.payload_generator.redeem_ticket(acked_ticket, domain_separator)?;
         Ok(self.client.post_transaction(payload).await?)
     }

--- a/chain/db/src/db.rs
+++ b/chain/db/src/db.rs
@@ -1762,10 +1762,7 @@ mod tests {
 
         assert!(stored_acked_tickets
             .iter()
-            .all(|acked_ticket| AcknowledgedTicketStatus::BeingAggregated {
-                start: 0u64,
-                end: u64::MAX,
-            } == acked_ticket.status));
+            .all(|acked_ticket| AcknowledgedTicketStatus::BeingAggregated == acked_ticket.status));
     }
 
     #[async_std::test]
@@ -1776,9 +1773,7 @@ mod tests {
         let (mut ack_tickets, channel) = generate_ack_tickets(&mut inner_db, amount_tickets).await;
 
         // Add some being redeemed tickets
-        ack_tickets[12].status = AcknowledgedTicketStatus::BeingRedeemed {
-            tx_hash: Hash::default(),
-        };
+        ack_tickets[12].status = AcknowledgedTicketStatus::BeingRedeemed;
 
         // Store ack tickets
         for ack in ack_tickets.iter() {
@@ -1798,10 +1793,7 @@ mod tests {
 
         assert!(stored_acked_tickets
             .iter()
-            .all(|acked_ticket| AcknowledgedTicketStatus::BeingAggregated {
-                start: 0u64,
-                end: u64::MAX,
-            } == acked_ticket.status));
+            .all(|acked_ticket| AcknowledgedTicketStatus::BeingAggregated == acked_ticket.status));
     }
 
     #[async_std::test]
@@ -1812,12 +1804,8 @@ mod tests {
         let (mut ack_tickets, channel) = generate_ack_tickets(&mut inner_db, amount_tickets).await;
 
         // Add some being redeemed tickets
-        ack_tickets[12].status = AcknowledgedTicketStatus::BeingRedeemed {
-            tx_hash: Hash::default(),
-        };
-        ack_tickets[17].status = AcknowledgedTicketStatus::BeingRedeemed {
-            tx_hash: Hash::default(),
-        };
+        ack_tickets[12].status = AcknowledgedTicketStatus::BeingRedeemed;
+        ack_tickets[17].status = AcknowledgedTicketStatus::BeingRedeemed;
 
         // Store ack tickets
         for ack in ack_tickets.iter() {
@@ -1837,10 +1825,7 @@ mod tests {
 
         assert!(stored_acked_tickets
             .iter()
-            .all(|acked_ticket| AcknowledgedTicketStatus::BeingAggregated {
-                start: 0u64,
-                end: u64::MAX,
-            } == acked_ticket.status));
+            .all(|acked_ticket| AcknowledgedTicketStatus::BeingAggregated == acked_ticket.status));
     }
 
     #[async_std::test]
@@ -1851,9 +1836,7 @@ mod tests {
         let (mut ack_tickets, channel) = generate_ack_tickets(&mut inner_db, amount_tickets).await;
 
         // Add some being redeemed tickets
-        ack_tickets[28].status = AcknowledgedTicketStatus::BeingRedeemed {
-            tx_hash: Hash::default(),
-        };
+        ack_tickets[28].status = AcknowledgedTicketStatus::BeingRedeemed;
 
         // Store ack tickets
         for ack in ack_tickets.iter() {

--- a/chain/types/src/actions.rs
+++ b/chain/types/src/actions.rs
@@ -1,3 +1,4 @@
+use hopr_crypto_types::prelude::*;
 use hopr_internal_types::prelude::*;
 use hopr_primitive_types::prelude::*;
 use std::fmt::{Display, Formatter};
@@ -7,8 +8,9 @@ use std::fmt::{Display, Formatter};
 #[derive(Clone, PartialEq, Debug, strum::EnumVariantNames, strum::IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum Action {
-    /// Redeem the given acknowledged ticket
-    RedeemTicket(AcknowledgedTicket),
+    /// Redeem the given acknowledged ticket. The domain separator is required
+    /// to expand VRF parameters such that they can get used in the smart contract.
+    RedeemTicket(AcknowledgedTicket, Hash),
 
     /// Open channel to the given destination with the given stake
     OpenChannel(Address, Balance),
@@ -32,7 +34,7 @@ pub enum Action {
 impl Display for Action {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Action::RedeemTicket(ack) => write!(f, "redeem action of {ack}"),
+            Action::RedeemTicket(ack, domain_separator) => write!(f, "redeem action of {ack}, used domain_separator: {domain_separator}"),
             Action::OpenChannel(dst, amount) => write!(f, "open channel action to {dst} with {amount}"),
             Action::FundChannel(channel, amount) => write!(
                 f,

--- a/chain/types/src/actions.rs
+++ b/chain/types/src/actions.rs
@@ -1,4 +1,3 @@
-use hopr_crypto_types::prelude::*;
 use hopr_internal_types::prelude::*;
 use hopr_primitive_types::prelude::*;
 use std::fmt::{Display, Formatter};
@@ -8,9 +7,8 @@ use std::fmt::{Display, Formatter};
 #[derive(Clone, PartialEq, Debug, strum::EnumVariantNames, strum::IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 pub enum Action {
-    /// Redeem the given acknowledged ticket. The domain separator is required
-    /// to expand VRF parameters such that they can get used in the smart contract.
-    RedeemTicket(AcknowledgedTicket, Hash),
+    /// Redeem the given acknowledged ticket.
+    RedeemTicket(AcknowledgedTicket),
 
     /// Open channel to the given destination with the given stake
     OpenChannel(Address, Balance),
@@ -34,7 +32,7 @@ pub enum Action {
 impl Display for Action {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
-            Action::RedeemTicket(ack, domain_separator) => write!(f, "redeem action of {ack}, used domain_separator: {domain_separator}"),
+            Action::RedeemTicket(ack) => write!(f, "redeem action of {ack}"),
             Action::OpenChannel(dst, amount) => write!(f, "open channel action to {dst} with {amount}"),
             Action::FundChannel(channel, amount) => write!(
                 f,

--- a/chain/types/src/lib.rs
+++ b/chain/types/src/lib.rs
@@ -234,7 +234,17 @@ impl<M: Middleware> From<&ContractInstances<M>> for ContractAddresses {
 /// Used for testing. When block time is given, new blocks are mined periodically.
 /// Otherwise, a new block is mined per transaction.
 pub fn create_anvil(block_time: Option<std::time::Duration>) -> ethers::utils::AnvilInstance {
-    let mut anvil = ethers::utils::Anvil::new();
+    let output = std::process::Command::new(env!("CARGO"))
+        .arg("locate-project")
+        .arg("--workspace")
+        .arg("--message-format=plain")
+        .output()
+        .unwrap()
+        .stdout;
+    let cargo_path = std::path::Path::new(std::str::from_utf8(&output).unwrap().trim());
+    let workspace_dir = cargo_path.parent().unwrap().to_path_buf();
+
+    let mut anvil = ethers::utils::Anvil::new().path(workspace_dir.join(".foundry/bin/anvil"));
 
     if let Some(bt) = block_time {
         anvil = anvil.block_time(bt.as_secs());

--- a/chain/types/src/lib.rs
+++ b/chain/types/src/lib.rs
@@ -234,17 +234,7 @@ impl<M: Middleware> From<&ContractInstances<M>> for ContractAddresses {
 /// Used for testing. When block time is given, new blocks are mined periodically.
 /// Otherwise, a new block is mined per transaction.
 pub fn create_anvil(block_time: Option<std::time::Duration>) -> ethers::utils::AnvilInstance {
-    let output = std::process::Command::new(env!("CARGO"))
-        .arg("locate-project")
-        .arg("--workspace")
-        .arg("--message-format=plain")
-        .output()
-        .unwrap()
-        .stdout;
-    let cargo_path = std::path::Path::new(std::str::from_utf8(&output).unwrap().trim());
-    let workspace_dir = cargo_path.parent().unwrap().to_path_buf();
-
-    let mut anvil = ethers::utils::Anvil::new().path(workspace_dir.join(".foundry/bin/anvil"));
+    let mut anvil = ethers::utils::Anvil::new();
 
     if let Some(bt) = block_time {
         anvil = anvil.block_time(bt.as_secs());

--- a/common/internal-types/src/acknowledgement.rs
+++ b/common/internal-types/src/acknowledgement.rs
@@ -585,7 +585,7 @@ pub mod test {
             )
             .is_ok());
 
-        deserialized_ticket.status = super::AcknowledgedTicketStatus::BeingAggregated { start: 1u64, end: 2u64 };
+        deserialized_ticket.status = super::AcknowledgedTicketStatus::BeingAggregated;
 
         assert_eq!(
             deserialized_ticket,

--- a/common/internal-types/src/acknowledgement.rs
+++ b/common/internal-types/src/acknowledgement.rs
@@ -207,11 +207,6 @@ impl AcknowledgedTicket {
 
         u64::from_be_bytes(computed_ticket_luck) <= u64::from_be_bytes(signed_ticket_luck)
     }
-
-    /// Recovers the signer of the ticket from its signature.
-    pub fn get_signer(&self, domain_separator: &Hash) -> crate::errors::Result<Address> {
-        Ok(self.ticket.recover_signer(domain_separator)?.to_address())
-    }
 }
 
 impl Display for AcknowledgedTicket {
@@ -301,11 +296,6 @@ impl UnacknowledgedTicket {
 
     pub fn get_response(&self, acknowledgement: &HalfKey) -> hopr_crypto_types::errors::Result<Response> {
         Response::from_half_keys(&self.own_key, acknowledgement)
-    }
-
-    /// Recovers the signer of the ticket from its signature.
-    pub fn get_signer(&self, domain_separator: &Hash) -> crate::errors::Result<Address> {
-        Ok(self.ticket.recover_signer(domain_separator)?.to_address())
     }
 
     /// Turn an unacknowledged ticket into an acknowledged ticket by adding

--- a/common/internal-types/src/channels.rs
+++ b/common/internal-types/src/channels.rs
@@ -287,11 +287,11 @@ impl ChannelChange {
 #[derive(Clone, Eq, PartialEq)]
 pub struct Ticket {
     pub channel_id: Hash,
-    pub amount: Balance,
-    pub index: u64,
-    pub index_offset: u32,
-    pub encoded_win_prob: EncodedWinProb,
-    pub channel_epoch: u32,
+    pub amount: Balance, // 92 ---
+    pub index: u64,  // 48
+    pub index_offset: u32, // 32
+    pub encoded_win_prob: EncodedWinProb, // 56
+    pub channel_epoch: u32, // 24
     pub challenge: EthereumChallenge,
     pub signature: Option<Signature>,
 }

--- a/common/internal-types/src/channels.rs
+++ b/common/internal-types/src/channels.rs
@@ -287,11 +287,11 @@ impl ChannelChange {
 #[derive(Clone, Eq, PartialEq)]
 pub struct Ticket {
     pub channel_id: Hash,
-    pub amount: Balance, // 92 ---
-    pub index: u64,  // 48
-    pub index_offset: u32, // 32
+    pub amount: Balance,                  // 92 ---
+    pub index: u64,                       // 48
+    pub index_offset: u32,                // 32
     pub encoded_win_prob: EncodedWinProb, // 56
-    pub channel_epoch: u32, // 24
+    pub channel_epoch: u32,               // 24
     pub challenge: EthereumChallenge,
     pub signature: Option<Signature>,
 }

--- a/common/internal-types/src/channels.rs
+++ b/common/internal-types/src/channels.rs
@@ -440,7 +440,7 @@ impl Ticket {
 
         let channel_id = generate_channel_id(&own_address, counterparty);
 
-        let mut ret = Ticket {
+        let mut ret = Self {
             channel_id,
             amount: amount.to_owned(),
             index: index.as_u64(),

--- a/common/internal-types/src/channels.rs
+++ b/common/internal-types/src/channels.rs
@@ -285,7 +285,7 @@ impl ChannelChange {
 }
 
 /// Contains the overall description of a ticket with a signature
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Clone, Eq)]
 pub struct Ticket {
     pub channel_id: Hash,
     pub amount: Balance,                  // 92 ---
@@ -298,6 +298,20 @@ pub struct Ticket {
     signer: OnceLock<PublicKey>,
 }
 
+impl PartialEq for Ticket {
+    fn eq(&self, other: &Self) -> bool {
+        // Exclude cached properties
+        self.channel_id == other.channel_id
+            && self.amount == other.amount
+            && self.index == other.index
+            && self.index_offset == other.index_offset
+            && self.encoded_win_prob == other.encoded_win_prob
+            && self.channel_epoch == other.channel_epoch
+            && self.challenge == other.challenge
+            && self.signature == other.signature
+    }
+}
+
 impl PartialOrd for Ticket {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
@@ -306,6 +320,8 @@ impl PartialOrd for Ticket {
 
 impl Ord for Ticket {
     fn cmp(&self, other: &Self) -> Ordering {
+        // Ordering:
+        // [channel_id][channel_epoch][ticket_index]
         match self.channel_id.cmp(&other.channel_id) {
             Ordering::Equal => match self.channel_epoch.cmp(&other.channel_epoch) {
                 Ordering::Equal => self.index.cmp(&other.index),

--- a/common/internal-types/src/channels.rs
+++ b/common/internal-types/src/channels.rs
@@ -424,9 +424,6 @@ impl Ticket {
 
         let channel_id = generate_channel_id(&own_address, counterparty);
 
-        let cached_signer = OnceLock::new();
-        cached_signer.set(signing_key.public().0.clone()).unwrap();
-
         let mut ret = Ticket {
             channel_id,
             amount: amount.to_owned(),
@@ -436,7 +433,7 @@ impl Ticket {
             challenge,
             encoded_win_prob: f64_to_win_prob(win_prob).expect("error encoding winning probability"),
             signature: None,
-            signer: cached_signer,
+            signer: OnceLock::new(),
         };
         ret.sign(signing_key, domain_separator);
 

--- a/crypto/sphinx/src/derivation.rs
+++ b/crypto/sphinx/src/derivation.rs
@@ -195,17 +195,21 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(params.s_b.to_projective_point(), cap_b * params.s);
+        assert_eq!(
+            params.get_s_b_witness(&keypair.public().to_address(), &message, dst),
+            (cap_b * params.s).to_encoded_point(false)
+        );
 
         let a: Scalar = ScalarPrimitive::<Secp256k1>::from_slice(&priv_key).unwrap().into();
-        assert_eq!(params.h_v.to_projective_point(), cap_b * a * params.h);
+        assert_eq!(params.get_h_v_witness(), (cap_b * a * params.h).to_encoded_point(false));
 
-        let r_v: ProjectivePoint<Secp256k1> = cap_b * params.s - params.v.to_projective_point() * params.h;
+        let r_v: ProjectivePoint<Secp256k1> =
+            cap_b * params.s - params.get_decompressed_v().unwrap().to_projective_point() * params.h;
 
         let h_check = Secp256k1::hash_to_scalar::<ExpandMsgXmd<sha3::Keccak256>>(
             &[
                 &pub_key.to_address().to_bytes(),
-                &params.v.to_bytes()[1..],
+                &params.get_decompressed_v().unwrap().to_bytes()[1..],
                 &r_v.to_affine().to_encoded_point(false).as_bytes()[1..],
                 &message,
             ],

--- a/crypto/types/Cargo.toml
+++ b/crypto/types/Cargo.toml
@@ -17,6 +17,7 @@ libp2p-identity = { workspace = true }
 log = { workspace = true }
 primitive-types = "0.12.2"
 serde = { workspace = true, features = ["derive"] }
+serde_bytes = { workspace = true }
 sha2 = "0.10"
 sha3 = "0.10"
 subtle = "2"

--- a/crypto/types/src/types.rs
+++ b/crypto/types/src/types.rs
@@ -458,6 +458,10 @@ impl Hash {
     pub fn hash(&self) -> Self {
         Self::create(&[&self.0])
     }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
 }
 
 impl BinarySerializable for Hash {
@@ -498,6 +502,12 @@ impl From<[u8; Self::SIZE]> for Hash {
 
 impl From<Hash> for [u8; Hash::SIZE] {
     fn from(value: Hash) -> Self {
+        value.0
+    }
+}
+
+impl From<&Hash> for [u8; Hash::SIZE] {
+    fn from(value: &Hash) -> Self {
         value.0
     }
 }

--- a/crypto/types/src/vrf.rs
+++ b/crypto/types/src/vrf.rs
@@ -17,7 +17,7 @@ use crate::utils::k256_scalar_from_bytes;
 ///
 /// The VRF is thereby needed because it generates on-demand deterministic
 /// entropy that can only be derived by the ticket redeemer.
-#[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Eq, Serialize, Deserialize)]
 pub struct VrfParameters {
     /// the pseudo-random point
     #[serde(with = "serde_bytes")]
@@ -26,6 +26,13 @@ pub struct VrfParameters {
     pub s: Scalar,
     #[serde(skip)]
     v_decompressed: OnceLock<CurvePoint>,
+}
+
+impl PartialEq for VrfParameters {
+    fn eq(&self, other: &Self) -> bool {
+        // Exclude cached properties
+        self.v == other.v && self.h == other.h && self.s == other.s
+    }
 }
 
 impl Default for VrfParameters {

--- a/crypto/types/src/vrf.rs
+++ b/crypto/types/src/vrf.rs
@@ -1,4 +1,4 @@
-use std::cell::OnceCell;
+use std::sync::OnceLock;
 
 use hopr_crypto_random::random_bytes;
 use hopr_primitive_types::prelude::*;
@@ -25,7 +25,7 @@ pub struct VrfParameters {
     pub h: Scalar,
     pub s: Scalar,
     #[serde(skip)]
-    v_decompressed: OnceCell<CurvePoint>,
+    v_decompressed: OnceLock<CurvePoint>,
 }
 
 impl Default for VrfParameters {
@@ -34,7 +34,7 @@ impl Default for VrfParameters {
             v: [0u8; CurvePoint::SIZE_COMPRESSED],
             h: Scalar::default(),
             s: Scalar::default(),
-            v_decompressed: OnceCell::new(),
+            v_decompressed: OnceLock::new(),
         }
     }
 }
@@ -64,7 +64,7 @@ impl BinarySerializable for VrfParameters {
                     &data[CurvePoint::SIZE_COMPRESSED + 32..CurvePoint::SIZE_COMPRESSED + 32 + 32],
                 )
                 .unwrap(),
-                v_decompressed: OnceCell::new(),
+                v_decompressed: OnceLock::new(),
             })
         } else {
             Err(GeneralError::ParseError)
@@ -145,7 +145,7 @@ impl VrfParameters {
 
     /// Returns decompressed `v`.
     pub fn get_decompressed_v(&self) -> crate::errors::Result<CurvePoint> {
-        // OnceCell::get_try_or_init is a perfect fit, but unstable
+        // OnceLock::get_try_or_init is a perfect fit, but unstable
 
         if let Some(cached_v) = self.v_decompressed.get() {
             Ok(*cached_v)
@@ -205,7 +205,7 @@ pub fn derive_vrf_parameters<const T: usize>(
         v: comp_v,
         h,
         s,
-        v_decompressed: OnceCell::new(),
+        v_decompressed: OnceLock::new(),
     })
 }
 

--- a/crypto/types/src/vrf.rs
+++ b/crypto/types/src/vrf.rs
@@ -15,72 +15,52 @@ use crate::utils::k256_scalar_from_bytes;
 ///
 /// The VRF is thereby needed because it generates on-demand deterministic
 /// entropy that can only be derived by the ticket redeemer.
-#[derive(Copy, Clone, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Copy, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub struct VrfParameters {
     /// the pseudo-random point
-    pub v: CurvePoint,
+    #[serde(with = "serde_bytes")]
+    pub v: [u8; CurvePoint::SIZE_COMPRESSED],
     pub h: Scalar,
     pub s: Scalar,
-    /// helper value for smart contract
-    pub h_v: CurvePoint,
-    /// helper value for smart contract
-    pub s_b: CurvePoint,
+}
+
+impl Default for VrfParameters {
+    fn default() -> Self {
+        Self {
+            v: [0u8; CurvePoint::SIZE_COMPRESSED],
+            h: Scalar::default(),
+            s: Scalar::default(),
+        }
+    }
 }
 
 impl std::fmt::Debug for VrfParameters {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let v_encoded = self.v.affine.to_encoded_point(false);
-        let h_v_encoded = self.h_v.affine.to_encoded_point(false);
-        let s_b_encoded = self.s_b.affine.to_encoded_point(false);
         f.debug_struct("VrfParameters")
             .field(
                 "V",
                 &format!(
-                    "({},{})",
-                    hex::encode(v_encoded.x().unwrap()),
-                    hex::encode(v_encoded.y().unwrap())
+                    "({}",
+                    hex::encode(self.v),
                 ),
             )
             .field("h", &hex::encode(self.h.to_bytes()))
             .field("s", &hex::encode(self.s.to_bytes()))
-            .field(
-                "h_v",
-                &format!(
-                    "({},{})",
-                    hex::encode(h_v_encoded.x().unwrap()),
-                    hex::encode(h_v_encoded.y().unwrap())
-                ),
-            )
-            .field(
-                "s_b",
-                &format!(
-                    "({},{})",
-                    hex::encode(s_b_encoded.x().unwrap()),
-                    hex::encode(s_b_encoded.y().unwrap())
-                ),
-            )
             .finish()
     }
 }
 
 impl BinarySerializable for VrfParameters {
-    const SIZE: usize = CurvePoint::SIZE + 32 + 32 + CurvePoint::SIZE + CurvePoint::SIZE;
+    const SIZE: usize = CurvePoint::SIZE_COMPRESSED + 32 + 32;
 
     fn from_bytes(data: &[u8]) -> hopr_primitive_types::errors::Result<Self> {
         if data.len() == Self::SIZE {
+            let mut v = [0u8; CurvePoint::SIZE_COMPRESSED];
+            v.copy_from_slice(&data[..CurvePoint::SIZE_COMPRESSED]);
             Ok(VrfParameters {
-                v: CurvePoint::from_bytes(&data[0..CurvePoint::SIZE]).unwrap(),
-                h: k256_scalar_from_bytes(&data[CurvePoint::SIZE..CurvePoint::SIZE + 32]).unwrap(),
-                s: k256_scalar_from_bytes(&data[CurvePoint::SIZE + 32..CurvePoint::SIZE + 32 + 32]).unwrap(),
-                h_v: CurvePoint::from_bytes(
-                    &data[CurvePoint::SIZE + 32 + 32..CurvePoint::SIZE + 32 + 32 + CurvePoint::SIZE],
-                )
-                .unwrap(),
-                s_b: CurvePoint::from_bytes(
-                    &data[CurvePoint::SIZE + 32 + 32 + CurvePoint::SIZE
-                        ..CurvePoint::SIZE + 32 + 32 + CurvePoint::SIZE + CurvePoint::SIZE],
-                )
-                .unwrap(),
+                v,
+                h: k256_scalar_from_bytes(&data[CurvePoint::SIZE_COMPRESSED..CurvePoint::SIZE_COMPRESSED + 32]).unwrap(),
+                s: k256_scalar_from_bytes(&data[CurvePoint::SIZE_COMPRESSED + 32..CurvePoint::SIZE_COMPRESSED + 32 + 32]).unwrap(),
             })
         } else {
             Err(GeneralError::ParseError)
@@ -89,11 +69,9 @@ impl BinarySerializable for VrfParameters {
 
     fn to_bytes(&self) -> Box<[u8]> {
         let mut ret = Vec::with_capacity(Self::SIZE);
-        ret.extend_from_slice(&self.v.to_bytes());
+        ret.extend_from_slice(&self.v);
         ret.extend_from_slice(&self.h.to_bytes());
         ret.extend_from_slice(&self.s.to_bytes());
-        ret.extend_from_slice(&self.h_v.to_bytes());
-        ret.extend_from_slice(&self.s_b.to_bytes());
         ret.into_boxed_slice()
     }
 }
@@ -104,22 +82,14 @@ impl VrfParameters {
         let cap_b =
             Secp256k1::hash_from_bytes::<ExpandMsgXmd<sha3::Keccak256>>(&[&creator.to_bytes(), msg], &[dst]).unwrap();
 
-        // Check point witness
-        if self.s_b.to_projective_point() != cap_b * self.s {
-            return Err(CalculationError);
-        }
+        let v = self.get_decompressed_v()?; // decompresses the point
 
-        // Check point witness
-        if self.h_v.to_projective_point() != self.v.to_projective_point() * self.h {
-            return Err(CalculationError);
-        }
-
-        let r_v: ProjectivePoint<Secp256k1> = cap_b * self.s - self.v.to_projective_point() * self.h;
+        let r_v: ProjectivePoint<Secp256k1> = cap_b * self.s - v.to_projective_point() * self.h;
 
         let h_check = Secp256k1::hash_to_scalar::<ExpandMsgXmd<sha3::Keccak256>>(
             &[
                 &creator.to_bytes(),
-                &self.v.to_bytes()[1..],
+                &v.to_bytes()[1..],
                 &r_v.to_affine().to_encoded_point(false).as_bytes()[1..],
                 msg,
             ],
@@ -132,6 +102,11 @@ impl VrfParameters {
         }
 
         Ok(())
+    }
+
+    /// Returns decompressed `v`.
+    pub fn get_decompressed_v(&self) -> crate::errors::Result<CurvePoint> {
+        Ok(CurvePoint::from_bytes(&self.v)?)
     }
 }
 
@@ -176,12 +151,14 @@ pub fn derive_vrf_parameters<const T: usize>(
     )?;
     let s = r + h * a;
 
+    // We only store the compressed point
+    let mut comp_v = [0u8; CurvePoint::SIZE_COMPRESSED];
+    comp_v.copy_from_slice(v.to_encoded_point(true).as_bytes());
+
     Ok(VrfParameters {
-        v: v.to_affine().into(),
+        v: comp_v,
         h,
         s,
-        h_v: (v * h).to_affine().into(),
-        s_b: (b * s).to_affine().into(),
     })
 }
 

--- a/transport/packet/src/validation.rs
+++ b/transport/packet/src/validation.rs
@@ -20,10 +20,7 @@ pub async fn validate_unacknowledged_ticket<T: HoprCoreEthereumDbActions>(
     check_unrealized_balance: bool,
     domain_separator: &Hash,
 ) -> Result<()> {
-    debug!(
-        "validating unack ticket from {}",
-        ticket.recover_signer(domain_separator)?
-    );
+    debug!("validating unack ticket from {sender}");
 
     // ticket signer MUST be the sender
     ticket

--- a/transport/protocol/src/ticket_aggregation/processor.rs
+++ b/transport/protocol/src/ticket_aggregation/processor.rs
@@ -163,7 +163,10 @@ impl AggregationList {
         let mut total_amount = Balance::zero(BalanceType::HOPR);
 
         for tkt in list.iter() {
-            if tkt.signer != signer || tkt.ticket.channel_id != channel_id || tkt.status != AcknowledgedTicketStatus::BeingAggregated {
+            if tkt.signer != signer
+                || tkt.ticket.channel_id != channel_id
+                || tkt.status != AcknowledgedTicketStatus::BeingAggregated
+            {
                 error!("{tkt} does not belong to the aggregation list");
                 return Err(ProtocolTicketAggregation(
                     "invalid list of tickets to aggregate given".into(),
@@ -842,9 +845,7 @@ mod tests {
 
             // Mark the first ticket as redeemed, so it does not enter the aggregation
             if i == 1 {
-                ack_ticket.status = AcknowledgedTicketStatus::BeingRedeemed {
-                    tx_hash: Hash::default(),
-                };
+                ack_ticket.status = AcknowledgedTicketStatus::BeingRedeemed;
             } else {
                 agg_balance = agg_balance.add(&ack_ticket.ticket.amount);
             }
@@ -937,9 +938,7 @@ mod tests {
         );
 
         assert_eq!(
-            AcknowledgedTicketStatus::BeingRedeemed {
-                tx_hash: Hash::default()
-            },
+            AcknowledgedTicketStatus::BeingRedeemed,
             stored_acked_tickets[0].status,
             "first ticket must being redeemed"
         );

--- a/transport/protocol/src/ticket_aggregation/processor.rs
+++ b/transport/protocol/src/ticket_aggregation/processor.rs
@@ -185,6 +185,7 @@ impl AggregationList {
 
 /// The input to the processor background pipeline
 #[allow(clippy::type_complexity)] // TODO: The type needs to be significantly refactored to easily move around
+#[allow(clippy::large_enum_variant)] // TODO: refactor the large types used in the enum
 #[derive(Debug)]
 pub enum TicketAggregationToProcess<T, U> {
     ToReceive(PeerId, std::result::Result<Ticket, String>, U),

--- a/transport/protocol/src/ticket_aggregation/processor.rs
+++ b/transport/protocol/src/ticket_aggregation/processor.rs
@@ -163,7 +163,7 @@ impl AggregationList {
         let mut total_amount = Balance::zero(BalanceType::HOPR);
 
         for tkt in list.iter() {
-            if tkt.signer != signer || tkt.ticket.channel_id != channel_id || !tkt.status.is_being_aggregated() {
+            if tkt.signer != signer || tkt.ticket.channel_id != channel_id || tkt.status != AcknowledgedTicketStatus::BeingAggregated {
                 error!("{tkt} does not belong to the aggregation list");
                 return Err(ProtocolTicketAggregation(
                     "invalid list of tickets to aggregate given".into(),


### PR DESCRIPTION
This PR add some important size optimizations of object sizes when serialized, namely:
- various Ticket-related objects (`AcknowledgedTicket`, `UnacknowledgedTicket`)
- caching some of the members which are heavy on computation

As for other optimizations:
- postpone cryptographic operations once they are really necessary
- remove unnecessary cryptographic values
- simplify the `AcknowledgedTicketStatus` enum (remove values that are not needed)