### PR TITLE
nix: Add patchelf step to cross-builds

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -27,10 +27,6 @@ on:
       target:
         required: true
         type: string
-      interpreter:
-        required: false
-        type: string
-        default: ''
 concurrency:
   group: ${{ github.ref }}-build-binary-${{ inputs.binary }}-${{ inputs.target }}
   cancel-in-progress: true
@@ -60,23 +56,11 @@ jobs:
         env:
           USER: runner
 
-      - name: Build ${{ inputs.binary }} binary
+      - name: Build ${{ inputs.binary }} binaries
         run: nix build .#${{inputs.binary}}${{ inputs.package_suffix }} -L
 
-      - name: Patch ${{ inputs.binary }} binary
-        if: ${{ inputs.interpreter != '' }}
-        run: nix-shell -I "nixpkgs=https://github.com/NixOS/nixpkgs/archive/refs/heads/nixos-24.05-small.zip" -p patchelf --command "patchelf --set-interpreter ${{ inputs.interpreter }} --output ${{ inputs.binary }}-patched ./result/bin/${{ inputs.binary }}"
-
-      - name: Upload ${{ inputs.binary }} binary
+      - name: Upload ${{ inputs.binary }} binaries
         uses: actions/upload-artifact@v4
-        if: ${{ inputs.interpreter == '' }}
         with:
           name: ${{ inputs.binary }}-${{ inputs.target }}
-          path: ${{ github.workspace }}/result/bin/${{ inputs.binary }}
-
-      - name: Upload ${{ inputs.binary }} patched binary
-        uses: actions/upload-artifact@v4
-        if: ${{ inputs.interpreter != '' }}
-        with:
-          name: ${{ inputs.binary }}-${{ inputs.target }}
-          path: ${{ github.workspace }}/${{ inputs.binary }}-patched
+          path: ${{ github.workspace }}/result/bin/*

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -57,12 +57,10 @@ jobs:
             package_suffix: -x86_64-linux
             runner: self-hosted-hoprnet-bigger
             runner_needs_nix_setup: false
-            interpreter: /lib64/ld-linux-x86-64.so.2
           - name: aarch64-linux
             package_suffix: -aarch64-linux
             runner: self-hosted-hoprnet-bigger
             runner_needs_nix_setup: false
-            interpreter: /lib64/ld-linux-aarch64.so.1
           - name: aarch64-darwin
             runner: macos-14 # M1 machine
           - name: x86_64-darwin
@@ -71,7 +69,6 @@ jobs:
             package_suffix: -armv7l-linux
             runner: self-hosted-hoprnet-bigger
             runner_needs_nix_setup: false
-            interpreter: /lib/ld-linux-armhf.so.3
     name: ${{ matrix.binary }}-${{ matrix.target.name }}
     uses: ./.github/workflows/build-binaries.yaml
     with:
@@ -80,7 +77,6 @@ jobs:
       target: ${{ matrix.target.name }}
       package_suffix: ${{ matrix.target.package_suffix }}
       runner: ${{ matrix.target.runner }}
-      interpreter: ${{ matrix.target.interpreter }}
     secrets: inherit
 
   label:

--- a/flake.nix
+++ b/flake.nix
@@ -36,6 +36,7 @@
       ];
       perSystem = { config, lib, self', inputs', system, ... }:
         let
+          rev = toString (self.shortRev or self.dirtyShortRev);
           fs = lib.fileset;
           localSystem = system;
           overlays = [ (import rust-overlay) foundry.overlay solc.overlay ];
@@ -118,7 +119,7 @@
           };
 
           hoprdBuildArgs = {
-            inherit src depsSrc;
+            inherit src depsSrc rev;
             cargoExtraArgs = "-p hoprd-api";
             cargoToml = ./hoprd/hoprd/Cargo.toml;
           };
@@ -147,7 +148,7 @@
           });
 
           hopliBuildArgs = {
-            inherit src depsSrc;
+            inherit src depsSrc rev;
             cargoToml = ./hopli/Cargo.toml;
             postInstall = ''
               mkdir -p $out/ethereum/contracts

--- a/hoprd/hoprd/build.rs
+++ b/hoprd/hoprd/build.rs
@@ -3,6 +3,10 @@ use vergen_gix::{Emitter, GixBuilder};
 
 pub fn main() -> Result<()> {
     // Adds a short SHA hash of the commit as `VERGEN_GIT_SHA` env variable
-    let git = GixBuilder::default().sha(true).build()?;
-    Emitter::default().add_instructions(&git)?.emit()
+    if let Err(_) = std::env::var("VERGEN_GIT_SHA") {
+        let git = GixBuilder::default().sha(true).build()?;
+        Emitter::default().add_instructions(&git)?.emit()
+    } else {
+        Ok(())
+    }
 }

--- a/hoprd/hoprd/build.rs
+++ b/hoprd/hoprd/build.rs
@@ -3,7 +3,7 @@ use vergen_gix::{Emitter, GixBuilder};
 
 pub fn main() -> Result<()> {
     // Adds a short SHA hash of the commit as `VERGEN_GIT_SHA` env variable
-    if let Err(_) = std::env::var("VERGEN_GIT_SHA") {
+    if std::env::var("VERGEN_GIT_SHA").is_err() {
         let git = GixBuilder::default().sha(true).build()?;
         Emitter::default().add_instructions(&git)?.emit()
     } else {


### PR DESCRIPTION
This ensures users who build cross-platform binaries don't have to perform the `patchelf` step separately. Also the Github actions are simplified that way.