### PR TITLE
Improvements to ticket metrics and deprecation of ticket displaying API endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3540,6 +3540,7 @@ dependencies = [
  "hopr-db-entity",
  "hopr-db-migration",
  "hopr-internal-types",
+ "hopr-metrics",
  "hopr-primitive-types",
  "lazy_static",
  "libp2p-identity",

--- a/db/api/Cargo.toml
+++ b/db/api/Cargo.toml
@@ -7,6 +7,10 @@ homepage = "https://hoprnet.org/"
 repository = "https://github.com/hoprnet/hoprnet"
 license = "GPL-3.0-only"
 
+[features]
+default = []
+prometheus = ["dep:lazy_static", "dep:hopr-metrics"]
+
 [dependencies]
 async-std = { workspace = true }
 async-lock = { workspace = true }
@@ -15,6 +19,7 @@ async-trait = { workspace = true }
 chrono = { workspace = true }
 bincode = "1.3.3"
 futures = { workspace = true }
+lazy_static = { workspace = true, optional = true }
 libp2p-identity = { workspace = true }
 moka = { workspace = true }
 multiaddr = { workspace = true }
@@ -34,6 +39,7 @@ hopr-primitive-types = { workspace = true}
 hopr-db-entity = { workspace = true }
 hopr-db-migration = { workspace = true }
 hopr-internal-types = { workspace = true }
+hopr-metrics = { workspace = true, optional = true }
 
 [dev-dependencies]
 async-std = { workspace = true, features = ["attributes"] }
@@ -42,4 +48,3 @@ lazy_static = { workspace = true }
 hopr-crypto-random = { workspace = true }
 hex-literal = { workspace = true }
 tracing-test = { workspace = true }
-

--- a/db/migration/src/lib.rs
+++ b/db/migration/src/lib.rs
@@ -14,6 +14,7 @@ mod m20240301_000011_tickets_create_ticket_stats;
 mod m20240301_000012_tickets_create_outgoing_ticket_index;
 mod m20240301_000013_initial_seed_tickets;
 mod m20240301_000014_create_ticket_stats_with_channel_id;
+mod m20240326_000015_recreate_ticket_stats;
 
 #[derive(PartialEq)]
 pub enum BackendType {
@@ -47,6 +48,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20240301_000014_create_ticket_stats_with_channel_id::Migration(
                 BackendType::Postgres,
             )),
+            Box::new(m20240326_000015_recreate_ticket_stats::Migration(BackendType::Postgres)),
         ]
     }
 }
@@ -98,6 +100,7 @@ impl MigratorTrait for MigratorTickets {
             Box::new(m20240301_000014_create_ticket_stats_with_channel_id::Migration(
                 BackendType::SQLite,
             )),
+            Box::new(m20240326_000015_recreate_ticket_stats::Migration(BackendType::SQLite)),
         ]
     }
 }

