### PR TITLE
Add HTTPS server communication tests

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,5 @@
 black==23.3.0
+cryptography==43.0.1
 pytest==7.2.1
 pytest-asyncio==0.21.0
 pytest-timeout==2.3.1 

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,13 +1,25 @@
 import asyncio
+import http.server
 import logging
 import multiprocessing
 import os
 import pytest
+import random
+import requests
 import socket
+import ssl
+import string
 import subprocess
+import urllib3
 
 from enum import Enum
+from functools import partial
 from contextlib import contextmanager, AsyncExitStack
+from cryptography import x509
+from cryptography.x509.oid import NameOID
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from datetime import datetime, timedelta
 
 from .conftest import random_distinct_pairs_from, barebone_nodes, TICKET_PRICE_PER_HOP, fixtures_dir
 from .node import Node
@@ -50,6 +62,7 @@ class EchoServer:
             self.process = multiprocessing.Process(target=udp_echo_server_func, args=(self.socket,self.recv_buf_len))
         self.process.start()
 
+        # If needed, tcp dump can be started to catch traffic on the local interface
         if self.with_tcpdump:
             pcap_file = fixtures_dir('test_session').joinpath(f'echo_server_{self.port}.pcap')
             self.tcp_dump_process = subprocess.Popen(['sudo', 'tcpdump', '-i', 'lo', '-w', f"{pcap_file}.log"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
@@ -78,15 +91,11 @@ def tcp_echo_server_func(s,buf_len):
             while True:
                 data = conn.recv(buf_len)
                 conn.sendall(data)
-                #logging.info(f"tcp server relayed {len(data)}")
-
 
 def udp_echo_server_func(s,buf_len):
         while True:
             data, addr = s.recvfrom(buf_len)
             s.sendto(data, addr)
-            #logging.info(f"udp server relayed {len(data)}")
-
 
 @contextmanager
 def connect_socket(sock_type: SocketType, port):
@@ -103,6 +112,90 @@ def connect_socket(sock_type: SocketType, port):
     finally:
         s.close()
 
+
+def fetch_random_local_text_file(port: int):
+    # Suppress only the single InsecureRequestWarning from urllib3 needed for self-signed certs
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    url = f'https://localhost:{port}/random.txt'
+    response = requests.get(url, verify=False)  # set verify=False for self-signed certs
+    return response
+
+def generate_self_signed_cert(cert_file_with_key):
+    key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=2048,
+    )
+
+    subject = issuer = x509.Name([
+        x509.NameAttribute(NameOID.COUNTRY_NAME, u"CH"),
+        x509.NameAttribute(NameOID.STATE_OR_PROVINCE_NAME, u"Switzerland"),
+        x509.NameAttribute(NameOID.LOCALITY_NAME, u"Zurich"),
+        x509.NameAttribute(NameOID.ORGANIZATION_NAME, u"HOPR"),
+        x509.NameAttribute(NameOID.COMMON_NAME, u"localhost"),
+    ])
+
+    cert = x509.CertificateBuilder().subject_name(
+        subject
+    ).issuer_name(
+        issuer
+    ).public_key(
+        key.public_key()
+    ).serial_number(
+        x509.random_serial_number()
+    ).not_valid_before(
+        datetime.utcnow()
+    ).not_valid_after(
+        datetime.utcnow() + timedelta(days=365)
+    ).add_extension(
+        x509.SubjectAlternativeName([x509.DNSName(u"localhost")]),
+        critical=False,
+    ).sign(key, hashes.SHA256())
+
+    # Combine the private key and certificate into a single PEM file
+    with open(cert_file_with_key, "wb") as f:
+        f.write(key.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.TraditionalOpenSSL,
+            encryption_algorithm=serialization.NoEncryption()
+        ))
+        f.write(cert.public_bytes(serialization.Encoding.PEM))
+
+class CustomHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
+    def __init__(self, content=None, *args, **kwargs):
+        self.content = content
+        super().__init__(*args, **kwargs)
+
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/plain')
+        self.end_headers()
+        self.wfile.write(self.content.encode('utf-8'))
+
+@contextmanager
+def run_https_server(served_text_content):
+    cert_file = "cert.pem"
+
+    # Generate the certificate and key if they don't exist
+    if not os.path.exists(cert_file):
+        logging.debug("generating self-signed certificate and key...")
+        generate_self_signed_cert(cert_file)
+
+    # Create a handler class with the content passed
+    handler_class = partial(CustomHTTPRequestHandler, served_text_content)
+
+    # Set up the HTTP server with a random port and SSL context
+    httpd = http.server.HTTPServer(('localhost', 0), handler_class)
+    httpd.socket = ssl.wrap_socket(httpd.socket, keyfile=cert_file, certfile=cert_file, server_side=True)
+
+    # Get the random port assigned to the server
+    port = httpd.server_address[1]
+    try:
+        logging.debug(f"serving on https://localhost:{port}")
+        yield httpd, port
+    finally:
+        logging.debug("shutting down the HTTP server...")
+        httpd.server_close()
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("src,dest", random_distinct_pairs_from(barebone_nodes(), count=PARAMETERIZED_SAMPLE_SIZE))
@@ -129,7 +222,6 @@ async def test_session_communication_with_a_tcp_echo_server(
 
         assert src_sock_port is not None, "Failed to open session"
         assert len(await src_peer.api.session_list_clients('tcp')) == 1
-        #logging.info(f"session to {dst_sock_port} opened successfully")
 
         with connect_socket(SocketType.TCP, src_sock_port) as s:
             s.settimeout(20)
@@ -193,7 +285,6 @@ async def test_session_communication_over_n_hop_with_a_tcp_echo_server(
 
             assert src_sock_port is not None, "Failed to open session"
             assert len(await src_peer.api.session_list_clients('tcp')) == 1
-            #logging.info(f"session to {dst_sock_port} opened successfully")
 
             with connect_socket(SocketType.TCP, src_sock_port) as s:
                 s.settimeout(20)
@@ -253,7 +344,7 @@ async def test_session_communication_with_a_udp_echo_server(
                 total_sent = total_sent - len(chunk)
                 actual.append(chunk.decode())
 
-    actual = [msg.strip() for msg in actual]
+    actual = [msg.strip() for msg in actual if len(msg.strip()) > 0]
     expected = [msg.strip() for msg in expected]
 
     actual.sort()
@@ -324,7 +415,7 @@ async def test_session_communication_over_n_hop_with_a_udp_echo_server(
                     total_sent = total_sent - len(chunk)
                     actual.append(chunk.decode())
 
-        actual = [msg.strip() for msg in actual]
+        actual = [msg.strip() for msg in actual if len(msg.strip()) > 0]
         expected = [msg.strip() for msg in expected]
 
         actual.sort()
@@ -335,4 +426,77 @@ async def test_session_communication_over_n_hop_with_a_udp_echo_server(
 
         assert await src_peer.api.session_close_client(protocol='udp', bound_ip='127.0.0.1', bound_port=src_sock_port) is True
         assert len(await src_peer.api.session_list_clients('udp')) == 0
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("src,dest", random_distinct_pairs_from(barebone_nodes(), count=PARAMETERIZED_SAMPLE_SIZE))
+async def test_session_communication_with_an_https_server(
+        src: str, dest: str, swarm7: dict[str, Node]
+):
+    file_len = 500
+    src_peer = swarm7[src]
+    dest_peer = swarm7[dest]
+
+    # Generate random text content to be served
+    expected = ''.join(random.choices(string.ascii_letters + string.digits, k=file_len))
+
+    with run_https_server(expected) as (server, dst_sock_port):
+        src_sock_port = await src_peer.api.session_client(dest_peer.peer_id, path={"Hops": 0}, protocol='tcp',
+                                                          target=f"localhost:{dst_sock_port}")
+        assert src_sock_port is not None, "Failed to open session"
+        assert len(await src_peer.api.session_list_clients('tcp')) == 1
+
+        # Fetch the random file contents via the HOPR tunnel
+        response = fetch_random_local_text_file(src_sock_port)
+        assert response.status_code == 200
+        assert response.text == expected
+
+        assert await src_peer.api.session_close_client(protocol='tcp', bound_ip='127.0.0.1', bound_port=src_sock_port) is True
+        assert len(await src_peer.api.session_list_clients('tcp')) == 0
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "route",
+    [shuffled(barebone_nodes())[:3] for _ in range(PARAMETERIZED_SAMPLE_SIZE)],
+    # + [shuffled(nodes())[:5] for _ in range(PARAMETERIZED_SAMPLE_SIZE)],
+)
+async def test_session_communication_over_n_hop_with_an_https_server(
+        route, swarm7: dict[str, Node]
+):
+    file_len=500
+
+    src_peer = swarm7[route[0]]
+    dest_peer = swarm7[route[-1]]
+    path = [swarm7[node].peer_id for node in route[1:-1]]
+
+    async with AsyncExitStack() as channels:
+        channels_to = [
+            channels.enter_async_context(
+                create_channel(swarm7[route[i]], swarm7[route[i + 1]], funding=100 * file_len * TICKET_PRICE_PER_HOP)
+            )
+            for i in range(len(route) - 1)
+        ]
+        channels_back = [
+            channels.enter_async_context(
+                create_channel(swarm7[route[i]], swarm7[route[i - 1]], funding=100 * file_len * TICKET_PRICE_PER_HOP)
+            )
+            for i in reversed(range(1, len(route)))
+        ]
+
+        await asyncio.gather(*(channels_to + channels_back))
+
+        # Generate random text content to be served
+        expected = ''.join(random.choices(string.ascii_letters + string.digits, k=file_len))
+
+        with run_https_server(expected) as (server, dst_sock_port):
+            src_sock_port = await src_peer.api.session_client(dest_peer.peer_id, path={"IntermediatePath": path}, protocol='tcp',
+                                                              target=f"localhost:{dst_sock_port}")
+            assert src_sock_port is not None, "Failed to open session"
+            assert len(await src_peer.api.session_list_clients('tcp')) == 1
+
+            response = fetch_random_local_text_file(src_sock_port)
+            assert response.status_code == 200
+            assert response.text == expected
+
+            assert await src_peer.api.session_close_client(protocol='tcp', bound_ip='127.0.0.1', bound_port=src_sock_port) is True
+            assert len(await src_peer.api.session_list_clients('tcp')) == 0
 


### PR DESCRIPTION
Added tests for session communication with HTTPS servers, including self-signed certificate generation and retrieval of random text files. Updated test requirements to include the `cryptography` library, and improved existing tests by filtering out empty messages.