### PR TITLE
Do not initialize the identity, if it is passed by the config

### DIFF
--- a/hoprd/hoprd/src/main.rs
+++ b/hoprd/hoprd/src/main.rs
@@ -90,7 +90,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Find or create an identity
     let identity_opts = IdentityOptions {
-        initialize: cfg.hopr.db.initialize,
+        initialize: true,
         id_path: cfg.identity.file.clone(),
         password: cfg.identity.password.clone(),
         private_key: cfg

--- a/hoprd/keypair/src/key_pair.rs
+++ b/hoprd/keypair/src/key_pair.rs
@@ -252,7 +252,7 @@ impl HoprKeys {
             }
         }
 
-        if opts.initialize {
+        if !exists && opts.initialize {
             info!(
                 "identity file {} not found, initializing and writing new identity file",
                 &opts.id_path


### PR DESCRIPTION
Minor fix to not overwrite an existing file

Fixes https://github.com/hoprnet/hoprnet/issues/6010