### PR TITLE
Properly initialize Prometheus metrics for ticket statistics

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -2,7 +2,7 @@
 
 This file is documenting and tracking all the metrics which can be collected
 by a Prometheus server. The metrics can be scraped by Prometheus from
-the `api/v2/node/metrics` API endpoint.
+the `api/v3/node/metrics` API endpoint.
 
 ## Example Prometheus configuration
 
@@ -66,3 +66,4 @@ scrape_configs:
 - `hopr_indexer_sync_progress`: Sync progress of the historical data by the indexer
 - `hopr_chain_actions_count`: Number of different chain actions and their results, keys: `action`, `result`
 - `hopr_indexer_contract_log_counters`: Counts of different HOPR contract logs processed by the Indexer, keys: `contract`
+- `hopr_tickets_incoming_statistics`: Ticket statistics for channels with incoming tickets, keys: `channel`, `statistic`

--- a/db/api/src/ticket_manager.rs
+++ b/db/api/src/ticket_manager.rs
@@ -15,7 +15,7 @@ use crate::{errors::Result, tickets::TicketSelector, OpenTransaction};
 /// Functionality related to locking and structural improvements to the underlying SQLite database
 ///
 /// With SQLite, it is only possible to have a single write lock per database, meaning that
-/// high frequency database access to tickets needed to be split from the rest of the database
+/// high-frequency database access to tickets needed to be split from the rest of the database
 /// operations.
 ///
 /// High frequency of locking originating from the ticket processing pipeline could starve the DB,
@@ -23,7 +23,7 @@ use crate::{errors::Result, tickets::TicketSelector, OpenTransaction};
 /// which allows bottle-necking the database write access on the mutex, as well as allowing arbitrary
 /// numbers of concurrent read operations.
 ///
