### PR TITLE
Add criterion benchmarks for crypto-packet crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1425,7 +1425,6 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
- "terminal_size",
 ]
 
 [[package]]
@@ -1528,12 +1527,6 @@ checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
 ]
-
-[[package]]
-name = "condtype"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "console-api"
@@ -2234,31 +2227,6 @@ name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.87",
-]
-
-[[package]]
-name = "divan"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e05d17bd4ff1c1e7998ed4623d2efd91f72f1e24141ac33aac9377974270e1f"
-dependencies = [
- "cfg-if",
- "clap",
- "condtype",
- "divan-macros",
- "libc",
- "regex-lite",
-]
-
-[[package]]
-name = "divan-macros"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b4464d46ce68bfc7cb76389248c7c254def7baca8bece0693b02b83842c4c88"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4098,7 +4066,7 @@ dependencies = [
  "async-std",
  "async-trait",
  "core-path",
- "divan",
+ "criterion",
  "hex",
  "hex-literal",
  "hopr-crypto-random",
@@ -7660,12 +7628,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-lite"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
-
-[[package]]
 name = "regex-syntax"
 version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9525,16 +9487,6 @@ dependencies = [
  "cfg-if",
  "fastrand 2.1.1",
  "once_cell",
- "rustix 0.38.39",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "terminal_size"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f599bd7ca042cfdf8f4512b277c02ba102247820f9d9d4a9f521f496751a6ef"
-dependencies = [
  "rustix 0.38.39",
  "windows-sys 0.59.0",
 ]

--- a/crypto/packet/Cargo.toml
+++ b/crypto/packet/Cargo.toml
@@ -30,7 +30,7 @@ hopr-primitive-types = { workspace = true }
 anyhow = { workspace = true }
 async-std = { workspace = true }
 async-trait = { workspace = true }
-divan = { workspace = true }
+criterion = { workspace = true }
 hex-literal = { workspace = true }
 libp2p-identity = { workspace = true }
 mockall = { workspace = true }

--- a/crypto/packet/benches/packet_crypto.rs
+++ b/crypto/packet/benches/packet_crypto.rs
@@ -1,4 +1,128 @@
-fn main() {
-    // Run registered benchmarks.
-    divan::main();
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use hopr_crypto_packet::chain::ChainPacketComponents;
+use hopr_crypto_types::prelude::{ChainKeypair, Keypair, OffchainKeypair};
+use hopr_crypto_types::types::Hash;
+use hopr_internal_types::prelude::{TicketBuilder, PAYLOAD_SIZE};
+use hopr_primitive_types::prelude::{Address, BytesEncodable};
+
+const SAMPLE_SIZE: usize = 100_000;
+
+pub fn packet_sending_bench(c: &mut Criterion) {
+    let chain_key = ChainKeypair::random();
+    let destination = Address::new(&hopr_crypto_random::random_bytes::<20>());
+
+    let path = (0..=3)
+        .map(|_| OffchainKeypair::random().public().clone())
+        .collect::<Vec<_>>();
+    let msg = hopr_crypto_random::random_bytes::<PAYLOAD_SIZE>();
+    let dst = Hash::default();
+
+    let mut group = c.benchmark_group("packet_sending");
+    group.sample_size(SAMPLE_SIZE);
+
+    for hop in [0, 1, 2, 3].iter() {
+        group.throughput(Throughput::Elements(1));
+        group.bench_with_input(BenchmarkId::from_parameter(format!("{hop} hop")), hop, |b, &hop| {
+            b.iter(|| {
+                // The number of hops for ticket creation does not matter for benchmark purposes
+                let tb = TicketBuilder::zero_hop().direction(&(&chain_key).into(), &destination);
+
+                ChainPacketComponents::into_outgoing(&msg, &path[0..=hop], &chain_key, tb, &dst)
+            });
+        });
+    }
+    group.finish();
 }
+
+pub fn packet_forwarding_bench(c: &mut Criterion) {
+    let chain_key = ChainKeypair::random();
+    let destination = Address::new(&hopr_crypto_random::random_bytes::<20>());
+
+    let sender = OffchainKeypair::random();
+    let relayer = OffchainKeypair::random();
+    let recipient = OffchainKeypair::random();
+    let path = [relayer.public().clone(), recipient.public().clone()];
+
+    let msg = hopr_crypto_random::random_bytes::<PAYLOAD_SIZE>();
+    let dst = Hash::default();
+
+    // The number of hops for ticket creation does not matter for benchmark purposes
+    let tb = TicketBuilder::zero_hop().direction(&(&chain_key).into(), &destination);
+
+    // Sender
+    let packet = match ChainPacketComponents::into_outgoing(&msg, &path, &chain_key, tb, &dst).unwrap() {
+        ChainPacketComponents::Outgoing { packet, ticket, .. } => {
+            let mut ret = Vec::with_capacity(ChainPacketComponents::SIZE);
+            ret.extend_from_slice(packet.as_ref());
+            ret.extend_from_slice(&ticket.clone().into_encoded());
+            ret.into_boxed_slice()
+        }
+        _ => panic!("should not happen"),
+    };
+
+    // Benchmark the relayer
+    let mut group = c.benchmark_group("packet_forwarding");
+    group.sample_size(SAMPLE_SIZE);
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("any hop", |b| {
+        b.iter(|| {
+            ChainPacketComponents::from_incoming(&packet, &relayer, sender.public().clone()).unwrap();
+        })
+    });
+}
+
+pub fn packet_receiving_bench(c: &mut Criterion) {
+    let chain_key = ChainKeypair::random();
+    let destination = Address::new(&hopr_crypto_random::random_bytes::<20>());
+
+    let sender = OffchainKeypair::random();
+    let relayer = OffchainKeypair::random();
+    let recipient = OffchainKeypair::random();
+    let path = [relayer.public().clone(), recipient.public().clone()];
+
+    let msg = hopr_crypto_random::random_bytes::<PAYLOAD_SIZE>();
+    let dst = Hash::default();
+
+    // The number of hops for ticket creation does not matter for benchmark purposes
+    let tb = TicketBuilder::zero_hop().direction(&(&chain_key).into(), &destination);
+
+    // Sender
+    let packet = match ChainPacketComponents::into_outgoing(&msg, &path, &chain_key, tb, &dst).unwrap() {
+        ChainPacketComponents::Outgoing { packet, ticket, .. } => {
+            let mut ret = Vec::with_capacity(ChainPacketComponents::SIZE);
+            ret.extend_from_slice(packet.as_ref());
+            ret.extend_from_slice(&ticket.clone().into_encoded());
+            ret.into_boxed_slice()
+        }
+        _ => panic!("should not happen"),
+    };
+
+    // Relayer
+    let packet = match ChainPacketComponents::from_incoming(&packet, &relayer, sender.public().clone()).unwrap() {
+        ChainPacketComponents::Forwarded { packet, ticket, .. } => {
+            let mut ret = Vec::with_capacity(ChainPacketComponents::SIZE);
+            ret.extend_from_slice(packet.as_ref());
+            ret.extend_from_slice(&ticket.clone().into_encoded());
+            ret.into_boxed_slice()
+        }
+        _ => panic!("should not happen"),
+    };
+
+    // Benchmark the recipient
+    let mut group = c.benchmark_group("packet_receiving");
+    group.sample_size(SAMPLE_SIZE);
+    group.throughput(Throughput::Elements(1));
+    group.bench_function("any hop", |b| {
+        b.iter(|| {
+            ChainPacketComponents::from_incoming(&packet, &recipient, relayer.public().clone()).unwrap();
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    packet_sending_bench,
+    packet_forwarding_bench,
+    packet_receiving_bench
+);
+criterion_main!(benches);


### PR DESCRIPTION
Add benchmarks for packet creation, forwarding and receiving. Excluding potential cache operations done to retrieve channel information.

These benchmarks represent the upper bound on potential packet throughput.

- `packet_sending_bench`: benchmarks the creation process  `n`-hop packets (for `n` = 0,1,2,3)
- `packet_forwarding_bench`: benchmarks the packet operation done by the relayer (regardless of the number of hops)
- `packet_receiving_bench`: benchmarks the packet operation done by the packet recipient to recover the actual packet payload (regardless of the number of hops)

To run: `cargo bench -p hopr-crypto-packet`