### PR TITLE
Fix API withdraw endpoint

### DIFF
--- a/hoprd/rest-api/src/account.rs
+++ b/hoprd/rest-api/src/account.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use std::sync::Arc;
 
-use hopr_lib::{Address, Balance, BalanceType, U256};
+use hopr_lib::{Address, Balance, BalanceType};
 
 use crate::{ApiErrorStatus, InternalState, BASE_PATH};
 
@@ -132,7 +132,7 @@ pub(crate) struct WithdrawBodyRequest {
     currency: BalanceType,
     #[serde_as(as = "DisplayFromStr")]
     #[schema(value_type = String)]
-    amount: U256,
+    amount: String,
     #[serde_as(as = "DisplayFromStr")]
     #[schema(value_type = String)]
     address: Address,
@@ -173,7 +173,10 @@ pub(super) async fn withdraw(
 ) -> impl IntoResponse {
     match state
         .hopr
-        .withdraw(req_data.address, Balance::new(req_data.amount, req_data.currency))
+        .withdraw(
+            req_data.address,
+            Balance::new_from_str(&req_data.amount, req_data.currency),
+        )
         .await
     {
         Ok(receipt) => (

--- a/hoprd/rest-api/src/account.rs
+++ b/hoprd/rest-api/src/account.rs
@@ -122,7 +122,7 @@ pub(super) async fn balances(State(state): State<Arc<InternalState>>) -> impl In
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 #[schema(example = json!({
         "address": "0xb4ce7e6e36ac8b01a974725d5ba730af2b156fbe",
-        "amount": 20000,
+        "amount": "20000",
         "currency": "HOPR"
     }))]
 #[serde(rename_all = "camelCase")]

--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -217,7 +217,7 @@ async fn build_api(
                 .route("/aliases/:alias", delete(alias::delete_alias))
                 .route("/account/addresses", get(account::addresses))
                 .route("/account/balances", get(account::balances))
-                .route("/account/withdraw", get(account::withdraw))
+                .route("/account/withdraw", post(account::withdraw))
                 .route("/peers/:peerId", get(peers::show_peer_info))
                 .route("/peers/:peerId/ping", post(peers::ping_peer))
                 .route("/channels", get(channels::list_channels))

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -37,6 +37,9 @@ craneLib.devShell {
     # test Github automation
     act
 
+    # documentation utilities
+    swagger-codegen3
+
     # docker image inspection and handling
     dive
     skopeo

--- a/tests/hopr.py
+++ b/tests/hopr.py
@@ -21,6 +21,7 @@ from hoprd_sdk.models import (
     OpenChannelBodyRequest,
     SendMessageBodyRequest,
     TagQueryRequest,
+    WithdrawBodyRequest,
 )
 from hoprd_sdk.rest import ApiException
 from urllib3.exceptions import MaxRetryError
@@ -61,7 +62,7 @@ class HoprdAPI:
                 )
                 return (True, response)
         except ApiException as e:
-            log.info(
+            log.error(
                 f"ApiException calling {api_callback.__qualname__} with kwargs: {kwargs}, args: {args}, error is: {e}"
             )
             return (False, None)
@@ -381,6 +382,18 @@ class HoprdAPI:
         """
         _, response = self.__call_api(NetworkApi, "price")
         return int(response.price) if hasattr(response, "price") else None
+
+    async def withdraw(self, amount: str, receipient: str, currency: str):
+        """
+        Withdraws the given amount of token (Native or HOPR) to the given receipient.
+        :param: amount: str
+        :param: receipient: str
+        :param: currency: str
+        :return:
+        """
+        body = WithdrawBodyRequest(receipient, amount, currency)
+        status, response = self.__call_api(AccountApi, "withdraw", body=body)
+        return status, response
 
     async def startedz(self):
         """

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -752,14 +752,13 @@ async def test_hoprd_strategy_UNFINISHED():
 @pytest.mark.asyncio
 @pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
 async def test_hoprd_check_native_withdraw(peer, swarm7: dict[str, Node]):
-    amount = 10
+    amount = "9876"
+
     before_balance = await swarm7[peer].api.balances()
-
-    await swarm7[peer].api.withdraw(f"{amount}", swarm7[peer].safe_address, "native")
-
+    await swarm7[peer].api.withdraw(amount, swarm7[peer].safe_address, "Native")
     after_balance = await swarm7[peer].api.balances()
 
-    assert after_balance.native + amount == before_balance.native
+    assert int(after_balance.safe_native) - int(before_balance.safe_native) == int(amount)
 
 
 @pytest.mark.asyncio

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -14,8 +14,8 @@ from .conftest import (
     TICKET_AGGREGATION_THRESHOLD,
     TICKET_PRICE_PER_HOP,
     barebone_nodes,
-    nodes_with_auth,
     default_nodes,
+    nodes_with_auth,
     random_distinct_pairs_from,
 )
 from .hopr import HoprdAPI
@@ -750,26 +750,16 @@ async def test_hoprd_strategy_UNFINISHED():
 
 
 @pytest.mark.asyncio
-async def test_hoprd_check_native_withdraw_results_UNFINISHED():
-    """
-    # this 2 functions are runned at the end of the tests when withdraw transaction should clear on blockchain
-    # and we don't have to block and wait for it
-    check_native_withdraw_results() {
-    local initial_native_balance="${1}"
+@pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
+async def test_hoprd_check_native_withdraw(peer, swarm7: dict[str, Node]):
+    amount = 10
+    before_balance = await swarm7[peer].api.balances()
 
-    balances=$(api_get_balances ${api1})
-    new_native_balance=$(echo ${balances} | jq -r .native)
-    [[ "${initial_native_balance}" == "${new_native_balance}" ]] && \
-        { msg "Native withdraw failed, pre: ${initial_native_balance}, post: ${new_native_balance}"; exit 1; }
+    await swarm7[peer].api.withdraw(f"{amount}", swarm7[peer].safe_address, "native")
 
-    echo "withdraw native successful"
-    }
+    after_balance = await swarm7[peer].api.balances()
 
-    # checking statuses of the long running tests
-    balances=$(api_get_balances ${api1})
-    native_balance=$(echo ${balances} | jq -r .native)
-    """
-    assert True
+    assert after_balance.native + amount == before_balance.native
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
- Change the definition of the endpoint from `get` to `post` in the routes list
- Fix the conversion in the API, from string to `Balance`