### PR TITLE
Do not re-announce on-chain if node has previously announced

### DIFF
--- a/chain/actions/src/errors.rs
+++ b/chain/actions/src/errors.rs
@@ -17,6 +17,9 @@ pub enum CoreEthereumActionsError {
     #[error("channel closure time has not elapsed yet, remaining {0}s")]
     ClosureTimeHasNotElapsed(u64),
 
+    #[error("multiaddress has been already announced on-chain")]
+    AlreadyAnnounced,
+
     #[error("network registry does not allow accessing this peer")]
     PeerAccessDenied,
 

--- a/chain/actions/src/node.rs
+++ b/chain/actions/src/node.rs
@@ -10,6 +10,7 @@ use hopr_internal_types::prelude::*;
 use hopr_primitive_types::prelude::*;
 use log::info;
 use multiaddr::Multiaddr;
+use hopr_crypto_types::prelude::Keypair;
 
 /// Contains all on-chain calls specific to HOPR node itself.
 #[async_trait]
@@ -47,7 +48,7 @@ impl<Db: HoprCoreEthereumDbActions + Clone + Send + Sync> NodeActions for CoreEt
             .await?
             .into_iter()
             .any(|account| {
-                account.get_multiaddr().is_some_and(|ma| ma.eq(multiaddr)) && account.public_key.eq(offchain_key)
+                account.get_multiaddr().is_some_and(|ma| ma.eq(multiaddr)) && account.public_key.eq(offchain_key.public())
             })
         {
             let announcement_data = AnnouncementData::new(multiaddr, Some(KeyBinding::new(self.me, offchain_key)))?;

--- a/chain/actions/src/node.rs
+++ b/chain/actions/src/node.rs
@@ -39,14 +39,14 @@ impl<Db: HoprCoreEthereumDbActions + Clone + Send + Sync> NodeActions for CoreEt
     }
 
     async fn announce(&self, multiaddr: &Multiaddr, offchain_key: &OffchainKeypair) -> Result<PendingAction> {
-        if self
+        if !self
             .db
             .read()
             .await
             .get_public_node_accounts()
             .await?
             .into_iter()
-            .none(|account| {
+            .any(|account| {
                 account.get_multiaddr().is_some_and(|ma| ma.eq(multiaddr)) && account.public_key.eq(offchain_key)
             })
         {

--- a/chain/actions/src/node.rs
+++ b/chain/actions/src/node.rs
@@ -6,11 +6,11 @@ use async_trait::async_trait;
 use chain_db::traits::HoprCoreEthereumDbActions;
 use chain_types::actions::Action;
 use hopr_crypto_types::keypairs::OffchainKeypair;
+use hopr_crypto_types::prelude::Keypair;
 use hopr_internal_types::prelude::*;
 use hopr_primitive_types::prelude::*;
 use log::info;
 use multiaddr::Multiaddr;
-use hopr_crypto_types::prelude::Keypair;
 
 /// Contains all on-chain calls specific to HOPR node itself.
 #[async_trait]
@@ -48,7 +48,8 @@ impl<Db: HoprCoreEthereumDbActions + Clone + Send + Sync> NodeActions for CoreEt
             .await?
             .into_iter()
             .any(|account| {
-                account.get_multiaddr().is_some_and(|ma| ma.eq(multiaddr)) && account.public_key.eq(offchain_key.public())
+                account.get_multiaddr().is_some_and(|ma| ma.eq(multiaddr))
+                    && account.public_key.eq(offchain_key.public())
             })
         {
             let announcement_data = AnnouncementData::new(multiaddr, Some(KeyBinding::new(self.me, offchain_key)))?;

--- a/chain/actions/src/node.rs
+++ b/chain/actions/src/node.rs
@@ -1,4 +1,5 @@
 use crate::action_queue::PendingAction;
+use crate::errors::CoreEthereumActionsError::AlreadyAnnounced;
 use crate::errors::{CoreEthereumActionsError::InvalidArguments, Result};
 use crate::CoreEthereumActions;
 use async_trait::async_trait;
@@ -16,7 +17,8 @@ pub trait NodeActions {
     /// Withdraws the specified `amount` of tokens to the given `recipient`.
     async fn withdraw(&self, recipient: Address, amount: Balance) -> Result<PendingAction>;
 
-    /// Announces node on-chain with key binding
+    /// Announces node on-chain with key binding.
+    /// The operation should also check if such announcement has not been already made on-chain.
     async fn announce(&self, multiaddr: &Multiaddr, offchain_key: &OffchainKeypair) -> Result<PendingAction>;
 
     /// Registers the safe address with the node
@@ -37,10 +39,24 @@ impl<Db: HoprCoreEthereumDbActions + Clone + Send + Sync> NodeActions for CoreEt
     }
 
     async fn announce(&self, multiaddr: &Multiaddr, offchain_key: &OffchainKeypair) -> Result<PendingAction> {
-        let announcement_data = AnnouncementData::new(multiaddr, Some(KeyBinding::new(self.me, offchain_key)))?;
+        if self
+            .db
+            .read()
+            .await
+            .get_public_node_accounts()
+            .await?
+            .into_iter()
+            .none(|account| {
+                account.get_multiaddr().is_some_and(|ma| ma.eq(multiaddr)) && account.public_key.eq(offchain_key)
+            })
+        {
+            let announcement_data = AnnouncementData::new(multiaddr, Some(KeyBinding::new(self.me, offchain_key)))?;
 
-        info!("initiating announcement {announcement_data}");
-        self.tx_sender.send(Action::Announce(announcement_data)).await
+            info!("initiating announcement {announcement_data}");
+            self.tx_sender.send(Action::Announce(announcement_data)).await
+        } else {
+            Err(AlreadyAnnounced)
+        }
     }
 
     async fn register_safe_by_node(&self, safe_address: Address) -> Result<PendingAction> {

--- a/common/internal-types/src/account.rs
+++ b/common/internal-types/src/account.rs
@@ -62,10 +62,7 @@ impl AccountEntry {
 
     /// Is the node announced?
     pub fn has_announced(&self) -> bool {
-        match &self.entry_type {
-            AccountType::NotAnnounced => false,
-            AccountType::Announced { .. } => true,
-        }
+        matches!(self.entry_type, AccountType::Announced { .. })
     }
 
     /// If the node has announced, did it announce with routing information ?

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -59,8 +59,7 @@ use core_transport::{
 use core_transport::{ChainKeypair, Hash, HoprTransport, OffchainKeypair};
 use core_transport::{ExternalNetworkInteractions, IndexerToProcess, Network, PeerEligibility, PeerOrigin};
 use hopr_platform::file::native::{join, read_file, remove_dir_all, write};
-use log::{debug, warn};
-use log::{error, info};
+use log::{debug, error, info};
 use utils_db::db::DB;
 use utils_db::CurrentDbShim;
 

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -837,7 +837,7 @@ impl Hopr {
                 .await
             {
                 Ok(_) => info!("Announcing node on chain: {:?}", &multiaddresses_to_announce[0]),
-                Err(CoreEthereumActionsError::AlreadyAnnounced) => warn!(
+                Err(CoreEthereumActionsError::AlreadyAnnounced) => info!(
                     "Node already announced on chain as {:?}",
                     &multiaddresses_to_announce[0]
                 ),


### PR DESCRIPTION
Added check that looks up the current node's account entry in the DB to check if the node has announced or not.

Fixes #5976