### PR TITLE
Handle restricted self registration

### DIFF
--- a/hoprd/rest-api/src/checks.rs
+++ b/hoprd/rest-api/src/checks.rs
@@ -77,10 +77,10 @@ pub(super) async fn eligiblez(State(state): State<Arc<AppState>>) -> impl IntoRe
                     if chain_api_err.to_string().contains("division by zero") {
                         (StatusCode::PRECONDITION_FAILED, "Node not eligible").into_response()
                     } else {
-                        (StatusCode::INTERNAL_SERVER_ERROR, format!("Error: {}", e)).into_response()
+                        (StatusCode::INTERNAL_SERVER_ERROR, format!("Error: {e}")).into_response()
                     }
                 }
-                _ => (StatusCode::INTERNAL_SERVER_ERROR, format!("Error: {}", e)).into_response(),
+                _ => (StatusCode::INTERNAL_SERVER_ERROR, format!("Error: {e}")).into_response(),
             }
         }
     }

--- a/hoprd/rest-api/src/checks.rs
+++ b/hoprd/rest-api/src/checks.rs
@@ -72,7 +72,7 @@ pub(super) async fn eligiblez(State(state): State<Arc<AppState>>) -> impl IntoRe
         Ok(false) => (StatusCode::PRECONDITION_FAILED, "Node not eligible").into_response(),
         Err(e) => {
             match e {
-                // when the error is deivision by zero, it's caused by the self-registration is forbidden to the public, and thus returns false.
+                // division by zero error is caused by the self-registration forbidden to the public, and thus returns false
                 hopr_lib::errors::HoprLibError::ChainApi(chain_api_err) => {
                     if chain_api_err.to_string().contains("division by zero") {
                         (StatusCode::PRECONDITION_FAILED, "Node not eligible").into_response()


### PR DESCRIPTION
Close #6560 
The root cause it that self-registration on the network registry is not enabled. The "div 0" error is expected.
The error can be better handled on the smart contract level, which will be tackled in https://github.com/hoprnet/hoprnet/issues/5501