### PR TITLE
Fix message API request bodies and session target acceptance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4650,7 +4650,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd-api"
-version = "3.7.0"
+version = "3.7.1"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/db/sql/src/db.rs
+++ b/db/sql/src/db.rs
@@ -177,7 +177,7 @@ impl HoprDb {
             .exec(&peers_db)
             .await
             .map_err(|e| crate::errors::DbSqlError::Construction(format!("must reset peers on init: {e}")))?;
-        debug!("Cleaned up {} rows from the 'peers' table", res.rows_affected);
+        debug!(rows = res.rows_affected, "Cleaned up rows from the 'peers' table");
 
         // Reset all BeingAggregated ticket states to Untouched
         ticket::Entity::update_many()

--- a/hoprd/rest-api/Cargo.toml
+++ b/hoprd/rest-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd-api"
-version = "3.7.0"
+version = "3.7.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "This Rest API enables developers to interact with a hoprd node programatically through HTTP."

--- a/hoprd/rest-api/src/messages.rs
+++ b/hoprd/rest-api/src/messages.rs
@@ -535,8 +535,8 @@ fn to_api_message(data: hopr_lib::ApplicationData, received_at: Duration) -> Res
         tag = "Messages"
     )]
 pub(super) async fn pop(
-    Query(TagQueryRequest { tag }): Query<TagQueryRequest>,
     State(state): State<Arc<InternalState>>,
+    Json(TagQueryRequest { tag }): Json<TagQueryRequest>,
 ) -> impl IntoResponse {
     if let Some(tag) = tag {
         if tag < RESERVED_TAG_UPPER_LIMIT {
@@ -586,8 +586,8 @@ pub(crate) struct MessagePopAllResponse {
         tag = "Messages"
     )]
 pub(super) async fn pop_all(
-    Query(TagQueryRequest { tag }): Query<TagQueryRequest>,
     State(state): State<Arc<InternalState>>,
+    Json(TagQueryRequest { tag }): Json<TagQueryRequest>,
 ) -> impl IntoResponse {
     if let Some(tag) = tag {
         if tag < RESERVED_TAG_UPPER_LIMIT {
@@ -638,8 +638,8 @@ pub(super) async fn pop_all(
         tag = "Messages"
     )]
 pub(super) async fn peek(
-    Query(TagQueryRequest { tag }): Query<TagQueryRequest>,
     State(state): State<Arc<InternalState>>,
+    Json(TagQueryRequest { tag }): Json<TagQueryRequest>,
 ) -> impl IntoResponse {
     if let Some(tag) = tag {
         if tag < RESERVED_TAG_UPPER_LIMIT {

--- a/scripts/local-cluster-hoprd.cfg.yaml
+++ b/scripts/local-cluster-hoprd.cfg.yaml
@@ -11,3 +11,5 @@ hopr:
         max_closure_overdue: 60
   protocol:
     outgoing_ticket_winning_prob: 0.00001
+  network_options:
+    ignore_timeframe: 0

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -21,7 +21,8 @@ EXTRA_HEADERS = [("X-Auth-Token", API_TOKEN)]
 DEFAULT_ARGS = [
     ("hops", 0),
     ("capabilities", "Segmentation"),
-    ("capabilities", "Retransmission")
+    ("capabilities", "Retransmission"),
+    ("target", "127.0.0.1:4677")
 ]
 
 


### PR DESCRIPTION
Fixes to the REST API behavior:
- [x] Fix the incorrect body/query acceptance for some `/messages/` endpoints
- [x] Make `target` for session creation in websocket mandatory

## Details
### Logging improvements:
* [`db/sql/src/db.rs`](diffhunk://#diff-8486b4d107ff48d05d4b876721cafc2d92649ae60b14ee2e16f3d8f3bd506899L163-R163): Updated the debug log statement to use structured logging for the number of rows affected.

### API request handling:
* [`hoprd/rest-api/src/messages.rs`](diffhunk://#diff-3d882919c608469f3817110ac12c79adbf27b25de00d91b55c6c5ceeb6cdfbf7L538-R539): Changed the request parameter type from `Query` to `Json` body for the `pop`, `pop_all`, and `peek` functions to handle JSON payloads. [[1]](diffhunk://#diff-3d882919c608469f3817110ac12c79adbf27b25de00d91b55c6c5ceeb6cdfbf7L538-R539) [[2]](diffhunk://#diff-3d882919c608469f3817110ac12c79adbf27b25de00d91b55c6c5ceeb6cdfbf7L589-R590) [[3]](diffhunk://#diff-3d882919c608469f3817110ac12c79adbf27b25de00d91b55c6c5ceeb6cdfbf7L641-R642)

### Session target specification:
* [`hoprd/rest-api/src/session.rs`](diffhunk://#diff-070aea0f31844b0c158d9e5fd8075d947936228402358bbb3ff7883e63bd2862L74-R82): Simplified the `from_str` implementation for `SessionTargetSpec` to return the result directly.
* [`hoprd/rest-api/src/session.rs`](diffhunk://#diff-070aea0f31844b0c158d9e5fd8075d947936228402358bbb3ff7883e63bd2862L115-R117): Changed `SessionWebsocketClientQueryRequest` to make `target` a required field and updated the related implementation to handle this change. [[1]](diffhunk://#diff-070aea0f31844b0c158d9e5fd8075d947936228402358bbb3ff7883e63bd2862L115-R117) [[2]](diffhunk://#diff-070aea0f31844b0c158d9e5fd8075d947936228402358bbb3ff7883e63bd2862L151-R151)

### Configuration settings:
* [`scripts/local-cluster-hoprd.cfg.yaml`](diffhunk://#diff-f070b357489f3b0487b414b71db697cfb4b468bfeb620a43d9ce8aca800a3b7cR14-R15): Added `network_options` with an `ignore_timeframe` setting to the configuration file.

## Notes
Fixes https://github.com/hoprnet/hoprnet/issues/6653