### PR TITLE
Add default session listen host option

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1644,7 +1644,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-network"
-version = "0.6.2"
+version = "0.6.3"
 dependencies = [
  "anyhow",
  "async-std",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-p2p"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "async-std",
@@ -4648,7 +4648,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd-api"
-version = "3.6.1"
+version = "3.7.0"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/hoprd/hoprd/example_cfg.yaml
+++ b/hoprd/hoprd/example_cfg.yaml
@@ -310,16 +310,24 @@ inbox:
   max_age: 900
   # Tags which are not allowed into the Inbox
   excluded_tags: [0]
-# Session Exit configuration for this node
+# Session Entry/Exit IP forwarding configuration for this node
 # This applies whenever the node is an Exit node of a Session.
-# exit:
+# session_ip_forwarding:
+#
 # List of IP address and port tuples (written as e.g.: "127.0.0.1:8080") which are allowed
 # to be targets of incoming Sessions.
 # If the value is not set, all targets are allowed (default).
 # For targets specifying a DNS name, the DNS resolution is performed first before the list is matched.
 # Production configuration should always use this allowlist, e.g.: target_allow_list: ["127.0.0.1:8080"]
 # target_allow_list:
+#
 # If the target is on TCP protocol, the Exit node can try to reach it this number of times.
 # max_tcp_target_retries: 10
+#
 # If a target on TCP protocol is retried to be reached, this is the delay in seconds between retries.
 # tcp_target_retry_delay: 2
+#
+# Specifies the default listen host for Session IP forwarding sockets.
+# This value is also used when the Session is opened with a partially specified listening host
+# to fill in the missing part.
+# default_entry_listen_host: 127.0.0.1:0

--- a/hoprd/hoprd/src/cli.rs
+++ b/hoprd/hoprd/src/cli.rs
@@ -118,6 +118,14 @@ pub struct CliArgs {
     pub api_port: Option<u16>,
 
     #[arg(
+        long,
+        env = "HOPRD_DEFAULT_SESSION_LISTEN_HOST",
+        help = "Default Session listening host for Session IP forwarding",
+        value_parser = ValueParser::new(parse_host),
+    )]
+    pub default_session_listen_host: Option<HostConfig>,
+
+    #[arg(
         long = "disableApiAuthentication",
         help = "Completely disables the token authentication for the API, overrides any apiToken if set",
         env = "HOPRD_DISABLE_API_AUTHENTICATION",

--- a/hoprd/hoprd/src/main.rs
+++ b/hoprd/hoprd/src/main.rs
@@ -307,6 +307,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 session_listener_sockets,
                 websocket_rx: ws_events_rx,
                 msg_encoder: Some(msg_encoder),
+                default_session_listen_host: cfg.session_ip_forwarding.default_entry_listen_host,
             })
             .await
             {

--- a/hoprd/rest-api/Cargo.toml
+++ b/hoprd/rest-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd-api"
-version = "3.6.1"
+version = "3.7.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "This Rest API enables developers to interact with a hoprd node programatically through HTTP."

--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -81,6 +81,7 @@ pub(crate) struct InternalState {
     pub websocket_rx: async_broadcast::InactiveReceiver<ApplicationData>,
     pub msg_encoder: Option<MessageEncoder>,
     pub open_listeners: ListenerJoinHandles,
+    pub default_listen_host: std::net::SocketAddr,
 }
 
 #[derive(OpenApi)]
@@ -198,6 +199,7 @@ pub struct RestApiParameters {
     pub session_listener_sockets: ListenerJoinHandles,
     pub websocket_rx: async_broadcast::InactiveReceiver<ApplicationData>,
     pub msg_encoder: Option<MessageEncoder>,
+    pub default_session_listen_host: std::net::SocketAddr,
 }
 
 /// Starts the Rest API listener and router.
@@ -212,6 +214,7 @@ pub async fn serve_api(params: RestApiParameters) -> Result<(), std::io::Error> 
         session_listener_sockets,
         websocket_rx,
         msg_encoder,
+        default_session_listen_host,
     } = params;
 
     let router = build_api(
@@ -223,6 +226,7 @@ pub async fn serve_api(params: RestApiParameters) -> Result<(), std::io::Error> 
         session_listener_sockets,
         websocket_rx,
         msg_encoder,
+        default_session_listen_host,
     )
     .await;
     axum::serve(listener, router).await
@@ -238,6 +242,7 @@ async fn build_api(
     open_listeners: ListenerJoinHandles,
     websocket_rx: async_broadcast::InactiveReceiver<ApplicationData>,
     msg_encoder: Option<MessageEncoder>,
+    default_listen_host: std::net::SocketAddr,
 ) -> Router {
     let state = AppState { hopr };
     let inner_state = InternalState {
@@ -249,6 +254,7 @@ async fn build_api(
         hoprd_db,
         websocket_rx,
         open_listeners,
+        default_listen_host,
     };
 
     Router::new()

--- a/hoprd/rest-api/src/messages.rs
+++ b/hoprd/rest-api/src/messages.rs
@@ -169,7 +169,8 @@ pub(super) async fn send_message(
         return Err((
             StatusCode::UNPROCESSABLE_ENTITY,
             ApiErrorStatus::InvalidPath("explicit paths are not allowed".into()),
-        ));
+        )
+            .into_response());
     }
 
     let options = if let Some(intermediate_path) = args.path {

--- a/transport/api/src/config.rs
+++ b/transport/api/src/config.rs
@@ -46,7 +46,7 @@ impl Default for HostType {
 ///
 /// This is used for the P2P and REST API listeners.
 ///
-/// Intentionally has no default, because it depends on the use case.
+/// Intentionally has no default because it depends on the use case.
 #[derive(Debug, Serialize, Deserialize, Validate, Clone, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct HostConfig {


### PR DESCRIPTION
This PR makes it possible to specify the default IP listening host (`ip:port`) for Session sockets (for IP forwarding) in the `session_ip_forwarding` section (via `default_entry_listen_host`)

The `listen_host` argument for the `POST session/udp and tcp` REST API now allows partial specification of the listening host. All the following values for `listen_host` are valid:

1) `0.0.0.0:0`
2) `1.2.3.4:1234`
3) `:0`
4) `0.0.0.0`
5) `1.2.3.4`
6) `:1234`

In cases 3-4 the corresponding missing part is replaced by the value from `default_entry_listen_host` (when specified).

The default value for `default_entry_listen_host` if unspecified is `127.0.0.1:0`.

The configuration code was refactored for clarity.