### PR TITLE
Make auto-path finding quality threshold configurable

### DIFF
--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -250,7 +250,7 @@ where
             path_planner: PathPlanner::new(
                 db.clone(),
                 DfsPathSelectorConfig {
-                    quality_threshold: cfg.network.quality_bad_threshold,
+                    quality_threshold: cfg.network.quality_auto_path_threshold,
                     ..Default::default()
                 },
                 channel_graph.clone(),

--- a/transport/network/src/config.rs
+++ b/transport/network/src/config.rs
@@ -90,6 +90,13 @@ impl Validate for NetworkConfig {
             );
         }
 
+        if !(0.0..=1.0).contains(&self.quality_auto_path_threshold) {
+            errors.add(
+                "quality_auto_path_threshold",
+                validator::ValidationError::new("quality_auto_path_threshold must be between 0 and 1"),
+            );
+        }
+
         // #[validate(range(min = 0.0, max = 1.0))]
         if !(0.0..=1.0).contains(&self.quality_offline_threshold) {
             errors.add(

--- a/transport/network/src/config.rs
+++ b/transport/network/src/config.rs
@@ -14,6 +14,8 @@ pub const DEFAULT_NETWORK_QUALITY_AVERAGE_WINDOW_SIZE: u32 = 25;
 pub const DEFAULT_NETWORK_BACKOFF_EXPONENT: f64 = 1.5;
 pub const DEFAULT_NETWORK_BACKOFF_MIN: f64 = 2.0;
 
+pub const DEFAULT_AUTO_PATH_QUALITY_THRESHOLD: f64 = 0.95;
+
 /// Configuration for the [`crate::network::Network`] object
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, SmartDefault, PartialEq)]
@@ -38,6 +40,10 @@ pub struct NetworkConfig {
     #[serde(default = "quality_offline_threshold")]
     #[default(quality_offline_threshold())]
     pub quality_offline_threshold: f64,
+
+    #[serde(default = "quality_auto_path_threshold")]
+    #[default(quality_auto_path_threshold())]
+    pub quality_auto_path_threshold: f64,
 
     #[serde(default = "quality_step")]
     #[default(quality_step())]
@@ -148,6 +154,11 @@ fn quality_bad_threshold() -> f64 {
 #[inline]
 fn quality_offline_threshold() -> f64 {
     DEFAULT_NETWORK_OFFLINE_QUALITY_THRESHOLD
+}
+
+#[inline]
+fn quality_auto_path_threshold() -> f64 {
+    DEFAULT_AUTO_PATH_QUALITY_THRESHOLD
 }
 
 #[inline]


### PR DESCRIPTION
This PR adds the `network.quality_auto_path_threshold` (defaults to 0.95) to allow the auto-path finding algorithm to ignore nodes, which have lower quality than this threshold.