### PR TITLE
Add indexer state to NodeInfoResponse

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -64,6 +64,5 @@ scrape_configs:
 - `hopr_chain_head_block_number`: Current block number of chain head
 - `hopr_indexer_block_number`: Current last processed block number by the indexer
 - `hopr_indexer_sync_progress`: Sync progress of the historical data by the indexer
-- `hopr_indexer_checksum`: Contains an unsigned integer that represents the low 32-bits of the Indexer checksum.
 - `hopr_chain_actions_count`: Number of different chain actions and their results, keys: `action`, `result`
 - `hopr_indexer_contract_log_counters`: Counts of different HOPR contract logs processed by the Indexer, keys: `contract`

--- a/chain/indexer/src/block.rs
+++ b/chain/indexer/src/block.rs
@@ -22,11 +22,6 @@ lazy_static::lazy_static! {
             "hopr_indexer_block_number",
             "Current last processed block number by the indexer",
     ).unwrap();
-    static ref METRIC_INDEXER_CHECKSUM: SimpleGauge =
-        SimpleGauge::new(
-            "hopr_indexer_checksum",
-            "Contains an unsigned integer that represents the low 32-bits of the Indexer checksum"
-    ).unwrap();
     static ref METRIC_INDEXER_SYNC_PROGRESS: SimpleGauge =
         SimpleGauge::new(
             "hopr_indexer_sync_progress",
@@ -213,13 +208,6 @@ where
                     match db.get_last_indexed_block(None).await {
                         Ok((_, checksum)) => {
                             info!("Current indexer state at block #{block_id} with checksum: {checksum}");
-
-                            #[cfg(all(feature = "prometheus", not(test)))]
-                            {
-                                let low_4_bytes =
-                                    hopr_primitive_types::prelude::U256::from_big_endian(checksum.as_slice()).low_u32();
-                                METRIC_INDEXER_CHECKSUM.set(low_4_bytes.into());
-                            }
                         }
                         Err(e) => error!("Cannot retrieve indexer state: {e}"),
                     }

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -958,6 +958,11 @@ impl Hopr {
         Ok(self.transport_api.get_public_nodes().await?)
     }
 
+    /// Gets the current indexer state: last indexed block ID and checksum
+    pub async fn get_indexer_state(&self) -> errors::Result<(u32, Hash)> {
+        Ok(self.db.get_last_indexed_block(None).await?)
+    }
+
     /// Test whether the peer with PeerId is allowed to access the network
     pub async fn is_allowed_to_access_network(&self, peer: &PeerId) -> errors::Result<bool> {
         Ok(self.transport_api.is_allowed_to_access_network(peer).await?)


### PR DESCRIPTION
- Adds indexer checksum and indexer current block into the `node/info` API endpoint.

- Removes the problematic `hopr_indexer_checksum` metric

Closes #6375