### PR TITLE
Disable optimize_on_close in SQLite configuration

### DIFF
--- a/db/api/src/db.rs
+++ b/db/api/src/db.rs
@@ -58,7 +58,7 @@ impl HoprDb {
             .journal_mode(SqliteJournalMode::Wal)
             .synchronous(SqliteSynchronous::Normal)
             .auto_vacuum(SqliteAutoVacuum::Full)
-            .optimize_on_close(true, None)
+            //.optimize_on_close(true, None) // Removed, because it causes optimization on each connection, due to min_connections being set to 0
             .page_size(4096)
             .pragma("cache_size", "-30000") // 32M
             .pragma("busy_timeout", "1000"); // 1000ms


### PR DESCRIPTION
The 'optimize_on_close' option in the SQLite configuration has been commented out. This change has been made because the option was causing optimization on each connection, due to the min_connections value being set to 0. This adjustment should help improve the overall performance, connection times and possible deadlocks.

Refs #6359