### PR TITLE
Add 503 as retryable HTTP code per-default, add global min retries

### DIFF
--- a/hopr/hopr-lib/src/chain.rs
+++ b/hopr/hopr-lib/src/chain.rs
@@ -321,7 +321,10 @@ where
     let rpc_http_config = chain_rpc::client::native::HttpPostRequestorConfig::default();
 
     // TODO: extract this from the global config type
-    let rpc_http_retry_policy = SimpleJsonRpcRetryPolicy::default();
+    let rpc_http_retry_policy = SimpleJsonRpcRetryPolicy {
+        min_retries: Some(2),
+        ..SimpleJsonRpcRetryPolicy::default()
+    };
 
     // TODO: extract this from the global config type
     let rpc_cfg = RpcOperationsConfig {


### PR DESCRIPTION
 As in title, this PR adds two things:

 - make HTTP error code 503 retried per default
 - add minimum number of retries regardless the error code, and set HOPRd default to 2.

Refs #6137 