### PR TITLE
Saint Louis fixes from practical testing session

### DIFF
--- a/.github/workflows/label.yaml
+++ b/.github/workflows/label.yaml
@@ -13,7 +13,6 @@ name: Labeler
 
 on:
   pull_request:
-  pull_request_target:
 
 concurrency:
   group: ${{ github.head_ref }}-label

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Ensure local changes were not committed
         run: |
-           test "$(grep -c -E "^solc = \"/nix/store/.*$" ethereum/contracts/foundry.toml)" -eq "0"
+          test "$(grep -c -E "^solc = \"/nix/store/.*$" ethereum/contracts/foundry.toml)" -eq "0"
 
       - name: Run linter
         run: nix develop -c make lint

--- a/chain/rpc/src/indexer.rs
+++ b/chain/rpc/src/indexer.rs
@@ -162,7 +162,7 @@ impl<P: JsonRpcClient + 'static> HoprIndexerRpcOperations for RpcOperations<P> {
                                         from_block = current_block_log.block_id;
                                         continue 'outer;
                                     } else {
-                                        panic!("!!! Cannot advance the chain indexing due to unrecoverable RPC errors. 
+                                        panic!("!!! Cannot advance the chain indexing due to unrecoverable RPC errors.
 
                                         The RPC provider does not seem to be working correctly. 
                                         

--- a/chain/rpc/src/indexer.rs
+++ b/chain/rpc/src/indexer.rs
@@ -162,7 +162,11 @@ impl<P: JsonRpcClient + 'static> HoprIndexerRpcOperations for RpcOperations<P> {
                                         from_block = current_block_log.block_id;
                                         continue 'outer;
                                     } else {
-                                        panic!("cannot advance due to unrecoverable RPC error: {e}");
+                                        panic!("!!! Cannot advance the chain indexing due to unrecoverable RPC errors. 
+
+                                        The RPC provider does not seem to be working correctly. 
+                                        
+                                        The last encountered error was: {e}");
                                     }
                                 }
                             }

--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -129,7 +129,7 @@ pub struct InternalState {
             tickets::NodeTicketStatisticsResponse, tickets::ChannelTicket,
             network::TicketPriceResponse,
             node::EntryNode, node::NodeInfoResponse, node::NodePeersQueryRequest,
-            node::HeartbeatInfo, node::PeerInfo, node::NodePeersResponse, node::NodeVersionResponse
+            node::HeartbeatInfo, node::PeerInfo, node::AnnouncedPeer, node::NodePeersResponse, node::NodeVersionResponse,
         )
     ),
     modifiers(&SecurityAddon),

--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -2263,7 +2263,7 @@ mod node {
         pub quality: Option<f64>,
     }
 
-    #[derive(Debug, Clone, serde::Serialize, utoipa::ToSchema)]
+    #[derive(Debug, Default, Clone, serde::Serialize, utoipa::ToSchema)]
     #[serde(rename_all = "camelCase")]
     pub(crate) struct HeartbeatInfo {
         pub sent: u64,
@@ -2292,11 +2292,23 @@ mod node {
         pub reported_version: String,
     }
 
+    #[serde_as]
+    #[derive(Debug, Clone, serde::Serialize, utoipa::ToSchema)]
+    #[serde(rename_all = "camelCase")]
+    pub(crate) struct AnnouncedPeer {
+        #[serde_as(as = "DisplayFromStr")]
+        #[schema(value_type = String)]
+        pub peer_id: PeerId,
+        #[serde_as(as = "DisplayFromStr")]
+        #[schema(value_type = String)]
+        pub peer_address: Address,
+    }
+
     #[derive(Debug, Clone, serde::Serialize, utoipa::ToSchema)]
     #[serde(rename_all = "camelCase")]
     pub(crate) struct NodePeersResponse {
         pub connected: Vec<PeerInfo>,
-        pub announced: Vec<PeerInfo>,
+        pub announced: Vec<AnnouncedPeer>,
     }
 
     /// Lists information for `connected peers` and `announced peers`.
@@ -2379,9 +2391,19 @@ mod node {
             .collect::<Vec<_>>()
             .await;
 
+        let announced_peers = hopr
+            .accounts_announced_on_chain()
+            .await?
+            .into_iter()
+            .map(|announced| AnnouncedPeer {
+                peer_id: announced.public_key.into(),
+                peer_address: announced.chain_addr,
+            })
+            .collect::<Vec<_>>();
+
         let body = NodePeersResponse {
-            connected: all_network_peers.clone(),
-            announced: all_network_peers, // TODO: currently these are the same, since everybody has to announce
+            connected: all_network_peers,
+            announced: announced_peers,
         };
 
         Ok(Response::builder(200).body(json!(body)).build())

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,4 +7,4 @@ ruff==0.0.261
 waiting==1.4.1
 websocket-client==1.5.1
 websockets==11.0.1
-hoprd-sdk @ git+https://github.com/hoprnet/hoprd-sdk-python@kauki/type-renaming-2.1
+hoprd-sdk @ git+https://github.com/hoprnet/hoprd-sdk-python@kauki/2.1.0-rc.3-updates

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -643,18 +643,6 @@ where
     }
 
     pub async fn all_tickets(&self) -> errors::Result<Vec<Ticket>> {
-        todo!()
-        /*Ok(self
-        .db
-        .read()
-        .await
-        .get_acknowledged_tickets(None)
-        .await
-        .map(|tickets| {
-            tickets
-                .into_iter()
-                .map(|acked_ticket| acked_ticket.ticket)
-                .collect::<Vec<_>>()
-        })?)*/
+        Ok(self.db.get_all_tickets().await?.into_iter().map(|v| v.ticket).collect())
     }
 }

--- a/transport/protocol/src/msg/mixer.rs
+++ b/transport/protocol/src/msg/mixer.rs
@@ -80,7 +80,7 @@ mod tests {
     #[async_std::test]
     async fn test_then_concurrent_proper_execution_results_in_concurrent_processing() {
         let constant_delay = Duration::from_millis(50);
-        let tolerance = Duration::from_millis(3);
+        let tolerance = constant_delay / 5;
 
         let expected = vec![1, 2, 3];
 
@@ -95,7 +95,7 @@ mod tests {
 
         let elapsed = start.elapsed();
         assert_gt!(elapsed, constant_delay);
-        assert_lt!((elapsed - constant_delay).as_millis(), tolerance.as_millis());
+        assert_lt!(elapsed.saturating_sub(constant_delay), tolerance);
     }
 
     #[async_std::test]


### PR DESCRIPTION
Fix minor bugs in the 2.1 implementation before the release.

- [x] Improve the RPC provider failures causing the node to shutdown panic message (closes #6118 )
- [x] Remove a forgotten `todo!()` in `the get_all_tickets` endpoint
- [x] Run PR labeler only for local PRs
- [x] Properly list all announced peers and update the announced output (closes #6098 ) 
- [x] Generate new python client API from spec at https://github.com/hoprnet/hoprd-sdk-python/pull/37