### PR TITLE
Fix retry queue counters and make contract call error logs more specific

### DIFF
--- a/chain/rpc/src/client.rs
+++ b/chain/rpc/src/client.rs
@@ -54,7 +54,7 @@ lazy_static::lazy_static! {
 /// at a constant delay of `initial_backoff` if `backoff_on_transport_errors` is not set.
 /// No more additional retries are allowed on new requests, if the maximum number of concurrent
 /// requests being retried has reached `max_retry_queue_size`.
-#[derive(Clone, Debug, Serialize, Deserialize, Validate)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Validate)]
 pub struct SimpleJsonRpcRetryPolicy {
     /// Maximum number of retries.
     /// If `None` is given, will keep retrying indefinitely.
@@ -80,10 +80,10 @@ pub struct SimpleJsonRpcRetryPolicy {
     /// Default is false.
     pub backoff_on_transport_errors: bool,
     /// List of JSON RPC errors that should be retried with backoff
-    /// Default is [429, -32005, -32016]
+    /// Default is \[429, -32005, -32016\]
     pub retryable_json_rpc_errors: Vec<i64>,
     /// List of HTTP errors that should be retried with backoff.
-    /// Default is [429]
+    /// Default is \[429\]
     pub retryable_http_errors: Vec<http_types::StatusCode>,
     /// Maximum number of different requests that are being retried at the same time.
     /// If any additional request fails after this number is attained, it won't be retried.
@@ -335,6 +335,8 @@ where
             RetryParams::Value(params)
         };
 
+        let in_queue = self.requests_enqueued.fetch_add(1, Ordering::SeqCst);
+
         let mut num_retries = 0;
         loop {
             let err;
@@ -363,17 +365,20 @@ where
                 }
             }
 
-            match self
-                .retry_policy
-                .is_retryable_error(&err, num_retries, self.requests_enqueued.load(Ordering::SeqCst))
-            {
+            match self.retry_policy.is_retryable_error(&err, num_retries, in_queue) {
                 NoRetry => {
+                    self.requests_enqueued.fetch_sub(1, Ordering::SeqCst);
+                    warn!("no more retries for RPC call {method}");
+
                     #[cfg(all(feature = "prometheus", not(test)))]
                     METRIC_RETRIES_PER_RPC_CALL.observe(&[method], num_retries as f64);
 
                     return Err(err);
                 }
-                RetryAfter(backoff) => async_std::task::sleep(backoff).await,
+                RetryAfter(backoff) => {
+                    warn!("RPC call {method} will retry in {}ms", backoff.as_millis());
+                    async_std::task::sleep(backoff).await
+                }
             }
         }
     }
@@ -394,12 +399,17 @@ pub mod native {
         /// Timeout for HTTP POST request
         /// Defaults to 5 seconds.
         pub http_request_timeout: Duration,
+
+        /// Maximum number of HTTP redirects to follow
+        /// Defaults to 3
+        pub max_redirects: u8,
     }
 
     impl Default for HttpPostRequestorConfig {
         fn default() -> Self {
             Self {
                 http_request_timeout: Duration::from_secs(5),
+                max_redirects: 3,
             }
         }
     }
@@ -417,7 +427,7 @@ pub mod native {
             // Here we do not set the timeout into the client's configuration
             // but rather the timeout is set on the entire Future in `http_post`
             Self {
-                client: surf::client(),
+                client: surf::client().with(surf::middleware::Redirect::new(cfg.max_redirects)),
                 cfg,
             }
         }
@@ -488,6 +498,7 @@ pub mod tests {
     use hopr_crypto_types::keypairs::{ChainKeypair, Keypair};
     use hopr_primitive_types::primitives::Address;
     use serde_json::json;
+    use std::sync::atomic::Ordering;
     use std::time::Duration;
 
     use crate::client::native::SurfRequestor;
@@ -540,6 +551,12 @@ pub mod tests {
             assert!(number.as_u64() > last_number, "next block number must be greater");
             last_number = number.as_u64();
         }
+
+        assert_eq!(
+            0,
+            client.requests_enqueued.load(Ordering::SeqCst),
+            "retry queue should be zero on successful requests"
+        );
     }
 
     #[async_std::test]
@@ -616,6 +633,11 @@ pub mod tests {
 
         m.assert();
         assert!(matches!(err, JsonRpcProviderClientError::BackendError(_)));
+        assert_eq!(
+            0,
+            client.requests_enqueued.load(Ordering::SeqCst),
+            "retry queue should be zero when policy says no more retries"
+        );
     }
 
     #[async_std::test]
@@ -639,6 +661,11 @@ pub mod tests {
 
         m.assert();
         assert!(matches!(err, JsonRpcProviderClientError::BackendError(_)));
+        assert_eq!(
+            0,
+            client.requests_enqueued.load(Ordering::SeqCst),
+            "retry queue should be zero when policy says no more retries"
+        );
     }
 
     #[async_std::test]
