### PR TITLE
Fix Indexer checksum computation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1246,7 +1246,7 @@ dependencies = [
 
 [[package]]
 name = "chain-indexer"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "async-lock 3.3.0",
  "async-std",

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-indexer"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Core-Ethereum-specific interaction with the backend database"

--- a/chain/indexer/src/handlers.rs
+++ b/chain/indexer/src/handlers.rs
@@ -722,6 +722,7 @@ where
                     let mut ret = Vec::with_capacity(block_with_logs.logs.len());
 
                     let mut log_tx_hashes = Vec::with_capacity(block_with_logs.logs.len());
+                    let block_id = block_with_logs.to_string();
 
                     // Process all logs in the block
                     for log in block_with_logs.logs {
@@ -737,20 +738,26 @@ where
                         log_tx_hashes.push(tx_hash);
                     }
 
+                    // Update the hash only if any logs were processed in this block
+                    let block_hash = if !log_tx_hashes.is_empty() {
+                        debug!("block {block_id} has hashes {:?}", log_tx_hashes);
+                        let h = Hash::create(
+                            log_tx_hashes
+                                .iter()
+                                .map(|h| h.as_slice())
+                                .collect::<Vec<_>>()
+                                .as_slice(),
+                        );
+                        debug!("block hash of {block_id} is {h}");
+                        Some(h)
+                    } else {
+                        None
+                    };
+
                     // Once we're done with the block, update the DB
                     myself
                         .db
-                        .set_last_indexed_block(
-                            Some(tx),
-                            block_with_logs.block_id as u32,
-                            Hash::create(
-                                log_tx_hashes
-                                    .iter()
-                                    .map(|h| h.as_slice())
-                                    .collect::<Vec<_>>()
-                                    .as_slice(),
-                            ),
-                        )
+                        .set_last_indexed_block(Some(tx), block_with_logs.block_id as u32, block_hash)
                         .await?;
                     Ok(ret)
                 })

--- a/hopr/hopr-lib/tests/chain_integration_tests.rs
+++ b/hopr/hopr-lib/tests/chain_integration_tests.rs
@@ -818,5 +818,19 @@ async fn integration_test_indexer() {
 
     info!("--> successfully initiated channel closure for Alice -> Bob");
 
+    let alice_checksum = alice_node.db.get_last_indexed_block(None).await.unwrap();
+    let bob_checksum = bob_node.db.get_last_indexed_block(None).await.unwrap();
+    info!("alice completed at {:?}", alice_checksum);
+    info!("bob completed at {:?}", bob_checksum);
+
+    assert_eq!(
+        alice_checksum.0, bob_checksum.0,
+        "alice and bob must be at the same indexed block"
+    );
+    assert_eq!(
+        alice_checksum.1, bob_checksum.1,
+        "alice and bob must have same indexer checksum"
+    );
+
     futures::future::join_all(alice_node.node_tasks.into_iter().map(|t| t.cancel())).await;
 }

--- a/hopr/hopr-lib/tests/chain_integration_tests.rs
+++ b/hopr/hopr-lib/tests/chain_integration_tests.rs
@@ -824,12 +824,8 @@ async fn integration_test_indexer() {
     info!("bob completed at {:?}", bob_checksum);
 
     assert_eq!(
-        alice_checksum.0, bob_checksum.0,
-        "alice and bob must be at the same indexed block"
-    );
-    assert_eq!(
-        alice_checksum.1, bob_checksum.1,
-        "alice and bob must have same indexer checksum"
+        alice_checksum, bob_checksum,
+        "alice and bob must be at the same indexed block and checksum"
     );
 
     futures::future::join_all(alice_node.node_tasks.into_iter().map(|t| t.cancel())).await;


### PR DESCRIPTION
The block logs checksum hash was incorrectly computed when a log without any logs was encountered. This led to incorrect checksum computation.

Also, checksum computation is now verified in the Indexer integration test (both nodes must finish at the same block and checksum).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new variable and updated logic for handling block hashes in the blockchain indexer.
	- Enhanced the method for setting the last indexed block to support optional transaction hash parameters, improving flexibility in block processing.

- **Tests**
	- Added new integration tests to verify checksum consistency between different users' indexed blocks, ensuring data integrity.

- **Chores**
	- Updated the version of the `chain-indexer` package to improve tracking and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->