### PR TITLE
Add node configuration endpoint

### DIFF
--- a/hoprd/hoprd/src/main.rs
+++ b/hoprd/hoprd/src/main.rs
@@ -254,6 +254,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             node_ingress,
             run_hopr_api(
                 &host_listen,
+                cfg.as_redacted_string()?,
                 &cfg.api,
                 node,
                 inbox.clone(),


### PR DESCRIPTION
Add the `node/configuration` endpoint that dumps a json format of redacted node configuration.

## Notes
Closes #6128 