### PR TITLE
Replace `ReaderStream` with `AsyncStreamReader` in WS Session handler

### DIFF
--- a/common/network-types/src/session/state.rs
+++ b/common/network-types/src/session/state.rs
@@ -113,7 +113,8 @@ use crate::prelude::protocol::SessionMessageIter;
 use crate::session::errors::SessionError;
 use crate::session::frame::{segment, FrameId, FrameReassembler, Segment, SegmentId};
 use crate::session::protocol::{FrameAcknowledgements, SegmentRequest, SessionMessage};
-use crate::session::utils::{AsyncReadStreamer, RetryResult, RetryToken};
+use crate::session::utils::{RetryResult, RetryToken};
+use crate::utils::AsyncReadStreamer;
 
 #[cfg(all(feature = "prometheus", not(test)))]
 lazy_static::lazy_static! {
@@ -962,7 +963,7 @@ impl<const C: usize> SessionSocket<C> {
 
         // Segment ingress from downstream
         spawn(
-            AsyncReadStreamer::<_, C>::new(downstream_read)
+            AsyncReadStreamer::<C, _>(downstream_read)
                 .map_err(|e| NetworkTypeError::SessionProtocolError(SessionError::ProcessingError(e.to_string())))
                 .and_then(|m| futures::future::ok(futures::stream::iter(SessionMessageIter::from(m.into_vec()))))
                 .try_flatten()

--- a/common/network-types/src/session/utils.rs
+++ b/common/network-types/src/session/utils.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 use futures::channel::mpsc::UnboundedSender;
 use futures::stream::BoxStream;
-use futures::{AsyncRead, AsyncWrite, Stream, StreamExt};
+use futures::{AsyncRead, AsyncWrite, StreamExt};
 use rand::distributions::Bernoulli;
 use rand::prelude::{thread_rng, Distribution, Rng, SeedableRng, StdRng};
 
@@ -75,39 +75,6 @@ impl RetryToken {
 
     pub fn time_since_creation(&self) -> Duration {
         self.created_at.elapsed()
-    }
-}
-
-/// Converts a [`AsyncRead`] into [`Stream`] by reading at most `S` bytes
-/// in each call to [`Stream::poll_next`].
-pub(crate) struct AsyncReadStreamer<R: AsyncRead + Unpin, const S: usize>(R);
-
-impl<R: AsyncRead + Unpin, const S: usize> AsyncReadStreamer<R, S> {
-    pub fn new(reader: R) -> Self {
-        Self(reader)
-    }
-}
-
-impl<R: AsyncRead + Unpin, const S: usize> Stream for AsyncReadStreamer<R, S> {
-    type Item = std::io::Result<Box<[u8]>>;
-
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let mut buffer = vec![0u8; S];
-
-        match Pin::new(&mut self.0).poll_read(cx, &mut buffer) {
-            Poll::Ready(result) => match result {
-                Ok(size) => {
-                    if size == 0 {
-                        Poll::Ready(None)
-                    } else {
-                        buffer.truncate(size);
-                        Poll::Ready(Some(Ok(buffer.into_boxed_slice())))
-                    }
-                }
-                Err(err) => Poll::Ready(Some(Err(err))),
-            },
-            Poll::Pending => Poll::Pending,
-        }
     }
 }
 
@@ -235,7 +202,6 @@ impl<const C: usize> FaultyNetwork<'_, C> {
 mod tests {
     use super::*;
     use futures::io::{AsyncReadExt, AsyncWriteExt};
-    use futures::TryStreamExt;
     use std::future::Future;
 
     fn spawn_single_byte_read_write<C>(
@@ -272,58 +238,6 @@ mod tests {
         });
 
         (read, written)
-    }
-
-    #[async_std::test]
-    async fn test_async_read_streamer_complete_chunk() {
-        let data = b"Hello, World!!";
-        let mut streamer = AsyncReadStreamer::<_, 14>::new(&data[..]);
-        let mut results = Vec::new();
-
-        while let Some(res) = streamer.try_next().await.unwrap() {
-            results.push(res);
-        }
-
-        assert_eq!(results, vec![Box::from(*data)]);
-    }
-
-    #[async_std::test]
-    async fn test_async_read_streamer_complete_more_chunks() {
-        let data = b"Hello, World and do it twice";
-        let mut streamer = AsyncReadStreamer::<_, 14>::new(&data[..]);
-        let mut results = Vec::new();
-
-        while let Some(res) = streamer.try_next().await.unwrap() {
-            results.push(res);
-        }
-
-        let (data1, data2) = data.split_at(14);
-        assert_eq!(results, vec![Box::from(data1), Box::from(data2)]);
-    }
-
-    #[async_std::test]
-    async fn test_async_read_streamer_complete_more_chunks_with_incomplete() -> anyhow::Result<()> {
-        let data = b"Hello, World and do it twice, ...";
-        let streamer = AsyncReadStreamer::<_, 14>::new(&data[..]);
-
-        let results = streamer.try_collect::<Vec<_>>().await?;
-
-        let (data1, rest) = data.split_at(14);
-        let (data2, data3) = rest.split_at(14);
-        assert_eq!(results, vec![Box::from(data1), Box::from(data2), Box::from(data3)]);
-
-        Ok(())
-    }
-
-    #[async_std::test]
-    async fn test_async_read_streamer_incomplete_chunk() -> anyhow::Result<()> {
-        let data = b"Hello, World!!";
-        let reader = &data[0..8]; // An incomplete chunk
-        let mut streamer = AsyncReadStreamer::<_, 14>::new(reader);
-
-        assert_eq!(Some(Box::from(reader)), streamer.try_next().await?);
-
-        Ok(())
     }
 
     #[async_std::test]


### PR DESCRIPTION
The `ReaderStream` has slightly different semantics of buffering data, and that led to data being incorrectly chunked into WS messages.

This has been replaced with `AsyncReadStreamer` which is a fairly simple converter from `AsyncRead` instance into the `Stream` of chunks - by always reading most up to the given number of bytes or waiting if there's nothing to read yet.

This has already been previously used inside the Session and is tested.

Small refactorings have been also made in this PR.