### PR TITLE
chain: replace hopr_boost topics with hopr_token topics

### DIFF
--- a/chain/indexer/src/constants.rs
+++ b/chain/indexer/src/constants.rs
@@ -1,7 +1,6 @@
 pub mod topics {
     use bindings::{
         hopr_announcements::{AddressAnnouncementFilter, KeyBindingFilter, RevokeAnnouncementFilter},
-        hopr_boost::{ApprovalFilter, TransferFilter},
         hopr_channels::{
             ChannelBalanceDecreasedFilter, ChannelBalanceIncreasedFilter, ChannelClosedFilter, ChannelOpenedFilter,
             DomainSeparatorUpdatedFilter, LedgerDomainSeparatorUpdatedFilter, OutgoingChannelClosureInitiatedFilter,
@@ -13,6 +12,7 @@ pub mod topics {
         },
         hopr_node_safe_registry::{DergisteredNodeSafeFilter, RegisteredNodeSafeFilter},
         hopr_ticket_price_oracle::TicketPriceUpdatedFilter,
+        hopr_token::{ApprovalFilter, TransferFilter},
     };
     use ethers::{contract::EthEvent, types::TxHash};
 


### PR DESCRIPTION
The topics for HOPR Token contract were by error used from the HOPR Boost contract.