### PR TITLE
Fix commit hash labeling docker images

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,6 +74,8 @@ jobs:
             echo "DOCKER_TAG=${docker_tag}" >> $GITHUB_OUTPUT
             echo "DOCKER_TAG_PR=${docker_tag_pr}" >> $GITHUB_OUTPUT
           fi
+        env:
+          GITHUB_SHA: ${{ github.sha }}
 
       - name: Build and push docker image - Default
         run: nix run .#${{ matrix.target }}-docker-build-and-upload

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,10 +74,11 @@ jobs:
             echo "DOCKER_TAG=${docker_tag}" >> $GITHUB_OUTPUT
             echo "DOCKER_TAG_PR=${docker_tag_pr}" >> $GITHUB_OUTPUT
           fi
+          echo "COMMIT_SHA=${{ github.event.pull_request.head.sha }}"
           echo "DOCKER_TAG=${docker_tag}"
           echo "DOCKER_TAG_PR=${docker_tag_pr}"
         env:
-          GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
 
       - name: Build and push docker image - Default
         run: nix run .#${{ matrix.target }}-docker-build-and-upload

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -75,7 +75,7 @@ jobs:
             echo "DOCKER_TAG_PR=${docker_tag_pr}" >> $GITHUB_OUTPUT
           fi
         env:
-          GITHUB_SHA: ${{ github.sha }}
+          GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
 
       - name: Build and push docker image - Default
         run: nix run .#${{ matrix.target }}-docker-build-and-upload

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,7 +74,6 @@ jobs:
             echo "DOCKER_TAG=${docker_tag}" >> $GITHUB_OUTPUT
             echo "DOCKER_TAG_PR=${docker_tag_pr}" >> $GITHUB_OUTPUT
           fi
-          echo "COMMIT_SHA=${{ github.event.pull_request.head.sha }}"
           echo "DOCKER_TAG=${docker_tag}"
           echo "DOCKER_TAG_PR=${docker_tag_pr}"
         env:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,6 +74,8 @@ jobs:
             echo "DOCKER_TAG=${docker_tag}" >> $GITHUB_OUTPUT
             echo "DOCKER_TAG_PR=${docker_tag_pr}" >> $GITHUB_OUTPUT
           fi
+          echo "DOCKER_TAG=${docker_tag}"
+          echo "DOCKER_TAG_PR=${docker_tag_pr}"
         env:
           GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
 

--- a/.github/workflows/clean-pr.yaml
+++ b/.github/workflows/clean-pr.yaml
@@ -49,16 +49,3 @@ jobs:
           do
             gh actions-cache delete $cacheKey -R hoprnet/hoprnet -B refs/pull/${{ github.event.inputs.pr_number }}/merge --confirm
           done
-
-      - name: Cleanup Docker Registry
-        run: |
-          docker_registry="europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/docker-images"
-          next_version=$(./scripts/get-next-version.sh Build)
-          images=('hopli' 'hoprd')
-          for image in "${images[@]}"; do
-            echo "Removing tag: $image:${next_version} and $image:${next_version}-cache"
-            gcloud artifacts docker images delete --quiet --delete-tags --async ${docker_registry}/$image:${next_version} || true
-            gcloud artifacts docker images delete --quiet --delete-tags --async ${docker_registry}/$image:${next_version}-cache || true
-          done
-        env:
-          GITHUB_SHA: ${{ github.sha }}

--- a/.github/workflows/clean-pr.yaml
+++ b/.github/workflows/clean-pr.yaml
@@ -60,3 +60,5 @@ jobs:
             gcloud artifacts docker images delete --quiet --delete-tags --async ${docker_registry}/$image:${next_version} || true
             gcloud artifacts docker images delete --quiet --delete-tags --async ${docker_registry}/$image:${next_version}-cache || true
           done
+        env:
+          GITHUB_SHA: ${{ github.sha }}

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -88,7 +88,7 @@ jobs:
           if ${{ contains(github.event.pull_request.labels.*.name, 'release') }}; then
             docker_pr_tag=$(./scripts/get-current-version.sh docker)
           else
-            docker_pr_tag=$(./scripts/get-next-version.sh Build | sed 's/+/-/')
+            docker_pr_tag=$(./scripts/get-next-version.sh Build | sed 's/+.*/-pr.'${{ github.event.pull_request.number }}'/')
           fi
           # Set docker release latest tag
           declare base_branch=${{ github.event.pull_request.base.ref }}

--- a/scripts/get-next-version.sh
+++ b/scripts/get-next-version.sh
@@ -93,7 +93,7 @@ fi
 
 # Adds Build information if needed
 if [ "${release_type}" = "Build" ]; then
-    short_sha=$(git rev-parse --short "${GITHUB_SHA:-HEAD}")
+    short_sha=$(git rev-parse --short "${COMMIT_SHA:-HEAD}")
     new_version="${new_version}+commit.${short_sha}"
 fi
 

--- a/scripts/get-next-version.sh
+++ b/scripts/get-next-version.sh
@@ -93,7 +93,7 @@ fi
 
 # Adds Build information if needed
 if [ "${release_type}" = "Build" ]; then
-    short_sha=$(git rev-parse --short HEAD)
+    short_sha=$(git rev-parse --short "${GITHUB_SHA:-HEAD}")
     new_version="${new_version}+commit.${short_sha}"
 fi
 


### PR DESCRIPTION
The docker tags are based on PR commit hash which disappears when the branch is gone. It needs to be based on commit hash.