### PR TITLE
api: Add additional indexer info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,7 +1281,7 @@ dependencies = [
 
 [[package]]
 name = "chain-indexer"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -4227,7 +4227,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-db-sql"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-lock 3.4.0",
@@ -4671,7 +4671,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd-api"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-indexer"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Core-Ethereum-specific interaction with the backend database"

--- a/db/sql/Cargo.toml
+++ b/db/sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-db-sql"
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 description = "Contains SQL DB functionality implementing the DB API traits to be used by other crates in the code base"
 homepage = "https://hoprnet.org/"

--- a/db/sql/src/info.rs
+++ b/db/sql/src/info.rs
@@ -467,11 +467,9 @@ impl HoprDbInfoOperations for HoprDb {
                         .one(tx.as_ref())
                         .await?
                         .ok_or(DbSqlError::MissingFixedTableEntry("chain_info".into()))
-                        .and_then(|m| {
-                            Ok(IndexerStateInfo {
-                                latest_block_number: m.last_indexed_block as u32,
-                                ..Default::default()
-                            })
+                        .map(|m| IndexerStateInfo {
+                            latest_block_number: m.last_indexed_block as u32,
+                            ..Default::default()
                         })
                 })
             })

--- a/db/sql/src/info.rs
+++ b/db/sql/src/info.rs
@@ -4,6 +4,7 @@ use sea_orm::{
     ActiveModelBehavior, ActiveModelTrait, ColumnTrait, EntityOrSelect, EntityTrait, IntoActiveModel, PaginatorTrait,
     QueryFilter, Set,
 };
+use tracing::trace;
 
 use hopr_crypto_types::prelude::Hash;
 use hopr_db_api::info::*;
@@ -19,13 +20,12 @@ use crate::errors::DbSqlError::MissingFixedTableEntry;
 use crate::errors::{DbSqlError, Result};
 use crate::{HoprDbGeneralModelOperations, OptTx, TargetDb, SINGULAR_TABLE_FIXED_ID};
 
-/// Enumerates different domain separators
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct DescribedBlock {
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub struct IndexerStateInfo {
+    // the latest block number that has been indexed and persisted to the database
     pub latest_block_number: u32,
-    pub checksum: Hash,
-    pub block_prior_to_checksum_update: u32,
-    pub log_count: u32,
+    pub latest_log_block_number: u32,
+    pub latest_log_checksum: Hash,
 }
 
 /// Defines DB access API for various node information.
@@ -98,6 +98,12 @@ pub trait HoprDbInfoOperations {
     /// To retrieve the stored ticket price, use [`HoprDbInfoOperations::get_indexer_data`],
     /// note that this setter should invalidate the cache.
     async fn update_ticket_price<'a>(&'a self, tx: OptTx<'a>, price: Balance) -> Result<()>;
+
+    /// Gets the indexer state info.
+    async fn get_indexer_state_info<'a>(&'a self, tx: OptTx<'a>) -> Result<IndexerStateInfo>;
+
+    /// Updates the indexer state info.
+    async fn set_indexer_state_info<'a>(&'a self, tx: OptTx<'a>, block_num: u32) -> Result<()>;
 
     /// Updates the network registry state.
     /// To retrieve the stored network registry state, use [`HoprDbInfoOperations::get_indexer_data`],
@@ -450,6 +456,55 @@ impl HoprDbInfoOperations for HoprDb {
             .invalidate(&CachedValueDiscriminants::IndexerDataCache)
             .await;
         Ok(())
+    }
+
+    async fn get_indexer_state_info<'a>(&'a self, tx: OptTx<'a>) -> Result<IndexerStateInfo> {
+        self.nest_transaction(tx)
+            .await?
+            .perform(|tx| {
+                Box::pin(async move {
+                    chain_info::Entity::find_by_id(SINGULAR_TABLE_FIXED_ID)
+                        .one(tx.as_ref())
+                        .await?
+                        .ok_or(DbSqlError::MissingFixedTableEntry("chain_info".into()))
+                        .and_then(|m| {
+                            Ok(IndexerStateInfo {
+                                latest_block_number: m.last_indexed_block as u32,
+                                ..Default::default()
+                            })
+                        })
+                })
+            })
+            .await
+    }
+
+    async fn set_indexer_state_info<'a>(&'a self, tx: OptTx<'a>, block_num: u32) -> Result<()> {
+        self.nest_transaction(tx)
+            .await?
+            .perform(|tx| {
+                Box::pin(async move {
+                    let model = chain_info::Entity::find_by_id(SINGULAR_TABLE_FIXED_ID)
+                        .one(tx.as_ref())
+                        .await?
+                        .ok_or(MissingFixedTableEntry("chain_info".into()))?;
+
+                    let current_last_indexed_block = model.last_indexed_block;
+
+                    let mut active_model = model.into_active_model();
+
+                    trace!(
+                        old_block = current_last_indexed_block,
+                        new_block = block_num,
+                        "update block"
+                    );
+
+                    active_model.last_indexed_block = Set(block_num as i32);
+                    active_model.update(tx.as_ref()).await?;
+
+                    Ok::<_, DbSqlError>(())
+                })
+            })
+            .await
     }
 
     async fn set_network_registry_enabled<'a>(&'a self, tx: OptTx<'a>, enabled: bool) -> Result<()> {

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -59,7 +59,7 @@ use hopr_db_sql::{
     api::{info::SafeInfo, resolver::HoprDbResolverOperations, tickets::HoprDbTicketOperations},
     channels::HoprDbChannelOperations,
     db::{HoprDb, HoprDbConfig},
-    info::HoprDbInfoOperations,
+    info::{HoprDbInfoOperations, IndexerStateInfo},
     prelude::{ChainOrPacketKey::ChainKey, DbSqlError, HoprDbPeersOperations},
     HoprDbAllOperations, HoprDbGeneralModelOperations,
 };
