### PR TITLE
Add feature to support building hoprd node with quic-v1 

### DIFF
--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -15,6 +15,7 @@ crate-type = ["rlib"]
 default = []
 session-client = []
 session-server = []
+transport-quic = ["hopr-transport/transport-quic"]
 runtime-async-std = [
   "chain-api/runtime-async-std",
   "chain-rpc/runtime-async-std",

--- a/hoprd/hoprd/Cargo.toml
+++ b/hoprd/hoprd/Cargo.toml
@@ -44,6 +44,7 @@ telemetry = [
   "dep:opentelemetry_sdk",
   "dep:tracing-opentelemetry",
 ]
+transport-quic = ["hopr-lib/transport-quic"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/transport/api/Cargo.toml
+++ b/transport/api/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["rlib"]
 
 [features]
 default = []
+transport-quic = []
 runtime-async-std = [
   "core-network/runtime-async-std",
   "hopr-async-runtime/runtime-async-std",


### PR DESCRIPTION
Allow building of binaries, where the announced address is quic-v1.