### PR TITLE
Add example_cfg.yaml with documentation

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -14,7 +14,7 @@ scrape_configs:
     scrape_interval: 5s
     static_configs:
       - targets: ['localhost:3001']
-    metrics_path: /api/v2/node/metrics
+    metrics_path: /api/v3/node/metrics
     basic_auth:
       username: ^MYtoken4testing^
       password: ''

--- a/hopr/hopr-lib/src/config.rs
+++ b/hopr/hopr-lib/src/config.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use validator::{Validate, ValidationError};
@@ -8,6 +6,7 @@ pub use core_strategy::StrategyConfig;
 pub use core_transport::config::{
     validate_external_host, HeartbeatConfig, HostConfig, NetworkConfig, ProtocolConfig, TransportConfig,
 };
+use core_transport::config::HostType;
 
 use hopr_primitive_types::prelude::*;
 
@@ -172,7 +171,10 @@ pub struct HoprLibConfig {
 
 #[inline]
 fn default_host() -> HostConfig {
-    HostConfig::from_str(format!("{DEFAULT_HOST}:{DEFAULT_PORT}").as_str()).unwrap()
+    HostConfig {
+        address: HostType::IPv4(DEFAULT_HOST.to_owned()),
+        port: DEFAULT_PORT,
+    }
 }
 
 impl Default for HoprLibConfig {

--- a/hopr/hopr-lib/src/config.rs
+++ b/hopr/hopr-lib/src/config.rs
@@ -3,9 +3,8 @@ use serde_with::{serde_as, DisplayFromStr};
 use validator::{Validate, ValidationError};
 
 pub use core_strategy::StrategyConfig;
-use core_transport::config::HostType;
 pub use core_transport::config::{
-    validate_external_host, HeartbeatConfig, HostConfig, NetworkConfig, ProtocolConfig, TransportConfig,
+    validate_external_host, HeartbeatConfig, HostConfig, HostType, NetworkConfig, ProtocolConfig, TransportConfig,
 };
 
 use hopr_primitive_types::prelude::*;

--- a/hopr/hopr-lib/src/config.rs
+++ b/hopr/hopr-lib/src/config.rs
@@ -3,10 +3,10 @@ use serde_with::{serde_as, DisplayFromStr};
 use validator::{Validate, ValidationError};
 
 pub use core_strategy::StrategyConfig;
+use core_transport::config::HostType;
 pub use core_transport::config::{
     validate_external_host, HeartbeatConfig, HostConfig, NetworkConfig, ProtocolConfig, TransportConfig,
 };
-use core_transport::config::HostType;
 
 use hopr_primitive_types::prelude::*;
 
@@ -169,6 +169,8 @@ pub struct HoprLibConfig {
     pub safe_module: SafeModule,
 }
 
+// NOTE: this intentionally does not validate (0.0.0.0) to force user to specify
+// their external IP.
 #[inline]
 fn default_host() -> HostConfig {
     HostConfig {

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -10,7 +10,7 @@ mod helpers;
 pub use {
     chain::{Network as ChainNetwork, ProtocolsConfig},
     chain_actions::errors::CoreEthereumActionsError,
-    core_strategy::{Strategy, Strategy::AutoRedeeming},
+    core_strategy::Strategy,
     core_transport::{
         config::{looks_like_domain, HostConfig, HostType},
         constants::PEER_METADATA_PROTOCOL_VERSION,

--- a/hoprd/hoprd/example_cfg.yaml
+++ b/hoprd/hoprd/example_cfg.yaml
@@ -1,3 +1,36 @@
+# Main node's identity that defined the on-chain and off-chain keys
+identity:
+  # Path to the identity file
+  # A new identity file will be created if it does not exist
+  file: path/to/identity.file
+
+  # Password for the identity file
+  password: 'change_me'
+
+  # If specified, the above identity file is ignored and the node
+  # directly uses the provided private key.
+  # private_key: ''
+
+# Configuration of the REST API
+api:
+
+  # Indicates whether the REST API should be enabled.
+  enable: false
+
+  # What kind of authentication the REST API should use.
+  # Possible value is `None` or `!Token <some token>` which will
+  # enforce Bearer token authentication.
+  auth: None
+
+  # Defines the local interface host where the API should
+  # listen on.
+  host:
+    # Address of the local interface to listen on
+    address: !IPv4 127.0.0.1
+    # REST API TCP listen port
+    port: 3001
+
+# Configuration of the HOPR protocol
 hopr:
 
   # Specifies host to listen on for the HOPR P2P protocol
@@ -24,16 +57,6 @@ hopr:
     # in the given directory.
     force_initialize: false
 
-  # Main node's identity that defined the on-chain and off-chain keys
-  identity:
-    # Path to the identity file
-    file: identity
-    # Password for the identity file
-    password: ''
-    # If specified, the above identity file is ignored and the node
-    # directly uses the provided private key.
-    private_key: ''
-
   # Configuration of node's Safe
   safe_module:
     # Node's safe transaction provider
@@ -45,37 +68,6 @@ hopr:
 
     # Node's safe module address, this must be provided by the user
     module_address: '0x0000000000000000000000000000000000000000'
-
-  # Message Inbox configuration
-  inbox:
-    # Capacity of messages in the Inbox, per message tag.
-    capacity: 512
-
-    # Maximum age of a message in Inbox in seconds
-    # Older messages are automatically purged
-    max_age: 900
-
-    # Tags which are not allowed into the Inbox
-    excluded_tags: [ 0 ]
-
-  # Configuration of the REST API
-  api:
-
-    # Indicates whether the REST API should be enabled.
-    enable: false
-
-    # What kind of authentication the REST API should use.
-    # Possible value is `None` or `!Token <some token>` which will
-    # enforce Bearer token authentication.
-    auth: None
-
-    # Defines the local interface host where the API should
-    # listen on.
-    host:
-      # Address of the local interface to listen on
-      address: !IPv4 127.0.0.1
-      # REST API TCP listen port
-      port: 3001
 
   # Configuration of HOPR channel strategies.
   strategy:
@@ -307,3 +299,15 @@ hopr:
     # when validating acknowledged tickets.
     # Strongly recommended to leave this enabled.
     check_unrealized_balance: true
+
+# HOPRd Message Inbox configuration
+inbox:
+  # Capacity of messages in the Inbox, per message tag.
+  capacity: 512
+
+  # Maximum age of a message in Inbox in seconds
+  # Older messages are automatically purged
+  max_age: 900
+
+  # Tags which are not allowed into the Inbox
+  excluded_tags: [ 0 ]

--- a/hoprd/hoprd/example_cfg.yaml
+++ b/hoprd/hoprd/example_cfg.yaml
@@ -1,43 +1,85 @@
 hopr:
+
   # Specifies host to listen on for the HOPR P2P protocol
   host:
     # Specifies the external IP address of the local interface
     # that is connected to the Internet. This address will be
     # announced on-chain.
     address: !IPv4 1.2.3.4
+
     # Listen TCP port
     port: 9091
 
   # Specifies details for the database used by the HOPR node
   db:
     # Path to the directory with the database
-    data: /tmp/db
+    data: /app/db
+
     # If set, database will be created (if it does not exist).
     # Otherwise, if false is given and database is not present,
     # the node will fail to start.
-    initialize: false
+    initialize: true
+
     # If set, will overwrite and re-initialize any existing database
     # in the given directory.
     force_initialize: false
 
+  # Main node's identity that defined the on-chain and off-chain keys
   identity:
+    # Path to the identity file
     file: identity
+    # Password for the identity file
     password: ''
+    # If specified, the above identity file is ignored and the node
+    # directly uses the provided private key.
     private_key: ''
+
+  # Configuration of node's Safe
+  safe_module:
+    # Node's safe transaction provider
+    # Such as https://safe-transaction.prod.hoprtech.net/
+    safe_transaction_service_provider: https:://provider.com/
+
+    # Node's safe address, this must be provided by the user
+    safe_address: '0x0000000000000000000000000000000000000000'
+
+    # Node's safe module address, this must be provided by the user
+    module_address: '0x0000000000000000000000000000000000000000'
+
+  # Message Inbox configuration
   inbox:
+    # Capacity of messages in the Inbox, per message tag.
     capacity: 512
+
+    # Maximum age of a message in Inbox in seconds
+    # Older messages are automatically purged
     max_age: 900
+
+    # Tags which are not allowed into the Inbox
     excluded_tags: [ 0 ]
-  # Configuration of the 
+
+  # Configuration of the REST API
   api:
+
+    # Indicates whether the REST API should be enabled.
     enable: false
+
+    # What kind of authentication the REST API should use.
+    # Possible value is `None` or `!Token <some token>` which will
+    # enforce Bearer token authentication.
     auth: None
+
+    # Defines the local interface host where the API should
+    # listen on.
     host:
+      # Address of the local interface to listen on
       address: !IPv4 127.0.0.1
+      # REST API TCP listen port
       port: 3001
 
   # Configuration of HOPR channel strategies.
   strategy:
+
     # Will not continue executing the next strategy in the chain
     # if one of them failed.
     on_fail_continue: true
@@ -55,7 +97,6 @@ hopr:
     # If left empty, the node will behave as if only `!Passive` strategy
     # was given.
     strategies:
-      -
       # Defines a promiscuous strategy that automatically manages HOPR channels
       # based on measured network qualities of HOPR nodes in the network.
       #- !Promiscuous
@@ -147,6 +188,7 @@ hopr:
   # is evaluated and criteria for nodes to be considered of good/bad quality.
   # This is closely related to the heartbeat mechanism.
   network_options:
+
     # Minimum delay (seconds) will be multiplied by backoff, it will be half the actual minimum value.
     min_delay: 1
 
@@ -177,8 +219,14 @@ hopr:
     # Maximum backoff (in seconds) when probing nodes
     backoff_max: 300.0
 
+  # Transport related configuration
   transport:
+    # Should local addresses be announced on chain?
+    # Set to true for testing only
     announce_local_addresses: false
+
+    # Should local addresses be preferred when dialing a peer?
+    # Set to true for testing only
     prefer_local_addresses: false
 
   # Configuration of various HOPR sub-protocols.
@@ -203,11 +251,22 @@ hopr:
     ticket_aggregation:
       # Timeout in seconds
       timeout: 15
+
+  # Blockchain specific configuration
   chain:
-    announce: false
-    network: testing
+    # Indicates whether node should announce itself on-chain
+    announce: true
+
+    # Which blockchain network should be used by the node
+    # Must be one of `protocols.networks`.
+    network: anvil-localhost
+
+    # RPC provider URL to use.
+    # If not given, it will use the network's chain default one.
     provider: null
+
     protocols:
+      # Enumerates different HOPR on-chain network deployments the node can use.
       networks:
         anvil-localhost:
           chain: anvil
@@ -228,6 +287,8 @@ hopr:
           confirmations: 2
           tx_polling_interval: 1000
           max_block_range: 200
+
+      # Lists actual blockchains that HOPR networks can be deployed at
       chains:
         anvil:
           description: Local Ethereum node, akin to Ganache, Hardhat chain
@@ -241,8 +302,8 @@ hopr:
           hopr_token_name: wxHOPR
           block_time: 5000
           tags: []
+
+    # Indicates whether node should check channel unrealized balance
+    # when validating acknowledged tickets.
+    # Strongly recommended to leave this enabled.
     check_unrealized_balance: true
-  safe_module:
-    safe_transaction_service_provider: https:://provider.com/
-    safe_address: '0x0000000000000000000000000000000000000000'
-    module_address: '0x0000000000000000000000000000000000000000'

--- a/hoprd/hoprd/src/config.rs
+++ b/hoprd/hoprd/src/config.rs
@@ -305,105 +305,7 @@ impl HoprdConfig {
 }
 
 /// Used in the testing and documentation
-pub const EXAMPLE_YAML: &str = r#"hopr:
-  host:
-    address: !IPv4 127.0.0.1
-    port: 47462
-  db:
-    data: /tmp/db
-    initialize: false
-    force_initialize: false
-  strategy:
-    on_fail_continue: true
-    allow_recursive: true
-    finalize_channel_closure: false
-    strategies: []
-  heartbeat:
-    variance: 0
-    interval: 0
-    threshold: 0
-  network_options:
-    min_delay: 1
-    max_delay: 300
-    quality_bad_threshold: 0.2
-    quality_offline_threshold: 0.0
-    quality_step: 0.1
-    quality_avg_window_size: 25
-    ignore_timeframe: 600
-    backoff_exponent: 1.5
-    backoff_min: 2.0
-    backoff_max: 300.0
-  transport:
-    announce_local_addresses: false
-    prefer_local_addresses: false
-  protocol:
-    ack:
-      timeout: 15
-    heartbeat:
-      timeout: 15
-    msg:
-      timeout: 15
-    ticket_aggregation:
-      timeout: 15
-  chain:
-    announce: false
-    network: testing
-    provider: null
-    protocols:
-      networks:
-        anvil-localhost:
-          chain: anvil
-          environment_type: local
-          version_range: '*'
-          indexer_start_block_number: 5
-          tags: []
-          addresses:
-            network_registry: 0x3aa5ebb10dc797cac828524e59a333d0a371443c
-            network_registry_proxy: 0x68b1d87f95878fe05b998f19b66f4baba5de1aed
-            channels: 0x9a9f2ccfde556a7e9ff0848998aa4a0cfd8863ae
-            token: 0x9a676e781a523b5d0c0e43731313a708cb607508
-            module_implementation: 0xa51c1fc2f0d1a1b8494ed1fe312d7c3a78ed91c0
-            node_safe_registry: 0x0dcd1bf9a1b36ce34237eeafef220932846bcd82
-            ticket_price_oracle: 0x7a2088a1bfc9d81c55368ae168c2c02570cb814f
-            announcements: 0x09635f643e140090a9a8dcd712ed6285858cebef
-            node_stake_v2_factory: 0xb7f8bc63bbcad18155201308c8f3540b07f84f5e
-          confirmations: 2
-          tx_polling_interval: 1000
-          max_block_range: 200
-      chains:
-        anvil:
-          description: Local Ethereum node, akin to Ganache, Hardhat chain
-          chain_id: 31337
-          live: false
-          default_provider: http://127.0.0.1:8545/
-          etherscan_api_url: null
-          max_fee_per_gas: 1 gwei
-          max_priority_fee_per_gas: 0.2 gwei
-          native_token_name: ETH
-          hopr_token_name: wxHOPR
-          block_time: 5000
-          tags: []
-    check_unrealized_balance: true
-  safe_module:
-    safe_transaction_service_provider: https:://provider.com/
-    safe_address: '0x0000000000000000000000000000000000000000'
-    module_address: '0x0000000000000000000000000000000000000000'
-identity:
-  file: identity
-  password: ''
-  private_key: ''
-inbox:
-  capacity: 512
-  max_age: 900
-  excluded_tags:
-  - 0
-api:
-  enable: false
-  auth: None
-  host:
-    address: !IPv4 127.0.0.1
-    port: 1233
-"#;
+pub const EXAMPLE_YAML: &str = include_str!("example_cfg.yaml");
 
 #[cfg(test)]
 mod tests {
@@ -413,32 +315,11 @@ mod tests {
     use tempfile::NamedTempFile;
 
     pub fn example_cfg() -> HoprdConfig {
-        HoprdConfig {
-            hopr: HoprLibConfig {
-                host: hopr_lib::config::HostConfig::from_str(format!("127.0.0.1:47462").as_str()).unwrap(),
-                db: hopr_lib::config::Db {
-                    data: "/tmp/db".to_owned(),
-                    initialize: false,
-                    force_initialize: false,
-                },
-                strategy: hopr_lib::config::StrategyConfig::default(),
-                heartbeat: hopr_lib::config::HeartbeatConfig {
-                    interval: std::time::Duration::from_secs(0),
-                    threshold: std::time::Duration::from_secs(0),
-                    variance: std::time::Duration::from_secs(0),
-                },
-                network_options: {
-                    let mut c = hopr_lib::config::NetworkConfig::default();
-                    c.quality_offline_threshold = 0.0;
-                    c
-                },
-                transport: hopr_lib::config::TransportConfig::default(),
-                protocol: hopr_lib::config::ProtocolConfig::default(),
-                chain: hopr_lib::config::Chain {
-                    announce: false,
-                    network: "testing".to_string(),
-                    protocols: hopr_lib::ProtocolsConfig::from_str(
-                        r#"
+        let chain = hopr_lib::config::Chain {
+            announce: false,
+            network: "testing".to_string(),
+            protocols: hopr_lib::ProtocolsConfig::from_str(
+                r#"
                     {
                         "networks": {
                           "anvil-localhost": {
@@ -480,28 +361,40 @@ mod tests {
                         }
                       }
                     "#,
-                    )
-                    .expect("protocol config should be valid"),
-                    provider: None,
-                    check_unrealized_balance: true,
-                },
-                safe_module: hopr_lib::config::SafeModule {
-                    safe_transaction_service_provider: "https:://provider.com/".to_owned(),
-                    safe_address: Address::from_str("0x0000000000000000000000000000000000000000").unwrap(),
-                    module_address: Address::from_str("0x0000000000000000000000000000000000000000").unwrap(),
-                },
+            )
+                .expect("protocol config should be valid"),
+            provider: None,
+            check_unrealized_balance: true,
+        };
+
+        let db =  hopr_lib::config::Db {
+            data: "/tmp/db".to_owned(),
+            initialize: false,
+            force_initialize: false,
+        };
+
+        let safe_module = hopr_lib::config::SafeModule {
+            safe_transaction_service_provider: "https:://provider.com/".to_owned(),
+            safe_address: Address::from_str("0x0000000000000000000000000000000000000000").unwrap(),
+            module_address: Address::from_str("0x0000000000000000000000000000000000000000").unwrap(),
+        };
+
+        let identity = Identity {
+            file: "identity".to_string(),
+            password: "".to_owned(),
+            private_key: Some("".to_owned()),
+        };
+
+
+        HoprdConfig {
+            hopr: HoprLibConfig {
+                db,
+                chain,
+                safe_module,
+                ..HoprLibConfig::default()
             },
-            identity: Identity {
-                file: "identity".to_string(),
-                password: "".to_owned(),
-                private_key: Some("".to_owned()),
-            },
-            inbox: MessageInboxConfiguration::default(),
-            api: Api {
-                enable: false,
-                auth: Auth::None,
-                host: hopr_lib::config::HostConfig::from_str(format!("127.0.0.1:1233").as_str()).unwrap(),
-            },
+            identity,
+            .. HoprdConfig::default()
         }
     }
 
@@ -509,9 +402,9 @@ mod tests {
     fn test_config_should_be_serializable_into_string() -> Result<(), Box<dyn std::error::Error>> {
         let cfg = example_cfg();
 
-        let yaml = serde_yaml::to_string(&cfg)?;
+        let from_yaml: HoprdConfig = serde_yaml::from_str(EXAMPLE_YAML)?;
 
-        assert_eq!(yaml, EXAMPLE_YAML);
+        assert_eq!(cfg, from_yaml);
 
         Ok(())
     }

--- a/hoprd/hoprd/src/config.rs
+++ b/hoprd/hoprd/src/config.rs
@@ -305,19 +305,18 @@ impl HoprdConfig {
 }
 
 /// Used in the testing and documentation
-pub const EXAMPLE_YAML: &str = include_str!("example_cfg.yaml");
+pub const EXAMPLE_YAML: &str = include_str!("../example_cfg.yaml");
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use clap::{Args, Command, FromArgMatches};
+    use hopr_lib::HostType;
     use std::io::{Read, Write};
     use tempfile::NamedTempFile;
 
     pub fn example_cfg() -> HoprdConfig {
         let chain = hopr_lib::config::Chain {
-            announce: false,
-            network: "testing".to_string(),
             protocols: hopr_lib::ProtocolsConfig::from_str(
                 r#"
                     {
@@ -362,15 +361,13 @@ mod tests {
                       }
                     "#,
             )
-                .expect("protocol config should be valid"),
-            provider: None,
-            check_unrealized_balance: true,
+            .expect("protocol config should be valid"),
+            ..hopr_lib::config::Chain::default()
         };
 
-        let db =  hopr_lib::config::Db {
-            data: "/tmp/db".to_owned(),
-            initialize: false,
-            force_initialize: false,
+        let db = hopr_lib::config::Db {
+            data: "/app/db".to_owned(),
+            ..hopr_lib::config::Db::default()
         };
 
         let safe_module = hopr_lib::config::SafeModule {
@@ -380,21 +377,26 @@ mod tests {
         };
 
         let identity = Identity {
-            file: "identity".to_string(),
+            file: "".to_string(),
             password: "".to_owned(),
-            private_key: Some("".to_owned()),
+            private_key: None,
         };
 
+        let host = HostConfig {
+            address: HostType::IPv4("1.2.3.4".into()),
+            port: 9091,
+        };
 
         HoprdConfig {
             hopr: HoprLibConfig {
+                host,
                 db,
                 chain,
                 safe_module,
                 ..HoprLibConfig::default()
             },
             identity,
-            .. HoprdConfig::default()
+            ..HoprdConfig::default()
         }
     }
 

--- a/hoprd/hoprd/src/config.rs
+++ b/hoprd/hoprd/src/config.rs
@@ -377,8 +377,8 @@ mod tests {
         };
 
         let identity = Identity {
-            file: "".to_string(),
-            password: "".to_owned(),
+            file: "path/to/identity.file".to_string(),
+            password: "change_me".to_owned(),
             private_key: None,
         };
 

--- a/hoprd/hoprd/src/config.rs
+++ b/hoprd/hoprd/src/config.rs
@@ -75,7 +75,8 @@ impl std::fmt::Debug for Identity {
 /// The configuration is composed of individual configuration of corresponding
 /// component configuration objects.
 ///
-/// An always up-to-date config YAML example can be found in [`EXAMPLE_YAML`].
+/// An always up-to-date config YAML example can be found in [example_cfg.yaml](https://github.com/hoprnet/hoprnet/tree/master/hoprd/example_cfg.yaml)
+/// which is always in the root of this crate.
 ///
 #[derive(Debug, Default, Serialize, Deserialize, Validate, Clone, PartialEq)]
 pub struct HoprdConfig {
@@ -304,9 +305,6 @@ impl HoprdConfig {
     }
 }
 
-/// Used in the testing and documentation
-pub const EXAMPLE_YAML: &str = include_str!("../example_cfg.yaml");
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -404,7 +402,7 @@ mod tests {
     fn test_config_should_be_serializable_into_string() -> Result<(), Box<dyn std::error::Error>> {
         let cfg = example_cfg();
 
-        let from_yaml: HoprdConfig = serde_yaml::from_str(EXAMPLE_YAML)?;
+        let from_yaml: HoprdConfig = serde_yaml::from_str(include_str!("../example_cfg.yaml"))?;
 
         assert_eq!(cfg, from_yaml);
 

--- a/hoprd/hoprd/src/example_cfg.yaml
+++ b/hoprd/hoprd/src/example_cfg.yaml
@@ -1,0 +1,116 @@
+hopr:
+  host:
+    address: !IPv4 0.0.0.0
+    port: 9091
+  db:
+    data: /tmp/db
+    initialize: false
+    force_initialize: false
+  strategy:
+    on_fail_continue: true
+    allow_recursive: false
+    finalize_channel_closure: false
+    strategies:
+      #- !Promiscuous
+      #  max_channels: 10
+      #  network_quality_threshold: 0.5
+      #  new_channel_stake: "1000000 HOPR"
+      #  minimum_node_balance: "10000000 HOPR"
+      #  min_network_size_samples: 20
+      #  enforce_max_channels: true
+      #  minimum_peer_version: ">=2.0.0"
+      - !AutoFunding
+        funding_amount: "10000000000000000000 HOPR"
+        min_stake_threshold: "1000000000000000000 HOPR"
+      - !Aggregating
+        aggregation_threshold: 100
+        unrealized_balance_ratio: 0.9
+        aggregation_timeout: 60
+        aggregate_on_channel_close: true
+      - !AutoRedeeming
+        redeem_only_aggregated: True
+  heartbeat:
+    variance: 2
+    interval: 60
+    threshold: 60
+  network_options:
+    min_delay: 1
+    max_delay: 300
+    quality_bad_threshold: 0.2
+    quality_offline_threshold: 0.5
+    quality_step: 0.1
+    quality_avg_window_size: 25
+    ignore_timeframe: 600
+    backoff_exponent: 1.5
+    backoff_min: 2.0
+    backoff_max: 300.0
+  transport:
+    announce_local_addresses: false
+    prefer_local_addresses: false
+  protocol:
+    ack:
+      timeout: 15
+    heartbeat:
+      timeout: 15
+    msg:
+      timeout: 15
+    ticket_aggregation:
+      timeout: 15
+  chain:
+    announce: false
+    network: testing
+    provider: null
+    protocols:
+      networks:
+        anvil-localhost:
+          chain: anvil
+          environment_type: local
+          version_range: '*'
+          indexer_start_block_number: 5
+          tags: []
+          addresses:
+            network_registry: 0x3aa5ebb10dc797cac828524e59a333d0a371443c
+            network_registry_proxy: 0x68b1d87f95878fe05b998f19b66f4baba5de1aed
+            channels: 0x9a9f2ccfde556a7e9ff0848998aa4a0cfd8863ae
+            token: 0x9a676e781a523b5d0c0e43731313a708cb607508
+            module_implementation: 0xa51c1fc2f0d1a1b8494ed1fe312d7c3a78ed91c0
+            node_safe_registry: 0x0dcd1bf9a1b36ce34237eeafef220932846bcd82
+            ticket_price_oracle: 0x7a2088a1bfc9d81c55368ae168c2c02570cb814f
+            announcements: 0x09635f643e140090a9a8dcd712ed6285858cebef
+            node_stake_v2_factory: 0xb7f8bc63bbcad18155201308c8f3540b07f84f5e
+          confirmations: 2
+          tx_polling_interval: 1000
+          max_block_range: 200
+      chains:
+        anvil:
+          description: Local Ethereum node, akin to Ganache, Hardhat chain
+          chain_id: 31337
+          live: false
+          default_provider: http://127.0.0.1:8545/
+          etherscan_api_url: null
+          max_fee_per_gas: 1 gwei
+          max_priority_fee_per_gas: 0.2 gwei
+          native_token_name: ETH
+          hopr_token_name: wxHOPR
+          block_time: 5000
+          tags: []
+    check_unrealized_balance: true
+  safe_module:
+    safe_transaction_service_provider: https:://provider.com/
+    safe_address: '0x0000000000000000000000000000000000000000'
+    module_address: '0x0000000000000000000000000000000000000000'
+identity:
+  file: identity
+  password: ''
+  private_key: ''
+inbox:
+  capacity: 512
+  max_age: 900
+  excluded_tags:
+    - 0
+api:
+  enable: false
+  auth: None
+  host:
+    address: !IPv4 127.0.0.1
+    port: 3001

--- a/hoprd/hoprd/src/example_cfg.yaml
+++ b/hoprd/hoprd/src/example_cfg.yaml
@@ -1,60 +1,207 @@
 hopr:
+  # Specifies host to listen on for the HOPR P2P protocol
   host:
-    address: !IPv4 0.0.0.0
+    # Specifies the external IP address of the local interface
+    # that is connected to the Internet. This address will be
+    # announced on-chain.
+    address: !IPv4 1.2.3.4
+    # Listen TCP port
     port: 9091
+
+  # Specifies details for the database used by the HOPR node
   db:
+    # Path to the directory with the database
     data: /tmp/db
+    # If set, database will be created (if it does not exist).
+    # Otherwise, if false is given and database is not present,
+    # the node will fail to start.
     initialize: false
+    # If set, will overwrite and re-initialize any existing database
+    # in the given directory.
     force_initialize: false
+
+  identity:
+    file: identity
+    password: ''
+    private_key: ''
+  inbox:
+    capacity: 512
+    max_age: 900
+    excluded_tags: [ 0 ]
+  # Configuration of the 
+  api:
+    enable: false
+    auth: None
+    host:
+      address: !IPv4 127.0.0.1
+      port: 3001
+
+  # Configuration of HOPR channel strategies.
   strategy:
+    # Will not continue executing the next strategy in the chain
+    # if one of them failed.
     on_fail_continue: true
+
+    # Allows nesting strategy chains via !MultiStrategy
     allow_recursive: false
+
+    # Activates a strategy which will issue channel closure transaction
+    # whenever a channel transitions to `PendingToClose` state.
+    # Otherwise, the user must manually issue such transaction manually
+    # on `PendingToClose` channels.
     finalize_channel_closure: false
+
+    # Contains the actual chain of strategies to execute in the given order.
+    # If left empty, the node will behave as if only `!Passive` strategy
+    # was given.
     strategies:
+      -
+      # Defines a promiscuous strategy that automatically manages HOPR channels
+      # based on measured network qualities of HOPR nodes in the network.
       #- !Promiscuous
-      #  max_channels: 10
-      #  network_quality_threshold: 0.5
-      #  new_channel_stake: "1000000 HOPR"
-      #  minimum_node_balance: "10000000 HOPR"
-      #  min_network_size_samples: 20
-      #  enforce_max_channels: true
-      #  minimum_peer_version: ">=2.0.0"
+      #
+      # # Maximum number of opened channels the strategy should maintain.
+      # max_channels: 10
+      #
+      # # A quality threshold between 0 and 1 used to determine whether the strategy should open channel with the peer.
+      # network_quality_threshold: 0.5
+      #
+      # # A stake of tokens that should be allocated to a channel opened by the strategy.
+      # new_channel_stake: "1000000 HOPR"
+      #
+      # # Minimum token balance of the node. When reached, the strategy will not open any new channels.
+      # minimum_node_balance: "10000000 HOPR"
+      #
+      # # Minimum number of network quality samples before the strategy can start making decisions.
+      # min_network_size_samples: 20
+      #
+      # # If set, the strategy will aggressively close channels (even with peers above the `network_quality_threshold`)
+      # # if the number of opened outgoing channels (regardless if opened by the strategy or manually) exceeds the
+      # enforce_max_channels: true
+      #
+      # # Specifies minimum version of the peer the strategy should open a channel to.
+      # # Accepts semver syntax.
+      # minimum_peer_version: ">=2.0.0"
+
+      # Channel auto-funding strategy.
+      # Automatically funds channels with the given funding amount
+      # if the stake on any channel drops below the given threshold
       - !AutoFunding
+        # Amount to automatically fund a channel that dropped
+        # below the threshold
         funding_amount: "10000000000000000000 HOPR"
+
+        # Auto funding threshold
         min_stake_threshold: "1000000000000000000 HOPR"
+
+      # Strategy performing automatic ticket aggregation
+      # once the amount of unredeemed tickets in a channel goes
+      # over the given threshold.
       - !Aggregating
+
+        # Number of acknowledged winning tickets in a channel that triggers the ticket aggregation
+        # in that channel when exceeded.
+        # This condition is independent of `unrealized_balance_ratio`.
         aggregation_threshold: 100
+
+        # Percentage of unrealized balance in unaggregated tickets in a channel
+        # that triggers the ticket aggregation when exceeded.
+        # The unrealized balance in this case is the proportion of the channel balance allocated in unredeemed unaggregated tickets.
+        # This condition is independent of `aggregation_threshold`.
         unrealized_balance_ratio: 0.9
+
+        # Maximum time to wait for the ticket aggregation to complete.
+        # This does not affect the runtime of the strategy `on_acknowledged_ticket` event processing.
         aggregation_timeout: 60
+
+        # If set, the strategy will automatically aggregate tickets in channel that has transitioned
+        # to the `PendingToClose` state. This happens regardless if `aggregation_threshold`
+        # or `unrealized_balance_ratio` thresholds are met on that channel.
+        # If the aggregation on-close fails, the tickets are automatically sent for redeeming instead.
         aggregate_on_channel_close: true
+
+      # Channel strategy that performs automatic redemption of
+      # a winning acknowledged ticket
       - !AutoRedeeming
-        redeem_only_aggregated: True
+
+        # If set, the strategy will redeem only aggregated tickets.
+        redeem_only_aggregated: true
+
+      # Passive strategy does nothing. This is equivalent as leaving
+      # the `strategies` array empty.
+      #- !Passive
+
+  # Configuration of the heartbeat mechanism for probing
+  # other nodes in the HOPR network.
   heartbeat:
-    variance: 2
+    # Interval in which the heartbeat is triggered in seconds
     interval: 60
+
+    # The time interval for which to consider peer heartbeat renewal in seconds
     threshold: 60
+
+    # Round-to-round variance to complicate network sync in seconds
+    variance: 2
+
+  # Defines how quality of nodes in the HOPR network
+  # is evaluated and criteria for nodes to be considered of good/bad quality.
+  # This is closely related to the heartbeat mechanism.
   network_options:
+    # Minimum delay (seconds) will be multiplied by backoff, it will be half the actual minimum value.
     min_delay: 1
+
+    # Maximum delay in seconds
     max_delay: 300
+
+    # Quality threshold since a node is considered having "bad" connectivity
     quality_bad_threshold: 0.2
+
+    # Quality threshold from which a node is considered available enough to be used
     quality_offline_threshold: 0.5
+
+    # Quality step on failed/successful ping probe
     quality_step: 0.1
+
+    # Size of the quality moving average window.
     quality_avg_window_size: 25
+
+    # Indicates how long (in seconds) a node is considered "ignored"
     ignore_timeframe: 600
+
+    # Backoff exponent when probing nodes
     backoff_exponent: 1.5
+
+    # Minimum backoff (in seconds) when probing nodes
     backoff_min: 2.0
+
+    # Maximum backoff (in seconds) when probing nodes
     backoff_max: 300.0
+
   transport:
     announce_local_addresses: false
     prefer_local_addresses: false
+
+  # Configuration of various HOPR sub-protocols.
   protocol:
+
+    # Message acknowledgement sub-protocol configuration.
     ack:
+      # Timeout in seconds
       timeout: 15
+
+    # Heartbeat sub-protocol configuration
     heartbeat:
+      # Timeout in seconds
       timeout: 15
+
+    # Message sub-protocol configuration
     msg:
+      # Timeout in seconds
       timeout: 15
+
+    # Ticket aggregation sub-protocol configuration
     ticket_aggregation:
+      # Timeout in seconds
       timeout: 15
   chain:
     announce: false
@@ -99,18 +246,3 @@ hopr:
     safe_transaction_service_provider: https:://provider.com/
     safe_address: '0x0000000000000000000000000000000000000000'
     module_address: '0x0000000000000000000000000000000000000000'
-identity:
-  file: identity
-  password: ''
-  private_key: ''
-inbox:
-  capacity: 512
-  max_age: 900
-  excluded_tags:
-    - 0
-api:
-  enable: false
-  auth: None
-  host:
-    address: !IPv4 127.0.0.1
-    port: 3001

--- a/logic/strategy/src/aggregating.rs
+++ b/logic/strategy/src/aggregating.rs
@@ -40,6 +40,7 @@ pub struct AggregatingStrategyConfig {
     /// Number of acknowledged winning tickets in a channel that triggers the ticket aggregation
     /// in that channel when exceeded.
     /// This condition is independent of `unrealized_balance_ratio`.
+    ///
     /// Default is 100.
     #[validate(range(min = 2))]
     pub aggregation_threshold: Option<u32>,
@@ -48,12 +49,14 @@ pub struct AggregatingStrategyConfig {
     /// that triggers the ticket aggregation when exceeded.
     /// The unrealized balance in this case is the proportion of the channel balance allocated in unredeemed unaggregated tickets.
     /// This condition is independent of `aggregation_threshold`.
+    ///
     /// Default is 0.9
     #[validate(range(min = 0_f32, max = 1.0_f32))]
     pub unrealized_balance_ratio: Option<f32>,
 
     /// Maximum time to wait for the ticket aggregation to complete.
     /// This does not affect the runtime of the strategy `on_acknowledged_ticket` event processing.
+    ///
     /// Default is 60 seconds.
     #[serde_as(as = "DurationSeconds<u64>")]
     pub aggregation_timeout: Duration,
@@ -62,6 +65,7 @@ pub struct AggregatingStrategyConfig {
     /// to the `PendingToClose` state. This happens regardless if `aggregation_threshold`
     /// or `unrealized_balance_ratio` thresholds are met on that channel.
     /// If the aggregation on-close fails, the tickets are automatically sent for redeeming instead.
+    ///
     /// Default is true.
     pub aggregate_on_channel_close: bool,
 }

--- a/logic/strategy/src/auto_funding.rs
+++ b/logic/strategy/src/auto_funding.rs
@@ -26,11 +26,13 @@ lazy_static::lazy_static! {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Validate, Serialize, Deserialize)]
 pub struct AutoFundingStrategyConfig {
     /// Minimum stake that a channel's balance must not go below.
+    ///
     /// Default is 1 HOPR
     #[serde_as(as = "DisplayFromStr")]
     pub min_stake_threshold: Balance,
 
     /// Funding amount.
+    ///
     /// Defaults to 10 HOPR.
     #[serde_as(as = "DisplayFromStr")]
     pub funding_amount: Balance,

--- a/logic/strategy/src/auto_redeeming.rs
+++ b/logic/strategy/src/auto_redeeming.rs
@@ -23,6 +23,7 @@ lazy_static::lazy_static! {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Validate, Serialize, Deserialize)]
 pub struct AutoRedeemingStrategyConfig {
     /// If set, the strategy will redeem only aggregated tickets.
+    ///
     /// Defaults to true.
     pub redeem_only_aggregated: bool,
 }

--- a/logic/strategy/src/promiscuous.rs
+++ b/logic/strategy/src/promiscuous.rs
@@ -76,6 +76,7 @@ pub struct PromiscuousStrategyConfig {
     pub enforce_max_channels: bool,
 
     /// Specifies minimum version of the peer the strategy should open a channel to.
+    /// Accepts semver syntax.
     /// Default is ">=2.0.0"
     #[serde_as(as = "DisplayFromStr")]
     pub minimum_peer_version: semver::VersionReq,

--- a/logic/strategy/src/promiscuous.rs
+++ b/logic/strategy/src/promiscuous.rs
@@ -82,7 +82,7 @@ pub struct PromiscuousStrategyConfig {
     pub enforce_max_channels: bool,
 
     /// Specifies minimum version (in semver syntax) of the peer the strategy should open a channel to.
-    /// 
+    ///
     /// Default is ">=2.0.0"
     #[serde_as(as = "DisplayFromStr")]
     pub minimum_peer_version: semver::VersionReq,

--- a/logic/strategy/src/promiscuous.rs
+++ b/logic/strategy/src/promiscuous.rs
@@ -45,26 +45,31 @@ lazy_static::lazy_static! {
 #[derive(Debug, Clone, PartialEq, Validate, Serialize, Deserialize)]
 pub struct PromiscuousStrategyConfig {
     /// A quality threshold between 0 and 1 used to determine whether the strategy should open channel with the peer.
+    ///
     /// Defaults to 0.5
     #[validate(range(min = 0_f32, max = 1.0_f32))]
     pub network_quality_threshold: f64,
 
     /// Minimum number of network quality samples before the strategy can start making decisions.
+    ///
     /// Defaults to 10
     #[validate(range(min = 1_u32))]
     pub min_network_size_samples: u32,
 
     /// A stake of tokens that should be allocated to a channel opened by the strategy.
+    ///
     /// Defaults to 10 HOPR
     #[serde_as(as = "DisplayFromStr")]
     pub new_channel_stake: Balance,
 
     /// Minimum token balance of the node. When reached, the strategy will not open any new channels.
+    ///
     /// Defaults to 10 HOPR
     #[serde_as(as = "DisplayFromStr")]
     pub minimum_node_balance: Balance,
 
     /// Maximum number of opened channels the strategy should maintain.
+    ///
     /// Defaults to square-root of the sampled network size.
     #[validate(range(min = 1))]
     pub max_channels: Option<usize>,
@@ -72,11 +77,12 @@ pub struct PromiscuousStrategyConfig {
     /// If set, the strategy will aggressively close channels (even with peers above the `network_quality_threshold`)
     /// if the number of opened outgoing channels (regardless if opened by the strategy or manually) exceeds the
     /// `max_channels` limit.
+    ///
     /// Defaults to true
     pub enforce_max_channels: bool,
 
-    /// Specifies minimum version of the peer the strategy should open a channel to.
-    /// Accepts semver syntax.
+    /// Specifies minimum version (in semver syntax) of the peer the strategy should open a channel to.
+    /// 
     /// Default is ">=2.0.0"
     #[serde_as(as = "DisplayFromStr")]
     pub minimum_peer_version: semver::VersionReq,

--- a/logic/strategy/src/strategy.rs
+++ b/logic/strategy/src/strategy.rs
@@ -130,10 +130,12 @@ pub struct MultiStrategyConfig {
     /// Determines if the strategy should continue executing the next strategy if the current one failed.
     /// If set to `true`, the strategy behaves like a logical AND chain of `SingularStrategies`
     /// Otherwise, it behaves like a logical OR chain of `SingularStrategies`.
+    ///
     /// Default is `true`.
     pub on_fail_continue: bool,
 
     /// Indicate whether the `MultiStrategy` can contain another `MultiStrategy`.
+    ///
     /// Default is `true`.
     pub allow_recursive: bool,
 
@@ -141,10 +143,12 @@ pub struct MultiStrategyConfig {
     /// elapsed the closure grace period, to issue another channel closing transaction to close them.
     /// If not set, the user has to trigger the channel closure manually once again after the grace period
     /// is over.
+    ///
     /// Default: false
     pub finalize_channel_closure: bool,
 
     /// Configuration of individual sub-strategies.
+    ///
     /// Default is empty, which makes the `MultiStrategy` behave as passive.
     pub strategies: Vec<Strategy>,
 }

--- a/transport/api/src/config.rs
+++ b/transport/api/src/config.rs
@@ -44,9 +44,11 @@ impl Default for HostType {
 #[derive(Debug, Serialize, Deserialize, Validate, Clone, PartialEq)]
 pub struct HostConfig {
     /// Host on which to listen
+    #[serde(default)] // must be defaulted to be mergeable from CLI args
     pub address: HostType,
     /// Listening TCP or UDP port (mandatory).
     #[validate(range(min = 1u16))]
+    #[serde(default)] // must be defaulted to be mergeable from CLI args
     pub port: u16,
 }
 

--- a/transport/api/src/config.rs
+++ b/transport/api/src/config.rs
@@ -1,3 +1,4 @@
+use std::fmt::{Display, Formatter};
 use std::num::ParseIntError;
 use std::str::FromStr;
 
@@ -22,9 +23,12 @@ pub fn is_reachable_domain(host: &str) -> bool {
     host.to_socket_addrs().map_or(false, |i| i.into_iter().next().is_some())
 }
 
+/// Enumerates possible host types.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum HostType {
+    /// IPv4 based host
     IPv4(String),
+    /// DNS based host
     Domain(String),
 }
 
@@ -34,12 +38,15 @@ impl Default for HostType {
     }
 }
 
-#[derive(Debug, Default, Serialize, Deserialize, Validate, Clone, PartialEq)]
+/// Configuration of the listening host.
+/// This is used for the P2P and REST API listeners.
+// NOTE: this intentionally has no default, because it depends on the use case
+#[derive(Debug, Serialize, Deserialize, Validate, Clone, PartialEq)]
 pub struct HostConfig {
-    #[serde(default)]
+    /// Host on which to listen
     pub address: HostType,
+    /// Listening TCP or UDP port (mandatory).
     #[validate(range(min = 1u16))]
-    #[serde(default)]
     pub port: u16,
 }
 
@@ -70,9 +77,9 @@ impl FromStr for HostConfig {
     }
 }
 
-impl ToString for HostConfig {
-    fn to_string(&self) -> String {
-        format!("{:?}:{}", self.address, self.port)
+impl Display for HostConfig {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}:{}", self.address, self.port)
     }
 }
 
@@ -111,7 +118,7 @@ pub fn validate_external_host(host: &HostConfig) -> Result<(), ValidationError> 
 #[derive(Debug, Default, Serialize, Deserialize, Validate, Clone, PartialEq)]
 pub struct TransportConfig {
     /// When true, assume that the node is running in an isolated network and does
-    /// not need any connection to nodes outside of the subnet
+    /// not need any connection to nodes outside the subnet
     #[serde(default)]
     pub announce_local_addresses: bool,
     /// When true, assume a testnet with multiple nodes running on the same machine

--- a/transport/network/src/network.rs
+++ b/transport/network/src/network.rs
@@ -37,6 +37,8 @@ lazy_static::lazy_static! {
     ).unwrap();
 }
 
+/// Defines how quality of nodes in the HOPR network
+/// is evaluated and criteria for nodes to be considered of good/bad quality.
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, Validate, PartialEq)]
 pub struct NetworkConfig {


### PR DESCRIPTION
Adds default `example_cfg.yaml` with documentation.

Closes #6005 