### PR TITLE
Remove checking if variable is set

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3673,7 +3673,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "2.1.1"
+version = "2.1.2"
 dependencies = [
  "async-lock 3.3.0",
  "async-std",

--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-lib"
-version = "2.1.1"
+version = "2.1.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "HOPR library containing the entire functionality importable without the HOPRd daemon"

--- a/scripts/get-next-version.sh
+++ b/scripts/get-next-version.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # exit on errors, undefined variables, ensure errors in pipes are not hidden
-set -Eeuo pipefail
+set -Eeo pipefail
 
 usage() {
   echo ""


### PR DESCRIPTION
This PR provides a fix for the close release pipeline failing due to a variable `pre_release` not set and checked in an if clause.