### PR TITLE
Fix websocket authentication

### DIFF
--- a/SETUP_LOCAL_CLUSTER.md
+++ b/SETUP_LOCAL_CLUSTER.md
@@ -40,7 +40,6 @@ If you want to enable authentication via API token on local cluster, run:
 HOPRD_DISABLE_API_AUTHENTICATION=0 ./scripts/setup-local-cluster.sh -i topologies/full_interconnected_cluster.sh
 ```
 
-
 **Important**, make sure to have both `curl` and `jq` installed in your computer before running the script, as both are used.
 Please be aware you also need a version of `bash` of `5.x` or superior, which in most macOS devices require an upgrade, the easiest being via `brew bash`.
 

--- a/SETUP_LOCAL_CLUSTER.md
+++ b/SETUP_LOCAL_CLUSTER.md
@@ -34,6 +34,13 @@ make -j deps && make -j build
 ./scripts/setup-local-cluster.sh -i topologies/full_interconnected_cluster.sh
 ```
 
+If you want to enable authentication via API token on local cluster, run:
+
+```
+HOPRD_DISABLE_API_AUTHENTICATION=0 ./scripts/setup-local-cluster.sh -i topologies/full_interconnected_cluster.sh
+```
+
+
 **Important**, make sure to have both `curl` and `jq` installed in your computer before running the script, as both are used.
 Please be aware you also need a version of `bash` of `5.x` or superior, which in most macOS devices require an upgrade, the easiest being via `brew bash`.
 

