### PR TITLE
Do not purge peers with records fresher than 5 mins from the DB on restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4203,7 +4203,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-db-sql"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-lock 3.4.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4224,6 +4224,7 @@ dependencies = [
  "hopr-internal-types",
  "hopr-metrics",
  "hopr-parallelize",
+ "hopr-platform",
  "hopr-primitive-types",
  "lazy_static",
  "libp2p-identity",

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ On top of the default configuration options generated for the command line, the 
 - `HOPR_INTERNAL_LIBP2P_MAX_NEGOTIATING_INBOUND_STREAM_COUNT` - the maximum number of negotiating inbound streams
 - `HOPR_INTERNAL_LIBP2P_YAMUX_MAX_NUM_STREAMS` - the maximum number of used yamux streams
 - `HOPR_INTERNAL_LIBP2P_SWARM_IDLE_TIMEOUT` - timeout for all idle libp2p swarm connections in seconds
+- `HOPR_DEFAULT_PEERS_DB_PERSISTENCE_AFTER_RESTART_IN_SECONDS` - cutoff duration from now to not retain the peers with older records in the peers database (e.g. after a restart)
 - `ENV_WORKER_THREADS` - the number of environment worker threads for the tokio executor
 - `HOPRD_SESSION_PORT_RANGE` - allows restricting the port range (syntax: `start:end` inclusive) of Session listener automatic port selection (when port 0 is specified).
 

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ On top of the default configuration options generated for the command line, the 
 - `HOPR_INTERNAL_LIBP2P_MAX_NEGOTIATING_INBOUND_STREAM_COUNT` - the maximum number of negotiating inbound streams
 - `HOPR_INTERNAL_LIBP2P_YAMUX_MAX_NUM_STREAMS` - the maximum number of used yamux streams
 - `HOPR_INTERNAL_LIBP2P_SWARM_IDLE_TIMEOUT` - timeout for all idle libp2p swarm connections in seconds
-- `HOPR_DEFAULT_PEERS_DB_PERSISTENCE_AFTER_RESTART_IN_SECONDS` - cutoff duration from now to not retain the peers with older records in the peers database (e.g. after a restart)
+- `HOPR_INTERNAL_DB_PEERS_PERSISTENCE_AFTER_RESTART_IN_SECONDS` - cutoff duration from now to not retain the peers with older records in the peers database (e.g. after a restart)
 - `ENV_WORKER_THREADS` - the number of environment worker threads for the tokio executor
 - `HOPRD_SESSION_PORT_RANGE` - allows restricting the port range (syntax: `start:end` inclusive) of Session listener automatic port selection (when port 0 is specified).
 

--- a/db/sql/Cargo.toml
+++ b/db/sql/Cargo.toml
@@ -57,6 +57,7 @@ hopr-async-runtime = { workspace = true }
 hopr-internal-types = { workspace = true }
 hopr-metrics = { workspace = true, optional = true }
 hopr-parallelize = { workspace = true, features = ["rayon"] }
+hopr-platform = { workspace = true }
 hopr-primitive-types = { workspace = true }
 
 [dev-dependencies]

--- a/db/sql/Cargo.toml
+++ b/db/sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-db-sql"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2021"
 description = "Contains SQL DB functionality implementing the DB API traits to be used by other crates in the code base"
 homepage = "https://hoprnet.org/"

--- a/db/sql/src/db.rs
+++ b/db/sql/src/db.rs
@@ -21,7 +21,7 @@ use crate::errors::Result;
 use crate::ticket_manager::TicketManager;
 use crate::HoprDbAllOperations;
 
-pub const DEFAULT_PEERS_DB_PERSISTENCE_AFTER_RESTART_IN_SECONDS: u64 = 5 * 60; // 5 minutes
+pub const HOPR_INTERNAL_DB_PEERS_PERSISTENCE_AFTER_RESTART_IN_SECONDS: u64 = 5 * 60; // 5 minutes
 
 #[derive(Debug, Clone, PartialEq, Eq, smart_default::SmartDefault)]
 pub struct HoprDbConfig {
@@ -165,10 +165,10 @@ impl HoprDb {
                             .checked_sub(std::time::Duration::from_secs(
                                 std::env::var("HOPR_INTERNAL_DB_PEERS_PERSISTENCE_AFTER_RESTART_IN_SECONDS")
                                     .unwrap_or_else(|_| {
-                                        DEFAULT_PEERS_DB_PERSISTENCE_AFTER_RESTART_IN_SECONDS.to_string()
+                                        HOPR_INTERNAL_DB_PEERS_PERSISTENCE_AFTER_RESTART_IN_SECONDS.to_string()
                                     })
                                     .parse::<u64>()
-                                    .unwrap_or(DEFAULT_PEERS_DB_PERSISTENCE_AFTER_RESTART_IN_SECONDS),
+                                    .unwrap_or(HOPR_INTERNAL_DB_PEERS_PERSISTENCE_AFTER_RESTART_IN_SECONDS),
                             ))
                             .unwrap_or_else(|| hopr_platform::time::native::current_time()),
                     )),

--- a/db/sql/src/db.rs
+++ b/db/sql/src/db.rs
@@ -170,7 +170,7 @@ impl HoprDb {
                                     .parse::<u64>()
                                     .unwrap_or(HOPR_INTERNAL_DB_PEERS_PERSISTENCE_AFTER_RESTART_IN_SECONDS),
                             ))
-                            .unwrap_or_else(|| hopr_platform::time::native::current_time()),
+                            .unwrap_or_else(hopr_platform::time::native::current_time),
                     )),
                 ),
             )


### PR DESCRIPTION
Previously the peers were all purged on DB start. This PR adds a new functionality, whereby the most recent records (last record update within the <5mins window) will be kept in the database, to allow orchestrated nodes (K8s, docker...) to retain parts of recent network knowledge after restart.

The most significant changes include the addition of a new configuration option for peer database persistence, updates to the database schema, and new tests to verify the correct behavior of peer cleanup on restarts.

### Configuration Changes:
* Added `HOPR_INTERNAL_DB_PEERS_PERSISTENCE_AFTER_RESTART_IN_SECONDS` configuration option to specify the cutoff duration for retaining peers in the database after a restart.
* Defined a default value for `HOPR_INTERNAL_DB_PEERS_PERSISTENCE_AFTER_RESTART_IN_SECONDS` in `db/sql/src/db.rs`.

### Dependency Updates:
* Added `hopr-platform` as a dependency in `db/sql/Cargo.toml`.

### Database Logic Updates:
* Updated the peer cleanup logic in `db/sql/src/db.rs` to use the new configuration option and remove peers not seen within the specified duration.

### Testing Enhancements:
* Renamed the test function to `peers_without_any_recent_updates_should_be_discarded_on_restarts` for clarity.
* Added a new test `peers_with_a_recent_update_should_be_retained_in_the_database` to ensure that peers with recent updates are not removed during the cleanup process.