### PR TITLE
Fix the network heartbeat behavior to be more robust and work with /node/peers

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,9 @@ Options:
 ```
 
 ### Environment variables
+
 On top of the default configuration options generated for the command line, the following environment variables can be used in order to tweak the node functionality:
+
 - `HOPRD_LOG_FORMAT` - override for the default stdout log formatter (follows tracing formatting options)
 - `HOPRD_USE_OPENTELEMETRY` - enable the opentelemetry output for this node
 - `OTEL_SERVICE_NAME` - the name of this node for the opentelemetry service

--- a/hoprd/hoprd/example_cfg.yaml
+++ b/hoprd/hoprd/example_cfg.yaml
@@ -186,9 +186,9 @@ hopr:
     # Maximum delay in seconds
     max_delay: 300
     # Quality threshold since a node is considered having "bad" connectivity
-    quality_bad_threshold: 0.2
+    quality_bad_threshold: 0.1
     # Quality threshold from which a node is considered available enough to be used
-    quality_offline_threshold: 0.5
+    quality_offline_threshold: 0.0
     # Quality step on failed/successful ping probe
     quality_step: 0.1
     # Size of the quality moving average window.

--- a/hoprd/rest-api/src/node.rs
+++ b/hoprd/rest-api/src/node.rs
@@ -172,7 +172,7 @@ pub(super) async fn peers(
             async move {
                 if let Ok(Some(info)) = hopr.network_peer_info(&peer).await {
                     let avg_quality = info.get_average_quality();
-                    if avg_quality > 0.0f64 && avg_quality >= quality {
+                    if avg_quality >= quality {
                         Some((peer, info))
                     } else {
                         None

--- a/hoprd/rest-api/src/node.rs
+++ b/hoprd/rest-api/src/node.rs
@@ -171,7 +171,8 @@ pub(super) async fn peers(
 
             async move {
                 if let Ok(Some(info)) = hopr.network_peer_info(&peer).await {
-                    if info.get_average_quality() >= quality {
+                    let avg_quality = info.get_average_quality();
+                    if avg_quality > 0.0f64 && avg_quality >= quality {
                         Some((peer, info))
                     } else {
                         None

--- a/tests/barebone-lower-win-prob.cfg.yaml
+++ b/tests/barebone-lower-win-prob.cfg.yaml
@@ -5,6 +5,9 @@ hopr:
     interval: 10
     threshold: 10
     variance: 1
+  network_options:
+    # ignore for shorter than heartbeat cycle
+    ignore_timeframe: 5
   strategy:
     on_fail_continue: true
     allow_recursive: false

--- a/tests/barebone-lower-win-prob.cfg.yaml
+++ b/tests/barebone-lower-win-prob.cfg.yaml
@@ -1,5 +1,10 @@
 ---
 hopr:
+  # run heartbeats more frequently
+  heartbeat:
+    interval: 10
+    threshold: 10
+    variance: 1
   strategy:
     on_fail_continue: true
     allow_recursive: false

--- a/tests/barebone.cfg.yaml
+++ b/tests/barebone.cfg.yaml
@@ -5,6 +5,9 @@ hopr:
     interval: 10
     threshold: 10
     variance: 1
+  network_options:
+    # ignore for shorter than heartbeat cycle
+    ignore_timeframe: 5
   strategy:
     on_fail_continue: true
     allow_recursive: false

--- a/tests/barebone.cfg.yaml
+++ b/tests/barebone.cfg.yaml
@@ -1,5 +1,10 @@
 ---
 hopr:
+  # run heartbeats more frequently
+  heartbeat:
+    interval: 10
+    threshold: 10
+    variance: 1
   strategy:
     on_fail_continue: true
     allow_recursive: false

--- a/tests/default.cfg.yaml
+++ b/tests/default.cfg.yaml
@@ -1,5 +1,10 @@
 ---
 hopr:
+  # run heartbeats more frequently
+  heartbeat:
+    interval: 10
+    threshold: 10
+    variance: 1
   strategy:
     on_fail_continue: true
     execution_interval: 1

--- a/tests/default.cfg.yaml
+++ b/tests/default.cfg.yaml
@@ -5,6 +5,9 @@ hopr:
     interval: 10
     threshold: 10
     variance: 1
+  network_options:
+    # ignore for shorter than heartbeat cycle
+    ignore_timeframe: 5
   strategy:
     on_fail_continue: true
     execution_interval: 1

--- a/tests/node.py
+++ b/tests/node.py
@@ -139,7 +139,6 @@ class Node:
                 ]
             ),
             "RUST_BACKTRACE": "full",
-            "HOPRD_NETWORK_QUALITY_THRESHOLD": "0.3",
             "HOPRD_USE_OPENTELEMETRY": trace_telemetry,
             "OTEL_SERVICE_NAME": f"hoprd-{self.p2p_port}",
         }

--- a/tests/node.py
+++ b/tests/node.py
@@ -139,9 +139,6 @@ class Node:
                 ]
             ),
             "RUST_BACKTRACE": "full",
-            "HOPRD_HEARTBEAT_INTERVAL": "2500",
-            "HOPRD_HEARTBEAT_THRESHOLD": "2500",
-            "HOPRD_HEARTBEAT_VARIANCE": "1000",
             "HOPRD_NETWORK_QUALITY_THRESHOLD": "0.3",
             "HOPRD_USE_OPENTELEMETRY": trace_telemetry,
             "OTEL_SERVICE_NAME": f"hoprd-{self.p2p_port}",

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -1266,7 +1266,7 @@ where
 
     #[tracing::instrument(level = "debug", skip(self))]
     pub async fn network_connected_peers(&self) -> errors::Result<Vec<PeerId>> {
-        Ok(self.network.peer_filter(|peer| async move { Some(peer.id.1) }).await?)
+        Ok(self.network.connected_peers().await?)
     }
 
     #[tracing::instrument(level = "debug", skip(self))]

--- a/transport/network/src/config.rs
+++ b/transport/network/src/config.rs
@@ -7,8 +7,8 @@ use validator::Validate;
 
 /// Network quality threshold since which a node is considered
 /// available enough to be used
-pub const DEFAULT_NETWORK_OFFLINE_QUALITY_THRESHOLD: f64 = 0.5;
-pub const DEFAULT_NETWORK_BAD_QUALITY_THRESHOLD: f64 = 0.2;
+pub const DEFAULT_NETWORK_OFFLINE_QUALITY_THRESHOLD: f64 = 0.0;
+pub const DEFAULT_NETWORK_BAD_QUALITY_THRESHOLD: f64 = 0.1;
 pub const DEFAULT_NETWORK_QUALITY_STEP: f64 = 0.1;
 pub const DEFAULT_NETWORK_QUALITY_AVERAGE_WINDOW_SIZE: u32 = 25;
 pub const DEFAULT_NETWORK_BACKOFF_EXPONENT: f64 = 1.5;
@@ -92,12 +92,12 @@ impl Validate for NetworkConfig {
             );
         }
 
-        // if self.quality_bad_threshold > self.quality_offline_threshold {
-        //     errors.add(
-        //         "quality_bad_threshold and quality_offline_threshold",
-        //         validator::ValidationError::new("quality_bad_threshold must be less than quality_offline_threshold"),
-        //     );
-        // }
+        if self.quality_bad_threshold > self.quality_offline_threshold {
+            errors.add(
+                "quality_bad_threshold and quality_offline_threshold",
+                validator::ValidationError::new("quality_bad_threshold must be greater than quality_offline_threshold"),
+            );
+        }
 
         // #[validate(range(min = 0.0, max = 1.0))]
         if !(0.0..=1.0).contains(&self.quality_step) {

--- a/transport/network/src/config.rs
+++ b/transport/network/src/config.rs
@@ -92,7 +92,7 @@ impl Validate for NetworkConfig {
             );
         }
 
-        if self.quality_bad_threshold > self.quality_offline_threshold {
+        if self.quality_bad_threshold < self.quality_offline_threshold {
             errors.add(
                 "quality_bad_threshold and quality_offline_threshold",
                 validator::ValidationError::new("quality_bad_threshold must be greater than quality_offline_threshold"),

--- a/transport/network/src/network.rs
+++ b/transport/network/src/network.rs
@@ -100,13 +100,6 @@ where
     T: HoprDbPeersOperations + Sync + Send + std::fmt::Debug,
 {
     pub fn new(my_peer_id: PeerId, my_multiaddresses: Vec<Multiaddr>, cfg: NetworkConfig, db: T) -> Self {
-        if cfg.quality_offline_threshold < cfg.quality_bad_threshold {
-            panic!(
-                "Strict requirement failed, bad quality threshold {} must be lower than quality offline threshold {}",
-                cfg.quality_bad_threshold, cfg.quality_offline_threshold
-            );
-        }
-
         #[cfg(all(feature = "prometheus", not(test)))]
         {
             METRIC_NETWORK_HEALTH.set(0.0);
@@ -244,7 +237,7 @@ where
 
                 let q = entry.get_quality();
 
-                if q < (self.cfg.quality_step / 2.0) || q < self.cfg.quality_bad_threshold {
+                if q < self.cfg.quality_bad_threshold {
                     entry.ignored = Some(current_time());
                 }
             }
@@ -258,13 +251,13 @@ where
                 self.refresh_metrics(&stats)
             }
 
-            if quality < (self.cfg.quality_step / 2.0) {
+            if quality <= self.cfg.quality_offline_threshold {
                 Ok(Some(NetworkTriggeredEvent::CloseConnection(peer_id)))
             } else {
                 Ok(Some(NetworkTriggeredEvent::UpdateQuality(peer_id, quality)))
             }
         } else {
-            debug!("Ignoring update request for unknown peer {}", peer);
+            debug!(%peer, "Ignoring update request for unknown peer");
             Ok(None)
         }
     }
@@ -296,8 +289,14 @@ where
         METRIC_NETWORK_HEALTH.set((health as i32).into());
     }
 
+    pub async fn connected_peers(&self) -> crate::errors::Result<Vec<PeerId>> {
+        let minimum_quality = self.cfg.quality_offline_threshold;
+        self.peer_filter(|peer| async move { (peer.get_quality() > minimum_quality).then_some(peer.id.1) })
+            .await
+    }
+
     // ======
-    pub async fn peer_filter<Fut, V, F>(&self, filter: F) -> crate::errors::Result<Vec<V>>
+    pub(crate) async fn peer_filter<Fut, V, F>(&self, filter: F) -> crate::errors::Result<Vec<V>>
     where
         F: FnMut(PeerStatus) -> Fut,
         Fut: std::future::Future<Output = Option<V>>,
@@ -569,7 +568,7 @@ mod tests {
             .await?;
         peers.update(&peer, Err(()), None).await?; // should drop to ignored
 
-        // peers.update(&peer, Err(()), None).await.expect("no error should occur");    // should drop from network
+        peers.update(&peer, Err(()), None).await.expect("no error should occur"); // should drop from network
 
         assert!(!peers.has(&peer).await);
 


### PR DESCRIPTION
Fix network behavior inconsistency related to improper ignoring of network peers and closing peer connections for offline peers.

- [x] Remove overriding variables
- [x] Fix the network behavior
- [x] Proper `/node/peers` output fix

## Notes
Fixes #6529 