### PR TITLE
Limit the weak crypto option to test and debug builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,8 +177,8 @@ run-local: ## run HOPRd from local repo
 	hoprd --init --api \
 		--password="local" --identity="${id_path}" \
 		--network "${network}" --announce \
-		--testUseWeakCrypto --testAnnounceLocalAddresses \
-		--testPreferLocalAddresses --disableApiAuthentication \
+		--testAnnounceLocalAddresses --testPreferLocalAddresses \
+		--disableApiAuthentication \
 		--protocolConfig $(mydir)scripts/protocol-config-anvil.json \
 		--data /tmp/ \
 		$(args)

--- a/hopli/src/key_pair.rs
+++ b/hopli/src/key_pair.rs
@@ -25,7 +25,7 @@ pub fn read_identities(files: Vec<PathBuf>, password: &str) -> Result<HashMap<St
         match HoprKeys::read_eth_keystore(file_str, password) {
             Ok((keys, needs_migration)) => {
                 if needs_migration {
-                    keys.write_eth_keystore(file_str, password, false)?
+                    keys.write_eth_keystore(file_str, password)?
                 }
                 let file_key = file.file_name().unwrap();
                 results.insert(String::from(file_key.to_str().unwrap()), keys);
@@ -73,7 +73,7 @@ pub fn create_identity(
     if path.exists() {
         return Err(HelperErrors::IdentityFileExists(file_path));
     } else {
-        keys.write_eth_keystore(&file_path, password, false)?;
+        keys.write_eth_keystore(&file_path, password)?;
     }
 
     path.file_name()

--- a/hoprd/hoprd/src/cli.rs
+++ b/hoprd/hoprd/src/cli.rs
@@ -268,16 +268,6 @@ pub struct CliArgs {
     pub test_prefer_local_addresses: bool,
 
     #[arg(
-        long = "testUseWeakCrypto",
-        env = "HOPRD_TEST_USE_WEAK_CRYPTO",
-        action = ArgAction::SetTrue,
-        help = "weaker crypto for faster node startup",
-        hide = true,
-        default_value_t = crate::config::Testing::default().use_weak_crypto
-    )]
-    pub test_use_weak_crypto: bool,
-
-    #[arg(
         long = "heartbeatInterval",
         help = "Interval in milliseconds in which the availability of other nodes get measured",
         value_name = "MILLISECONDS",
@@ -356,6 +346,18 @@ pub struct CliArgs {
     pub protocol_config_path: Option<String>,
 
     // ==================================
+    /// deprecated
+    #[deprecated]
+    #[arg(
+        long = "testUseWeakCrypto",
+        env = "HOPRD_TEST_USE_WEAK_CRYPTO",
+        action = ArgAction::SetTrue,
+        help = "DEPRECATED",
+        hide = true,
+        default_value_t = false
+    )]
+    pub test_use_weak_crypto: bool,
+
     /// deprecated
     #[deprecated]
     #[arg(

--- a/hoprd/hoprd/src/config.rs
+++ b/hoprd/hoprd/src/config.rs
@@ -65,85 +65,12 @@ impl std::fmt::Debug for Identity {
     }
 }
 
-#[derive(Debug, Default, Serialize, Deserialize, Validate, Clone, PartialEq)]
-pub struct Testing {
-    pub use_weak_crypto: bool,
-}
-
 /// The main configuration object of the entire node.
 ///
 /// The configuration is composed of individual configuration of corresponding
 /// component configuration objects.
 ///
 /// An always up-to-date config YAML example can be found in [`EXAMPLE_YAML`].
