### PR TITLE
Optimized getLogs queries

### DIFF
--- a/chain/rpc/src/indexer.rs
+++ b/chain/rpc/src/indexer.rs
@@ -71,7 +71,7 @@ impl<P: JsonRpcClient + 'static> HoprIndexerRpcOperations for RpcOperations<P> {
 
                         // Range of blocks to fetch is always bounded
                         let range_size = self.cfg.max_block_range_fetch_size.min(latest_block - from_block);
-                        debug!("polling logs from blocks #{from_block} - #{latest_block} (range size {page_size})");
+                        debug!("polling logs from blocks #{from_block} - #{latest_block} (range size {range_size})");
 
                         // If we're fetching logs from wide block range, we'll use the pagination log query.
                         let mut retrieved_logs = if range_size >= self.cfg.min_block_range_fetch_size {

--- a/chain/rpc/src/indexer.rs
+++ b/chain/rpc/src/indexer.rs
@@ -70,19 +70,18 @@ impl<P: JsonRpcClient + 'static> HoprIndexerRpcOperations for RpcOperations<P> {
                             .to_block(BlockNumber::Number(latest_block.into()));
 
                         // Range of blocks to fetch is always bounded
-                        let page_size = self.cfg.max_block_range_fetch_size.min(latest_block - from_block);
+                        let range_size = self.cfg.max_block_range_fetch_size.min(latest_block - from_block);
+                        debug!("polling logs from blocks #{from_block} - #{latest_block} (range size {page_size})");
 
                         // If we're fetching logs from wide block range, we'll use the pagination log query.
-                        // For just a single block, we use the ordinary getLogs call which minimizes RPC calls
-                        let mut retrieved_logs = if page_size > 0 {
-                            debug!("polling logs from blocks #{from_block} - #{latest_block} (page {page_size})");
-                            self.provider.get_logs_paginated(&range_filter, page_size).boxed()
+                        let mut retrieved_logs = if range_size >= self.cfg.min_block_range_fetch_size {
+                            self.provider.get_logs_paginated(&range_filter, range_size).boxed()
                         } else {
-                            debug!("polling logs from block #{from_block}");
+                            // For smaller block ranges, we use the ordinary getLogs call which minimizes RPC calls
                             futures::stream::iter(self.provider.get_logs(&range_filter)
                                 .await
                                 .unwrap_or_else(|e| {
-                                    error!("polling logs from block #{from_block} failed: {e}");
+                                    error!("polling logs from #{from_block} - #{latest_block} failed: {e}");
                                     Vec::new()
                                 })
                                 .into_iter()

--- a/chain/rpc/src/rpc.rs
+++ b/chain/rpc/src/rpc.rs
@@ -34,8 +34,13 @@ pub struct RpcOperationsConfig {
     /// Expected block time of the blockchain
     /// Defaults to 5 seconds
     pub expected_block_time: Duration,
-    /// The largest amount of blocks to fetch at once when fetching a historical range of blocks.
-    /// If the requested block range is N, then the client will always fetch `min(N, max_block_range_fetch_size)`
+    /// Minimum size of the block range where batch fetch query should be used.
+    /// For block ranges smaller than this size, the ordinary `getLogs` will be called without pagination.
+    /// Defaults to 3.
+    #[validate(range(min = 1))]
+    pub min_block_range_fetch_size: u64,
+    /// The largest amount of blocks to fetch at once when fetching a range of blocks.
+    /// If the requested block range size is N, then the client will always fetch `min(N, max_block_range_fetch_size)`
     /// Defaults to 2500 blocks
     #[validate(range(min = 1))]
     pub max_block_range_fetch_size: u64,
@@ -59,6 +64,7 @@ impl Default for RpcOperationsConfig {
             chain_id: 100,
             contract_addrs: Default::default(),
             module_address: Default::default(),
+            min_block_range_fetch_size: 3,
             max_block_range_fetch_size: 2500,
             expected_block_time: Duration::from_secs(5),
             tx_polling_interval: Duration::from_secs(7),

--- a/chain/types/src/chain_events.rs
+++ b/chain/types/src/chain_events.rs
@@ -14,6 +14,12 @@ pub struct SignificantChainEvent {
     pub event_type: ChainEventType,
 }
 
+impl Display for SignificantChainEvent {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} @ tx {}", self.event_type, self.tx_hash)
+    }
+}
+
 /// Status of a node in network registry.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum NetworkRegistryStatus {

--- a/hopr/hopr-lib/src/chain.rs
+++ b/hopr/hopr-lib/src/chain.rs
@@ -359,6 +359,7 @@ where
         expected_block_time: Duration::from_millis(chain_config.chain.block_time),
         tx_polling_interval: Duration::from_millis(chain_config.tx_polling_interval),
         finality: chain_config.confirmations,
+        min_block_range_fetch_size: 3,
         max_block_range_fetch_size: chain_config.max_block_range,
     };
 

--- a/hopr/hopr-lib/tests/chain_integration_tests.rs
+++ b/hopr/hopr-lib/tests/chain_integration_tests.rs
@@ -270,6 +270,7 @@ async fn integration_test_indexer() {
         expected_block_time: block_time,
         tx_polling_interval: Duration::from_millis(100),
         max_block_range_fetch_size: 100,
+        min_block_range_fetch_size: 3,
     };
 
     let actions_cfg = ActionQueueConfig {


### PR DESCRIPTION
The raw `eth_getLogs` is now used for small block ranges (0-2), for wider block ranges (>= 3,practically only during sync) the paginated getLogs query is used.

Previously, the pagination was used already from ranges of size >= 2