@@ -680,6 +707,11 @@ pub mod tests {
 
         m.assert();
         assert!(matches!(err, JsonRpcProviderClientError::JsonRpcError(_)));
+        assert_eq!(
+            0,
+            client.requests_enqueued.load(Ordering::SeqCst),
+            "retry queue should be zero when policy says no more retries"
+        );
     }
 
     #[async_std::test]
@@ -721,6 +753,11 @@ pub mod tests {
 
         m.assert();
         assert!(matches!(err, JsonRpcProviderClientError::JsonRpcError(_)));
+        assert_eq!(
+            0,
+            client.requests_enqueued.load(Ordering::SeqCst),
+            "retry queue should be zero when policy says no more retries"
+        );
     }
 
     #[async_std::test]
@@ -761,5 +798,10 @@ pub mod tests {
 
         m.assert();
         assert!(matches!(err, JsonRpcProviderClientError::SerdeJson { .. }));
+        assert_eq!(
+            0,
+            client.requests_enqueued.load(Ordering::SeqCst),
+            "retry queue should be zero when policy says no more retries"
+        );
     }
 }

--- a/chain/rpc/src/errors.rs
+++ b/chain/rpc/src/errors.rs
@@ -1,6 +1,5 @@
 use ethers::prelude::nonce_manager::NonceManagerError;
 use ethers::prelude::signer::SignerMiddlewareError;
-use ethers::prelude::ContractError;
 use ethers_providers::{JsonRpcError, ProviderError};
 use thiserror::Error;
 
@@ -9,8 +8,8 @@ pub enum RpcError {
     #[error("error on backend interface: {0}")]
     InterfaceError(String),
 
-    #[error("contract error: {0}")]
-    ContractError(String),
+    #[error("error in smart contract '{0}' while executing '{1}': {2}")]
+    ContractError(String, String, String),
 
     #[error("middleware error: {0}")]
     MiddlewareError(String),
@@ -55,15 +54,6 @@ where
 {
     fn from(value: SignerMiddlewareError<M, S>) -> Self {
         Self::MiddlewareError(value.to_string())
-    }
-}
-
-impl<M> From<ContractError<M>> for RpcError
-where
-    M: ethers::middleware::Middleware,
-{
-    fn from(value: ContractError<M>) -> Self {
-        Self::ContractError(value.to_string())
     }
 }
 

--- a/chain/rpc/src/rpc.rs
+++ b/chain/rpc/src/rpc.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 use validator::Validate;
 
 use crate::errors::Result;
+use crate::errors::RpcError::ContractError;
 use crate::{HoprRpcOperations, PendingTransaction};
 
 /// Configuration of the RPC related parameters.
@@ -132,46 +133,72 @@ impl<P: JsonRpcClient + 'static> HoprRpcOperations for RpcOperations<P> {
 
                 Ok(Balance::new(native, BalanceType::Native))
             }
-            BalanceType::HOPR => {
-                let token_balance = self.contract_instances.token.balance_of(address.into()).call().await?;
-
-                Ok(Balance::new(token_balance, BalanceType::HOPR))
-            }
+            BalanceType::HOPR => match self.contract_instances.token.balance_of(address.into()).call().await {
+                Ok(token_balance) => Ok(Balance::new(token_balance, BalanceType::HOPR)),
+                Err(e) => Err(ContractError(
+                    "HoprToken".to_string(),
+                    "balance_of".to_string(),
+                    e.to_string(),
+                )),
+            },
         }
     }
 
     async fn get_node_management_module_target_info(&self, target: Address) -> Result<Option<U256>> {
-        let (exists, target) = self.node_module.try_get_target(target.into()).call().await?;
-
-        Ok(exists.then_some(target))
+        match self.node_module.try_get_target(target.into()).call().await {
+            Ok((exists, target)) => Ok(exists.then_some(target)),
+            Err(e) => Err(ContractError(
+                "NodeModule".to_string(),
+                "try_get_target".to_string(),
+                e.to_string(),
+            )),
+        }
     }
 
     async fn get_safe_from_node_safe_registry(&self, node_address: Address) -> Result<Address> {
-        let addr = self
+        match self
             .contract_instances
             .safe_registry
             .node_to_safe(node_address.into())
             .call()
-            .await?;
-
-        Ok(addr.into())
+            .await
+        {
+            Ok(addr) => Ok(addr.into()),
+            Err(e) => Err(ContractError(
+                "SafeRegistry".to_string(),
+                "node_to_safe".to_string(),
+                e.to_string(),
+            )),
+        }
     }
 
     async fn get_module_target_address(&self) -> Result<Address> {
-        let owner = self.node_module.owner().call().await?;
-        Ok(owner.into())
+        match self.node_module.owner().call().await {
+            Ok(owner) => Ok(owner.into()),
+            Err(e) => Err(ContractError(
+                "NodeModule".to_string(),
+                "owner".to_string(),
+                e.to_string(),
+            )),
+        }
     }
 
     async fn get_channel_closure_notice_period(&self) -> Result<Duration> {
         // TODO: should we cache this value internally ?
-        let notice_period = self
+        match self
             .contract_instances
             .channels
             .notice_period_channel_closure()
             .call()
-            .await?;
-
-        Ok(Duration::from_secs(notice_period as u64))
+            .await
+        {
+            Ok(notice_period) => Ok(Duration::from_secs(notice_period as u64)),
+            Err(e) => Err(ContractError(
+                "HoprChannels".to_string(),
+                "notice_period_channel_closure".to_string(),
+                e.to_string(),
+            )),
+        }
     }
 
     async fn send_transaction(&self, tx: TypedTransaction) -> Result<PendingTransaction> {
@@ -185,8 +212,7 @@ impl<P: JsonRpcClient + 'static> HoprRpcOperations for RpcOperations<P> {
             .send_transaction(tx, None)
             .await?
             .confirmations(self.cfg.tx_confirmations)
-            .interval(self.cfg.tx_polling_interval); // This is the default, but let's be explicit
-                                                     // This has built-in max polling retries set to 3
+            .interval(self.cfg.tx_polling_interval);
 
         Ok(sent_tx.into())
     }

