### PR TITLE
Add missing CORS headers and max age

### DIFF
--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -265,7 +265,9 @@ async fn build_api(
                 .layer(
                     CorsLayer::new()
                         .allow_methods([Method::GET, Method::POST, Method::OPTIONS, Method::DELETE])
-                        .allow_origin(Any),
+                        .allow_origin(Any)
+                        .allow_headers(Any)
+                        .max_age(std::time::Duration::from_secs(86400)),
                 )
                 .layer(middleware::from_fn(prometheus::record))
                 .layer(CompressionLayer::new())


### PR DESCRIPTION
The CORS were not properly configured, adding missing headers:
- [x] add allow certain headers
- [x] add max age 

## Notes
Fixes #6426 