### PR TITLE
Remove ticket validation from the last hop

### DIFF
--- a/common/internal-types/src/protocol.rs
+++ b/common/internal-types/src/protocol.rs
@@ -221,7 +221,7 @@ impl ApplicationData {
                 plain_text: (&data[2..]).into(),
             })
         } else {
-            Err(GeneralError::ParseError)
+            Err(GeneralError::ParseError("ApplicationData".into()))
         }
     }
 

--- a/common/internal-types/src/tickets.rs
+++ b/common/internal-types/src/tickets.rs
@@ -83,7 +83,7 @@ pub struct TicketBuilder {
 }
 
 impl TicketBuilder {
-    /// Initializes the builder for a zero hop ticket.
+    /// Initializes the builder for a zero-hop ticket.
     #[must_use]
     pub fn zero_hop() -> Self {
         Self {
@@ -488,31 +488,38 @@ impl TryFrom<&[u8]> for Ticket {
 
     fn try_from(value: &[u8]) -> std::result::Result<Self, Self::Error> {
         if value.len() == Self::SIZE {
-            // TODO: not necessary to transmit over the wire, only the counterparty is sufficient
-            let channel_id = Hash::try_from(&value[0..32])?;
+            let mut offset = 0;
+
+            // TODO: not necessary to the ChannelId over the wire, only the counterparty is sufficient
+            let channel_id = Hash::try_from(&value[offset..offset + Hash::SIZE])?;
+            offset += Hash::SIZE;
+
             let mut amount = [0u8; 32];
-            amount[20..32].copy_from_slice(&value[Hash::SIZE..Hash::SIZE + 12]);
+            amount[20..32].copy_from_slice(&value[offset..offset + 12]);
+            offset += 12;
 
             let mut index = [0u8; 8];
-            index[2..8].copy_from_slice(&value[Hash::SIZE + 12..Hash::SIZE + 12 + 6]);
+            index[2..8].copy_from_slice(&value[offset..offset + 6]);
+            offset += 6;
 
             let mut index_offset = [0u8; 4];
-            index_offset.copy_from_slice(&value[Hash::SIZE + 12 + 6..Hash::SIZE + 12 + 6 + 4]);
+            index_offset.copy_from_slice(&value[offset..offset + 4]);
+            offset += 4;
 
             let mut channel_epoch = [0u8; 4];
-            channel_epoch[1..4].copy_from_slice(&value[Hash::SIZE + 12 + 6 + 4..Hash::SIZE + 12 + 6 + 4 + 3]);
+            channel_epoch[1..4].copy_from_slice(&value[offset..offset + 3]);
+            offset += 3;
 
             let mut encoded_win_prob = [0u8; 7];
-            encoded_win_prob.copy_from_slice(&value[Hash::SIZE + 12 + 6 + 4 + 3..Hash::SIZE + 12 + 6 + 4 + 3 + 7]);
+            encoded_win_prob.copy_from_slice(&value[offset..offset + 7]);
+            offset += 7;
 
-            let challenge = EthereumChallenge::try_from(
-                &value[ENCODED_TICKET_LENGTH..ENCODED_TICKET_LENGTH + EthereumChallenge::SIZE],
-            )?;
+            debug_assert_eq!(offset, ENCODED_TICKET_LENGTH);
 
-            let signature = Signature::try_from(
-                &value[ENCODED_TICKET_LENGTH + EthereumChallenge::SIZE
-                    ..ENCODED_TICKET_LENGTH + EthereumChallenge::SIZE + Signature::SIZE],
-            )?;
+            let challenge = EthereumChallenge::try_from(&value[offset..offset + EthereumChallenge::SIZE])?;
+            offset += EthereumChallenge::SIZE;
+
+            let signature = Signature::try_from(&value[offset..offset + Signature::SIZE])?;
 
             // Validate the boundaries of the parsed values
             TicketBuilder::default()
@@ -525,9 +532,9 @@ impl TryFrom<&[u8]> for Ticket {
                 .challenge(challenge)
                 .signature(signature)
                 .build()
-                .map_err(|_| GeneralError::ParseError)
+                .map_err(|e| GeneralError::ParseError(format!("ticket build failed: {e}")))
         } else {
-            Err(GeneralError::ParseError)
+            Err(GeneralError::ParseError("Ticket".into()))
         }
     }
 }

--- a/common/primitive-types/src/errors.rs
+++ b/common/primitive-types/src/errors.rs
@@ -8,8 +8,8 @@ pub type AnyError = Box<dyn std::error::Error + Send + Sync + 'static>;
 /// Listing of some general re-usable errors
 #[derive(Error, Debug, Serialize, Deserialize, PartialEq)]
 pub enum GeneralError {
-    #[error("failed to parse/deserialize the data")]
-    ParseError,
+    #[error("failed to parse/deserialize the data: {0}")]
+    ParseError(String),
 
     #[error("input argument to the function is invalid")]
     InvalidInput,

--- a/common/primitive-types/src/lib.rs
+++ b/common/primitive-types/src/lib.rs
@@ -31,16 +31,18 @@ pub mod rlp {
 
     pub fn decode(data: &[u8]) -> crate::errors::Result<(Box<[u8]>, Duration)> {
         let rlp_data = rlp::Rlp::new(data);
-        let mut list = rlp_data.as_list::<Vec<u8>>().map_err(|_| GeneralError::ParseError)?;
+        let mut list = rlp_data
+            .as_list::<Vec<u8>>()
+            .map_err(|_| GeneralError::ParseError("invalid rlp structure".into()))?;
 
         if list.len() != 2 {
-            return Err(GeneralError::ParseError);
+            return Err(GeneralError::ParseError("invalid rlp length".into()));
         }
 
         let enc_ts = list.remove(1);
         let ts_len = enc_ts.len();
         if ts_len > 8 {
-            return Err(GeneralError::ParseError);
+            return Err(GeneralError::ParseError("invalid rlp list length".into()));
         }
 
         let mut ts = [0u8; 8];

--- a/common/primitive-types/src/primitives.rs
+++ b/common/primitive-types/src/primitives.rs
@@ -61,12 +61,12 @@ impl TryFrom<&[u8]> for Address {
     type Error = GeneralError;
 
     fn try_from(value: &[u8]) -> std::result::Result<Self, Self::Error> {
-        Ok(Self(value.try_into().map_err(|_| ParseError)?))
+        Ok(Self(value.try_into().map_err(|_| ParseError("Address".into()))?))
     }
 }
 
 impl BytesRepresentable for Address {
-    /// Fixed size of the address when encoded as bytes (e.g. via `as_ref()`).
+    /// Fixed size of the address when encoded as bytes (e.g., via `as_ref()`).
     const SIZE: usize = 20;
 }
 
@@ -304,15 +304,15 @@ impl FromStr for Balance {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let regex = Regex::new(r"^\s*(\d+)\s*([A-z]+)\s*$").expect("should use valid regex pattern");
-        let cap = regex.captures(s).ok_or(ParseError)?;
+        let cap = regex.captures(s).ok_or(ParseError("Balance".into()))?;
 
         if cap.len() == 3 {
             Ok(Self::new_from_str(
                 &cap[1],
-                BalanceType::from_str(&cap[2]).map_err(|_| ParseError)?,
+                BalanceType::from_str(&cap[2]).map_err(|_| ParseError("Balance".into()))?,
             ))
         } else {
-            Err(ParseError)
+            Err(ParseError("Balance".into()))
         }
     }
 }
@@ -342,7 +342,9 @@ impl TryFrom<&[u8]> for EthereumChallenge {
     type Error = GeneralError;
 
     fn try_from(value: &[u8]) -> std::result::Result<Self, Self::Error> {
-        Ok(Self(value.try_into().map_err(|_| ParseError)?))
+        Ok(Self(
+            value.try_into().map_err(|_| ParseError("EthereumChallenge".into()))?,
+        ))
     }
 }
 

--- a/common/primitive-types/src/traits.rs
+++ b/common/primitive-types/src/traits.rs
@@ -71,10 +71,10 @@ impl<T: BytesRepresentable> ToHex for T {
             };
 
             hex::decode(data)
-                .map_err(|_| ParseError)
+                .map_err(|e| ParseError(e.to_string()))
                 .and_then(|bytes| T::try_from(&bytes))
         } else {
-            Err(ParseError)
+            Err(ParseError("invalid hex length".into()))
         }
     }
 }

--- a/crypto/packet/benches/packet_crypto.rs
+++ b/crypto/packet/benches/packet_crypto.rs
@@ -8,6 +8,11 @@ use hopr_primitive_types::prelude::{Address, BytesEncodable};
 const SAMPLE_SIZE: usize = 100_000;
 
 pub fn packet_sending_bench(c: &mut Criterion) {
+    assert!(
+        !hopr_crypto_random::is_rng_fixed(),
+        "RNG must not be fixed for bench tests"
+    );
+
     let chain_key = ChainKeypair::random();
     let destination = Address::new(&hopr_crypto_random::random_bytes::<20>());
 
@@ -35,6 +40,11 @@ pub fn packet_sending_bench(c: &mut Criterion) {
 }
 
 pub fn packet_forwarding_bench(c: &mut Criterion) {
+    assert!(
+        !hopr_crypto_random::is_rng_fixed(),
+        "RNG must not be fixed for bench tests"
+    );
+
     let chain_key = ChainKeypair::random();
     let destination = Address::new(&hopr_crypto_random::random_bytes::<20>());
 
@@ -72,6 +82,11 @@ pub fn packet_forwarding_bench(c: &mut Criterion) {
 }
 
 pub fn packet_receiving_bench(c: &mut Criterion) {
+    assert!(
+        !hopr_crypto_random::is_rng_fixed(),
+        "RNG must not be fixed for bench tests"
+    );
+
     let chain_key = ChainKeypair::random();
     let destination = Address::new(&hopr_crypto_random::random_bytes::<20>());
 

--- a/crypto/packet/src/packet.rs
+++ b/crypto/packet/src/packet.rs
@@ -312,7 +312,7 @@ impl<S: SphinxSuite> TryFrom<&[u8]> for MetaPacket<S> {
                 _s: PhantomData,
             })
         } else {
-            Err(GeneralError::ParseError)
+            Err(GeneralError::ParseError("MetaPacket".into()))
         }
     }
 }

--- a/crypto/packet/src/por.rs
+++ b/crypto/packet/src/por.rs
@@ -81,7 +81,7 @@ impl TryFrom<&[u8]> for ProofOfRelayString {
                 hint: HalfKeyChallenge::new(hint),
             })
         } else {
-            Err(GeneralError::ParseError)
+            Err(GeneralError::ParseError("ProofOfRelayString".into()))
         }
     }
 }

