### PR TITLE
Fix TagBloomFilter behavior after updating the crate to 2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4251,6 +4251,7 @@ dependencies = [
  "bindings",
  "bloomfilter",
  "cbor4ii",
+ "criterion",
  "ethers",
  "hex-literal",
  "hopr-crypto-random",

--- a/common/internal-types/Cargo.toml
+++ b/common/internal-types/Cargo.toml
@@ -36,6 +36,7 @@ hopr-primitive-types = { workspace = true }
 anyhow = { workspace = true }
 async-std = { workspace = true }
 bincode = { workspace = true }
+criterion = { workspace = true }
 cbor4ii = { version = "0.3.2", features = ["serde1", "use_std"] }
 lazy_static = { workspace = true }
 rand = { workspace = true }
@@ -43,3 +44,7 @@ rayon = { workspace = true }
 
 [features]
 default = []
+
+[[bench]]
+name = "bloom_filter"
+harness = false

--- a/common/internal-types/benches/bloom_filter.rs
+++ b/common/internal-types/benches/bloom_filter.rs
@@ -1,15 +1,19 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use hopr_crypto_types::types::PACKET_TAG_LENGTH;
 use hopr_internal_types::prelude::TagBloomFilter;
 
 fn tag_bloom_filter_bench(c: &mut Criterion) {
     // Fill up the Bloom filter first
     let mut bloom = TagBloomFilter::default();
     for _ in 1..bloom.capacity() {
-        bloom.set(&hopr_crypto_random::random_bytes());
+        let mut tag = hopr_crypto_random::random_bytes();
+        tag[0] = 0xaa;
+        bloom.set(&tag);
     }
 
-    let tag = hopr_crypto_random::random_bytes();
-    bloom.set(&tag);
+    let mut existing_tag = hopr_crypto_random::random_bytes();
+    existing_tag[0] = 0xaa;
+    bloom.set(&existing_tag);
 
     let mut group = c.benchmark_group("tag_bloom_filter");
     group.sample_size(100_000);
@@ -17,7 +21,14 @@ fn tag_bloom_filter_bench(c: &mut Criterion) {
 
     group.bench_function("check", |b| {
         b.iter(|| {
-            bloom.check(black_box(&tag));
+            bloom.check(black_box(&existing_tag));
+        })
+    });
+
+    let non_existent_tag = [0u8; PACKET_TAG_LENGTH];
+    group.bench_function("check_non_existent", |b| {
+        b.iter(|| {
+            bloom.check(black_box(&non_existent_tag));
         })
     });
 }

--- a/common/internal-types/benches/bloom_filter.rs
+++ b/common/internal-types/benches/bloom_filter.rs
@@ -1,0 +1,26 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion, Throughput};
+use hopr_internal_types::prelude::TagBloomFilter;
+
+fn tag_bloom_filter_bench(c: &mut Criterion) {
+    // Fill up the Bloom filter first
+    let mut bloom = TagBloomFilter::default();
+    for _ in 1..bloom.capacity() {
+        bloom.set(&hopr_crypto_random::random_bytes());
+    }
+
+    let tag = hopr_crypto_random::random_bytes();
+    bloom.set(&tag);
+
+    let mut group = c.benchmark_group("tag_bloom_filter");
+    group.sample_size(100_000);
+    group.throughput(Throughput::Elements(1));
+
+    group.bench_function("check", |b| {
+        b.iter(|| {
+            bloom.check(black_box(&tag));
+        })
+    });
+}
+
+criterion_group!(benches, tag_bloom_filter_bench);
+criterion_main!(benches);

--- a/common/internal-types/src/protocol.rs
+++ b/common/internal-types/src/protocol.rs
@@ -97,24 +97,29 @@ pub enum PendingAcknowledgement {
 pub struct TagBloomFilter {
     bloom: Bloom<PacketTag>,
     count: usize,
+    capacity: usize,
 }
 
 impl TagBloomFilter {
-    // Allowed false positive rate. This amounts to 0.01% chance
-    const FALSE_POSITIVE_RATE: f64 = 0.0001_f64;
+    // Allowed false positive rate. This amounts to 0.001% chance
+    const FALSE_POSITIVE_RATE: f64 = 0.00001_f64;
 
-    // Maximum number of packet tags this Bloom filter can hold.
-    // After this many packets, the Bloom filter resets and packet replays are possible.
-    const MAX_ITEMS: usize = 10_000_000;
+    // The default maximum number of packet tags this Bloom filter can hold.
+    // After these many packets, the Bloom filter resets and packet replays are possible.
+    const DEFAULT_MAX_ITEMS: usize = 10_000_000;
 
     /// Returns the current number of items in this Bloom filter.
     pub fn count(&self) -> usize {
         self.count
     }
 
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
     /// Puts a packet tag into the Bloom filter
     pub fn set(&mut self, tag: &PacketTag) {
-        if self.count == Self::MAX_ITEMS {
+        if self.count == self.capacity {
             warn!("maximum number of items in the Bloom filter reached!");
             self.bloom.clear();
             self.count = 0;
@@ -124,7 +129,7 @@ impl TagBloomFilter {
         self.count += 1;
     }
 
-    /// Check if packet tag is in the Bloom filter.
+    /// Check if the packet tag is in the Bloom filter.
     /// False positives are possible.
     pub fn check(&self, tag: &PacketTag) -> bool {
         self.bloom.check(tag)
@@ -132,31 +137,53 @@ impl TagBloomFilter {
 
     /// Checks and sets a packet tag (if not present) in a single operation.
     pub fn check_and_set(&mut self, tag: &PacketTag) -> bool {
-        if self.bloom.check_and_set(tag) {
-            self.count += 1;
-            true
+        // If we're at full capacity, we do only "check" and conditionally reset with the new entry
+        if self.count == self.capacity {
+            if !self.bloom.check(tag) {
+                // There cannot be false negatives, so we can reset the filter
+                warn!("maximum number of items in the Bloom filter reached!");
+                self.bloom.clear();
+                self.bloom.set(tag);
+                self.count = 1;
+                false
+            } else {
+                true
+            }
         } else {
-            false
+            // If not at full capacity, we can do check_and_set
+            if self.bloom.check_and_set(tag) {
+                true
+            } else {
+                self.count += 1;
+                false
+            }
         }
     }
 
+    /// Deserializes the filter from the given byte array.
     pub fn from_bytes(data: &[u8]) -> Result<Self> {
         bincode::deserialize(data).map_err(|e| CoreTypesError::ParseError(e.to_string()))
     }
 
+    /// Serializes the filter to the given byte array.
     pub fn to_bytes(&self) -> Box<[u8]> {
         bincode::serialize(&self)
             .expect("serialization must not fail")
             .into_boxed_slice()
     }
+
+    fn with_capacity(size: usize) -> Self {
+        Self {
+            bloom: Bloom::new_for_fp_rate_with_seed(size, Self::FALSE_POSITIVE_RATE, &random_bytes()),
+            count: 0,
+            capacity: size,
+        }
+    }
 }
 
 impl Default for TagBloomFilter {
     fn default() -> Self {
-        Self {
-            bloom: Bloom::new_for_fp_rate_with_seed(Self::MAX_ITEMS, Self::FALSE_POSITIVE_RATE, &random_bytes()),
-            count: 0,
-        }
+        Self::with_capacity(Self::DEFAULT_MAX_ITEMS)
     }
 }
 
@@ -275,12 +302,12 @@ mod tests {
 
         //let len = filter1.to_bytes().len();
 
-        // Count number of items in the BF (incl. false positives)
+        // Count the number of items in the BF (incl. false positives)
         let match_count_1 = items.iter().filter(|item| filter1.check(item)).count();
 
         let filter2 = TagBloomFilter::from_bytes(&filter1.to_bytes())?;
 
-        // Count number of items in the BF (incl. false positives)
+        // Count the number of items in the BF (incl. false positives)
         let match_count_2 = items.iter().filter(|item| filter2.check(item)).count();
 
         assert_eq!(
@@ -290,15 +317,53 @@ mod tests {
         assert_eq!(filter1.count(), filter2.count(), "the number of items must be equal");
 
         // All zeroes must not be present in neither BF, we ensured we never insert a zero tag
-        assert!(
-            !filter1.check(&[0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8]),
-            "bf 1 must not contain zero tag"
-        );
-        assert!(
-            !filter2.check(&[0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8]),
-            "bf 2 must not contain zero tag"
-        );
+        assert!(!filter1.check(&[0u8; 16]), "bf 1 must not contain zero tag");
+        assert!(!filter2.check(&[0u8; 16]), "bf 2 must not contain zero tag");
 
         Ok(())
+    }
+
+    #[test]
+    fn tag_bloom_filter_count() {
+        let mut filter = TagBloomFilter::default();
+        assert!(!filter.check_and_set(&[0u8; 16]));
+        assert_eq!(1, filter.count());
+
+        assert!(filter.check_and_set(&[0u8; 16]));
+        assert_eq!(1, filter.count());
+
+        assert!(!filter.check_and_set(&[1u8; 16]));
+        assert_eq!(2, filter.count());
+
+        assert!(filter.check_and_set(&[1u8; 16]));
+        assert_eq!(2, filter.count());
+    }
+
+    #[test]
+    fn tag_bloom_filter_wrap_around() {
+        let mut filter = TagBloomFilter::with_capacity(1000);
+        for _ in 1..filter.capacity() {
+            let mut tag: PacketTag = hopr_crypto_random::random_bytes();
+            tag[0] = 0xaa; // ensure it's not all zeroes
+            assert!(!filter.check_and_set(&tag));
+        }
+        // Not yet at full capacity
+        assert_eq!(filter.capacity() - 1, filter.count());
+
+        // This entry is not there yet
+        assert!(!filter.check_and_set(&[0u8; 16]));
+
+        // Now the filter is at capacity and contains the previously inserted entry
+        assert_eq!(filter.capacity(), filter.count());
+        assert!(filter.check(&[0u8; 16]));
+
+        // This will not clear out the filter, since the entry is there
+        assert!(filter.check_and_set(&[0u8; 16]));
+        assert_eq!(filter.capacity(), filter.count());
+
+        // This will clear out the filter, since this other entry is definitely not there
+        assert!(!filter.check_and_set(&[1u8; 16]));
+        assert_eq!(1, filter.count());
+        assert!(filter.check(&[1u8; 16]));
     }
 }


### PR DESCRIPTION
The `Bloom` filter no longer behaves as a ring buffer after the update to 2.0

This fact has been addressed in the `TagBloomFilter` wrapper, which makes sure that the count of the entries in the filter is correctly tracked.

Also, the false-positive rate decreased to 0.001%
and the capacity is kept at 10M replay tags.

Unit tests have been added to correctly test the new required behavior.

Benchmark was added for Bloom filter performance measurements