### PR TITLE
Generate and use Python SDK within DevShell

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,9 +75,7 @@ test: smart-contract-test ## run unit tests for all packages, or a single packag
 
 .PHONY: smoke-tests
 smoke-tests: ## run smoke tests
-	source .venv/bin/activate
-	make generate-python-sdk && pip install -e hoprd-sdk-python
-	python3 -m pytest tests/
+	source .venv/bin/activate && python3 -m pytest tests/
 
 .PHONY: stress-test-local-swarm
 stress-test-local-swarm: ## run stress tests on a local node swarm

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,9 @@ test: smart-contract-test ## run unit tests for all packages, or a single packag
 
 .PHONY: smoke-tests
 smoke-tests: ## run smoke tests
-	source .venv/bin/activate && python3 -m pytest tests/
+	source .venv/bin/activate
+	make generate-python-sdk && pip install -e hoprd-sdk-python
+	python3 -m pytest tests/
 
 .PHONY: stress-test-local-swarm
 stress-test-local-swarm: ## run stress tests on a local node swarm

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -59,6 +59,7 @@ craneLib.devShell {
   venvDir = "./.venv";
   postVenvCreation = ''
     unset SOURCE_DATE_EPOCH
+    make generate-python-sdk
     pip install -U pip setuptools wheel
     pip install -r tests/requirements.txt
   '' + pkgs.lib.optionalString pkgs.stdenv.isLinux ''

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,3 +8,4 @@ ruff==0.0.261
 waiting==1.4.1
 websocket-client==1.5.1
 websockets==11.0.1
+./hoprd-sdk-python

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -8,4 +8,3 @@ ruff==0.0.261
 waiting==1.4.1
 websocket-client==1.5.1
 websockets==11.0.1
-hoprd-sdk @ git+https://github.com/hoprnet/hoprd-sdk-python@kauki/2.2.0/session-updates-20240718


### PR DESCRIPTION
Before, when modifying HOPRd's API, one should
- create a temp branch in the `hoprd-python-sdk` repo
- generate the new SDK from the monorepo
- push the modification to the temp branch
-  modify the `requirement.txt` file to point to the temp `hoprd-python-sdk` branch 

This manual dance between the two repo is bothering.

This PR generates the Python SDK right before running the smoke tests with the `make` command, and install the locally generated HOPRd library using `pip`.