### PR TITLE
Extension alias endpoints to return ETH addresses in addition to PeerIds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4671,7 +4671,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd-api"
-version = "3.10.1"
+version = "3.11.0"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4671,7 +4671,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd-api"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/hoprd/rest-api/Cargo.toml
+++ b/hoprd/rest-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd-api"
-version = "3.10.1"
+version = "3.11.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "This Rest API enables developers to interact with a hoprd node programatically through HTTP."

--- a/hoprd/rest-api/Cargo.toml
+++ b/hoprd/rest-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd-api"
-version = "3.9.3"
+version = "3.9.4"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "This Rest API enables developers to interact with a hoprd node programatically through HTTP."

--- a/hoprd/rest-api/src/alias.rs
+++ b/hoprd/rest-api/src/alias.rs
@@ -3,6 +3,7 @@ use axum::{
     http::status::StatusCode,
     response::IntoResponse,
 };
+use hopr_lib::Address;
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 use std::{collections::HashMap, str::FromStr, sync::Arc};
@@ -36,7 +37,7 @@ pub(crate) struct PeerIdResponse {
 pub(crate) struct AddressResponse {
     #[serde_as(as = "DisplayFromStr")]
     #[schema(value_type = String)]
-    pub address: String,
+    pub address: Address,
 }
 
 #[serde_as]
@@ -293,7 +294,7 @@ pub(super) async fn get_alias_address(
                 Ok(destination) => (
                     StatusCode::OK,
                     Json(AddressResponse {
-                        address: destination.address.to_string(),
+                        address: destination.address,
                     }),
                 )
                     .into_response(),

--- a/hoprd/rest-api/src/alias.rs
+++ b/hoprd/rest-api/src/alias.rs
@@ -30,7 +30,7 @@ pub(crate) struct PeerIdResponse {
 #[serde_as]
 #[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
 #[schema(example = json!({
-        "address": "12D3KooWRWeTozREYHzWTbuCYskdYhED1MXpDwTrmccwzFrd2mEA"
+        "address": "0x07eaf07d6624f741e04f4092a755a9027aaab7f6"
     }))]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct AddressResponse {
@@ -96,8 +96,8 @@ pub(super) async fn aliases(State(state): State<Arc<InternalState>>) -> impl Int
         path = const_format::formatcp!("{BASE_PATH}/aliases_addresses"),
         responses(
             (status = 200, description = "Each alias with its corresponding Address", body = HashMap<String, String>, example = json!({
-                    "alice": "12D3KooWPWD5P5ZzMRDckgfVaicY5JNoo7JywGotoAv17d7iKx1z",
-                    "me": "12D3KooWJmLm8FnBfvYQ5BAZ5qcYBxQFFBzAAEYUBUNJNE8cRsYS"
+                    "alice": "0xb4ce7e6e36ac8b01a974725d5ba730af2b156fbe",
+                    "me": "0x07eaf07d6624f741e04f4092a755a9027aaab7f6"
             })),
             (status = 401, description = "Invalid authorization token.", body = ApiError),
             (status = 404, description = "No aliases found", body = ApiError),

--- a/hoprd/rest-api/src/alias.rs
+++ b/hoprd/rest-api/src/alias.rs
@@ -123,12 +123,12 @@ pub(super) async fn aliases_addresses(State(state): State<Arc<InternalState>>) -
                 async move {
                     let peer_or_address = match PeerOrAddress::from_str(peer_id.as_str()) {
                         Ok(destination) => destination,
-                        Err(_) => return (alias, "Invalid PeerId".to_string()),
+                        Err(_) => return (alias, ApiErrorStatus::PeerNotFound.to_string()),
                     };
 
                     match HoprIdentifier::new_with(peer_or_address, hopr.peer_resolver()).await {
                         Ok(destination) => (alias, destination.address.to_string()),
-                        Err(_) => (alias, "Invalid PeerId".to_string()),
+                        Err(_) => (alias, ApiErrorStatus::PeerNotFound.to_string()),
                     }
                 }
             });

