### PR TITLE
Remove deprecated docker images from workflows

### DIFF
--- a/.github/workflows/clean-pr.yaml
+++ b/.github/workflows/clean-pr.yaml
@@ -54,7 +54,7 @@ jobs:
         run: |
           docker_registry="europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/docker-images"
           next_version=$(./scripts/get-next-version.sh Build ${{ github.event.inputs.pr_number }})
-          images=('hopli' 'hoprd' 'hopr-anvil' 'hopr-pluto')
+          images=('hopli' 'hoprd')
           for image in "${images[@]}"; do
             echo "Removing tag: $image:${next_version} and $image:${next_version}-cache"
             gcloud artifacts docker images delete --quiet --delete-tags --async ${docker_registry}/$image:${next_version} || true

--- a/.github/workflows/clean-pr.yaml
+++ b/.github/workflows/clean-pr.yaml
@@ -54,7 +54,7 @@ jobs:
         run: |
           docker_registry="europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/docker-images"
           next_version=$(./scripts/get-next-version.sh Build ${{ github.event.inputs.pr_number }})
-          images=('hopli' 'hoprd' 'hopr-anvil' 'hopr-pluto' 'hopr-toolchain')
+          images=('hopli' 'hoprd' 'hopr-anvil' 'hopr-pluto')
           for image in "${images[@]}"; do
             echo "Removing tag: $image:${next_version} and $image:${next_version}-cache"
             gcloud artifacts docker images delete --quiet --delete-tags --async ${docker_registry}/$image:${next_version} || true

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -53,7 +53,7 @@ jobs:
         run: |
           docker_registry="europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/docker-images"
           date=`date +%Y-%m-%d'T'%H:%M'Z' -d "60 days ago"`
-          images=('hopli' 'hoprd' 'hopr-anvil' 'hopr-pluto')
+          images=('hopli' 'hoprd')
           for image in "${images[@]}"; do
             old_pr_image_tags=$(gcloud artifacts docker images list --include-tags ${docker_registry}/${image} --format="json" 2> /dev/null | jq -r --arg date "$date"  '.[]  | select(.updateTime < $date) | select(.tags | match("-pr.")).version')
             old_untagged_images=$(gcloud artifacts docker images list --include-tags ${docker_registry}/${image} --format="json" 2> /dev/null | jq -r --arg date "$date"  '.[]  | select(.updateTime < $date) | select(.tags | length == 0).version')

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -53,7 +53,7 @@ jobs:
         run: |
           docker_registry="europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/docker-images"
           date=`date +%Y-%m-%d'T'%H:%M'Z' -d "60 days ago"`
-          images=('hopli' 'hoprd' 'hopr-anvil' 'hopr-pluto' 'hopr-toolchain')
+          images=('hopli' 'hoprd' 'hopr-anvil' 'hopr-pluto')
           for image in "${images[@]}"; do
             old_pr_image_tags=$(gcloud artifacts docker images list --include-tags ${docker_registry}/${image} --format="json" 2> /dev/null | jq -r --arg date "$date"  '.[]  | select(.updateTime < $date) | select(.tags | match("-pr.")).version')
             old_untagged_images=$(gcloud artifacts docker images list --include-tags ${docker_registry}/${image} --format="json" 2> /dev/null | jq -r --arg date "$date"  '.[]  | select(.updateTime < $date) | select(.tags | length == 0).version')

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -99,7 +99,7 @@ jobs:
           fi
 
           # Tag images
-          images=(hopli hoprd hopr-anvil hopr-pluto)
+          images=(hopli hoprd)
           for image in ${images[@]}; do
             echo "Tagging ${image}:${docker_release_latest_tag}"
             gcloud artifacts docker tags add ${docker_registry}/${image}:${docker_pr_tag} ${docker_registry}/${image}:${docker_release_latest_tag}
@@ -201,7 +201,7 @@ jobs:
       - name: Tag docker images with release name
         run: |
           docker_registry="europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/docker-images"
-          images=(hopli hoprd hopr-anvil hopr-pluto)
+          images=(hopli hoprd)
           for image in ${images[@]};
           do
             echo "Tagging ${image}:${{ steps.tag.outputs.release_name }}"

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -99,7 +99,7 @@ jobs:
           fi
 
           # Tag images
-          images=(hopr-toolchain hopli hoprd hopr-anvil hopr-pluto)
+          images=(hopli hoprd hopr-anvil hopr-pluto)
           for image in ${images[@]}; do
             echo "Tagging ${image}:${docker_release_latest_tag}"
             gcloud artifacts docker tags add ${docker_registry}/${image}:${docker_pr_tag} ${docker_registry}/${image}:${docker_release_latest_tag}
@@ -201,7 +201,7 @@ jobs:
       - name: Tag docker images with release name
         run: |
           docker_registry="europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/docker-images"
-          images=(hopr-toolchain hopli hoprd hopr-anvil hopr-pluto)
+          images=(hopli hoprd hopr-anvil hopr-pluto)
           for image in ${images[@]};
           do
             echo "Tagging ${image}:${{ steps.tag.outputs.release_name }}"

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Tag docker images with release name
         run: |
           docker_registry="europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/docker-images"
-          images=(hopr-toolchain hopli hoprd hopr-anvil hopr-pluto)
+          images=(hopli hoprd hopr-anvil hopr-pluto)
           for image in ${images[@]};
           do
             echo "Tagging ${image}"

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Tag docker images with release name
         run: |
           docker_registry="europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/docker-images"
-          images=(hopli hoprd hopr-anvil hopr-pluto)
+          images=(hopli hoprd)
           for image in ${images[@]};
           do
             echo "Tagging ${image}"


### PR DESCRIPTION
As in title, removes the `hopr-toolchain`, `hopr-anvil` and `hopr-pluto` images from the GH workflows, as these images no longer exist.