### PR TITLE
Fix backwards compatibility of the withdraw endpoint in currency

### DIFF
--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -801,6 +801,23 @@ mod account {
         Ok(Response::builder(200).body(json!(account_balances)).build())
     }
 
+    // #[deprecated(
+    //     since = "3.2.0",
+    //     note = "The `BalanceType` enum deserialization using all capitals is deprecated and will be removed in hoprd v3.0 REST API"
+    // )]
+    fn deserialize_balance_type<'de, D>(deserializer: D) -> Result<BalanceType, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let buf = <String as serde::Deserialize>::deserialize(deserializer)?;
+
+        match buf.as_str() {
+            "Native" | "NATIVE" => Ok(BalanceType::Native),
+            "HOPR" => Ok(BalanceType::HOPR),
+            _ => Err(serde::de::Error::custom("Unsupported balance type")),
+        }
+    }
+
     #[serde_as]
     #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, utoipa::ToSchema)]
     #[schema(example = json!({
@@ -810,7 +827,8 @@ mod account {
     }))]
     #[serde(rename_all = "camelCase")]
     pub(crate) struct WithdrawBodyRequest {
-        #[serde_as(as = "DisplayFromStr")]
+        // #[serde_as(as = "DisplayFromStr")]
+        #[serde(deserialize_with = "deserialize_balance_type")]
         #[schema(value_type = String)]
         currency: BalanceType,
         #[serde_as(as = "DisplayFromStr")]


### PR DESCRIPTION
The string will now be parsed using the new and legacy approach as well.

## Notes
Fixes #6568 