### PR TITLE
Heartbeat improvements and configurability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1644,7 +1644,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-network"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "anyhow",
  "async-std",
@@ -4466,7 +4466,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "async-lock 3.4.0",
  "async-std",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1665,6 +1665,7 @@ dependencies = [
  "mockall",
  "more-asserts",
  "multiaddr",
+ "rand 0.8.5",
  "serde",
  "serde_with",
  "smart-default",

--- a/hoprd/hoprd/example_cfg.yaml
+++ b/hoprd/hoprd/example_cfg.yaml
@@ -186,6 +186,8 @@ hopr:
   # Configuration of the heartbeat mechanism for probing
   # other nodes in the HOPR network.
   heartbeat:
+    # The maximum number of concurrent heartbeat probes
+    max_parallel_probes: 14
     # Interval in which the heartbeat is triggered in seconds
     interval: 60
     # The time interval for which to consider peer heartbeat renewal in seconds
@@ -209,7 +211,7 @@ hopr:
     # Size of the quality moving average window.
     quality_avg_window_size: 25
     # Indicates how long (in seconds) a node is considered "ignored"
-    ignore_timeframe: 1
+    ignore_timeframe: 240
     # Backoff exponent when probing nodes
     backoff_exponent: 1.5
     # Minimum backoff (in seconds) when probing nodes

--- a/transport/api/Cargo.toml
+++ b/transport/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Implements the main HOPR interface for the core library"
 edition = "2021"

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -296,7 +296,7 @@ where
 
         let ping_cfg = PingConfig {
             timeout: self.cfg.protocol.heartbeat.timeout,
-            ..PingConfig::default()
+            max_parallel_pings: self.cfg.heartbeat.max_parallel_probes,
         };
 
         let ping: Pinger<network_notifier::PingExternalInteractions<T>> = Pinger::new(

--- a/transport/network/Cargo.toml
+++ b/transport/network/Cargo.toml
@@ -22,6 +22,7 @@ futures = { workspace = true }
 lazy_static = { workspace = true }
 libp2p-identity = { workspace = true }
 multiaddr = { workspace = true }
+rand = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
 smart-default = { workspace = true }

--- a/transport/network/Cargo.toml
+++ b/transport/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-network"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 license = "GPL-3.0-only"

--- a/transport/network/src/config.rs
+++ b/transport/network/src/config.rs
@@ -48,8 +48,8 @@ pub struct NetworkConfig {
     pub quality_avg_window_size: u32,
 
     #[serde_as(as = "DurationSeconds<u64>")]
-    #[serde(default = "duration_1_sec")]
-    #[default(duration_1_sec())]
+    #[serde(default = "duration_4_min")]
+    #[default(duration_4_min())]
     pub ignore_timeframe: Duration,
 
     #[serde(default = "backoff_exponent")]
@@ -162,8 +162,8 @@ fn quality_average_window_size() -> u32 {
 
 /// Enforcing backwards compatibility with the "no ignore behaviour" of the previous release
 #[inline]
-fn duration_1_sec() -> Duration {
-    Duration::from_secs(1)
+fn duration_4_min() -> Duration {
+    Duration::from_secs(4 * 60)
 }
 
 #[inline]

--- a/transport/network/src/config.rs
+++ b/transport/network/src/config.rs
@@ -160,7 +160,6 @@ fn quality_average_window_size() -> u32 {
     DEFAULT_NETWORK_QUALITY_AVERAGE_WINDOW_SIZE
 }
 
-/// Enforcing backwards compatibility with the "no ignore behaviour" of the previous release
 #[inline]
 fn duration_4_min() -> Duration {
     Duration::from_secs(4 * 60)

--- a/transport/network/src/constants.rs
+++ b/transport/network/src/constants.rs
@@ -9,5 +9,5 @@ pub const DEFAULT_HEARTBEAT_THRESHOLD: std::time::Duration = std::time::Duration
 /// all the nodes start their interval at the same time
 pub const DEFAULT_HEARTBEAT_INTERVAL_VARIANCE: std::time::Duration = std::time::Duration::from_secs(2);
 
-/// The maximum number of parallel ping operation the heartbeat performs
+/// The maximum number of parallel probes the heartbeat performs
 pub const DEFAULT_MAX_PARALLEL_PINGS: usize = 14;

--- a/transport/network/src/constants.rs
+++ b/transport/network/src/constants.rs
@@ -8,3 +8,6 @@ pub const DEFAULT_HEARTBEAT_THRESHOLD: std::time::Duration = std::time::Duration
 /// Randomization of the heartbeat interval to make sure not
 /// all the nodes start their interval at the same time
 pub const DEFAULT_HEARTBEAT_INTERVAL_VARIANCE: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// The maximum number of parallel ping operation the heartbeat performs
+pub const DEFAULT_MAX_PARALLEL_PINGS: usize = 14;

--- a/transport/network/src/heartbeat.rs
+++ b/transport/network/src/heartbeat.rs
@@ -27,7 +27,10 @@ lazy_static::lazy_static! {
 
 use hopr_platform::time::native::current_time;
 
-use crate::constants::{DEFAULT_HEARTBEAT_INTERVAL, DEFAULT_HEARTBEAT_INTERVAL_VARIANCE, DEFAULT_HEARTBEAT_THRESHOLD};
+use crate::constants::{
+    DEFAULT_HEARTBEAT_INTERVAL, DEFAULT_HEARTBEAT_INTERVAL_VARIANCE, DEFAULT_HEARTBEAT_THRESHOLD,
+    DEFAULT_MAX_PARALLEL_PINGS,
+};
 use crate::network::Network;
 use crate::ping::Pinging;
 
@@ -36,6 +39,12 @@ use crate::ping::Pinging;
 #[derive(Debug, Clone, Copy, PartialEq, smart_default::SmartDefault, Validate, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct HeartbeatConfig {
+    /// Maximum number of parallel probes performed by the heartbeat mechanism
+    #[validate(range(min = 0))]
+    #[default(default_max_parallel_pings())]
+    #[serde(default = "default_max_parallel_pings")]
+    pub max_parallel_probes: usize,
+
     /// Round-to-round variance to complicate network sync in seconds
     #[serde_as(as = "DurationSeconds<u64>")]
     #[serde(default = "default_heartbeat_variance")]
@@ -51,6 +60,11 @@ pub struct HeartbeatConfig {
     #[serde(default = "default_heartbeat_threshold")]
     #[default(default_heartbeat_threshold())]
     pub threshold: std::time::Duration,
+}
+
+#[inline]
+fn default_max_parallel_pings() -> usize {
+    DEFAULT_MAX_PARALLEL_PINGS
 }
 
 #[inline]
@@ -235,6 +249,7 @@ mod tests {
             variance: std::time::Duration::from_millis(0u64),
             interval: std::time::Duration::from_millis(5u64),
             threshold: std::time::Duration::from_millis(0u64),
+            max_parallel_probes: 14,
         }
     }
 


### PR DESCRIPTION
Improvements to the heartbeat logic:
- [x] Bump the default ignore timeout interval to 4 minutes
- [x] Randomly shuffle the list of peers to probe
- [x] Extend the configuration to allow parallelization of the heartbeat operation 

## Notes
Refs #6662 