### PR TITLE
Add constants for session protocol and transport config

### DIFF
--- a/common/network-types/src/session/frame.rs
+++ b/common/network-types/src/session/frame.rs
@@ -161,12 +161,6 @@ impl Segment {
     /// The minimum size of a segment: [`Segment::HEADER_SIZE`] + 1 byte of data.
     pub const MINIMUM_SIZE: usize = Self::HEADER_SIZE + 1;
 
-    /// The maximum size of a segment: [`Segment::HEADER_SIZE`] + data, regardless
-    /// any MTU.
-    /// This number is currently set, so that segment length is expressible
-    /// with just 10-bits and fits typical Ethernet MTU size.
-    pub const MAXIMUM_SIZE: usize = 1500;
-
     /// Returns the [SegmentId] for this segment.
     pub fn id(&self) -> SegmentId {
         SegmentId(self.frame_id, self.seq_idx)
@@ -214,10 +208,6 @@ impl TryFrom<&[u8]> for Segment {
     type Error = SessionError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        if value.len() > Segment::MAXIMUM_SIZE {
-            return Err(SessionError::DataTooLong);
-        }
-
         let (header, data) = value.split_at(Self::HEADER_SIZE);
         let segment = Segment {
             frame_id: FrameId::from_be_bytes(header[0..4].try_into().map_err(|_| SessionError::InvalidSegment)?),

--- a/common/network-types/src/session/protocol.rs
+++ b/common/network-types/src/session/protocol.rs
@@ -308,6 +308,11 @@ impl<const C: usize> SessionMessage<C> {
     /// This amounts to [`SessionMessage::HEADER_SIZE`] + [`Segment::HEADER_SIZE`].
     pub const SEGMENT_OVERHEAD: usize = Self::HEADER_SIZE + Segment::HEADER_SIZE;
 
+    /// Maximum size of the Session protocol message.
+    ///
+    /// This is directly the maximum size of a [`Segment`].
+    pub const MAX_MESSAGE_SIZE: usize = Segment::MAXIMUM_SIZE;
+
     /// Current version of the protocol.
     pub const VERSION: u8 = 1;
 
@@ -414,6 +419,19 @@ impl<'a, const C: usize> SessionMessageIter<'a, C> {
         ) as usize;
         offset += mem::size_of::<u16>();
 
+        if len > SessionMessage::<C>::MAX_MESSAGE_SIZE {
+            return Err(SessionError::IncorrectMessageLength);
+        }
+
+        // The upper 6 bits of the size are reserved for future use,
+        // since MAX_MESSAGE_SIZE always fits within 10 bits (<= MAX_MESSAGE_SIZE = 1500)
+        let reserved = len & 0b111111_0000000000;
+
+        // In version 1 check that the reserved bits are all 0
+        if reserved != 0 {
+            return Err(SessionError::ParseError);
+        }
+
         // Read the message
         let res = match SessionMessageDiscriminants::from_repr(disc).ok_or(SessionError::UnknownMessageTag)? {
             SessionMessageDiscriminants::Segment => {
@@ -479,6 +497,8 @@ mod tests {
         assert_eq!(4, SessionMessage::<0>::HEADER_SIZE);
         assert_eq!(10, SessionMessage::<0>::SEGMENT_OVERHEAD);
         assert_eq!(8, SessionMessage::<0>::MAX_SEGMENTS_PER_FRAME);
+
+        assert!(SessionMessage::<0>::MAX_MESSAGE_SIZE < 2048);
     }
 
     #[test]

--- a/common/network-types/src/session/protocol.rs
+++ b/common/network-types/src/session/protocol.rs
@@ -310,8 +310,8 @@ impl<const C: usize> SessionMessage<C> {
 
     /// Maximum size of the Session protocol message.
     ///
-    /// This is directly the maximum size of a [`Segment`].
-    pub const MAX_MESSAGE_SIZE: usize = Segment::MAXIMUM_SIZE;
+    /// This is equal to the typical Ethernet MTU size minus [`Self::SEGMENT_OVERHEAD`].
+    pub const MAX_MESSAGE_SIZE: usize = 1492 - Self::SEGMENT_OVERHEAD;
 
     /// Current version of the protocol.
     pub const VERSION: u8 = 1;

--- a/transport/api/src/config.rs
+++ b/transport/api/src/config.rs
@@ -200,7 +200,7 @@ fn validate_session_idle_timeout(value: &std::time::Duration) -> Result<(), Vali
 pub struct SessionGlobalConfig {
     /// Maximum time before an idle Session is closed.
     ///
-    /// Defaults to 2 minutes.
+    /// Defaults to 3 minutes.
     #[validate(custom(function = "validate_session_idle_timeout"))]
     #[default(DEFAULT_SESSION_IDLE_TIMEOUT)]
     #[serde(default = "default_session_idle_timeout")]

--- a/transport/api/src/config.rs
+++ b/transport/api/src/config.rs
@@ -1,12 +1,12 @@
-use std::fmt::{Display, Formatter};
-use std::net::ToSocketAddrs;
-use std::num::ParseIntError;
-use std::str::FromStr;
-
 use libp2p::Multiaddr;
 use proc_macro_regex::regex;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
+use std::fmt::{Display, Formatter};
+use std::net::ToSocketAddrs;
+use std::num::ParseIntError;
+use std::str::FromStr;
+use std::time::Duration;
 use validator::{Validate, ValidationError};
 
 pub use core_network::{config::NetworkConfig, heartbeat::HeartbeatConfig};
@@ -165,21 +165,28 @@ pub struct TransportConfig {
     pub prefer_local_addresses: bool,
 }
 
-fn just_three() -> u32 {
-    3
+const DEFAULT_SESSION_IDLE_TIMEOUT: Duration = Duration::from_secs(180);
+
+const SESSION_IDLE_MIN_TIMEOUT: Duration = Duration::from_secs(60);
+
+const DEFAULT_SESSION_ESTABLISH_RETRY_DELAY: Duration = Duration::from_secs(2);
+
+const DEFAULT_SESSION_ESTABLISH_MAX_RETRIES: u32 = 3;
+
+fn default_session_establish_max_retries() -> u32 {
+    DEFAULT_SESSION_ESTABLISH_MAX_RETRIES
 }
 
-fn two_minutes() -> std::time::Duration {
-    std::time::Duration::from_secs(120)
+fn default_session_idle_timeout() -> std::time::Duration {
+    DEFAULT_SESSION_IDLE_TIMEOUT
 }
 
-fn two_seconds() -> std::time::Duration {
-    std::time::Duration::from_secs(2)
+fn default_session_establish_retry_delay() -> std::time::Duration {
+    DEFAULT_SESSION_ESTABLISH_RETRY_DELAY
 }
 
 fn validate_session_idle_timeout(value: &std::time::Duration) -> Result<(), ValidationError> {
-    let min_idle = std::time::Duration::from_secs(60);
-    if min_idle <= *value {
+    if SESSION_IDLE_MIN_TIMEOUT <= *value {
         Ok(())
     } else {
         Err(ValidationError::new("session idle timeout is too low"))
@@ -195,8 +202,8 @@ pub struct SessionGlobalConfig {
     ///
     /// Defaults to 2 minutes.
     #[validate(custom(function = "validate_session_idle_timeout"))]
-    #[default(std::time::Duration::from_secs(120))]
-    #[serde(default = "two_minutes")]
+    #[default(DEFAULT_SESSION_IDLE_TIMEOUT)]
+    #[serde(default = "default_session_idle_timeout")]
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
     pub idle_timeout: std::time::Duration,
 
@@ -205,15 +212,15 @@ pub struct SessionGlobalConfig {
     ///
     /// Defaults to 3, maximum is 20.
     #[validate(range(min = 0, max = 20))]
-    #[default(3)]
-    #[serde(default = "just_three")]
+    #[default(DEFAULT_SESSION_ESTABLISH_MAX_RETRIES)]
+    #[serde(default = "default_session_establish_max_retries")]
     pub establish_max_retries: u32,
 
     /// Delay between Session establishment retries.
     ///
     /// Default is 2 seconds.
-    #[default(std::time::Duration::from_secs(2))]
-    #[serde(default = "two_seconds")]
+    #[default(DEFAULT_SESSION_ESTABLISH_RETRY_DELAY)]
+    #[serde(default = "default_session_establish_retry_delay")]
     #[serde_as(as = "serde_with::DurationSeconds<u64>")]
     pub establish_retry_timeout: std::time::Duration,
 }


### PR DESCRIPTION
Introduced `MAX_MESSAGE_SIZE` constant in session protocol and added validation for message length. The upper six bits of length are reserved for future use.

Also, replaced magic numbers with constants for timeout and retries in transport configuration.