### PR TITLE
Fix comparison of invalid balance types

### DIFF
--- a/chain/actions/src/channels.rs
+++ b/chain/actions/src/channels.rs
@@ -76,13 +76,13 @@ where
             .await?
             .perform(|tx| {
                 Box::pin(async move {
-                    let allowance = db_clone.get_safe_allowance(Some(tx)).await?;
+                    let allowance = db_clone.get_safe_hopr_allowance(Some(tx)).await?;
                     debug!("current staking safe allowance is {allowance}");
                     if allowance.lt(&amount) {
                         return Err(NotEnoughAllowance);
                     }
 
-                    let hopr_balance = db_clone.get_safe_balance(Some(tx)).await?;
+                    let hopr_balance = db_clone.get_safe_hopr_balance(Some(tx)).await?;
                     debug!("current Safe HOPR balance is {hopr_balance}");
                     if hopr_balance.lt(&amount) {
                         return Err(BalanceTooLow);
@@ -126,13 +126,13 @@ where
             .await?
             .perform(|tx| {
                 Box::pin(async move {
-                    let allowance = db_clone.get_safe_allowance(Some(tx)).await?;
+                    let allowance = db_clone.get_safe_hopr_allowance(Some(tx)).await?;
                     debug!("current staking safe allowance is {allowance}");
                     if allowance.lt(&amount) {
                         return Err(NotEnoughAllowance);
                     }
 
-                    let hopr_balance = db_clone.get_safe_balance(Some(tx)).await?;
+                    let hopr_balance = db_clone.get_safe_hopr_balance(Some(tx)).await?;
                     debug!("current Safe HOPR balance is {hopr_balance}");
                     if hopr_balance.lt(&amount) {
                         return Err(BalanceTooLow);
@@ -267,10 +267,10 @@ mod tests {
             .perform(|tx| {
                 Box::pin(async move {
                     db_clone
-                        .set_safe_allowance(Some(tx), Balance::new(10_000_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_allowance(Some(tx), Balance::new(10_000_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone
-                        .set_safe_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone
                         .set_domain_separator(Some(tx), DomainSeparator::Channel, Default::default())
@@ -344,10 +344,10 @@ mod tests {
             .perform(|tx| {
                 Box::pin(async move {
                     db_clone
-                        .set_safe_allowance(Some(tx), Balance::new(10_000_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_allowance(Some(tx), Balance::new(10_000_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone
-                        .set_safe_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone.set_network_registry_enabled(Some(tx), false).await?;
                     db_clone
@@ -391,10 +391,10 @@ mod tests {
             .perform(|tx| {
                 Box::pin(async move {
                     db_clone
-                        .set_safe_allowance(Some(tx), Balance::new(10_000_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_allowance(Some(tx), Balance::new(10_000_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone
-                        .set_safe_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone.set_network_registry_enabled(Some(tx), false).await?;
                     db_clone
@@ -435,10 +435,10 @@ mod tests {
             .perform(|tx| {
                 Box::pin(async move {
                     db_clone
-                        .set_safe_allowance(Some(tx), Balance::new(10_000_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_allowance(Some(tx), Balance::new(10_000_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone
-                        .set_safe_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone.set_network_registry_enabled(Some(tx), false).await?;
                     db_clone
@@ -491,10 +491,10 @@ mod tests {
             .perform(|tx| {
                 Box::pin(async move {
                     db_clone
-                        .set_safe_allowance(Some(tx), Balance::new(1_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_allowance(Some(tx), Balance::new(1_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone
-                        .set_safe_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone.set_network_registry_enabled(Some(tx), false).await?;
                     db_clone
@@ -537,10 +537,10 @@ mod tests {
             .perform(|tx| {
                 Box::pin(async move {
                     db_clone
-                        .set_safe_allowance(Some(tx), Balance::new(10_000_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_allowance(Some(tx), Balance::new(10_000_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone
-                        .set_safe_balance(Some(tx), Balance::new(1_u64, BalanceType::HOPR))
+                        .set_safe_hopr_balance(Some(tx), Balance::new(1_u64, BalanceType::HOPR))
                         .await?;
                     db_clone.set_network_registry_enabled(Some(tx), false).await?;
                     db_clone
@@ -585,10 +585,10 @@ mod tests {
             .perform(|tx| {
                 Box::pin(async move {
                     db_clone
-                        .set_safe_allowance(Some(tx), Balance::new(10_000_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_allowance(Some(tx), Balance::new(10_000_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone
-                        .set_safe_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone.set_network_registry_enabled(Some(tx), false).await?;
                     db_clone
@@ -659,10 +659,10 @@ mod tests {
             .perform(|tx| {
                 Box::pin(async move {
                     db_clone
-                        .set_safe_allowance(Some(tx), Balance::new(10_000_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_allowance(Some(tx), Balance::new(10_000_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone
-                        .set_safe_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone.set_network_registry_enabled(Some(tx), false).await?;
                     db_clone
@@ -705,10 +705,10 @@ mod tests {
             .perform(|tx| {
                 Box::pin(async move {
                     db_clone
-                        .set_safe_allowance(Some(tx), Balance::new(10_000_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_allowance(Some(tx), Balance::new(10_000_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone
-                        .set_safe_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone.set_network_registry_enabled(Some(tx), false).await?;
                     db_clone
@@ -760,10 +760,10 @@ mod tests {
             .perform(|tx| {
                 Box::pin(async move {
                     db_clone
-                        .set_safe_allowance(Some(tx), Balance::new(1_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_allowance(Some(tx), Balance::new(1_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone
-                        .set_safe_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone.set_network_registry_enabled(Some(tx), false).await?;
                     db_clone
@@ -806,10 +806,10 @@ mod tests {
             .perform(|tx| {
                 Box::pin(async move {
                     db_clone
-                        .set_safe_allowance(Some(tx), Balance::new(100_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_allowance(Some(tx), Balance::new(100_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone
-                        .set_safe_balance(Some(tx), Balance::new(1_u64, BalanceType::HOPR))
+                        .set_safe_hopr_balance(Some(tx), Balance::new(1_u64, BalanceType::HOPR))
                         .await?;
                     db_clone.set_network_registry_enabled(Some(tx), false).await?;
                     db_clone
@@ -855,10 +855,10 @@ mod tests {
             .perform(|tx| {
                 Box::pin(async move {
                     db_clone
-                        .set_safe_allowance(Some(tx), Balance::new(1_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_allowance(Some(tx), Balance::new(1_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone
-                        .set_safe_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone.set_network_registry_enabled(Some(tx), false).await?;
                     db_clone
@@ -975,10 +975,10 @@ mod tests {
             .perform(|tx| {
                 Box::pin(async move {
                     db_clone
-                        .set_safe_allowance(Some(tx), Balance::new(1_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_allowance(Some(tx), Balance::new(1_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone
-                        .set_safe_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone.set_network_registry_enabled(Some(tx), false).await?;
                     db_clone
@@ -1057,10 +1057,10 @@ mod tests {
             .perform(|tx| {
                 Box::pin(async move {
                     db_clone
-                        .set_safe_allowance(Some(tx), Balance::new(1_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_allowance(Some(tx), Balance::new(1_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone
-                        .set_safe_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone.set_network_registry_enabled(Some(tx), false).await?;
                     db_clone
@@ -1106,10 +1106,10 @@ mod tests {
             .perform(|tx| {
                 Box::pin(async move {
                     db_clone
-                        .set_safe_allowance(Some(tx), Balance::new(1_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_allowance(Some(tx), Balance::new(1_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone
-                        .set_safe_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone.set_network_registry_enabled(Some(tx), false).await?;
                     db_clone
@@ -1156,10 +1156,10 @@ mod tests {
             .perform(|tx| {
                 Box::pin(async move {
                     db_clone
-                        .set_safe_allowance(Some(tx), Balance::new(1_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_allowance(Some(tx), Balance::new(1_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone
-                        .set_safe_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
+                        .set_safe_hopr_balance(Some(tx), Balance::new(5_000_000_u64, BalanceType::HOPR))
                         .await?;
                     db_clone.set_network_registry_enabled(Some(tx), false).await?;
                     db_clone

--- a/chain/api/src/lib.rs
+++ b/chain/api/src/lib.rs
@@ -204,7 +204,7 @@ impl<T: HoprDbAllOperations + Send + Sync + Clone + std::fmt::Debug + 'static> H
     }
 
     pub async fn safe_allowance(&self) -> errors::Result<Balance> {
-        Ok(self.db.get_safe_allowance(None).await?)
+        Ok(self.db.get_safe_hopr_allowance(None).await?)
     }
 
     pub fn actions_ref(&self) -> &ChainActions<T> {

--- a/chain/indexer/src/handlers.rs
+++ b/chain/indexer/src/handlers.rs
@@ -459,7 +459,7 @@ where
                     &self.safe_address,
                 );
 
-                let mut current_balance = self.db.get_safe_balance(Some(tx)).await?;
+                let mut current_balance = self.db.get_safe_hopr_balance(Some(tx)).await?;
                 let transferred_value = transferred.value;
 
                 if to.ne(&self.safe_address) && from.ne(&self.safe_address) {
@@ -474,7 +474,7 @@ where
                     current_balance = current_balance - transferred_value;
                 }
 
-                self.db.set_safe_balance(Some(tx), current_balance).await?;
+                self.db.set_safe_hopr_balance(Some(tx), current_balance).await?;
             }
             HoprTokenEvents::ApprovalFilter(approved) => {
                 let owner: Address = approved.owner.into();
@@ -488,7 +488,7 @@ where
                 // if approval is for tokens on Safe contract to be spent by HoprChannels
                 if owner.eq(&self.safe_address) && spender.eq(&self.addresses.channels) {
                     self.db
-                        .set_safe_allowance(Some(tx), BalanceType::HOPR.balance(approved.value))
+                        .set_safe_hopr_allowance(Some(tx), BalanceType::HOPR.balance(approved.value))
                         .await?;
                 } else {
                     return Ok(None);
@@ -1161,7 +1161,7 @@ pub mod tests {
         assert!(event_type.is_none(), "token transfer does not have chain event type");
 
         assert_eq!(
-            db.get_safe_balance(None).await.unwrap(),
+            db.get_safe_hopr_balance(None).await.unwrap(),
             Balance::new(value, BalanceType::HOPR)
         )
     }
@@ -1174,7 +1174,7 @@ pub mod tests {
 
         let value = U256::max_value();
 
-        db.set_safe_balance(None, BalanceType::HOPR.balance(value))
+        db.set_safe_hopr_balance(None, BalanceType::HOPR.balance(value))
             .await
             .unwrap();
 
@@ -1199,7 +1199,7 @@ pub mod tests {
 
         assert!(event_type.is_none(), "token transfer does not have chain event type");
 
-        assert_eq!(db.get_safe_balance(None).await.unwrap(), BalanceType::HOPR.zero())
+        assert_eq!(db.get_safe_hopr_balance(None).await.unwrap(), BalanceType::HOPR.zero())
     }
 
     #[async_std::test]
@@ -1220,7 +1220,7 @@ pub mod tests {
         };
 
         assert_eq!(
-            db.get_safe_allowance(None).await.unwrap(),
+            db.get_safe_hopr_allowance(None).await.unwrap(),
             Balance::new(U256::from(0u64), BalanceType::HOPR)
         );
 
@@ -1239,16 +1239,16 @@ pub mod tests {
         assert!(event_type.is_none(), "token approval does not have chain event type");
 
         assert_eq!(
-            db.get_safe_allowance(None).await.unwrap(),
+            db.get_safe_hopr_allowance(None).await.unwrap(),
             Balance::new(U256::from(1000u64), BalanceType::HOPR)
         );
 
         // reduce allowance manually to verify a second time
         let _ = db
-            .set_safe_allowance(None, Balance::new(U256::from(10u64), BalanceType::HOPR))
+            .set_safe_hopr_allowance(None, Balance::new(U256::from(10u64), BalanceType::HOPR))
             .await;
         assert_eq!(
-            db.get_safe_allowance(None).await.unwrap(),
+            db.get_safe_hopr_allowance(None).await.unwrap(),
             Balance::new(U256::from(10u64), BalanceType::HOPR)
         );
 
@@ -1264,7 +1264,7 @@ pub mod tests {
         assert!(event_type.is_none(), "token approval does not have chain event type");
 
         assert_eq!(
-            db.get_safe_allowance(None).await.unwrap(),
+            db.get_safe_hopr_allowance(None).await.unwrap(),
             Balance::new(U256::from(1000u64), BalanceType::HOPR)
         );
     }

--- a/db/api/src/info.rs
+++ b/db/api/src/info.rs
@@ -78,17 +78,17 @@ pub enum DomainSeparator {
 ///
 #[async_trait]
 pub trait HoprDbInfoOperations {
-    /// Gets node's Safe balance.
-    async fn get_safe_balance<'a>(&'a self, tx: OptTx<'a>) -> Result<Balance>;
+    /// Gets node's Safe balance of HOPR tokens.
+    async fn get_safe_hopr_balance<'a>(&'a self, tx: OptTx<'a>) -> Result<Balance>;
 
-    /// Sets node's Safe balance.
-    async fn set_safe_balance<'a>(&'a self, tx: OptTx<'a>, new_balance: Balance) -> Result<()>;
+    /// Sets node's Safe balance of HOPR tokens.
+    async fn set_safe_hopr_balance<'a>(&'a self, tx: OptTx<'a>, new_balance: Balance) -> Result<()>;
 
-    /// Gets node's Safe allowance.
-    async fn get_safe_allowance<'a>(&'a self, tx: OptTx<'a>) -> Result<Balance>;
+    /// Gets node's Safe allowance of HOPR tokens.
+    async fn get_safe_hopr_allowance<'a>(&'a self, tx: OptTx<'a>) -> Result<Balance>;
 
-    /// Sets node's Safe allowance.
-    async fn set_safe_allowance<'a>(&'a self, tx: OptTx<'a>, new_allowance: Balance) -> Result<()>;
+    /// Sets node's Safe allowance of HOPR tokens.
+    async fn set_safe_hopr_allowance<'a>(&'a self, tx: OptTx<'a>, new_allowance: Balance) -> Result<()>;
 
     /// Gets node's Safe addresses info.
     async fn get_safe_info<'a>(&'a self, tx: OptTx<'a>) -> Result<Option<SafeInfo>>;
@@ -139,7 +139,7 @@ pub trait HoprDbInfoOperations {
 
 #[async_trait]
 impl HoprDbInfoOperations for HoprDb {
-    async fn get_safe_balance<'a>(&'a self, tx: OptTx<'a>) -> Result<Balance> {
+    async fn get_safe_hopr_balance<'a>(&'a self, tx: OptTx<'a>) -> Result<Balance> {
         self.nest_transaction(tx)
             .await?
             .perform(|tx| {
@@ -154,7 +154,7 @@ impl HoprDbInfoOperations for HoprDb {
             .await
     }
 
-    async fn set_safe_balance<'a>(&'a self, tx: OptTx<'a>, new_balance: Balance) -> Result<()> {
+    async fn set_safe_hopr_balance<'a>(&'a self, tx: OptTx<'a>, new_balance: Balance) -> Result<()> {
         self.nest_transaction(tx)
             .await?
             .perform(|tx| {
@@ -175,7 +175,7 @@ impl HoprDbInfoOperations for HoprDb {
         Ok(())
     }
 
-    async fn get_safe_allowance<'a>(&'a self, tx: OptTx<'a>) -> Result<Balance> {
+    async fn get_safe_hopr_allowance<'a>(&'a self, tx: OptTx<'a>) -> Result<Balance> {
         self.nest_transaction(tx)
             .await?
             .perform(|tx| {
@@ -190,7 +190,7 @@ impl HoprDbInfoOperations for HoprDb {
             .await
     }
 
-    async fn set_safe_allowance<'a>(&'a self, tx: OptTx<'a>, new_allowance: Balance) -> Result<()> {
+    async fn set_safe_hopr_allowance<'a>(&'a self, tx: OptTx<'a>, new_allowance: Balance) -> Result<()> {
         self.nest_transaction(tx)
             .await?
             .perform(|tx| {
@@ -536,16 +536,16 @@ mod tests {
 
         assert_eq!(
             BalanceType::HOPR.zero(),
-            db.get_safe_balance(None).await.unwrap(),
+            db.get_safe_hopr_balance(None).await.unwrap(),
             "balance must be 0"
         );
 
         let balance = BalanceType::HOPR.balance(10_000);
-        db.set_safe_balance(None, balance).await.unwrap();
+        db.set_safe_hopr_balance(None, balance).await.unwrap();
 
         assert_eq!(
             balance,
-            db.get_safe_balance(None).await.unwrap(),
+            db.get_safe_hopr_balance(None).await.unwrap(),
             "balance must be {balance}"
         );
     }
@@ -556,16 +556,16 @@ mod tests {
 
         assert_eq!(
             BalanceType::HOPR.zero(),
-            db.get_safe_allowance(None).await.unwrap(),
+            db.get_safe_hopr_allowance(None).await.unwrap(),
             "balance must be 0"
         );
 
         let balance = BalanceType::HOPR.balance(10_000);
-        db.set_safe_allowance(None, balance).await.unwrap();
+        db.set_safe_hopr_allowance(None, balance).await.unwrap();
 
         assert_eq!(
             balance,
-            db.get_safe_allowance(None).await.unwrap(),
+            db.get_safe_hopr_allowance(None).await.unwrap(),
             "balance must be {balance}"
         );
     }

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -93,6 +93,7 @@ use hopr_db_api::{
 use hopr_db_api::{channels::HoprDbChannelOperations, HoprDbAllOperations};
 
 use hopr_crypto_types::prelude::OffchainPublicKey;
+use hopr_db_api::prelude::DbError;
 #[cfg(all(feature = "prometheus", not(test)))]
 use {
     hopr_metrics::metrics::{MultiGauge, SimpleCounter, SimpleGauge},
@@ -756,7 +757,7 @@ impl Hopr {
                             );
                             my_db.set_safe_hopr_balance(Some(tx), safe_balance).await?;
                         }
-                        Ok(())
+                        Ok::<_, DbError>(())
                     })
                 })
                 .await?;

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -742,21 +742,26 @@ impl Hopr {
             .get_safe_balance(self.safe_module_cfg.safe_address, balance_type)
             .await?;
 
-        let my_db = self.db.clone();
-        self.db
-            .begin_transaction()
-            .await?
-            .perform(|tx| {
-                Box::pin(async move {
-                    let db_safe_balance = my_db.get_safe_balance(Some(tx)).await?;
-                    if safe_balance != db_safe_balance {
-                        warn!("Safe balance in the DB {db_safe_balance} mismatches on chain balance: {safe_balance}");
-                        my_db.set_safe_balance(Some(tx), safe_balance).await?;
-                    }
-                    Ok(safe_balance)
+        if balance_type == BalanceType::HOPR {
+            let my_db = self.db.clone();
+            self.db
+                .begin_transaction()
+                .await?
+                .perform(|tx| {
+                    Box::pin(async move {
+                        let db_safe_balance = my_db.get_safe_hopr_balance(Some(tx)).await?;
+                        if safe_balance != db_safe_balance {
+                            warn!(
+                                "Safe balance in the DB {db_safe_balance} mismatches on chain balance: {safe_balance}"
+                            );
+                            my_db.set_safe_hopr_balance(Some(tx), safe_balance).await?;
+                        }
+                        Ok(())
+                    })
                 })
-            })
-            .await
+                .await?;
+        }
+        Ok(safe_balance)
     }
 
     pub fn get_safe_config(&self) -> SafeModule {

--- a/logic/strategy/src/promiscuous.rs
+++ b/logic/strategy/src/promiscuous.rs
@@ -353,7 +353,7 @@ where
             new_channel_candidates.truncate(max_auto_channels - occupied);
             debug!("got {} new channel candidates", new_channel_candidates.len());
 
-            let mut remaining_balance = self.db.get_safe_balance(None).await?;
+            let mut remaining_balance = self.db.get_safe_hopr_balance(None).await?;
 
             // Go through the new candidates for opening channels allow them to open based on our available node balance
             for (address, _) in new_channel_candidates {
@@ -585,8 +585,8 @@ mod tests {
             .unwrap()
             .perform(|tx| {
                 Box::pin(async move {
-                    db.set_safe_balance(Some(tx), node_balance).await?;
-                    db.set_safe_allowance(Some(tx), node_balance).await?;
+                    db.set_safe_hopr_balance(Some(tx), node_balance).await?;
+                    db.set_safe_hopr_allowance(Some(tx), node_balance).await?;
                     for (chain_key, peer_id) in PEERS.iter() {
                         db.insert_account(
                             Some(tx),


### PR DESCRIPTION
Node Safe's HOPR balance was incorrectly compared with Safe's Native balance.