### PR TITLE
Add README section for the additional optional environment var based configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ On top of the default configuration options generated for the command line, the 
 - `HOPRD_USE_OPENTELEMETRY` - enable the opentelemetry output for this node
 - `OTEL_SERVICE_NAME` - the name of this node for the opentelemetry service
 - `HOPR_INTERNAL_LIBP2P_MAX_CONCURRENTLY_DIALED_PEER_COUNT` - the maximum number of concurrently dialed peers in libp2p
-- `HOPR_INTERNAL_LIBP2P_MAX_NEGOTIATING_INBOUND_STREAM_COUNT` - the maximum number of negotiating inboud streams
+- `HOPR_INTERNAL_LIBP2P_MAX_NEGOTIATING_INBOUND_STREAM_COUNT` - the maximum number of negotiating inbound streams
 - `ENV_WORKER_THREADS` - the number of environment worker threads for the tokio executor
 
 ### Example execution

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
   - [Install via Docker](#install-via-docker)
   - [Install via Nix package manager](#install-via-nix-package-manager)
 - [Usage](#usage)
+  - [Environment variables](#environment-variables)
   - [Example execution](#example-execution)
   - [Using Docker Compose with extended HOPR node monitoring](#using-docker-compose-with-extended-hopr-node-monitoring)
 - [Testnet accessibility](#testnet-accessibility)
@@ -191,6 +192,15 @@ Options:
   -V, --version
           Print version
 ```
+
+### Environment variables
+On top of the default configuration options generated for the command line, the following environment variables can be used in order to tweak the node functionality:
+- `HOPRD_LOG_FORMAT` - override for the default stdout log formatter (follows tracing formatting options)
+- `HOPRD_USE_OPENTELEMETRY` - enable the opentelemetry output for this node
+- `OTEL_SERVICE_NAME` - the name of this node for the opentelemetry service
+- `HOPR_INTERNAL_LIBP2P_MAX_CONCURRENTLY_DIALED_PEER_COUNT` - the maximum number of concurrently dialed peers in libp2p
+- `HOPR_INTERNAL_LIBP2P_MAX_NEGOTIATING_INBOUND_STREAM_COUNT` - the maximum number of negotiating inboud streams
+- `ENV_WORKER_THREADS` - the number of environment worker threads for the tokio executor
 
 ### Example execution
 
@@ -440,8 +450,6 @@ With the environment activated, execute the tests locally:
 ```shell
 make smoke-tests
 ```
-
-####
 
 ## Contact
 


### PR DESCRIPTION
Update the 2.2.x documentation in terms of extra configurable environment options.

# Notes
Fixes #6544 