### PR TITLE
Improve state management timing in the Session protocol

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ async-broadcast = "0.7.1"
 async-channel = "2.3.1"
 async-lock = "3.4.0"
 async-signal = "0.2.8"
-async-std = { version = "1.12.0", features = ["attributes"] }
+async-std = { version = "1.12.0", features = ["attributes", "unstable"] }
 async-stream = "0.3.5"
 async-trait = "0.1.80"
 aquamarine = "0.5.0"

--- a/common/async-runtime/Cargo.toml
+++ b/common/async-runtime/Cargo.toml
@@ -17,5 +17,5 @@ runtime-async-std = ["dep:async-std"]
 runtime-tokio = ["dep:tokio"]
 
 [dependencies]
-async-std = { workspace = true, optional = true }
+async-std = { workspace = true, optional = true, features = ["unstable"] }
 tokio = { workspace = true, optional = true }

--- a/common/async-runtime/Cargo.toml
+++ b/common/async-runtime/Cargo.toml
@@ -17,5 +17,5 @@ runtime-async-std = ["dep:async-std"]
 runtime-tokio = ["dep:tokio"]
 
 [dependencies]
-async-std = { workspace = true, optional = true, features = ["unstable"] }
+async-std = { workspace = true, optional = true }
 tokio = { workspace = true, optional = true }

--- a/common/network-types/src/session/state.rs
+++ b/common/network-types/src/session/state.rs
@@ -785,6 +785,7 @@ mod tests {
 
     const MTU: usize = 466; // MTU used by HOPR
 
+    // Using static RNG seed to make tests reproducible between different runs
     const RNG_SEED: [u8; 32] = hex!("d8a471f1c20490a3442b96fdde9d1807428096e1601b0cef0eea7e6d44a24c01");
 
     #[derive(Debug, Clone)]

--- a/common/network-types/src/session/state.rs
+++ b/common/network-types/src/session/state.rs
@@ -705,8 +705,12 @@ impl<const C: usize> SessionSocket<C> {
             let mut state_clone = state.clone();
             spawn_local(async move {
                 // TODO: make the max message configurable or derive it
+                let timeout = cfg
+                    .rto_base_receiver
+                    .min(cfg.rto_base_sender)
+                    .min(cfg.frame_expiration_age / 3);
                 while state_clone.advance(None).await.is_ok() {
-                    sleep(cfg.frame_expiration_age / 3).await;
+                    sleep(timeout).await;
                 }
             });
         }
@@ -771,13 +775,17 @@ mod tests {
     use futures::io::{AsyncReadExt, AsyncWriteExt};
     use futures::pin_mut;
     use futures::stream::BoxStream;
+    use hex_literal::hex;
     use parameterized::parameterized;
-    use rand::{thread_rng, Rng};
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
     use std::fmt::Debug;
     use std::iter::Extend;
     use test_log::test;
 
     const MTU: usize = 466; // MTU used by HOPR
+
+    const RNG_SEED: [u8; 32] = hex!("d8a471f1c20490a3442b96fdde9d1807428096e1601b0cef0eea7e6d44a24c01");
 
     #[derive(Debug, Clone)]
     pub struct FaultyNetworkConfig {
@@ -846,11 +854,13 @@ mod tests {
         pub fn new(cfg: FaultyNetworkConfig) -> Self {
             let (ingress, egress) = futures::channel::mpsc::unbounded::<Box<[u8]>>();
 
-            let egress = egress.filter(move |_| futures::future::ready(thread_rng().gen_bool(1.0 - cfg.fault_prob)));
+            let mut rng = StdRng::from_seed(RNG_SEED);
+            let egress = egress.filter(move |_| futures::future::ready(rng.gen_bool(1.0 - cfg.fault_prob)));
 
             let egress = if cfg.mixing_factor > 0 {
+                let mut rng = StdRng::from_seed(RNG_SEED);
                 egress
-                    .map(|e| futures::future::ready(e).delay(Duration::from_micros(thread_rng().gen_range(0..20))))
+                    .map(move |e| futures::future::ready(e).delay(Duration::from_micros(rng.gen_range(0..20))))
                     .buffer_unordered(cfg.mixing_factor)
                     .boxed()
             } else {


### PR DESCRIPTION
- Modified network-types' session state for calculations of timeout and frame expiration age. 
- Updated the 'async-std' dependency in 'async-runtime/Cargo.toml' to include the 'unstable' feature. 
- Changes to tests also include a consistent seed for the RNG to improve reproducibility.