### PR TITLE
tokio: Pin main loop on heap

### DIFF
--- a/chain/rpc/src/indexer.rs
+++ b/chain/rpc/src/indexer.rs
@@ -72,8 +72,8 @@ impl<P: JsonRpcClient + 'static> RpcOperations<P> {
                 let prov_clone = self.provider.clone();
                 async move {
                     trace!(
-                        from = ?subrange.get_from_block(),
-                        to = ?subrange.get_to_block(),
+                        from = %subrange.get_from_block(),
+                        to = %subrange.get_to_block(),
                         "fetching logs in block subrange"
                     );
                     match prov_clone.get_logs(&subrange).await {

--- a/chain/rpc/src/indexer.rs
+++ b/chain/rpc/src/indexer.rs
@@ -71,7 +71,7 @@ impl<P: JsonRpcClient + 'static> RpcOperations<P> {
             .then(|subrange| {
                 let prov_clone = self.provider.clone();
                 async move {
-                    debug!(
+                    trace!(
                         from = ?subrange.get_from_block(),
                         to = ?subrange.get_to_block(),
                         "fetching logs in block subrange"

--- a/chain/rpc/src/indexer.rs
+++ b/chain/rpc/src/indexer.rs
@@ -72,8 +72,8 @@ impl<P: JsonRpcClient + 'static> RpcOperations<P> {
                 let prov_clone = self.provider.clone();
                 async move {
                     trace!(
-                        from = %subrange.get_from_block(),
-                        to = %subrange.get_to_block(),
+                        from = ?subrange.get_from_block(),
+                        to = ?subrange.get_to_block(),
                         "fetching logs in block subrange"
                     );
                     match prov_clone.get_logs(&subrange).await {

--- a/chain/rpc/src/indexer.rs
+++ b/chain/rpc/src/indexer.rs
@@ -71,6 +71,11 @@ impl<P: JsonRpcClient + 'static> RpcOperations<P> {
             .then(|subrange| {
                 let prov_clone = self.provider.clone();
                 async move {
+                    debug!(
+                        from = ?subrange.get_from_block(),
+                        to = ?subrange.get_to_block(),
+                        "fetching logs in block subrange"
+                    );
                     match prov_clone.get_logs(&subrange).await {
                         Ok(logs) => Ok(logs),
                         Err(e) => {

--- a/hoprd/hoprd/src/main.rs
+++ b/hoprd/hoprd/src/main.rs
@@ -156,9 +156,20 @@ impl std::fmt::Debug for HoprdProcesses {
     }
 }
 
-#[cfg_attr(feature = "runtime-async-std", async_std::main)]
-#[cfg_attr(all(feature = "runtime-tokio", not(feature = "runtime-async-std")), tokio::main)]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(all(feature = "runtime-tokio", not(feature = "runtime-async-std")))]
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_stack_size(8 * 1024 * 1024)
+        .build()
+        .unwrap()
+        .block_on(Box::pin(inner_main()))
+
+    // #[cfg_attr(feature = "runtime-async-std", async_std::main)]
+    // async_std::task::block_on(async { inner_main().await })
+}
+
+async fn inner_main() -> Result<(), Box<dyn std::error::Error>> {
     init_logger()?;
 
     if hopr_crypto_random::is_rng_fixed() {

--- a/hoprd/hoprd/src/main.rs
+++ b/hoprd/hoprd/src/main.rs
@@ -160,7 +160,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(all(feature = "runtime-tokio", not(feature = "runtime-async-std")))]
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
-        .thread_stack_size(8 * 1024 * 1024)
+        .thread_stack_size(2 * 1024 * 1024)
         .build()
         .unwrap()
         .block_on(Box::pin(inner_main()))

--- a/hoprd/hoprd/src/main.rs
+++ b/hoprd/hoprd/src/main.rs
@@ -158,15 +158,17 @@ impl std::fmt::Debug for HoprdProcesses {
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(all(feature = "runtime-tokio", not(feature = "runtime-async-std")))]
-    tokio::runtime::Builder::new_multi_thread()
+    let res = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .thread_stack_size(2 * 1024 * 1024)
         .build()
-        .unwrap()
-        .block_on(Box::pin(inner_main()))
+        .expect("The tokio runtime must be buildable")
+        .block_on(Box::pin(inner_main()));
 
-    // #[cfg_attr(feature = "runtime-async-std", async_std::main)]
-    // async_std::task::block_on(async { inner_main().await })
+    #[cfg(feature = "runtime-async-std")]
+    let res = async_std::task::block_on(async { inner_main().await });
+
+    res
 }
 
 async fn inner_main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
By pinning the main loop onto the heap the internally generated futures and respective scaffolding would live on the heap as well instead of blowing up the stack.

Fixes #6656 

Some references:

https://users.rust-lang.org/t/tools-for-inspecting-stack-usage/115132
https://rust-lang.github.io/wg-async/vision/submitted_stories/status_quo/alan_runs_into_stack_trouble.html
https://deislabs.io/posts/a-heaping-helping-of-stacks/