### PR TITLE
Include provider url in info endpoint

### DIFF
--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -678,6 +678,14 @@ impl Hopr {
         self.chain_cfg.clone()
     }
 
+    pub fn get_provider(&self) -> String {
+        self.cfg
+            .chain
+            .provider
+            .clone()
+            .unwrap_or(self.chain_cfg.chain.default_provider.clone())
+    }
+
     #[inline]
     fn is_public(&self) -> bool {
         self.cfg.chain.announce

--- a/hoprd/rest-api/src/node.rs
+++ b/hoprd/rest-api/src/node.rs
@@ -258,6 +258,7 @@ pub(super) async fn metrics() -> impl IntoResponse {
             "/ip4/10.0.2.100/tcp/19092"
         ],
         "chain": "anvil-localhost",
+        "provider": "http://127.0.0.1:8545",
         "channelClosurePeriod": 15,
         "connectivityStatus": "Green",
         "hoprChannels": "0x9a9f2ccfde556a7e9ff0848998aa4a0cfd8863ae",
@@ -285,6 +286,7 @@ pub(crate) struct NodeInfoResponse {
     #[schema(value_type = Vec<String>)]
     listening_address: Vec<Multiaddr>,
     chain: String,
+    provider: String,
     #[serde_as(as = "DisplayFromStr")]
     #[schema(value_type = String)]
     hopr_token: Address,
@@ -349,6 +351,7 @@ pub(super) async fn info(State(state): State<Arc<InternalState>>) -> Result<impl
                 announced_address: hopr.local_multiaddresses(),
                 listening_address: hopr.local_multiaddresses(),
                 chain: chain_config.id,
+                provider: hopr.get_provider(),
                 hopr_token: chain_config.token,
                 hopr_channels: chain_config.channels,
                 hopr_network_registry: chain_config.network_registry,


### PR DESCRIPTION
Add the provider url into `/info` endpoint. It returns the "default_provider" of the network, if no custom provider is specified.
Close https://github.com/hoprnet/hoprnet/issues/6443
