### PR TITLE
Include `apiVersion` into `node/version` endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4671,7 +4671,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd-api"
-version = "3.9.1"
+version = "3.10.0"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/hoprd/rest-api/Cargo.toml
+++ b/hoprd/rest-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd-api"
-version = "3.9.1"
+version = "3.10.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "This Rest API enables developers to interact with a hoprd node programatically through HTTP."

--- a/hoprd/rest-api/src/node.rs
+++ b/hoprd/rest-api/src/node.rs
@@ -18,10 +18,13 @@ use crate::{
 
 #[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 #[schema(example = json!({
-        "version": "2.1.0"
+        "version": "2.1.0",
+        "apiVersion": "3.10.0"
     }))]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct NodeVersionResponse {
     version: String,
+    api_version: String,
 }
 
 /// Get the release version of the running node.
@@ -40,8 +43,8 @@ pub(crate) struct NodeVersionResponse {
     )]
 pub(super) async fn version(State(state): State<Arc<InternalState>>) -> impl IntoResponse {
     let version = state.hopr.version();
-
-    (StatusCode::OK, Json(NodeVersionResponse { version })).into_response()
+    let api_version = env!("CARGO_PKG_VERSION").to_owned();
+    (StatusCode::OK, Json(NodeVersionResponse { version, api_version })).into_response()
 }
 
 /// Get the configuration of the running node.


### PR DESCRIPTION
- Updated the `NodeVersionResponse` struct to include a new `apiVersion` field and adjusted the `version` endpoint to return this additional information. Added `serde` attribute for consistent JSON formatting.
- Bumped the package version in Cargo files to 3.10.0.

Closes #6697