### PR TITLE
Fix off-by-1 in the Indexer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "chain-indexer"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "async-lock 3.3.0",
  "async-std",

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-indexer"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Core-Ethereum-specific interaction with the backend database"


### PR DESCRIPTION
The initial block was always reprocessed by the Indexer, since `try_stream_blocks` argument is inclusive.

Fixes #6209

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the block processing logic in the chain indexer to improve synchronization accuracy and efficiency.
- **Bug Fixes**
  - Fixed an issue to prevent reprocessing of the last processed block in the chain indexer.
- **Refactor**
  - Updated logging to better reflect the current state of block processing.
- **Tests**
  - Added new tests to verify that blocks are not reprocessed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->