### PR TITLE
Fix withdraw endpoint

### DIFF
--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -8,6 +8,7 @@ use std::{collections::HashMap, sync::Arc};
 use async_lock::RwLock;
 use futures::StreamExt;
 use futures_concurrency::stream::Merge;
+use hopr_crypto_types::prelude::Hash;
 use hopr_lib::{
     errors::HoprLibError,
     TransportOutput, {Address, Balance, BalanceType, Hopr},
@@ -820,6 +821,7 @@ mod account {
         address: Address,
     }
 
+    #[serde_as]
     #[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
     #[schema(example = json!({
             "receipt": "0xb4ce7e6e36ac8b01a974725d5ba730af2b156fbe",
@@ -863,11 +865,7 @@ mod account {
             )
             .await
         {
-            Ok(receipt) => Ok(Response::builder(200)
-                .body(json!(WithdrawResponse {
-                    receipt: receipt.to_string(),
-                }))
-                .build()),
+            Ok(receipt) => Ok(Response::builder(200).body(json!(WithdrawResponse { receipt })).build()),
             Err(e) => Ok(Response::builder(422).body(ApiErrorStatus::from(e)).build()),
         }
     }

--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -323,7 +323,7 @@ pub async fn run_hopr_api(
 
         api.at("/account/addresses").get(account::addresses);
         api.at("/account/balances").get(account::balances);
-        api.at("/account/withdraw").get(account::withdraw);
+        api.at("/account/withdraw").post(account::withdraw);
 
         api.at("/peers/:peerId")
             .get(peers::show_peer_info)
@@ -691,8 +691,6 @@ mod alias {
 }
 
 mod account {
-    use hopr_lib::U256;
-
     use super::*;
 
     #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
@@ -806,7 +804,7 @@ mod account {
     #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
     #[schema(example = json!({
         "address": "0xb4ce7e6e36ac8b01a974725d5ba730af2b156fbe",
-        "amount": 20000,
+        "amount": "20000",
         "currency": "HOPR"
     }))]
     #[serde(rename_all = "camelCase")]
@@ -816,7 +814,7 @@ mod account {
         currency: BalanceType,
         #[serde_as(as = "DisplayFromStr")]
         #[schema(value_type = String)]
-        amount: U256,
+        amount: String,
         #[serde_as(as = "DisplayFromStr")]
         #[schema(value_type = String)]
         address: Address,
@@ -850,7 +848,7 @@ mod account {
             .hopr
             .withdraw(
                 withdraw_req_data.address,
-                Balance::new(withdraw_req_data.amount, withdraw_req_data.currency),
+                Balance::new_from_str(&withdraw_req_data.amount, withdraw_req_data.currency),
             )
             .await
         {

--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -826,7 +826,9 @@ mod account {
     }))]
     #[serde(rename_all = "camelCase")]
     pub(crate) struct WithdrawResponse {
-        receipt: String,
+        #[serde_as(as = "DisplayFromStr")]
+        #[schema(value_type = String)]
+        receipt: Hash,
     }
 
     /// Withdraw funds from this node to the ethereum wallet address.

--- a/tests/hopr.py
+++ b/tests/hopr.py
@@ -21,6 +21,7 @@ from hoprd_sdk.models import (
     OpenChannelBodyRequest,
     SendMessageBodyRequest,
     TagQueryRequest,
+    WithdrawBodyRequest,
 )
 from hoprd_sdk.rest import ApiException
 from urllib3.exceptions import MaxRetryError
@@ -61,7 +62,7 @@ class HoprdAPI:
                 )
                 return (True, response)
         except ApiException as e:
-            log.info(
+            log.error(
                 f"ApiException calling {api_callback.__qualname__} with kwargs: {kwargs}, args: {args}, error is: {e}"
             )
             return (False, None)
@@ -381,6 +382,18 @@ class HoprdAPI:
         """
         _, response = self.__call_api(NetworkApi, "price")
         return int(response.price) if hasattr(response, "price") else None
+
+    async def withdraw(self, amount: str, receipient: str, currency: str):
+        """
+        Withdraws the given amount of token (Native or HOPR) to the given receipient.
+        :param: amount: str
+        :param: receipient: str
+        :param: currency: str
+        :return:
+        """
+        body = WithdrawBodyRequest(receipient, amount, currency)
+        status, response = self.__call_api(AccountApi, "withdraw", body=body)
+        return status, response
 
     async def startedz(self):
         """

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -7,4 +7,4 @@ ruff==0.0.261
 waiting==1.4.1
 websocket-client==1.5.1
 websockets==11.0.1
-hoprd-sdk @ git+https://github.com/hoprnet/hoprd-sdk-python@kauki/2.1.0-rc-3-update-20240326
+hoprd-sdk @ git+https://github.com/hoprnet/hoprd-sdk-python@jean/withdraw-endpoint

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -750,26 +750,15 @@ async def test_hoprd_strategy_UNFINISHED():
 
 
 @pytest.mark.asyncio
-async def test_hoprd_check_native_withdraw_results_UNFINISHED():
-    """
-    # this 2 functions are runned at the end of the tests when withdraw transaction should clear on blockchain
-    # and we don't have to block and wait for it
-    check_native_withdraw_results() {
-    local initial_native_balance="${1}"
+@pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
+async def test_hoprd_check_native_withdraw(peer, swarm7: dict[str, Node]):
+    amount = "9876"
 
-    balances=$(api_get_balances ${api1})
-    new_native_balance=$(echo ${balances} | jq -r .native)
-    [[ "${initial_native_balance}" == "${new_native_balance}" ]] && \
-        { msg "Native withdraw failed, pre: ${initial_native_balance}, post: ${new_native_balance}"; exit 1; }
+    before_balance = await swarm7[peer].api.balances()
+    await swarm7[peer].api.withdraw(amount, swarm7[peer].safe_address, "Native")
+    after_balance = await swarm7[peer].api.balances()
 
-    echo "withdraw native successful"
-    }
-
-    # checking statuses of the long running tests
-    balances=$(api_get_balances ${api1})
-    native_balance=$(echo ${balances} | jq -r .native)
-    """
-    assert True
+    assert int(after_balance.safe_native) - int(before_balance.safe_native) == int(amount)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes the withdraw endpoint in the API. The issue was that the amount withdrawn wasn't internally converted into a `Balance` instance.