### PR TITLE
Output routing options in the session listing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,12 +893,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bimap"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
-
-[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4649,7 +4643,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd-api"
-version = "3.8.0"
+version = "3.9.0"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4657,7 +4651,6 @@ dependencies = [
  "axum",
  "axum-extra",
  "base64 0.22.1",
- "bimap",
  "const_format",
  "futures",
  "futures-concurrency",
@@ -4669,8 +4662,6 @@ dependencies = [
  "hopr-network-types",
  "hopr-transport-session",
  "hoprd-db-api",
- "hoprd-db-entity",
- "hoprd-db-migration",
  "hoprd-inbox",
  "lazy_static",
  "libp2p-identity",
@@ -4682,9 +4673,7 @@ dependencies = [
  "smart-default",
  "strum",
  "tokio",
- "tokio-retry",
  "tokio-stream",
- "tokio-util",
  "tower 0.5.1",
  "tower-http",
  "tracing",

--- a/hoprd/hoprd/src/main.rs
+++ b/hoprd/hoprd/src/main.rs
@@ -392,7 +392,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             | HoprdProcesses::Inbox(jh)
                             | HoprdProcesses::RestApi(jh) => join_handles.push(jh),
                             HoprdProcesses::ListenerSockets(jhs) => {
-                                join_handles.extend(jhs.write().await.drain().map(|(_, (_, jh))| jh));
+                                join_handles.extend(jhs.write().await.drain().map(|(_, entry)| entry.jh));
                             }
                         }
                         futures::stream::iter(join_handles)

--- a/hoprd/rest-api/Cargo.toml
+++ b/hoprd/rest-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd-api"
-version = "3.8.0"
+version = "3.9.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "This Rest API enables developers to interact with a hoprd node programatically through HTTP."
@@ -28,7 +28,6 @@ async-broadcast = { workspace = true }
 async-lock = { workspace = true }
 axum = { workspace = true, features = ["ws", "http2"] }
 axum-extra = { version = "0.9.4", features = ["query"] }
-bimap = { workspace = true }
 base64 = { workspace = true }
 const_format = { workspace = true }
 futures = { workspace = true }
@@ -47,8 +46,6 @@ serde_with = { workspace = true }
 smart-default = { workspace = true }
 strum = { workspace = true }
 tokio = { workspace = true }
-tokio-util = { workspace = true, features = ["compat"] }
-tokio-retry = { workspace = true }
 tokio-stream = { version = "0.1.15", features = ["net"] }
 tower = "0.5.1"
 tower-http = { version = "0.6.1", features = [
@@ -68,8 +65,6 @@ validator = { workspace = true }
 hopr-lib = { workspace = true, features = ["runtime-tokio", "session-client"] }
 hopr-db-api = { workspace = true }
 hoprd-db-api = { workspace = true }
-hoprd-db-entity = { workspace = true }
-hoprd-db-migration = { workspace = true }
 hoprd-inbox = { workspace = true }
 hopr-crypto-types = { workspace = true }
 hopr-network-types = { workspace = true, features = ["runtime-tokio"] }

--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -52,7 +52,7 @@ use utoipa_scalar::{Scalar, Servable as ScalarServable};
 use utoipa_swagger_ui::SwaggerUi;
 
 use crate::config::Auth;
-use crate::session::SessionTargetSpec;
+use crate::session::StoredSessionEntry;
 use hopr_lib::{errors::HoprLibError, ApplicationData, Hopr};
 use hopr_network_types::prelude::IpProtocol;
 
@@ -68,8 +68,7 @@ pub type MessageEncoder = fn(&[u8]) -> Box<[u8]>;
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct ListenerId(pub IpProtocol, pub std::net::SocketAddr);
 
-pub type ListenerJoinHandles =
-    Arc<RwLock<HashMap<ListenerId, (SessionTargetSpec, hopr_async_runtime::prelude::JoinHandle<()>)>>>;
+pub type ListenerJoinHandles = Arc<RwLock<HashMap<ListenerId, StoredSessionEntry>>>;
 
 #[derive(Clone)]
 pub(crate) struct InternalState {
@@ -391,6 +390,7 @@ enum ApiErrorStatus {
     TooManyOpenWebsocketConnections,
     InvalidQuality,
     NotReady,
+    ListenHostAlreadyUsed,
     #[strum(serialize = "INVALID_PATH")]
     InvalidPath(String),
     #[strum(serialize = "UNKNOWN_FAILURE")]


### PR DESCRIPTION
When Session gets created and listed (via create/list REST API) endpoints, the `path` now gets returned as well reflecting on the routing options for that Session.

Also, new return code has been added when the listening host for a new session is already occupied.

Closes #6693 
Closes #6694 