### PR TITLE
Update transports and their configurations

### DIFF
--- a/transport/p2p/Cargo.toml
+++ b/transport/p2p/Cargo.toml
@@ -14,7 +14,7 @@ default = []
 [dependencies]
 futures = { workspace = true }
 futures-lite = { workspace = true }
-libp2p = { workspace = true, features = ["async-std", "noise", "request-response", "cbor", "macros", "tcp", "dns", "yamux"] }
+libp2p = { workspace = true, features = ["async-std", "noise", "request-response", "cbor", "macros", "tcp", "quic", "dns", "yamux"] }
 libp2p-mplex = { workspace = true }
 serde = { workspace = true, features = ["derive"]}
 thiserror = { workspace = true }


### PR DESCRIPTION
Changes not directly affecting the usability of 2.1.x, but necessary for evolution into 2.2.x line:
- [x] Add QUIC transport (albeit without any possible usage now) to the swarm transport on construction
- [x] Add [TCP_NODELAY](https://brooker.co.za/blog/2024/05/09/nagle.html) and port reuse option for the TCP transport