### PR TITLE
Fix duplicate redeem strategy configuration from the CLI

### DIFF
--- a/hoprd/hoprd/src/config.rs
+++ b/hoprd/hoprd/src/config.rs
@@ -197,12 +197,23 @@ impl HoprdConfig {
             cfg.identity.private_key = Some(x)
         };
 
+        // TODO: strategy configuration from the CLI should be removed in 3.0!
+
         // strategy
         if let Some(x) = cli_args.default_strategy.and_then(|s| Strategy::from_str(&s).ok()) {
-            cfg.hopr.strategy.strategies.push(x);
+            // Clear all the default strategies and just use the given one
+            cfg.hopr.strategy.strategies = vec![x];
         }
 
-        if cli_args.auto_redeem_tickets == 0 {
+        // Add auto-redeeming strategy if not already there
+        if cli_args.auto_redeem_tickets == 0
+            && !cfg
+                .hopr
+                .strategy
+                .strategies
+                .iter()
+                .any(|s| matches!(s, AutoRedeeming(_)))
+        {
             cfg.hopr.strategy.strategies.push(AutoRedeeming(Default::default()));
         }
 


### PR DESCRIPTION
This PR fixes incorrectly doubled AutoRedeeming strategy configuration when the `auto_redeem_tickets` CLI argument was specified. This fixes the doubled on-chain transaction seen when the strategy was triggered.

Also when `default_strategy` is given on the CLI argument, it will be the only one used, clearing all the defaults.

Fixes #6015