### PR TITLE
Fix tokio stack overflow crash during indexing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "chain-indexer"
-version = "0.5.3"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -4024,7 +4024,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-rpc"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-std",
@@ -4155,7 +4155,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-db-api"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "async-trait",
  "futures",
@@ -4203,7 +4203,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-db-sql"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "anyhow",
  "async-lock 3.4.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7660,6 +7660,7 @@ version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bytes 1.8.0",
  "encoding_rs",
@@ -7695,6 +7696,7 @@ dependencies = [
  "tokio-native-tls",
  "tokio-rustls",
  "tokio-socks",
+ "tokio-util",
  "tower-service",
  "url",
  "wasm-bindgen",

--- a/README.md
+++ b/README.md
@@ -498,7 +498,9 @@ The following files in the node's database folder are required:
 
 ### Post-sync Behavior
 
-- If index data exists, the node will skip fast sync and start in normal sync mode
+- If index data exists but is incomplete, the node will resume fast sync at the
+last processed log
+- If index data exists and is complete, the node will skip fast sync and start in normal sync mode
 - After fast sync completes, the node automatically switches to normal sync mode
 
 ## Profiling & Instrumentation

--- a/README.md
+++ b/README.md
@@ -499,7 +499,7 @@ The following files in the node's database folder are required:
 ### Post-sync Behavior
 
 - If index data exists but is incomplete, the node will resume fast sync at the
-last processed log
+  last processed log
 - If index data exists and is complete, the node will skip fast sync and start in normal sync mode
 - After fast sync completes, the node automatically switches to normal sync mode
 

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-indexer"
-version = "0.5.3"
+version = "0.6.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Core-Ethereum-specific interaction with the backend database"

--- a/chain/indexer/src/block.rs
+++ b/chain/indexer/src/block.rs
@@ -311,7 +311,8 @@ where
                     expected = block_id,
                     actual = log.block_number,
                     "block number mismatch in logs from database"
-                )
+                );
+                panic!("block number mismatch in logs from database")
             }
         }
 

--- a/chain/indexer/src/block.rs
+++ b/chain/indexer/src/block.rs
@@ -193,7 +193,7 @@ where
 
         info!(next_block_to_process, "Indexer start point");
 
