### PR TITLE
Reorder multistrategy to first start to happen only once the node is fully running

### DIFF
--- a/db/api/src/ticket_manager.rs
+++ b/db/api/src/ticket_manager.rs
@@ -121,10 +121,19 @@ impl TicketManager {
             ))
         })?;
 
+        #[cfg(all(feature = "prometheus", not(test)))]
+        {
+            crate::tickets::METRIC_HOPR_TICKETS_INCOMING_STATISTICS.set(
+                &[&channel.to_string(), "unredeemed"],
+                (unrealized_value + value).amount().as_u128() as f64,
+            );
+        }
+
         self.caches
             .unrealized_value
             .insert(channel, unrealized_value + value)
             .await;
+
         Ok(())
     }
 

--- a/logic/strategy/src/aggregating.rs
+++ b/logic/strategy/src/aggregating.rs
@@ -180,7 +180,7 @@ where
                     .await
                 {
                     Ok(_) => {
-                        debug!("completed ticket aggregation in channel {channel_id}");
+                        debug!("tried ticket aggregation in channel {channel_id} without any issues");
                     }
                     Err(e) => {
                         error!("cannot complete aggregation in channel {channel_id}: {e}");

--- a/transport/api/src/p2p.rs
+++ b/transport/api/src/p2p.rs
@@ -322,7 +322,7 @@ pub async fn p2p_loop<T>(
                 },
                 Inputs::TicketAggregation(task) => match task {
                     TicketAggregationProcessed::Send(peer, acked_tickets, finalizer) => {
-                        debug!("transport input - ticket aggregation - send request to '{peer}'");
+                        debug!("transport input - ticket aggregation - send request to '{peer}' to aggregate {} tickets", acked_tickets.len());
                         let request_id = swarm.behaviour_mut().ticket_aggregation.send_request(&peer, acked_tickets);
                         active_aggregation_requests.insert(request_id, finalizer);
                     },


### PR DESCRIPTION
This fixes the issue of partially initialized objects and allows running the strategies only when all other components are operational.
- [x] Fixes the positioning and execution of multistrategies
- [x] Fixes the missing per channel unredeemed value metric
- [x] Fixes logs