### PR TITLE
Early initialize lazy static metrics to prime them

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1644,7 +1644,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-network"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "async-std",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-p2p"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-std",
@@ -4527,7 +4527,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-protocol"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-lock 3.4.0",

--- a/transport/protocol/Cargo.toml
+++ b/transport/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-protocol"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 license = "GPL-3.0-only"

--- a/transport/protocol/src/lib.rs
+++ b/transport/protocol/src/lib.rs
@@ -160,6 +160,20 @@ where
 {
     let mut processes = HashMap::new();
 
+    #[cfg(all(feature = "prometheus", not(test)))]
+    {
+        // Initialize the lazy statics here
+        lazy_static::initialize(&METRIC_RECEIVED_ACKS);
+        lazy_static::initialize(&METRIC_SENT_ACKS);
+        lazy_static::initialize(&METRIC_TICKETS_COUNT);
+        lazy_static::initialize(&METRIC_PACKET_COUNT);
+        lazy_static::initialize(&METRIC_PACKET_COUNT_PER_PEER);
+        lazy_static::initialize(&METRIC_REPLAYED_PACKET_COUNT);
+        lazy_static::initialize(&METRIC_REJECTED_TICKETS_COUNT);
+        lazy_static::initialize(&METRIC_QUEUE_SIZE);
+        lazy_static::initialize(&METRIC_MIXER_AVERAGE_DELAY);
+    }
+
     let tbf = if let Some(bloom_filter_persistent_path) = bloom_filter_persistent_path {
         let tbf = bloom::WrappedTagBloomFilter::new(bloom_filter_persistent_path);
         let tbf_2 = tbf.clone();
@@ -210,7 +224,6 @@ where
                             METRIC_TICKETS_COUNT.increment(&["losing"]);
                         }
                         Err(_e) => {
-                            #[cfg(all(feature = "prometheus", not(test)))]
                             METRIC_RECEIVED_ACKS.increment(&["false"]);
                         }
                     }


### PR DESCRIPTION
Since all metrics are `lazy_static!`, it means they are not primed (set to 0) immediately, but at a point they are first accessed.

This means, that they do not appear in the `node/metrics` endpoint until they were accessed for the first time.

This PR forcibly initializes the lazy static metrics everywhere, where they might not be used early.