### PR TITLE
Allow high traffic throughput communication for VPN like traffic

### DIFF
--- a/transport/p2p/src/lib.rs
+++ b/transport/p2p/src/lib.rs
@@ -123,7 +123,7 @@ impl HoprNetworkBehavior {
                     .with_max_concurrent_streams(
                         std::env::var("HOPR_INTERNAL_LIBP2P_MSG_ACK_MAX_TOTAL_STREAMS")
                             .and_then(|v| v.parse::<usize>().map_err(|_e| std::env::VarError::NotPresent))
-                            .unwrap_or(1024),
+                            .unwrap_or(1024 * 10),
                     ),
             ),
             ack: libp2p::request_response::cbor::Behaviour::<Acknowledgement, ()>::new(
@@ -136,7 +136,7 @@ impl HoprNetworkBehavior {
                     .with_max_concurrent_streams(
                         std::env::var("HOPR_INTERNAL_LIBP2P_MSG_ACK_MAX_TOTAL_STREAMS")
                             .and_then(|v| v.parse::<usize>().map_err(|_e| std::env::VarError::NotPresent))
-                            .unwrap_or(1024),
+                            .unwrap_or(1024 * 10),
                     ),
             ),
             ticket_aggregation: libp2p::request_response::cbor::Behaviour::<


### PR DESCRIPTION
Update the maximum allowed number of stream for msg and ack to enable VPN like traffic.

(cherry picked from commit dc1b969247d09cfe4387235507f248a65340a005)