### PR TITLE
Fixes for issues found in the hopr-sdk testing

### DIFF
--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -802,21 +802,7 @@ impl Hopr {
         });
 
         info!("Loading initial peers from the storage");
-        let index_updater = self.transport_api.index_updater();
-        for (peer_id, _address, multiaddresses) in self.transport_api.get_public_nodes().await?.into_iter() {
-            if self.transport_api.is_allowed_to_access_network(&peer_id).await {
-                debug!("Using initial public node '{peer_id}'");
-                index_updater
-                    .emit_indexer_update(core_transport::IndexerToProcess::EligibilityUpdate(
-                        peer_id,
-                        PeerEligibility::Eligible,
-                    ))
-                    .await;
-                index_updater
-                    .emit_indexer_update(core_transport::IndexerToProcess::Announce(peer_id, multiaddresses))
-                    .await;
-            }
-        }
+        self.transport_api.init_from_db().await?;
 
         // Possibly register node-safe pair to NodeSafeRegistry. Following that the
         // connector is set to use safe tx variants.

--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -14,6 +14,7 @@ use libp2p_identity::PeerId;
 use log::{debug, error, warn};
 use serde_json::json;
 use serde_with::{serde_as, DisplayFromStr, DurationMilliSeconds};
+use tide::http::headers::HeaderValue;
 use tide::{
     http::{
         headers::{HeaderName, AUTHORIZATION},
@@ -304,7 +305,11 @@ pub async fn run_hopr_api(
     let mut app = tide::with_state(state.clone());
 
     app.with(LogRequestMiddleware(log::Level::Debug));
-    app.with(CorsMiddleware::new().allow_origin(Origin::from("*")));
+    app.with(
+        CorsMiddleware::new()
+            .allow_methods("GET, POST, OPTIONS, DELETE".parse::<HeaderValue>().unwrap())
+            .allow_origin(Origin::from("*")),
+    );
 
     app.at("/api-docs/openapi.json")
         .get(|_| async move { Ok(Response::builder(200).body(json!(ApiDoc::openapi()))) });

--- a/transport/network/src/ping.rs
+++ b/transport/network/src/ping.rs
@@ -172,7 +172,8 @@ impl<T: PingExternalAPI + std::marker::Send> Pinging for Ping<T> {
                             info!("Successfully pinged peer {}", peer);
                             Ok(current_time()
                                 .as_unix_timestamp()
-                                .saturating_sub(std::time::Duration::from_millis(start).div(2u32)))
+                                .saturating_sub(std::time::Duration::from_millis(start))
+                                .div(2u32))
                         } else {
                             error!("Failed to verify the challenge for ping to peer: {}", peer.to_string());
                             Err(())


### PR DESCRIPTION
Minor usability fixes for the API:
- [x] Add `DELETE` to CORS in the API
- [x] lastSeenLatency was showing an incorrectly divided value
- [x] `node/info` does not contain multiaddress data for the announced nodes

## Notes
Fixes #6008
Fixes #6034 
Fixes #6036