### PR TITLE
Fix nulls in peer endpoint

### DIFF
--- a/db/api/src/peers.rs
+++ b/db/api/src/peers.rs
@@ -446,7 +446,10 @@ impl TryFrom<hopr_db_entity::network_peer::Model> for PeerStatus {
             last_seen_latency: Duration::from_millis(value.last_seen_latency as u64),
             heartbeats_sent: value.heartbeats_sent.unwrap_or_default() as u64,
             heartbeats_succeeded: value.heartbeats_successful.unwrap_or_default() as u64,
-            backoff: value.backoff.unwrap_or(1.0),
+            backoff: value
+                .backoff
+                .map(|x| if x.is_nan() { 1.0f64 } else { x })
+                .unwrap_or(1.0f64),
             ignored: if let Some(v) = value.ignored {
                 Some(
                     chrono::DateTime::<chrono::Utc>::from_str(&v)

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -596,12 +596,17 @@ where
 
     #[tracing::instrument(level = "debug", skip(self))]
     pub async fn network_observed_multiaddresses(&self, peer: &PeerId) -> Vec<Multiaddr> {
-        self.network
-            .get(peer)
-            .await
-            .unwrap_or(None)
-            .map(|peer| peer.multiaddresses)
-            .unwrap_or(vec![])
+        match self.network.get(peer).await {
+            Ok(Some(peer)) => peer.multiaddresses,
+            Ok(None) => {
+                tracing::debug!("Peer not found in network storage");
+                vec![]
+            }
+            Err(e) => {
+                tracing::error!("Failed to get peer from network storage: {e}");
+                vec![]
+            }
+        }
     }
 
     #[tracing::instrument(level = "debug", skip(self))]

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -603,7 +603,7 @@ where
                 vec![]
             }
             Err(e) => {
-                tracing::error!(peer=%peer, "Failed to get peer from network storage {e}");
+                tracing::error!(peer=%peer, error=%e, "Failed to get peer from network storage");
                 vec![]
             }
         }

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -599,7 +599,7 @@ where
         match self.network.get(peer).await {
             Ok(Some(peer)) => peer.multiaddresses,
             Ok(None) => {
-                tracing::debug!("Peer not found in network storage");
+                tracing::trace!(peer=%peer, "Peer not found in network storage");
                 vec![]
             }
             Err(e) => {

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -603,7 +603,7 @@ where
                 vec![]
             }
             Err(e) => {
-                tracing::error!(peer=%peer, error, "Failed to get peer from network storage");
+                tracing::error!(peer=%peer, "Failed to get peer from network storage {e}");
                 vec![]
             }
         }

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -603,7 +603,7 @@ where
                 vec![]
             }
             Err(e) => {
-                tracing::error!("Failed to get peer from network storage: {e}");
+                tracing::error!(peer=%peer, error, "Failed to get peer from network storage");
                 vec![]
             }
         }

--- a/transport/network/src/config.rs
+++ b/transport/network/src/config.rs
@@ -14,7 +14,7 @@ pub const DEFAULT_NETWORK_QUALITY_AVERAGE_WINDOW_SIZE: u32 = 25;
 pub const DEFAULT_NETWORK_BACKOFF_EXPONENT: f64 = 1.5;
 pub const DEFAULT_NETWORK_BACKOFF_MIN: f64 = 2.0;
 
-/// Configuration for the [`Network`] object
+/// Configuration for the [`crate::network::Network`] object
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, SmartDefault, PartialEq)]
 #[serde(deny_unknown_fields)]


### PR DESCRIPTION
Close #6535 and #6340 
- Handle f64::NAN after reading backoff from the DB
- Insert multiaddress for incoming connection
- Improve returned result handling in `Network`