### PR TITLE
Peer version check to Promiscuous strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1599,7 +1599,7 @@ dependencies = [
 
 [[package]]
 name = "core-strategy"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-lock 2.8.0",
  "async-std",
@@ -1609,6 +1609,7 @@ dependencies = [
  "chain-types",
  "core-network",
  "core-protocol",
+ "core-transport",
  "env_logger",
  "futures",
  "hex-literal",
@@ -1622,6 +1623,7 @@ dependencies = [
  "log",
  "mockall",
  "rand 0.8.5",
+ "semver 1.0.21",
  "serde",
  "serde_with",
  "strum 0.25.0",

--- a/chain/actions/src/action_queue.rs
+++ b/chain/actions/src/action_queue.rs
@@ -118,7 +118,7 @@ impl ActionSender {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
 pub struct ActionQueueConfig {
     /// Maximum time (in seconds) to wait for the action to be confirmed on-chain and indexed
     /// Defaults to 150 seconds.
@@ -157,7 +157,7 @@ where
             db: self.db.clone(),
             action_state: self.action_state.clone(),
             tx_exec: self.tx_exec.clone(),
-            cfg: self.cfg.clone(),
+            cfg: self.cfg,
         }
     }
 }

--- a/chain/types/src/lib.rs
+++ b/chain/types/src/lib.rs
@@ -234,7 +234,17 @@ impl<M: Middleware> From<&ContractInstances<M>> for ContractAddresses {
 /// Used for testing. When block time is given, new blocks are mined periodically.
 /// Otherwise, a new block is mined per transaction.
 pub fn create_anvil(block_time: Option<std::time::Duration>) -> ethers::utils::AnvilInstance {
-    let mut anvil = ethers::utils::Anvil::new();
+    let output = std::process::Command::new(env!("CARGO"))
+        .arg("locate-project")
+        .arg("--workspace")
+        .arg("--message-format=plain")
+        .output()
+        .unwrap()
+        .stdout;
+    let cargo_path = std::path::Path::new(std::str::from_utf8(&output).unwrap().trim());
+    let workspace_dir = cargo_path.parent().unwrap().to_path_buf();
+
+    let mut anvil = ethers::utils::Anvil::new().path(workspace_dir.join(".foundry/bin/anvil"));
 
     if let Some(bt) = block_time {
         anvil = anvil.block_time(bt.as_secs());

--- a/chain/types/src/lib.rs
+++ b/chain/types/src/lib.rs
@@ -234,17 +234,7 @@ impl<M: Middleware> From<&ContractInstances<M>> for ContractAddresses {
 /// Used for testing. When block time is given, new blocks are mined periodically.
 /// Otherwise, a new block is mined per transaction.
 pub fn create_anvil(block_time: Option<std::time::Duration>) -> ethers::utils::AnvilInstance {
-    let output = std::process::Command::new(env!("CARGO"))
-        .arg("locate-project")
-        .arg("--workspace")
-        .arg("--message-format=plain")
-        .output()
-        .unwrap()
-        .stdout;
-    let cargo_path = std::path::Path::new(std::str::from_utf8(&output).unwrap().trim());
-    let workspace_dir = cargo_path.parent().unwrap().to_path_buf();
-
-    let mut anvil = ethers::utils::Anvil::new().path(workspace_dir.join(".foundry/bin/anvil"));
+    let mut anvil = ethers::utils::Anvil::new();
 
     if let Some(bt) = block_time {
         anvil = anvil.block_time(bt.as_secs());

--- a/logic/strategy/Cargo.toml
+++ b/logic/strategy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-strategy"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Contains implementations of different HOPR strategies"
 edition = "2021"
@@ -18,15 +18,18 @@ async-std = { workspace = true, features = ["unstable"]}
 futures = { workspace = true }
 rand = "0.8.5"
 serde = { workspace = true, features = ["derive"] }
-serde_with = "3.3.0"
+serde_with = { workspace = true }
 lazy_static = { workspace = true }
+semver = "1.0"
 strum = { workspace = true }
 thiserror = { workspace = true }
 validator = { workspace = true }
 
+hopr-crypto-random = { workspace = true }
 hopr-crypto-types = { workspace = true }
 core-network = { workspace = true }
 core-protocol = { workspace = true }
+core-transport = { workspace = true }
 chain-db = { workspace = true }
 chain-actions = { workspace = true }
 utils-db = { workspace = true }

--- a/logic/strategy/src/strategy.rs
+++ b/logic/strategy/src/strategy.rs
@@ -195,7 +195,7 @@ impl MultiStrategy {
         for strategy in cfg.strategies.iter() {
             match strategy {
                 Strategy::Promiscuous(sub_cfg) => strategies.push(Box::new(PromiscuousStrategy::new(
-                    *sub_cfg,
+                    sub_cfg.clone(),
                     db.clone(),
                     network.clone(),
                     chain_actions.clone(),

--- a/misc/utils-db/src/sqlite.rs
+++ b/misc/utils-db/src/sqlite.rs
@@ -296,7 +296,7 @@ mod tests {
         let expected = vec![value_1.as_bytes().into(), value_3.as_bytes().into()];
 
         let mut received = Vec::new();
-        let mut data_stream = kv_storage
+        let data_stream = kv_storage
             .iterate(prefix.as_bytes().into(), (prefixed_key_1.len() - prefix.len()) as u32)
             .await
             .unwrap();

--- a/transport/network/src/network.rs
+++ b/transport/network/src/network.rs
@@ -505,20 +505,6 @@ impl<T: NetworkExternalActions> Network<T> {
         self.entries.values().filter(f).map(|x| x.id).collect::<Vec<_>>()
     }
 
-    pub fn all_peers_with_quality(&self) -> Vec<(PeerId, f64)> {
-        self.entries
-            .values()
-            .map(|status: &PeerStatus| (status.id, status.get_quality()))
-            .collect::<Vec<_>>()
-    }
-
-    pub fn all_peers_with_avg_quality(&self) -> Vec<(PeerStatus, f64)> {
-        self.entries
-            .values()
-            .map(|status: &PeerStatus| (status.clone(), status.get_average_quality()))
-            .collect::<Vec<_>>()
-    }
-
     pub fn all_peers(&self) -> Vec<&PeerStatus> {
         self.entries.values().collect()
     }

--- a/transport/network/src/network.rs
+++ b/transport/network/src/network.rs
@@ -175,7 +175,7 @@ pub trait NetworkExternalActions {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct PeerStatus {
-    id: PeerId,
+    pub id: PeerId,
     pub origin: PeerOrigin,
     pub is_public: bool,
     pub last_seen: u64,         // timestamp
@@ -512,11 +512,15 @@ impl<T: NetworkExternalActions> Network<T> {
             .collect::<Vec<_>>()
     }
 
-    pub fn all_peers_with_avg_quality(&self) -> Vec<(PeerId, f64)> {
+    pub fn all_peers_with_avg_quality(&self) -> Vec<(PeerStatus, f64)> {
         self.entries
             .values()
-            .map(|status: &PeerStatus| (status.id, status.get_average_quality()))
+            .map(|status: &PeerStatus| (status.clone(), status.get_average_quality()))
             .collect::<Vec<_>>()
+    }
+
+    pub fn all_peers(&self) -> Vec<&PeerStatus> {
+        self.entries.values().collect()
     }
 
     pub fn find_peers_to_ping(&self, threshold: u64) -> Vec<PeerId> {

--- a/transport/protocol/src/msg/processor.rs
+++ b/transport/protocol/src/msg/processor.rs
@@ -755,6 +755,7 @@ impl PacketInteraction {
 
                 async move {
                     match processed {
+                        #[cfg_attr(test, allow(unused_variables))]
                         Ok((processed_msg, metadata)) => {
                             #[cfg(all(feature = "prometheus", not(test)))]
                             if let MsgProcessed::Forward(_, _, _, _) = &processed_msg {


### PR DESCRIPTION
This PR introduces check on the minimal node version in order for the promiscuous strategy to start opening channels with it.

The newly introduced `minimum_peer_version` configuration option in `PromiscuousStrategyConfig` is currently set to `>=2.0.0`. The field fully supports Semver version requirement syntax.

Closes #5929