### PR TITLE
Properly remove Session from the list when it terminates spontaneously

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,7 +4331,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-network-types"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4564,7 +4564,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4648,7 +4648,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd-api"
-version = "3.6.0"
+version = "3.6.1"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/common/network-types/Cargo.toml
+++ b/common/network-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-network-types"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Contains types used for networking over the HOPR protocol"
 edition = "2021"

--- a/hoprd/rest-api/Cargo.toml
+++ b/hoprd/rest-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd-api"
-version = "3.6.0"
+version = "3.6.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "This Rest API enables developers to interact with a hoprd node programatically through HTTP."

--- a/transport/session/Cargo.toml
+++ b/transport/session/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-session"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Session functionality providing session abstraction over the HOPR transport"


### PR DESCRIPTION
When UDP-based Session goes idle or is closed by the other side, it should be correctly removed from the Session list.

Also added some cosmetic code improvements.