### PR TITLE
Improve ticket redemption handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1220,7 +1220,7 @@ dependencies = [
 
 [[package]]
 name = "chain-actions"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4203,7 +4203,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-db-sql"
-version = "0.8.4"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-lock 3.4.0",
@@ -4239,7 +4239,6 @@ dependencies = [
  "strum",
  "thiserror",
  "tracing",
- "tracing-test",
 ]
 
 [[package]]

--- a/chain/actions/Cargo.toml
+++ b/chain/actions/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-actions"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "High-level Core-Ethereum functions that translate to on-chain transactions"

--- a/chain/actions/src/action_queue.rs
+++ b/chain/actions/src/action_queue.rs
@@ -355,7 +355,6 @@ where
     /// Consumes self and runs the main queue processing loop until the queue is closed.
     ///
     /// The method will panic if the Channel Domain Separator is not yet populated in the DB.
-    //#[allow(clippy::async_yields_async)]
     #[tracing::instrument(level = "debug", skip(self))]
     pub async fn start(self) {
         let queue_recv = self.queue_recv.clone();

--- a/chain/actions/src/errors.rs
+++ b/chain/actions/src/errors.rs
@@ -28,6 +28,9 @@ pub enum ChainActionsError {
     #[error("acknowledged {0} is in a wrong state for the operation")]
     WrongTicketState(String),
 
+    #[error("given ticket has a superseded ticket index")]
+    OldTicket,
+
     #[error("ticket is not a win")]
     NotAWinningTicket,
 

--- a/chain/actions/src/redeem.rs
+++ b/chain/actions/src/redeem.rs
@@ -212,6 +212,8 @@ where
                 return Err(OldTicket);
             }
 
+            debug!(%ack_ticket, %channel, "redeeming single ticket");
+
             let selector = TicketSelector::from(&channel)
                 .with_index(ack_ticket.verified_ticket().index)
                 .with_state(AcknowledgedTicketStatus::Untouched);
@@ -233,6 +235,8 @@ where
                     .ok_or(InvalidState("missing channel dst".into()))?;
 
                 let redeemable = ticket.into_redeemable(&self.chain_key, &channel_dst)?;
+
+                debug!(%ack_ticket, "ticket is redeemable");
                 Ok(self.tx_sender.send(Action::RedeemTicket(redeemable)).await?)
             } else {
                 Err(WrongTicketState(ack_ticket.to_string()))

--- a/chain/actions/src/redeem.rs
+++ b/chain/actions/src/redeem.rs
@@ -15,8 +15,8 @@
 //! [BeingAggregated](hopr_internal_types::tickets::AcknowledgedTicketStatus::BeingAggregated) in the DB),
 //! If they are redeemable, their state is changed to
 //! [BeingRedeemed](hopr_internal_types::tickets::AcknowledgedTicketStatus::BeingRedeemed) (while having acquired the exclusive DB write lock).
-//! Subsequently, the ticket in such state is transmitted into the [ActionQueue](crate::action_queue::ActionQueue) so the redemption is soon executed on-chain.
-//! The functions return immediately, but provide futures that can be awaited in case the callers wishes to await the on-chain
+//! Subsequently, the ticket in such a state is transmitted into the [ActionQueue](crate::action_queue::ActionQueue) so the redemption is soon executed on-chain.
+//! The functions return immediately but provide futures that can be awaited in case the callers wish to await the on-chain
 //! confirmation of each ticket redemption.
 //!
 //! See the details in [ActionQueue](crate::action_queue::ActionQueue) on how the confirmation is realized by awaiting the respective [SignificantChainEvent](chain_types::chain_events::SignificantChainEvent).
@@ -34,7 +34,7 @@ use hopr_primitive_types::prelude::*;
 use tracing::{debug, error, info, warn};
 
 use crate::action_queue::PendingAction;
-use crate::errors::ChainActionsError::{ChannelDoesNotExist, InvalidState};
+use crate::errors::ChainActionsError::{ChannelDoesNotExist, InvalidState, OldTicket};
 use crate::errors::{ChainActionsError::WrongTicketState, Result};
 use crate::ChainActions;
 
@@ -43,7 +43,7 @@ lazy_static::lazy_static! {
     static ref EMPTY_TX_HASH: Hash = Hash::default();
 }
 
-/// Gathers all the ticket redemption related on-chain calls.
+/// Gathers all the ticket redemption-related on-chain calls.
 #[async_trait]
 pub trait TicketRedeemActions {
     /// Redeems all redeemable tickets in all channels.
@@ -62,6 +62,9 @@ pub trait TicketRedeemActions {
         channel: &ChannelEntry,
         only_aggregated: bool,
     ) -> Result<Vec<PendingAction>>;
+
+    /// Redeems all tickets based on the given [`TicketSelector`].
+    async fn redeem_tickets(&self, selector: TicketSelector) -> Result<Vec<PendingAction>>;
 
     /// Tries to redeem the given ticket. If the ticket is not redeemable, returns an error.
     /// Otherwise, the transaction hash of the on-chain redemption is returned.
@@ -105,7 +108,6 @@ where
         Ok(receivers)
     }
 
-    /// Redeems all redeemable tickets in the incoming channel from the given counterparty.
     #[tracing::instrument(level = "debug", skip(self))]
     async fn redeem_tickets_with_counterparty(
         &self,
@@ -123,23 +125,27 @@ where
         }
     }
 
-    /// Redeems all redeemable tickets in the given channel.
     #[tracing::instrument(level = "debug", skip(self))]
     async fn redeem_tickets_in_channel(
         &self,
         channel: &ChannelEntry,
         only_aggregated: bool,
     ) -> Result<Vec<PendingAction>> {
-        let channel_id = channel.get_id();
+        self.redeem_tickets(
+            TicketSelector::from(channel)
+                .with_aggregated_only(only_aggregated)
+                .with_index_range(channel.ticket_index.as_u64()..)
+                .with_state(AcknowledgedTicketStatus::Untouched),
+        )
+        .await
+    }
 
-        let selector = TicketSelector::from(channel)
-            .with_aggregated_only(only_aggregated)
-            .with_state(AcknowledgedTicketStatus::Untouched);
-
+    #[tracing::instrument(level = "debug", skip(self))]
+    async fn redeem_tickets(&self, selector: TicketSelector) -> Result<Vec<PendingAction>> {
         let (count_redeemable_tickets, _) = self.db.get_tickets_value(selector.clone()).await?;
 
         info!(
-            count_redeemable_tickets, channel = %channel_id,
+            count_redeemable_tickets, %selector,
             "acknowledged tickets in channel that can be redeemed"
         );
 
@@ -155,10 +161,13 @@ where
             .domain_separator(DomainSeparator::Channel)
             .ok_or(InvalidState("missing channel dst".into()))?;
 
+        let selector_id = selector.to_string();
+
         let mut redeem_stream = self
             .db
             .update_ticket_states_and_fetch(selector, AcknowledgedTicketStatus::BeingRedeemed)
             .await?;
+
         let mut receivers: Vec<PendingAction> = vec![];
         while let Some(ack_ticket) = redeem_stream.next().await {
             let ticket_id = ack_ticket.to_string();
@@ -180,16 +189,13 @@ where
 
         info!(
             count = receivers.len(),
-            channel = %channel_id,
+            selector = selector_id,
             "acknowledged tickets were submitted to redeem in channel",
-
         );
 
         Ok(receivers)
     }
 
-    /// Tries to redeem the given ticket. If the ticket is not redeemable, returns an error.
-    /// Otherwise, the transaction hash of the on-chain redemption is returned.
     #[tracing::instrument(level = "debug", skip(self))]
     async fn redeem_ticket(&self, ack_ticket: AcknowledgedTicket) -> Result<PendingAction> {
         if let Some(channel) = self
@@ -197,6 +203,12 @@ where
             .get_channel_by_id(None, &ack_ticket.verified_ticket().channel_id)
             .await?
         {
+            // Check if not trying to redeem a ticket that cannot be redeemed.
+            // Such tickets are automatically cleaned up (neglected) after successful redemption.
+            if ack_ticket.verified_ticket().index < channel.ticket_index.as_u64() {
+                return Err(OldTicket);
+            }
+
             let selector = TicketSelector::from(&channel)
                 .with_index(ack_ticket.verified_ticket().index)
                 .with_state(AcknowledgedTicketStatus::Untouched);
@@ -335,7 +347,7 @@ mod tests {
         let ticket_count = 5;
         let db = HoprDb::new_in_memory(ALICE.clone()).await?;
 
-        // all the tickets can be redeemed, coz they are issued with the same epoch as channel
+        // All the tickets can be redeemed because they are issued with the same channel epoch
         let (channel_from_bob, bob_tickets) =
             create_channel_with_ack_tickets(db.clone(), ticket_count, &BOB, 4u32).await?;
         let (channel_from_charlie, charlie_tickets) =
@@ -435,11 +447,15 @@ mod tests {
         let ticket_count = 5;
         let db = HoprDb::new_in_memory(ALICE.clone()).await?;
 
-        // all the tickets can be redeemed, coz they are issued with the same epoch as channel
-        let (channel_from_bob, bob_tickets) =
+        // All the tickets can be redeemed because they are issued with the same channel epoch
+        let (mut channel_from_bob, bob_tickets) =
             create_channel_with_ack_tickets(db.clone(), ticket_count, &BOB, 4u32).await?;
         let (channel_from_charlie, _) =
             create_channel_with_ack_tickets(db.clone(), ticket_count, &CHARLIE, 4u32).await?;
+
+        // Tickets with index 0 will be skipped, as that is already past
+        channel_from_bob.ticket_index = 1_u32.into();
+        db.upsert_channel(None, channel_from_bob.clone()).await?;
 
         let mut indexer_action_tracker = MockActionState::new();
         let mut seq2 = mockall::Sequence::new();
@@ -462,7 +478,7 @@ mod tests {
         let mut tx_exec = MockTransactionExecutor::new();
         tx_exec
             .expect_redeem_ticket()
-            .times(ticket_count)
+            .times(ticket_count - 1)
             .withf(move |t| bob_tickets.iter().any(|tk| tk.ticket.eq(&t.ticket)))
             .returning(move |_| Ok(random_hash));
 
@@ -483,7 +499,8 @@ mod tests {
         )
         .await?;
 
-        assert_eq!(ticket_count, confirmations.len(), "must have all confirmations");
+        // First ticket is skipped, because its index is lower than the index on the channel entry
+        assert_eq!(ticket_count - 1, confirmations.len(), "must have all confirmations");
         assert!(
             confirmations.into_iter().all(|c| c.tx_hash == random_hash),
             "tx hashes must be equal"
@@ -496,6 +513,7 @@ mod tests {
         assert!(
             db_acks_bob
                 .into_iter()
+                .take_while(|tkt| tkt.verified_ticket().index != 0)
                 .all(|tkt| tkt.status == AcknowledgedTicketStatus::BeingRedeemed),
             "all bob's tickets must be in BeingRedeemed state"
         );
@@ -732,6 +750,107 @@ mod tests {
                 "cannot redeem a ticket that's from the next epoch"
             );
         }
+
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn test_should_redeem_single_ticket() -> anyhow::Result<()> {
+        let db = HoprDb::new_in_memory(ALICE.clone()).await?;
+        let random_hash = Hash::from(random_bytes::<{ Hash::SIZE }>());
+
+        let (channel_from_bob, tickets) = create_channel_with_ack_tickets(db.clone(), 1, &BOB, 1u32).await?;
+
+        let ticket = tickets.into_iter().next().unwrap();
+
+        let mut tx_exec = MockTransactionExecutor::new();
+        let ticket_clone = ticket.clone();
+        tx_exec
+            .expect_redeem_ticket()
+            .once()
+            .withf(move |t| ticket_clone.ticket.eq(&t.ticket))
+            .returning(move |_| Ok(random_hash));
+
+        let mut indexer_action_tracker = MockActionState::new();
+        let ticket_clone = ticket.clone();
+        indexer_action_tracker
+            .expect_register_expectation()
+            .once()
+            .return_once(move |_| {
+                Ok(futures::future::ok(SignificantChainEvent {
+                    tx_hash: random_hash,
+                    event_type: TicketRedeemed(channel_from_bob, Some(ticket_clone)),
+                })
+                .boxed())
+            });
+
+        // Start the ActionQueue with the mock TransactionExecutor
+        let tx_queue = ActionQueue::new(db.clone(), indexer_action_tracker, tx_exec, Default::default());
+        let tx_sender = tx_queue.new_sender();
+        async_std::task::spawn(async move {
+            tx_queue.start().await;
+        });
+
+        let actions = ChainActions::new(&ALICE, db.clone(), tx_sender.clone());
+
+        let confirmation = actions.redeem_ticket(ticket).await?.await?;
+
+        assert_eq!(confirmation.tx_hash, random_hash);
+
+        assert!(
+            db.get_tickets((&channel_from_bob).into())
+                .await?
+                .into_iter()
+                .all(|tkt| tkt.status == AcknowledgedTicketStatus::BeingRedeemed),
+            "all bob's tickets must be in BeingRedeemed state"
+        );
+
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn test_should_not_redeem_single_ticket_with_lower_index_than_channel_index() -> anyhow::Result<()> {
+        let db = HoprDb::new_in_memory(ALICE.clone()).await?;
+        let random_hash = Hash::from(random_bytes::<{ Hash::SIZE }>());
+
+        let (mut channel_from_bob, tickets) = create_channel_with_ack_tickets(db.clone(), 1, &BOB, 1u32).await?;
+
+        channel_from_bob.ticket_index = 2_u32.into();
+        db.upsert_channel(None, channel_from_bob.clone()).await?;
+
+        let ticket = tickets.into_iter().next().unwrap();
+
+        let mut tx_exec = MockTransactionExecutor::new();
+        let ticket_clone = ticket.clone();
+        tx_exec
+            .expect_redeem_ticket()
+            .never()
+            .withf(move |t| ticket_clone.ticket.eq(&t.ticket))
+            .returning(move |_| Ok(random_hash));
+
+        let mut indexer_action_tracker = MockActionState::new();
+        let ticket_clone = ticket.clone();
+        indexer_action_tracker
+            .expect_register_expectation()
+            .never()
+            .return_once(move |_| {
+                Ok(futures::future::ok(SignificantChainEvent {
+                    tx_hash: random_hash,
+                    event_type: TicketRedeemed(channel_from_bob, Some(ticket_clone)),
+                })
+                .boxed())
+            });
+
+        // Start the ActionQueue with the mock TransactionExecutor
+        let tx_queue = ActionQueue::new(db.clone(), indexer_action_tracker, tx_exec, Default::default());
+        let tx_sender = tx_queue.new_sender();
+        async_std::task::spawn(async move {
+            tx_queue.start().await;
+        });
+
+        let actions = ChainActions::new(&ALICE, db.clone(), tx_sender.clone());
+
+        assert!(matches!(actions.redeem_ticket(ticket).await, Err(OldTicket)));
 
         Ok(())
     }

--- a/chain/types/src/chain_events.rs
+++ b/chain/types/src/chain_events.rs
@@ -60,7 +60,7 @@ pub enum ChainEventType {
     /// Channel balance has decreased by an amount.
     ChannelBalanceDecreased(ChannelEntry, Balance),
     /// Ticket has been redeemed on a channel.
-    /// If the channel is node's own, also contains the ticket that has been redeemed.
+    /// If the channel is a node's own, it also contains the ticket that has been redeemed.
     TicketRedeemed(ChannelEntry, Option<AcknowledgedTicket>),
     /// Safe has been registered with the node.
     NodeSafeRegistered(Address),

--- a/common/internal-types/src/announcement.rs
+++ b/common/internal-types/src/announcement.rs
@@ -73,9 +73,9 @@ pub fn decapsulate_multiaddress(multiaddr: Multiaddr) -> Multiaddr {
         .collect()
 }
 
-/// Structure containing data used for on-chain announcement.
+/// Structure containing data used for an on-chain announcement.
 /// That is the decapsulated multiaddress (with the /p2p/{peer_id} suffix removed) and
-/// optional `KeyBinding` (announcement can be done with key bindings or without)
+/// optional `KeyBinding` (an announcement can be done with key bindings or without)
 ///
 /// NOTE: This currently supports only announcing of a single multiaddress
 #[derive(Clone, Debug, PartialEq)]
@@ -96,7 +96,7 @@ impl AnnouncementData {
         }
 
         if let Some(binding) = &key_binding {
-            // Encapsulate first (if already encapsulated the operation verifies that peer id matches the given one)
+            // Encapsulate first (if already encapsulated, the operation verifies that peer id matches the given one)
             match multiaddress.with_p2p(binding.packet_key.into()) {
                 Ok(mut multiaddress) => {
                     // Now decapsulate again, because we store decapsulated multiaddress only (without the /p2p/<peer_id> suffix)

--- a/db/sql/Cargo.toml
+++ b/db/sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-db-sql"
-version = "0.8.4"
+version = "0.9.0"
 edition = "2021"
 description = "Contains SQL DB functionality implementing the DB API traits to be used by other crates in the code base"
 homepage = "https://hoprnet.org/"
@@ -74,4 +74,3 @@ sqlx = { workspace = true, features = ["runtime-async-std-rustls"] }
 lazy_static = { workspace = true }
 hopr-crypto-random = { workspace = true }
 hex-literal = { workspace = true }
-tracing-test = { workspace = true }

--- a/db/sql/src/db.rs
+++ b/db/sql/src/db.rs
@@ -1,10 +1,11 @@
 use std::sync::Arc;
 
 use crate::cache::HoprDbCaches;
+use futures::channel::mpsc::UnboundedSender;
 use hopr_crypto_types::keypairs::Keypair;
 use hopr_crypto_types::prelude::ChainKeypair;
 use hopr_db_entity::ticket;
-use hopr_internal_types::prelude::AcknowledgedTicketStatus;
+use hopr_internal_types::prelude::{AcknowledgedTicket, AcknowledgedTicketStatus};
 use hopr_primitive_types::primitives::Address;
 use migration::{MigratorChainLogs, MigratorIndex, MigratorPeers, MigratorTickets, MigratorTrait};
 use sea_orm::{ColumnTrait, EntityTrait, QueryFilter, SqlxSqliteConnector};
@@ -202,6 +203,12 @@ impl HoprDb {
             tickets_db,
             caches,
         })
+    }
+
+    /// Starts ticket processing by the [TicketManager].
+    /// Without calling this method, tickets will not be persisted into the DB.
+    pub fn start_ticket_processing(&self, ticket_notifier: UnboundedSender<AcknowledgedTicket>) -> Result<()> {
+        self.ticket_manager.start_ticket_processing(ticket_notifier)
     }
 }
 

--- a/db/sql/src/db.rs
+++ b/db/sql/src/db.rs
@@ -205,10 +205,17 @@ impl HoprDb {
         })
     }
 
-    /// Starts ticket processing by the [TicketManager].
+    /// Starts ticket processing by the [TicketManager] with an optional new ticket notifier.
     /// Without calling this method, tickets will not be persisted into the DB.
-    pub fn start_ticket_processing(&self, ticket_notifier: UnboundedSender<AcknowledgedTicket>) -> Result<()> {
-        self.ticket_manager.start_ticket_processing(ticket_notifier)
+    ///
+    /// If the notifier is given, it will receive notifications once new ticket has been
+    /// persisted into the Tickets DB.
+    pub fn start_ticket_processing(&self, ticket_notifier: Option<UnboundedSender<AcknowledgedTicket>>) -> Result<()> {
+        if let Some(notifier) = ticket_notifier {
+            self.ticket_manager.start_ticket_processing(notifier)
+        } else {
+            self.ticket_manager.start_ticket_processing(futures::sink::drain())
+        }
     }
 }
 

--- a/db/sql/src/ticket_manager.rs
+++ b/db/sql/src/ticket_manager.rs
@@ -139,6 +139,9 @@ impl TicketManager {
     }
 
     /// Sends a new acknowledged ticket into the FIFO queue.
+    ///
+    /// The [`start_ticket_processing`](TicketManager::start_ticket_processing) method
+    /// must be called before calling this method.
     pub async fn insert_ticket(&self, ticket: AcknowledgedTicket) -> Result<()> {
         let channel = ticket.verified_ticket().channel_id;
         let value = ticket.verified_ticket().amount;

--- a/deploy/compose/prometheus/metricspusher.sh
+++ b/deploy/compose/prometheus/metricspusher.sh
@@ -6,11 +6,6 @@ if [ -z "${HOPRD_API_TOKEN}" ]; then
     exit 1
 fi
 
-if [ -z "${HOPRD_API_PORT}" ]; then
-    echo "Error: HOPRD_API_PORT is not set"
-    exit 1
-fi
-
 METRICS_PUSH_URL=${1}
 if [ -z "${METRICS_PUSH_URL}" ]; then
     echo "Error: METRICS_PUSH_URL argument is required"
@@ -21,7 +16,7 @@ fi
 while true; do 
     echo Publishing metrics ...
     # Add timeout and retry with backoff
-    if ! metrics=$(curl -s --max-time 10 -H "X-Auth-Token: ${HOPRD_API_TOKEN}" "http://hoprd:${HOPRD_API_PORT}/api/v3/node/metrics"); then
+    if ! metrics=$(curl -s --max-time 10 -H "X-Auth-Token: ${HOPRD_API_TOKEN}" "http://hoprd:3001/api/v3/node/metrics"); then
         echo "Error: Failed to fetch metrics from Hoprd API"
         sleep 5
         continue

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -953,7 +953,7 @@ impl Hopr {
         // notifier on acknowledged ticket reception
         let multi_strategy_ack_ticket = self.multistrategy.clone();
         let (on_ack_tkt_tx, mut on_ack_tkt_rx) = unbounded::<AcknowledgedTicket>();
-        self.db.start_ticket_processing(on_ack_tkt_tx)?;
+        self.db.start_ticket_processing(Some(on_ack_tkt_tx))?;
         processes.insert(
             HoprLibProcesses::OnReceivedAcknowledgement,
             spawn(async move {

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -953,6 +953,7 @@ impl Hopr {
         // notifier on acknowledged ticket reception
         let multi_strategy_ack_ticket = self.multistrategy.clone();
         let (on_ack_tkt_tx, mut on_ack_tkt_rx) = unbounded::<AcknowledgedTicket>();
+        self.db.start_ticket_processing(on_ack_tkt_tx)?;
         processes.insert(
             HoprLibProcesses::OnReceivedAcknowledgement,
             spawn(async move {
@@ -1004,7 +1005,6 @@ impl Hopr {
                     errors::HoprLibError::GeneralError(format!("Failed to construct the bloom filter: {e}"))
                 })?,
                 transport_output_tx,
-                on_ack_tkt_tx,
                 indexer_peer_update_rx,
                 session_tx,
             )

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -956,11 +956,14 @@ impl Hopr {
             HoprLibProcesses::OnReceivedAcknowledgement,
             spawn(async move {
                 while let Some(ack) = on_ack_tkt_rx.next().await {
-                    let _ = hopr_strategy::strategy::SingularStrategy::on_acknowledged_winning_ticket(
+                    if let Err(error) = hopr_strategy::strategy::SingularStrategy::on_acknowledged_winning_ticket(
                         &*multi_strategy_ack_ticket,
                         &ack,
                     )
-                    .await;
+                    .await
+                    {
+                        error!(%error, "failed to process acknowledged winning ticket with the strategy");
+                    }
                 }
             }),
         );

--- a/logic/path/src/selectors/legacy.rs
+++ b/logic/path/src/selectors/legacy.rs
@@ -296,6 +296,7 @@ mod tests {
     }
 
     /// Quickly define a graph with edge weights.
+    ///
     /// Syntax:
     /// `0 [1] -> 1` => edge from `0` to `1` with edge weight `1`
     /// `0 <- [1] 1` => edge from `1` to `0` with edge weight `1`
@@ -412,8 +413,30 @@ mod tests {
     }
 
     #[test]
-    fn test_should_not_find_zero_path() {
+    fn test_should_not_find_zero_weight_path() {
         let isolated = define_graph("0 [0] -> 1", ADDRESSES[0], |_, _| 1_f64);
+
+        let selector = DfsPathSelector::<TestWeights>::default();
+
+        selector
+            .select_path(&isolated, ADDRESSES[0], ADDRESSES[5], 1, 1)
+            .expect_err("should not find a path");
+    }
+
+    #[test]
+    fn test_should_not_find_one_hop_path_when_unrelated_channels_are_in_the_graph() {
+        let isolated = define_graph("1 [1] -> 2", ADDRESSES[0], |_, _| 1_f64);
+
+        let selector = DfsPathSelector::<TestWeights>::default();
+
+        selector
+            .select_path(&isolated, ADDRESSES[0], ADDRESSES[5], 1, 1)
+            .expect_err("should not find a path");
+    }
+
+    #[test]
+    fn test_should_not_find_one_hop_path_in_empty_graph() {
+        let isolated = define_graph("", ADDRESSES[0], |_, _| 1_f64);
 
         let selector = DfsPathSelector::<TestWeights>::default();
 

--- a/logic/strategy/src/aggregating.rs
+++ b/logic/strategy/src/aggregating.rs
@@ -283,7 +283,7 @@ mod tests {
     use crate::strategy::SingularStrategy;
     use anyhow::Context;
     use async_std::prelude::FutureExt as AsyncStdFutureExt;
-    use futures::{FutureExt, StreamExt};
+    use futures::{pin_mut, FutureExt, StreamExt};
     use hex_literal::hex;
     use hopr_crypto_types::prelude::*;
     use hopr_db_sql::accounts::HoprDbAccountOperations;
@@ -500,6 +500,9 @@ mod tests {
         init_db(db_alice.clone()).await?;
         init_db(db_bob.clone()).await?;
 
+        let (bob_notify_tx, bob_notify_rx) = futures::channel::mpsc::unbounded();
+        db_bob.start_ticket_processing(bob_notify_tx.into())?;
+
         let (_, channel) = populate_db_with_ack_tickets(db_bob.clone(), 5).await?;
 
         db_alice.upsert_channel(None, channel).await?;
@@ -524,8 +527,12 @@ mod tests {
         let f2 = pin!(async_std::task::sleep(Duration::from_secs(5)).fuse());
         let _ = futures::future::select(f1, f2).await;
 
+        pin_mut!(bob_notify_rx);
+        let notified_ticket = bob_notify_rx.next().await.expect("should have a ticket");
+
         let tickets = db_bob.get_tickets((&channel).into()).await?;
         assert_eq!(tickets.len(), 1, "there should be a single aggregated ticket");
+        assert_eq!(notified_ticket, tickets[0]);
 
         Ok(())
     }
@@ -539,6 +546,9 @@ mod tests {
 
         init_db(db_alice.clone()).await?;
         init_db(db_bob.clone()).await?;
+
+        let (bob_notify_tx, bob_notify_rx) = futures::channel::mpsc::unbounded();
+        db_bob.start_ticket_processing(bob_notify_tx.into())?;
 
         let (_, channel) = populate_db_with_ack_tickets(db_bob.clone(), 4).await?;
 
@@ -564,8 +574,12 @@ mod tests {
         let f2 = pin!(async_std::task::sleep(Duration::from_secs(5)));
         let _ = futures::future::select(f1, f2).await;
 
+        pin_mut!(bob_notify_rx);
+        let notified_ticket = bob_notify_rx.next().await.expect("should have a ticket");
+
         let tickets = db_bob.get_tickets((&channel).into()).await?;
         assert_eq!(tickets.len(), 1, "there should be a single aggregated ticket");
+        assert_eq!(notified_ticket, tickets[0]);
 
         Ok(())
     }
@@ -580,6 +594,8 @@ mod tests {
 
         init_db(db_alice.clone()).await?;
         init_db(db_bob.clone()).await?;
+
+        db_bob.start_ticket_processing(None)?;
 
         const NUM_TICKETS: usize = 4;
         let (mut acked_tickets, mut channel) = populate_db_with_ack_tickets(db_bob.clone(), NUM_TICKETS).await?;
@@ -629,6 +645,9 @@ mod tests {
         init_db(db_alice.clone()).await?;
         init_db(db_bob.clone()).await?;
 
+        let (bob_notify_tx, bob_notify_rx) = futures::channel::mpsc::unbounded();
+        db_bob.start_ticket_processing(bob_notify_tx.into())?;
+
         let (_, mut channel) = populate_db_with_ack_tickets(db_bob.clone(), 5).await?;
 
         let cfg = super::AggregatingStrategyConfig {
@@ -661,8 +680,13 @@ mod tests {
         // Wait until aggregation has finished
         awaiter.timeout(Duration::from_secs(5)).await.context("Timeout")??;
 
+        pin_mut!(bob_notify_rx);
+        let notified_ticket = bob_notify_rx.next().await.expect("should have a ticket");
+
         let tickets = db_bob.get_tickets((&channel).into()).await?;
         assert_eq!(tickets.len(), 1, "there should be a single aggregated ticket");
+        assert_eq!(notified_ticket, tickets[0]);
+
         Ok(())
     }
 
@@ -676,6 +700,8 @@ mod tests {
 
         init_db(db_alice.clone()).await?;
         init_db(db_bob.clone()).await?;
+
+        db_bob.start_ticket_processing(None)?;
 
         const NUM_TICKETS: usize = 1;
         let (_, channel) = populate_db_with_ack_tickets(db_bob.clone(), NUM_TICKETS).await?;

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -280,7 +280,6 @@ where
         network: Arc<Network<T>>,
         tbf_path: String,
         on_transport_output: UnboundedSender<ApplicationData>,
-        on_acknowledged_ticket: UnboundedSender<AcknowledgedTicket>,
         transport_updates: UnboundedReceiver<PeerDiscovery>,
         new_session_notifier: UnboundedSender<IncomingSession>,
     ) -> HashMap<HoprTransportProcess, JoinHandle<()>> {
@@ -368,10 +367,7 @@ where
             tkt_agg_writer,
         );
 
-        processes.insert(
-            HoprTransportProcess::Swarm,
-            spawn(transport_layer.run(version, on_acknowledged_ticket.clone())),
-        );
+        processes.insert(HoprTransportProcess::Swarm, spawn(transport_layer.run(version)));
 
         // initiate the msg-ack protocol stack over the wire transport
         let packet_cfg = PacketInteractionConfig::new(
@@ -387,7 +383,6 @@ where
             &self.me,
             &self.me_onchain,
             Some(tbf_path),
-            on_acknowledged_ticket,
             (ack_to_send_tx, ack_received_rx),
             (msg_to_send_tx, msg_received_rx),
             (tx_from_protocol, external_msg_rx),

--- a/transport/protocol/src/lib.rs
+++ b/transport/protocol/src/lib.rs
@@ -61,26 +61,22 @@ pub mod msg;
 pub mod ticket_aggregation;
 
 pub mod timer;
-use ack::processor::AckResult;
-use core_path::path::TransportPath;
-use hopr_crypto_types::keypairs::{ChainKeypair, OffchainKeypair};
 pub use timer::execute_on_tick;
 
-use futures::{SinkExt, StreamExt};
 pub use msg::processor::DEFAULT_PRICE_PER_PACKET;
-use msg::processor::{PacketSendFinalizer, PacketUnwrapping, PacketWrapping};
 
+use core_path::path::TransportPath;
+use futures::{SinkExt, StreamExt};
 use libp2p::PeerId;
+use msg::processor::{PacketSendFinalizer, PacketUnwrapping, PacketWrapping};
 use rust_stream_ext_concurrent::then_concurrent::StreamThenConcurrentExt;
 use std::collections::HashMap;
 use tracing::{error, trace};
 
 use hopr_async_runtime::prelude::{sleep, spawn};
+use hopr_crypto_types::prelude::*;
 use hopr_db_api::protocol::HoprDbProtocolOperations;
-use hopr_internal_types::{
-    protocol::{Acknowledgement, ApplicationData},
-    tickets::AcknowledgedTicket,
-};
+use hopr_internal_types::protocol::{Acknowledgement, ApplicationData};
 
 #[cfg(all(feature = "prometheus", not(test)))]
 use hopr_metrics::metrics::{MultiCounter, SimpleCounter, SimpleGauge};
@@ -141,7 +137,6 @@ pub async fn run_msg_ack_protocol<Db>(
     me: &OffchainKeypair,
     me_onchain: &ChainKeypair,
     bloom_filter_persistent_path: Option<String>,
-    on_ack_ticket: impl futures::Sink<AcknowledgedTicket> + Send + Sync + 'static,
     wire_ack: (
         impl futures::Sink<(PeerId, Acknowledgement)> + Send + Sync + 'static,
         impl futures::Stream<Item = (PeerId, Acknowledgement)> + Send + Sync + 'static,
@@ -204,38 +199,30 @@ where
         spawn(async move {
             let _neverending = wire_ack
                 .1
-                .then_concurrent(move |(peer, ack)| {
+                .for_each_concurrent(None, move |(peer, ack)| {
                     let ack_processor = ack_processor_read.clone();
 
-                    async move { ack_processor.recv(&peer, ack).await }
-                })
-                .filter_map(|v| async move {
-                    #[cfg(all(feature = "prometheus", not(test)))]
-                    match &v {
-                        Ok(AckResult::Sender(_)) => {
-                            METRIC_RECEIVED_ACKS.increment(&["true"]);
-                        }
-                        Ok(AckResult::RelayerWinning(_)) => {
-                            METRIC_RECEIVED_ACKS.increment(&["true"]);
-                            METRIC_TICKETS_COUNT.increment(&["winning"]);
-                        }
-                        Ok(AckResult::RelayerLosing) => {
-                            METRIC_RECEIVED_ACKS.increment(&["true"]);
-                            METRIC_TICKETS_COUNT.increment(&["losing"]);
-                        }
-                        Err(_e) => {
-                            METRIC_RECEIVED_ACKS.increment(&["false"]);
+                    async move {
+                        let _ack_result = ack_processor.recv(&peer, ack).await;
+                        #[cfg(all(feature = "prometheus", not(test)))]
+                        match &_ack_result {
+                            Ok(hopr_db_api::prelude::AckResult::Sender(_)) => {
+                                METRIC_RECEIVED_ACKS.increment(&["true"]);
+                            }
+                            Ok(hopr_db_api::prelude::AckResult::RelayerWinning(_)) => {
+                                METRIC_RECEIVED_ACKS.increment(&["true"]);
+                                METRIC_TICKETS_COUNT.increment(&["winning"]);
+                            }
+                            Ok(hopr_db_api::prelude::AckResult::RelayerLosing) => {
+                                METRIC_RECEIVED_ACKS.increment(&["true"]);
+                                METRIC_TICKETS_COUNT.increment(&["losing"]);
+                            }
+                            Err(_) => {
+                                METRIC_RECEIVED_ACKS.increment(&["false"]);
+                            }
                         }
                     }
-
-                    if let Ok(AckResult::RelayerWinning(acknowledged_ticket)) = v {
-                        Some(acknowledged_ticket)
-                    } else {
-                        None
-                    }
                 })
-                .map(Ok)
-                .forward(on_ack_ticket)
                 .await;
         }),
     );

--- a/transport/protocol/tests/msg_ack_workflows.rs
+++ b/transport/protocol/tests/msg_ack_workflows.rs
@@ -213,13 +213,14 @@ async fn peer_setup_for(count: usize) -> anyhow::Result<(Vec<WireChannels>, Vec<
             outgoing_ticket_win_prob: 1.0,
         };
 
+        db.start_ticket_processing(received_ack_tickets_tx)?;
+
         hopr_transport_protocol::run_msg_ack_protocol(
             cfg,
             db,
             &PEERS[i],
             &PEERS_CHAIN[i],
             None,
-            received_ack_tickets_tx,
             (wire_ack_recv_tx, wire_ack_send_rx),
             (wire_msg_recv_tx, wire_msg_send_rx),
             (api_recv_tx, api_send_rx),
@@ -363,7 +364,7 @@ async fn packet_relayer_workflow_n_peers(peer_count: usize, pending_packets: usi
             .collect(),
     )
     .await;
-    assert_eq!(peer_count - 1, packet_path.length() as usize, "path has invalid length");
+    assert_eq!(peer_count - 1, packet_path.length(), "path has invalid length");
 
     async_std::task::spawn(emulate_channel_communication(pending_packets, wire_apis));
 
@@ -411,6 +412,8 @@ async fn packet_relayer_workflow_n_peers(peer_count: usize, pending_packets: usi
         "test timed out after {} seconds",
         TIMEOUT_SECONDS.as_secs()
     );
+
+    assert_eq!(ticket_channels.len(), peer_count);
 
     for (i, rx) in ticket_channels.into_iter().enumerate() {
         let expected_tickets = if i != 0 && i != peer_count - 1 {

--- a/transport/protocol/tests/msg_ack_workflows.rs
+++ b/transport/protocol/tests/msg_ack_workflows.rs
@@ -213,7 +213,7 @@ async fn peer_setup_for(count: usize) -> anyhow::Result<(Vec<WireChannels>, Vec<
             outgoing_ticket_win_prob: 1.0,
         };
 
-        db.start_ticket_processing(received_ack_tickets_tx)?;
+        db.start_ticket_processing(Some(received_ack_tickets_tx))?;
 
         hopr_transport_protocol::run_msg_ack_protocol(
             cfg,


### PR DESCRIPTION
- update ticket redemption code to not try to redeem tickets with index lower than on the channel entry
- add unit tests for such scenarios
- do not hold ticket redeem DB stream opened for too long
- reorder processing of the acknowledged ticket notification: now the notification is done by the TicketManager *after* the ticket has been persisted into the DB.
- ticket replacement after aggregation has been moved into the TicketManager