### PR TITLE
Neglect tickets with lower index after redeeming & skip aggregating tickets with lower index than on channel

### DIFF
--- a/db/api/src/errors.rs
+++ b/db/api/src/errors.rs
@@ -19,7 +19,7 @@ pub enum DbError {
     #[error("ticket aggregation error: {0}")]
     TicketAggregationError(String),
 
-    #[error("ticket validation error for {0:?}")]
+    #[error("ticket validation error for {:?}: {}", 0.0, 0.1)]
     TicketValidationError(Box<(Ticket, String)>),
 
     #[error("transaction error: {0}")]

--- a/db/api/src/tickets.rs
+++ b/db/api/src/tickets.rs
@@ -1,5 +1,6 @@
 use async_stream::stream;
 use hopr_db_entity::ticket_statistics;
+use std::collections::HashSet;
 use std::fmt::{Display, Formatter};
 use std::ops::Add;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -37,6 +38,32 @@ lazy_static::lazy_static! {
     ).unwrap();
 }
 
+/// Allows selecting a range of ticket indices in [TicketSelector].
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum TicketIndexSelector {
+    /// Selects no ticket index specifically.
+    /// This makes the [TicketSelector] less restrictive.
+    #[default]
+    None,
+    /// Selects a single ticket with the given index.
+    Single(u64),
+    /// Selects multiple tickets with the given indices.
+    Multiple(HashSet<u64>),
+    /// Selects multiple tickets with indices strictly less than the given bound.
+    LessThan(u64),
+}
+
+impl Display for TicketIndexSelector {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match &self {
+            TicketIndexSelector::None => write!(f, ""),
+            TicketIndexSelector::Single(idx) => write!(f, "with index {idx}"),
+            TicketIndexSelector::Multiple(indices) => write!(f, "with indices {indices:?}"),
+            TicketIndexSelector::LessThan(bound) => write!(f, "with indices less than {bound}"),
+        }
+    }
+}
+
 /// Allows selecting multiple tickets (if `index` does not contain a single value)
 /// or a single ticket (with unitary `index`) in the given channel and epoch.
 /// The selection can be further restricted to select ticket only in the given `state`.
@@ -46,9 +73,10 @@ pub struct TicketSelector {
     pub channel_id: Hash,
     /// Channel epoch
     pub epoch: U256,
-    /// If given, will select ticket(s) with the given index
+    /// If given, will select ticket(s) with the given indices
     /// in the given channel and epoch.
-    pub index: Vec<u64>,
+    /// See [TicketIndexSelector] for possible options.
+    pub index: TicketIndexSelector,
     /// Further restriction to tickets with the given state.
     pub state: Option<AcknowledgedTicketStatus>,
     /// Further restrict to only aggregated tickets.
@@ -57,21 +85,17 @@ pub struct TicketSelector {
 
 impl Display for TicketSelector {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "ticket selector in {} epoch {}{}{}{}",
+        let out = format!(
+            "ticket selector in {} epoch {} {}{}{}",
             self.channel_id,
             self.epoch,
-            if !self.index.is_empty() {
-                format!(" with indices {:?}", self.index)
-            } else {
-                String::default()
-            },
+            self.index,
             self.state
                 .map(|state| format!(" in state {state}"))
                 .unwrap_or("".into()),
             if self.only_aggregated { " only aggregated" } else { "" }
-        )
+        );
+        write!(f, "{}", out.trim())
     }
 }
 