--- a/db/migration/src/m20240326_000015_recreate_ticket_stats.rs
+++ b/db/migration/src/m20240326_000015_recreate_ticket_stats.rs
@@ -1,0 +1,110 @@
+use crate::BackendType;
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration(pub BackendType);
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // TODO: we have to drop here, if the previous non-release migration is retained.
+        // Remove, if the previous ticket_stats migration is compacted before the release
+        // and compact this change as well.
+        manager
+            .get_connection()
+            .execute_unprepared("DROP TRIGGER trig_ticket_stats_update_timestamp;")
+            .await?;
+
+        manager
+            .drop_table(Table::drop().table(TicketStatistics::Table).to_owned())
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(TicketStatistics::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(TicketStatistics::Id)
+                            .integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(TicketStatistics::ChannelId)
+                            .string_len(64)
+                            .not_null()
+                            .unique_key(),
+                    )
+                    .col(ColumnDef::new(TicketStatistics::LastUpdated).timestamp().null())
+                    .col(
+                        ColumnDef::new(TicketStatistics::WinningTickets)
+                            .not_null()
+                            .integer()
+                            .default(0),
+                    )
+                    .col(
+                        ColumnDef::new(TicketStatistics::RedeemedValue)
+                            .binary_len(12)
+                            .not_null()
+                            .default(vec![0u8; 12]),
+                    )
+                    .col(
+                        ColumnDef::new(TicketStatistics::NeglectedValue)
+                            .binary_len(12)
+                            .not_null()
+                            .default(vec![0u8; 12]),
+                    )
+                    .col(
+                        ColumnDef::new(TicketStatistics::RejectedValue)
+                            .binary_len(12)
+                            .not_null()
+                            .default(vec![0u8; 12]),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        let conn = manager.get_connection();
+
+        conn.execute_unprepared(
+            r#"
+            CREATE TRIGGER IF NOT EXISTS trig_ticket_stats_update_timestamp
+                AFTER UPDATE
+                ON ticket_statistics
+                FOR EACH ROW
+                WHEN OLD.last_updated IS NULL OR NEW.last_updated < OLD.last_updated --- avoid infinite loop
+            BEGIN
+                UPDATE ticket_statistics SET last_updated=CURRENT_TIMESTAMP WHERE id=OLD.id;
+            END;
+        "#,
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+
+        conn.execute_unprepared("DROP TRIGGER trig_ticket_stats_update_timestamp;")
+            .await?;
+
+        manager
+            .drop_table(Table::drop().table(TicketStatistics::Table).to_owned())
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+enum TicketStatistics {
+    Table,
+    Id,
+    ChannelId,
+    LastUpdated,
+    WinningTickets,
+    RedeemedValue,
+    NeglectedValue,
+    RejectedValue,
+}

--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -51,4 +51,4 @@ ethers = { workspace = true }
 
 [features]
 default = ["prometheus"]
-prometheus = ["dep:hopr-metrics", "core-transport/prometheus", "chain-api/prometheus", "chain-indexer/prometheus", "chain-rpc/prometheus",  ]
+prometheus = ["dep:hopr-metrics", "core-transport/prometheus", "chain-api/prometheus", "chain-indexer/prometheus", "chain-rpc/prometheus", "hopr-db-api/prometheus" ]

--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -2051,6 +2051,7 @@ mod tickets {
 
     #[derive(Debug, Clone, serde::Serialize, utoipa::ToSchema)]
     #[schema(example = json!({
+        "winning_count": "0",
         "neglectedValue": "0",
         "redeemedValue": "100",
         "rejectedValue": "0",
@@ -2059,6 +2060,7 @@ mod tickets {
     #[serde(rename_all = "camelCase")]
     // TODO: see if tide support u128 instead on the ticket counts
     pub(crate) struct NodeTicketStatisticsResponse {
+        pub winning_count: u64,
         pub unredeemed_value: String,
         pub redeemed_value: String,
         pub neglected_value: String,
@@ -2068,6 +2070,7 @@ mod tickets {
     impl From<TicketStatistics> for NodeTicketStatisticsResponse {
         fn from(value: TicketStatistics) -> Self {
             Self {
+                winning_count: value.winning_count as u64,
                 unredeemed_value: value.unredeemed_value.amount().to_string(),
                 redeemed_value: value.redeemed_value.amount().to_string(),
                 neglected_value: value.neglected_value.amount().to_string(),

--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -2013,17 +2013,16 @@ mod tickets {
         ),
         tag = "Channels"
     )]
+    #[deprecated]
     pub(super) async fn show_channel_tickets(req: Request<InternalState>) -> tide::Result<Response> {
         let hopr = req.state().hopr.clone();
 
         match Hash::from_hex(req.param("channelId")?) {
             Ok(channel_id) => match hopr.tickets_in_channel(&channel_id).await {
-                Ok(Some(tickets)) => Ok(Response::builder(200)
-                    .body(json!(tickets
-                        .into_iter()
-                        .map(|t| ChannelTicket::from(t.ticket))
-                        .collect::<Vec<_>>()))
-                    .build()),
+                Ok(Some(_tickets)) => {
+                    let tickets: Vec<ChannelTicket> = vec![];
+                    Ok(Response::builder(200).body(json!(tickets)).build())
+                }
                 Ok(None) => Ok(Response::builder(404).body(ApiErrorStatus::ChannelNotFound).build()),
                 Err(e) => Ok(Response::builder(422).body(ApiErrorStatus::from(e)).build()),
             },
@@ -2046,14 +2045,10 @@ mod tickets {
         ),
         tag = "Tickets"
     )]
-    pub(super) async fn show_all_tickets(req: Request<InternalState>) -> tide::Result<Response> {
-        let hopr = req.state().hopr.clone();
-        match hopr.all_tickets().await {
-            Ok(tickets) => Ok(Response::builder(200)
-                .body(json!(tickets.into_iter().map(ChannelTicket::from).collect::<Vec<_>>()))
-                .build()),
-            Err(e) => Ok(Response::builder(422).body(ApiErrorStatus::from(e)).build()),
-        }
+    #[deprecated]
+    pub(super) async fn show_all_tickets(_req: Request<InternalState>) -> tide::Result<Response> {
+        let tickets: Vec<ChannelTicket> = vec![];
+        Ok(Response::builder(200).body(json!(tickets)).build())
     }
 
     #[derive(Debug, Clone, serde::Serialize, utoipa::ToSchema)]

--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -2058,7 +2058,6 @@ mod tickets {
         "unredeemedValue": "200",
     }))]
     #[serde(rename_all = "camelCase")]
-    // TODO: see if tide support u128 instead on the ticket counts
     pub(crate) struct NodeTicketStatisticsResponse {
         pub winning_count: u64,
         pub unredeemed_value: String,

--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -2013,7 +2013,6 @@ mod tickets {
         ),
         tag = "Channels"
     )]
-    #[deprecated]
     pub(super) async fn show_channel_tickets(req: Request<InternalState>) -> tide::Result<Response> {
         let hopr = req.state().hopr.clone();
 
@@ -2045,7 +2044,6 @@ mod tickets {
         ),
         tag = "Tickets"
     )]
-    #[deprecated]
     pub(super) async fn show_all_tickets(_req: Request<InternalState>) -> tide::Result<Response> {
         let tickets: Vec<ChannelTicket> = vec![];
         Ok(Response::builder(200).body(json!(tickets)).build())
@@ -2053,44 +2051,26 @@ mod tickets {
 
     #[derive(Debug, Clone, serde::Serialize, utoipa::ToSchema)]
     #[schema(example = json!({
-        "losingTickets": 0,
-        "neglected": 0,
         "neglectedValue": "0",
-        "redeemed": 1,
         "redeemedValue": "100",
-        "rejected": 0,
         "rejectedValue": "0",
-        "unredeemed": 2,
         "unredeemedValue": "200",
-        "winProportion": 1
     }))]
     #[serde(rename_all = "camelCase")]
     // TODO: see if tide support u128 instead on the ticket counts
     pub(crate) struct NodeTicketStatisticsResponse {
-        pub win_proportion: f64,
-        pub unredeemed: u64,
         pub unredeemed_value: String,
-        pub redeemed: u64,
         pub redeemed_value: String,
-        pub losing_tickets: u64,
-        pub neglected: u64,
         pub neglected_value: String,
-        pub rejected: u64,
         pub rejected_value: String,
     }
 
     impl From<TicketStatistics> for NodeTicketStatisticsResponse {
         fn from(value: TicketStatistics) -> Self {
             Self {
-                win_proportion: value.win_proportion,
-                unredeemed: value.unredeemed as u64,
                 unredeemed_value: value.unredeemed_value.amount().to_string(),
-                redeemed: value.redeemed as u64,
                 redeemed_value: value.redeemed_value.amount().to_string(),
-                losing_tickets: value.losing as u64,
-                neglected: value.neglected as u64,
                 neglected_value: value.neglected_value.amount().to_string(),
-                rejected: value.rejected as u64,
                 rejected_value: value.rejected_value.amount().to_string(),
             }
         }

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,4 +7,4 @@ ruff==0.0.261
 waiting==1.4.1
 websocket-client==1.5.1
 websockets==11.0.1
-hoprd-sdk @ git+https://github.com/hoprnet/hoprd-sdk-python@kauki/2.1.0-rc.3-updates
+hoprd-sdk @ git+https://github.com/hoprnet/hoprd-sdk-python@kauki/2.1.0-rc-3-update-20240326

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -516,9 +516,11 @@ async def test_hoprd_should_create_redeemable_tickets_on_routing_in_1_hop_to_sel
 
         # ensure ticket stats are updated after messages are sent
         statistics_after = await swarm7[dest].api.get_tickets_statistics()
-        
-        unredeemed_value = (balance_str_to_int(statistics_after.unredeemed_value) - balance_str_to_int(statistics_before.unredeemed_value))
-        
+
+        unredeemed_value = balance_str_to_int(statistics_after.unredeemed_value) - balance_str_to_int(
+            statistics_before.unredeemed_value
+        )
+
         assert statistics_after.redeemed_value == statistics_before.redeemed_value
         assert unredeemed_value == (len(packets) * TICKET_PRICE_PER_HOP)
 
@@ -528,7 +530,10 @@ async def test_hoprd_should_create_redeemable_tickets_on_routing_in_1_hop_to_sel
 
         # ensure ticket stats are updated after redemption
         statistics_after_redemption = await swarm7[dest].api.get_tickets_statistics()
-        assert (balance_str_to_int(statistics_after_redemption.redeemed_value) - balance_str_to_int(statistics_after.redeemed_value)) == (len(packets) * TICKET_PRICE_PER_HOP)
+        assert (
+            balance_str_to_int(statistics_after_redemption.redeemed_value)
+            - balance_str_to_int(statistics_after.redeemed_value)
+        ) == (len(packets) * TICKET_PRICE_PER_HOP)
         assert balance_str_to_int(statistics_after_redemption.unredeemed_value) == 0
 
 

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -248,6 +248,7 @@ impl ChannelEventEmitter {
 /// Ticket statistics data exposed by the ticket mechanism.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TicketStatistics {
+    pub winning_count: u128,
     pub unredeemed_value: hopr_primitive_types::primitives::Balance,
     pub redeemed_value: hopr_primitive_types::primitives::Balance,
     pub neglected_value: hopr_primitive_types::primitives::Balance,
@@ -618,6 +619,7 @@ where
         let ticket_stats = self.db.get_ticket_statistics(None, None).await?;
 
         Ok(TicketStatistics {
+            winning_count: ticket_stats.winning_tickets,
             unredeemed_value: ticket_stats.unredeemed_value,
             redeemed_value: ticket_stats.redeemed_value,
             neglected_value: ticket_stats.neglected_value,

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -248,15 +248,9 @@ impl ChannelEventEmitter {
 /// Ticket statistics data exposed by the ticket mechanism.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct TicketStatistics {
-    pub losing: u128,
-    pub win_proportion: f64,
-    pub unredeemed: u128,
     pub unredeemed_value: hopr_primitive_types::primitives::Balance,
-    pub redeemed: u128,
     pub redeemed_value: hopr_primitive_types::primitives::Balance,
-    pub neglected: u128,
     pub neglected_value: hopr_primitive_types::primitives::Balance,
-    pub rejected: u128,
     pub rejected_value: hopr_primitive_types::primitives::Balance,
 }
 
@@ -622,22 +616,11 @@ where
     pub async fn ticket_statistics(&self) -> errors::Result<TicketStatistics> {
         // TODO: add parameter to specify which channel are we interested in
         let ticket_stats = self.db.get_ticket_statistics(None, None).await?;
-        let received_tickets = ticket_stats.unredeemed_tickets + ticket_stats.losing_tickets;
 
         Ok(TicketStatistics {
-            win_proportion: if received_tickets > 0 {
-                ticket_stats.unredeemed_tickets as f64 / received_tickets as f64
-            } else {
-                0f64
-            },
-            losing: ticket_stats.losing_tickets,
-            unredeemed: ticket_stats.unredeemed_tickets,
             unredeemed_value: ticket_stats.unredeemed_value,
-            redeemed: ticket_stats.redeemed_tickets,
             redeemed_value: ticket_stats.redeemed_value,
-            neglected: ticket_stats.neglected_tickets,
             neglected_value: ticket_stats.neglected_value,
-            rejected: ticket_stats.rejected_tickets,
             rejected_value: ticket_stats.rejected_value,
         })
     }

--- a/transport/protocol/src/ticket_aggregation/processor.rs
+++ b/transport/protocol/src/ticket_aggregation/processor.rs
@@ -120,7 +120,7 @@ where
         let mut awaiter = self.writer.clone().aggregate_tickets(channel, prerequisites)?;
 
         if let Err(e) = awaiter.consume_and_wait(self.agg_timeout).await {
-            error!("Error occured on ticket aggregation for '{channel}', performing a rollback: {e}");
+            warn!("Error occured on ticket aggregation for '{channel}', performing a rollback: {e}");
             self.db.rollback_aggregation_in_channel(*channel).await?;
         }
 


### PR DESCRIPTION
Deprecate the no longer necessary API functionality in the form of ticket displaying through the API endpoints and replace it with a useful implementation of metric export.

- [x] Deprecate the `*/tickets` endpoints
- [x] Introduce the metrics for per channel and summary ticket statistics
- [x] Update the tests
- [x] Generate the new API (https://github.com/hoprnet/hoprd-sdk-python/pull/38)  

## Notes
Closes #6127 