### PR TITLE
Missing length check for send message packet

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,6 +1,7 @@
 import asyncio
 import random
 import re
+import string
 from contextlib import AsyncExitStack, asynccontextmanager
 
 import pytest
@@ -348,6 +349,18 @@ async def test_hoprd_should_be_able_to_send_0_hop_messages_without_open_channels
 
     packets = [f"0 hop message #{i:08d}" for i in range(message_count)]
     await send_and_receive_packets_with_pop(packets, src=swarm7[src], dest=swarm7[dest], path=[])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("src, dest", random_distinct_pairs_from(barebone_nodes(), count=PARAMETERIZED_SAMPLE_SIZE))
+async def test_hoprd_should_fail_sending_a_message_that_is_too_large(src: Node, dest: Node, swarm7: dict[str, Node]):
+    MAXIMUM_PAYLOAD_SIZE = 500
+    random_tag = random.randint(10, 65530)
+
+    packet = "0 hop message too large: " + "".join(
+        random.choices(string.ascii_uppercase + string.digits, k=MAXIMUM_PAYLOAD_SIZE)
+    )
+    assert await swarm7[src].api.send_message(swarm7[dest].peer_id, packet, [], random_tag) == None
 
 
 @pytest.mark.asyncio

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -412,6 +412,12 @@ where
     ) -> crate::errors::Result<HalfKeyChallenge> {
         let app_data = ApplicationData::new(application_tag, &msg)?;
 
+        if msg.len() > PAYLOAD_SIZE {
+            return Err(crate::errors::HoprTransportError::Api(format!(
+                "Message exceeds the maximum allowed size of {PAYLOAD_SIZE} bytes"
+            )));
+        }
+
         let path: TransportPath = if let Some(intermediate_path) = intermediate_path {
             let mut full_path = intermediate_path;
             full_path.push(destination);


### PR DESCRIPTION
The missing check causes `panic!`, but should be present for 2.1.0.

## Notes
Fixes #6286 