### PR TITLE
show correct balances in `/api/v3/balances`

### DIFF
--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -729,27 +729,27 @@ mod account {
         let mut account_balances = AccountBalances::default();
 
         match hopr.get_balance(BalanceType::Native).await {
-            Ok(v) => account_balances.native = v.to_string(),
+            Ok(v) => account_balances.native = v.to_formatted_string(),
             Err(e) => return Ok(Response::builder(422).body(ApiErrorStatus::from(e)).build()),
         }
 
         match hopr.get_balance(BalanceType::HOPR).await {
-            Ok(v) => account_balances.hopr = v.to_string(),
+            Ok(v) => account_balances.hopr = v.to_formatted_string(),
             Err(e) => return Ok(Response::builder(422).body(ApiErrorStatus::from(e)).build()),
         }
 
         match hopr.get_safe_balance(BalanceType::Native).await {
-            Ok(v) => account_balances.safe_native = v.to_string(),
+            Ok(v) => account_balances.safe_native = v.to_formatted_string(),
             Err(e) => return Ok(Response::builder(422).body(ApiErrorStatus::from(e)).build()),
         }
 
         match hopr.get_safe_balance(BalanceType::HOPR).await {
-            Ok(v) => account_balances.safe_hopr = v.to_string(),
+            Ok(v) => account_balances.safe_hopr = v.to_formatted_string(),
             Err(e) => return Ok(Response::builder(422).body(ApiErrorStatus::from(e)).build()),
         }
 
         match hopr.safe_allowance().await {
-            Ok(v) => account_balances.safe_hopr_allowance = v.to_string(),
+            Ok(v) => account_balances.safe_hopr_allowance = v.to_formatted_string(),
             Err(e) => return Ok(Response::builder(422).body(ApiErrorStatus::from(e)).build()),
         }
 


### PR DESCRIPTION
Fixes the output of the API such that instead of

```
  "hopr": "0 HOPR",
  "native": "1724078124190735752 Native",
  "safeHopr": "30000000000000000000000 HOPR",
  "safeHoprAllowance": "1000000000000000000000 HOPR",
  "safeNative": "2000000000000000000 Native"
```
it shows
```

  "hopr": "0 HOPR",
  "native": "1.724078124190735752 Native",
  "safeHopr": "30000.000000000000000000 HOPR",
  "safeHoprAllowance": "1000.000000000000000000 HOPR",
  "safeNative": "2.000000000000000000 Native"
```