### PR TITLE
Fail hard on failure to load the block number from RPC provider

### DIFF
--- a/chain/indexer/src/block.rs
+++ b/chain/indexer/src/block.rs
@@ -130,8 +130,7 @@ where
 
         spawn(async move {
             let is_synced = Arc::new(std::sync::atomic::AtomicBool::new(false));
-
-            let mut chain_head = 0;
+            let chain_head = Arc::new(std::sync::atomic::AtomicU64::new(0));
 
             let event_stream = rpc
                 .try_stream_logs(next_block_to_process, log_filter)
@@ -139,6 +138,7 @@ where
                 .then(|block_with_logs| {
                     let rpc = &rpc;
                     let mut tx = tx.clone();
+                    let chain_head = chain_head.clone();
                     let is_synced = is_synced.clone();
 
                     async move {
@@ -152,16 +152,20 @@ where
 
                         match rpc.block_number().await {
                             Ok(current_chain_block_number) => {
-                                chain_head = current_chain_block_number;
+                                chain_head.store(current_chain_block_number, std::sync::atomic::Ordering::Relaxed)
                             }
                             Err(error) => {
-                                error!("failed to fetch block number from RPC: {error}");
-                                chain_head = chain_head.max(current_block);
+                                error!(
+                                    "Failed to fetch block number from RPC, cannot continue indexing due to {error}"
+                                );
+                                panic!("Failed to fetch block number from RPC, cannot continue indexing due to {error}")
                             }
-                        }
+                        };
+
+                        let head = chain_head.load(std::sync::atomic::Ordering::Relaxed);
 
                         if !is_synced.load(std::sync::atomic::Ordering::Relaxed) {
-                            let block_difference = chain_head - next_block_to_process;
+                            let block_difference = head - next_block_to_process;
                             let progress = if block_difference == 0 {
                                 1_f64
                             } else {
@@ -173,7 +177,7 @@ where
                             #[cfg(all(feature = "prometheus", not(test)))]
                             METRIC_INDEXER_SYNC_PROGRESS.set(progress);
 
-                            if current_block >= chain_head {
+                            if current_block >= head {
                                 info!("Indexer sync successfully completed");
                                 is_synced.store(true, std::sync::atomic::Ordering::Relaxed);
                                 if let Err(e) = tx.try_send(()) {


### PR DESCRIPTION
Not failing hard in this step let's the node to think that it reached the tip of the chain and declares the indexing finished, instead of failing and restarting, until the RPC provider can be polled for the block information.