### PR TITLE
Workaround version matching issue in Promiscuous strategy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1687,7 +1687,7 @@ dependencies = [
 
 [[package]]
 name = "core-strategy"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "async-lock 3.3.0",
  "async-std",

--- a/logic/strategy/Cargo.toml
+++ b/logic/strategy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-strategy"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Contains implementations of different HOPR strategies"
 edition = "2021"

--- a/logic/strategy/src/promiscuous.rs
+++ b/logic/strategy/src/promiscuous.rs
@@ -656,6 +656,11 @@ mod tests {
         mock_channel(db.clone(), PEERS[2].0, balance).await;
         let for_closing = mock_channel(db.clone(), PEERS[5].0, balance).await;
 
+        // Peer 3 has an accepted pre-release version
+        let mut status_3 = db.get_network_peer(&PEERS[3].1).await.unwrap().unwrap();
+        status_3.peer_version = Some("2.1.0-rc.3+commit.f75bc6c8".into());
+        db.update_network_peer(status_3).await.unwrap();
+
         // Peer 10 has an old node version
         let mut status_10 = db.get_network_peer(&PEERS[9].1).await.unwrap().unwrap();
         status_10.peer_version = Some("1.92.0".into());


### PR DESCRIPTION
Due to https://github.com/dtolnay/semver/issues/315, the partial versions in the Promiscuous strategy were not matched correctly.

This PR implements a workaround which only takes the Major, Minor and Patch components into account when checking for minimum version match in Promiscuous strategy.