### PR TITLE
make: Add target to run local stress test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ smoke-tests: ## run smoke tests
 stress-test-local-swarm: ## run stress tests on a local node swarm
 	source .venv/bin/activate && \
 		python3 -m pytest tests/test_stress.py \
-		--stress-request-count=10000 \
+		--stress-request-count=3000 \
 		--stress-sources='[{"url": "localhost:19091", "token": "e2e-API-token^^"}]' \
 		--stress-target='{"url": "localhost:19093", "token": "e2e-API-token^^"}'
 

--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,14 @@ test: smart-contract-test ## run unit tests for all packages, or a single packag
 smoke-tests: ## run smoke tests
 	source .venv/bin/activate && python3 -m pytest tests/
 
+.PHONY: stress-test-local-swarm
+stress-test-local-swarm: ## run stress tests on a local node swarm
+	source .venv/bin/activate && \
+		python3 -m pytest tests/test_stress.py \
+		--stress-request-count=10000 \
+		--stress-sources='[{"url": "localhost:19091", "token": "e2e-API-token^^"}]' \
+		--stress-target='{"url": "localhost:19093", "token": "e2e-API-token^^"}'
+
 .PHONY: smart-contract-test
 smart-contract-test: # forge test smart contracts
 	$(MAKE) -C ethereum/contracts/ sc-test

--- a/README.md
+++ b/README.md
@@ -449,8 +449,10 @@ deactivate
 With the environment activated, execute the tests locally:
 
 ```shell
-make smoke-test-full
+make smoke-tests
 ```
+
+####
 
 ## Contact
 

--- a/tests/test_stress.py
+++ b/tests/test_stress.py
@@ -11,6 +11,7 @@ import websockets
 
 from .conftest import TICKET_PRICE_PER_HOP, to_ws_url
 from .hopr import HoprdAPI
+from .node import Node
 from .test_integration import create_channel
 
 
@@ -53,7 +54,7 @@ class ApiWrapper:
 @pytest.mark.skipif(
     os.getenv("CI", "false") == "true", reason="stress tests fail randomly on CI due to resource constraints"
 )
-async def test_stress_relayed_flood_test_with_sources_performing_1_hop_to_self(stress_fixture):
+async def test_stress_relayed_flood_test_with_sources_performing_1_hop_to_self(stress_fixture, swarm7: dict[str, Node]):
     STRESS_1_HOP_TO_SELF_MESSAGE_COUNT = stress_fixture["request_count"]
 
     api_sources = [HoprdAPI(f'http://{d["url"]}', d["token"]) for d in stress_fixture["sources"]]


### PR DESCRIPTION
This allows anyone to launch quick local stress tests. Combined with the changes from #6391 the startup of these local tests  will be fast.