### PR TITLE
Use the quic-v1 multiaddress as a default for announcement

### DIFF
--- a/hoprd/hoprd/Cargo.toml
+++ b/hoprd/hoprd/Cargo.toml
@@ -14,7 +14,7 @@ default = [
   "runtime-tokio",
   "prometheus",
   "telemetry",
-  "transport-quic"
+  "transport-quic",
 ] # uses tokio by default because of axum
 prometheus = [
   "dep:hopr-metrics",

--- a/hoprd/hoprd/Cargo.toml
+++ b/hoprd/hoprd/Cargo.toml
@@ -14,6 +14,7 @@ default = [
   "runtime-tokio",
   "prometheus",
   "telemetry",
+  "transport-quic"
 ] # uses tokio by default because of axum
 prometheus = [
   "dep:hopr-metrics",


### PR DESCRIPTION
Use the QUIC transport on the libp2p layer by default:
1. announce a quic-v1 multiaddress
2. be reachable by TCP and have TCP transport for backwards compatibility