### PR TITLE
Allow manual configuration of the ticket price

### DIFF
--- a/chain/api/src/lib.rs
+++ b/chain/api/src/lib.rs
@@ -349,4 +349,8 @@ impl<T: HoprDbAllOperations + Send + Sync + Clone + std::fmt::Debug + 'static> H
     pub async fn get_minimum_winning_probability(&self) -> errors::Result<f64> {
         Ok(self.rpc_operations.get_minimum_network_winning_probability().await?)
     }
+
+    pub async fn get_minimum_ticket_price(&self) -> errors::Result<Balance> {
+        Ok(self.rpc_operations.get_minimum_network_ticket_price().await?)
+    }
 }

--- a/chain/rpc/src/lib.rs
+++ b/chain/rpc/src/lib.rs
@@ -375,6 +375,10 @@ pub trait HoprRpcOperations {
     /// calling the network's winning probability oracle.
     async fn get_minimum_network_winning_probability(&self) -> Result<f64>;
 
+    /// Retrieves the minimum ticket prices by directly calling the network's
+    /// ticket price oracle.
+    async fn get_minimum_network_ticket_price(&self) -> Result<Balance>;
+
     /// Retrieves the node's eligibility status
     async fn get_eligibility_status(&self, address: Address) -> Result<bool>;
 

--- a/chain/rpc/src/rpc.rs
+++ b/chain/rpc/src/rpc.rs
@@ -202,6 +202,17 @@ impl<P: JsonRpcClient + 'static> HoprRpcOperations for RpcOperations<P> {
         }
     }
 
