### PR TITLE
Fix bugs in log processing and fast-sync

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "chain-indexer"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -4202,7 +4202,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-db-sql"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-lock 3.4.0",

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-indexer"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Core-Ethereum-specific interaction with the backend database"

--- a/chain/indexer/src/block.rs
+++ b/chain/indexer/src/block.rs
@@ -140,7 +140,7 @@ where
         //   1. Delete the existing indexed data
         //   2. Reset fast sync progress
         //   3. Run the fast sync process until completion
-        //   4. Finally starting the rpc indexer.
+        //   4. Finally, starting the rpc indexer.
         let fast_sync_configured = self.cfg.fast_sync;
         let index_empty = self.db.index_is_empty().await?;
 
@@ -158,7 +158,8 @@ where
                 self.db.set_logs_unprocessed(None, None).await?;
 
                 // Now fast-sync can start
-                while let Some(block_number) = self.db.get_logs_block_numbers(None, None).await?.next().await {
+                let mut stream = self.db.get_logs_block_numbers(None, None).await?;
+                while let Some(block_number) = stream.next().await {
                     Self::process_block_by_id(&db, &logs_handler, block_number).await?;
                 }
             }
@@ -309,7 +310,8 @@ where
                 block.logs.insert(log);
             } else {
                 error!(
-                    expected = block_id, actual = log.block_number,
+                    expected = block_id,
+                    actual = log.block_number,
                     "block number mismatch in logs stream"
                 )
             }

--- a/chain/indexer/src/handlers.rs
+++ b/chain/indexer/src/handlers.rs
@@ -267,8 +267,9 @@ where
                     // Check that we're not receiving the Open event without the channel being Close prior
                     if channel_edits.entry().status != ChannelStatus::Closed {
                         return Err(CoreEthereumIndexerError::ProcessError(format!(
-                            "trying to re-open channel {} which is not closed",
-                            channel_edits.entry().get_id()
+                            "trying to re-open channel {} which is not closed, but {}",
+                            channel_edits.entry().get_id(),
+                            channel_edits.entry().status,
                         )));
                     }
 

--- a/chain/indexer/src/lib.rs
+++ b/chain/indexer/src/lib.rs
@@ -7,7 +7,7 @@
 //!
 //! The processing itself transforms the on-chain data into hoprd specific data, while also
 //! triggering specific actions for each event, ensuring finality, storing the data in the
-//! local storage and further reactively triggering higher level components of the business
+//! local storage, and further reactively triggering higher level components of the business
 //! logic.
 
 pub mod block;

--- a/db/sql/Cargo.toml
+++ b/db/sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-db-sql"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2021"
 description = "Contains SQL DB functionality implementing the DB API traits to be used by other crates in the code base"
 homepage = "https://hoprnet.org/"


### PR DESCRIPTION
This PR fixes multiple bugs found in the Indexing code so far:

1. The error handling in `collect_block_events` method was causing an early termination of log processing within the block if an error was encountered. This resulted in the remaining logs in the given block to be unprocessed. This also currently affects all 2.1.x versions and is **`the most likely cause of diverging Indexer checksums and rejected tickets`**.

2. invalid querying of the block number stream in Fast-Sync (https://github.com/hoprnet/hoprnet/blob/bf696e4ad2e537d1e084d6f0360e0992b1eef50d/chain/indexer/src/block.rs#L161) results in an infinite loop. It didn't cause an infinite loop before due to side-effects of the bug 1)

3. when Fast-Sync determines if the Indexer DB is empty, it incorrectly accounted node's own AccountEntry which should be always even in an empty Indexer DB.

4. when Fast-Sync clears up the Indexer DB, it incorrectly removes prime rows in NodeInfo and ChainInfo tables, which results in Fast-Sync failure. This was also the cause of #6638 and was not immediately visible until 1) was fixed.

Closes #6638
Closes #6639