### PR TITLE
Separate `get_peer_with_quality` expression

### DIFF
--- a/logic/strategy/src/promiscuous.rs
+++ b/logic/strategy/src/promiscuous.rs
@@ -211,10 +211,16 @@ where
     }
 
     async fn get_peers_with_quality(&self) -> HashMap<Address, f64> {
-        self.network
+        let all_peers = self
+            .network
             .read()
             .await
             .all_peers()
+            .into_iter()
+            .cloned()
+            .collect::<Vec<_>>();
+
+        all_peers
             .into_iter()
             .filter_map(|status| match OffchainPublicKey::try_from(status.id) {
                 Ok(offchain_key) => {


### PR DESCRIPTION
Separating this expression ensures any interlocking cannot happen in this area, at the cost of slightly worse performance.