### PR TITLE
Move the peers database purge immediately into the DB creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3558,6 +3558,7 @@ dependencies = [
  "moka",
  "multiaddr",
  "num_enum",
+ "rand 0.8.5",
  "sea-orm",
  "sea-query",
  "sea-query-binder",

--- a/db/api/Cargo.toml
+++ b/db/api/Cargo.toml
@@ -44,6 +44,7 @@ hopr-metrics = { workspace = true, optional = true }
 [dev-dependencies]
 async-std = { workspace = true, features = ["attributes"] }
 env_logger = { workspace = true }
+rand = "0.8.5"
 lazy_static = { workspace = true }
 hopr-crypto-random = { workspace = true }
 hex-literal = { workspace = true }

--- a/db/api/src/ticket_manager.rs
+++ b/db/api/src/ticket_manager.rs
@@ -1,13 +1,15 @@
 use futures::{future::BoxFuture, StreamExt, TryStreamExt};
 use hopr_db_entity::ticket;
 use hopr_primitive_types::primitives::{Balance, BalanceType};
-use sea_orm::{ActiveModelTrait, EntityTrait, QueryFilter, TransactionTrait};
+use hopr_primitive_types::traits::ToHex;
+use sea_orm::{ActiveModelTrait, ColumnTrait, EntityTrait, QueryFilter, TransactionTrait};
 use std::sync::Arc;
 use tracing::error;
 
 use hopr_internal_types::acknowledgement::AcknowledgedTicket;
 
 use crate::cache::HoprDbCaches;
+use crate::prelude::DbError;
 use crate::{errors::Result, tickets::TicketSelector, OpenTransaction};
 
 /// Functionality related to locking and structural improvements to the underlying SQLite database
@@ -45,12 +47,54 @@ impl TicketManager {
             // TODO: it would be beneficial to check the size hint and extract as much, as possible
             // in this step to avoid relocking for each individual ticket.
             while let Some(acknowledged_ticket) = rx.next().await {
-                let _guard = mutex_clone.lock().await;
-                if let Err(e) = hopr_db_entity::ticket::ActiveModel::from(acknowledged_ticket)
-                    .insert(&db_clone)
+                match db_clone
+                    .begin_with_config(None, None)
                     .await
+                    .map_err(crate::errors::DbError::BackendError)
                 {
-                    error!("failed to insert a winning ticket into the DB: {e}")
+                    Ok(transaction) => {
+                        let transaction = OpenTransaction(transaction, crate::TargetDb::Tickets);
+
+                        let _quard = mutex_clone.lock().await;
+
+                        if let Err(e) = transaction
+                            .perform(|tx| {
+                                Box::pin(async move {
+                                    let channel_id = acknowledged_ticket.ticket.channel_id.to_hex();
+
+                                    hopr_db_entity::ticket::ActiveModel::from(acknowledged_ticket)
+                                        .insert(tx.as_ref())
+                                        .await?;
+
+                                    if let Some(model) = hopr_db_entity::ticket_statistics::Entity::find()
+                                        .filter(
+                                            hopr_db_entity::ticket_statistics::Column::ChannelId.eq(channel_id.clone()),
+                                        )
+                                        .one(tx.as_ref())
+                                        .await?
+                                    {
+                                        hopr_db_entity::ticket_statistics::ActiveModel {
+                                            winning_tickets: sea_orm::Set(model.winning_tickets + 1),
+                                            ..Default::default()
+                                        }
+                                    } else {
+                                        hopr_db_entity::ticket_statistics::ActiveModel {
+                                            channel_id: sea_orm::Set(channel_id),
+                                            winning_tickets: sea_orm::Set(1),
+                                            ..Default::default()
+                                        }
+                                    }
+                                    .insert(tx.as_ref())
+                                    .await
+                                    .map_err(DbError::from)
+                                })
+                            })
+                            .await
+                        {
+                            error!("failed to insert the winning ticket and update the ticket stats: {e}")
+                        };
+                    }
+                    Err(e) => error!("Failed to create a transaction for ticket insertion: {e}"),
                 }
             }
         });

--- a/db/api/src/tickets.rs
+++ b/db/api/src/tickets.rs
@@ -389,7 +389,10 @@ impl Default for ChannelTicketStatistics {
     }
 }
 
-async fn find_stats_for_channel(tx: &OpenTransaction, channel_id: &Hash) -> Result<ticket_statistics::Model> {
+pub(crate) async fn find_stats_for_channel(
+    tx: &OpenTransaction,
+    channel_id: &Hash,
+) -> Result<ticket_statistics::Model> {
     if let Some(model) = ticket_statistics::Entity::find()
         .filter(ticket_statistics::Column::ChannelId.eq(channel_id.to_hex()))
         .one(tx.as_ref())
@@ -686,6 +689,7 @@ impl HoprDbTicketOperations for HoprDb {
                                         acc.redeemed_value + BalanceType::HOPR.balance_bytes(stats.redeemed_value);
                                     acc.rejected_value =
                                         acc.rejected_value + BalanceType::HOPR.balance_bytes(stats.rejected_value);
+                                    acc.winning_tickets += stats.winning_tickets as u128;
                                     acc
                                 });
 

--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -2242,7 +2242,7 @@ mod node {
     /// Get the configuration of the running node.
     #[utoipa::path(
         get,
-        path = "/node/configuration",
+        path = const_format::formatcp!("{BASE_PATH}/node/configuration"),
         responses(
             (status = 200, description = "Fetched node configuration", body = String),
             (status = 401, description = "Invalid authorization token.", body = ApiError),

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -335,8 +335,6 @@ where
     }
 
     pub async fn init_from_db(&self) -> errors::Result<()> {
-        info!("Loading initial peers from the storage");
-
         let index_updater = self.index_updater();
 
         for (peer, _address, multiaddresses) in self.get_public_nodes().await? {

--- a/transport/network/src/network.rs
+++ b/transport/network/src/network.rs
@@ -7,7 +7,7 @@ use libp2p_identity::PeerId;
 use multiaddr::Multiaddr;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DurationSeconds};
-use tracing::{debug, error};
+use tracing::debug;
 use validator::Validate;
 
 pub use hopr_db_api::peers::{PeerOrigin, PeerStatus, Stats};
@@ -173,10 +173,6 @@ where
             METRIC_PEERS_BY_QUALITY.set(&["public", "low"], 0.0);
             METRIC_PEERS_BY_QUALITY.set(&["nonPublic", "high"], 0.0);
             METRIC_PEERS_BY_QUALITY.set(&["nonPublic", "low"], 0.0);
-        }
-
-        if let Err(e) = async_std::task::block_on(db.cleanup_network_peers()) {
-            error!("Failed to initially cleanup the 'peers' database: {e}")
         }
 
         Self {


### PR DESCRIPTION
Minor fixes identified by running the 2.1.0 candidate:
- [x] Solves the issue of peers being present in the persistent DB for a short time and picked up for a heartbeat round, even though the `PeerId`s are not yet available in the swarm.
- [x] Fixes the configuration endpoint generated swagger UI.
- [x] Fixes the ticket statistics winning count value.