### PR TITLE
chain: do not fetch logs if no topics are set

### DIFF
--- a/chain/indexer/src/block.rs
+++ b/chain/indexer/src/block.rs
@@ -113,9 +113,9 @@ where
         let mut addresses = vec![];
         let mut topics = vec![];
         db_processor.contract_addresses().iter().for_each(|address| {
-            let contract_topics = db_processor.contract_address_topics(address.clone());
+            let contract_topics = db_processor.contract_address_topics(*address);
             if !contract_topics.is_empty() {
-                addresses.push(address.clone());
+                addresses.push(*address);
                 topics.extend(contract_topics);
             }
         });

--- a/chain/indexer/src/block.rs
+++ b/chain/indexer/src/block.rs
@@ -109,16 +109,19 @@ where
 
         info!("DB latest processed block: {db_latest_block}, next block to process {next_block_to_process}");
 
+        // we skip on addresses which have no topics
+        let mut addresses = vec![];
         let mut topics = vec![];
-        topics.extend(crate::constants::topics::announcement());
-        topics.extend(crate::constants::topics::channel());
-        topics.extend(crate::constants::topics::node_safe_registry());
-        topics.extend(crate::constants::topics::network_registry());
-        topics.extend(crate::constants::topics::ticket_price_oracle());
-        topics.extend(crate::constants::topics::token());
+        db_processor.contract_addresses().iter().for_each(|address| {
+            let contract_topics = db_processor.contract_address_topics(address.clone());
+            if !contract_topics.is_empty() {
+                addresses.push(address.clone());
+                topics.extend(contract_topics);
+            }
+        });
 
         let log_filter = LogFilter {
-            address: db_processor.contract_addresses(),
+            address: addresses,
             topics: topics.into_iter().map(Hash::from).collect(),
         };
 
@@ -364,7 +367,7 @@ pub mod tests {
 
         let head_block = 1000;
         let latest_block = 15u64;
-        db.set_last_indexed_block(None, latest_block as u32, Hash::default())
+        db.set_last_indexed_block(None, latest_block as u32, Some(Hash::default()))
             .await
             .unwrap();
         rpc.expect_block_number().return_once(move || Ok(head_block));
@@ -507,7 +510,7 @@ pub mod tests {
         let last_processed_block = 100_u64;
 
         let db = create_stub_db().await;
-        db.set_last_indexed_block(None, last_processed_block as u32, Hash::default())
+        db.set_last_indexed_block(None, last_processed_block as u32, Some(Hash::default()))
             .await
             .unwrap();
 

--- a/chain/indexer/src/constants.rs
+++ b/chain/indexer/src/constants.rs
@@ -64,4 +64,8 @@ pub mod topics {
     pub fn ticket_price_oracle() -> Vec<TxHash> {
         vec![TicketPriceUpdatedFilter::signature()]
     }
+
+    pub fn module_implementation() -> Vec<TxHash> {
+        vec![]
+    }
 }

--- a/chain/indexer/src/handlers.rs
+++ b/chain/indexer/src/handlers.rs
@@ -10,6 +10,7 @@ use chain_rpc::{BlockWithLogs, Log};
 use chain_types::chain_events::{ChainEventType, NetworkRegistryStatus, SignificantChainEvent};
 use chain_types::ContractAddresses;
 use ethers::contract::EthLogDecode;
+use ethers::types::TxHash;
 use hopr_crypto_types::keypairs::ChainKeypair;
 use hopr_crypto_types::prelude::{Hash, Keypair};
 use hopr_crypto_types::types::OffchainSignature;
@@ -701,14 +702,34 @@ where
 {
     fn contract_addresses(&self) -> Vec<Address> {
         vec![
-            self.addresses.channels,
-            self.addresses.token,
-            self.addresses.network_registry,
             self.addresses.announcements,
-            self.addresses.safe_registry,
+            self.addresses.channels,
             self.addresses.module_implementation,
+            self.addresses.network_registry,
             self.addresses.price_oracle,
+            self.addresses.safe_registry,
+            self.addresses.token,
         ]
+    }
+
+    fn contract_address_topics(&self, contract: Address) -> Vec<TxHash> {
+        if contract.eq(&self.addresses.announcements) {
+            crate::constants::topics::announcement()
+        } else if contract.eq(&self.addresses.channels) {
+            crate::constants::topics::channel()
+        } else if contract.eq(&self.addresses.module_implementation) {
+            crate::constants::topics::module_implementation()
+        } else if contract.eq(&self.addresses.network_registry) {
+            crate::constants::topics::network_registry()
+        } else if contract.eq(&self.addresses.price_oracle) {
+            crate::constants::topics::ticket_price_oracle()
+        } else if contract.eq(&self.addresses.safe_registry) {
+            crate::constants::topics::node_safe_registry()
+        } else if contract.eq(&self.addresses.token) {
+            crate::constants::topics::token()
+        } else {
+            vec![]
+        }
     }
 
     async fn collect_block_events(&self, block_with_logs: BlockWithLogs) -> Result<Vec<SignificantChainEvent>> {

--- a/chain/indexer/src/traits.rs
+++ b/chain/indexer/src/traits.rs
@@ -3,12 +3,15 @@ use async_trait::async_trait;
 use crate::errors::Result;
 use chain_rpc::BlockWithLogs;
 use chain_types::chain_events::SignificantChainEvent;
+use ethers::types::TxHash;
 use hopr_primitive_types::prelude::*;
 
 #[cfg_attr(test, mockall::automock)]
 #[async_trait]
 pub trait ChainLogHandler {
     fn contract_addresses(&self) -> Vec<Address>;
+
+    fn contract_address_topics(&self, contract: Address) -> Vec<TxHash>;
 
     async fn collect_block_events(&self, block_with_logs: BlockWithLogs) -> Result<Vec<SignificantChainEvent>>;
 }

--- a/db/api/src/info.rs
+++ b/db/api/src/info.rs
@@ -637,7 +637,7 @@ mod tests {
         let checksum = Hash::default().hash();
         let expexted_block_num = 100000;
 
-        db.set_last_indexed_block(None, expexted_block_num, checksum)
+        db.set_last_indexed_block(None, expexted_block_num, Some(checksum))
             .await
             .unwrap();
 


### PR DESCRIPTION
Previously the logs filter would include addresses which had an empty set of topics. Thus, the log filter behaviour becomes unclear. This is now strict such that the address itself is only used if at least one topic is set.