### PR TITLE
Add metrics for logs processed by the Indexer

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -68,3 +68,4 @@ scrape_configs:
 - `hopr_indexer_block_number`: Current last processed block number by the indexer
 - `hopr_indexer_sync_progress`: Sync progress of the historical data by the indexer
 - `hopr_chain_actions_count`: Number of different chain actions and their results, keys: `action`, `result`
+- `hopr_indexer_contract_log_counters`: Counts of different HOPR contract logs processed by the Indexer, keys: `contract`


### PR DESCRIPTION
Adds a multicounter that counts logs of different HOPR contracts seen by the Indexer.