-        let indexing_proc = spawn(Box::pin(async move {
+        let indexing_proc = spawn(async move {
             let is_synced = Arc::new(AtomicBool::new(false));
             let chain_head = Arc::new(AtomicU64::new(0));
 
@@ -219,7 +219,7 @@ where
                 .filter_map(|block| {
                     let db = db.clone();
 
-                    Box::pin(async move {
+                    async move {
                         debug!(%block, "storing logs from block");
                         let logs = block.logs.clone();
                         let logs_vec = logs.into_iter().map(SerializableLog::from).collect();
@@ -242,13 +242,13 @@ where
                                 None
                             }
                         }
-                    })
+                    }
                 })
                 .filter_map(|block| {
                     let db = db.clone();
                     let logs_handler = logs_handler.clone();
 
-                    Box::pin(async move {
+                    async move {
                         match Self::process_block_by_id(&db, &logs_handler, block.block_id).await {
                             Ok(events) => events,
                             Err(error) => {
@@ -256,7 +256,7 @@ where
                                 None
                             }
                         }
-                    })
+                    }
                 })
                 .flat_map(stream::iter);
 
@@ -276,7 +276,7 @@ where
                     "Indexer event stream has been terminated. This error may be caused by a failed RPC connection."
                 );
             }
-        }));
+        });
 
         if rx.next().await.is_some() {
             Ok(indexing_proc)

--- a/chain/indexer/src/block.rs
+++ b/chain/indexer/src/block.rs
@@ -193,7 +193,7 @@ where
 
         info!(next_block_to_process, "Indexer start point");
 
-        let indexing_proc = spawn(async move {
+        let indexing_proc = spawn(Box::pin(async move {
             let is_synced = Arc::new(AtomicBool::new(false));
             let chain_head = Arc::new(AtomicU64::new(0));
 
@@ -216,41 +216,47 @@ where
                         tx.clone(),
                     )
                 })
-                .then(|block| {
-                    debug!(%block, "storing logs from block");
-                    let logs = block.logs.clone();
-                    let logs_vec = logs.into_iter().map(SerializableLog::from).collect();
-                    db.store_logs(logs_vec)
-                })
-                .filter_map(|results| async move {
-                    match results {
-                        Ok(store_results) => {
-                            let mut store_results_iter = store_results.into_iter();
-                            if store_results_iter.any(|r| r.is_err()) {
-                                None
-                            } else {
-                                if let Some(log) = store_results_iter.filter(|r| r.is_ok()).map(|r| r.unwrap()).next() {
-                                    Some(log.block_number)
-                                } else {
+                .filter_map(|block| {
+                    let db = db.clone();
+
+                    Box::pin(async move {
+                        debug!(%block, "storing logs from block");
+                        let logs = block.logs.clone();
+                        let logs_vec = logs.into_iter().map(SerializableLog::from).collect();
+                        match db.store_logs(logs_vec).await {
+                            Ok(store_results) => {
+                                if let Some(error) = store_results
+                                    .into_iter()
+                                    .filter(|r| r.is_err())
+                                    .map(|r| r.unwrap_err())
+                                    .next()
+                                {
+                                    error!(%block, %error, "failed to processed stored logs from block");
                                     None
+                                } else {
+                                    Some(block)
                                 }
                             }
+                            Err(error) => {
+                                error!(%block, %error, "failed to store logs from block");
+                                None
+                            }
                         }
-                        Err(error) => {
-                            error!(%error, "failed to store logs");
-                            None
-                        }
-                    }
+                    })
                 })
-                .then(|block_id| Self::process_block_by_id(&db, &logs_handler, block_id))
-                .filter_map(|res| async move {
-                    match res {
-                        Ok(events) => events,
-                        Err(error) => {
-                            error!(%error, "failed to process logs from block");
-                            None
+                .filter_map(|block| {
+                    let db = db.clone();
+                    let logs_handler = logs_handler.clone();
+
+                    Box::pin(async move {
+                        match Self::process_block_by_id(&db, &logs_handler, block.block_id).await {
+                            Ok(events) => events,
+                            Err(error) => {
+                                error!(%block, %error, "failed to process logs from block");
+                                None
+                            }
                         }
-                    }
+                    })
                 })
                 .flat_map(stream::iter);
 
@@ -270,7 +276,7 @@ where
                     "Indexer event stream has been terminated. This error may be caused by a failed RPC connection."
                 );
             }
-        });
+        }));
 
         if rx.next().await.is_some() {
             Ok(indexing_proc)

--- a/chain/indexer/src/block.rs
+++ b/chain/indexer/src/block.rs
@@ -193,7 +193,7 @@ where
 
         info!(next_block_to_process, "Indexer start point");
 
-        let indexing_proc = spawn(async move {
+        let indexing_proc = spawn(Box::pin(async move {
             let is_synced = Arc::new(AtomicBool::new(false));
             let chain_head = Arc::new(AtomicU64::new(0));
 
@@ -219,7 +219,7 @@ where
                 .filter_map(|block| {
                     let db = db.clone();
 
-                    async move {
+                    Box::pin(async move {
                         debug!(%block, "storing logs from block");
                         let logs = block.logs.clone();
                         let logs_vec = logs.into_iter().map(SerializableLog::from).collect();
@@ -242,13 +242,13 @@ where
                                 None
                             }
                         }
-                    }
+                    })
                 })
                 .filter_map(|block| {
                     let db = db.clone();
                     let logs_handler = logs_handler.clone();
 
-                    async move {
+                    Box::pin(async move {
                         match Self::process_block_by_id(&db, &logs_handler, block.block_id).await {
                             Ok(events) => events,
                             Err(error) => {
@@ -256,7 +256,7 @@ where
                                 None
                             }
                         }
-                    }
+                    })
                 })
                 .flat_map(stream::iter);
 
@@ -276,7 +276,7 @@ where
                     "Indexer event stream has been terminated. This error may be caused by a failed RPC connection."
                 );
             }
-        });
+        }));
 
         if rx.next().await.is_some() {
             Ok(indexing_proc)

--- a/chain/rpc/Cargo.toml
+++ b/chain/rpc/Cargo.toml
@@ -41,7 +41,11 @@ http-types = { workspace = true }
 lazy_static = { workspace = true }
 moka = { workspace = true }
 primitive-types = { workspace = true }
-reqwest = { workspace = true, optional = true, features = ["brotli", "zstd", "gzip"] }
+reqwest = { workspace = true, optional = true, features = [
+  "brotli",
+  "zstd",
+  "gzip",
+] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/chain/rpc/Cargo.toml
+++ b/chain/rpc/Cargo.toml
@@ -41,7 +41,7 @@ http-types = { workspace = true }
 lazy_static = { workspace = true }
 moka = { workspace = true }
 primitive-types = { workspace = true }
-reqwest = { workspace = true, optional = true }
+reqwest = { workspace = true, optional = true, features = ["brotli", "zstd", "gzip"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/chain/rpc/Cargo.toml
+++ b/chain/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-chain-rpc"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Abstraction over Ethereum RPC provider client"

--- a/chain/rpc/src/indexer.rs
+++ b/chain/rpc/src/indexer.rs
@@ -72,8 +72,8 @@ impl<P: JsonRpcClient + 'static> RpcOperations<P> {
                 let prov_clone = self.provider.clone();
                 async move {
                     trace!(
-                        from = ?subrange.get_from_block(),
-                        to = ?subrange.get_to_block(),
+                        from = %subrange.get_from_block(),
+                        to = %subrange.get_to_block(),
                         "fetching logs in block subrange"
                     );
                     match prov_clone.get_logs(&subrange).await {

--- a/chain/rpc/src/indexer.rs
+++ b/chain/rpc/src/indexer.rs
@@ -70,7 +70,7 @@ impl<P: JsonRpcClient + 'static> RpcOperations<P> {
         fetch_ranges
             .then(|subrange| {
                 let prov_clone = self.provider.clone();
-                async move {
+                Box::pin(async move {
                     trace!(
                         from = ?subrange.get_from_block(),
                         to = ?subrange.get_to_block(),
@@ -88,7 +88,7 @@ impl<P: JsonRpcClient + 'static> RpcOperations<P> {
                             Err(e)
                         }
                     }
-                }
+                })
             })
             .flat_map(|result| {
                 futures::stream::iter(match result {

--- a/chain/rpc/src/indexer.rs
+++ b/chain/rpc/src/indexer.rs
@@ -43,18 +43,19 @@ fn split_range<'a>(
     assert!(from_block <= to_block, "invalid block range");
     assert!(max_chunk_size > 0, "chunk size must be greater than 0");
 
-    futures::stream::unfold((from_block, to_block), move |(start, to)| {
-        if start <= to {
-            let end = to_block.min(start + max_chunk_size - 1);
-            let filter = ethers::types::Filter::from(filter.clone())
-                .from_block(start)
-                .to_block(end);
-            futures::future::ready(Some((filter, (end + 1, to))))
-        } else {
-            futures::future::ready(None)
-        }
-    })
-    .boxed()
+    let mut start = from_block;
+    let mut filters = Vec::new();
+
+    while start <= to_block {
+        let end = to_block.min(start + max_chunk_size - 1);
+        let filter = ethers::types::Filter::from(filter.clone())
+            .from_block(start)
+            .to_block(end);
+        filters.push(filter);
+        start = end + 1;
+    }
+
+    futures::stream::iter(filters).boxed()
 }
 
 impl<P: JsonRpcClient + 'static> RpcOperations<P> {
@@ -68,26 +69,15 @@ impl<P: JsonRpcClient + 'static> RpcOperations<P> {
         );
 
         fetch_ranges
-            .then(|subrange| {
-                let prov_clone = self.provider.clone();
-                async move {
-                    trace!(
-                        from = ?subrange.get_from_block(),
-                        to = ?subrange.get_to_block(),
-                        "fetching logs in block subrange"
+            .then(move |subrange| async move { self.provider.get_logs(&subrange).await })
+            .map(|result| match result {
+                Ok(logs) => Ok(logs),
+                Err(error) => {
+                    error!(
+                        %error,
+                        "failed to fetch logs in block subrange"
                     );
-                    match prov_clone.get_logs(&subrange).await {
-                        Ok(logs) => Ok(logs),
-                        Err(e) => {
-                            error!(
-                                from = ?subrange.get_from_block(),
-                                to = ?subrange.get_to_block(),
-                                error = %e,
-                                "failed to fetch logs in block subrange"
-                            );
-                            Err(e)
-                        }
-                    }
+                    Err(error)
                 }
             })
             .flat_map(|result| {

--- a/chain/rpc/src/indexer.rs
+++ b/chain/rpc/src/indexer.rs
@@ -72,8 +72,8 @@ impl<P: JsonRpcClient + 'static> RpcOperations<P> {
                 let prov_clone = self.provider.clone();
                 async move {
                     trace!(
-                        from = %subrange.get_from_block(),
-                        to = %subrange.get_to_block(),
+                        from = ?subrange.get_from_block(),
+                        to = ?subrange.get_to_block(),
                         "fetching logs in block subrange"
                     );
                     match prov_clone.get_logs(&subrange).await {

--- a/chain/rpc/src/indexer.rs
+++ b/chain/rpc/src/indexer.rs
@@ -70,7 +70,8 @@ impl<P: JsonRpcClient + 'static> RpcOperations<P> {
         fetch_ranges
             .then(|subrange| {
                 let prov_clone = self.provider.clone();
-                Box::pin(async move {
+
+                async move {
                     trace!(
                         from = ?subrange.get_from_block(),
                         to = ?subrange.get_to_block(),
@@ -88,7 +89,7 @@ impl<P: JsonRpcClient + 'static> RpcOperations<P> {
                             Err(e)
                         }
                     }
-                })
+                }
             })
             .flat_map(|result| {
                 futures::stream::iter(match result {

--- a/db/api/Cargo.toml
+++ b/db/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-db-api"
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 description = "API interface specifying the desired implementation details of the HOPR database."
 homepage = "https://hoprnet.org/"

--- a/db/api/src/logs.rs
+++ b/db/api/src/logs.rs
@@ -76,6 +76,7 @@ pub trait HoprDbLogOperations {
     ///
     /// * `block_number` - An optional block number filter.
     /// * `block_offset` - An optional block offset filter.
+    /// * `processed` - An optional processed filter.
     ///
     /// # Returns
     ///
@@ -84,6 +85,7 @@ pub trait HoprDbLogOperations {
         &'a self,
         block_number: Option<u64>,
         block_offset: Option<u64>,
+        processed: Option<bool>,
     ) -> Result<Vec<u64>>;
 
     /// Marks a specific log entry as processed.

--- a/db/api/src/logs.rs
+++ b/db/api/src/logs.rs
@@ -14,8 +14,8 @@ pub trait HoprDbLogOperations {
     ///
     /// # Returns
     ///
-    /// A `Result` which is `Ok(SerializableLog)` if the operation succeeds or an error if it fails.
-    async fn store_log<'a>(&'a self, log: SerializableLog) -> Result<SerializableLog>;
+    /// A `Result` which is `Ok(())` if the operation succeeds or an error if it fails.
+    async fn store_log<'a>(&'a self, log: SerializableLog) -> Result<()>;
 
     /// Stores multiple log entries in the database.
     ///
@@ -25,8 +25,8 @@ pub trait HoprDbLogOperations {
     ///
     /// # Returns
     ///
-    /// A `Result` containing a vector of `Result<SerializableLog>`, each representing the result of storing an individual log entry.
-    async fn store_logs(&self, logs: Vec<SerializableLog>) -> Result<Vec<Result<SerializableLog>>>;
+    /// A `Result` containing a vector of `Result<()>`, each representing the result of storing an individual log entry.
+    async fn store_logs(&self, logs: Vec<SerializableLog>) -> Result<Vec<Result<()>>>;
 
     /// Retrieves a specific log entry from the database.
     ///

--- a/db/api/src/logs.rs
+++ b/db/api/src/logs.rs
@@ -14,8 +14,8 @@ pub trait HoprDbLogOperations {
     ///
     /// # Returns
     ///
-    /// A `Result` which is `Ok(())` if the operation succeeds or an error if it fails.
-    async fn store_log<'a>(&'a self, log: SerializableLog) -> Result<()>;
+    /// A `Result` which is `Ok(SerializableLog)` if the operation succeeds or an error if it fails.
+    async fn store_log<'a>(&'a self, log: SerializableLog) -> Result<SerializableLog>;
 
     /// Stores multiple log entries in the database.
     ///
@@ -25,8 +25,8 @@ pub trait HoprDbLogOperations {
     ///
     /// # Returns
     ///
-    /// A `Result` containing a vector of `Result<()>`, each representing the result of storing an individual log entry.
-    async fn store_logs(&self, logs: Vec<SerializableLog>) -> Result<Vec<Result<()>>>;
+    /// A `Result` containing a vector of `Result<SerializableLog>`, each representing the result of storing an individual log entry.
+    async fn store_logs(&self, logs: Vec<SerializableLog>) -> Result<Vec<Result<SerializableLog>>>;
 
     /// Retrieves a specific log entry from the database.
     ///

--- a/db/api/src/logs.rs
+++ b/db/api/src/logs.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 
+use hopr_crypto_types::prelude::Hash;
 use hopr_primitive_types::prelude::SerializableLog;
 
 use crate::errors::Result;
@@ -131,6 +132,6 @@ pub trait HoprDbLogOperations {
     ///
     /// # Returns
     ///
-    /// A `Result` which is `Ok(())` if the operation succeeds or an error if it fails.
-    async fn update_logs_checksums(&self) -> Result<()>;
+    /// A `Result` which is `Ok(Hash)` if the operation succeeds or an error if it fails.
+    async fn update_logs_checksums(&self) -> Result<Hash>;
 }

--- a/db/sql/Cargo.toml
+++ b/db/sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-db-sql"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 description = "Contains SQL DB functionality implementing the DB API traits to be used by other crates in the code base"
 homepage = "https://hoprnet.org/"

--- a/db/sql/src/logs.rs
+++ b/db/sql/src/logs.rs
@@ -330,7 +330,7 @@ impl HoprDbLogOperations for HoprDb {
                                 match updated_status.update(tx.as_ref()).await {
                                     Ok(_) => {
                                         last_checksum = next_checksum;
-                                        trace!(log=%slog, checksum=%next_checksum, "Generated log checksum");
+                                        trace!(log = %slog, checksum = %next_checksum, "Generated log checksum");
                                     }
                                     Err(error) => {
                                         error!(%error, "Failed to update log status checksum in db");

--- a/db/sql/src/logs.rs
+++ b/db/sql/src/logs.rs
@@ -387,7 +387,6 @@ fn create_log(raw_log: log::Model, status: log_status::Model) -> crate::errors::
 mod tests {
     use super::*;
 
-    use futures::StreamExt;
     use hopr_crypto_types::prelude::{ChainKeypair, Hash, Keypair};
 
     #[async_std::test]

--- a/db/sql/src/logs.rs
+++ b/db/sql/src/logs.rs
@@ -28,7 +28,7 @@ struct BlockNumber {
 
 #[async_trait]
 impl HoprDbLogOperations for HoprDb {
-    async fn store_log<'a>(&'a self, log: SerializableLog) -> Result<()> {
+    async fn store_log<'a>(&'a self, log: SerializableLog) -> Result<SerializableLog> {
         match self.store_logs([log].to_vec()).await {
             Ok(results) => {
                 if let Some(result) = results.into_iter().next() {
@@ -41,15 +41,15 @@ impl HoprDbLogOperations for HoprDb {
         }
     }
 
-    async fn store_logs(&self, logs: Vec<SerializableLog>) -> Result<Vec<Result<()>>> {
+    async fn store_logs(&self, logs: Vec<SerializableLog>) -> Result<Vec<Result<SerializableLog>>> {
         self.nest_transaction_in_db(None, TargetDb::Logs)
             .await?
             .perform(|tx| {
                 Box::pin(async move {
                     let results = stream::iter(logs).then(|log| async {
                         let model = log::ActiveModel::from(log.clone());
-                        let status_model = log_status::ActiveModel::from(log);
-                        let log_status_query = LogStatus::insert(status_model).on_conflict(
+                        let status_model = log_status::ActiveModel::from(log.clone());
+                        let log_status_query = LogStatus::insert(status_model.clone()).on_conflict(
                             OnConflict::columns([
                                 log_status::Column::LogIndex,
                                 log_status::Column::TransactionIndex,
@@ -70,15 +70,15 @@ impl HoprDbLogOperations for HoprDb {
 
                         match log_status_query.exec(tx.as_ref()).await {
                             Ok(_) => match log_query.exec(tx.as_ref()).await {
-                                Ok(_) => Ok(()),
-                                Err(e) => {
-                                    error!("Failed to insert log into db: {:?}", e);
-                                    Err(DbError::General(e.to_string()))
+                                Ok(_) => Ok(log),
+                                Err(error) => {
+                                    error!(%log, %error, "Failed to insert log into db");
+                                    Err(DbError::General(error.to_string()))
                                 }
                             },
-                            Err(e) => {
-                                error!("Failed to insert log status into db: {:?}", e);
-                                Err(DbError::General(e.to_string()))
+                            Err(error) => {
+                                error!(?status_model, %error, "Failed to insert log status into db");
+                                Err(DbError::General(error.to_string()))
                             }
                         }
                     });

--- a/hoprd/hoprd/src/main.rs
+++ b/hoprd/hoprd/src/main.rs
@@ -160,10 +160,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(all(feature = "runtime-tokio", not(feature = "runtime-async-std")))]
     let res = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
-        .thread_stack_size(2 * 1024 * 1024)
+        .max_blocking_threads(1024)
         .build()
         .expect("The tokio runtime must be buildable")
-        // .block_on(Box::pin(inner_main()));
         .block_on(inner_main());
 
     #[cfg(feature = "runtime-async-std")]

--- a/hoprd/hoprd/src/main.rs
+++ b/hoprd/hoprd/src/main.rs
@@ -156,22 +156,9 @@ impl std::fmt::Debug for HoprdProcesses {
     }
 }
 
-fn main() -> Result<(), Box<dyn std::error::Error>> {
-    #[cfg(all(feature = "runtime-tokio", not(feature = "runtime-async-std")))]
-    let res = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
-        .max_blocking_threads(1024)
-        .build()
-        .expect("The tokio runtime must be buildable")
-        .block_on(inner_main());
-
-    #[cfg(feature = "runtime-async-std")]
-    let res = async_std::task::block_on(async { inner_main().await });
-
-    res
-}
-
-async fn inner_main() -> Result<(), Box<dyn std::error::Error>> {
+#[cfg_attr(all(feature = "runtime-tokio", not(feature = "runtime-async-std")), tokio::main)]
+#[cfg_attr(feature = "runtime-async-std", async_std::main)]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
     init_logger()?;
 
     if hopr_crypto_random::is_rng_fixed() {

--- a/hoprd/hoprd/src/main.rs
+++ b/hoprd/hoprd/src/main.rs
@@ -163,7 +163,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .thread_stack_size(2 * 1024 * 1024)
         .build()
         .expect("The tokio runtime must be buildable")
-        .block_on(Box::pin(inner_main()));
+        // .block_on(Box::pin(inner_main()));
+        .block_on(inner_main());
 
     #[cfg(feature = "runtime-async-std")]
     let res = async_std::task::block_on(async { inner_main().await });


### PR DESCRIPTION
The indexer hot-path crashed during the processing of logs. The hot-path has been improved to do fewer db operations and be more performant.

Moreover, fast-sync resume has been added. Previously, if the node crashed during fast-sync, it would end up with an incomplete index and never complete it.

Lastly, the http client has been configured to accept brotli and zstd content encoding, drastically reducing the transmitted data, and keep TCP connections open for 30 seconds.

Fixes #6665
Fixes #6664