### PR TITLE
Fix ticket aggregation criteria

### DIFF
--- a/db/entity/src/conversions/tickets.rs
+++ b/db/entity/src/conversions/tickets.rs
@@ -8,7 +8,7 @@ use sea_orm::Set;
 /// TODO: implement as TryFrom trait once https://github.com/hoprnet/hoprnet/pull/6018 is merged
 pub fn model_to_acknowledged_ticket(
     db_ticket: &ticket::Model,
-    domain_separator: Hash,
+    domain_separator: &Hash,
     chain_keypair: &ChainKeypair,
 ) -> crate::errors::Result<AcknowledgedTicket> {
     let response = Response::from_bytes(&db_ticket.response)?;
@@ -28,9 +28,9 @@ pub fn model_to_acknowledged_ticket(
     ticket.challenge = response.to_challenge().to_ethereum_challenge();
     ticket.signature = Some(Signature::from_bytes(&db_ticket.signature)?);
 
-    let signer = ticket.recover_signer(&domain_separator)?.to_address();
+    let signer = ticket.recover_signer(domain_separator)?.to_address();
 
-    let mut ticket = AcknowledgedTicket::new(ticket, response, signer, chain_keypair, &domain_separator)?;
+    let mut ticket = AcknowledgedTicket::new(ticket, response, signer, chain_keypair, domain_separator)?;
     ticket.status = AcknowledgedTicketStatus::try_from(db_ticket.state as u8)
         .map_err(|_| DbEntityError::ConversionError("invalid ticket state".into()))?;
 

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -487,7 +487,7 @@ where
         Ok(self
             .ticket_aggregate_actions
             .clone()
-            .aggregate_tickets(&entry.get_id(), None)?
+            .aggregate_tickets(&entry.get_id(), Default::default())?
             .consume_and_wait(std::time::Duration::from_millis(60000))
             .await?)
     }

--- a/transport/protocol/src/ticket_aggregation/processor.rs
+++ b/transport/protocol/src/ticket_aggregation/processor.rs
@@ -51,7 +51,7 @@ pub const TICKET_AGGREGATION_RX_QUEUE_SIZE: usize = 2048;
 pub enum TicketAggregationToProcess<T, U> {
     ToReceive(PeerId, std::result::Result<Ticket, String>, U),
     ToProcess(PeerId, Vec<AcknowledgedTicket>, T),
-    ToSend(Hash, Option<AggregationPrerequisites>, TicketAggregationFinalizer),
+    ToSend(Hash, AggregationPrerequisites, TicketAggregationFinalizer),
 }
 
 /// Emitted by the processor background pipeline once processed
@@ -115,7 +115,7 @@ where
     pub async fn aggregate_tickets_in_the_channel(
         &self,
         channel: &Hash,
-        prerequisites: Option<AggregationPrerequisites>,
+        prerequisites: AggregationPrerequisites,
     ) -> Result<()> {
         let mut awaiter = self.writer.clone().aggregate_tickets(channel, prerequisites)?;
 
@@ -221,7 +221,7 @@ impl<T, U> TicketAggregationActions<T, U> {
     pub fn aggregate_tickets(
         &mut self,
         channel: &Hash,
-        prerequisites: Option<AggregationPrerequisites>,
+        prerequisites: AggregationPrerequisites,
     ) -> Result<TicketAggregationAwaiter> {
         let (tx, rx) = oneshot::channel::<()>();
 
@@ -558,7 +558,7 @@ mod tests {
 
         let mut awaiter = bob
             .writer()
-            .aggregate_tickets(&channel_alice_bob.get_id(), None)
+            .aggregate_tickets(&channel_alice_bob.get_id(), Default::default())
             .unwrap();
 
         let mut finalizer = None;


### PR DESCRIPTION
There were multiple bugs discovered in matching the criteria before requesting a ticket aggregation:

- ticket aggregation triggered too often for all channels and draining the connection pool (https://github.com/hoprnet/hoprnet/issues/6138)
- off by one issue when aggregating

This PR should fix them.