### PR TITLE
gha: Enable docker production build in PR

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -66,7 +66,7 @@ jobs:
         id: options
         run: |
           nix_debug_option="-debug"
-          if ${{ inputs.production }}; then
+          if [[ ${{ inputs.production }} || ${{ contains(steps.pr-labels.outputs.labels, ' docker-production-build ') }} ]]; then
             nix_debug_option=""
           fi
           declare docker_tag docker_tag_pr docker_release_latest_tag

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,7 +39,7 @@ jobs:
           - DAppNodePackage-Hopr
           - DAppNodePackage-Hopr-testnet
     name: ${{ matrix.repository }}
-    needs: 
+    needs:
       - build-docker
     uses: ./.github/workflows/build-dappnode.yaml
     with:


### PR DESCRIPTION
By default PRs build docker images which include a hoprd debug build. This is done to have faster build times in the CI. This PR adds the option to build production images by adding the Github label `docker-production-build` to a PR and rebuilding the image.