### PR TITLE
The `/node/peers` API endpoint sometimes returned empty multiaddreses as `announced`

### DIFF
--- a/db/api/src/accounts.rs
+++ b/db/api/src/accounts.rs
@@ -516,7 +516,7 @@ mod tests {
     }
 
     #[async_std::test]
-    async fn test_should_allow_reannouncement() {
+    async fn test_should_allow_reannouncement() -> std::result::Result<(), Box<dyn std::error::Error>> {
         let db = HoprDb::new_in_memory(ChainKeypair::random()).await;
 
         let chain_1 = ChainKeypair::random().public().to_address();
@@ -526,11 +526,11 @@ mod tests {
             .await
             .unwrap();
 
-        db.insert_announcement(None, chain_1, "/ip4/1.2.3.4/tcp/8000".parse().unwrap(), 100)
+        db.insert_announcement(None, chain_1, "/ip4/1.2.3.4/tcp/8000".parse()?, 100)
             .await
             .unwrap();
 
-        let ae = db.get_account(None, chain_1).await.unwrap().unwrap();
+        let ae = db.get_account(None, chain_1).await?.ok_or(MissingAccount)?;
 
         assert_eq!("/ip4/1.2.3.4/tcp/8000", ae.get_multiaddr().unwrap().to_string());
 
@@ -538,9 +538,11 @@ mod tests {
             .await
             .unwrap();
 
-        let ae = db.get_account(None, chain_1).await.unwrap().unwrap();
+        let ae = db.get_account(None, chain_1).await?.ok_or(MissingAccount)?;
 
         assert_eq!("/ip4/1.2.3.4/tcp/8001", ae.get_multiaddr().unwrap().to_string());
+
+        Ok(())
     }
 
     #[async_std::test]

--- a/db/api/src/accounts.rs
+++ b/db/api/src/accounts.rs
@@ -522,21 +522,15 @@ mod tests {
         let chain_1 = ChainKeypair::random().public().to_address();
         let packet_1 = OffchainKeypair::random().public().clone();
 
-        db.insert_account(None, AccountEntry::new(packet_1, chain_1, AccountType::NotAnnounced))
-            .await
-            .unwrap();
+        db.insert_account(None, AccountEntry::new(packet_1, chain_1, AccountType::NotAnnounced)).await?;
 
-        db.insert_announcement(None, chain_1, "/ip4/1.2.3.4/tcp/8000".parse()?, 100)
-            .await
-            .unwrap();
+        db.insert_announcement(None, chain_1, "/ip4/1.2.3.4/tcp/8000".parse()?, 100).await?;
 
         let ae = db.get_account(None, chain_1).await?.ok_or(MissingAccount)?;
 
         assert_eq!("/ip4/1.2.3.4/tcp/8000", ae.get_multiaddr().unwrap().to_string());
 
-        db.insert_announcement(None, chain_1, "/ip4/1.2.3.4/tcp/8001".parse().unwrap(), 110)
-            .await
-            .unwrap();
+        db.insert_announcement(None, chain_1, "/ip4/1.2.3.4/tcp/8001".parse().unwrap(), 110).await?;
 
         let ae = db.get_account(None, chain_1).await?.ok_or(MissingAccount)?;
 

--- a/db/api/src/accounts.rs
+++ b/db/api/src/accounts.rs
@@ -522,15 +522,18 @@ mod tests {
         let chain_1 = ChainKeypair::random().public().to_address();
         let packet_1 = OffchainKeypair::random().public().clone();
 
-        db.insert_account(None, AccountEntry::new(packet_1, chain_1, AccountType::NotAnnounced)).await?;
+        db.insert_account(None, AccountEntry::new(packet_1, chain_1, AccountType::NotAnnounced))
+            .await?;
 
-        db.insert_announcement(None, chain_1, "/ip4/1.2.3.4/tcp/8000".parse()?, 100).await?;
+        db.insert_announcement(None, chain_1, "/ip4/1.2.3.4/tcp/8000".parse()?, 100)
+            .await?;
 
         let ae = db.get_account(None, chain_1).await?.ok_or(MissingAccount)?;
 
         assert_eq!("/ip4/1.2.3.4/tcp/8000", ae.get_multiaddr().unwrap().to_string());
 
-        db.insert_announcement(None, chain_1, "/ip4/1.2.3.4/tcp/8001".parse().unwrap(), 110).await?;
+        db.insert_announcement(None, chain_1, "/ip4/1.2.3.4/tcp/8001".parse().unwrap(), 110)
+            .await?;
 
         let ae = db.get_account(None, chain_1).await?.ok_or(MissingAccount)?;
 

--- a/db/api/src/accounts.rs
+++ b/db/api/src/accounts.rs
@@ -516,6 +516,34 @@ mod tests {
     }
 
     #[async_std::test]
+    async fn test_should_allow_reannouncement() {
+        let db = HoprDb::new_in_memory(ChainKeypair::random()).await;
+
+        let chain_1 = ChainKeypair::random().public().to_address();
+        let packet_1 = OffchainKeypair::random().public().clone();
+
+        db.insert_account(None, AccountEntry::new(packet_1, chain_1, AccountType::NotAnnounced))
+            .await
+            .unwrap();
+
+        db.insert_announcement(None, chain_1, "/ip4/1.2.3.4/tcp/8000".parse().unwrap(), 100)
+            .await
+            .unwrap();
+
+        let ae = db.get_account(None, chain_1).await.unwrap().unwrap();
+
+        assert_eq!("/ip4/1.2.3.4/tcp/8000", ae.get_multiaddr().unwrap().to_string());
+
+        db.insert_announcement(None, chain_1, "/ip4/1.2.3.4/tcp/8001".parse().unwrap(), 110)
+            .await
+            .unwrap();
+
+        let ae = db.get_account(None, chain_1).await.unwrap().unwrap();
+
+        assert_eq!("/ip4/1.2.3.4/tcp/8001", ae.get_multiaddr().unwrap().to_string());
+    }
+
+    #[async_std::test]
     async fn test_should_not_insert_account_announcement_to_nonexisting_account() {
         let db = HoprDb::new_in_memory(ChainKeypair::random()).await;
 

--- a/db/api/src/peers.rs
+++ b/db/api/src/peers.rs
@@ -471,7 +471,7 @@ impl TryFrom<hopr_db_entity::network_peer::Model> for PeerStatus {
             multiaddresses: value
                 .multi_addresses
                 .split(',')
-                .filter(|s| !s.is_empty())
+                .filter(|s| !s.trim().is_empty())
                 .map(Multiaddr::try_from)
                 .collect::<core::result::Result<Vec<_>, multiaddr::Error>>()
                 .map_err(|_| Self::Error::DecodingError)?,

--- a/db/api/src/peers.rs
+++ b/db/api/src/peers.rs
@@ -471,6 +471,7 @@ impl TryFrom<hopr_db_entity::network_peer::Model> for PeerStatus {
             multiaddresses: value
                 .multi_addresses
                 .split(',')
+                .filter(|s| !s.is_empty())
                 .map(Multiaddr::try_from)
                 .collect::<core::result::Result<Vec<_>, multiaddr::Error>>()
                 .map_err(|_| Self::Error::DecodingError)?,

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -1029,9 +1029,27 @@ impl Hopr {
         self.transport_api.network_observed_multiaddresses(peer).await
     }
 
-    /// List all multiaddresses for this node announced to DHT
-    pub async fn multiaddresses_announced_to_dht(&self, peer: &PeerId) -> Vec<Multiaddr> {
-        self.transport_api.multiaddresses_announced_to_dht(peer).await
+    /// List all multiaddresses announced on-chain for the given node.
+    pub async fn multiaddresses_announced_on_chain(&self, peer: &PeerId) -> Vec<Multiaddr> {
+        let key = match OffchainPublicKey::try_from(peer) {
+            Ok(k) => k,
+            Err(e) => {
+                error!("failed to convert peer id {peer} to off-chain key: {e}");
+                return vec![];
+            }
+        };
+
+        match self.db.get_account(None, key).await {
+            Ok(Some(entry)) => Vec::from_iter(entry.get_multiaddr()),
+            Ok(None) => {
+                error!("no information about {peer}");
+                vec![]
+            }
+            Err(e) => {
+                error!("failed to retrieve information about {peer}: {e}");
+                vec![]
+            }
+        }
     }
 
     // Network =========

--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -2391,7 +2391,7 @@ mod node {
                     let address = hopr.peerid_to_chain_key(&peer_id).await.ok().flatten();
 
                     // WARNING: Only in Providence and Saint-Louis are all peers public
-                    let multiaddresses = hopr.multiaddresses_announced_on_chain(&peer_id).await;
+                    let multiaddresses = hopr.network_observed_multiaddresses(&peer_id).await;
 
                     Some((address, peer_id, multiaddresses, info))
                 }

--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -893,7 +893,7 @@ mod peers {
         match PeerId::from_str(req.param("peerId")?) {
             Ok(peer) => Ok(Response::builder(200)
                 .body(json!(NodePeerInfoResponse {
-                    announced: hopr.multiaddresses_announced_to_dht(&peer).await,
+                    announced: hopr.multiaddresses_announced_on_chain(&peer).await,
                     observed: hopr.network_observed_multiaddresses(&peer).await
                 }))
                 .build()),
@@ -2391,7 +2391,7 @@ mod node {
                     let address = hopr.peerid_to_chain_key(&peer_id).await.ok().flatten();
 
                     // WARNING: Only in Providence and Saint-Louis are all peers public
-                    let multiaddresses = hopr.multiaddresses_announced_to_dht(&peer_id).await;
+                    let multiaddresses = hopr.multiaddresses_announced_on_chain(&peer_id).await;
 
                     Some((address, peer_id, multiaddresses, info))
                 }
@@ -2418,19 +2418,11 @@ mod node {
             .accounts_announced_on_chain()
             .await?
             .into_iter()
-            .map(|announced| {
-                let hopr_clone = hopr.clone();
-                async move {
-                    // WARNING: Only in Providence and Saint-Louis are all peers public
-                    let multiaddresses = hopr_clone
-                        .multiaddresses_announced_to_dht(&announced.public_key.into())
-                        .await;
-
-                    AnnouncedPeer {
-                        peer_id: announced.public_key.into(),
-                        peer_address: announced.chain_addr,
-                        multiaddr: multiaddresses.first().cloned(),
-                    }
+            .map(|announced| async move {
+                AnnouncedPeer {
+                    peer_id: announced.public_key.into(),
+                    peer_address: announced.chain_addr,
+                    multiaddr: announced.get_multiaddr(),
                 }
             })
             .collect::<FuturesUnordered<_>>()

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -580,16 +580,6 @@ where
     }
 
     #[tracing::instrument(level = "debug", skip(self))]
-    pub async fn multiaddresses_announced_to_dht(&self, peer: &PeerId) -> Vec<Multiaddr> {
-        self.network
-            .get(peer)
-            .await
-            .unwrap_or(None)
-            .map(|peer| peer.multiaddresses)
-            .unwrap_or(vec![])
-    }
-
-    #[tracing::instrument(level = "debug", skip(self))]
     pub async fn network_observed_multiaddresses(&self, peer: &PeerId) -> Vec<Multiaddr> {
         self.network
             .get(peer)


### PR DESCRIPTION
The trailing `,` in the `multi_address` column in the peers table caused empty multiaddress being returned.

Also the aforementioned endpoint should returned the announced addresses from the chain, not the ones being observed (those are in the `observed` field).