--- a/hopr/hopr-lib/src/chain.rs
+++ b/hopr/hopr-lib/src/chain.rs
@@ -345,13 +345,13 @@ pub fn build_chain_components<Db>(
 where
     Db: HoprCoreEthereumDbActions + Clone + Send + Sync + 'static,
 {
-    let rpc_client = JsonRpcClient::new(
-        &chain_config.chain.default_provider,
-        DefaultHttpPostRequestor::default(),
-        SimpleJsonRpcRetryPolicy::default(),
-    );
+    // TODO: extract this from the global config type
+    let rpc_http_config = chain_rpc::client::native::HttpPostRequestorConfig::default();
 
-    // TODO: extract these configs from the global config type
+    // TODO: extract this from the global config type
+    let rpc_http_retry_policy = SimpleJsonRpcRetryPolicy::default();
+
+    // TODO: extract this from the global config type
     let rpc_cfg = RpcOperationsConfig {
         chain_id: chain_config.chain.chain_id as u64,
         contract_addrs,
@@ -361,26 +361,43 @@ where
         tx_confirmations: chain_config.confirmations as usize,
         logs_page_size: chain_config.logs_page_size,
     };
+
+    // TODO: extract this from the global config type
     let rpc_client_cfg = RpcEthereumClientConfig::default();
+
+    // TODO: extract this from the global config type
     let action_queue_cfg = ActionQueueConfig::default();
 
+    // --- Configs done ---
+
+    // Build JSON RPC client
+    let rpc_client = JsonRpcClient::new(
+        &chain_config.chain.default_provider,
+        DefaultHttpPostRequestor::new(rpc_http_config),
+        rpc_http_retry_policy,
+    );
+
+    // Build RPC operations
     let rpc_operations = RpcOperations::new(rpc_client, me_onchain, rpc_cfg).expect("failed to initialize RPC");
 
+    // Build the Ethereum Transaction Executor that uses RpcOperations as backend
     let ethereum_tx_executor = EthereumTransactionExecutor::new(
         RpcEthereumClient::new(rpc_operations.clone(), rpc_client_cfg),
         SafePayloadGenerator::new(me_onchain, contract_addrs, module_address),
     );
 
-    let tx_queue = ActionQueue::new(
+    // Build the Action Queue
+    let action_queue = ActionQueue::new(
         db.clone(),
         IndexerActionTracker::default(),
         ethereum_tx_executor,
         action_queue_cfg,
     );
 
-    let chain_actions = CoreEthereumActions::new(me_onchain.public().to_address(), db, tx_queue.new_sender());
+    // Instantiate Chain Actions
+    let chain_actions = CoreEthereumActions::new(me_onchain.public().to_address(), db, action_queue.new_sender());
 
-    (tx_queue, chain_actions, rpc_operations)
+    (action_queue, chain_actions, rpc_operations)
 }
 
 #[allow(clippy::too_many_arguments)] // TODO: refactor this function into a reasonable group of components once fully rearchitected


### PR DESCRIPTION
This PR addresses the following issues:

- fix the retry queue counter in `JsonRpcProviderClient`
- add logs to contract errors
- allow HTTP client for JSON-RPC to follow redirects, defaults to 3
- consolidate chain config structs in hopr-lib

Fixes #5940