+    async fn get_minimum_network_ticket_price(&self) -> Result<Balance> {
+        match self.contract_instances.price_oracle.current_ticket_price().call().await {
+            Ok(ticket_price) => Ok(BalanceType::HOPR.balance(ticket_price)),
+            Err(e) => Err(ContractError(
+                "PriceOracle".to_string(),
+                "current_ticket_price".to_string(),
+                e.to_string(),
+            )),
+        }
+    }
+
     async fn get_eligibility_status(&self, address: Address) -> Result<bool> {
         match self
             .contract_instances

--- a/crypto/packet/src/validation.rs
+++ b/crypto/packet/src/validation.rs
@@ -18,7 +18,7 @@ pub fn validate_unacknowledged_ticket(
 ) -> Result<VerifiedTicket, TicketValidationError> {
     debug!(source = %channel.source, "validating unack ticket");
 
-    // ticket signer MUST be the sender
+    // The ticket signer MUST be the sender
     let verified_ticket = ticket
         .verify(&channel.source, domain_separator)
         .map_err(|ticket| TicketValidationError {
@@ -28,7 +28,7 @@ pub fn validate_unacknowledged_ticket(
 
     let inner_ticket = verified_ticket.verified_ticket();
 
-    // ticket amount MUST be greater or equal to minTicketAmount
+    // The ticket amount MUST be greater or equal to min_ticket_amount
     if !inner_ticket.amount.ge(&min_ticket_amount) {
         return Err(TicketValidationError {
             reason: format!(
@@ -39,7 +39,7 @@ pub fn validate_unacknowledged_ticket(
         });
     }
 
-    // ticket must have at least required winning probability
+    // The ticket must have at least the required winning probability
     if !f64_approx_eq(
         verified_ticket.win_prob(),
         required_win_prob,
@@ -55,7 +55,7 @@ pub fn validate_unacknowledged_ticket(
         });
     }
 
-    // channel MUST be open or pending to close
+    // The channel MUST be open or pending to close
     if channel.status == ChannelStatus::Closed {
         return Err(TicketValidationError {
             reason: format!("payment channel {} is not opened or pending to close", channel.get_id()),
@@ -63,7 +63,7 @@ pub fn validate_unacknowledged_ticket(
         });
     }
 
-    // ticket's channelEpoch MUST match the current channel's epoch
+    // The ticket's channelEpoch MUST match the current channel's epoch
     if !channel.channel_epoch.eq(&inner_ticket.channel_epoch.into()) {
         return Err(TicketValidationError {
             reason: format!(
@@ -76,7 +76,7 @@ pub fn validate_unacknowledged_ticket(
         });
     }
 
-    // ensure sender has enough funds
+    // Ensure sender has enough funds
     if inner_ticket.amount.gt(&unrealized_balance) {
         return Err(TicketValidationError {
             reason: format!(

--- a/crypto/packet/src/validation.rs
+++ b/crypto/packet/src/validation.rs
@@ -76,7 +76,7 @@ pub fn validate_unacknowledged_ticket(
         });
     }
 
-    // Ensure sender has enough funds
+    // Ensure that sender has enough funds
     if inner_ticket.amount.gt(&unrealized_balance) {
         return Err(TicketValidationError {
             reason: format!(

--- a/db/api/src/protocol.rs
+++ b/db/api/src/protocol.rs
@@ -1,10 +1,10 @@
 use async_trait::async_trait;
 use std::{fmt::Debug, result::Result};
 
+use crate::prelude::DbError;
 use hopr_crypto_types::prelude::*;
 use hopr_internal_types::prelude::*;
-
-use crate::prelude::DbError;
+use hopr_primitive_types::prelude::Balance;
 
 /// Trait defining all DB functionality needed by packet/acknowledgement processing pipeline.
 #[async_trait]
@@ -18,8 +18,11 @@ pub trait HoprDbProtocolOperations {
     async fn handle_acknowledgement(&self, ack: Acknowledgement, me: &ChainKeypair)
         -> crate::errors::Result<AckResult>;
 
-    /// Loads (presumably cached) value of the network winning probability from the DB.
+    /// Loads (presumably cached) value of the network's minimum winning probability from the DB.
     async fn get_network_winning_probability(&self) -> crate::errors::Result<f64>;
+
+    /// Loads (presumably cached) value of the network's minimum ticket price from the DB.
+    async fn get_network_ticket_price(&self) -> crate::errors::Result<Balance>;
 
     /// Process the data into an outgoing packet
     async fn to_send(
@@ -28,6 +31,7 @@ pub trait HoprDbProtocolOperations {
         me: ChainKeypair,
         path: Vec<OffchainPublicKey>,
         outgoing_ticket_win_prob: f64,
+        outgoing_ticket_price: Balance,
     ) -> Result<TransportPacketWithChainData, DbError>;
 
     /// Process the incoming packet into data
@@ -39,6 +43,7 @@ pub trait HoprDbProtocolOperations {
         pkt_keypair: &OffchainKeypair,
         sender: OffchainPublicKey,
         outgoing_ticket_win_prob: f64,
+        outgoing_ticket_price: Balance,
     ) -> crate::errors::Result<TransportPacketWithChainData>;
 }
 

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -737,14 +737,10 @@ impl Hopr {
 
         // Once we are able to query the chain,
         // check if the ticket price is configured correctly.
-        let network_min_ticket_price = self
-            .chain_api
-            .ticket_price()
-            .await
-            .and_then(|price| price.ok_or(HoprChainError::Api("network does not set the ticket price".into())))?;
+        let network_min_ticket_price = self.chain_api.get_minimum_ticket_price().await?;
 
         let configured_ticket_price = self.cfg.protocol.outgoing_ticket_price;
-        if configured_ticket_price.is_some_and(|c| c.amount() < network_min_ticket_price) {
+        if configured_ticket_price.is_some_and(|c| c < network_min_ticket_price) {
             return Err(HoprLibError::ChainApi(HoprChainError::Api(format!(
                 "configured outgoing ticket price is lower than the network minimum ticket price: {configured_ticket_price:?} < {network_min_ticket_price}"
             ))));

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -736,6 +736,21 @@ impl Hopr {
         }
 
         // Once we are able to query the chain,
+        // check if the ticket price is configured correctly.
+        let network_min_ticket_price = self
+            .chain_api
+            .ticket_price()
+            .await
+            .and_then(|price| price.ok_or(HoprChainError::Api("network does not set the ticket price".into())))?;
+
+        let configured_ticket_price = self.cfg.protocol.outgoing_ticket_price;
+        if configured_ticket_price.is_some_and(|c| c.amount() < network_min_ticket_price) {
+            return Err(HoprLibError::ChainApi(HoprChainError::Api(format!(
+                "configured outgoing ticket price is lower than the network minimum ticket price: {configured_ticket_price:?} < {network_min_ticket_price}"
+            ))));
+        }
+
+        // Once we are able to query the chain,
         // check if the winning probability is configured correctly.
         let network_min_win_prob = self.chain_api.get_minimum_winning_probability().await?;
         let configured_win_prob = self.cfg.protocol.outgoing_ticket_winning_prob;

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -381,6 +381,7 @@ where
             &self.me,
             &self.me_onchain,
             self.cfg.protocol.outgoing_ticket_winning_prob,
+            self.cfg.protocol.outgoing_ticket_price,
         );
 
         let (tx_from_protocol, rx_from_protocol) = futures::channel::mpsc::unbounded::<ApplicationData>();

--- a/transport/protocol/src/config.rs
+++ b/transport/protocol/src/config.rs
@@ -1,3 +1,4 @@
+use hopr_primitive_types::prelude::Balance;
 use serde::{Deserialize, Serialize};
 use validator::Validate;
 
@@ -9,6 +10,8 @@ pub struct ProtocolConfig {
     /// If not set, the network value is used.
     #[validate(range(min = 0.0, max = 1.0))]
     pub outgoing_ticket_winning_prob: Option<f64>,
+    /// Possible override of the network outgoing ticket price.
+    pub outgoing_ticket_price: Option<Balance>,
     /// `heartbeat` protocol config
     #[serde(default)]
     pub heartbeat: crate::heartbeat::config::HeartbeatProtocolConfig,

--- a/transport/protocol/src/msg/processor.rs
+++ b/transport/protocol/src/msg/processor.rs
@@ -84,6 +84,7 @@ where
                 self.cfg.chain_keypair.clone(),
                 path?,
                 self.determine_actual_outgoing_win_prob().await,
+                self.determine_actual_outgoing_ticket_price().await?,
             )
             .await
             .map_err(|e| PacketError::PacketConstructionError(e.to_string()))?;
@@ -116,6 +117,7 @@ where
                 &self.cfg.packet_keypair,
                 previous_hop,
                 self.determine_actual_outgoing_win_prob().await,
+                self.determine_actual_outgoing_ticket_price().await?,
             )
             .await
             .map_err(|e| match e {
@@ -194,6 +196,18 @@ where
         self.tbf
             .with_write_lock(|inner: &mut TagBloomFilter| inner.check_and_set(tag))
             .await
+    }
+
+    // NOTE: as opposed to the winning probability, the ticket price does not have
+    // a reasonable default and therefore the operation fails
+    async fn determine_actual_outgoing_ticket_price(&self) -> Result<Balance> {
+        // This operation hits the cache unless the new value is fetched for the first time
+        let network_ticket_price =
+            self.db.get_network_ticket_price().await.map_err(|e| {
+                PacketError::LogicError(format!("failed to determine current network ticket price: {e}"))
+            })?;
+
+        Ok(self.cfg.outgoing_ticket_price.unwrap_or(network_ticket_price))
     }
 
     async fn determine_actual_outgoing_win_prob(&self) -> f64 {
@@ -300,11 +314,11 @@ impl MsgSender {
 /// Configuration parameters for the packet interaction.
 #[derive(Clone, Debug)]
 pub struct PacketInteractionConfig {
-    pub check_unrealized_balance: bool,
     pub packet_keypair: OffchainKeypair,
     pub chain_keypair: ChainKeypair,
     pub mixer: MixerConfig,
     pub outgoing_ticket_win_prob: Option<f64>,
+    pub outgoing_ticket_price: Option<Balance>,
 }
 
 impl PacketInteractionConfig {
@@ -312,13 +326,14 @@ impl PacketInteractionConfig {
         packet_keypair: &OffchainKeypair,
         chain_keypair: &ChainKeypair,
         outgoing_ticket_win_prob: Option<f64>,
+        outgoing_ticket_price: Option<Balance>,
     ) -> Self {
         Self {
             packet_keypair: packet_keypair.clone(),
             chain_keypair: chain_keypair.clone(),
-            check_unrealized_balance: true,
             mixer: MixerConfig::default(),
             outgoing_ticket_win_prob,
+            outgoing_ticket_price,
         }
     }
 }

--- a/transport/protocol/tests/msg_ack_workflows.rs
+++ b/transport/protocol/tests/msg_ack_workflows.rs
@@ -206,11 +206,11 @@ async fn peer_setup_for(count: usize) -> anyhow::Result<(Vec<WireChannels>, Vec<
         let opk: &OffchainKeypair = &PEERS[i];
         let ock: &ChainKeypair = &PEERS_CHAIN[i];
         let cfg = PacketInteractionConfig {
-            check_unrealized_balance: true,
             packet_keypair: opk.clone(),
             chain_keypair: ock.clone(),
             mixer: MixerConfig::default(), // TODO: unnecessary, can be removed
             outgoing_ticket_win_prob: Some(1.0),
+            outgoing_ticket_price: Some(Balance::new(100, BalanceType::HOPR)),
         };
 
         db.start_ticket_processing(Some(received_ack_tickets_tx))?;


### PR DESCRIPTION
This change allows to configure manually the ticket price (using `protocol.outgoing_ticket_price` option) to override the value from the oracle with the higher possible price.

Prices lower than the network value are not possible and validated on the node start.

Also a bug has been fixed in the ticket validation, where the expected minimum ticket value should not be the value from the oracle, but it should be multiplied by the path position.