### PR TITLE
Add Loopback service to simplify usage for the CT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,12 +893,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bimap"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4466,7 +4460,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "async-lock 3.4.0",
  "async-std",
@@ -4565,7 +4559,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.3.1"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4649,7 +4643,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd-api"
-version = "3.8.0"
+version = "3.8.1"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4657,7 +4651,6 @@ dependencies = [
  "axum",
  "axum-extra",
  "base64 0.22.1",
- "bimap",
  "const_format",
  "futures",
  "futures-concurrency",
@@ -4669,12 +4662,9 @@ dependencies = [
  "hopr-network-types",
  "hopr-transport-session",
  "hoprd-db-api",
- "hoprd-db-entity",
- "hoprd-db-migration",
  "hoprd-inbox",
  "lazy_static",
  "libp2p-identity",
- "mime",
  "regex",
  "serde",
  "serde_json",
@@ -4682,9 +4672,7 @@ dependencies = [
  "smart-default",
  "strum",
  "tokio",
- "tokio-retry",
  "tokio-stream",
- "tokio-util",
  "tower 0.5.1",
  "tower-http",
  "tracing",

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -84,7 +84,7 @@ pub use {
         errors::{HoprTransportError, NetworkingError, ProtocolError},
         libp2p::identity::PeerId,
         ApplicationData, HalfKeyChallenge, Health, IncomingSession as HoprIncomingSession, Keypair, Multiaddr,
-        OffchainKeypair as HoprOffchainKeypair, SendMsg, Session as HoprSession, SessionCapability,
+        OffchainKeypair as HoprOffchainKeypair, SendMsg, ServiceId, Session as HoprSession, SessionCapability,
         SessionClientConfig, SessionId as HoprSessionId, SessionTarget, TicketStatistics, SESSION_USABLE_MTU_SIZE,
     },
 };

--- a/hoprd/hoprd/src/exit.rs
+++ b/hoprd/hoprd/src/exit.rs
@@ -1,5 +1,5 @@
 use hopr_lib::errors::HoprLibError;
-use hopr_lib::{transfer_session, HoprOffchainKeypair};
+use hopr_lib::{transfer_session, HoprOffchainKeypair, ServiceId};
 use hopr_network_types::prelude::ForeignDataMode;
 use hopr_network_types::udp::UdpStreamParallelism;
 use hoprd_api::{HOPR_TCP_BUFFER_SIZE, HOPR_UDP_BUFFER_SIZE, HOPR_UDP_QUEUE_SIZE};
@@ -38,6 +38,8 @@ impl HoprServerIpForwardingReactor {
         })
     }
 }
+
+pub const SERVICE_ID_LOOPBACK: ServiceId = 0;
 
 #[hopr_lib::async_trait]
 impl hopr_lib::HoprSessionReactor for HoprServerIpForwardingReactor {
@@ -186,10 +188,10 @@ impl hopr_lib::HoprSessionReactor for HoprServerIpForwardingReactor {
                             %tcp_target,
                             "server bridged session to TCP ended"
                         ),
-                        Err(e) => tracing::error!(
+                        Err(error) => tracing::error!(
                             ?session_id,
                             %tcp_target,
-                            error = %e,
+                            %error,
                             "TCP server stream is closed"
                         ),
                     }
@@ -197,6 +199,27 @@ impl hopr_lib::HoprSessionReactor for HoprServerIpForwardingReactor {
                     #[cfg(all(feature = "prometheus", not(test)))]
                     METRIC_ACTIVE_TARGETS.decrement(&["tcp"], 1.0);
                 });
+
+                Ok(())
+            }
+            hopr_lib::SessionTarget::ExitNode(SERVICE_ID_LOOPBACK) => {
+                tracing::debug!(?session_id, "bridging the session to the loopback service");
+                let (mut reader, mut writer) = tokio::io::split(session.session);
+
+                #[cfg(all(feature = "prometheus", not(test)))]
+                METRIC_ACTIVE_TARGETS.increment(&["loopback"], 1.0);
+
+                match tokio::io::copy(&mut reader, &mut writer).await {
+                    Ok(copied) => tracing::info!(?session_id, copied, "server loopback session service ended"),
+                    Err(error) => tracing::error!(
+                        ?session_id,
+                        %error,
+                        "server loopback session service ended with an error"
+                    ),
+                }
+
+                #[cfg(all(feature = "prometheus", not(test)))]
+                METRIC_ACTIVE_TARGETS.decrement(&["loopback"], 1.0);
 
                 Ok(())
             }

