### PR TITLE
Add minimum ticket redeeming value configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "core-strategy"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
  "async-lock 3.3.0",
  "async-std",

--- a/hoprd/hoprd/example_cfg.yaml
+++ b/hoprd/hoprd/example_cfg.yaml
@@ -97,6 +97,12 @@ hopr:
         #
         # If set, the strategy will redeem only aggregated tickets.
         redeem_only_aggregated: true
+        #
+        # The strategy will only redeem an acknowledged winning ticket if it has at least this value of HOPR.
+        # If 0 is given, the strategy will redeem tickets regardless of their value.
+        # This is not used for cases where `on_close_redeem_single_tickets_value_min` applies.
+        # minimum_redeem_ticket_value: "0 HOPR"
+        #
         # The strategy will automatically redeem if there's a single ticket left when a channel
         # transitions to `PendingToClose` and it has at least this value of HOPR.
         # This happens regardless of the `redeem_only_aggregated` setting.

--- a/logic/strategy/Cargo.toml
+++ b/logic/strategy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-strategy"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Contains implementations of different HOPR strategies"
 edition = "2021"

--- a/logic/strategy/src/lib.rs
+++ b/logic/strategy/src/lib.rs
@@ -100,6 +100,7 @@ pub fn hopr_default_strategies() -> MultiStrategyConfig {
             }),
             AutoRedeeming(AutoRedeemingStrategyConfig {
                 redeem_only_aggregated: true,
+                minimum_redeem_ticket_value: BalanceType::HOPR.zero(),
                 on_close_redeem_single_tickets_value_min: Balance::new_from_str("90000000000000000", BalanceType::HOPR),
             }),
         ],


### PR DESCRIPTION
The AutoRedeemingStrategyConfig object now includes a new minimum_redeem_ticket_value setting. This determines if the strategy will redeem an acknowledged winning ticket based on its HOPR value. Checks and tests have been added to verify this functionality. The package version has been updated to reflect this new feature addition.

The default value for this setting is 0 HOPR, which means no threshold applies. This is also set a default in the config file.