### PR TITLE
Soft-restart indexer loop on error, expose `max_block_range` on the CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "chain-rpc"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-std",
  "async-stream",
@@ -1157,7 +1157,6 @@ dependencies = [
  "chain-types",
  "env_logger",
  "ethers",
- "ethers-providers",
  "futures",
  "futures-timer",
  "hopr-crypto-types",

--- a/chain/rpc/Cargo.toml
+++ b/chain/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-rpc"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Abstraction over Ethereum RPC provider client"
@@ -16,7 +16,6 @@ async-trait = { workspace = true }
 async-std = { workspace = true, features = ["unstable"] }
 async-stream = "0.3.5"
 ethers = { workspace = true }
-ethers-providers = { version = "2", default-features = false }
 futures = { workspace = true }
 futures-timer = { workspace = true }
 http-types = "2.12.0"

--- a/chain/rpc/src/client.rs
+++ b/chain/rpc/src/client.rs
@@ -12,7 +12,7 @@
 //! async runtimes (the default HTTP client in `ethers` is using `reqwest`, which is `tokio` specific).
 //! Secondly, this abstraction also allows to implement WASM-compatible HTTP client if needed at some point.
 use async_trait::async_trait;
-use ethers_providers::{JsonRpcClient, JsonRpcError};
+use ethers::providers::{JsonRpcClient, JsonRpcError};
 use log::{debug, trace, warn};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
@@ -512,7 +512,7 @@ pub fn create_rpc_client_to_anvil<R: HttpPostRequestor + Debug>(
 pub mod tests {
     use chain_types::utils::create_anvil;
     use chain_types::{ContractAddresses, ContractInstances};
-    use ethers_providers::JsonRpcClient;
+    use ethers::providers::JsonRpcClient;
     use hopr_crypto_types::keypairs::{ChainKeypair, Keypair};
     use hopr_primitive_types::primitives::Address;
     use serde_json::json;

--- a/chain/rpc/src/errors.rs
+++ b/chain/rpc/src/errors.rs
@@ -1,7 +1,7 @@
 /// Errors produced by this crate and other error-related types.
 use ethers::prelude::nonce_manager::NonceManagerError;
 use ethers::prelude::signer::SignerMiddlewareError;
-use ethers_providers::{JsonRpcError, ProviderError};
+use ethers::providers::{JsonRpcError, ProviderError};
 use thiserror::Error;
 
 /// Enumerates different errors produced by this crate.
@@ -35,7 +35,7 @@ pub enum RpcError {
     KeypairError(#[from] ethers::signers::WalletError),
 
     #[error(transparent)]
-    ProviderError(#[from] ethers_providers::ProviderError),
+    ProviderError(#[from] ProviderError),
 }
 
 pub type Result<T> = std::result::Result<T, RpcError>;

--- a/chain/rpc/src/helper.rs
+++ b/chain/rpc/src/helper.rs
@@ -2,7 +2,7 @@
 //!
 //! Most of these types were taken as-is from <https://github.com/gakonst/ethers-rs>, because
 //! they are not exposed as public from the `ethers` crate.
-use ethers_providers::JsonRpcError;
+use ethers::providers::JsonRpcError;
 use serde::de::{MapAccess, Unexpected, Visitor};
 use serde::{de, Deserialize, Serialize};
 use serde_json::value::RawValue;

--- a/chain/rpc/src/lib.rs
+++ b/chain/rpc/src/lib.rs
@@ -221,7 +221,7 @@ impl PendingTransaction<'_> {
 impl<'a, P: ethers::providers::JsonRpcClient> From<ethers::providers::PendingTransaction<'a, P>>
     for PendingTransaction<'a>
 {
-    fn from(value: ethers_providers::PendingTransaction<'a, P>) -> Self {
+    fn from(value: ethers::providers::PendingTransaction<'a, P>) -> Self {
         let tx_hash = Hash::from(value.tx_hash());
         Self {
             tx_hash,

--- a/chain/rpc/src/rpc.rs
+++ b/chain/rpc/src/rpc.rs
@@ -8,9 +8,9 @@ use chain_types::{ContractAddresses, ContractInstances};
 use ethers::middleware::{MiddlewareBuilder, NonceManagerMiddleware, SignerMiddleware};
 use ethers::prelude::k256::ecdsa::SigningKey;
 use ethers::prelude::transaction::eip2718::TypedTransaction;
+use ethers::providers::{JsonRpcClient, Middleware, Provider};
 use ethers::signers::{LocalWallet, Signer, Wallet};
 use ethers::types::{BlockId, NameOrAddress};
-use ethers_providers::{JsonRpcClient, Middleware, Provider};
 use hopr_crypto_types::keypairs::{ChainKeypair, Keypair};
 use hopr_primitive_types::prelude::*;
 use log::debug;
@@ -58,7 +58,7 @@ pub struct RpcOperationsConfig {
     ///
     /// Defaults to 2500 blocks
     #[validate(range(min = 1))]
-    #[default = 2500]
+    #[default = 1000]
     pub max_block_range_fetch_size: u64,
     /// Interval for polling on TX submission
     ///

--- a/hopr/hopr-lib/data/protocol-config.json
+++ b/hopr/hopr-lib/data/protocol-config.json
@@ -29,7 +29,7 @@
       "confirmations": 8,
       "environment_type": "staging",
       "indexer_start_block_number": 29521261,
-      "max_block_range": 2000,
+      "max_block_range": 1000,
       "tags": ["development"],
       "tx_polling_interval": 3000,
       "version_range": "*"
@@ -50,7 +50,7 @@
       "confirmations": 8,
       "environment_type": "production",
       "indexer_start_block_number": 29706814,
-      "max_block_range": 2000,
+      "max_block_range": 1000,
       "tags": ["etherscan"],
       "tx_polling_interval": 3000,
       "version_range": "2.*"
@@ -71,7 +71,7 @@
       "confirmations": 8,
       "environment_type": "production",
       "indexer_start_block_number": 24097267,
-      "max_block_range": 2000,
+      "max_block_range": 1000,
       "tags": ["etherscan"],
       "tx_polling_interval": 3000,
       "version_range": "1.89||1.90||1.91||1.92||1.93"
@@ -92,7 +92,7 @@
       "confirmations": 8,
       "environment_type": "staging",
       "indexer_start_block_number": 29690361,
-      "max_block_range": 2000,
+      "max_block_range": 1000,
       "tags": ["etherscan"],
       "tx_polling_interval": 3000,
       "version_range": "2.*"

--- a/hoprd/hoprd/src/cli.rs
+++ b/hoprd/hoprd/src/cli.rs
@@ -200,6 +200,15 @@ pub struct CliArgs {
     pub check_unrealized_balance: u8,
 
     #[arg(
+        long = "maxBlockRange",
+        help = "Maximum number of blocks that can be fetched in a batch request from the RPC provider.",
+        env = "HOPRD_MAX_BLOCK_RANGE",
+        value_name = "MAX_BLOCK_RANGE",
+        value_parser = clap::value_parser ! (u64)
+    )]
+    pub max_block_range: Option<u64>,
+
+    #[arg(
         long,
         help = "A custom RPC provider to be used for the node to connect to blockchain",
         env = "HOPRD_PROVIDER",

--- a/hoprd/hoprd/src/config.rs
+++ b/hoprd/hoprd/src/config.rs
@@ -245,8 +245,16 @@ impl HoprdConfig {
 
         //   TODO: custom provider is redundant with the introduction of protocol-config.json
         if let Some(x) = cli_args.provider {
-            cfg.hopr.chain.provider = Some(x)
-        };
+            cfg.hopr.chain.provider = Some(x);
+        }
+
+        if let Some(x) = cli_args.max_block_range {
+            // Override all max_block_range setting in all networks
+            for (_, n) in cfg.hopr.chain.protocols.networks.iter_mut() {
+                n.max_block_range = x;
+            }
+        }
+
         if cli_args.check_unrealized_balance == 0 {
             cfg.hopr.chain.check_unrealized_balance = true;
         }


### PR DESCRIPTION
This PR exposes the `max_block_range` parameter on the CLI and ENV variables.

The default value of `max_block_range` is decreased from 2000 to 1000.

Also, as a follow-up to #6057, the logic in RPC log fetching loop (used by the Indexer) is improved, so it does not always panic on fatal errors.

This PR supersedes #6052
Refs #6039