### PR TITLE
Remove tickets that are within an aggregated ticket prior to sending aggregation request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3673,7 +3673,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "2.1.3"
+version = "2.1.4"
 dependencies = [
  "async-lock 3.3.0",
  "async-std",

--- a/chain/actions/src/redeem.rs
+++ b/chain/actions/src/redeem.rs
@@ -134,7 +134,7 @@ where
             .with_aggregated_only(only_aggregated)
             .with_state(AcknowledgedTicketStatus::Untouched);
 
-        let (count_redeemable_tickets, _) = self.db.get_tickets_value(None, selector).await?;
+        let (count_redeemable_tickets, _) = self.db.get_tickets_value(None, selector.clone()).await?;
 
         info!(
             "there are {count_redeemable_tickets} acknowledged tickets in channel {channel_id} which can be redeemed"

--- a/db/api/src/ticket_manager.rs
+++ b/db/api/src/ticket_manager.rs
@@ -147,6 +147,7 @@ impl TicketManager {
             crate::TargetDb::Tickets,
         );
 
+        let selector_clone = selector.clone();
         Ok(self
             .caches
             .unrealized_value
@@ -155,7 +156,7 @@ impl TicketManager {
                     .perform(|tx| {
                         Box::pin(async move {
                             ticket::Entity::find()
-                                .filter(selector)
+                                .filter(selector_clone)
                                 .stream(tx.as_ref())
                                 .await
                                 .map_err(crate::errors::DbError::from)?

--- a/db/api/src/tickets.rs
+++ b/db/api/src/tickets.rs
@@ -37,8 +37,8 @@ lazy_static::lazy_static! {
     ).unwrap();
 }
 
-/// Allows selecting multiple tickets (if `index` is `None`)
-/// or a single ticket (with given `index`) in the given channel and epoch.
+/// Allows selecting multiple tickets (if `index` does not contain a single value)
+/// or a single ticket (with unitary `index`) in the given channel and epoch.
 /// The selection can be further restricted to select ticket only in the given `state`.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TicketSelector {


### PR DESCRIPTION
In certain situations, the database can contain an aggregated ticket and also a ticket that is inside this aggregation ticket.
E.g. the DB contains a ticket with Index 1 and Offset 4, but also a ticket with Index 3, Offset 1.

This can happen when packets are arriving out of order, and only e.g. a single ticket is needed to trigger an aggregation.

Example:

- aggregation threshold is set to 3
- there are 2 unredeemed tickets (index 0, offset 1, index 1 offset 1)
- ticket with index 4, offset 1 arrives, completing the batch and the aggregation is triggered
- ticket with index 2 offset 1 and index 3 offset 1 arrive
- aggregated ticket with index 0 offset 5 arrives from the aggregator

This results in tickets: (2,1), (3,1) and (0,5) being in the DB, which have overlapping index intervals. This will subsequently result in aggregation failure, when another aggregation attempt is made.

This PR fixes the issue by removing the single tickets that overlap with an aggregated ticket (marking them as neglected).
However, this comes at certain  loss. This cannot be prevented unless more sophisticated buffering algorithm is introduced before the aggregation takes place. 
An ultimate solution is to get rid of aggregation completely, which is planned for future releases.

Closes #6419