### PR TITLE
Add support for opentelemetry into hoprd

### DIFF
--- a/deploy/compose/.env.example
+++ b/deploy/compose/.env.example
@@ -29,6 +29,14 @@ HOPR_ADMIN_PORT=8080
 HOPR_ADMIN_MEM_REQUEST=256M
 HOPR_ADMIN_MEM_LIMIT=256M
 
+
+#### Tracing Configuration ####
+JAEGER_IMAGE=jaegertracing/all-in-one:latest
+
+HOPRD_USE_OPENTELEMETRY=true
+OTEL_SERVICE_NAME=hoprd
+OTEL_EXPORTER_OTLP_ENDPOINT=http://jaeger:4317/
+
 #### Monitoring Configuration ####
 
 # cAdvisor image name

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -30,7 +30,9 @@ services:
       - RUST_BACKTRACE=full
       - HOPRD_CONFIGURATION_FILE_PATH=/app/hoprd.cfg.yaml
       - HOPRD_API_PORT=3001
-      # - OPENTELEMETRY_COLLECTOR_URL=http://server.
+      - "HOPRD_USE_OPENTELEMETRY=${HOPRD_USE_OPENTELEMETRY}"
+      - "OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME}"
+      - "OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT}"
     volumes:
       - ./hoprd.cfg.yaml:/app/hoprd.cfg.yaml
       - ./hopr.id:/app/hopr.id
@@ -68,6 +70,23 @@ services:
           memory: "${HOPR_ADMIN_MEM_LIMIT}"
     profiles:
       - admin-ui
+
+  jaeger:
+    image: "${JAEGER_IMAGE}"
+    restart: unless-stopped
+    platform: ${DOCKER_PLATFORM}
+    container_name: jaeger
+    hostname: jaeger
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+      - "16686:16686"
+    networks:
+      - hoprnet
+    environment:
+      - COLLECTOR_OTLP_ENABLED=true
+    profiles:
+      - tracing
 
   cadvisor:
     image: "${METRICS_CADVISOR_IMAGE}"

