### PR TITLE
Version string fix for 2.1 metrics

### DIFF
--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -633,7 +633,7 @@ impl Hopr {
         {
             METRIC_PROCESS_START_TIME.set(current_time().as_unix_timestamp().as_secs_f64());
             METRIC_HOPR_LIB_VERSION.set(
-                &["version"],
+                &[const_format::formatcp!("{}", constants::APP_VERSION)],
                 f64::from_str(const_format::formatcp!(
                     "{}.{}",
                     env!("CARGO_PKG_VERSION_MAJOR"),


### PR DESCRIPTION
The metrics version had a minor parsing issue.