### PR TITLE
Update config to fix issues and allow mergability of configuration files

### DIFF
--- a/hopr/hopr-lib/src/config.rs
+++ b/hopr/hopr-lib/src/config.rs
@@ -12,20 +12,46 @@ pub const DEFAULT_SAFE_TRANSACTION_SERVICE_PROVIDER: &str = "https://safe-transa
 pub const DEFAULT_HOST: &str = "0.0.0.0";
 pub const DEFAULT_PORT: u16 = 9091;
 
+fn validate_announced(v: &bool) -> Result<(), ValidationError> {
+    if *v {
+        Ok(())
+    } else {
+        Err(ValidationError::new(
+            "Announce option should be turned ON in 2.*, only public nodes are supported",
+        ))
+    }
+}
+
+#[inline]
+fn default_network() -> String {
+    "anvil-localhost".to_owned()
+}
+
+#[inline]
+fn default_is_true() -> bool {
+    true
+}
+
 #[derive(Debug, Serialize, Deserialize, Validate, Clone, PartialEq)]
 pub struct Chain {
+    #[validate(custom = "validate_announced")]
+    #[serde(default = "default_is_true")]
     pub announce: bool,
+    #[serde(default = "default_network")]
     pub network: String,
+    #[serde(default)]
     pub provider: Option<String>,
+    #[serde(default)]
     pub protocols: crate::chain::ProtocolsConfig,
+    #[serde(default = "default_is_true")]
     pub check_unrealized_balance: bool,
 }
 
 impl Default for Chain {
     fn default() -> Self {
         Self {
-            announce: false,
-            network: "anvil-localhost".to_owned(),
+            announce: true,
+            network: default_network(),
             provider: None,
             protocols: crate::chain::ProtocolsConfig::default(),
             check_unrealized_balance: true,

--- a/hopr/hopr-lib/src/config.rs
+++ b/hopr/hopr-lib/src/config.rs
@@ -28,14 +28,14 @@ fn default_network() -> String {
 }
 
 #[inline]
-fn default_is_true() -> bool {
+fn just_true() -> bool {
     true
 }
 
 #[derive(Debug, Serialize, Deserialize, Validate, Clone, PartialEq)]
 pub struct Chain {
     #[validate(custom = "validate_announced")]
-    #[serde(default = "default_is_true")]
+    #[serde(default = "just_true")]
     pub announce: bool,
     #[serde(default = "default_network")]
     pub network: String,
@@ -43,7 +43,7 @@ pub struct Chain {
     pub provider: Option<String>,
     #[serde(default)]
     pub protocols: crate::chain::ProtocolsConfig,
-    #[serde(default = "default_is_true")]
+    #[serde(default = "just_true")]
     pub check_unrealized_balance: bool,
 }
 
@@ -59,23 +59,36 @@ impl Default for Chain {
     }
 }
 
+#[inline]
+fn default_invalid_address() -> Address {
+    Address::from_bytes(&[0; Address::SIZE]).unwrap()
+}
+
+#[inline]
+fn default_safe_transaction_service_provider() -> String {
+    DEFAULT_SAFE_TRANSACTION_SERVICE_PROVIDER.to_owned()
+}
+
 #[serde_as]
 #[derive(Debug, Serialize, Deserialize, Validate, Clone, PartialEq)]
 pub struct SafeModule {
     #[validate(url)]
+    #[serde(default = "default_safe_transaction_service_provider")]
     pub safe_transaction_service_provider: String,
     #[serde_as(as = "DisplayFromStr")]
+    #[serde(default = "default_invalid_address")]
     pub safe_address: Address,
     #[serde_as(as = "DisplayFromStr")]
+    #[serde(default = "default_invalid_address")]
     pub module_address: Address,
 }
 
 impl Default for SafeModule {
     fn default() -> Self {
         Self {
-            safe_transaction_service_provider: DEFAULT_SAFE_TRANSACTION_SERVICE_PROVIDER.to_owned(),
-            safe_address: Address::from_bytes(&[0; Address::SIZE]).unwrap(),
-            module_address: Address::from_bytes(&[0; Address::SIZE]).unwrap(),
+            safe_transaction_service_provider: default_safe_transaction_service_provider(),
+            safe_address: default_invalid_address(),
+            module_address: default_invalid_address(),
         }
     }
 }
@@ -92,8 +105,11 @@ fn validate_directory_exists(s: &str) -> Result<(), ValidationError> {
 #[derive(Debug, Serialize, Deserialize, Validate, Clone, PartialEq)]
 pub struct Db {
     /// Path to the directory containing the database
+    #[serde(default)]
     pub data: String,
+    #[serde(default = "just_true")]
     pub initialize: bool,
+    #[serde(default)]
     pub force_initialize: bool,
 }
 
@@ -111,43 +127,54 @@ impl Default for Db {
 pub struct HoprLibConfig {
     /// Configuration related to host specifics
     #[validate]
+    #[serde(default = "default_host")]
     pub host: HostConfig,
-    // /// Configuration regarding the identity of the node
-    // #[validate]
-    // pub identity: Identity,
     /// Configuration of the underlying database engine
     #[validate]
+    #[serde(default)]
     pub db: Db,
     /// Configuration of underlying node behavior in the form strategies
     ///
     /// Strategies represent automatically executable behavior performed by
     /// the node given pre-configured triggers.
     #[validate]
+    #[serde(default = "core_strategy::hopr_default_strategies")]
     pub strategy: StrategyConfig,
     /// Configuration of the protocol heartbeat mechanism
     #[validate]
+    #[serde(default)]
     pub heartbeat: HeartbeatConfig,
     /// Configuration of network properties
     #[validate]
+    #[serde(default)]
     pub network_options: NetworkConfig,
-    /// Configuration specific to protocol execution on the p2p layer
+    /// Configuration specific to transport mechanics
     #[validate]
+    #[serde(default)]
     pub transport: TransportConfig,
     /// Configuration specific to protocol execution on the p2p layer
     #[validate]
+    #[serde(default)]
     pub protocol: ProtocolConfig,
     /// Blockchain specific configuration
     #[validate]
+    #[serde(default)]
     pub chain: Chain,
     /// Configuration of the `Safe` mechanism
     #[validate]
+    #[serde(default)]
     pub safe_module: SafeModule,
+}
+
+#[inline]
+fn default_host() -> HostConfig {
+    HostConfig::from_str(format!("{DEFAULT_HOST}:{DEFAULT_PORT}").as_str()).unwrap()
 }
 
 impl Default for HoprLibConfig {
     fn default() -> Self {
         Self {
-            host: HostConfig::from_str(format!("{DEFAULT_HOST}:{DEFAULT_PORT}").as_str()).unwrap(),
+            host: default_host(),
             db: Db::default(),
             strategy: core_strategy::hopr_default_strategies(),
             heartbeat: HeartbeatConfig::default(),

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -544,12 +544,6 @@ pub struct Hopr {
 
 impl Hopr {
     pub fn new(mut cfg: config::HoprLibConfig, me: &OffchainKeypair, me_onchain: &ChainKeypair) -> Self {
-        // pre-flight checks
-        // Announced limitation for the `providence` release
-        if !cfg.chain.announce {
-            panic!("Announce option should be turned ON in Providence, only public nodes are supported");
-        }
-
         let multiaddress = match &cfg.host.address {
             core_transport::config::HostType::IPv4(ip) => {
                 Multiaddr::from_str(format!("/ip4/{}/tcp/{}", ip.as_str(), cfg.host.port).as_str()).unwrap()

--- a/hoprd/hoprd/src/config.rs
+++ b/hoprd/hoprd/src/config.rs
@@ -17,7 +17,9 @@ fn validate_file_path(s: &str) -> Result<(), ValidationError> {
     if std::path::Path::new(s).is_file() {
         Ok(())
     } else {
-        Err(ValidationError::new("Invalid file path specified"))
+        Err(ValidationError::new(
+            "Invalid file path specified, the file does not exist or is not a file",
+        ))
     }
 }
 
@@ -46,10 +48,13 @@ fn validate_optional_private_key(s: &str) -> Result<(), ValidationError> {
 #[derive(Default, Serialize, Deserialize, Validate, Clone, PartialEq)]
 pub struct Identity {
     #[validate(custom = "validate_file_path")]
+    #[serde(default)]
     pub file: String,
     #[validate(custom = "validate_password")]
+    #[serde(default)]
     pub password: String,
     #[validate(custom = "validate_optional_private_key")]
+    #[serde(default)]
     pub private_key: Option<String>,
 }
 
@@ -76,15 +81,19 @@ impl std::fmt::Debug for Identity {
 pub struct HoprdConfig {
     /// Configuration related to hopr functionality
     #[validate]
+    #[serde(default)]
     pub hopr: HoprLibConfig,
     /// Configuration regarding the identity of the node
     #[validate]
+    #[serde(default)]
     pub identity: Identity,
     /// Configuration of the underlying database engine
     #[validate]
+    #[serde(default)]
     pub inbox: MessageInboxConfiguration,
     /// Configuration relevant for the API of the node
     #[validate]
+    #[serde(default)]
     pub api: Api,
 }
 

--- a/hoprd/hoprd/src/main.rs
+++ b/hoprd/hoprd/src/main.rs
@@ -91,7 +91,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     info!(
         "This node has packet key '{}' and uses a blockchain address '{}'",
         hopr_lib::Keypair::public(&hopr_keys.packet_key).to_peerid_str(),
-        hopr_lib::Keypair::public(&hopr_keys.chain_key).to_hex()
+        hopr_lib::Keypair::public(&hopr_keys.chain_key).to_address().to_hex()
     );
 
     // TODO: the following check can be removed once [PR](https://github.com/hoprnet/hoprnet/pull/5665) is merged

--- a/hoprd/inbox/src/config.rs
+++ b/hoprd/inbox/src/config.rs
@@ -21,22 +21,39 @@ pub struct MessageInboxConfiguration {
     /// Maximum capacity per-each application tag.
     /// In the current implementation, the capacity must be a power of two.
     #[validate(custom = "validate_is_power_of_two")]
+    #[serde(default = "default_capacity")]
     pub capacity: u32,
     /// Maximum age of a message held in the inbox until it is purged.
     #[serde_as(as = "DurationSeconds<u64>")]
+    #[serde(default = "just_15_minutes")]
     pub max_age: Duration,
     /// List of tags that are excluded on `push`.
+    #[serde(default = "default_excluded_tags")]
     pub excluded_tags: Vec<Tag>,
 }
 
-const RAW_15_MINUTES: Duration = Duration::from_secs(15 * 60);
+#[inline]
+fn just_15_minutes() -> Duration {
+    const RAW_15_MINUTES: Duration = Duration::from_secs(15 * 60);
+    RAW_15_MINUTES
+}
+
+#[inline]
+fn default_capacity() -> u32 {
+    512
+}
+
+#[inline]
+fn default_excluded_tags() -> Vec<Tag> {
+    vec![DEFAULT_APPLICATION_TAG]
+}
 
 impl Default for MessageInboxConfiguration {
     fn default() -> Self {
         Self {
-            capacity: 512,
-            max_age: RAW_15_MINUTES,
-            excluded_tags: vec![DEFAULT_APPLICATION_TAG],
+            capacity: default_capacity(),
+            max_age: just_15_minutes(),
+            excluded_tags: default_excluded_tags(),
         }
     }
 }

--- a/hoprd/rest-api/src/config.rs
+++ b/hoprd/rest-api/src/config.rs
@@ -29,20 +29,35 @@ pub enum Auth {
 
 #[derive(Debug, Validate, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Api {
+    /// Selects whether the REST API is enabled
+    #[serde(default)]
     pub enable: bool,
     /// Auth enum holding the API auth configuration
     #[validate(custom = "validate_api_auth")]
+    #[serde(default = "default_api_auth_form")]
     pub auth: Auth,
+    /// Host and port combination where the REST API should be located
     #[validate]
+    #[serde(default = "default_api_host")]
     pub host: HostConfig,
+}
+
+#[inline]
+fn default_api_auth_form() -> Auth {
+    Auth::None
+}
+
+#[inline]
+fn default_api_host() -> HostConfig {
+    HostConfig::from_str(format!("{DEFAULT_API_HOST}:{DEFAULT_API_PORT}").as_str()).unwrap()
 }
 
 impl Default for Api {
     fn default() -> Self {
         Self {
             enable: false,
-            auth: Auth::None,
-            host: HostConfig::from_str(format!("{DEFAULT_API_HOST}:{DEFAULT_API_PORT}").as_str()).unwrap(),
+            auth: default_api_auth_form(),
+            host: default_api_host(),
         }
     }
 }

--- a/transport/api/src/adaptors/network.rs
+++ b/transport/api/src/adaptors/network.rs
@@ -20,7 +20,7 @@ impl ExternalNetworkInteractions {
 
 impl NetworkExternalActions for ExternalNetworkInteractions {
     fn is_public(&self, _: &PeerId) -> bool {
-        // NOTE: In the Providence release all nodes are public
+        // NOTE: In the 2.* releases all nodes are public
         true
     }
 

--- a/transport/api/src/config.rs
+++ b/transport/api/src/config.rs
@@ -28,21 +28,20 @@ pub enum HostType {
     Domain(String),
 }
 
-#[derive(Debug, Serialize, Deserialize, Validate, Clone, PartialEq)]
-pub struct HostConfig {
-    #[validate(custom = "validate_host_address")]
-    pub address: HostType,
-    #[validate(range(min = 1u16))]
-    pub port: u16,
+impl Default for HostType {
+    fn default() -> Self {
+        HostType::IPv4("127.0.0.1".to_owned())
+    }
 }
 
-impl Default for HostConfig {
-    fn default() -> Self {
-        Self {
-            address: HostType::IPv4("127.0.0.1".to_owned()),
-            port: 0,
-        }
-    }
+#[derive(Debug, Default, Serialize, Deserialize, Validate, Clone, PartialEq)]
+pub struct HostConfig {
+    #[validate(custom = "validate_host_address")]
+    #[serde(default)]
+    pub address: HostType,
+    #[validate(range(min = 1u16))]
+    #[serde(default)]
+    pub port: u16,
 }
 
 impl FromStr for HostConfig {
@@ -105,9 +104,11 @@ fn validate_host_address(host: &HostType) -> Result<(), ValidationError> {
 pub struct TransportConfig {
     /// When true, assume that the node is running in an isolated network and does
     /// not need any connection to nodes outside of the subnet
+    #[serde(default)]
     pub announce_local_addresses: bool,
     /// When true, assume a testnet with multiple nodes running on the same machine
     /// or in the same private IPv4 network
+    #[serde(default)]
     pub prefer_local_addresses: bool,
 }
 

--- a/transport/network/src/heartbeat.rs
+++ b/transport/network/src/heartbeat.rs
@@ -39,21 +39,39 @@ use crate::ping::Pinging;
 pub struct HeartbeatConfig {
     /// Round-to-round variance to complicate network sync in seconds
     #[serde_as(as = "DurationSeconds<u64>")]
+    #[serde(default = "default_heartbeat_variance")]
     pub variance: std::time::Duration,
     /// Interval in which the heartbeat is triggered in seconds
     #[serde_as(as = "DurationSeconds<u64>")]
+    #[serde(default = "default_heartbeat_interval")]
     pub interval: std::time::Duration,
     /// The time interval for which to consider peer heartbeat renewal in seconds
     #[serde_as(as = "DurationSeconds<u64>")]
+    #[serde(default = "default_heartbeat_threshold")]
     pub threshold: std::time::Duration,
+}
+
+#[inline]
+fn default_heartbeat_interval() -> std::time::Duration {
+    DEFAULT_HEARTBEAT_INTERVAL
+}
+
+#[inline]
+fn default_heartbeat_threshold() -> std::time::Duration {
+    DEFAULT_HEARTBEAT_THRESHOLD
+}
+
+#[inline]
+fn default_heartbeat_variance() -> std::time::Duration {
+    DEFAULT_HEARTBEAT_INTERVAL_VARIANCE
 }
 
 impl Default for HeartbeatConfig {
     fn default() -> Self {
         Self {
-            interval: DEFAULT_HEARTBEAT_INTERVAL,
-            threshold: DEFAULT_HEARTBEAT_THRESHOLD,
-            variance: DEFAULT_HEARTBEAT_INTERVAL_VARIANCE,
+            interval: default_heartbeat_interval(),
+            threshold: default_heartbeat_threshold(),
+            variance: default_heartbeat_variance(),
         }
     }
 }

--- a/transport/protocol/src/config.rs
+++ b/transport/protocol/src/config.rs
@@ -4,11 +4,15 @@ use validator::Validate;
 #[derive(Debug, Default, Serialize, Deserialize, Validate, Copy, Clone, PartialEq)]
 pub struct ProtocolConfig {
     /// `ack` protocol config
+    #[serde(default)]
     pub ack: crate::ack::config::AckProtocolConfig,
     /// `heartbeat` protocol config
+    #[serde(default)]
     pub heartbeat: crate::heartbeat::config::HeartbeatProtocolConfig,
     /// `msg` protocol config
+    #[serde(default)]
     pub msg: crate::msg::config::MsgProtocolConfig,
     /// `ticket_aggregation` protocol config
+    #[serde(default)]
     pub ticket_aggregation: crate::ticket_aggregation::config::TicketAggregationProtocolConfig,
 }


### PR DESCRIPTION
The PR fixes smaller configuration issues and increases the ergonomics of config file usage:
- [x] Remove unused code in tests
- [x] Fix on-chain address display log
- [x] Fix announce to be set to `true` by default and validate it inside the config before the node starts
- [x] Allow the protocol-config to not be specified in the configuration file to use a default one
- [x] Update all config to have a properly defaulted values for deserialization 

## Notes
Fixes #5928 