-/// The queue based mechanism also splits the storage of the ticket inside the database from the processing,
+/// The queue-based mechanism also splits the storage of the ticket inside the database from the processing,
 /// effectively allowing the processing pipelines to be independent of a database write access.
 #[derive(Debug, Clone)]
 pub(crate) struct TicketManager {

--- a/db/api/src/tickets.rs
+++ b/db/api/src/tickets.rs
@@ -694,7 +694,7 @@ impl HoprDbTicketOperations for HoprDb {
                                     #[cfg(all(feature = "prometheus", not(test)))]
                                     per_channel_unredeemed
                                         .entry(x.channel_id)
-                                        .and_modify(|v| *v = *v + unredeemed_value)
+                                        .and_modify(|v| *v += unredeemed_value)
                                         .or_insert(U256::zero());
 
                                     futures::future::ok(amount + unredeemed_value)

--- a/db/api/src/tickets.rs
+++ b/db/api/src/tickets.rs
@@ -694,7 +694,7 @@ impl HoprDbTicketOperations for HoprDb {
                                     per_channel_unredeemed
                                         .entry(x.channel_id)
                                         .and_modify(|v| *v += unredeemed_value)
-                                        .or_insert(U256::zero());
+                                        .or_insert(unredeemed_value);
 
                                     futures::future::ok(amount + unredeemed_value)
                                 })

--- a/db/api/src/tickets.rs
+++ b/db/api/src/tickets.rs
@@ -1,6 +1,5 @@
 use async_stream::stream;
 use hopr_db_entity::ticket_statistics;
-use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::ops::Add;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -679,7 +678,7 @@ impl HoprDbTicketOperations for HoprDb {
         match channel_id {
             None => {
                 #[cfg(all(feature = "prometheus", not(test)))]
-                let mut per_channel_unredeemed = HashMap::new();
+                let mut per_channel_unredeemed = std::collections::HashMap::new();
 
                 self.nest_transaction_in_db(tx, TargetDb::Tickets)
                     .await?

--- a/db/api/src/tickets.rs
+++ b/db/api/src/tickets.rs
@@ -1,5 +1,6 @@
 use async_stream::stream;
 use hopr_db_entity::ticket_statistics;
+use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::ops::Add;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -677,6 +678,9 @@ impl HoprDbTicketOperations for HoprDb {
     ) -> Result<ChannelTicketStatistics> {
         match channel_id {
             None => {
+                #[cfg(all(feature = "prometheus", not(test)))]
+                let mut per_channel_unredeemed = HashMap::new();
+
                 self.nest_transaction_in_db(tx, TargetDb::Tickets)
                     .await?
                     .perform(|tx| {
@@ -684,23 +688,57 @@ impl HoprDbTicketOperations for HoprDb {
                             let unredeemed_value = ticket::Entity::find()
                                 .stream(tx.as_ref())
                                 .await?
-                                .try_fold(U256::zero(), |amount, x| async move {
-                                    Ok(amount + U256::from_be_bytes(x.amount))
+                                .try_fold(U256::zero(), |amount, x| {
+                                    let unredeemed_value = U256::from_be_bytes(x.amount);
+
+                                    #[cfg(all(feature = "prometheus", not(test)))]
+                                    per_channel_unredeemed
+                                        .entry(x.channel_id)
+                                        .and_modify(|v| *v = *v + unredeemed_value)
+                                        .or_insert(U256::zero());
+
+                                    futures::future::ok(amount + unredeemed_value)
                                 })
                                 .await?;
+
+                            #[cfg(all(feature = "prometheus", not(test)))]
+                            for (channel_id, unredeemed_value) in per_channel_unredeemed {
+                                METRIC_HOPR_TICKETS_INCOMING_STATISTICS
+                                    .set(&[&channel_id, "unredeemed"], unredeemed_value.as_u128() as f64);
+                            }
 
                             let mut all_stats = ticket_statistics::Entity::find()
                                 .all(tx.as_ref())
                                 .await?
                                 .into_iter()
                                 .fold(ChannelTicketStatistics::default(), |mut acc, stats| {
-                                    acc.neglected_value =
-                                        acc.neglected_value + BalanceType::HOPR.balance_bytes(stats.neglected_value);
-                                    acc.redeemed_value =
-                                        acc.redeemed_value + BalanceType::HOPR.balance_bytes(stats.redeemed_value);
-                                    acc.rejected_value =
-                                        acc.rejected_value + BalanceType::HOPR.balance_bytes(stats.rejected_value);
+                                    let neglected_value = BalanceType::HOPR.balance_bytes(stats.neglected_value);
+                                    acc.neglected_value = acc.neglected_value + neglected_value;
+                                    let redeemed_value = BalanceType::HOPR.balance_bytes(stats.redeemed_value);
+                                    acc.redeemed_value = acc.redeemed_value + redeemed_value;
+                                    let rejected_value = BalanceType::HOPR.balance_bytes(stats.rejected_value);
+                                    acc.rejected_value = acc.rejected_value + rejected_value;
+
                                     acc.winning_tickets += stats.winning_tickets as u128;
+
+                                    #[cfg(all(feature = "prometheus", not(test)))]
+                                    {
+                                        METRIC_HOPR_TICKETS_INCOMING_STATISTICS.set(
+                                            &[&stats.channel_id, "neglected"],
+                                            neglected_value.amount().as_u128() as f64,
+                                        );
+
+                                        METRIC_HOPR_TICKETS_INCOMING_STATISTICS.set(
+                                            &[&stats.channel_id, "redeemed"],
+                                            redeemed_value.amount().as_u128() as f64,
+                                        );
+
+                                        METRIC_HOPR_TICKETS_INCOMING_STATISTICS.set(
+                                            &[&stats.channel_id, "rejected"],
+                                            rejected_value.amount().as_u128() as f64,
+                                        );
+                                    }
+
                                     acc
                                 });
 
@@ -712,8 +750,8 @@ impl HoprDbTicketOperations for HoprDb {
                     .await
             }
             Some(channel) => {
-                // We need to make sure the channel exists, to avoid creating
-                // stats entry for a non-existing channel
+                // We need to make sure the channel exists to avoid creating
+                // statistic entry for a non-existing channel
                 if self.get_channel_by_id(None, &channel).await?.is_none() {
                     return Err(DbError::ChannelNotFound(channel));
                 }
@@ -727,8 +765,8 @@ impl HoprDbTicketOperations for HoprDb {
                                 .filter(ticket::Column::ChannelId.eq(channel.to_hex()))
                                 .stream(tx.as_ref())
                                 .await?
-                                .try_fold(U256::zero(), |amount, x| async move {
-                                    Ok(amount + U256::from_be_bytes(x.amount))
+                                .try_fold(U256::zero(), |amount, x| {
+                                    futures::future::ok(amount + U256::from_be_bytes(x.amount))
                                 })
                                 .await?;
 
@@ -1336,7 +1374,7 @@ impl HoprDb {
             .await?
             .perform(|tx| {
                 Box::pin(async move {
-                    // For purpose of upserting, we must select only by the triplet (channel id, epoch, index)
+                    // For upserting, we must select only by the triplet (channel id, epoch, index)
                     let selector = TicketSelector::new(
                         acknowledged_ticket.ticket.channel_id,
                         acknowledged_ticket.ticket.channel_epoch,

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -84,17 +84,12 @@ use crate::config::HoprLibConfig;
 use crate::config::SafeModule;
 use crate::constants::{MIN_NATIVE_BALANCE, SUGGESTED_NATIVE_BALANCE};
 
-use hopr_db_api::{
-    accounts::HoprDbAccountOperations,
-    db::{HoprDb, HoprDbConfig},
-    info::{HoprDbInfoOperations, SafeInfo},
-    resolver::HoprDbResolverOperations,
+use hopr_db_api::prelude::{
+    ChainOrPacketKey::ChainKey, HoprDb, HoprDbAccountOperations, HoprDbAllOperations, HoprDbChannelOperations,
+    HoprDbConfig, HoprDbInfoOperations, HoprDbPeersOperations, HoprDbResolverOperations, SafeInfo,
 };
-use hopr_db_api::{channels::HoprDbChannelOperations, HoprDbAllOperations};
 
 use hopr_crypto_types::prelude::OffchainPublicKey;
-use hopr_db_api::prelude::ChainOrPacketKey::ChainKey;
-use hopr_db_api::prelude::{HoprDbPeersOperations, HoprDbTicketOperations};
 
 #[cfg(all(feature = "prometheus", not(test)))]
 use {
@@ -687,6 +682,7 @@ impl Hopr {
             );
 
             // Calling get_ticket_statistics will initialize the respective metrics on tickets
+            use hopr_db_api::prelude::HoprDbTicketOperations;
             if let Err(e) = async_std::task::block_on(db.get_ticket_statistics(None, None)) {
                 error!("failed to initialize ticket statistics metrics: {e}");
             }

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -94,7 +94,8 @@ use hopr_db_api::{channels::HoprDbChannelOperations, HoprDbAllOperations};
 
 use hopr_crypto_types::prelude::OffchainPublicKey;
 use hopr_db_api::prelude::ChainOrPacketKey::ChainKey;
-use hopr_db_api::prelude::HoprDbPeersOperations;
+use hopr_db_api::prelude::{HoprDbPeersOperations, HoprDbTicketOperations};
+
 #[cfg(all(feature = "prometheus", not(test)))]
 use {
     hopr_metrics::metrics::{MultiGauge, SimpleGauge},
@@ -684,6 +685,11 @@ impl Hopr {
                 ))
                 .unwrap_or(0.0),
             );
+
+            // Calling get_ticket_statistics will initialize the respective metrics on tickets
+            if let Err(e) = async_std::task::block_on(db.get_ticket_statistics(None, None)) {
+                error!("failed to initialize ticket statistics metrics: {e}");
+            }
         }
 
         Self {


### PR DESCRIPTION
Improved Prometheus metrics to track neglected, redeemed, and rejected ticket statistics per channel. Also ensured metrics are initialized when the database loads ticket statistics. Improved documentation and fixed typos for better clarity.

Closes #6434
Closes #6424