### PR TITLE
Update heartbeat default value to better match with Dufour network

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1644,7 +1644,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-network"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "anyhow",
  "async-std",
@@ -4550,7 +4550,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-protocol"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-lock 3.4.0",

--- a/hoprd/hoprd/example_cfg.yaml
+++ b/hoprd/hoprd/example_cfg.yaml
@@ -177,11 +177,11 @@ hopr:
   # other nodes in the HOPR network.
   heartbeat:
     # The maximum number of concurrent heartbeat probes
-    max_parallel_probes: 14
+    max_parallel_probes: 50
     # Interval in which the heartbeat is triggered in seconds
     interval: 60
     # The time interval for which to consider peer heartbeat renewal in seconds
-    threshold: 60
+    threshold: 40
     # Round-to-round variance to complicate network sync in seconds
     variance: 2
   # Defines how the quality of nodes in the HOPR network
@@ -224,7 +224,7 @@ hopr:
     # Heartbeat sub-protocol configuration
     heartbeat:
       # Timeout in seconds
-      timeout: 15
+      timeout: 7
     # Message sub-protocol configuration
     ticket_aggregation:
       # Timeout in seconds

--- a/transport/network/Cargo.toml
+++ b/transport/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-network"
-version = "0.6.4"
+version = "0.6.5"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 license = "GPL-3.0-only"

--- a/transport/network/src/constants.rs
+++ b/transport/network/src/constants.rs
@@ -3,11 +3,11 @@
 pub const DEFAULT_HEARTBEAT_INTERVAL: std::time::Duration = std::time::Duration::from_secs(60);
 
 /// Time after which the availability of a node gets rechecked
-pub const DEFAULT_HEARTBEAT_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(60);
+pub const DEFAULT_HEARTBEAT_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(40);
 
 /// Randomization of the heartbeat interval to make sure not
 /// all the nodes start their interval at the same time
 pub const DEFAULT_HEARTBEAT_INTERVAL_VARIANCE: std::time::Duration = std::time::Duration::from_secs(2);
 
 /// The maximum number of parallel probes the heartbeat performs
-pub const DEFAULT_MAX_PARALLEL_PINGS: usize = 14;
+pub const DEFAULT_MAX_PARALLEL_PINGS: usize = 50;

--- a/transport/protocol/Cargo.toml
+++ b/transport/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-protocol"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 license = "GPL-3.0-only"

--- a/transport/protocol/src/heartbeat/config.rs
+++ b/transport/protocol/src/heartbeat/config.rs
@@ -10,6 +10,6 @@ use validator::Validate;
 pub struct HeartbeatProtocolConfig {
     /// Maximum duration before the request times out
     #[serde_as(as = "DurationSeconds<u64>")]
-    #[default(Duration::from_secs(15))]
+    #[default(Duration::from_secs(7))]
     pub timeout: Duration,
 }

--- a/transport/protocol/src/heartbeat/config.rs
+++ b/transport/protocol/src/heartbeat/config.rs
@@ -8,7 +8,8 @@ use validator::Validate;
 #[serde_as]
 #[derive(Debug, Copy, Clone, smart_default::SmartDefault, Validate, Serialize, Deserialize, Eq, PartialEq)]
 pub struct HeartbeatProtocolConfig {
-    /// Maximum duration before the request times out
+    /// Maximum duration before the request times out.
+    /// The default is chosen to be close to the maximum expected worst-case roundtrip time.
     #[serde_as(as = "DurationSeconds<u64>")]
     #[default(Duration::from_secs(7))]
     pub timeout: Duration,


### PR DESCRIPTION
Update heartbeat default values:
- `timeout` decreased from 15s to 7s
- `max_probes` increased from 14 to 50
- `threshold` reduced from 60 to 40