### PR TITLE
Add back challenge into the send_message endpoint

### DIFF
--- a/hoprd/rest-api/Cargo.toml
+++ b/hoprd/rest-api/Cargo.toml
@@ -46,7 +46,7 @@ smart-default = { workspace = true }
 strum = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { version = "0.1.15", features = ["net"] }
-tower = "0.5.1"
+tower = "0.5.2"
 tower-http = { version = "0.6.1", features = [
   "validate-request",
   "compression-full",

--- a/hoprd/rest-api/Cargo.toml
+++ b/hoprd/rest-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd-api"
-version = "3.9.1"
+version = "3.9.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "This Rest API enables developers to interact with a hoprd node programatically through HTTP."
@@ -46,7 +46,7 @@ smart-default = { workspace = true }
 strum = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { version = "0.1.15", features = ["net"] }
-tower = "0.5.2"
+tower = "0.5.1"
 tower-http = { version = "0.6.1", features = [
   "validate-request",
   "compression-full",


### PR DESCRIPTION
Fix the missing challenge in the send message response for backwards compatibility.

## Note
Fixes #6674 