### PR TITLE
Make aggregation protocol backwards compatible with 2.0.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3604,6 +3604,7 @@ dependencies = [
  "bincode",
  "bindings",
  "bloomfilter",
+ "cbor4ii",
  "ethers",
  "hex-literal",
  "hopr-crypto-random",

--- a/common/internal-types/Cargo.toml
+++ b/common/internal-types/Cargo.toml
@@ -33,7 +33,7 @@ hopr-primitive-types = { workspace = true }
 
 [dev-dependencies]
 bincode = "1.3.3"
-cbor4ii = "0.3.2"
+cbor4ii = { version = "0.3.2", features = ["serde1", "use_std"] }
 lazy_static = { workspace = true }
 
 [features]

--- a/common/internal-types/Cargo.toml
+++ b/common/internal-types/Cargo.toml
@@ -33,6 +33,7 @@ hopr-primitive-types = { workspace = true }
 
 [dev-dependencies]
 bincode = "1.3.3"
+cbor4ii = "0.3.2"
 lazy_static = { workspace = true }
 
 [features]

--- a/common/internal-types/src/legacy.rs
+++ b/common/internal-types/src/legacy.rs
@@ -69,3 +69,54 @@ impl From<crate::acknowledgement::AcknowledgedTicket> for AcknowledgedTicket {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use hex_literal::hex;
+    use lazy_static::lazy_static;
+    use hopr_crypto_random::random_bytes;
+    use hopr_crypto_types::prelude::{ChainKeypair, Keypair};
+    use hopr_crypto_types::types::Hash;
+    use hopr_primitive_types::prelude::{BalanceType, BinarySerializable, EthereumChallenge};
+    use hopr_primitive_types::primitives::Address;
+    use crate::prelude::Ticket;
+
+
+    #[test]
+    fn test_legacy_binary_compatibility_with_2_0_8() {
+        let ckp = ChainKeypair::from_secret(&hex!("14d2d952715a51aadbd4cc6bfac9aa9927182040da7b336d37d5bb7247aa7566")).unwrap();
+        let dst = hex!("345ae204774ff2b3e8d4cac884dad3d1603b5917");
+        let channel_dst = hex!("57dc754bb522f2fe7799e471fd6efd0b6139a2120198f15b92f4a78cb882af35");
+        let challenge = hex!("4162339a4204a1cedf43c92049875a19cb09dd20");
+        let response = hex!("83c841f72b270440b7c8cd7b4f7d806a84f40ead5b04edccbb9a4c8936b91436");
+
+        let ticket = Ticket::new(
+            &Address::new(&dst),
+            &BalanceType::HOPR.balance(1000000_u64),
+            10.into(),
+            2.into(),
+            1.0_f64,
+            2.into(),
+            EthereumChallenge::new(&challenge),
+            &ckp,
+            &Hash::new(&channel_dst)
+        ).unwrap();
+
+        let mut signer = crate::legacy::Address::default();
+        signer.addr.copy_from_slice(&ckp.public().to_address().to_bytes());
+
+        let ack_ticket = crate::legacy::AcknowledgedTicket {
+            status: crate::legacy::AcknowledgedTicketStatus::BeingAggregated {start: 0, end: 0},
+            ticket,
+            response: crate::legacy::Response { response },
+            vrf_params: Default::default(),
+            signer,
+        };
+
+        let serialized = cbor4ii::serde::to_vec(Vec::with_capacity(300), &ack_ticket).unwrap();
+
+        let expected = hex!("00");
+
+        //assert_eq!(expected.as_ref(), serialized.as_slice());
+    }
+}

--- a/common/internal-types/src/legacy.rs
+++ b/common/internal-types/src/legacy.rs
@@ -1,3 +1,7 @@
+//! This module should be removed in 3.0. It introduces the missing binary format separation
+//! from business objects (AcknowledgedTicket), to ensure backwards compatibility of
+//! Ticket Aggregation in 2.x releases
+
 use ethers::core::k256::AffinePoint;
 use ethers::prelude::k256::elliptic_curve::sec1::FromEncodedPoint;
 use ethers::prelude::k256::Scalar;

--- a/common/internal-types/src/legacy.rs
+++ b/common/internal-types/src/legacy.rs
@@ -1,0 +1,71 @@
+use serde::{Deserialize, Serialize};
+use hopr_crypto_types::prelude::*;
+use hopr_primitive_types::prelude::*;
+
+use crate::channels::Ticket;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AcknowledgedTicket {
+    #[serde(default)]
+    pub status: AcknowledgedTicketStatus,
+    pub ticket: Ticket,
+    pub response: Response,
+    pub vrf_params: VrfParameters,
+    pub signer: Address,
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash, PartialOrd, Ord)]
+pub struct Address {
+    addr: [u8; 20],
+}
+
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, PartialOrd, Ord, std::hash::Hash)]
+pub struct Hash {
+    hash: [u8; 32],
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Response {
+    response: [u8; 32],
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub enum AcknowledgedTicketStatus {
+    /// The ticket is available for redeeming or aggregating
+    #[default]
+    Untouched,
+    /// Ticket is currently being redeemed in and on-going redemption process
+    BeingRedeemed { tx_hash: Hash },
+    /// Ticket is currently being aggregated in and on-going aggregation process
+    BeingAggregated { start: u64, end: u64 },
+}
+
+impl From<AcknowledgedTicket> for crate::acknowledgement::AcknowledgedTicket {
+    fn from(value: AcknowledgedTicket) -> Self {
+        Self {
+            status: crate::acknowledgement::AcknowledgedTicketStatus::Untouched,
+            ticket: value.ticket,
+            response: hopr_crypto_types::types::Response::new(&value.response.response),
+            vrf_params: value.vrf_params,
+            signer: hopr_primitive_types::primitives::Address::new(&value.signer.addr),
+        }
+    }
+}
+
+impl From<crate::acknowledgement::AcknowledgedTicket> for AcknowledgedTicket {
+    fn from(value: crate::acknowledgement::AcknowledgedTicket) -> Self {
+        let mut response = Response::default();
+        response.response.copy_from_slice(&value.response.to_bytes());
+
+        let mut signer = Address::default();
+        signer.addr.copy_from_slice(value.signer.as_ref());
+
+        Self {
+            status: AcknowledgedTicketStatus::BeingAggregated {start: 0, end: 0}, // values not  used
+            ticket: value.ticket,
+            response,
+            vrf_params: value.vrf_params,
+            signer,
+        }
+    }
+}

--- a/common/internal-types/src/lib.rs
+++ b/common/internal-types/src/lib.rs
@@ -16,6 +16,9 @@ pub mod errors;
 pub mod protocol;
 
 #[doc(hidden)]
+pub mod legacy; // TODO: remove this in 3.0
+
+#[doc(hidden)]
 pub mod prelude {
     pub use super::account::*;
     pub use super::acknowledgement::*;

--- a/hopr/hopr-lib/tests/chain_integration_tests.rs
+++ b/hopr/hopr-lib/tests/chain_integration_tests.rs
@@ -411,7 +411,7 @@ async fn integration_test_indexer() {
         bob_chain_key.public().to_address()
     );
 
-    async_std::task::sleep(Duration::from_millis(100)).await;
+    async_std::task::sleep(Duration::from_millis(1000)).await;
 
     assert_eq!(
         Some(alice_node.chain_key.public().to_address()),
@@ -586,7 +586,7 @@ async fn integration_test_indexer() {
         _ => panic!("invalid confirmation"),
     };
 
-    async_std::task::sleep(Duration::from_millis(100)).await;
+    async_std::task::sleep(Duration::from_millis(1000)).await;
 
     let channel_bob_alice = alice_node
         .db
@@ -691,7 +691,7 @@ async fn integration_test_indexer() {
         _ => panic!("invalid confirmation"),
     };
 
-    async_std::task::sleep(Duration::from_millis(100)).await;
+    async_std::task::sleep(Duration::from_millis(1000)).await;
 
     let bob_ack_tickets = alice_node
         .db
@@ -799,7 +799,7 @@ async fn integration_test_indexer() {
         _ => panic!("invalid confirmation"),
     }
 
-    async_std::task::sleep(Duration::from_millis(100)).await;
+    async_std::task::sleep(Duration::from_millis(1000)).await;
 
     let channel_alice_bob = alice_node
         .db

--- a/logic/strategy/src/aggregating.rs
+++ b/logic/strategy/src/aggregating.rs
@@ -457,10 +457,11 @@ mod tests {
             match bob.next().await {
                 Some(TicketAggregationProcessed::Send(_, acked_tickets, request_finalizer)) => {
                     let _ = finalizer.insert(request_finalizer);
-                    match alice
-                        .writer()
-                        .receive_aggregation_request(PEERS[1].public().into(), acked_tickets, ())
-                    {
+                    match alice.writer().receive_aggregation_request(
+                        PEERS[1].public().into(),
+                        acked_tickets.into_iter().map(AcknowledgedTicket::from).collect(),
+                        (),
+                    ) {
                         Ok(_) => {}
                         Err(e) => error!("{e}"),
                     }

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -101,7 +101,7 @@ pub fn build_ticket_aggregation<Db>(
     chain_keypair: &ChainKeypair,
 ) -> TicketAggregationInteraction<ResponseChannel<Result<Ticket, String>>, OutboundRequestId>
 where
-    Db: HoprDbTicketOperations + Send + Sync + Clone + std::fmt::Debug + 'static,
+    Db: HoprDbTicketOperations + HoprDbInfoOperations + Send + Sync + Clone + std::fmt::Debug + 'static,
 {
     TicketAggregationInteraction::new(db, chain_keypair)
 }
@@ -269,7 +269,7 @@ use core_protocol::errors::ProtocolError;
 use futures::future::{select, Either};
 use futures::pin_mut;
 use hopr_db_api::errors::DbError;
-use hopr_db_api::prelude::HoprDbProtocolOperations;
+use hopr_db_api::prelude::{HoprDbInfoOperations, HoprDbProtocolOperations};
 use hopr_internal_types::channels::ChannelStatus;
 use hopr_primitive_types::prelude::*;
 

--- a/transport/api/src/p2p.rs
+++ b/transport/api/src/p2p.rs
@@ -95,8 +95,8 @@ impl From<IndexerProcessed> for Inputs {
     }
 }
 
-use std::net::ToSocketAddrs;
 use hopr_internal_types::legacy;
+use std::net::ToSocketAddrs;
 
 /// Replaces the IPv4 and IPv6 from the network layer with a unspecified interface in any multiaddress.
 fn replace_transport_with_unspecified(ma: &multiaddr::Multiaddr) -> crate::errors::Result<multiaddr::Multiaddr> {
@@ -324,7 +324,6 @@ pub async fn p2p_loop<T>(
                 Inputs::TicketAggregation(task) => match task {
                     TicketAggregationProcessed::Send(peer, acked_tickets, finalizer) => {
                         debug!("transport input - ticket aggregation - send request to '{peer}'");
-                        let acked_tickets = acked_tickets.into_iter().map(legacy::AcknowledgedTicket::from).collect::<Vec<_>>();
                         let request_id = swarm.behaviour_mut().ticket_aggregation.send_request(&peer, acked_tickets);
                         active_aggregation_requests.insert(request_id, finalizer);
                     },

--- a/transport/p2p/src/lib.rs
+++ b/transport/p2p/src/lib.rs
@@ -49,6 +49,7 @@ use serde::{Deserialize, Serialize};
 
 use core_network::messaging::ControlMessage;
 use hopr_internal_types::acknowledgement::Acknowledgement;
+use hopr_internal_types::legacy;
 use hopr_internal_types::prelude::*;
 
 /// `Ping` protocol base type for the ping operation
@@ -72,7 +73,7 @@ pub struct HoprNetworkBehavior {
     pub msg: libp2p::request_response::cbor::Behaviour<Box<[u8]>, ()>,
     pub ack: libp2p::request_response::cbor::Behaviour<Acknowledgement, ()>,
     pub ticket_aggregation:
-        libp2p::request_response::cbor::Behaviour<Vec<AcknowledgedTicket>, std::result::Result<Ticket, String>>,
+        libp2p::request_response::cbor::Behaviour<Vec<legacy::AcknowledgedTicket>, std::result::Result<Ticket, String>>,
 }
 
 impl Debug for HoprNetworkBehavior {
@@ -111,7 +112,7 @@ impl HoprNetworkBehavior {
                 libp2p::request_response::Config::default().with_request_timeout(ack_cfg.timeout),
             ),
             ticket_aggregation: libp2p::request_response::cbor::Behaviour::<
-                Vec<AcknowledgedTicket>,
+                Vec<legacy::AcknowledgedTicket>,
                 std::result::Result<Ticket, String>,
             >::new(
                 [(
@@ -144,7 +145,7 @@ pub enum HoprNetworkBehaviorEvent {
     Heartbeat(libp2p::request_response::Event<Ping, Pong>),
     Message(libp2p::request_response::Event<Box<[u8]>, ()>),
     Acknowledgement(libp2p::request_response::Event<Acknowledgement, ()>),
-    TicketAggregation(libp2p::request_response::Event<Vec<AcknowledgedTicket>, std::result::Result<Ticket, String>>),
+    TicketAggregation(libp2p::request_response::Event<Vec<legacy::AcknowledgedTicket>, std::result::Result<Ticket, String>>),
     KeepAlive(void::Void),
 }
 
@@ -166,11 +167,11 @@ impl From<libp2p::request_response::Event<Box<[u8]>, ()>> for HoprNetworkBehavio
     }
 }
 
-impl From<libp2p::request_response::Event<Vec<AcknowledgedTicket>, std::result::Result<Ticket, String>>>
+impl From<libp2p::request_response::Event<Vec<legacy::AcknowledgedTicket>, std::result::Result<Ticket, String>>>
     for HoprNetworkBehaviorEvent
 {
     fn from(
-        event: libp2p::request_response::Event<Vec<AcknowledgedTicket>, std::result::Result<Ticket, String>>,
+        event: libp2p::request_response::Event<Vec<legacy::AcknowledgedTicket>, std::result::Result<Ticket, String>>,
     ) -> Self {
         Self::TicketAggregation(event)
     }

--- a/transport/p2p/src/lib.rs
+++ b/transport/p2p/src/lib.rs
@@ -145,7 +145,9 @@ pub enum HoprNetworkBehaviorEvent {
     Heartbeat(libp2p::request_response::Event<Ping, Pong>),
     Message(libp2p::request_response::Event<Box<[u8]>, ()>),
     Acknowledgement(libp2p::request_response::Event<Acknowledgement, ()>),
-    TicketAggregation(libp2p::request_response::Event<Vec<legacy::AcknowledgedTicket>, std::result::Result<Ticket, String>>),
+    TicketAggregation(
+        libp2p::request_response::Event<Vec<legacy::AcknowledgedTicket>, std::result::Result<Ticket, String>>,
+    ),
     KeepAlive(void::Void),
 }
 

--- a/transport/protocol/src/ticket_aggregation/processor.rs
+++ b/transport/protocol/src/ticket_aggregation/processor.rs
@@ -50,7 +50,7 @@ pub const TICKET_AGGREGATION_RX_QUEUE_SIZE: usize = 2048;
 #[derive(Debug)]
 pub enum TicketAggregationToProcess<T, U> {
     ToReceive(PeerId, std::result::Result<Ticket, String>, U),
-    ToProcess(PeerId, Vec<AcknowledgedTicket>, T),
+    ToProcess(PeerId, Vec<legacy::AcknowledgedTicket>, T),
     ToSend(Hash, AggregationPrerequisites, TicketAggregationFinalizer),
 }
 
@@ -58,9 +58,9 @@ pub enum TicketAggregationToProcess<T, U> {
 #[allow(clippy::large_enum_variant)] // TODO: refactor the large types used in the enum
 #[derive(Debug)]
 pub enum TicketAggregationProcessed<T, U> {
-    Receive(PeerId, AcknowledgedTicket, U),
+    Receive(PeerId, legacy::AcknowledgedTicket, U),
     Reply(PeerId, std::result::Result<Ticket, String>, T),
-    Send(PeerId, Vec<AcknowledgedTicket>, TicketAggregationFinalizer),
+    Send(PeerId, Vec<legacy::AcknowledgedTicket>, TicketAggregationFinalizer),
 }
 
 #[derive(Debug)]
@@ -341,7 +341,7 @@ where
                                     METRIC_AGGREGATION_COUNT.increment();
                                 }
 
-                                Some(TicketAggregationProcessed::Send(source.into(), tickets, finalizer))
+                                Some(TicketAggregationProcessed::Send(source.into(), tickets.into_iter().map(), finalizer))
                             }
                             Ok(None) => { finalizer.finalize(); None },
                             Err(e) => {
@@ -392,6 +392,76 @@ where
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> Poll<Option<Self::Item>> {
         Pin::new(self).ack_event_queue.1.poll_next(cx)
+    }
+}
+
+// TODO: remove this in 3.0
+#[doc(hidden)]
+mod legacy {
+    use serde::{Deserialize, Serialize};
+    use hopr_crypto_types::prelude::*;
+    use hopr_internal_types::prelude::*;
+    use hopr_primitive_types::prelude::*;
+
+    #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash, PartialOrd, Ord)]
+    pub struct Address {
+        addr: [u8; Self::SIZE],
+    }
+
+    #[derive(Debug, Default, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, PartialOrd, Ord, std::hash::Hash)]
+    pub struct Hash {
+        hash: [u8; Self::SIZE],
+    }
+
+    #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct Response {
+        response: [u8; Self::SIZE],
+    }
+
+    #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+    pub enum AcknowledgedTicketStatus {
+        /// The ticket is available for redeeming or aggregating
+        #[default]
+        Untouched,
+        /// Ticket is currently being redeemed in and on-going redemption process
+        BeingRedeemed { tx_hash: Hash },
+        /// Ticket is currently being aggregated in and on-going aggregation process
+        BeingAggregated { start: u64, end: u64 },
+    }
+
+
+    #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+    pub struct AcknowledgedTicket {
+        #[serde(default)]
+        pub status: AcknowledgedTicketStatus,
+        pub ticket: Ticket,
+        pub response: Response,
+        pub vrf_params: VrfParameters,
+        pub signer: Address,
+    }
+
+    impl From<AcknowledgedTicket> for hopr_internal_types::acknowledgement::AcknowledgedTicket {
+        fn from(value: AcknowledgedTicket) -> Self {
+            Self {
+                status: hopr_internal_types::acknowledgement::AcknowledgedTicketStatus::Untouched,
+                ticket: value.ticket,
+                response: hopr_crypto_types::types::Response::new(&value.response.response),
+                vrf_params: value.vrf_params,
+                signer: hopr_primitive_types::primitives::Address::new(&value.signer.addr),
+            }
+        }
+    }
+
+    impl From<hopr_internal_types::acknowledgement::AcknowledgedTicket> for AcknowledgedTicket {
+        fn from(value: hopr_internal_types::acknowledgement::AcknowledgedTicket) -> Self {
+            Self {
+                status: AcknowledgedTicketStatus::BeingAggregated {start: 0, end: 0}, // values not  used
+                ticket: value.ticket,
+                response: value.response,
+                vrf_params: Default::default(),
+                signer: Default::default(),
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Introduces dummy layer which serializes to the same `cbor4ii` format as in the 2.0.8 version.

A unit test has been added ensuring that the binary representation matches the 2.0.8 format.

This should be removed in 3.0, as that release will be backwards incompatible and should be replaced with proper Ticket Aggregation protocol binary format, see https://github.com/hoprnet/hoprnet/issues/6159.

Closes #6155 