### PR TITLE
Fix failing unit tests

### DIFF
--- a/logic/strategy/src/auto_redeeming.rs
+++ b/logic/strategy/src/auto_redeeming.rs
@@ -298,8 +298,11 @@ mod tests {
         };
 
         let ars = AutoRedeemingStrategy::new(cfg, db, actions);
-        ars.on_acknowledged_winning_ticket(&ack_ticket_unagg).await?;
+        ars.on_acknowledged_winning_ticket(&ack_ticket_unagg)
+            .await
+            .expect_err("non-agg ticket should not satisfy");
         ars.on_acknowledged_winning_ticket(&ack_ticket_agg).await?;
+
         Ok(())
     }
 


### PR DESCRIPTION
Use `spawn` for log retrieval and directly handle channel funding. This refactor moves the log retrieval logic into a spawned task and ensures channel funding completes before proceeding. Additionally, `on_acknowledged_winning_ticket` now expects errors for non-aggregated tickets, improving error management.