### PR TITLE
Fix workflow for PRs from outside the organization  

### DIFF
--- a/.github/workflows/new-pr.yaml
+++ b/.github/workflows/new-pr.yaml
@@ -5,7 +5,7 @@
 name: New PR
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
 concurrency:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,7 +10,7 @@ env:
 
 on:
   merge_group:
-  pull_request:
+  pull_request_target:
     types:
       - synchronize
       - ready_for_review


### PR DESCRIPTION
Should fix #5870.

The issue seams to be that some actions are not able to access GH secrets when the PR's coming from private forks.

It seams to be a deliberate behaviour from GH to avoid running untrusted code from forks (see https://securitylab.github.com/research/github-actions-preventing-pwn-requests/). However, for converting a PR to draft and for testing this should be ok, even-though one of the main issue is the `checkout` of an untrusted PR, which still happens in the `Convert to draft` and `tests` job.

For the `docker build` failing (see issue), I am not sure it's a good idea to automatically build docker images from forks by default, as we don't know what's in the PR before looking at it.

We could also leave it as is, as it seams that anyone from the organization can manually trigger the workflows for such a PR if it looks safe enough.