### PR TITLE
docker: Preset session listen host

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -183,6 +183,7 @@
 
             # if the default listen host has not been set by the user,
             # we will set it to the container's ip address
+            # defaulting to port 50000
 
             listen_host="''${HOPRD_DEFAULT_SESSION_LISTEN_HOST:-}"
             listen_host_preset_ip="''${listen_host%%:*}"
@@ -192,7 +193,7 @@
               listen_host_ip="$(hostname -i)"
 
               if [ -z "''${listen_host_preset_port:-}" ]; then
-                listen_host="''${listen_host_ip}"
+                listen_host="''${listen_host_ip}:50000"
               else
                 listen_host="''${listen_host_ip}:''${listen_host_preset_port}"
               fi

--- a/flake.nix
+++ b/flake.nix
@@ -177,6 +177,38 @@
             rust-bin.stable.latest.minimal
             valgrind
           ];
+
+          dockerHoprdEntrypoint = pkgs.writeShellScriptBin "docker-entrypoint.sh" ''
+            set -euo pipefail
+
+            # if the default listen host has not been set by the user,
+            # we will set it to the container's ip address
+
+            listen_host="''${HOPRD_DEFAULT_SESSION_LISTEN_HOST:-}"
+            listen_host_preset_ip="''${listen_host%%:*}"
+            listen_host_preset_port="''${listen_host#*:}"
+
+            if [ -z "''${listen_host_preset_ip:-}" ]; then
+              listen_host_ip="$(hostname -i)"
+
+              if [ -z "''${listen_host_preset_port:-}" ]; then
+                listen_host="''${listen_host_ip}"
+              else
+                listen_host="''${listen_host_ip}:''${listen_host_preset_port}"
+              fi
+            fi
+
+            export HOPRD_DEFAULT_SESSION_LISTEN_HOST="''${listen_host}"
+
+            if [ -x "/bin/''${1:-}" ]; then
+              # allow execution of auxiliary commands
+              exec "''$@"
+            else
+              # default to hoprd
+              exec /bin/hoprd "''$@"
+            fi
+          '';
+
           # FIXME: the docker image built is not working on macOS arm platforms
           # and will simply lead to a non-working image. Likely, some form of
           # cross-compilation or distributed build is required.
@@ -184,11 +216,13 @@
             inherit pkgs;
             name = "hoprd";
             extraContents = [
+              dockerHoprdEntrypoint
               package
             ] ++ deps;
             Entrypoint = [
-              "/bin/hoprd"
+              "/bin/docker-entrypoint.sh"
             ];
+            Cmd = [ "hoprd" ];
           };
           hoprd-docker = import ./nix/docker-builder.nix (hoprdDockerArgs hoprd [ ]);
           hoprd-debug-docker = import ./nix/docker-builder.nix (hoprdDockerArgs hoprd-debug [ ]);

--- a/nix/docker-builder.nix
+++ b/nix/docker-builder.nix
@@ -1,4 +1,5 @@
-{ Entrypoint
+{ Cmd
+, Entrypoint
 , env ? [ ]
 , extraContents ? [ ]
 , name
@@ -6,11 +7,12 @@
 }:
 let
   contents = with pkgs; [
-    iana-etc
-    cacert
     bash
-    findutils
+    cacert
     coreutils
+    findutils
+    iana-etc
+    nettools
   ] ++ extraContents;
   Env = [
     "NO_COLOR=true" # suppress colored log output
@@ -24,6 +26,6 @@ pkgs.dockerTools.buildLayeredImage {
   # breaks binary reproducibility, but makes usage easier
   created = "now";
   config = {
-    inherit Entrypoint Env;
+    inherit Cmd Entrypoint Env;
   };
 }

--- a/nix/docker-builder.nix
+++ b/nix/docker-builder.nix
@@ -1,4 +1,4 @@
-{ Cmd
+{ Cmd ? [ ]
 , Entrypoint
 , env ? [ ]
 , extraContents ? [ ]


### PR DESCRIPTION
This pull request introduces a new Docker entrypoint script which sets the environment variable `HOPRD_DEFAULT_SESSION_LISTEN_HOST` to the docker container's IP, unless it was configured by the user beforehand.

This allows session users to only specify the listen port when opening a session, e.g. `:50001`, and the hoprd node will use the default internal docker ip automatically.

Moreover, other hopr binaries can now be run using the docker image by specifying them as commands. E.g.

```
docker run -ti --rm hoprd:latest hoprd-api-schema
```