### PR TITLE
libp2p: Extend the new configuration to allow higher outbound connections counts

### DIFF
--- a/transport/api/src/p2p.rs
+++ b/transport/api/src/p2p.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{net::Ipv4Addr, sync::Arc};
 
 use crate::{processes::indexer::IndexerProcessed, PeerId};
 use async_lock::RwLock;
@@ -83,13 +83,27 @@ impl From<IndexerProcessed> for Inputs {
 
 use std::net::ToSocketAddrs;
 
+fn replace_transport_with_unspecified(ma: &multiaddr::Multiaddr) -> crate::errors::Result<multiaddr::Multiaddr> {
+    let mut out = multiaddr::Multiaddr::empty();
+
+    for proto in ma.iter() {
+        match proto {
+            multiaddr::Protocol::Ip4(_) => out.push(std::net::IpAddr::V4(Ipv4Addr::UNSPECIFIED).into()),
+            multiaddr::Protocol::Ip6(_) => out.push(std::net::IpAddr::V6(std::net::Ipv6Addr::UNSPECIFIED).into()),
+            _ => out.push(proto),
+        }
+    }
+
+    Ok(out)
+}
+
 fn alter_multiaddress_to_allow_listening(ma: &multiaddr::Multiaddr) -> crate::errors::Result<multiaddr::Multiaddr> {
     let mut out = multiaddr::Multiaddr::empty();
 
     for proto in ma.iter() {
         match proto {
             multiaddr::Protocol::Dns4(domain) => {
-                let p = format!("{domain}:443") // dummy port, irrevelant at this point
+                let ip = format!("{domain}:443") // dummy port, irrevelant at this point
                     .to_socket_addrs()
                     .map_err(|e| crate::errors::HoprTransportError::Api(e.to_string()))?
                     .filter(|sa| sa.is_ipv4())
@@ -100,10 +114,10 @@ fn alter_multiaddress_to_allow_listening(ma: &multiaddr::Multiaddr) -> crate::er
                     )))?
                     .ip();
 
-                out.push(p.into());
+                out.push(ip.into())
             }
             multiaddr::Protocol::Dns6(domain) => {
-                let p = format!("{domain}:443") // dummy port, irrevelant at this point
+                let ip = format!("{domain}:443") // dummy port, irrevelant at this point
                     .to_socket_addrs()
                     .map_err(|e| crate::errors::HoprTransportError::Api(e.to_string()))?
                     .filter(|sa| sa.is_ipv6())
@@ -114,7 +128,7 @@ fn alter_multiaddress_to_allow_listening(ma: &multiaddr::Multiaddr) -> crate::er
                     )))?
                     .ip();
 
-                out.push(p.into());
+                out.push(ip.into())
             }
             _ => out.push(proto),
         }
@@ -160,13 +174,37 @@ pub async fn p2p_loop(
             Ok(ma) => {
                 if let Err(e) = swarm.listen_on(ma.clone()) {
                     error!("Failed to listen_on using the multiaddress '{}': {}", multiaddress, e);
+
+                    match replace_transport_with_unspecified(&ma) {
+                        Ok(ma) => {
+                            if let Err(e) = swarm.listen_on(ma.clone()) {
+                                error!(
+                                    "Failed to listen_on also using the unspecified multiaddress '{}': {}",
+                                    ma, e
+                                );
+                            } else {
+                                info!("Successfully started listening on {ma} (from {multiaddress})");
+                                swarm.add_external_address(multiaddress.clone());
+                            }
+                        }
+                        Err(e) => {
+                            error!("Failed to transform the multiaddress '{ma}' to unspecified: {e}")
+                        }
+                    }
                 } else {
-                    info!("Successfully started listening on {ma} (from {multiaddress})")
+                    info!("Successfully started listening on {ma} (from {multiaddress})");
+                    swarm.add_external_address(multiaddress.clone());
                 }
             }
             Err(_) => error!("Failed to transform the multiaddress '{multiaddress}' - skipping"),
         }
     }
+
+    // NOTE: This would be a valid check but is not immediate
+    // assert!(
+    //     swarm.listeners().count() > 0,
+    //     "The node failed to listen on at least one of the specified interfaces"
+    // );
 
     let mut heartbeat_responds = heartbeat_responds;
     let mut manual_ping_responds = manual_ping_responds;

--- a/transport/protocol/src/constants.rs
+++ b/transport/protocol/src/constants.rs
@@ -4,3 +4,5 @@ pub const HOPR_ACKNOWLEDGE_PROTOCOL_V_0_1_0: &str = "/hopr/ack/0.1.0";
 pub const HOPR_TICKET_AGGREGATION_PROTOCOL_V_0_1_0: &str = "/hopr/ticket-aggregation/0.1.0";
 
 pub const HOPR_SWARM_IDLE_CONNECTION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3600); // 1 hour
+pub const HOPR_SWARM_CONCURRENTLY_DIALED_PEER_COUNT: u8 = 255;
+pub const HOPR_SWARM_CONCURRENTLY_NEGOTIATING_INBOUND_PEER_COUNT: usize = 255;


### PR DESCRIPTION
Introduce new libp2p configuration to allow significantly more concurrently dialed outbound connections.

Allows setting the values with secret env overridable values:
- `HOPR_INTERNAL_LIBP2P_MAX_CONCURRENTLY_DIALED_PEER_COUNT`
- `HOPR_INTERNAL_LIBP2P_MAX_NEGOTIATING_INBOUND_STREAM_COUNT`

Fix the listen_on issue for external interfaces not propagated into NATted machines (e.g. by port-forwarding, docker...)