### PR TITLE
Cleanup the stress test and rework it over the websocket

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,28 @@ logging.basicConfig(format="%(asctime)s %(message)s")
 SEED = int.from_bytes(os.urandom(8), byteorder="big")
 random.seed(SEED)
 
+
+def pytest_addoption(parser: pytest.Parser):
+    parser.addoption(
+        "--stress-request-count",
+        action="store",
+        default=500,
+        help="Number of requests performed by each source node towards the stressed target",
+    )
+    parser.addoption(
+        "--stress-sources",
+        action="store",
+        type=str,
+        help="The JSON string containing the list of dicts with 'url' and 'token' keys for each stress test source node",
+    )
+    parser.addoption(
+        "--stress-target",
+        action="store",
+        type=str,
+        help="The JSON string containing the dict with 'url' and 'token' keys for the stressed target node",
+    )
+
+
 # Global variables
 LOCALHOST = "127.0.0.1"
 OPEN_CHANNEL_FUNDING_VALUE_HOPR = 1000
@@ -116,46 +138,6 @@ NODES = {
         FIXTURES_DIR.joinpath(f"{NODE_NAME_PREFIX}_barebone.cfg.yaml"),
     ),
 }
-
-
-def pytest_addoption(parser: pytest.Parser):
-    parser.addoption(
-        "--stress-seq-request-count",
-        action="store",
-        default=500,
-        help="Number of sequential requests in the stress test",
-    )
-    parser.addoption(
-        "--stress-par-request-count", action="store", default=200, help="Number of parallel requests in the stress test"
-    )
-    parser.addoption(
-        "--stress-tested-api",
-        action="store",
-        default=f"http://{LOCALHOST}:{NODES['1'].api_port}",
-        help="The API towards which the stress test is performed",
-    )
-    parser.addoption(
-        "--stress-tested-api-token",
-        action="store",
-        default=API_TOKEN,
-        help="The token for the stress tested API",
-    )
-    parser.addoption(
-        "--stress-minimum-peer-count", action="store", default=3, help="The minimum peer count to start the stress test"
-    )
-
-
-@pytest.fixture
-def cmd_line_args(request: pytest.FixtureRequest):
-    args = {
-        "stress_seq_request_count": request.config.getoption("--stress-seq-request-count"),
-        "stress_par_request_count": request.config.getoption("--stress-par-request-count"),
-        "stress_tested_api": request.config.getoption("--stress-tested-api"),
-        "stress_tested_api_token": request.config.getoption("--stress-tested-api-token"),
-        "stress_minimum_peer_count": request.config.getoption("--stress-minimum-peer-count"),
-    }
-
-    return args
 
 
 def barebone_nodes():
@@ -390,3 +372,7 @@ async def swarm7(request):
     # POST TEST CLEANUP
     logging.debug(f"Tearing down the {len(nodes)} nodes cluster")
     [node.clean_up() for node in nodes.values()]
+
+
+def to_ws_url(host, port):
+    return f"ws://{host}:{port}/api/v3/messages/websocket"

--- a/tests/test_stress.py
+++ b/tests/test_stress.py
@@ -1,22 +1,20 @@
 import asyncio
 from contextlib import AsyncExitStack
+import json
 import os
 import random
+import time
 
+import logging
 import pytest
+import websockets
 
 from .conftest import TICKET_PRICE_PER_HOP, to_ws_url
 from .hopr import HoprdAPI
-from .test_integration import create_channel, send_and_receive_packets_with_pop
+from .test_integration import create_channel
 
-import json
-import random
-import re
 
-import websockets
-
-from .conftest import API_TOKEN, nodes_with_auth, random_distinct_pairs_from
-from .node import Node
+logging.basicConfig(format="%(asctime)s %(message)s")
 
 
 @pytest.fixture
@@ -28,23 +26,34 @@ async def stress_fixture(request: pytest.FixtureRequest):
     }
 
 
-async def has_peer(me, target):
+async def peer_is_present(me, target):
     while True:
         if target in [x["peer_id"] for x in await me.peers()]:
-            import logging
-
-            logging.error("peer {} not found in {await me.peers()}".format(["peer_id"]))
             break
         else:
             await asyncio.sleep(1)
             continue
 
 
