### PR TITLE
Disable default `transport-quic` feature

### DIFF
--- a/hoprd/hoprd/Cargo.toml
+++ b/hoprd/hoprd/Cargo.toml
@@ -14,7 +14,7 @@ default = [
   "runtime-tokio",
   "prometheus",
   "telemetry",
-  "transport-quic",
+  # "transport-quic", # TODO: re-enable this once properly tested
 ] # uses tokio by default because of axum
 prometheus = [
   "dep:hopr-metrics",


### PR DESCRIPTION
Temporarily comment out the `transport-quic` dependency in order to prevent potential untested issues. This change will be reverted once proper testing and validation are completed.