-///
-/// The default configuration as it would appear from the configuration YAML file.
-/// ```yaml
-/// ---
-///
-/// host:
-///   address: !IPv4 127.0.0.1
-///   port: 47462
-/// identity:
-///   file: identity
-///   password: ''
-///   private_key: ''
-/// db:
-///   data: /tmp/db
-///   initialize: false
-///   force_initialize: false
-/// inbox:
-///   capacity: 512
-///   max_age: 900
-///   excluded_tags:
-///   - 0
-/// api:
-///   enable: true
-///   auth: !Token sdjkghsfg
-/// host:
-///   address: !IPv4 127.0.0.1
-///   port: 1233
-/// strategy:
-///   on_fail_continue: true
-///   allow_recursive: true
-///   strategies: []
-/// heartbeat:
-///   variance: 0
-///   interval: 0
-///   threshold: 0
-/// network_options:
-///   min_delay: 1
-///   max_delay: 300
-///   quality_bad_threshold: 0.2
-///   quality_offline_threshold: 0.0
-///   quality_step: 0.1
-///   ignore_timeframe: 600
-///   backoff_exponent: 1.5
-///   backoff_min: 2.0
-///   backoff_max: 300.0
-/// protocol:
-///   ack:
-///     timeout: 15
-///   heartbeat:
-///     timeout: 15
-///   msg:
-///     timeout: 15
-///   ticket_aggregation:
-///     timeout: 15
-/// network: anvil-localhost
-/// chain:
-///   announce: false
-///   provider: null
-///   check_unrealized_balance: true
-/// safe_module:
-///   safe_transaction_service_provider: null
-///   safe_address: null
-///   module_address: null
-/// test:
-///   announce_local_addresses: false
-///   prefer_local_addresses: false
-///   use_weak_crypto: false
-/// ```
 ///
 #[derive(Debug, Default, Serialize, Deserialize, Validate, Clone, PartialEq)]
 pub struct HoprdConfig {
@@ -159,9 +86,6 @@ pub struct HoprdConfig {
     /// Configuration relevant for the API of the node
     #[validate]
     pub api: Api,
-    /// Testing configurations
-    #[validate]
-    pub test: Testing,
 }
 
 impl From<HoprdConfig> for HoprLibConfig {
@@ -295,9 +219,6 @@ impl HoprdConfig {
             cfg.hopr.safe_module.module_address =
                 Address::from_str(&x).map_err(|e| HoprdError::ValidationError(e.to_string()))?
         };
-
-        // test
-        cfg.test.use_weak_crypto = cli_args.test_use_weak_crypto;
 
         // additional updates
         let home_symbol = '~';
@@ -459,8 +380,6 @@ api:
   host:
     address: !IPv4 127.0.0.1
     port: 1233
-test:
-  use_weak_crypto: false
 "#;
 
 #[cfg(test)]
@@ -560,7 +479,6 @@ mod tests {
                 auth: Auth::None,
                 host: hopr_lib::config::HostConfig::from_str(format!("127.0.0.1:1233").as_str()).unwrap(),
             },
-            test: Testing { use_weak_crypto: false },
         }
     }
 

--- a/hoprd/hoprd/src/main.rs
+++ b/hoprd/hoprd/src/main.rs
@@ -79,7 +79,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         initialize: cfg.hopr.db.initialize,
         id_path: cfg.identity.file.clone(),
         password: cfg.identity.password.clone(),
-        use_weak_crypto: Some(cfg.test.use_weak_crypto),
         private_key: cfg
             .identity
             .private_key

--- a/scripts/setup-local-cluster.sh
+++ b/scripts/setup-local-cluster.sh
@@ -176,7 +176,6 @@ function setup_node() {
       --apiPort "${api_port}" \
       --testAnnounceLocalAddresses \
       --testPreferLocalAddresses \
-      --testUseWeakCrypto \
       --protocolConfig ${protocol_config} \
       ${additional_args} \
       > "${log}" 2>&1 &

--- a/scripts/vm-nat-testing/docker-compose-nat.yaml
+++ b/scripts/vm-nat-testing/docker-compose-nat.yaml
@@ -29,7 +29,7 @@ services:
         hoprd \
           --healthCheck --healthCheckHost 0.0.0.0 --init --api --apiHost 0.0.0.0 --network anvil-localhost \
           --apiToken MyT0ken123^ --password switzerland --testPreferLocalAddresses \
-          --identity /var/hopr/identities/local-nat-node1.id --testUseWeakCrypto
+          --identity /var/hopr/identities/local-nat-node1.id
     volumes:
       - '/var/hopr/identities:/var/hopr/identities'
     networks:
@@ -48,7 +48,7 @@ services:
         hoprd \
           --healthCheck --healthCheckHost 0.0.0.0 --init --api --apiHost 0.0.0.0 --network anvil-localhost \
           --apiToken MyT0ken123^ --password switzerland --testPreferLocalAddresses \
-          --identity /var/hopr/identities/local-nat-node2.id --testUseWeakCrypto
+          --identity /var/hopr/identities/local-nat-node2.id
     volumes:
       - '/var/hopr/identities:/var/hopr/identities'
     networks:

--- a/scripts/vm-nat-testing/docker-compose-pub.yaml
+++ b/scripts/vm-nat-testing/docker-compose-pub.yaml
@@ -16,7 +16,7 @@ services:
         hoprd \
           --healthCheck --healthCheckHost 0.0.0.0 --init --api --apiHost 0.0.0.0 --network anvil-localhost \
           --apiToken MyT0ken123^ --password switzerland --testPreferLocalAddresses \
-          --identity /var/hopr/identities/local-public.id --testUseWeakCrypto --announce
+          --identity /var/hopr/identities/local-public.id --announce
     volumes:
       - '/var/hopr/identities:/var/hopr/identities'
     networks:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -179,7 +179,6 @@ def setup_node(args: dict):
         "--init",
         "--testAnnounceLocalAddresses",
         "--testPreferLocalAddresses",
-        "--testUseWeakCrypto",
         f"--apiPort={args['api_port']}",
         f"--data={args['dir']}",
         f"--host={args['host_addr']}:{args['p2p_port']}",

--- a/tests/node_5.cfg.yaml
+++ b/tests/node_5.cfg.yaml
@@ -121,5 +121,3 @@ healthcheck:
   enable: true
   host: 127.0.0.1
   port: 18085
-test:
-  use_weak_crypto: true


### PR DESCRIPTION
The release build will not have the possibility to use weak-crypto in order to safe-guard possible futures issues associated with such a setup.