### PR TITLE
Fix Fast-Sync CLI parameters and behavior when full re-sync is required

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "chain-indexer"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-indexer"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Core-Ethereum-specific interaction with the backend database"

--- a/chain/indexer/src/block.rs
+++ b/chain/indexer/src/block.rs
@@ -827,9 +827,13 @@ mod tests {
         let mut handlers = MockChainLogHandler::new();
         handlers.expect_contract_addresses().return_const(vec![]);
 
+        let indexer_cfg = IndexerConfig {
+            start_block_number: 0,
+            fast_sync: false,
+        };
+
         let (tx_events, _) = async_channel::unbounded();
-        let mut indexer =
-            Indexer::new(rpc, handlers, db.clone(), IndexerConfig::default(), tx_events).without_panic_on_completion();
+        let mut indexer = Indexer::new(rpc, handlers, db.clone(), indexer_cfg, tx_events).without_panic_on_completion();
         indexer.start().await?;
 
         Ok(())

--- a/chain/indexer/src/block.rs
+++ b/chain/indexer/src/block.rs
@@ -148,8 +148,14 @@ where
             (true, false) => {
                 warn!("Fast sync is enabled, but the index database is not empty. In order to use fast-sync again you must stop this node and remove the index database manually.");
             }
-            (false, _) => {
-                info!("Fast sync is disabled");
+            (false, true) => {
+                info!("Fast sync is disabled, but the index database is empty. Doing a full re-sync.");
+                // Clean the last processed log from the Log DB, to allow full resync
+                self.db.clear_index_db(None).await?;
+                self.db.set_logs_unprocessed(None, None).await?;
+            }
+            (false, false) => {
+                info!("Fast sync is disabled and the index database is not empty. Continuing normal sync.")
             }
             (true, true) => {
                 info!("Fast sync is enabled, starting the fast sync process");

--- a/chain/indexer/src/config.rs
+++ b/chain/indexer/src/config.rs
@@ -14,6 +14,9 @@ pub struct IndexerConfig {
 
     /// Whether to use fast synchronization during indexing.
     /// When enabled, it allows for quicker indexing of existing logs during node startup.
+    ///
+    /// Default is `true`.
+    #[default(true)]
     pub fast_sync: bool,
 }
 

--- a/hoprd/hoprd/src/cli.rs
+++ b/hoprd/hoprd/src/cli.rs
@@ -150,7 +150,7 @@ pub struct CliArgs {
         help = "Disables checking of unrealized balance before validating unacknowledged tickets.",
         action = ArgAction::Count
     )]
-    pub check_unrealized_balance: u8,
+    pub no_check_unrealized_balance: u8,
 
     #[arg(
         long = "noKeepLogs",

--- a/hoprd/hoprd/src/config.rs
+++ b/hoprd/hoprd/src/config.rs
@@ -263,23 +263,19 @@ impl HoprdConfig {
         }
 
         if let Some(x) = cli_args.max_block_range {
-            // Override all max_block_range setting in all networks
+            // Override all max_block_range settings in all networks
             for (_, n) in cfg.hopr.chain.protocols.networks.iter_mut() {
                 n.max_block_range = x;
             }
         }
 
-        if cli_args.check_unrealized_balance == 0 {
-            cfg.hopr.chain.check_unrealized_balance = true;
-        }
+        // The --no*/--disable* CLI flags are Count-based, therefore, if they equal to 0,
+        // it means they have not been specified on the CLI and thus the
+        // corresponding config value should be enabled.
 
-        if cli_args.no_fast_sync == 0 {
-            cfg.hopr.chain.fast_sync = false;
-        }
-
-        if cli_args.no_keep_logs == 0 {
-            cfg.hopr.chain.keep_logs = false;
-        }
+        cfg.hopr.chain.check_unrealized_balance = cli_args.no_check_unrealized_balance == 0;
+        cfg.hopr.chain.fast_sync = cli_args.no_fast_sync == 0;
+        cfg.hopr.chain.keep_logs = cli_args.no_keep_logs == 0;
 
         // safe module
         if let Some(x) = cli_args.safe_transaction_service_provider {


### PR DESCRIPTION
This PR fixes the following two issues:

1. When `hopr_logs.db` is present, the Index DB is empty, but Fast-Sync is disabled, the node should sync fully from the RPC. However, it was mistakenly using the last processed block from the `hopr_logs.db`

2. The CLI parameters where incorrectly parsed: the `--noXYY` or `--disableXYZ` CLI args are count-based, and therefore the corresponding config feature should be enabled when these CLI args are equal to 0.