### PR TITLE
API: add "/eligiblez" endpoint to get node eligibility via a direct RPC call

### DIFF
--- a/chain/api/src/lib.rs
+++ b/chain/api/src/lib.rs
@@ -341,4 +341,8 @@ impl<T: HoprDbAllOperations + Send + Sync + Clone + std::fmt::Debug + 'static> H
     pub async fn get_channel_closure_notice_period(&self) -> errors::Result<Duration> {
         Ok(self.rpc_operations.get_channel_closure_notice_period().await?)
     }
+
+    pub async fn get_eligibility_status(&self) -> errors::Result<bool> {
+        Ok(self.rpc_operations.get_eligibility_status(self.me_onchain()).await?)
+    }
 }

--- a/chain/rpc/src/lib.rs
+++ b/chain/rpc/src/lib.rs
@@ -307,6 +307,9 @@ pub trait HoprRpcOperations {
     /// Retrieves the node's account balance of the given type.
     async fn get_balance(&self, address: Address, balance_type: BalanceType) -> Result<Balance>;
 
+    /// Retrieves the node's eligibility status
+    async fn get_eligibility_status(&self, address: Address) -> Result<bool>;
+
     /// Retrieves info of the given node module's target.
     async fn get_node_management_module_target_info(&self, target: Address) -> Result<Option<U256>>;
 

--- a/chain/rpc/src/rpc.rs
+++ b/chain/rpc/src/rpc.rs
@@ -168,6 +168,23 @@ impl<P: JsonRpcClient + 'static> HoprRpcOperations for RpcOperations<P> {
         }
     }
 
+    async fn get_eligibility_status(&self, address: Address) -> Result<bool> {
+        match self
+            .contract_instances
+            .network_registry
+            .is_node_registered_and_eligible(address.into())
+            .call()
+            .await
+        {
+            Ok(eligible) => Ok(eligible),
+            Err(e) => Err(ContractError(
+                "NetworkRegistry".to_string(),
+                "is_node_registered_and_eligible".to_string(),
+                e.to_string(),
+            )),
+        }
+    }
+
     async fn get_node_management_module_target_info(&self, target: Address) -> Result<Option<U256>> {
         match self.node_module.try_get_target(target.into()).call().await {
             Ok((exists, target)) => Ok(exists.then_some(target)),

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -592,6 +592,10 @@ impl Hopr {
         Ok(self.chain_api.get_balance(balance_type).await?)
     }
 
+    pub async fn get_eligiblity_status(&self) -> errors::Result<bool> {
+        Ok(self.chain_api.get_eligibility_status().await?)
+    }
+
     pub async fn get_safe_balance(&self, balance_type: BalanceType) -> errors::Result<Balance> {
         let safe_balance = self
             .chain_api

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -592,7 +592,7 @@ impl Hopr {
         Ok(self.chain_api.get_balance(balance_type).await?)
     }
 
-    pub async fn get_eligiblity_status(&self) -> errors::Result<bool> {
+    pub async fn get_eligibility_status(&self) -> errors::Result<bool> {
         Ok(self.chain_api.get_eligibility_status().await?)
     }
 

--- a/hoprd/rest-api/src/checks.rs
+++ b/hoprd/rest-api/src/checks.rs
@@ -53,3 +53,22 @@ fn is_running(state: Arc<AppState>) -> impl IntoResponse {
         _ => (StatusCode::PRECONDITION_FAILED, "").into_response(),
     }
 }
+
+/// Check whether the node is eligible in the network.
+#[utoipa::path(
+        get,
+        path = "/eligiblez",
+        responses(
+            (status = 200, description = "The node is allowed in the network"),
+            (status = 412, description = "The node is not allowed in the network"),
+        ),
+        tag = "Checks"
+    )]
+pub(super) async fn eligiblez(State(state): State<Arc<AppState>>) -> impl IntoResponse {
+    let hopr = state.hopr.clone();
+
+    match hopr.get_eligiblity_status().await {
+        Ok(true) => (StatusCode::OK, "").into_response(),
+        _ => (StatusCode::PRECONDITION_FAILED, "").into_response(),
+    }
+}

--- a/hoprd/rest-api/src/checks.rs
+++ b/hoprd/rest-api/src/checks.rs
@@ -67,7 +67,7 @@ fn is_running(state: Arc<AppState>) -> impl IntoResponse {
 pub(super) async fn eligiblez(State(state): State<Arc<AppState>>) -> impl IntoResponse {
     let hopr = state.hopr.clone();
 
-    match hopr.get_eligiblity_status().await {
+    match hopr.get_eligibility_status().await {
         Ok(true) => (StatusCode::OK, "").into_response(),
         _ => (StatusCode::PRECONDITION_FAILED, "").into_response(),
     }

--- a/hoprd/rest-api/src/checks.rs
+++ b/hoprd/rest-api/src/checks.rs
@@ -61,6 +61,7 @@ fn is_running(state: Arc<AppState>) -> impl IntoResponse {
         responses(
             (status = 200, description = "The node is allowed in the network"),
             (status = 412, description = "The node is not allowed in the network"),
+            (status = 500, description = "Internal server error"),
         ),
         tag = "Checks"
     )]
@@ -69,6 +70,7 @@ pub(super) async fn eligiblez(State(state): State<Arc<AppState>>) -> impl IntoRe
 
     match hopr.get_eligibility_status().await {
         Ok(true) => (StatusCode::OK, "").into_response(),
-        _ => (StatusCode::PRECONDITION_FAILED, "").into_response(),
+        Ok(false) => (StatusCode::PRECONDITION_FAILED, "Node not eligible").into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, format!("Error: {}", e)).into_response(),
     }
 }

--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -82,6 +82,7 @@ pub(crate) struct InternalState {
         channels::list_channels,
         channels::open_channel,
         channels::show_channel,
+        checks::eligiblez,
         checks::healthyz,
         checks::readyz,
         checks::startedz,
@@ -206,6 +207,7 @@ async fn build_api(
                 .route("/startedz", get(checks::startedz))
                 .route("/readyz", get(checks::readyz))
                 .route("/healthyz", get(checks::healthyz))
+                .route("/eligiblez", get(checks::eligiblez))
                 .with_state(state.into()),
         )
         .nest(


### PR DESCRIPTION
PR adds an API endpoint `eligiblez` which requires no authentications to check if the node is allowed in the network, through a direct RPC call.