--- a/hoprd/rest-api/src/preconditions.rs
+++ b/hoprd/rest-api/src/preconditions.rs
@@ -41,9 +41,15 @@ pub(crate) async fn authenticate(
                 || uri.path().starts_with("/api/v3/session/websocket")
             {
                 uri.query()
-                    .map(|q| match decode(q) {
-                        Ok(decoded) => decoded.into_owned().contains(&format!("apiToken={}", expected_token)),
-                        Err(_) => false,
+                    .map(|q| {
+                        // Reasonable limit for query string
+                        if q.len() > 2048 {
+                            return false;
+                        }
+                        match decode(q) {
+                            Ok(decoded) => decoded.into_owned().contains(&format!("apiToken={}", expected_token)),
+                            Err(_) => false,
+                        }
                     })
                     .unwrap_or(false)
             } else {

--- a/hoprd/rest-api/src/preconditions.rs
+++ b/hoprd/rest-api/src/preconditions.rs
@@ -43,7 +43,7 @@ pub(crate) async fn authenticate(
                 uri.query()
                     .map(|q| match decode(q) {
                         Ok(decoded) => decoded.into_owned().contains(&format!("apiToken={}", expected_token)),
-                        Err(x) => false,
+                        Err(_) => false,
                     })
                     .unwrap_or(false)
             } else {

--- a/hoprd/rest-api/src/preconditions.rs
+++ b/hoprd/rest-api/src/preconditions.rs
@@ -9,6 +9,7 @@ use axum::{
     response::IntoResponse,
 };
 use std::str::FromStr;
+use urlencoding::decode;
 
 use crate::{ApiErrorStatus, Auth, InternalState};
 
@@ -36,14 +37,18 @@ pub(crate) async fn authenticate(
                 .collect::<Vec<_>>();
 
             // We have multiple websocket routes that need authentication checks
-            let is_ws_auth =
-                if uri.path().starts_with("/messages/websocket") || uri.path().starts_with("/session/websocket") {
-                    uri.query()
-                        .unwrap_or("")
-                        .contains(&format!("apiToken={}", expected_token))
-                } else {
-                    false
-                };
+            let is_ws_auth = if uri.path().starts_with("/api/v3/messages/websocket")
+                || uri.path().starts_with("/api/v3/session/websocket")
+            {
+                uri.query()
+                    .map(|q| match decode(q) {
+                        Ok(decoded) => decoded.into_owned().contains(&format!("apiToken={}", expected_token)),
+                        Err(x) => false,
+                    })
+                    .unwrap_or(false)
+            } else {
+                false
+            };
             // Use "Authorization Bearer <token>" and "X-Auth-Token <token>" headers and "Sec-Websocket-Protocol"
             (!auth_headers.is_empty()
                     && (auth_headers.contains(&(&AUTHORIZATION, &format!("Bearer {}", expected_token)))

--- a/scripts/setup-local-cluster.sh
+++ b/scripts/setup-local-cluster.sh
@@ -162,6 +162,7 @@ function setup_node() {
       --api \
       --apiHost "${host}" \
       --apiPort "${api_port}" \
+      --apiToken "${api_token}" \
       --testAnnounceLocalAddresses \
       --testPreferLocalAddresses \
       --protocolConfig ${protocol_config} \

--- a/scripts/setup-local-cluster.sh
+++ b/scripts/setup-local-cluster.sh
@@ -147,6 +147,11 @@ function setup_node() {
 
   log "Additional args: \"${additional_args}\""
 
+  # we can only provide apiToken param if we want authentication
+  local api_token_param=""
+  if [[ "${HOPRD_DISABLE_API_AUTHENTICATION:-1}" == 0 ]]; then
+      api_token_param="--apiToken ${api_token}"
+  fi
   env \
     TOKIO_CONSOLE_BIND=localhost:$((api_port + 100)) \
     RUST_LOG="debug,libp2p_mplex=info,multistream_select=info,isahc=error,sea_orm=warn,sqlx=warn,hyper_util=warn,libp2p_tcp=info,libp2p_dns=info" \
@@ -162,7 +167,7 @@ function setup_node() {
       --api \
       --apiHost "${host}" \
       --apiPort "${api_port}" \
-      --apiToken "${api_token}" \
+      "${api_token_param}" \
       --testAnnounceLocalAddresses \
       --testPreferLocalAddresses \
       --protocolConfig ${protocol_config} \

--- a/scripts/setup-local-cluster.sh
+++ b/scripts/setup-local-cluster.sh
@@ -148,9 +148,9 @@ function setup_node() {
   log "Additional args: \"${additional_args}\""
 
   # we can only provide apiToken param if we want authentication
-  local api_token_param=""
+  local api_token_params="--api"
   if [[ "${HOPRD_DISABLE_API_AUTHENTICATION:-1}" == 0 ]]; then
-      api_token_param="--apiToken ${api_token}"
+      api_token_params="${api_token_params} --apiToken ${api_token}"
   fi
   env \
     TOKIO_CONSOLE_BIND=localhost:$((api_port + 100)) \
@@ -164,10 +164,9 @@ function setup_node() {
       --identity="${id_file}" \
       --init \
       --password="${password}" \
-      --api \
+      "${api_token_params}" \
       --apiHost "${host}" \
       --apiPort "${api_port}" \
-      "${api_token_param}" \
       --testAnnounceLocalAddresses \
       --testPreferLocalAddresses \
       --protocolConfig ${protocol_config} \

--- a/scripts/setup-local-cluster.sh
+++ b/scripts/setup-local-cluster.sh
@@ -151,9 +151,9 @@ function setup_node() {
     TOKIO_CONSOLE_BIND=localhost:$((api_port + 100)) \
     RUST_LOG="debug,libp2p_mplex=info,multistream_select=info,isahc=error,sea_orm=warn,sqlx=warn,hyper_util=warn,libp2p_tcp=info,libp2p_dns=info" \
     RUST_BACKTRACE=1 \
+    HOPRD_DISABLE_API_AUTHENTICATION="${HOPRD_DISABLE_API_AUTHENTICATION:-1}" \
     ${hoprd_command} \
       --announce \
-      --disableApiAuthentication \
       --data="${dir}" \
       --host="${host}:${p2p_port}" \
       --identity="${id_file}" \


### PR DESCRIPTION
- websocket authentication needed to decode the URI string to compare against a valid token
- allow local cluster with api authentication as documented in [SETUP_LOCAL_CLUSTER.md](https://github.com/hoprnet/hoprnet/compare/este/clusterAuth?expand=1#diff-7bc89c354a4ac2167f5c0942d569c5383711a4c492d4fecb9be030c848bcf299)