### PR TITLE
Cap on aggregation batch size and fix swarm notifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1644,7 +1644,7 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-network"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "async-std",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-db-sql"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-lock 3.4.0",
@@ -4527,7 +4527,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-p2p"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "async-std",
@@ -4551,7 +4551,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-protocol"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-lock 3.4.0",

--- a/db/sql/Cargo.toml
+++ b/db/sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-db-sql"
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 description = "Contains SQL DB functionality implementing the DB API traits to be used by other crates in the code base"
 homepage = "https://hoprnet.org/"

--- a/transport/network/Cargo.toml
+++ b/transport/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "core-network"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 license = "GPL-3.0-only"

--- a/transport/network/src/ping.rs
+++ b/transport/network/src/ping.rs
@@ -73,14 +73,14 @@ pub type PingQueryResult = Result<(std::time::Duration, String)>;
 
 /// Helper object allowing to send a ping query as a wrapped channel combination
 /// that can be filled up on the transport part and awaited locally by the `Pinger`.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PingQueryReplier {
-    notifier: futures::channel::oneshot::Sender<PingQueryResult>,
+    notifier: UnboundedSender<PingQueryResult>,
     challenge: Box<(u64, ControlMessage)>,
 }
 
 impl PingQueryReplier {
-    pub fn new(notifier: futures::channel::oneshot::Sender<PingQueryResult>) -> Self {
+    pub fn new(notifier: UnboundedSender<PingQueryResult>) -> Self {
         Self {
             notifier,
             challenge: Box::new((
@@ -110,7 +110,7 @@ impl PingQueryReplier {
             Err(NetworkingError::DecodingError)
         };
 
-        if self.notifier.send(timed_result).is_err() {
+        if self.notifier.unbounded_send(timed_result).is_err() {
             warn!("Failed to notify the ping query result due to upper layer ping timeout");
         }
     }
@@ -123,7 +123,7 @@ pub fn to_active_ping(
     sender: HeartbeatSendPingTx,
     timeout: std::time::Duration,
 ) -> impl std::future::Future<Output = (PeerId, Result<std::time::Duration>, String)> {
-    let (tx, rx) = futures::channel::oneshot::channel::<PingQueryResult>();
+    let (tx, mut rx) = futures::channel::mpsc::unbounded::<PingQueryResult>();
     let replier = PingQueryReplier::new(tx);
 
     if let Err(e) = sender.unbounded_send((peer, replier)) {
@@ -131,12 +131,12 @@ pub fn to_active_ping(
     }
 
     async move {
-        match timeout_fut(timeout, rx).await {
-            Ok(Ok(Ok((latency, version)))) => {
+        match timeout_fut(timeout, rx.next()).await {
+            Ok(Some(Ok((latency, version)))) => {
                 debug!(latency = latency.as_millis(), %peer, %version, "Ping succeeded",);
                 (peer, Ok(latency), version)
             }
-            Ok(Ok(Err(e))) => {
+            Ok(Some(Err(e))) => {
                 let error = if let NetworkingError::DecodingError = e {
                     NetworkingError::PingerError(peer, "incorrect pong response".into())
                 } else {
@@ -146,7 +146,7 @@ pub fn to_active_ping(
                 debug!(%peer, %error, "Ping failed internally",);
                 (peer, Err(error), "unknown".into())
             }
-            Ok(Err(_)) => {
+            Ok(None) => {
                 debug!(%peer, "Ping canceled");
                 (
                     peer,
@@ -276,7 +276,7 @@ mod tests {
     #[async_std::test]
     async fn ping_query_replier_should_return_ok_result_when_the_pong_is_correct_for_the_challenge(
     ) -> anyhow::Result<()> {
-        let (tx, rx) = futures::channel::oneshot::channel::<PingQueryResult>();
+        let (tx, mut rx) = futures::channel::mpsc::unbounded::<PingQueryResult>();
 
         let replier = PingQueryReplier::new(tx);
         let challenge = replier.challenge.clone();
@@ -286,7 +286,7 @@ mod tests {
             "version".to_owned(),
         );
 
-        assert!(rx.await?.is_ok());
+        assert!(rx.next().await.is_some_and(|r| r.is_ok()));
 
         Ok(())
     }
@@ -294,7 +294,7 @@ mod tests {
     #[async_std::test]
     async fn ping_query_replier_should_return_err_result_when_the_pong_is_incorrect_for_the_challenge(
     ) -> anyhow::Result<()> {
-        let (tx, rx) = futures::channel::oneshot::channel::<PingQueryResult>();
+        let (tx, mut rx) = futures::channel::mpsc::unbounded::<PingQueryResult>();
 
         let replier = PingQueryReplier::new(tx);
 
@@ -303,14 +303,14 @@ mod tests {
             "version".to_owned(),
         );
 
-        assert!(rx.await?.is_err());
+        assert!(rx.next().await.is_some_and(|r| r.is_err()));
 
         Ok(())
     }
 
     #[async_std::test]
     async fn ping_query_replier_should_return_the_unidirectional_latency() -> anyhow::Result<()> {
-        let (tx, rx) = futures::channel::oneshot::channel::<PingQueryResult>();
+        let (tx, mut rx) = futures::channel::mpsc::unbounded::<PingQueryResult>();
 
         let replier = PingQueryReplier::new(tx);
         let challenge = replier.challenge.clone();
@@ -324,7 +324,9 @@ mod tests {
         );
 
         let actual_latency = rx
-            .await?
+            .next()
+            .await
+            .ok_or_else(|| anyhow::anyhow!("should contain a result value"))?
             .map_err(|_e| anyhow::anyhow!("should contain a result value"))?
             .0;
         assert!(actual_latency > delay / 2);

--- a/transport/p2p/Cargo.toml
+++ b/transport/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-p2p"
-version = "0.5.3"
+version = "0.5.4"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 license = "GPL-3.0-only"

--- a/transport/p2p/src/swarm.rs
+++ b/transport/p2p/src/swarm.rs
@@ -1,7 +1,7 @@
 use futures::{pin_mut, select, StreamExt};
 use futures_concurrency::stream::Merge;
 use libp2p::{request_response::OutboundRequestId, PeerId};
-use std::{num::NonZeroU8, sync::Arc};
+use std::num::NonZeroU8;
 use tracing::{debug, error, info, trace, warn};
 
 use core_network::{messaging::ControlMessage, network::NetworkTriggeredEvent, ping::PingQueryReplier};
@@ -284,13 +284,13 @@ impl HoprSwarmWithProcessors {
         let mut swarm: libp2p::Swarm<HoprNetworkBehavior> = self.swarm.into();
 
         // NOTE: an improvement would be a forgetting cache for the active requests
-        let active_pings: moka::future::Cache<libp2p::request_response::OutboundRequestId, Arc<PingQueryReplier>> =
+        let active_pings: moka::future::Cache<libp2p::request_response::OutboundRequestId, PingQueryReplier> =
             moka::future::CacheBuilder::new(1000)
                 .time_to_live(std::time::Duration::from_secs(40))
                 .build();
         let active_aggregation_requests: moka::future::Cache<
             libp2p::request_response::OutboundRequestId,
-            Arc<TicketAggregationFinalizer>,
+            TicketAggregationFinalizer,
         > = moka::future::CacheBuilder::new(1000)
             .time_to_live(std::time::Duration::from_secs(40))
             .build();
@@ -466,11 +466,7 @@ impl HoprSwarmWithProcessors {
                                         if let Some(replier) = active_pings.remove(&request_id).await {
                                             active_pings.run_pending_tasks().await;     // needed to remove the invalidated, but still present instance of Arc inside
                                             trace!(%peer, %request_id, "Processing manual ping response");
-                                            if let Some(replier) = Arc::<PingQueryReplier>::into_inner(replier) {
-                                                replier.notify(response.0, response.1)
-                                            } else {
-                                                warn!(%peer, %request_id, "Failed to notify with replier, multiple instances exist")
-                                            }
+                                            replier.notify(response.0, response.1)
                                         } else {
                                             debug!(%peer, %request_id, "Failed to find heartbeat replier");
                                         }
@@ -522,7 +518,7 @@ impl HoprSwarmWithProcessors {
                                 let ack_tkt_count = acked_tickets.len();
                                 let request_id = swarm.behaviour_mut().ticket_aggregation.send_request(&peer, acked_tickets);
                                 debug!(%peer, %request_id, "Sending request to aggregate {ack_tkt_count} tickets");
-                                active_aggregation_requests.insert(request_id, Arc::new(finalizer)).await;
+                                active_aggregation_requests.insert(request_id, finalizer).await;
                             },
                             TicketAggregationProcessed::Reply(peer, ticket, response) => {
                                 debug!(%peer, "Enqueuing a response'");
@@ -533,12 +529,8 @@ impl HoprSwarmWithProcessors {
                             TicketAggregationProcessed::Receive(peer, _, request) => {
                                 match active_aggregation_requests.remove(&request).await {
                                     Some(finalizer) => {
-                                        active_aggregation_requests.run_pending_tasks().await;     // needed to remove the invalidated, but still present instance of Arc inside
-                                        if let Some(finalizer) = Arc::<TicketAggregationFinalizer>::into_inner(finalizer) {
-                                            finalizer.finalize();
-                                        } else {
-                                            warn!(%peer, request_id = %request, "Failed to finalize ticket aggregation, multiple instances of request exist")
-                                        }
+                                        active_aggregation_requests.run_pending_tasks().await;
+                                        finalizer.finalize();
                                     },
                                     None => {
                                         warn!(%peer, request_id = %request, "Response already handled")
@@ -554,7 +546,7 @@ impl HoprSwarmWithProcessors {
                         match event {
                             crate::behavior::heartbeat::Event::ToProbe((peer, replier)) => {
                                 let req_id = swarm.behaviour_mut().heartbeat.send_request(&peer, Ping(replier.challenge()));
-                                active_pings.insert(req_id, Arc::new(replier)).await;
+                                active_pings.insert(req_id, replier).await;
                             },
                         }
                     }

--- a/transport/protocol/Cargo.toml
+++ b/transport/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-protocol"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 license = "GPL-3.0-only"


### PR DESCRIPTION
A cap of 10k tickets per aggregation batch was added. The maximum number of tickets in the aggregation request will not go over this limit.

This PR also fixes the notifier problem, that may occur when `Arc<oneshot::Sender>` was cloned by the cache. That resulted in the notification about ping/aggregation not being called and therefore, stalling tickets in the `BeingAggregated` state.

Closes #6813