### PR TITLE
Fix ticket deletion check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4227,7 +4227,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-db-sql"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "async-lock 3.4.0",

--- a/db/sql/Cargo.toml
+++ b/db/sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-db-sql"
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 description = "Contains SQL DB functionality implementing the DB API traits to be used by other crates in the code base"
 homepage = "https://hoprnet.org/"

--- a/db/sql/src/ticket_manager.rs
+++ b/db/sql/src/ticket_manager.rs
@@ -145,9 +145,9 @@ impl TicketManager {
                                                 .exec(tx.as_ref())
                                                 .await?;
 
-                                            if deleted.rows_affected < offset {
+                                            if deleted.rows_affected > offset {
                                                 return Err(DbSqlError::LogicalError(format!(
-                                                    "deleted ticket count ({}) must be least the ticket index offset {offset}",
+                                                    "deleted ticket count ({}) must not be more than the ticket index offset {offset}",
                                                     deleted.rows_affected,
                                                 )));
                                             }

--- a/db/sql/src/ticket_manager.rs
+++ b/db/sql/src/ticket_manager.rs
@@ -145,9 +145,9 @@ impl TicketManager {
                                                 .exec(tx.as_ref())
                                                 .await?;
 
-                                            if deleted.rows_affected != offset {
+                                            if deleted.rows_affected <= offset {
                                                 return Err(DbSqlError::LogicalError(format!(
-                                                    "deleted ticket count ({}) does not correspond to the ticket index offset {offset}",
+                                                    "deleted ticket count ({}) must be least the ticket index offset {offset}",
                                                     deleted.rows_affected,
                                                 )));
                                             }

--- a/db/sql/src/ticket_manager.rs
+++ b/db/sql/src/ticket_manager.rs
@@ -145,7 +145,7 @@ impl TicketManager {
                                                 .exec(tx.as_ref())
                                                 .await?;
 
-                                            if deleted.rows_affected <= offset {
+                                            if deleted.rows_affected < offset {
                                                 return Err(DbSqlError::LogicalError(format!(
                                                     "deleted ticket count ({}) must be least the ticket index offset {offset}",
                                                     deleted.rows_affected,


### PR DESCRIPTION
Adjusted the ticket deletion logic in `ticket_manager.rs` to ensure the deleted ticket count is validated correctly, preventing logical errors.

Bumped the crate version to 0.11.1 in `Cargo.toml` and `Cargo.lock` to reflect changes.

Closes #6761