### PR TITLE
Return backwards compatible configuration with 2.1.x versions

### DIFF
--- a/hoprd/hoprd/example_cfg.yaml
+++ b/hoprd/hoprd/example_cfg.yaml
@@ -209,7 +209,7 @@ hopr:
     # Size of the quality moving average window.
     quality_avg_window_size: 25
     # Indicates how long (in seconds) a node is considered "ignored"
-    ignore_timeframe: 600
+    ignore_timeframe: 1
     # Backoff exponent when probing nodes
     backoff_exponent: 1.5
     # Minimum backoff (in seconds) when probing nodes

--- a/transport/network/Cargo.toml
+++ b/transport/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-network"
-version = "0.6.2"
+version = "0.6.3"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 license = "GPL-3.0-only"

--- a/transport/network/src/config.rs
+++ b/transport/network/src/config.rs
@@ -48,8 +48,8 @@ pub struct NetworkConfig {
     pub quality_avg_window_size: u32,
 
     #[serde_as(as = "DurationSeconds<u64>")]
-    #[serde(default = "duration_10_min")]
-    #[default(duration_10_min())]
+    #[serde(default = "duration_1_sec")]
+    #[default(duration_1_sec())]
     pub ignore_timeframe: Duration,
 
     #[serde(default = "backoff_exponent")]
@@ -160,9 +160,10 @@ fn quality_average_window_size() -> u32 {
     DEFAULT_NETWORK_QUALITY_AVERAGE_WINDOW_SIZE
 }
 
+/// Enforcing backwards compatibility with the "no ignore behaviour" of the previous release
 #[inline]
-fn duration_10_min() -> Duration {
-    Duration::from_secs(600)
+fn duration_1_sec() -> Duration {
+    Duration::from_secs(1)
 }
 
 #[inline]

--- a/transport/p2p/Cargo.toml
+++ b/transport/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-p2p"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 license = "GPL-3.0-only"

--- a/transport/p2p/src/swarm.rs
+++ b/transport/p2p/src/swarm.rs
@@ -47,14 +47,14 @@ async fn build_p2p_network(
     protocol_cfg: ProtocolConfig,
 ) -> Result<libp2p::Swarm<HoprNetworkBehavior>> {
     let tcp_upgrade = libp2p::core::upgrade::SelectUpgrade::new(
-        if let Ok(num_streams) = std::env::var("HOPR_INTERNAL_LIBP2P_YAMUX_MAX_NUM_STREAMS")
-            .and_then(|v| v.parse::<usize>().map_err(|_e| std::env::VarError::NotPresent))
         {
+            let num_streams = std::env::var("HOPR_INTERNAL_LIBP2P_YAMUX_MAX_NUM_STREAMS")
+                .and_then(|v| v.parse::<usize>().map_err(|_e| std::env::VarError::NotPresent))
+                .unwrap_or(1024);
+
             let mut cfg = libp2p::yamux::Config::default();
             cfg.set_max_num_streams(num_streams);
             cfg
-        } else {
-            libp2p::yamux::Config::default()
         },
         libp2p_mplex::MplexConfig::new()
             .set_max_num_streams(1024)


### PR DESCRIPTION
The configuration created a behavior different from 2.1.x which unnecessarily complicated the node interactions. The configuration will be revisited in 3.0 to set proper new values.

@ausias-armesto FYI.