### PR TITLE
Use QUIC as a default transport announcement 

### DIFF
--- a/hoprd/hoprd/Cargo.toml
+++ b/hoprd/hoprd/Cargo.toml
@@ -15,7 +15,7 @@ default = [
   "prometheus",
   "telemetry",
   "explicit-path",
-  # "transport-quic", # TODO: re-enable this once properly tested
+  "transport-quic",
 ] # uses tokio by default because of axum
 prometheus = [
   "dep:hopr-metrics",


### PR DESCRIPTION
Fixes #6710 