### PR TITLE
Update identity password from CLI

### DIFF
--- a/ethereum/contracts/foundry.toml
+++ b/ethereum/contracts/foundry.toml
@@ -3,7 +3,7 @@
 [profile.default]
 # Don't commit changes to this line which point to /nix/store/...
 # These are part of the `nix develop` shell setup.
-solc = "0.8.19"
+solc = "/nix/store/4g52a63s8r5pdv2nn6ymwm2ggydmrf5q-solc-default/bin/solc"
 src = 'src'
 test = 'test'
 out = 'out'

--- a/ethereum/contracts/foundry.toml
+++ b/ethereum/contracts/foundry.toml
@@ -3,7 +3,7 @@
 [profile.default]
 # Don't commit changes to this line which point to /nix/store/...
 # These are part of the `nix develop` shell setup.
-solc = "/nix/store/4g52a63s8r5pdv2nn6ymwm2ggydmrf5q-solc-default/bin/solc"
+solc = "0.8.19"
 src = 'src'
 test = 'test'
 out = 'out'

--- a/hopli/README.md
+++ b/hopli/README.md
@@ -166,6 +166,20 @@ hopli sync-network-registry --network anvil-localhost \
     --eligibility true
 ```
 
+### Update identities password
+
+To update some identites' password with old and new password as env variables. Alternatively, paths to the passwords files can be provided with `--old-password-path` and `--new-password-path`.
+
+```
+IDENTITY_PASSWORD=old_pwd
+NEW_IDENTITY_PASSWORD=new_pwd
+hopli update_identity_password \
+    --identity-directory "./test"
+```
+
+The identities will be modified inplace.
+
+
 ## Development
 
 ### Run local development

--- a/hopli/src/identity_update.rs
+++ b/hopli/src/identity_update.rs
@@ -1,0 +1,68 @@
+use crate::identity_input::LocalIdentityArgs;
+use crate::key_pair::{read_identity, update_identity_password};
+use crate::password::PasswordArgs;
+use crate::utils::{Cmd, HelperErrors};
+use clap::Parser;
+use tracing::{debug, error};
+
+#[derive(Parser, Clone, Debug)]
+pub struct IdentityUpdateArgs {
+    #[clap(flatten)]
+    old_password: PasswordArgs,
+
+    #[clap(flatten)]
+    new_password: PasswordArgs,
+
+    #[clap(flatten)]
+    local_identity: LocalIdentityArgs,
+}
+
+impl IdentityUpdateArgs {
+    /// Execute the command with given parameters
+    fn execute_identity_password_update(self) -> Result<(), HelperErrors> {
+        let IdentityUpdateArgs {
+            old_password,
+            new_password,
+            local_identity,
+        } = self;
+
+        let pwd = match old_password.read_password() {
+            Ok(read_pwd) => read_pwd,
+            Err(e) => return Err(e),
+        };
+        let new_pwd = match new_password.read_password() {
+            Ok(read_pwd) => read_pwd,
+            Err(e) => return Err(e),
+        };
+
+        if local_identity.identity_from_directory.is_none() {
+            error!("Does not support file. Must provide an identity-directory");
+            return Err(HelperErrors::MissingIdentityDirectory);
+        }
+
+        let files = local_identity.get_files();
+        debug!("Identities read {:?}", files.len());
+
+        for file in files {
+
+            let keys = match read_identity(&file, &pwd) {
+                Ok((_, keys)) => keys,
+                Err(_) => return Err(HelperErrors::UnableToUpdateIdentityPassword),
+            };
+
+            match update_identity_password(keys, &file, &new_pwd) {
+                Ok(_) => (),
+                Err(_) => return Err(HelperErrors::UnableToUpdateIdentityPassword),
+            }
+        }
+
+        Ok(())
+    }
+}
+
+impl Cmd for IdentityUpdateArgs {
+    /// Run the execute_identity_password_update function
+    fn run(self) -> Result<(), HelperErrors> {
+        self.execute_identity_password_update()
+    }
+}

--- a/hopli/src/identity_update.rs
+++ b/hopli/src/identity_update.rs
@@ -1,6 +1,6 @@
 use crate::identity_input::LocalIdentityArgs;
 use crate::key_pair::{read_identity, update_identity_password};
-use crate::password::PasswordArgs;
+use crate::password::PasswordsArgs;
 use crate::utils::{Cmd, HelperErrors};
 use clap::Parser;
 use tracing::{debug, error};
@@ -8,10 +8,7 @@ use tracing::{debug, error};
 #[derive(Parser, Clone, Debug)]
 pub struct IdentityUpdateArgs {
     #[clap(flatten)]
-    old_password: PasswordArgs,
-
-    #[clap(flatten)]
-    new_password: PasswordArgs,
+    passwords: PasswordsArgs,
 
     #[clap(flatten)]
     local_identity: LocalIdentityArgs,
@@ -21,16 +18,15 @@ impl IdentityUpdateArgs {
     /// Execute the command with given parameters
     fn execute_identity_password_update(self) -> Result<(), HelperErrors> {
         let IdentityUpdateArgs {
-            old_password,
-            new_password,
+            passwords,
             local_identity,
         } = self;
 
-        let pwd = match old_password.read_password() {
+        let pwd = match passwords.read_old_password() {
             Ok(read_pwd) => read_pwd,
             Err(e) => return Err(e),
         };
-        let new_pwd = match new_password.read_password() {
+        let new_pwd = match passwords.read_new_password() {
             Ok(read_pwd) => read_pwd,
             Err(e) => return Err(e),
         };
@@ -44,7 +40,6 @@ impl IdentityUpdateArgs {
         debug!("Identities read {:?}", files.len());
 
         for file in files {
-
             let keys = match read_identity(&file, &pwd) {
                 Ok((_, keys)) => keys,
                 Err(_) => return Err(HelperErrors::UnableToUpdateIdentityPassword),

--- a/hopli/src/key_pair.rs
+++ b/hopli/src/key_pair.rs
@@ -70,13 +70,9 @@ pub fn update_identity_password(
 
     if path.exists() && path.is_file() && file_path.ends_with(".id") {
         // insert remove actual file with name `file_path`
-        match fs::remove_file(file_path) {
-            Ok(_) => {
-                keys.write_eth_keystore(file_path, password)?;
-                Ok(Some((String::from(file_path), keys)))
-            }
-            Err(_) => Err(HelperErrors::UnableToUpdateIdentityPassword),
-        }
+        fs::remove_file(file_path).map_err(|_err| HelperErrors::UnableToUpdateIdentityPassword)?;
+        keys.write_eth_keystore(file_path, password)?;
+        Ok(Some((String::from(file_path), keys)))
     } else {
         warn!(
             "Could not update keystore file at {}. {}",

--- a/hopli/src/key_pair.rs
+++ b/hopli/src/key_pair.rs
@@ -64,7 +64,9 @@ pub fn update_identity_password(
     path: &PathBuf,
     password: &str,
 ) -> Result<Option<(String, HoprKeys)>, HelperErrors> {
-    let file_path = path.to_str().ok_or(HelperErrors::IncorrectFilename(path.to_string_lossy().to_string()))?;
+    let file_path = path
+        .to_str()
+        .ok_or(HelperErrors::IncorrectFilename(path.to_string_lossy().to_string()))?;
 
     if file_path.ends_with(".id") {
         // insert remove actual file with name `file_path`

--- a/hopli/src/key_pair.rs
+++ b/hopli/src/key_pair.rs
@@ -5,7 +5,7 @@ use std::{
     fs,
     path::{Path, PathBuf},
 };
-use tracing::warn;
+use tracing::{error, warn};
 
 pub fn read_identity(file: &PathBuf, password: &str) -> Result<(String, HoprKeys), HelperErrors> {
     let file_str = file
@@ -22,7 +22,7 @@ pub fn read_identity(file: &PathBuf, password: &str) -> Result<(String, HoprKeys
             Ok((String::from(file_key.to_str().unwrap()), keys))
         }
         Err(e) => {
-            warn!("Could not decrypt keystore file at {}. {}", file_str, e.to_string());
+            error!("Could not decrypt keystore file at {}. {}", file_str, e.to_string());
             Err(HelperErrors::UnableToReadIdentity)
         }
     }
@@ -68,7 +68,7 @@ pub fn update_identity_password(
         .to_str()
         .ok_or(HelperErrors::IncorrectFilename(path.to_string_lossy().to_string()))?;
 
-    if file_path.ends_with(".id") {
+    if path.exists() && path.is_file() && file_path.ends_with(".id") {
         // insert remove actual file with name `file_path`
         match fs::remove_file(file_path) {
             Ok(_) => {

--- a/hopli/src/key_pair.rs
+++ b/hopli/src/key_pair.rs
@@ -7,15 +7,35 @@ use std::{
 };
 use tracing::warn;
 
-/// Decrypt identity files and returns an vec of PeerIds and Ethereum Addresses
+pub fn read_identity(file: &PathBuf, password: &str) -> Result<(String, HoprKeys), HelperErrors> {
+    let file_str = file
+        .to_str()
+        .ok_or(HelperErrors::IncorrectFilename(file.to_string_lossy().to_string()))
+        .unwrap();
+
+    match HoprKeys::read_eth_keystore(file_str, password) {
+        Ok((keys, needs_migration)) => {
+            if needs_migration {
+                keys.write_eth_keystore(file_str, password).unwrap();
+            }
+            let file_key = file.file_name().unwrap();
+            Ok((String::from(file_key.to_str().unwrap()), keys))
+        }
+        Err(e) => {
+            warn!("Could not decrypt keystore file at {}. {}", file_str, e.to_string());
+            Err(HelperErrors::UnableToReadIdentity)
+        }
+    }
+}
+
+/// Decrypts identity files and returns an vec of PeerIds and Ethereum Addresses
 ///
 /// # Arguments
 ///
-/// * `identity_directory` - Directory to all the identity files
+/// * `files` - List of identity files
 /// * `password` - Password to unlock all the identity files
-/// * `identity_prefix` - Prefix of identity files. Only identity files with the provided are decrypted with the password
 pub fn read_identities(files: Vec<PathBuf>, password: &str) -> Result<HashMap<String, HoprKeys>, HelperErrors> {
-    let mut results = HashMap::with_capacity(files.len());
+    let mut results: HashMap<String, HoprKeys> = HashMap::with_capacity(files.len());
 
     for file in files.iter() {
         let file_str = file
@@ -37,6 +57,31 @@ pub fn read_identities(files: Vec<PathBuf>, password: &str) -> Result<HashMap<St
     }
 
     Ok(results)
+}
+
+pub fn update_identity_password(
+    keys: HoprKeys,
+    path: &PathBuf,
+    password: &str,
+) -> Result<Option<(String, HoprKeys)>, HelperErrors> {
+    let file_path = path.to_str().ok_or(HelperErrors::IncorrectFilename(path.to_string_lossy().to_string()))?;
+
+    if file_path.ends_with(".id") {
+        // insert remove actual file with name `file_path`
+        match fs::remove_file(file_path) {
+            Ok(_) => {
+                keys.write_eth_keystore(file_path, password)?;
+                return Ok(Some((String::from(file_path), keys)));
+            }
+            Err(_) => return Err(HelperErrors::UnableToUpdateIdentityPassword),
+        }
+    } else {
+        warn!(
+            "Could not update keystore file at {}. {}",
+            file_path, "File name does not end with `.id`"
+        );
+        Err(HelperErrors::UnableToUpdateIdentityPassword)
+    }
 }
 
 /// Create one identity file and return the ethereum address

--- a/hopli/src/key_pair.rs
+++ b/hopli/src/key_pair.rs
@@ -7,7 +7,7 @@ use std::{
 };
 use tracing::{error, warn};
 
-pub fn read_identity(file: &PathBuf, password: &str) -> Result<(String, HoprKeys), HelperErrors> {
+pub fn read_identity(file: &Path, password: &str) -> Result<(String, HoprKeys), HelperErrors> {
     let file_str = file
         .to_str()
         .ok_or(HelperErrors::IncorrectFilename(file.to_string_lossy().to_string()))
@@ -61,7 +61,7 @@ pub fn read_identities(files: Vec<PathBuf>, password: &str) -> Result<HashMap<St
 
 pub fn update_identity_password(
     keys: HoprKeys,
-    path: &PathBuf,
+    path: &Path,
     password: &str,
 ) -> Result<Option<(String, HoprKeys)>, HelperErrors> {
     let file_path = path
@@ -73,9 +73,9 @@ pub fn update_identity_password(
         match fs::remove_file(file_path) {
             Ok(_) => {
                 keys.write_eth_keystore(file_path, password)?;
-                return Ok(Some((String::from(file_path), keys)));
+                Ok(Some((String::from(file_path), keys)))
             }
-            Err(_) => return Err(HelperErrors::UnableToUpdateIdentityPassword),
+            Err(_) => Err(HelperErrors::UnableToUpdateIdentityPassword),
         }
     } else {
         warn!(

--- a/hopli/src/main.rs
+++ b/hopli/src/main.rs
@@ -2,6 +2,7 @@
 use crate::create_safe_module::CreateSafeModuleArgs;
 use crate::faucet::FaucetArgs;
 use crate::identity::IdentityArgs;
+use crate::identity_update::IdentityUpdateArgs;
 use crate::initialize_node::InitializeNodeArgs;
 use crate::migrate_safe_module::MigrateSafeModuleArgs;
 use crate::move_node_to_safe_module::MoveNodeToSafeModuleArgs;
@@ -15,6 +16,7 @@ pub mod environment_config;
 pub mod faucet;
 pub mod identity;
 pub mod identity_input;
+pub mod identity_update;
 pub mod initialize_node;
 pub mod key_pair;
 pub mod migrate_safe_module;
@@ -42,6 +44,8 @@ struct Cli {
 enum Commands {
     #[clap(about = "Create and store identity files")]
     Identity(IdentityArgs),
+    #[clap(about = "Update identity password")]
+    UpdateIdentityPassword(IdentityUpdateArgs),
     #[clap(about = "Fund given address and/or addressed derived from identity files native tokens or HOPR tokens")]
     Faucet(FaucetArgs),
     #[clap(about = "Registry some nodes peer ids to the network registery contract")]
@@ -77,6 +81,9 @@ fn main() -> Result<(), HelperErrors> {
 
     match cli.command {
         Commands::Identity(opt) => {
+            opt.run()?;
+        }
+        Commands::UpdateIdentityPassword(opt) => {
             opt.run()?;
         }
         Commands::Faucet(opt) => {

--- a/hopli/src/password.rs
+++ b/hopli/src/password.rs
@@ -40,3 +40,75 @@ impl PasswordArgs {
         }
     }
 }
+
+/// Verification provider arguments
+#[derive(Debug, Clone, Parser, Default)]
+pub struct PasswordsArgs {
+    #[clap(
+        long,
+        help = "The path to a file containing the old password",
+        long_help = "The path to read the old password. If not specified, the IDENTITY_PASSWORD environment variable.",
+        value_hint = ValueHint::FilePath,
+        name = "old_password",
+        value_name = "OLD_PASSWORD"
+    )]
+    old_password_path: Option<PathBuf>,
+
+    #[clap(
+        long,
+        help = "The path to a file containing the new password",
+        long_help = "The path to read the new password. If not specified, the NEW_IDENTITY_PASSWORD environment variable.",
+        value_hint = ValueHint::FilePath,
+        name = "new_password",
+        value_name = "NEW_PASSWORD"
+    )]
+    new_password_path: Option<PathBuf>,
+}
+
+impl PasswordsArgs {
+    pub fn read_old_password(&self) -> Result<String, HelperErrors> {
+        match self.old_password_path {
+            Some(ref old_password_path) => {
+                // read password from file
+                if let Ok(pwd_from_file) = read_to_string(old_password_path) {
+                    Ok(pwd_from_file)
+                } else {
+                    println!("Cannot read from password_path");
+                    Err(HelperErrors::UnableToReadPassword)
+                }
+            }
+            None => {
+                // read password from environment variable
+                if let Ok(pwd_from_env) = env::var("IDENTITY_PASSWORD") {
+                    Ok(pwd_from_env)
+                } else {
+                    println!("Cannot read old password from env var");
+                    Err(HelperErrors::UnableToReadPassword)
+                }
+            }
+        }
+    }
+
+    pub fn read_new_password(&self) -> Result<String, HelperErrors> {
+        match self.new_password_path {
+            Some(ref new_password_path) => {
+                // read password from file
+                if let Ok(pwd_from_file) = read_to_string(new_password_path) {
+                    Ok(pwd_from_file)
+                } else {
+                    println!("Cannot read from password_path");
+                    Err(HelperErrors::UnableToReadPassword)
+                }
+            }
+            None => {
+                // read password from environment variable
+                if let Ok(pwd_from_env) = env::var("NEW_IDENTITY_PASSWORD") {
+                    Ok(pwd_from_env)
+                } else {
+                    println!("Cannot read new password from env var");
+                    Err(HelperErrors::UnableToReadPassword)
+                }
+            }
+        }
+    }
+}

--- a/hopli/src/password.rs
+++ b/hopli/src/password.rs
@@ -49,8 +49,8 @@ pub struct PasswordsArgs {
         help = "The path to a file containing the old password",
         long_help = "The path to read the old password. If not specified, the IDENTITY_PASSWORD environment variable.",
         value_hint = ValueHint::FilePath,
-        name = "old_password",
-        value_name = "OLD_PASSWORD"
+        name = "old-password-path",
+        value_name = "IDENTITY_PASSWORD"
     )]
     old_password_path: Option<PathBuf>,
 
@@ -59,8 +59,8 @@ pub struct PasswordsArgs {
         help = "The path to a file containing the new password",
         long_help = "The path to read the new password. If not specified, the NEW_IDENTITY_PASSWORD environment variable.",
         value_hint = ValueHint::FilePath,
-        name = "new_password",
-        value_name = "NEW_PASSWORD"
+        name = "new-password-path",
+        value_name = "NEW_IDENTITY_PASSWORD"
     )]
     new_password_path: Option<PathBuf>,
 }

--- a/hopli/src/password.rs
+++ b/hopli/src/password.rs
@@ -66,49 +66,33 @@ pub struct PasswordsArgs {
 }
 
 impl PasswordsArgs {
-    pub fn read_old_password(&self) -> Result<String, HelperErrors> {
-        match self.old_password_path {
-            Some(ref old_password_path) => {
+    fn read_password(&self, password_path: &Option<PathBuf>, default_key: &str) -> Result<String, HelperErrors> {
+        match password_path {
+            Some(ref password_path) => {
                 // read password from file
-                if let Ok(pwd_from_file) = read_to_string(old_password_path) {
+                if let Ok(pwd_from_file) = read_to_string(password_path) {
                     Ok(pwd_from_file)
                 } else {
-                    println!("Cannot read from password_path");
+                    println!("Cannot read from password_path {}", password_path.display());
                     Err(HelperErrors::UnableToReadPassword)
                 }
             }
             None => {
                 // read password from environment variable
-                if let Ok(pwd_from_env) = env::var("IDENTITY_PASSWORD") {
+                if let Ok(pwd_from_env) = env::var(default_key) {
                     Ok(pwd_from_env)
                 } else {
-                    println!("Cannot read old password from env var");
+                    println!("Cannot read from env var for {}", default_key);
                     Err(HelperErrors::UnableToReadPassword)
                 }
             }
         }
     }
+    pub fn read_old_password(&self) -> Result<String, HelperErrors> {
+        self.read_password(&self.old_password_path, "IDENTITY_PASSWORD")
+    }
 
     pub fn read_new_password(&self) -> Result<String, HelperErrors> {
-        match self.new_password_path {
-            Some(ref new_password_path) => {
-                // read password from file
-                if let Ok(pwd_from_file) = read_to_string(new_password_path) {
-                    Ok(pwd_from_file)
-                } else {
-                    println!("Cannot read from password_path");
-                    Err(HelperErrors::UnableToReadPassword)
-                }
-            }
-            None => {
-                // read password from environment variable
-                if let Ok(pwd_from_env) = env::var("NEW_IDENTITY_PASSWORD") {
-                    Ok(pwd_from_env)
-                } else {
-                    println!("Cannot read new password from env var");
-                    Err(HelperErrors::UnableToReadPassword)
-                }
-            }
-        }
+        self.read_password(&self.new_password_path, "NEW_IDENTITY_PASSWORD")
     }
 }

--- a/hopli/src/utils.rs
+++ b/hopli/src/utils.rs
@@ -21,6 +21,9 @@ pub enum HelperErrors {
     #[error("unable to create identity")]
     UnableToCreateIdentity,
 
+    #[error("unable to update identity password")]
+    UnableToUpdateIdentityPassword,
+
     #[error("incorrect filename: {0}")]
     IncorrectFilename(String),
 


### PR DESCRIPTION
Added a hopli command to update and identity password.

Accepts the same kind of arguments as the `identity` command, except that two passwords needs to be provided, either via two files containing the passwords, or two environment variables. See usage:
```
Usage: hopli update-identity-password [OPTIONS]

Options:
      --old-password-path <OLD_PASSWORD>
          The path to read the old password. If not specified, the IDENTITY_PASSWORD environment variable.

      --new-password-path <NEW_PASSWORD>
          The path to read the new password. If not specified, the NEW_IDENTITY_PASSWORD environment variable.

  -d, --identity-directory <IDENTITY_DIRECTORY>
          Path to the directory that stores identity files

  -x, --identity-prefix <IDENTITY_PREFIX>
          Only use identity files with prefix

      --identity-from-path <identity_from_path>
          The path to an identity file

  -h, --help
          Print help (see a summary with '-h')
```

If the password update is successful, the old identity file is modified in place.