### PR TITLE
nix: Fix cross-build on same platform

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -96,26 +96,31 @@
           rust-builder-x86_64-linux = import ./nix/rust-builder.nix {
             inherit nixpkgs rust-overlay crane foundry solc localSystem;
             crossSystem = pkgs.lib.systems.examples.gnu64;
+            isCross = true;
           };
 
           rust-builder-x86_64-darwin = import ./nix/rust-builder.nix {
             inherit nixpkgs rust-overlay crane foundry solc localSystem;
             crossSystem = pkgs.lib.systems.examples.x86_64-darwin;
+            isCross = true;
           };
 
           rust-builder-aarch64-linux = import ./nix/rust-builder.nix {
             inherit nixpkgs rust-overlay crane foundry solc localSystem;
             crossSystem = pkgs.lib.systems.examples.aarch64-multiplatform;
+            isCross = true;
           };
 
           rust-builder-aarch64-darwin = import ./nix/rust-builder.nix {
             inherit nixpkgs rust-overlay crane foundry solc localSystem;
             crossSystem = pkgs.lib.systems.examples.aarch64-darwin;
+            isCross = true;
           };
 
           rust-builder-armv7l-linux = import ./nix/rust-builder.nix {
             inherit nixpkgs rust-overlay crane foundry solc localSystem;
             crossSystem = pkgs.lib.systems.examples.armv7l-hf-multiplatform;
+            isCross = true;
           };
 
           hoprdBuildArgs = {

--- a/nix/rust-builder.nix
+++ b/nix/rust-builder.nix
@@ -1,6 +1,7 @@
 { crane
 , crossSystem ? localSystem
 , foundry
+, isCross ? false
 , localSystem
 , nixpkgs
 , rust-overlay
@@ -64,7 +65,12 @@ in
   inherit rustToolchain;
 
   callPackage = (package: args:
-    let crate = pkgs.callPackage package (args // { inherit foundryBin solcDefault craneLib; });
+    let
+      crate = pkgs.callPackage package (args //
+        {
+          inherit foundryBin
+            solcDefault craneLib isCross;
+        });
     in
     # Override the derivation to add cross-compilation environment variables.
     crate.overrideAttrs (previous: buildEnv // {

--- a/nix/rust-package.nix
+++ b/nix/rust-package.nix
@@ -8,6 +8,7 @@
 , foundryBin
 , git
 , html-tidy
+, isCross ? false
 , lib
 , libiconv
 , makeSetupHook
@@ -30,8 +31,6 @@ let
   hostPlatform = stdenv.hostPlatform;
 
   # The target interpreter is used to patch the interpreter in the binary
-  isCross = buildPlatform != hostPlatform;
-
   targetInterpreter =
     if hostPlatform.isLinux && hostPlatform.isx86_64 then "/lib64/ld-linux-x86-64.so.2"
     else if hostPlatform.isLinux && hostPlatform.isAarch64 then "/lib64/ld-linux-aarch64.so.1"


### PR DESCRIPTION
The problem was the cross build identification when the build platform was the same as the target platform. This has been made explicit in the configuration of the builder now.

Fixes #6689 
