### PR TITLE
Fix on channel close aggregation criteria

### DIFF
--- a/db/api/src/tickets.rs
+++ b/db/api/src/tickets.rs
@@ -1147,6 +1147,7 @@ impl HoprDbTicketOperations for HoprDb {
             })
             .await?;
 
+        info!("successfully processed received aggregated {acked_aggregated_ticket}");
         Ok(acked_aggregated_ticket)
     }
 


### PR DESCRIPTION
The ticket aggregation criteria in the Aggregating strategy were wrong for the `on_own_channel_closed` event, so this has been fixed.

Also some logging was made less verbose.