### PR TITLE
Update default strategy execution interval handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4162,7 +4162,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-strategy"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "async-lock 3.4.0",
  "async-std",

--- a/logic/strategy/Cargo.toml
+++ b/logic/strategy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-strategy"
-version = "0.11.1"
+version = "0.11.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Contains implementations of different HOPR strategies"
 edition = "2021"

--- a/logic/strategy/src/strategy.rs
+++ b/logic/strategy/src/strategy.rs
@@ -112,7 +112,7 @@ pub struct MultiStrategyConfig {
 
     /// Execution interval of the configured strategies in seconds.
     ///
-    /// Default is 60.
+    /// Default is 60, minimum is 5.
     #[default = 60]
     #[serde(default = "sixty")]
     #[validate(range(min = 5))]

--- a/logic/strategy/src/strategy.rs
+++ b/logic/strategy/src/strategy.rs
@@ -79,6 +79,11 @@ fn just_true() -> bool {
 }
 
 #[inline]
+fn sixty() -> u64 {
+    60
+}
+
+#[inline]
 fn empty_vector() -> Vec<Strategy> {
     vec![]
 }
@@ -109,7 +114,8 @@ pub struct MultiStrategyConfig {
     ///
     /// Default is 60.
     #[default = 60]
-    #[serde(default)]
+    #[serde(default = "sixty")]
+    #[validate(range(min = 5))]
     pub execution_interval: u64,
 
     /// Configuration of individual sub-strategies.

--- a/logic/strategy/src/strategy.rs
+++ b/logic/strategy/src/strategy.rs
@@ -112,10 +112,10 @@ pub struct MultiStrategyConfig {
 
     /// Execution interval of the configured strategies in seconds.
     ///
-    /// Default is 60, minimum is 5.
+    /// Default is 60, minimum is 1.
     #[default = 60]
     #[serde(default = "sixty")]
-    #[validate(range(min = 5))]
+    #[validate(range(min = 1))]
     pub execution_interval: u64,
 
     /// Configuration of individual sub-strategies.


### PR DESCRIPTION
Introduced a helper function to set the default execution interval to 60 with the `serde(default)` attribute, ensuring a minimum value validation of 5.

Closes #6472