--- a/crypto/types/src/vrf.rs
+++ b/crypto/types/src/vrf.rs
@@ -95,14 +95,14 @@ impl TryFrom<&[u8]> for VrfParameters {
             Ok(VrfParameters {
                 V: CurvePoint::try_from(&value[..CurvePoint::SIZE_COMPRESSED])?,
                 h: k256_scalar_from_bytes(&value[CurvePoint::SIZE_COMPRESSED..CurvePoint::SIZE_COMPRESSED + 32])
-                    .map_err(|_| GeneralError::ParseError)?,
+                    .map_err(|_| GeneralError::ParseError("VrfParameters".into()))?,
                 s: k256_scalar_from_bytes(
                     &value[CurvePoint::SIZE_COMPRESSED + 32..CurvePoint::SIZE_COMPRESSED + 32 + 32],
                 )
-                .map_err(|_| GeneralError::ParseError)?,
+                .map_err(|_| GeneralError::ParseError("VrfParameters".into()))?,
             })
         } else {
-            Err(GeneralError::ParseError)
+            Err(GeneralError::ParseError("VrfParameters".into()))
         }
     }
 }

--- a/hoprd/rest-api/src/types.rs
+++ b/hoprd/rest-api/src/types.rs
@@ -39,11 +39,11 @@ impl FromStr for PeerOrAddress {
         if value.starts_with("0x") {
             Address::from_str(value)
                 .map(PeerOrAddress::from)
-                .map_err(|_e| GeneralError::ParseError)
+                .map_err(|_e| GeneralError::ParseError("PeerOrAddress".into()))
         } else {
             PeerId::from_str(value)
                 .map(PeerOrAddress::from)
-                .map_err(|_e| GeneralError::ParseError)
+                .map_err(|_e| GeneralError::ParseError("PeerOrAddress".into()))
         }
     }
 }

--- a/transport/network/src/messaging.rs
+++ b/transport/network/src/messaging.rs
@@ -91,7 +91,7 @@ impl TryFrom<&[u8]> for PingMessage {
             ret.nonce.copy_from_slice(&value[0..Self::SIZE]);
             Ok(ret)
         } else {
-            Err(hopr_primitive_types::errors::GeneralError::ParseError)
+            Err(GeneralError::ParseError("PingMessage".into()))
         }
     }
 }


### PR DESCRIPTION
Ticket received on the last hop has no value and therefore does not need to be validated. This was causing a backwards compatibility bug, when a 2.1.x version sent an invalid Index Offset on the last ticket anyway.

This fixes backwards compatibility of 2.2 with 2.1.x

Also adds better ParseError traceability.