### PR TITLE
Add PeerID <-> Public key converter to hopli

### DIFF
--- a/crypto/types/src/types.rs
+++ b/crypto/types/src/types.rs
@@ -18,7 +18,6 @@ use k256::{
     },
     AffinePoint, Secp256k1,
 };
-use libp2p_identity::PeerId;
 use serde::{Deserialize, Serialize};
 use sha2::Sha512;
 use std::fmt::Debug;
@@ -38,6 +37,8 @@ use crate::{
     keypairs::{ChainKeypair, Keypair, OffchainKeypair},
     primitives::{DigestLike, EthDigest},
 };
+
+pub use libp2p_identity::PeerId;
 
 /// Extend support for arbitrary array sizes in serde
 ///

--- a/hopli/src/key_pair.rs
+++ b/hopli/src/key_pair.rs
@@ -203,7 +203,7 @@ pub struct ManagerPrivateKeyArgs {
     #[clap(
         long,
         short = 'q',
-        help = "Private key to unlock the account with priviledge that broadcasts the transaction",
+        help = "Private key to unlock the account with privilege that broadcasts the transaction",
         name = "manager_private_key",
         value_name = "MANAGER_PRIVATE_KEY"
     )]

--- a/hopli/src/utils.rs
+++ b/hopli/src/utils.rs
@@ -16,7 +16,7 @@ pub enum HelperErrors {
     UnableToReadFromPath(#[from] std::io::Error),
 
     /// Error in parsing provided comma-separated addresses
-    #[error("error parsig address: {0:?}")]
+    #[error("error parsing address: {0:?}")]
     UnableToParseAddress(String),
 
     /// System time rrror


### PR DESCRIPTION
Add a hopli command that allows converting between PeerID in Base58 and hex representation of offchain public key.

## Examples:
- `hopli id convert-peer --peer-or-key 12D3KooWBoumtsUgQfbzuMafgQN2a8q1RKGMKDMRVKdZAGyH3JFR`
- `hopli id convert-peer --peer-or-key 0x1d9987b58e08f7982ffb575c3d2655c57537a6963178106d801a1f621c5acf38`