### PR TITLE
Do not sort the heartbeat peers ascending by last seen date

### DIFF
--- a/transport/network/src/network.rs
+++ b/transport/network/src/network.rs
@@ -308,7 +308,7 @@ where
     pub async fn find_peers_to_ping(&self, threshold: SystemTime) -> crate::errors::Result<Vec<PeerId>> {
         let stream = self
             .db
-            .get_network_peers(PeerSelector::default().with_last_seen_lte(threshold), true)
+            .get_network_peers(PeerSelector::default().with_last_seen_lte(threshold), false)
             .await?;
         futures::pin_mut!(stream);
         let mut data: Vec<PeerStatus> = stream


### PR DESCRIPTION
Do not use ascending sort on last seen datetime, but use a descending, favoring more recently seen peers and pushing the later seen peers to the latter stage.

## Notes
Fixes #6360 