--- a/hoprd/hoprd/Cargo.toml
+++ b/hoprd/hoprd/Cargo.toml
@@ -13,6 +13,7 @@ build = "build.rs"
 default = [
   "runtime-tokio",
   "prometheus",
+  "telemetry",
 ] # uses tokio by default because of axum
 prometheus = [
   "dep:hopr-metrics",

--- a/hoprd/hoprd/src/lib.rs
+++ b/hoprd/hoprd/src/lib.rs
@@ -2,7 +2,7 @@
 //! a dedicated REST API.
 //!
 //! When the Rest API is enabled, the node serves a Swagger UI to inspect and test
-//! the Rest API v3 at: http://localhost:3001/swagger-ui/index.html
+//! the Rest API v3 at: http://localhost:3001/scalar
 //!
 //! NOTE: Hostname and port can be different, since they depend on the settings `--apiHost` and `--apiPort`.
 //!

--- a/hoprd/hoprd/src/main.rs
+++ b/hoprd/hoprd/src/main.rs
@@ -9,6 +9,7 @@ use futures::StreamExt;
 
 #[cfg(feature = "telemetry")]
 use {
+    opentelemetry::trace::TracerProvider,
     opentelemetry_otlp::WithExportConfig as _,
     opentelemetry_sdk::trace::{RandomIdGenerator, Sampler},
 };
@@ -57,51 +58,48 @@ fn init_logger() -> Result<(), Box<dyn std::error::Error>> {
         .with_thread_ids(true)
         .with_thread_names(false);
 
-    #[cfg(not(feature = "telemetry"))]
-    tracing::subscriber::set_global_default(tracing_subscriber::Registry::default().with(env_filter).with(format))
-        .expect("Failed to set tracing subscriber");
+    let registry = tracing_subscriber::Registry::default().with(env_filter).with(format);
+
+    let mut telemetry = None;
 
     #[cfg(feature = "telemetry")]
     {
-        if let Ok(telemetry_url) = std::env::var("HOPRD_OPENTELEMETRY_COLLECTOR_URL") {
-            let tracer = opentelemetry_otlp::new_pipeline()
-                .tracing()
-                .with_exporter(
-                    opentelemetry_otlp::new_exporter()
-                        .http()
-                        .with_endpoint(telemetry_url)
-                        .with_protocol(opentelemetry_otlp::Protocol::HttpBinary)
-                        .with_timeout(std::time::Duration::from_secs(5)),
-                )
-                .with_trace_config(
-                    opentelemetry_sdk::trace::config()
-                        .with_sampler(Sampler::AlwaysOn)
-                        .with_id_generator(RandomIdGenerator::default())
-                        .with_max_events_per_span(64)
-                        .with_max_attributes_per_span(16)
-                        .with_resource(opentelemetry_sdk::Resource::new(vec![opentelemetry::KeyValue::new(
-                            "service.name",
-                            env!("CARGO_PKG_NAME"),
-                        )])),
-                )
-                .install_batch(opentelemetry_sdk::runtime::AsyncStd)?;
+        match std::env::var("HOPRD_USE_OPENTELEMETRY") {
+            Ok(v) if v == "true" => {
+                let tracer = opentelemetry_otlp::new_pipeline()
+                    .tracing()
+                    .with_exporter(
+                        opentelemetry_otlp::new_exporter()
+                            .tonic()
+                            // .http()
+                            .with_protocol(opentelemetry_otlp::Protocol::HttpBinary)
+                            .with_timeout(std::time::Duration::from_secs(5)),
+                    )
+                    .with_trace_config(
+                        opentelemetry_sdk::trace::Config::default()
+                            .with_sampler(Sampler::AlwaysOn)
+                            .with_id_generator(RandomIdGenerator::default())
+                            .with_max_events_per_span(64)
+                            .with_max_attributes_per_span(16)
+                            .with_resource(opentelemetry_sdk::Resource::new(vec![opentelemetry::KeyValue::new(
+                                "service.name",
+                                env!("CARGO_PKG_NAME"),
+                            )])),
+                    )
+                    .install_batch(opentelemetry_sdk::runtime::Tokio)?
+                    .tracer(env!("CARGO_PKG_NAME"));
 
-            tracing::subscriber::set_global_default(
-                tracing_subscriber::Registry::default()
-                    .with(env_filter)
-                    .with(format)
-                    .with(tracing_opentelemetry::layer().with_tracer(tracer)),
-            )
-            .expect("Failed to set tracing subscriber");
-        } else {
-            tracing::subscriber::set_global_default(
-                tracing_subscriber::Registry::default().with(env_filter).with(format),
-            )
-            .expect("Failed to set tracing subscriber");
-        };
+                telemetry = Some(tracing_opentelemetry::layer().with_tracer(tracer))
+            }
+            _ => {}
+        }
     }
 
-    Ok(())
+    Ok(if let Some(telemetry) = telemetry {
+        tracing::subscriber::set_global_default(registry.with(telemetry))?
+    } else {
+        tracing::subscriber::set_global_default(registry)?
+    })
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
@@ -114,7 +112,7 @@ enum HoprdProcesses {
 #[cfg_attr(feature = "runtime-async-std", async_std::main)]
 #[cfg_attr(all(feature = "runtime-tokio", not(feature = "runtime-async-std")), tokio::main)]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    let _ = init_logger();
+    init_logger()?;
 
     let args = <CliArgs as clap::Parser>::parse();
     let cfg = hoprd::config::HoprdConfig::from_cli_args(args, false)?;

--- a/scripts/setup-local-cluster.sh
+++ b/scripts/setup-local-cluster.sh
@@ -383,7 +383,7 @@ for node_id in ${!id_files[@]}; do
   log "\t${node_name}"
   log "\t\tPeer Id:\t${peers[$node_id]}"
   log "\t\tAddress:\t${node_addrs[$node_id]}"
-  log "\t\tRest API:\thttp://${listen_host}:${api_port}/swagger-ui/index.html"
+  log "\t\tRest API:\thttp://${listen_host}:${api_port}/scalar"
   log "\t\tAdmin UI:\thttp://${listen_host}:3000/?apiEndpoint=http://${listen_host}:${api_port}&apiToken=${api_token}"
   log "\t\tWebSocket:\tws://${listen_host}:${api_port}/api/v3/messages/websocket?apiToken=${api_token}"
 

--- a/tests/node.py
+++ b/tests/node.py
@@ -80,12 +80,14 @@ class Node:
     def setup(self, password: str, config_file: Path, dir: Path):
         api_token_param = f"--api-token={self.api_token}" if self.api_token else "--disableApiAuthentication"
         custom_env = {
-            "RUST_LOG": "debug,libp2p_mplex=info,multistream_select=info,isahc::handler=error,isahc::client=error",
+            "RUST_LOG": "debug,libp2p_swarm=info,libp2p_mplex=info,multistream_select=info,isahc::handler=error,isahc::client=error",
             "RUST_BACKTRACE": "full",
             "HOPRD_HEARTBEAT_INTERVAL": "2500",
             "HOPRD_HEARTBEAT_THRESHOLD": "2500",
             "HOPRD_HEARTBEAT_VARIANCE": "1000",
             "HOPRD_NETWORK_QUALITY_THRESHOLD": "0.3",
+            "HOPRD_USE_OPENTELEMETRY": "false",
+            "OTEL_SERVICE_NAME": f"hoprd-{self.p2p_port}" 
         }
 
         cmd = [


### PR DESCRIPTION
`hoprd` is now able to stream opentelemetry using `tonic` and the default docker-compose setup was extended to allow running a `jaeger` instance.

- [x] extend docker-compose to include jaeger under a tracing profile
- [x] fix and update the logger initialization
- [x] turn the telemetry feature by default on  
- [x] fix obsolete `swagger-ui` references to point to `scalar` 

## Demo
<img width="1726" alt="Screenshot 2024-08-01 at 16 20 00" src="https://github.com/user-attachments/assets/9834894c-7d08-4a2b-8f30-39b64b6cce0f">


## Notes
Fixes #6362 
As seen in: https://broch.tech/posts/rust-tracing-opentelemetry/