@@ -81,7 +105,7 @@ impl TicketSelector {
         Self {
             channel_id,
             epoch: epoch.into(),
-            index: vec![],
+            index: TicketIndexSelector::None,
             state: None,
             only_aggregated: false,
         }
@@ -89,13 +113,31 @@ impl TicketSelector {
 
     /// If `false` is returned, the selector can fetch more than a single ticket.
     pub fn is_unique(&self) -> bool {
-        self.index.len() == 1
+        matches!(&self.index, TicketIndexSelector::Single(_))
+            || matches!(&self.index, TicketIndexSelector::Multiple(indices) if indices.len() == 1)
     }
 
     /// Returns this instance with a ticket index set.
     /// This method can be called multiple times to select multiple tickets.
+    /// /// If [TicketSelector::with_index_lt] was previously called, it will be replaced.
     pub fn with_index(mut self, index: u64) -> Self {
-        self.index.push(index);
+        self.index = match self.index {
+            TicketIndexSelector::None | TicketIndexSelector::LessThan(_) => TicketIndexSelector::Single(index),
+            TicketIndexSelector::Single(existing) => {
+                TicketIndexSelector::Multiple(HashSet::from_iter([existing, index]))
+            }
+            TicketIndexSelector::Multiple(mut existing) => {
+                existing.insert(index);
+                TicketIndexSelector::Multiple(existing)
+            }
+        };
+        self
+    }
+
+    /// Returns this instance with a ticket index upper bound set.
+    /// If [TicketSelector::with_index] was previously called, it will be replaced.
+    pub fn with_index_lt(mut self, index_bound: u64) -> Self {
+        self.index = TicketIndexSelector::LessThan(index_bound);
         self
     }
 
@@ -123,7 +165,7 @@ impl From<&AcknowledgedTicket> for TicketSelector {
         Self {
             channel_id: value.ticket.channel_id,
             epoch: value.ticket.channel_epoch.into(),
-            index: vec![value.ticket.index],
+            index: TicketIndexSelector::Single(value.ticket.index),
             state: Some(value.status),
             only_aggregated: value.ticket.index_offset > 1,
         }
@@ -135,7 +177,7 @@ impl From<&ChannelEntry> for TicketSelector {
         Self {
             channel_id: value.get_id(),
             epoch: value.channel_epoch,
-            index: vec![],
+            index: TicketIndexSelector::None,
             state: None,
             only_aggregated: false,
         }
@@ -154,8 +196,15 @@ impl IntoCondition for TicketSelector {
             .eq(self.channel_id.to_hex())
             .and(ticket::Column::ChannelEpoch.eq(self.epoch.to_be_bytes().to_vec()));
 
-        if !self.index.is_empty() {
-            expr = expr.and(ticket::Column::Index.is_in(self.index.iter().map(|i| i.to_be_bytes().to_vec())));
+        match self.index {
+            TicketIndexSelector::None => {}
+            TicketIndexSelector::Single(idx) => expr = expr.and(ticket::Column::Index.eq(idx.to_be_bytes().to_vec())),
+            TicketIndexSelector::Multiple(idxs) => {
+                expr = expr.and(ticket::Column::Index.is_in(idxs.into_iter().map(|i| i.to_be_bytes().to_vec())));
+            }
+            TicketIndexSelector::LessThan(bound) => {
+                expr = expr.and(ticket::Column::Index.lt(bound.to_be_bytes().to_vec()))
+            }
         }
 
         if let Some(state) = self.state {
@@ -986,6 +1035,9 @@ impl HoprDbTicketOperations for HoprDb {
                         .map(|m| U256::from_be_bytes(m.index).as_u64() + 1)
                         .unwrap_or(0_u64); // go from the lowest possible index of none is found
 
+                    // The first index to take should not be less than the ticket index on the Channel entry
+                    let first_idx_to_take = first_idx_to_take.max(channel_entry.ticket_index.as_u64());
+
                     // get the list of all tickets to be aggregated
                     let to_be_aggregated = ticket::Entity::find()
                         .filter(TicketSelector::from(&channel_entry))
@@ -1008,9 +1060,10 @@ impl HoprDbTicketOperations for HoprDb {
                         // Clean up any tickets in this channel that are already inside an aggregated ticket.
                         // This situation cannot be avoided 100% as aggregation can be triggered when out-of-order
                         // tickets arrive and only some of them are necessary to satisfy the aggregation threshold.
-                        // The following code assumes that only the first ticket with the lowest index can be an aggregate.
+                        // The following code *assumes* that only the first ticket with the lowest index *can be* an aggregate.
                         let first_ticket = to_be_aggregated[0].ticket.clone();
                         let mut i = 1;
+                        let mut count_neglected = 0;
                         while i < to_be_aggregated.len() {
                             let current_idx = to_be_aggregated[i].ticket.index;
                             if (first_ticket.index..first_ticket.index + first_ticket.index_offset as u64).contains(&current_idx) {
@@ -1020,6 +1073,7 @@ impl HoprDbTicketOperations for HoprDb {
                                 warn!("ticket {current_idx} in channel {channel_id} has been already aggregated in {first_ticket} and will be removed");
                                 neglected = neglected.with_index(current_idx);
                                 to_be_aggregated.remove(i);
+                                count_neglected += 1;
                             } else {
                                 i += 1;
                             }
@@ -1039,7 +1093,7 @@ impl HoprDbTicketOperations for HoprDb {
                             .exec(tx.as_ref())
                             .await?;
 
-                        if marked.rows_affected as usize != to_be_aggregated.len() + neglected.index.len() {
+                        if marked.rows_affected as usize != to_be_aggregated.len() + count_neglected {
                             return Err(DbError::LogicalError(format!(
                                 "expected to mark {}, but was able to mark {}",
                                 to_be_aggregated.len(),
@@ -1060,7 +1114,7 @@ impl HoprDbTicketOperations for HoprDb {
             .await?;
 
         // Neglect the tickets that were found as duplicates within a single transaction
-        if !neglected.index.is_empty() {
+        if !matches!(neglected.index, TicketIndexSelector::None) {
             let neglected_due_to_duplication = self.mark_tickets_neglected(neglected).await?;
             warn!("{neglected_due_to_duplication} were neglected in channel {channel_id} due to duplication in an aggregated ticket!");
         }
@@ -1481,7 +1535,7 @@ mod tests {
             BOB.public().to_address(),
             ALICE.public().to_address(),
             BalanceType::HOPR.balance(u32::MAX),
-            (count_tickets + 1).into(),
+            0_u32.into(),
             ChannelStatus::Open,
             4_u32.into(),
         );

--- a/logic/strategy/src/aggregating.rs
+++ b/logic/strategy/src/aggregating.rs
@@ -395,7 +395,7 @@ mod tests {
             (&PEERS_CHAIN[0]).into(),
             (&PEERS_CHAIN[1]).into(),
             total_value,
-            (amount as u32).into(),
+            0_u32.into(),
             ChannelStatus::Open,
             1u32.into(),
         );

--- a/transport/protocol/src/ticket_aggregation/processor.rs
+++ b/transport/protocol/src/ticket_aggregation/processor.rs
@@ -564,7 +564,7 @@ mod tests {
             alice_addr,
             bob_addr,
             agg_balance.mul(10),
-            NUM_TICKETS.into(),
+            1_u32.into(),
             ChannelStatus::Open,
             1u32.into(),
         );
@@ -588,6 +588,11 @@ mod tests {
         match bob.next().timeout(Duration::from_secs(5)).await {
             Ok(Some(TicketAggregationProcessed::Send(_, acked_tickets, request_finalizer))) => {
                 let _ = finalizer.insert(request_finalizer);
+                assert_eq!(
+                    NUM_TICKETS - 1,
+                    acked_tickets.len() as u64,
+                    "invalid number of tickets to aggregate"
+                );
                 alice
                     .writer()
                     .receive_aggregation_request(
@@ -630,7 +635,7 @@ mod tests {
         );
         assert!(
             stored_acked_tickets[1].ticket.is_aggregated(),
-            "aggregated balance invalid"
+            "last ticket must be the aggregated one"
         );
         assert_eq!(
             AcknowledgedTicketStatus::Untouched,
@@ -639,6 +644,122 @@ mod tests {
         );
         assert_eq!(
             agg_balance, stored_acked_tickets[1].ticket.amount,
+            "aggregated balance invalid"
+        );
+
+        awaiter.consume_and_wait(Duration::from_millis(2000)).await.unwrap();
+    }
+
+    #[async_std::test]
+    async fn test_ticket_aggregation_skip_lower_indices() {
+        let _ = env_logger::builder().is_test(true).try_init();
+
+        let db_alice = HoprDb::new_in_memory(PEERS_CHAIN[0].clone()).await;
+        let db_bob = HoprDb::new_in_memory(PEERS_CHAIN[1].clone()).await;
+        init_db(db_alice.clone()).await;
+        init_db(db_bob.clone()).await;
+
+        const NUM_TICKETS: u64 = 30;
+        const CHANNEL_TICKET_IDX: u64 = 20;
+
+        let mut tickets = vec![];
+        let mut agg_balance = Balance::zero(BalanceType::HOPR);
+        // Generate acknowledged tickets
+        for i in 1..=NUM_TICKETS {
+            let ack_ticket = mock_acknowledged_ticket(&PEERS_CHAIN[0], &PEERS_CHAIN[1], i);
+            if i >= CHANNEL_TICKET_IDX {
+                agg_balance = agg_balance.add(&ack_ticket.ticket.amount);
+            }
+            tickets.push(ack_ticket)
+        }
+
+        let alice_addr: Address = (&PEERS_CHAIN[0]).into();
+        let bob_addr: Address = (&PEERS_CHAIN[1]).into();
+
+        let alice_packet_key = PEERS[0].public().into();
+        let bob_packet_key = PEERS[1].public().into();
+
+        let channel_alice_bob = ChannelEntry::new(
+            alice_addr,
+            bob_addr,
+            agg_balance.mul(10),
+            CHANNEL_TICKET_IDX.into(),
+            ChannelStatus::Open,
+            1u32.into(),
+        );
+
+        db_alice.upsert_channel(None, channel_alice_bob).await.unwrap();
+        db_bob.upsert_channel(None, channel_alice_bob).await.unwrap();
+
+        for ticket in tickets.into_iter() {
+            db_bob.upsert_ticket(None, ticket).await.unwrap();
+        }
+
+        let mut alice = super::TicketAggregationInteraction::<(), ()>::new(db_alice.clone(), &PEERS_CHAIN[0]);
+        let mut bob = super::TicketAggregationInteraction::<(), ()>::new(db_bob.clone(), &PEERS_CHAIN[1]);
+
+        let mut awaiter = bob
+            .writer()
+            .aggregate_tickets(&channel_alice_bob.get_id(), Default::default())
+            .unwrap();
+
+        let mut finalizer = None;
+        match bob.next().timeout(Duration::from_secs(5)).await {
+            Ok(Some(TicketAggregationProcessed::Send(_, acked_tickets, request_finalizer))) => {
+                let _ = finalizer.insert(request_finalizer);
+                assert_eq!(
+                    NUM_TICKETS - CHANNEL_TICKET_IDX + 1,
+                    acked_tickets.len() as u64,
+                    "invalid number of tickets to aggregate"
+                );
+                alice
+                    .writer()
+                    .receive_aggregation_request(
+                        bob_packet_key,
+                        acked_tickets.into_iter().map(AcknowledgedTicket::from).collect(),
+                        (),
+                    )
+                    .unwrap();
+            }
+            _ => panic!("unexpected action happened while sending agg request by Bob"),
+        };
+
+        match alice.next().timeout(Duration::from_secs(5)).await {
+            Ok(Some(TicketAggregationProcessed::Reply(_, aggregated_ticket, ()))) => bob
+                .writer()
+                .receive_ticket(alice_packet_key, aggregated_ticket, ())
+                .unwrap(),
+            _ => panic!("unexpected action happened while awaiting agg request at Alice"),
+        };
+
+        match bob.next().timeout(Duration::from_secs(5)).await {
+            Ok(Some(TicketAggregationProcessed::Receive(_destination, _acked_tkt, ()))) => {
+                finalizer.take().unwrap().finalize()
+            }
+            _ => panic!("unexpected action happened while awaiting agg response at Bob"),
+        }
+
+        let stored_acked_tickets = db_bob.get_tickets(None, (&channel_alice_bob).into()).await.unwrap();
+
+        assert_eq!(
+            stored_acked_tickets.len(),
+            20,
+            "there should be 1 aggregated ticket and 19 old tickets"
+        );
+
+        assert!(
+            stored_acked_tickets[19].ticket.is_aggregated(),
+            "last ticket must be the aggregated one"
+        );
+        for i in 0..19 {
+            assert_eq!(
+                AcknowledgedTicketStatus::Untouched,
+                stored_acked_tickets[i].status,
+                "ticket #{i} must be untouched"
+            );
+        }
+        assert_eq!(
+            agg_balance, stored_acked_tickets[19].ticket.amount,
             "aggregated balance invalid"
         );
 


### PR DESCRIPTION

This PR fixes the following issues discovered during testing:

1. after a ticket is redeemed in a channel, all tickets with lower ticket indices in that channel are marked as neglected. This makes sure any out-of-order tickets will not be attempted to get redeemed or aggregated at a later point.

2. there was a bug when preparing the aggregation process: the aggregation should not be considered for the tickets that have an index lower than the current ticket index at the channel entry. This makes sure aggregation will not be requested on ticket indices that were already redeemed or neglected. Such left-over tickets will be eventually neglected via 1.

These changes required some modifications in the `TicketSelector` type.

Refs #6421