### PR TITLE
cfg: Cleanup the example configuration

### DIFF
--- a/hoprd/hoprd/example_cfg.yaml
+++ b/hoprd/hoprd/example_cfg.yaml
@@ -109,16 +109,6 @@ hopr:
         # If set, the strategy will redeem only aggregated tickets.
         redeem_only_aggregated: true
         #
-        # The strategy will only redeem an acknowledged winning ticket if it has at least this value of HOPR.
-        # If 0 is given, the strategy will redeem tickets regardless of their value.
-        # This is not used for cases where `on_close_redeem_single_tickets_value_min` applies.
-        # minimum_redeem_ticket_value: "90000000000000000 HOPR"
-        #
-        # The strategy will automatically redeem if there's a single ticket left when a channel
-        # transitions to `PendingToClose` and it has at least this value of HOPR.
-        # This happens regardless of the `redeem_only_aggregated` setting.
-        on_close_redeem_single_tickets_value_min: "2000000000000000000 HOPR"
-        #
         ############################################
         #
         # Channel auto-funding strategy.


### PR DESCRIPTION
Remove no longer existing configuration options from the example config:
- [x] `on_close_redeem_single_tickets_value_min`