### PR TITLE
Remove unnecessary safety check for HOPR Safe Balance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3673,7 +3673,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "2.1.2"
+version = "2.1.3"
 dependencies = [
  "async-lock 3.3.0",
  "async-std",

--- a/chain/indexer/src/handlers.rs
+++ b/chain/indexer/src/handlers.rs
@@ -761,7 +761,7 @@ where
 
                     // Update the hash only if any logs were processed in this block
                     let block_hash = if !log_tx_hashes.is_empty() {
-                        debug!("block {block_id} has hashes {:?}", log_tx_hashes);
+                        debug!("{block_id} has hashes {:?}", log_tx_hashes);
                         let h = Hash::create(
                             log_tx_hashes
                                 .iter()


### PR DESCRIPTION
The safety check on HOPR Safe Balance API endpoint is not necessary as the related incorrect smart contract address has been fixed in https://github.com/hoprnet/hoprnet/pull/6229

This safety check could result in database interlocking during Indexer sync phase when the UI was opened at the same time. This could result in skipping chain event logs and incorrect node synchronization.

Closes #6359