--- a/hoprd/rest-api/src/alias.rs
+++ b/hoprd/rest-api/src/alias.rs
@@ -91,7 +91,7 @@ pub(super) async fn aliases(State(state): State<Arc<InternalState>>) -> impl Int
     }
 }
 
-/// (deprecated, will be removed in v3.0) Get each previously set alias and its corresponding ETH address as a hashmap.
+// TODO(deprecated, will be removed in v3.0) Get each previously set alias and its corresponding ETH address as a hashmap.
 #[utoipa::path(
         get,
         path = const_format::formatcp!("{BASE_PATH}/aliases_addresses"),
@@ -251,7 +251,7 @@ pub(super) async fn get_alias(
     }
 }
 
-/// (deprecated, will be removed in v3.0) Get alias for the address (ETH address) that have this alias assigned to it.
+// TODO(deprecated, will be removed in v3.0) Get alias for the address (ETH address) that have this alias assigned to it.
 #[utoipa::path(
         get,
         path = const_format::formatcp!("{BASE_PATH}/aliases_addresses/{{alias}}"),

--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -91,8 +91,10 @@ pub(crate) struct InternalState {
         account::balances,
         account::withdraw,
         alias::aliases,
+        alias::aliases_addresses,
         alias::set_alias,
         alias::get_alias,
+        alias::get_alias_address,
         alias::delete_alias,
         alias::clear_aliases,
         channels::close_channel,
@@ -279,9 +281,11 @@ async fn build_api(
             BASE_PATH,
             Router::new()
                 .route("/aliases", get(alias::aliases))
+                .route("/aliases_addresses", get(alias::aliases_addresses))
                 .route("/aliases", post(alias::set_alias))
                 .route("/aliases", delete(alias::clear_aliases))
                 .route("/aliases/:alias", get(alias::get_alias))
+                .route("/aliases_addresses/:alias", get(alias::get_alias_address))
                 .route("/aliases/:alias", delete(alias::delete_alias))
                 .route("/account/addresses", get(account::addresses))
                 .route("/account/balances", get(account::balances))

--- a/sdk/python/api/hopr.py
+++ b/sdk/python/api/hopr.py
@@ -163,24 +163,20 @@ class HoprdAPI:
         :param: return_address: bool. If true, returns addresses instead of peer_ids
         :return: aliases: list
         """
-        if return_address:
-            is_ok, response = await self.__call_api(HTTPMethod.GET, "aliases_addresses")
-            return response if is_ok else None
-        else:
-            is_ok, response = await self.__call_api(HTTPMethod.GET, "aliases")
-            return response if is_ok else None
+        endpoint = f"aliases_addresses" if return_address else f"aliases"
+        is_ok, response = await self.__call_api(HTTPMethod.GET, endpoint)
+        return response if is_ok else None
 
     async def aliases_get_alias(self, alias: str, return_address: bool = False) -> Optional[Union[Alias, AliasAddress]]:
         """
         Returns the peer id recognized by the node.
         :return: alias: Alias
         """
-        if return_address:
-            is_ok, response = await self.__call_api(HTTPMethod.GET, f"aliases_addresses/{alias}")
-            return AliasAddress(response) if is_ok else None
-        else:
-            is_ok, response = await self.__call_api(HTTPMethod.GET, f"aliases/{alias}")
-            return Alias(response) if is_ok else None
+
+        endpoint = f"aliases_addresses/{alias}" if return_address else f"aliases/{alias}"
+        response_class = AliasAddress if return_address else Alias
+        is_ok, response = await self.__call_api(HTTPMethod.GET, endpoint)
+        return response_class(response) if is_ok else None
 
     async def aliases_set_alias(self, alias: str, destination: str):
         """

--- a/sdk/python/api/hopr.py
+++ b/sdk/python/api/hopr.py
@@ -2,7 +2,7 @@ import asyncio
 import base64
 import logging
 import random
-from typing import Optional
+from typing import Optional, Union
 
 import aiohttp
 import base58
@@ -30,6 +30,7 @@ from .request_objects import (
 from .response_objects import (
     Addresses,
     Alias,
+    AliasAddress,
     Balances,
     Channel,
     Channels,
@@ -156,13 +157,30 @@ class HoprdAPI:
             logging.error(f"TimeoutError calling {method} {endpoint}")
             return (False, None)
 
-    async def aliases_get_alias(self, alias: str):
+    async def aliases_get_aliases(self, return_address: bool = False):
+        """
+        Returns all aliases.
+        :param: return_address: bool. If true, returns addresses instead of peer_ids
+        :return: aliases: list
+        """
+        if return_address:
+            is_ok, response = await self.__call_api(HTTPMethod.GET, "aliases_addresses")
+            return response if is_ok else None
+        else:
+            is_ok, response = await self.__call_api(HTTPMethod.GET, "aliases")
+            return response if is_ok else None
+
+    async def aliases_get_alias(self, alias: str, return_address: bool = False) -> Optional[Union[Alias, AliasAddress]]:
         """
         Returns the peer id recognized by the node.
-        :return: peer_id: str
+        :return: alias: Alias
         """
-        is_ok, response = await self.__call_api(HTTPMethod.GET, f"aliases/{alias}")
-        return Alias(response) if is_ok else None
+        if return_address:
+            is_ok, response = await self.__call_api(HTTPMethod.GET, f"aliases_addresses/{alias}")
+            return AliasAddress(response) if is_ok else None
+        else:
+            is_ok, response = await self.__call_api(HTTPMethod.GET, f"aliases/{alias}")
+            return Alias(response) if is_ok else None
 
     async def aliases_set_alias(self, alias: str, destination: str):
         """

--- a/sdk/python/api/response_objects.py
+++ b/sdk/python/api/response_objects.py
@@ -66,6 +66,10 @@ class Alias(ApiResponseObject):
     keys = {"peer_id": "peerId"}
 
 
+class AliasAddress(ApiResponseObject):
+    keys = {"address": "address"}
+
+
 class Balances(ApiResponseObject):
     keys = {
         "hopr": "hopr",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -16,11 +16,11 @@ from sdk.python.localcluster.node import Node
 
 from .conftest import barebone_nodes, default_nodes, random_distinct_pairs_from
 from .utils import (
-    TICKET_AGGREGATION_THRESHOLD,
     AGGREGATED_TICKET_PRICE,
     MULTIHOP_MESSAGE_SEND_TIMEOUT,
     PARAMETERIZED_SAMPLE_SIZE,
     RESERVED_TAG_UPPER_BOUND,
+    TICKET_AGGREGATION_THRESHOLD,
     check_all_tickets_redeemed,
     check_native_balance_below,
     check_received_packets_with_peek,
@@ -92,6 +92,10 @@ async def test_hoprd_should_be_able_to_remove_existing_aliases(peer: str, swarm7
     assert await swarm7[peer].api.aliases_get_alias("Alice") is None
     assert await swarm7[peer].api.aliases_set_alias("Alice", alice.address) is True
     assert (await swarm7[peer].api.aliases_get_alias("Alice")).peer_id == alice.peer_id
+    assert (await swarm7[peer].api.aliases_get_alias("Alice", True)).address == alice.address.lower()
+
+    assert (await swarm7[peer].api.aliases_get_aliases())["Alice"] == alice.peer_id
+    assert (await swarm7[peer].api.aliases_get_aliases(True))["Alice"] == alice.address.lower()
 
     assert await swarm7[peer].api.aliases_remove_alias("Alice")
     assert await swarm7[peer].api.aliases_get_alias("Alice") is None


### PR DESCRIPTION
The API endpoints `GET aliases` and `GET aliases/:alias` have been doubled in this PR, as  `GET aliases_addresses` and `GET aliases_addresses/:alias` to be able to get peer ETH address from those endpoints.