### PR TITLE
Divide the RTT time by 2 to get a single direction value

### DIFF
--- a/transport/network/src/ping.rs
+++ b/transport/network/src/ping.rs
@@ -1,5 +1,5 @@
-use std::collections::hash_map::Entry;
 use std::pin::Pin;
+use std::{collections::hash_map::Entry, ops::Div};
 
 use async_trait::async_trait;
 use futures::{future::poll_fn, StreamExt};
@@ -151,7 +151,7 @@ impl<T: PingExternalAPI + std::marker::Send> Pinging for Ping<T> {
                             info!("Successfully pinged peer {}", peer);
                             Ok(current_time()
                                 .as_unix_timestamp()
-                                .saturating_sub(std::time::Duration::from_millis(start)))
+                                .saturating_sub(std::time::Duration::from_millis(start).div(2u32)))
                         } else {
                             error!("Failed to verify the challenge for ping to peer: {}", peer.to_string());
                             Err(())


### PR DESCRIPTION
Basic sanity value should be produced... to not have to mentally subtract the values.