### PR TITLE
Alias to an existing peer_id or an existing alias should fail

### DIFF
--- a/hoprd/db/api/src/errors.rs
+++ b/hoprd/db/api/src/errors.rs
@@ -6,6 +6,9 @@ pub enum DbError {
     #[error("alias not found: {0}")]
     AliasNotFound(String),
 
+    #[error("alias or peer id already exists")]
+    AliasOrPeerIdAlreadyExists,
+
     #[error("transaction error: {0}")]
     TransactionError(Box<dyn std::error::Error + Send + Sync>),
 

--- a/hoprd/rest-api/src/alias.rs
+++ b/hoprd/rest-api/src/alias.rs
@@ -84,7 +84,7 @@ pub(super) async fn aliases(State(state): State<Arc<InternalState>>) -> impl Int
             (status = 201, description = "Alias set successfully.", body = PeerIdResponse),
             (status = 400, description = "Invalid PeerId: The format or length of the peerId is incorrect.", body = ApiError),
             (status = 401, description = "Invalid authorization token.", body = ApiError),
-            (status = 409, description = "Given PeerId is already aliased.", body = ApiError),
+            (status = 409, description = "Either alias exists or the peer_id is already aliased.", body = ApiError),
             (status = 422, description = "Unknown failure", body = ApiError)
         ),
         security(
@@ -118,6 +118,9 @@ pub(super) async fn set_alias(
         )
             .into_response(),
         Err(DbError::LogicalError(_)) => (StatusCode::BAD_REQUEST, ApiErrorStatus::PeerNotFound).into_response(),
+        Err(DbError::AliasOrPeerIdAlreadyExists) => {
+            (StatusCode::CONFLICT, ApiErrorStatus::AliasOrPeerIdAliasAlreadyExists).into_response()
+        }
         Err(e) => (StatusCode::UNPROCESSABLE_ENTITY, ApiErrorStatus::from(e)).into_response(),
     }
 }

--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -359,6 +359,7 @@ enum ApiErrorStatus {
     ChannelAlreadyOpen,
     ChannelNotOpen,
     AliasNotFound,
+    AliasOrPeerIdAliasAlreadyExists,
     DatabaseError,
     UnsupportedFeature,
     Timeout,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -85,35 +85,33 @@ async def test_hoprd_protocol_check_balances_without_prior_tests(swarm7: dict[st
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
-async def test_hoprd_node_should_be_able_to_alias_other_peers_with_peer_id(peer: str, swarm7: dict[str, Node]):
+async def test_hoprd_should_not_be_able_to_set_multiple_aliases_to_a_single_peerid(peer: str, swarm7: dict[str, Node]):
     other_peers = barebone_nodes()
     other_peers.remove(peer)
 
-    alice_peer_id = swarm7[random.choice(other_peers)].peer_id
+    rufus_peer_id = swarm7[random.choice(other_peers)].peer_id
     my_peer_id = swarm7[peer].peer_id
-    assert alice_peer_id != my_peer_id
+    assert rufus_peer_id != my_peer_id
 
-    assert await swarm7[peer].api.aliases_set_alias("Alice", alice_peer_id) is True
-
-    assert await swarm7[peer].api.aliases_get_alias("Alice") == alice_peer_id
-    assert await swarm7[peer].api.aliases_set_alias("Alice New", alice_peer_id) is True
-
-    assert await swarm7[peer].api.aliases_remove_alias("Alice New") is True
-    assert await swarm7[peer].api.aliases_get_alias("Alice New") is None
-    assert await swarm7[peer].api.aliases_get_alias("Alice") is None
+    assert await swarm7[peer].api.aliases_set_alias("Rufus", rufus_peer_id) is True
+    assert await swarm7[peer].api.aliases_set_alias("Simon", rufus_peer_id) is False
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
-async def test_hoprd_node_should_be_able_to_alias_other_peers_with_address(peer: str, swarm7: dict[str, Node]):
+async def test_hoprd_node_should_contain_self_alias_automatically(peer: str, swarm7: dict[str, Node]):
+    assert await swarm7[peer].api.aliases_get_alias("me") == swarm7[peer].peer_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
+async def test_hoprd_should_be_able_to_remove_existing_aliases(peer: str, swarm7: dict[str, Node]):
     other_peers = barebone_nodes()
     other_peers.remove(peer)
 
     alice = swarm7[random.choice(other_peers)]
 
     assert alice.address != swarm7[peer].address
-
-    assert await swarm7[peer].api.aliases_get_alias("me") == swarm7[peer].peer_id
 
     assert await swarm7[peer].api.aliases_get_alias("Alice") is None
     assert await swarm7[peer].api.aliases_set_alias("Alice", alice.address) is True


### PR DESCRIPTION
Reintroduce backwards compatible and POST compliant behavior on alias entry:
1. if an alias exists -> fail with 409
2. if the peer id is already assigned to an alias -> fail with 409
3. otherwise introduce the alias


## Notes
Refixes #6206 