### PR TITLE
`rust-libp2p` configuration tweaks to improve the hopr-lib throughput

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ On top of the default configuration options generated for the command line, the 
 - `HOPR_INTERNAL_LIBP2P_MAX_CONCURRENTLY_DIALED_PEER_COUNT` - the maximum number of concurrently dialed peers in libp2p
 - `HOPR_INTERNAL_LIBP2P_MAX_NEGOTIATING_INBOUND_STREAM_COUNT` - the maximum number of negotiating inbound streams
 - `HOPR_INTERNAL_LIBP2P_YAMUX_MAX_NUM_STREAMS` - the maximum number of used yamux streams
+- `HOPR_INTERNAL_LIBP2P_MSG_ACK_MAX_TOTAL_STREAMS` - the maximum number of used outbound and inbound streams for the `msg` and `ack` protocols
 - `HOPR_INTERNAL_LIBP2P_SWARM_IDLE_TIMEOUT` - timeout for all idle libp2p swarm connections in seconds
 - `HOPR_INTERNAL_DB_PEERS_PERSISTENCE_AFTER_RESTART_IN_SECONDS` - cutoff duration from now to not retain the peers with older records in the peers database (e.g. after a restart)
 - `ENV_WORKER_THREADS` - the number of environment worker threads for the tokio executor

--- a/transport/p2p/src/lib.rs
+++ b/transport/p2p/src/lib.rs
@@ -127,14 +127,26 @@ impl HoprNetworkBehavior {
                     StreamProtocol::new(HOPR_MESSAGE_PROTOCOL_V_0_1_0),
                     libp2p::request_response::ProtocolSupport::Full,
                 )],
-                libp2p::request_response::Config::default().with_request_timeout(MSG_ACK_TIMEOUT),
+                libp2p::request_response::Config::default()
+                    .with_request_timeout(MSG_ACK_TIMEOUT)
+                    .with_max_concurrent_streams(
+                        std::env::var("HOPR_INTERNAL_LIBP2P_MSG_ACK_MAX_TOTAL_STREAMS")
+                            .and_then(|v| v.parse::<usize>().map_err(|_e| std::env::VarError::NotPresent))
+                            .unwrap_or(1024),
+                    ),
             ),
             ack: libp2p::request_response::cbor::Behaviour::<Acknowledgement, ()>::new(
                 [(
                     StreamProtocol::new(HOPR_ACKNOWLEDGE_PROTOCOL_V_0_1_0),
                     libp2p::request_response::ProtocolSupport::Full,
                 )],
-                libp2p::request_response::Config::default().with_request_timeout(MSG_ACK_TIMEOUT),
+                libp2p::request_response::Config::default()
+                    .with_request_timeout(MSG_ACK_TIMEOUT)
+                    .with_max_concurrent_streams(
+                        std::env::var("HOPR_INTERNAL_LIBP2P_MSG_ACK_MAX_TOTAL_STREAMS")
+                            .and_then(|v| v.parse::<usize>().map_err(|_e| std::env::VarError::NotPresent))
+                            .unwrap_or(1024),
+                    ),
             ),
             ticket_aggregation: libp2p::request_response::cbor::Behaviour::<
                 Vec<legacy::AcknowledgedTicket>,


### PR DESCRIPTION
Minor improvements, tweaks and enhancements to improve the node throughput and overall functionality.

- [x] Increase and make configurable the msg and ack combined stream count