+class ApiWrapper:
+    def __init__(self, api, address):
+        self.inner = api
+        self.addr = address
+
+    @property
+    def api(self):
+        return self.inner
+
+    @property
+    def address(self):
+        return self.addr
+
+
 @pytest.mark.asyncio
 @pytest.mark.skipif(
     os.getenv("CI", "false") == "true", reason="stress tests fail randomly on CI due to resource constraints"
 )
-async def test_stress_relayed_flood_test_with_sources_performing_1_hop_to_self(stress_fixture, swarm7):
+async def test_stress_relayed_flood_test_with_sources_performing_1_hop_to_self(stress_fixture):
     STRESS_1_HOP_TO_SELF_MESSAGE_COUNT = stress_fixture["request_count"]
 
     api_sources = [HoprdAPI(f'http://{d["url"]}', d["token"]) for d in stress_fixture["sources"]]
@@ -53,15 +62,15 @@ async def test_stress_relayed_flood_test_with_sources_performing_1_hop_to_self(s
 
     async with AsyncExitStack() as channels:
         await asyncio.gather(
-            *[asyncio.wait_for(has_peer(source, target_peer_id), timeout=15.0) for source in api_sources]
+            *[asyncio.wait_for(peer_is_present(source, target_peer_id), timeout=15.0) for source in api_sources]
         )
 
         await asyncio.gather(
             *[
                 channels.enter_async_context(
                     create_channel(
-                        source,
-                        api_target,
+                        ApiWrapper(source, await source.addresses("native")),
+                        ApiWrapper(api_target, await api_target.addresses("native")),
                         funding=STRESS_1_HOP_TO_SELF_MESSAGE_COUNT * TICKET_PRICE_PER_HOP,
                         close_from_dest=False,
                     )
@@ -70,45 +79,69 @@ async def test_stress_relayed_flood_test_with_sources_performing_1_hop_to_self(s
             ]
         )
 
-        async def send_and_receive_all_messages(host, port, token, target_peer_id):
-            socket = websockets.connect(
+        async def send_and_receive_all_messages(host, port, token, self_peer_id, target_peer_id):
+            start_time = time.time()
+
+            async with websockets.connect(
                 f"{to_ws_url(host, port)}",
-                header={"X-Auth-Token": token},
-            )
+                extra_headers=[("X-Auth-Token", token)],
+            ) as socket:
+                tag = random.randint(30000, 60000)
+                packets = [
+                    f"1 hop stress msg to self ({host}:{port}) through {target_peer_id} #{i+1:08d}/{STRESS_1_HOP_TO_SELF_MESSAGE_COUNT:08d}"
+                    for i in range(STRESS_1_HOP_TO_SELF_MESSAGE_COUNT)
+                ]
 
-            tag = random.randint(30000, 60000)
-            packets = [
-                f"1 hop stress msg to self ({host}:{port}) through {target_peer_id} #{i+1:08d}/{STRESS_1_HOP_TO_SELF_MESSAGE_COUNT:08d}"
-                for i in range(STRESS_1_HOP_TO_SELF_MESSAGE_COUNT)
-            ]
+                recv_packets = []
+                recv_ack_challenges = 0
+                recv_acks = 0
 
-            recv_packets = []
+                for packet in packets:
+                    msg = {
+                        "cmd": "sendmsg",
+                        "args": {"body": packet, "peerId": self_peer_id, "path": [target_peer_id], "tag": tag},
+                    }
+                    await socket.send(json.dumps(msg))
 
-            for packet in packets:
-                msg = {"cmd": "sendmsg", "args": {"body": packet, "peerId": target_peer_id, "path": [], "tag": tag}}
-                await socket.send(json.dumps(msg))
+                packets.sort()
 
-            # receive all messages, acks and ack-challenges
-            for _ in range(packets.len() * 3):
-                try:
-                    msg = await asyncio.wait_for(socket.recv(), timeout=5)
-                    if re.match(r"^.*\"message\".*$", msg):
-                        recv_packets.append(msg)
-                except Exception:
-                    pytest.fail(f"Timeout when receiving an expected item from socket")
+                # receive all messages, acks and ack-challenges
+                for _ in range(len(packets) * 3):
+                    try:
+                        msg = await asyncio.wait_for(socket.recv(), timeout=5)
+                        msg = json.loads(msg)
+                        if msg["type"] == "message-ack":
+                            recv_acks += 1
+                        elif msg["type"] == "message-ack-challenge":
+                            recv_ack_challenges += 1
+                        elif msg["type"] == "message":
+                            recv_packets.append(msg["body"])
+                    except Exception:
+                        break
 
-            packets.sort()
-            recv_packets.sort()
-            assert packets == recv_packets
+                end_time = time.time()
+
+                logging.info(
+                    f"The websocket stress test ran at {STRESS_1_HOP_TO_SELF_MESSAGE_COUNT/(end_time - start_time)} packets/s/node"
+                )
+
+                recv_packets.sort()
+                assert recv_packets == packets
+                assert recv_acks == len(packets)
+                assert recv_ack_challenges == len(packets)
 
         await asyncio.gather(
             *[
                 asyncio.wait_for(
                     send_and_receive_all_messages(
-                        source["url"].split(":")[0], source["url"].split(":")[1], source["token"], target_peer_id
+                        source["url"].split(":")[0],
+                        source["url"].split(":")[1],
+                        source["token"],
+                        await HoprdAPI(f'http://{source["url"]}', source["token"]).addresses("hopr"),
+                        target_peer_id,
                     ),
-                    timeout=20.0,
+                    timeout=60.0,
                 )
-                for source in api_sources
+                for source in stress_fixture["sources"]
             ]
         )

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -8,12 +8,8 @@ import pytest
 import websocket
 import websockets
 
-from .conftest import API_TOKEN, nodes_with_auth, random_distinct_pairs_from
+from .conftest import API_TOKEN, nodes_with_auth, random_distinct_pairs_from, to_ws_url
 from .node import Node
-
-
-def url(host, port):
-    return f"ws://{host}:{port}/api/v3/messages/websocket"
 
 
 EXTRA_HEADERS = [("X-Auth-Token", API_TOKEN)]
@@ -23,7 +19,7 @@ EXTRA_HEADERS = [("X-Auth-Token", API_TOKEN)]
 def test_hoprd_websocket_api_should_reject_a_connection_without_a_valid_token(peer: str, swarm7: dict[str, Node]):
     ws = websocket.WebSocket()
     try:
-        ws.connect(url(swarm7[peer].host_addr, swarm7[peer].api_port))
+        ws.connect(to_ws_url(swarm7[peer].host_addr, swarm7[peer].api_port))
     except websocket.WebSocketBadStatusException as e:
         assert "401 Unauthorized" in str(e)
     else:
@@ -35,7 +31,7 @@ def test_hoprd_websocket_api_should_reject_a_connection_with_an_invalid_token(pe
     ws = websocket.WebSocket()
     try:
         ws.connect(
-            url(swarm7[peer].host_addr, swarm7[peer].api_port),
+            to_ws_url(swarm7[peer].host_addr, swarm7[peer].api_port),
             header={"X-Auth-Token": "InvAliD_toKeN"},
         )
     except websocket.WebSocketBadStatusException as e:
@@ -52,7 +48,7 @@ def test_hoprd_websocket_api_should_accept_a_connection_with_an_invalid_token_pa
 
     try:
         ws.connect(
-            url(swarm7[peer].host_addr, swarm7[peer].api_port) + "?apiToken=InvAlidShit",
+            to_ws_url(swarm7[peer].host_addr, swarm7[peer].api_port) + "?apiToken=InvAlidShit",
         )
     except websocket.WebSocketBadStatusException as e:
         assert "401 Unauthorized" in str(e)
@@ -67,7 +63,7 @@ def test_hoprd_websocket_api_should_reject_a_connection_with_an_invalid_bearer_t
     ws = websocket.WebSocket()
     try:
         ws.connect(
-            url(swarm7[peer].host_addr, swarm7[peer].api_port),
+            to_ws_url(swarm7[peer].host_addr, swarm7[peer].api_port),
             header={"Authorization": "Bearer InvAliD_toKeN"},
         )
     except websocket.WebSocketBadStatusException as e:
@@ -80,7 +76,7 @@ def test_hoprd_websocket_api_should_reject_a_connection_with_an_invalid_bearer_t
 def test_hoprd_websocket_api_should_accept_a_connection_with_a_valid_token(peer: str, swarm7: dict[str, Node]):
     ws = websocket.WebSocket()
     ws.connect(
-        url(swarm7[peer].host_addr, swarm7[peer].api_port),
+        to_ws_url(swarm7[peer].host_addr, swarm7[peer].api_port),
         header={"X-Auth-Token": API_TOKEN},
     )
 
@@ -93,7 +89,7 @@ def test_hoprd_websocket_api_should_accept_a_connection_with_a_valid_token_passe
 ):
     ws = websocket.WebSocket()
     ws.connect(
-        url(swarm7[peer].host_addr, swarm7[peer].api_port) + f"?apiToken={API_TOKEN}",
+        to_ws_url(swarm7[peer].host_addr, swarm7[peer].api_port) + f"?apiToken={API_TOKEN}",
     )
 
     time.sleep(0.5)
@@ -103,7 +99,7 @@ def test_hoprd_websocket_api_should_accept_a_connection_with_a_valid_token_passe
 def test_hoprd_websocket_api_should_accept_a_connection_with_a_valid_bearer_token(peer: str, swarm7: dict[str, Node]):
     ws = websocket.WebSocket()
     ws.connect(
-        url(swarm7[peer].host_addr, swarm7[peer].api_port),
+        to_ws_url(swarm7[peer].host_addr, swarm7[peer].api_port),
         header={"Authorization": "Bearer " + API_TOKEN},
     )
 
@@ -115,7 +111,7 @@ def test_hoprd_websocket_api_should_reject_connection_on_invalid_path(peer: str,
     ws = websocket.WebSocket()
     try:
         ws.connect(
-            f"{url(swarm7[peer].host_addr, swarm7[peer].api_port)}/defIniteLY_InVAliD_paTh",
+            f"{to_ws_url(swarm7[peer].host_addr, swarm7[peer].api_port)}/defIniteLY_InVAliD_paTh",
             header={"X-Auth-Token": API_TOKEN},
         )
     except websocket.WebSocketBadStatusException as e:
@@ -127,12 +123,14 @@ def test_hoprd_websocket_api_should_reject_connection_on_invalid_path(peer: str,
 @pytest.fixture
 async def ws_connections(swarm7: dict[str, Node]):
     async with websockets.connect(
-        url(swarm7["1"].host_addr, swarm7["1"].api_port), extra_headers=EXTRA_HEADERS
+        to_ws_url(swarm7["1"].host_addr, swarm7["1"].api_port), extra_headers=EXTRA_HEADERS
     ) as ws1, websockets.connect(
-        url(swarm7["2"].host_addr, swarm7["2"].api_port), extra_headers=EXTRA_HEADERS
+        to_ws_url(swarm7["2"].host_addr, swarm7["2"].api_port), extra_headers=EXTRA_HEADERS
     ) as ws2, websockets.connect(
-        url(swarm7["3"].host_addr, swarm7["3"].api_port), extra_headers=EXTRA_HEADERS
-    ) as ws3, websockets.connect(url(swarm7["4"].host_addr, swarm7["4"].api_port), extra_headers=EXTRA_HEADERS) as ws4:
+        to_ws_url(swarm7["3"].host_addr, swarm7["3"].api_port), extra_headers=EXTRA_HEADERS
+    ) as ws3, websockets.connect(
+        to_ws_url(swarm7["4"].host_addr, swarm7["4"].api_port), extra_headers=EXTRA_HEADERS
+    ) as ws4:
         yield {"1": ws1, "2": ws2, "3": ws3, "4": ws4}
 
 


### PR DESCRIPTION
The test now uses websockets to allow multiple stressors to focus message sending towards a single relay.

The pytest can be run as:
```
.venv/bin/python3 -m pytest tests/test_stress.py --stress-sources='[{"url": "localhost:19091", "token": "e2e-API-token^^"}]' --stress-target='{"url": "localhost:19093", "token": "e2e-API-token^^"}'
```

Where the sources and target must be already running APIs with valid tokens.

