### PR TITLE
Path finding should only consider nodes that proven to be reliable

### DIFF
--- a/logic/path/src/selectors/legacy.rs
+++ b/logic/path/src/selectors/legacy.rs
@@ -137,9 +137,8 @@ where
             return false;
         }
 
-        // Check node reliability, new nodes are considered reliable
-        // unless the opposite has been observed
-        if channel.quality.unwrap_or(1.0f64) < self.quality_threshold {
+        // Check node reliability, new nodes are NOT considered reliable yet
+        if channel.quality.unwrap_or(0.0f64) < self.quality_threshold {
             // Only use nodes that have shown to be somewhat reliable
             return false;
         }

--- a/logic/strategy/src/promiscuous.rs
+++ b/logic/strategy/src/promiscuous.rs
@@ -20,7 +20,6 @@
 //!
 //! For details on default parameters see [PromiscuousStrategyConfig].
 //!
-use hopr_crypto_types::types::OffchainPublicKey;
 use hopr_internal_types::prelude::*;
 use hopr_primitive_types::prelude::*;
 use std::collections::HashMap;
@@ -214,29 +213,24 @@ where
                 }) {
                     // Check if the reported version matches the version semver expression
                     if self.cfg.minimum_peer_version.matches(&version) {
-                        if let Ok(offchain_key) = OffchainPublicKey::try_from(status.id) {
-                            // Resolve peer's chain key and average quality
-                            if let Ok(addr) = self
-                                .db
-                                .resolve_chain_key(&offchain_key)
-                                .await
-                                .and_then(|addr| addr.ok_or(DbError::MissingAccount))
-                            {
-                                Some((addr, status.get_average_quality()))
-                            } else {
-                                error!("could not find on-chain address for {}", status.id);
-                                None
-                            }
+                        // Resolve peer's chain key and average quality
+                        if let Ok(addr) = self
+                            .db
+                            .resolve_chain_key(&status.id.0)
+                            .await
+                            .and_then(|addr| addr.ok_or(DbError::MissingAccount))
+                        {
+                            Some((addr, status.get_average_quality()))
                         } else {
-                            error!("encountered invalid peer id: {}", status.id);
+                            error!("could not find on-chain address for {}", status.id.1);
                             None
                         }
                     } else {
-                        debug!("version of peer {} reports non-matching version {version}", status.id);
+                        debug!("version of peer {} reports non-matching version {version}", status.id.1);
                         None
                     }
                 } else {
-                    error!("cannot get version for peer id: {}", status.id);
+                    error!("cannot get version for peer id: {}", status.id.1);
                     None
                 }
             })

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -606,7 +606,7 @@ where
 
     #[tracing::instrument(level = "debug", skip(self))]
     pub async fn network_connected_peers(&self) -> errors::Result<Vec<PeerId>> {
-        Ok(self.network.peer_filter(|peer| async move { Some(peer.id) }).await?)
+        Ok(self.network.peer_filter(|peer| async move { Some(peer.id.1) }).await?)
     }
 
     #[tracing::instrument(level = "debug", skip(self))]

--- a/transport/api/src/processes/indexer.rs
+++ b/transport/api/src/processes/indexer.rs
@@ -83,7 +83,7 @@ impl IndexerActions {
                     // TODO: when is this even triggered? network registry missing?
                     IndexerToProcess::RegisterStatusUpdate => {
                         let peers = network
-                            .peer_filter(|peer| async move { Some(peer.id) })
+                            .peer_filter(|peer| async move { Some(peer.id.1) })
                             .await
                             .unwrap_or(vec![]);
 

--- a/transport/network/src/network.rs
+++ b/transport/network/src/network.rs
@@ -302,8 +302,8 @@ where
                 entry.update_quality(0.0_f64.max(entry.get_quality() - self.cfg.quality_step));
 
                 if entry.get_quality() < (self.cfg.quality_step / 2.0) {
-                    self.db.remove_network_peer(&entry.id).await?;
-                    return Ok(Some(NetworkTriggeredEvent::CloseConnection(entry.id)));
+                    self.db.remove_network_peer(&entry.id.1).await?;
+                    return Ok(Some(NetworkTriggeredEvent::CloseConnection(entry.id.1)));
                 } else if entry.get_quality() < self.cfg.quality_bad_threshold {
                     entry.ignored = Some(current_time());
                 }
@@ -318,7 +318,7 @@ where
             }
 
             Ok(Some(NetworkTriggeredEvent::UpdateQuality(
-                entry.id,
+                entry.id.1,
                 entry.get_quality(),
             )))
         } else {
@@ -373,7 +373,7 @@ where
         futures::pin_mut!(stream);
         let mut data: Vec<PeerStatus> = stream
             .filter_map(|v| async move {
-                if v.id == self.me {
+                if v.id.1 == self.me {
                     return None;
                 }
                 let backoff = v.backoff.powf(self.cfg.backoff_exponent);
@@ -396,7 +396,7 @@ where
             }
         });
 
-        Ok(data.into_iter().map(|peer| peer.id).collect())
+        Ok(data.into_iter().map(|peer| peer.id.1).collect())
     }
 
     pub(crate) fn should_still_be_ignored(&self, peer: &PeerStatus) -> bool {


### PR DESCRIPTION
Previously, the assumption was that a new node (or a node that we don't have quality info about) is automatically considered reliable. This is not correct.

This PR considers all nodes (node, or missing) without a "quality" information to be automatically unreliable and thus not considered for automatic path finding.

The `PeerStatus` type has also been refactored to carry `OffchainPublicKey` and `PeerId` as conversions between those 2 were done quite often.

The peer qualities are also synced to the ChannelGraph (if there are any). This change currently has no effect, as the peers DB is cleaned-up on each run.