### PR TITLE
Better handling of missing block errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3329,7 +3329,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "2.1.0-rc.2"
+version = "2.1.0-rc.3"
 dependencies = [
  "async-lock 2.8.0",
  "async-std",

--- a/chain/rpc/src/client.rs
+++ b/chain/rpc/src/client.rs
@@ -66,6 +66,9 @@ lazy_static::lazy_static! {
 /// namely all the JSON RPC error codes specified in `retryable_json_rpc_errors` and all the HTTP errors
 /// specified in `retryable_http_errors`.
 ///
+/// The total wait time will be `(initial_backoff/backoff_coefficient) * ((1 + backoff_coefficient)^max_retries - 1)`.
+/// or `max_backoff`, whatever is lower.
+///
 /// Transport and connection errors (such as connection timeouts) are retried without backoff
 /// at a constant delay of `initial_backoff` if `backoff_on_transport_errors` is not set.
 ///
@@ -77,9 +80,9 @@ pub struct SimpleJsonRpcRetryPolicy {
     ///
     /// If `None` is given, will keep retrying indefinitely.
     ///
-    /// Default is 10.
+    /// Default is 7.
     #[validate(range(min = 1))]
-    #[default(Some(10))]
+    #[default(Some(7))]
     pub max_retries: Option<u32>,
     /// Initial wait before retries.
     ///

--- a/chain/rpc/src/indexer.rs
+++ b/chain/rpc/src/indexer.rs
@@ -33,7 +33,7 @@ lazy_static::lazy_static! {
     ).unwrap();
 }
 
-fn is_missing_block_error(err: LogQueryError<ProviderError>) -> bool {
+fn is_missing_block_error(err: &LogQueryError<ProviderError>) -> bool {
     match err {
         LogQueryError::LoadLastBlockError(ProviderError::JsonRpcClientError(e))
         | LogQueryError::LoadLogsError(ProviderError::JsonRpcClientError(e)) => e
@@ -147,7 +147,7 @@ impl<P: JsonRpcClient + 'static> HoprIndexerRpcOperations for RpcOperations<P> {
                                     // Workaround for some RPC providers complaining about
                                     // ethers pagination algorithm that might be requesting blocks
                                     // from the outside of the given range (in future).
-                                    if is_missing_block_error(e) {
+                                    if is_missing_block_error(&e) {
                                         warn!("pagination requested future blocks when processing range #{from_block} - #{latest_block}");
                                         break;
                                     }

--- a/chain/rpc/src/rpc.rs
+++ b/chain/rpc/src/rpc.rs
@@ -46,19 +46,19 @@ pub struct RpcOperationsConfig {
     pub expected_block_time: Duration,
     /// Minimum size of the block range where batch fetch query should be used.
     ///
-    /// For block ranges smaller than this size, the ordinary `getLogs` will be called without pagination.
+    /// For block ranges smaller than this size, the ordinary `eth_getLogs` will be called without pagination.
     ///
-    /// Defaults to 3.
+    /// Defaults to 100.
     #[validate(range(min = 1))]
-    #[default = 3]
+    #[default = 100]
     pub min_block_range_fetch_size: u64,
     /// The largest amount of blocks to fetch at once when fetching a range of blocks.
     ///
     /// If the requested block range size is N, then the client will always fetch `min(N, max_block_range_fetch_size)`
     ///
-    /// Defaults to 2500 blocks
+    /// Defaults to 2000 blocks
     #[validate(range(min = 1))]
-    #[default = 1000]
+    #[default = 2000]
     pub max_block_range_fetch_size: u64,
     /// Interval for polling on TX submission
     ///


### PR DESCRIPTION
The log pagination algorithm in `ethers` might request blocks outside the fixed block range, which is handled differently by different RPC providers.

This PR handles the missing block error (-32001) so it is not considered fatal and further blocks are not requested.

Also the minimum block limit to use pagination has been increased to 100, and the maximum block range was as well increased to 2000.