### PR TITLE
gha: tag docker image as pr only in prs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -86,6 +86,7 @@ jobs:
 
       - name: Build and push docker image - PR
         run: nix run .#${{ matrix.target }}-docker-build-and-upload
+        if: github.event_name == 'pull_request'
         env:
           GOOGLE_ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
           IMAGE_TARGET: europe-west3-docker.pkg.dev/${{ secrets.GOOGLE_HOPRASSOCIATION_PROJECT }}/docker-images/${{ matrix.target }}:${{ steps.update.outputs.DOCKER_TAG_PR }}


### PR DESCRIPTION
This step would lead to incorrect docker image tags when run outside of a PR.