### PR TITLE
nix: Use native solc for macos-aarch

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -83,11 +83,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1707516017,
-        "narHash": "sha256-RuMnQDlX+kxsdaSSocleAVvoaaKU9EvpFyKIc1AmUbI=",
+        "lastModified": 1708509800,
+        "narHash": "sha256-Aq0pD6Knm0JPol3FGzWZbDh7bEWGT60j20znD8XebQ8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "440117328b114fbbb76c6b91233af2d0519cbf6c",
+        "rev": "37377f6e62b088ff314c795bc849bd48357ceb6a",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1706563406,
-        "narHash": "sha256-XoMphCwfqx00wx/2nALvMPEAmD32A8lwSmwI5MNopyA=",
-        "owner": "hellwolf",
+        "lastModified": 1708510088,
+        "narHash": "sha256-Y4tbFuwnMeOqd2UA+Qxc8adoEonRc9H2A+FyLadpJiU=",
+        "owner": "hoprnet",
         "repo": "solc.nix",
-        "rev": "c863de2fa3721fc4201484c084a49e996ce21e19",
+        "rev": "b537586ab902ccbd3b6c0ae975ea7c7f81013add",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -168,7 +168,8 @@
         "type": "github"
       },
       "original": {
-        "owner": "hellwolf",
+        "owner": "hoprnet",
+        "ref": "tb/20240129-solc-0.8.24",
         "repo": "solc.nix",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -83,11 +83,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708509800,
-        "narHash": "sha256-Aq0pD6Knm0JPol3FGzWZbDh7bEWGT60j20znD8XebQ8=",
+        "lastModified": 1708511848,
+        "narHash": "sha256-X7/4attuvaG5DiORUuTjYMK5+ktai80GjtCLYWsuvts=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "37377f6e62b088ff314c795bc849bd48357ceb6a",
+        "rev": "7e5e0e3c9f31fa60340a4ab4b0c84477d5cf261b",
         "type": "github"
       },
       "original": {
@@ -160,11 +160,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1708510088,
-        "narHash": "sha256-Y4tbFuwnMeOqd2UA+Qxc8adoEonRc9H2A+FyLadpJiU=",
+        "lastModified": 1708511980,
+        "narHash": "sha256-Nf04LYEAMDZ+H4s0t7/PIV6Xe9lHuCnNM3qESlIhJl4=",
         "owner": "hoprnet",
         "repo": "solc.nix",
-        "rev": "b537586ab902ccbd3b6c0ae975ea7c7f81013add",
+        "rev": "29a2a4a0c0787bcffdebcb0046c1b5a43f955ef3",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,5 @@
 {
   description = "hoprnet monorepo";
-
-
   inputs.flake-utils.url = github:numtide/flake-utils;
   inputs.flake-parts.url = github:hercules-ci/flake-parts;
   inputs.nixpkgs.url = github:NixOS/nixpkgs/master;
@@ -11,7 +9,8 @@
   # using a fork with an added source filter
   inputs.crane.url = github:hoprnet/crane/tb/20240117-find-filter;
   inputs.foundry.url = github:shazow/foundry.nix/monthly;
-  inputs.solc.url = github:hellwolf/solc.nix;
+  # use change to add solc 0.8.24
+  inputs.solc.url = github:hoprnet/solc.nix/tb/20240129-solc-0.8.24;
 
   inputs.rust-overlay.inputs.nixpkgs.follows = "nixpkgs";
   inputs.rust-overlay.inputs.flake-utils.follows = "flake-utils";
@@ -44,7 +43,7 @@
             version = pkgs.lib.strings.concatStringsSep "."
               (pkgs.lib.lists.take 3 (builtins.splitVersion hoprdCrateInfoOriginal.version));
           };
-          solcDefault = with pkgs; (solc.mkDefault pkgs solc_0_8_19);
+          solcDefault = with pkgs; (solc.mkDefault pkgs solc_0_8_24);
           depsSrc = fs.toSource {
             root = ./.;
             fileset = fs.unions [

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,6 @@
 {
   description = "hoprnet monorepo";
+
   inputs.flake-utils.url = github:numtide/flake-utils;
   inputs.flake-parts.url = github:hercules-ci/flake-parts;
   inputs.nixpkgs.url = github:NixOS/nixpkgs/master;
@@ -43,7 +44,7 @@
             version = pkgs.lib.strings.concatStringsSep "."
               (pkgs.lib.lists.take 3 (builtins.splitVersion hoprdCrateInfoOriginal.version));
           };
-          solcDefault = with pkgs; (solc.mkDefault pkgs solc_0_8_24);
+          solcDefault = with pkgs; (solc.mkDefault pkgs solc_0_8_19);
           depsSrc = fs.toSource {
             root = ./.;
             fileset = fs.unions [


### PR DESCRIPTION
Using an adapted solc overlay which chooses the correct source for the `solc` binary to support macos-aarch.

Uses changes from https://github.com/hellwolf/solc.nix/pull/2