--- a/hoprd/hoprd/src/exit.rs
+++ b/hoprd/hoprd/src/exit.rs
@@ -209,6 +209,7 @@ impl hopr_lib::HoprSessionReactor for HoprServerIpForwardingReactor {
                 #[cfg(all(feature = "prometheus", not(test)))]
                 METRIC_ACTIVE_TARGETS.increment(&["loopback"], 1.0);
 
+                // Uses 4 kB buffer for copying
                 match tokio::io::copy(&mut reader, &mut writer).await {
                     Ok(copied) => tracing::info!(?session_id, copied, "server loopback session service ended"),
                     Err(error) => tracing::error!(

--- a/hoprd/rest-api/Cargo.toml
+++ b/hoprd/rest-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd-api"
-version = "3.8.0"
+version = "3.8.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "This Rest API enables developers to interact with a hoprd node programatically through HTTP."
@@ -28,7 +28,6 @@ async-broadcast = { workspace = true }
 async-lock = { workspace = true }
 axum = { workspace = true, features = ["ws", "http2"] }
 axum-extra = { version = "0.9.4", features = ["query"] }
-bimap = { workspace = true }
 base64 = { workspace = true }
 const_format = { workspace = true }
 futures = { workspace = true }
@@ -39,7 +38,6 @@ libp2p-identity = { workspace = true, features = [
   "ed25519",
   "serde",
 ] }
-mime = "0.3.17"
 regex = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -47,8 +45,6 @@ serde_with = { workspace = true }
 smart-default = { workspace = true }
 strum = { workspace = true }
 tokio = { workspace = true }
-tokio-util = { workspace = true, features = ["compat"] }
-tokio-retry = { workspace = true }
 tokio-stream = { version = "0.1.15", features = ["net"] }
 tower = "0.5.1"
 tower-http = { version = "0.6.1", features = [
@@ -68,8 +64,6 @@ validator = { workspace = true }
 hopr-lib = { workspace = true, features = ["runtime-tokio", "session-client"] }
 hopr-db-api = { workspace = true }
 hoprd-db-api = { workspace = true }
-hoprd-db-entity = { workspace = true }
-hoprd-db-migration = { workspace = true }
 hoprd-inbox = { workspace = true }
 hopr-crypto-types = { workspace = true }
 hopr-network-types = { workspace = true, features = ["runtime-tokio"] }

--- a/tests/hopr.py
+++ b/tests/hopr.py
@@ -459,7 +459,7 @@ class HoprdAPI:
         return int(response.price) if hasattr(response, "price") else None
 
     async def session_client(
-        self, destination: str, path: str, protocol: str, target: str, listen_on: str = "127.0.0.1:0", capabilities=None, sealed_target=False
+        self, destination: str, path: str, protocol: str, target: str, listen_on: str = "127.0.0.1:0", capabilities=None, sealed_target=False, service=False
     ):
         """
         Returns the port of the client session.
@@ -470,10 +470,11 @@ class HoprdAPI:
         :param listen_on: The host to listen on for input packets (default: "127.0.0.1:0")
         :param capabilities: Optional list of capabilities for the session (default: None)
         :param sealed_target: The target parameter will be encrypted (default: False)
+        :param service: If set, the target must be an integer representing Exit node service (default: False)
         """
         actual_target = {
             "Sealed": base64.b64encode(seal_with_peerid(destination, bytes(target,'utf-8'), 50)).decode('ascii')
-        } if sealed_target else { "Plain": target }
+        } if sealed_target else { "Service": int(target) } if service else { "Plain": target }
 
         if capabilities is None:
             body = SessionClientRequest(destination=destination, path=path, target=actual_target, listen_host=listen_on)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -373,6 +373,59 @@ async def test_session_communication_with_a_udp_echo_server(
     assert len(await src_peer.api.session_list_clients('udp')) == 0
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("src,dest", random_distinct_pairs_from(barebone_nodes(), count=PARAMETERIZED_SAMPLE_SIZE))
+async def test_session_communication_with_udp_loopback_service(
+        src: str, dest: str, swarm7: dict[str, Node]
+):
+    """
+    HOPR UDP socket buffers are set to 462 bytes to mimic the underlying MTU of the HOPR protocol.
+    """
+
+    packet_count = 100 if os.getenv("CI", default="false") == "false" else 50
+    expected = [f"{i}".rjust(HOPR_SESSION_MAX_PAYLOAD_SIZE) for i in range(packet_count)]
+
+    assert [len(x) for x in expected] == packet_count * [HOPR_SESSION_MAX_PAYLOAD_SIZE]
+
+    src_peer = swarm7[src]
+    dest_peer = swarm7[dest]
+
+    actual = []
+
+    # Service 0 session will loop back all the data at Exit back to the Entry
+    # Therefore, we do not need the Echo service here
+    src_sock_port = await src_peer.api.session_client(dest_peer.peer_id, path={"Hops": 0}, protocol='udp',
+                                                      target=f"0", service=True)
+
+    assert src_sock_port is not None, "Failed to open session"
+    assert len(await src_peer.api.session_list_clients('udp')) == 1
+    #logging.info(f"session to {dst_sock_port} opened successfully")
+
+    addr = ('127.0.0.1', src_sock_port)
+    with connect_socket(SocketType.UDP, None) as s:
+        s.settimeout(20)
+        total_sent = 0
+        for message in expected:
+            total_sent = total_sent + s.sendto(message.encode(), addr)
+            await asyncio.sleep(0.01) # UDP has no flow-control, so we must insert an artificial gap
+
+        while total_sent > 0:
+            chunk, _ = s.recvfrom(min(HOPR_SESSION_MAX_PAYLOAD_SIZE, total_sent))
+            total_sent = total_sent - len(chunk)
+            # Adapt for situations when data arrive completely unordered (also within the buffer)
+            actual.extend([m for m in re.split(r'\s+', chunk.decode().strip()) if len(m) > 0])
+
+    expected = [msg.strip() for msg in expected]
+
+    actual.sort()
+    expected.sort()
+
+    assert len(actual) == len(expected)
+    assert actual == expected
+
+    assert await src_peer.api.session_close_client(protocol='udp', bound_ip='127.0.0.1', bound_port=src_sock_port) is True
+    assert len(await src_peer.api.session_list_clients('udp')) == 0
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "route",
     [shuffled(barebone_nodes())[:3] for _ in range(PARAMETERIZED_SAMPLE_SIZE)],

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -252,8 +252,8 @@ async def test_session_communication_with_a_tcp_echo_server(
 
     assert ''.join(expected) == actual
 
-    assert await src_peer.api.session_close_client(protocol='tcp', bound_ip='127.0.0.1', bound_port=src_sock_port) is True
-    assert len(await src_peer.api.session_list_clients('tcp')) == 0
+    assert await src_peer.api.session_close_client(protocol='tcp', bound_ip='127.0.0.1', bound_port=src_sock_port)
+    assert await src_peer.api.session_list_clients('tcp') == []
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
@@ -315,8 +315,8 @@ async def test_session_communication_over_n_hop_with_a_tcp_echo_server(
 
         assert ''.join(expected) == actual
 
-        assert await src_peer.api.session_close_client(protocol='tcp', bound_ip='127.0.0.1', bound_port=src_sock_port) is True
-        assert len(await src_peer.api.session_list_clients('tcp')) == 0
+        assert await src_peer.api.session_close_client(protocol='tcp', bound_ip='127.0.0.1', bound_port=src_sock_port)
+        assert await src_peer.api.session_list_clients('tcp') == []
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("src,dest", random_distinct_pairs_from(barebone_nodes(), count=PARAMETERIZED_SAMPLE_SIZE))
@@ -366,11 +366,10 @@ async def test_session_communication_with_a_udp_echo_server(
     actual.sort()
     expected.sort()
 
-    assert len(actual) == len(expected)
     assert actual == expected
 
-    assert await src_peer.api.session_close_client(protocol='udp', bound_ip='127.0.0.1', bound_port=src_sock_port) is True
-    assert len(await src_peer.api.session_list_clients('udp')) == 0
+    assert await src_peer.api.session_close_client(protocol='udp', bound_ip='127.0.0.1', bound_port=src_sock_port)
+    assert await src_peer.api.session_list_clients('udp') == []
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("src,dest", random_distinct_pairs_from(barebone_nodes(), count=PARAMETERIZED_SAMPLE_SIZE))
@@ -419,11 +418,10 @@ async def test_session_communication_with_udp_loopback_service(
     actual.sort()
     expected.sort()
 
-    assert len(actual) == len(expected)
     assert actual == expected
 
-    assert await src_peer.api.session_close_client(protocol='udp', bound_ip='127.0.0.1', bound_port=src_sock_port) is True
-    assert len(await src_peer.api.session_list_clients('udp')) == 0
+    assert await src_peer.api.session_close_client(protocol='udp', bound_ip='127.0.0.1', bound_port=src_sock_port)
+    assert await src_peer.api.session_list_clients('udp') == []
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
@@ -490,11 +488,10 @@ async def test_session_communication_over_n_hop_with_a_udp_echo_server(
         actual.sort()
         expected.sort()
 
-        assert len(actual) == len(expected)
         assert actual == expected
 
-        assert await src_peer.api.session_close_client(protocol='udp', bound_ip='127.0.0.1', bound_port=src_sock_port) is True
-        assert len(await src_peer.api.session_list_clients('udp')) == 0
+        assert await src_peer.api.session_close_client(protocol='udp', bound_ip='127.0.0.1', bound_port=src_sock_port)
+        assert await src_peer.api.session_list_clients('udp') == []
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("src,dest", random_distinct_pairs_from(barebone_nodes(), count=PARAMETERIZED_SAMPLE_SIZE))
@@ -518,8 +515,8 @@ async def test_session_communication_with_an_https_server(
         assert response is not None
         assert response.text == expected
 
-        assert await src_peer.api.session_close_client(protocol='tcp', bound_ip='127.0.0.1', bound_port=src_sock_port) is True
-        assert len(await src_peer.api.session_list_clients('tcp')) == 0
+        assert await src_peer.api.session_close_client(protocol='tcp', bound_ip='127.0.0.1', bound_port=src_sock_port)
+        assert await src_peer.api.session_list_clients('tcp') == []
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
@@ -565,8 +562,8 @@ async def test_session_communication_over_n_hop_with_an_https_server(
             assert response is not None
             assert response.text == expected
 
-            assert await src_peer.api.session_close_client(protocol='tcp', bound_ip='127.0.0.1', bound_port=src_sock_port) is True
-            assert len(await src_peer.api.session_list_clients('tcp')) == 0
+            assert await src_peer.api.session_close_client(protocol='tcp', bound_ip='127.0.0.1', bound_port=src_sock_port)
+            assert await src_peer.api.session_list_clients('tcp') == []
 
 
 @pytest.mark.skipif(

--- a/transport/api/Cargo.toml
+++ b/transport/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Implements the main HOPR interface for the core library"
 edition = "2021"

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -94,7 +94,7 @@ pub use hopr_transport_session::types::transfer_session;
 use crate::constants::SESSION_INITIATION_TIMEOUT_BASE;
 pub use crate::helpers::{IndexerTransportEvent, PeerEligibility, TicketStatistics};
 pub use hopr_network_types::prelude::RoutingOptions;
-pub use hopr_transport_session::types::SessionTarget;
+pub use hopr_transport_session::types::{ServiceId, SessionTarget};
 
 /*#[cfg(all(feature = "prometheus", not(test)))]
 lazy_static::lazy_static! {

--- a/transport/session/Cargo.toml
+++ b/transport/session/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-session"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Session functionality providing session abstraction over the HOPR transport"

--- a/transport/session/src/lib.rs
+++ b/transport/session/src/lib.rs
@@ -11,6 +11,7 @@ pub mod types;
 
 pub use manager::{DispatchResult, SessionManager, SessionManagerConfig};
 
+use crate::types::SessionTarget;
 use hopr_network_types::prelude::state::SessionFeature;
 pub use hopr_network_types::types::*;
 use libp2p_identity::PeerId;
@@ -71,11 +72,8 @@ pub struct SessionClientConfig {
     /// The fixed path options for the session.
     pub path_options: RoutingOptions,
 
-    /// Protocol to be used to connect to the target
-    pub target_protocol: IpProtocol,
-
-    /// Optionally encrypted target of the session.
-    pub target: SealedHost,
+    /// Contains target protocol and optionally encrypted target of the session.
+    pub target: SessionTarget,
 
     /// Capabilities offered by the session.
     pub capabilities: Vec<Capability>,

--- a/transport/session/src/types.rs
+++ b/transport/session/src/types.rs
@@ -116,6 +116,13 @@ pub const SESSION_USABLE_MTU_SIZE: usize =
 trait AsyncReadWrite: futures::AsyncWrite + futures::AsyncRead + Send {}
 impl<T: futures::AsyncWrite + futures::AsyncRead + Send> AsyncReadWrite for T {}
 
+/// Describes a node service target.
+/// These are specialized [`SessionTargets`](SessionTarget::ExitNode)
+/// that are local to the Exit node and have different purposes, such as Cover Traffic.
+///
+/// These targets cannot be [sealed](SealedHost) from the Entry node.
+pub type ServiceId = u32;
+
 /// Defines what should happen with the data at the recipient where the
 /// data from the established session are supposed to be forwarded to some `target`.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -125,8 +132,8 @@ pub enum SessionTarget {
     UdpStream(SealedHost),
     /// Target is running over TCP with the given address and port.
     TcpStream(SealedHost),
-    /// Target is a service directly at the exit node with a given service ID.
-    ExitNode(u32),
+    /// Target is a service directly at the exit node with the given service ID.
+    ExitNode(ServiceId),
 }
 
 /// Wrapper for incoming [Session] along with other information


### PR DESCRIPTION
The PR introduces a special target, which makes the Exit node to perform loopback of data received on a session back to it.

This is especially useful for the CT, so that no special echo service needs to be set up and the CT operation can be done from a single socket per each node.

This loopback service has ID 0, thus for `target`, the user specifies `"target": {"Service": 0}` in the REST API endpoint (instead of usual `"Plain": ...`)