@@ -1109,8 +1109,23 @@ impl Hopr {
     }
 
     /// Returns the most recently indexed log, if any.
-    pub async fn get_indexer_state(&self) -> errors::Result<Option<SerializableLog>> {
-        Ok(self.db.get_last_checksummed_log().await?)
+    pub async fn get_indexer_state(&self) -> errors::Result<IndexerStateInfo> {
+        let indexer_state_info = self.db.get_indexer_state_info(None).await?;
+
+        match self.db.get_last_checksummed_log().await? {
+            Some(log) => {
+                let checksum = match log.checksum {
+                    Some(checksum) => Hash::from_hex(checksum.as_str())?,
+                    None => Hash::default(),
+                };
+                Ok(IndexerStateInfo {
+                    latest_log_block_number: log.block_number as u32,
+                    latest_log_checksum: checksum,
+                    ..indexer_state_info
+                })
+            }
+            None => Ok(indexer_state_info),
+        }
     }
 
     /// Test whether the peer with PeerId is allowed to access the network

--- a/hoprd/rest-api/Cargo.toml
+++ b/hoprd/rest-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd-api"
-version = "3.9.1"
+version = "3.9.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "This Rest API enables developers to interact with a hoprd node programatically through HTTP."

--- a/hoprd/rest-api/src/node.rs
+++ b/hoprd/rest-api/src/node.rs
@@ -6,7 +6,7 @@ use axum::{
 use futures::stream::FuturesUnordered;
 use futures::StreamExt;
 use hopr_crypto_types::prelude::Hash;
-use hopr_lib::{Address, AsUnixTimestamp, GraphExportConfig, Health, Multiaddr, ToHex};
+use hopr_lib::{Address, AsUnixTimestamp, GraphExportConfig, Health, Multiaddr};
 use libp2p_identity::PeerId;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
@@ -351,8 +351,10 @@ pub(super) async fn channel_graph(
         ],
         "network": "anvil-localhost",
         "indexerBlock": 123456,
-        "indexerChecksum": "cfde556a7e9ff0848998aa4a9a9f2ccfde556a7e9ff0848998aa4a0cfd8863ae",
-        "indexBlockPrevChecksum": 123450,
+        "indexerChecksum": "0000000000000000000000000000000000000000000000000000000000000000",
+        "indexBlockPrevChecksum": 0,
+        "indexerLastLogBlock": 123450,
+        "indexerLastLogChecksum": "cfde556a7e9ff0848998aa4a9a9f2ccfde556a7e9ff0848998aa4a0cfd8863ae",
     }))]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct NodeInfoResponse {
@@ -394,6 +396,10 @@ pub(crate) struct NodeInfoResponse {
     #[schema(value_type = String)]
     indexer_checksum: Hash,
     index_block_prev_checksum: u32,
+    indexer_last_log_block: u32,
+    #[serde_as(as = "DisplayFromStr")]
+    #[schema(value_type = String)]
+    indexer_last_log_checksum: Hash,
 }
 
 /// Get information about this HOPR Node.
@@ -417,15 +423,8 @@ pub(super) async fn info(State(state): State<Arc<InternalState>>) -> Result<impl
     let safe_config = hopr.get_safe_config();
     let network = hopr.network();
 
-    let (indexer_block, indexer_checksum) = match hopr.get_indexer_state().await {
-        Ok(Some(slog)) => (
-            slog.block_number as u32,
-            match slog.checksum {
-                Some(checksum) => Hash::from_hex(checksum.as_str())?,
-                None => Hash::default(),
-            },
-        ),
-        Ok(None) => (0u32, Hash::default()),
+    let indexer_state_info = match hopr.get_indexer_state().await {
+        Ok(info) => info,
         Err(error) => return Ok((StatusCode::UNPROCESSABLE_ENTITY, ApiErrorStatus::from(error)).into_response()),
     };
 
@@ -446,11 +445,15 @@ pub(super) async fn info(State(state): State<Arc<InternalState>>) -> Result<impl
                 is_eligible: hopr.is_allowed_to_access_network(&hopr.me_peer_id()).await?,
                 connectivity_status: hopr.network_health().await,
                 channel_closure_period: channel_closure_notice_period.as_secs(),
-                indexer_block,
-                indexer_checksum,
+                indexer_block: indexer_state_info.latest_block_number,
                 // FIXME: this is only done for backwards-compatibility, ideally we don't return
                 // this value
-                index_block_prev_checksum: indexer_block,
+                indexer_checksum: Hash::default(),
+                // FIXME: this is only done for backwards-compatibility, ideally we don't return
+                // this value
+                index_block_prev_checksum: 0,
+                indexer_last_log_block: indexer_state_info.latest_log_block_number,
+                indexer_last_log_checksum: indexer_state_info.latest_log_checksum,
             };
 
             Ok((StatusCode::OK, Json(body)).into_response())


### PR DESCRIPTION
Sunsets existing indexer checksum info in the API's node info endpoint and adds additional values which reflect the new log implementation.

Fixes #6659 