### PR TITLE
Improve hopli read identitys to print out peerids

### DIFF
--- a/hopli/src/identity.rs
+++ b/hopli/src/identity.rs
@@ -161,8 +161,14 @@ impl IdentitySubcommands {
             .map(|n| n.chain_key.public().to_address())
             .collect();
 
+        let peer_ids: Vec<String> = node_identities
+            .values()
+            .map(|n| n.packet_key.public().to_peerid_str())
+            .collect();
+
         info!("Identities: {:?}", node_identities);
-        info!("Identity addresses: {:?}", node_addresses);
+        println!("Identity addresses: {:?}", node_addresses);
+        println!("Identity peerids: {:?}", peer_ids);
         Ok(())
     }
 


### PR DESCRIPTION
- Print out peer ids to stdout `Identity addresses: [0x..., 0x...]`
- Print out addresses to stdout `Identity peerids: ["12D3...", "12D3..."]`