### PR TITLE
Add endpoint for exporting Channel Graph in DOT format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -200,6 +200,8 @@ debug-identity
 
 # make sure anything which is vendored is copied
 !/vendor/**/*
+vendor/.DS_Store
+vendor/cargo/.DS_Store
 
 # technical docs
 /docs/*/.structurizr

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1677,7 +1677,7 @@ dependencies = [
 
 [[package]]
 name = "core-path"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-std",
@@ -4649,7 +4649,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd-api"
-version = "3.7.2"
+version = "3.8.0"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1690,6 +1690,7 @@ dependencies = [
  "hopr-db-sql",
  "hopr-internal-types",
  "hopr-metrics",
+ "hopr-platform",
  "hopr-primitive-types",
  "lazy_static",
  "libp2p-identity",

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -73,6 +73,7 @@ pub use {
     chain_api::config::{
         Addresses as NetworkContractAddresses, EnvironmentType, Network as ChainNetwork, ProtocolsConfig,
     },
+    core_path::channel_graph::GraphExportConfig,
     hopr_internal_types::prelude::*,
     hopr_network_types::prelude::{IpProtocol, RoutingOptions},
     hopr_primitive_types::prelude::*,
@@ -1496,7 +1497,7 @@ impl Hopr {
             .map(|pk| pk.map(|v| v.into()))?)
     }
 
-    pub async fn export_channel_graph(&self) -> String {
-        self.channel_graph.read().await.as_graphviz()
+    pub async fn export_channel_graph(&self, cfg: GraphExportConfig) -> String {
+        self.channel_graph.read().await.as_dot(cfg)
     }
 }

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -1495,4 +1495,8 @@ impl Hopr {
             .await
             .map(|pk| pk.map(|v| v.into()))?)
     }
+
+    pub async fn export_channel_graph(&self) -> String {
+        self.channel_graph.read().await.as_graphviz()
+    }
 }

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -956,11 +956,14 @@ impl Hopr {
             HoprLibProcesses::OnReceivedAcknowledgement,
             spawn(async move {
                 while let Some(ack) = on_ack_tkt_rx.next().await {
-                    let _ = hopr_strategy::strategy::SingularStrategy::on_acknowledged_winning_ticket(
+                    if let Err(error) = hopr_strategy::strategy::SingularStrategy::on_acknowledged_winning_ticket(
                         &*multi_strategy_ack_ticket,
                         &ack,
                     )
-                    .await;
+                    .await
+                    {
+                        error!(%error, "failed to process acknowledged winning ticket with the strategy");
+                    }
                 }
             }),
         );

--- a/hoprd/rest-api/Cargo.toml
+++ b/hoprd/rest-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd-api"
-version = "3.7.2"
+version = "3.8.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "This Rest API enables developers to interact with a hoprd node programatically through HTTP."

--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -146,7 +146,7 @@ pub(crate) struct InternalState {
             network::TicketPriceResponse,
             network::TicketProbabilityResponse,
             node::EntryNode, node::NodeInfoResponse, node::NodePeersQueryRequest,
-            node::HeartbeatInfo, node::PeerInfo, node::AnnouncedPeer, node::NodePeersResponse, node::NodeVersionResponse,
+            node::HeartbeatInfo, node::PeerInfo, node::AnnouncedPeer, node::NodePeersResponse, node::NodeVersionResponse, node::GraphExportRequest,
             peers::NodePeerInfoResponse, peers::PingResponse,
             session::SessionClientRequest, session::SessionClientResponse, session::SessionCloseClientRequest,
             tickets::NodeTicketStatisticsResponse, tickets::ChannelTicket,

--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -321,6 +321,7 @@ async fn build_api(
                 .route("/node/peers", get(node::peers))
                 .route("/node/entryNodes", get(node::entry_nodes))
                 .route("/node/metrics", get(node::metrics))
+                .route("/node/graph", get(node::channel_graph))
                 .route("/peers/:destination/ping", post(peers::ping_peer))
                 .route("/session/websocket", get(session::websocket))
                 .route("/session/:protocol", post(session::create_client))

--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -118,6 +118,7 @@ pub(crate) struct InternalState {
         node::entry_nodes,
         node::info,
         node::metrics,
+        node::channel_graph,
         node::peers,
         node::version,
         peers::ping_peer,

--- a/hoprd/rest-api/src/node.rs
+++ b/hoprd/rest-api/src/node.rs
@@ -264,6 +264,24 @@ pub(super) async fn metrics() -> impl IntoResponse {
     }
 }
 
+/// Retrieve node's channel graph in DOT (graphviz) format.
+#[utoipa::path(
+    get,
+    path = const_format::formatcp!("{BASE_PATH}/node/graph"),
+    responses(
+            (status = 200, description = "Fetched channel graph", body = String),
+            (status = 401, description = "Invalid authorization token.", body = ApiError),
+    ),
+    security(
+            ("api_token" = []),
+            ("bearer_token" = [])
+    ),
+    tag = "Node"
+)]
+pub(super) async fn channel_graph(State(state): State<Arc<InternalState>>) -> impl IntoResponse {
+    (StatusCode::OK, state.hopr.export_channel_graph().await).into_response()
+}
+
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 #[schema(example = json!({

--- a/logic/path/Cargo.toml
+++ b/logic/path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-path"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Contains mixnet path construction and path selection logic"

--- a/logic/path/Cargo.toml
+++ b/logic/path/Cargo.toml
@@ -33,6 +33,7 @@ hopr-db-api = { workspace = true }
 hopr-metrics = { workspace = true, optional = true }
 hopr-internal-types = { workspace = true }
 hopr-primitive-types = { workspace = true }
+hopr-platform = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/logic/path/src/channel_graph.rs
+++ b/logic/path/src/channel_graph.rs
@@ -240,10 +240,7 @@ impl ChannelGraph {
 
     /// Outputs the channel graph in the DOT (graphviz) format.
     pub fn as_graphviz(&self) -> String {
-        petgraph::dot::Dot::with_attr_getters(&self.graph, &[], &|_, (_, _, e)| e.to_string(), &|_, (_, n)| {
-            n.to_string()
-        })
-        .to_string()
+        petgraph::dot::Dot::with_config(&self.graph, &[]).to_string()
     }
 }
 

--- a/logic/path/src/channel_graph.rs
+++ b/logic/path/src/channel_graph.rs
@@ -259,9 +259,11 @@ impl ChannelGraph {
             }))
             .to_string()
         } else if cfg.ignore_disconnected_components {
+            // Create a filtered graph with only Opened channels edges
             let only_open_graph =
                 EdgeFiltered::from_fn(&self.graph, |e| e.weight().channel.status == ChannelStatus::Open);
 
+            // Filter out nodes that are not connected to this node
             Dot::new(&NodeFiltered::from_fn(&self.graph, |n| {
                 let mut dfs_state = DfsSpace::new(&only_open_graph);
                 has_path_connecting(&only_open_graph, self.me, n, Some(&mut dfs_state))

--- a/logic/path/src/selectors/legacy.rs
+++ b/logic/path/src/selectors/legacy.rs
@@ -133,7 +133,7 @@ where
 
         if destination.eq(&channel.channel.destination) {
             // We cannot use destination as last intermediate hop as
-            // this would be a loopback which does not give any privacy
+            // this would be a loopback that does not give any privacy
             return false;
         }
 
@@ -166,7 +166,7 @@ where
     /// that goes from `source` to `destination`. There does not need to be
     /// a payment channel to `destination`, so the path only includes intermediate hops.
     ///
-    /// Implements a randomized best-first search through the path space. The graph
+    /// The function implements a randomized best-first search through the path space. The graph
     /// traversal is bounded by `self.max_iterations` to prevent from long-running path
     /// selection runs.
     fn select_path(
@@ -207,15 +207,15 @@ where
                     );
                 }
 
-                if current_len >= min_hops && current_len <= max_hops {
-                    return Ok(ChannelPath::new_valid(current.path));
+                return if current_len >= min_hops && current_len <= max_hops {
+                    Ok(ChannelPath::new_valid(current.path))
                 } else {
-                    return Err(PathError::PathNotFound(
+                    Err(PathError::PathNotFound(
                         max_hops,
                         source.to_string(),
                         destination.to_string(),
-                    ));
-                }
+                    ))
+                };
             }
 
             let last_peer = *current.path.last().unwrap();

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -32,6 +32,9 @@ craneLib.devShell {
     gnumake
     which
 
+    # docs utilities
+    graphviz
+
     # github integration
     gh
 


### PR DESCRIPTION
This PR add a new REST API endpoint `/node/graph` that outputs the channel/transport graph as DOT-formatted file. This format can be visualized using tools such as `graphviz`.