### PR TITLE
Fix winning probability comparison when preparing ticket aggregation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-db-sql"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "async-lock 3.4.0",

--- a/common/internal-types/src/tickets.rs
+++ b/common/internal-types/src/tickets.rs
@@ -981,6 +981,7 @@ impl From<RedeemableTicket> for TransferableWinningTicket {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use crate::prelude::LOWEST_POSSIBLE_WINNING_PROB;
     use crate::tickets::AcknowledgedTicket;
     use hex_literal::hex;
     use hopr_crypto_types::{
@@ -1031,6 +1032,15 @@ pub mod tests {
         assert_eq!(test_bit_string, super::f64_to_win_prob(0.125f64)?);
 
         Ok(())
+    }
+
+    #[test]
+    pub fn test_win_prob_approx_eq() {
+        let wp_0 = win_prob_to_f64(&hex!("0020C49BBFFFFF"));
+        let wp_1 = win_prob_to_f64(&hex!("0020C49BA5E34F"));
+
+        assert_ne!(wp_0, wp_1);
+        assert!(f64_approx_eq(wp_0, wp_1, LOWEST_POSSIBLE_WINNING_PROB));
     }
 
     #[test]

--- a/db/sql/Cargo.toml
+++ b/db/sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-db-sql"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 description = "Contains SQL DB functionality implementing the DB API traits to be used by other crates in the code base"
 homepage = "https://hoprnet.org/"

--- a/db/sql/src/tickets.rs
+++ b/db/sql/src/tickets.rs
@@ -158,6 +158,7 @@ pub(crate) fn filter_satisfying_ticket_models(
     prerequisites: AggregationPrerequisites,
     models: Vec<ticket::Model>,
     channel_entry: &ChannelEntry,
+    min_win_prob: f64,
 ) -> crate::errors::Result<Vec<ticket::Model>> {
     let channel_id = channel_entry.get_id();
 
@@ -166,6 +167,20 @@ pub(crate) fn filter_satisfying_ticket_models(
     let mut unaggregated_balance = BalanceType::HOPR.zero();
 
     for m in models {
+        let ticket_wp = win_prob_to_f64(
+            m.winning_probability
+                .as_slice()
+                .try_into()
+                .map_err(|_| DbSqlError::DecodingError)?,
+        );
+        if !f64_approx_eq(ticket_wp, min_win_prob, LOWEST_POSSIBLE_WINNING_PROB) && ticket_wp < min_win_prob {
+            warn!(
+                channel_id = %channel_entry.get_id(),
+                ticket_wp, min_win_prob, "encountered ticket with winning probability lower than the minimum threshold"
+            );
+            continue;
+        }
+
         let to_add = BalanceType::HOPR.balance_bytes(&m.amount);
         // Count only balances of unaggregated tickets
         if m.index_offset == 1 {
@@ -767,7 +782,7 @@ impl HoprDbTicketOperations for HoprDb {
 
         let channel_id = *channel;
 
-        let (channel_entry, peer, domain_separator, encoded_min_win_prob) = self
+        let (channel_entry, peer, domain_separator, min_win_prob) = self
             .nest_transaction_in_db(None, TargetDb::Index)
             .await?
             .perform(|tx| {
@@ -799,10 +814,12 @@ impl HoprDbTicketOperations for HoprDb {
                         .channels_dst
                         .ok_or_else(|| crate::errors::DbSqlError::LogicalError("domain separator missing".into()))?;
 
-                    let encoded_min_win_prob = f64_to_win_prob(indexer_data.minimum_incoming_ticket_winning_prob)
-                        .map_err(|e| DbSqlError::LogicalError(e.to_string()))?;
-
-                    Ok((entry, pk, domain_separator, encoded_min_win_prob))
+                    Ok((
+                        entry,
+                        pk,
+                        domain_separator,
+                        indexer_data.minimum_incoming_ticket_winning_prob,
+                    ))
                 })
             })
             .await?;
@@ -843,7 +860,6 @@ impl HoprDbTicketOperations for HoprDb {
                         .filter(WrappedTicketSelector::from(TicketSelector::from(&channel_entry)))
                         .filter(ticket::Column::Index.gte(first_idx_to_take.to_be_bytes().to_vec()))
                         .filter(ticket::Column::State.ne(AcknowledgedTicketStatus::BeingAggregated as u8))
-                        .filter(ticket::Column::WinningProbability.gte(encoded_min_win_prob.to_vec()))
                         .order_by_asc(ticket::Column::Index)// tickets must be sorted by indices in ascending order
                         .limit(MAX_TICKETS_TO_AGGREGATE_BATCH)
                         .all(tx.as_ref())
@@ -851,7 +867,7 @@ impl HoprDbTicketOperations for HoprDb {
 
                     // Filter the list of tickets according to the prerequisites
                     let mut to_be_aggregated =
-                        filter_satisfying_ticket_models(prerequisites, to_be_aggregated, &channel_entry)?
+                        filter_satisfying_ticket_models(prerequisites, to_be_aggregated, &channel_entry, min_win_prob)?
                             .into_iter()
                             .map(|model| {
                                 AcknowledgedTicket::try_from(model)
@@ -893,13 +909,9 @@ impl HoprDbTicketOperations for HoprDb {
                         }
 
                         // mark all tickets with appropriate characteristics as being aggregated
-                        let last_idx_to_take = to_be_aggregated.last().unwrap().ticket.index;
                         let marked: sea_orm::UpdateResult = ticket::Entity::update_many()
                             .filter(WrappedTicketSelector::from(TicketSelector::from(&channel_entry)))
-                            .filter(ticket::Column::Index.gte(first_idx_to_take.to_be_bytes().to_vec()))
-                            .filter(ticket::Column::Index.lte(last_idx_to_take.to_be_bytes().to_vec()))
-                            .filter(ticket::Column::Index.is_not_in(neglected_idxs.into_iter().map(|i| i.to_be_bytes().to_vec())))
-                            .filter(ticket::Column::WinningProbability.gte(encoded_min_win_prob.to_vec()))
+                            .filter(ticket::Column::Index.is_in(to_be_aggregated.iter().map(|t| t.ticket.index.to_be_bytes().to_vec())))
                             .filter(ticket::Column::State.ne(AcknowledgedTicketStatus::BeingAggregated as u8))
                             .col_expr(
                                 ticket::Column::State,
@@ -1926,7 +1938,7 @@ mod tests {
             amount: U256::from(amount).to_be_bytes().to_vec(),
             index: idx.to_be_bytes().to_vec(),
             index_offset: idx_offset as i32,
-            winning_probability: vec![],
+            winning_probability: hex!("0020C49BA5E34F").to_vec(), // 0.0005
             channel_epoch: vec![],
             signature: vec![],
             response: vec![],
@@ -1952,11 +1964,38 @@ mod tests {
 
         let dummy_tickets = vec![dummy_ticket_model(channel.get_id(), 1, 1, 1)];
 
-        let filtered_tickets = filter_satisfying_ticket_models(prerequisites, dummy_tickets.clone(), &channel)?;
+        let filtered_tickets = filter_satisfying_ticket_models(prerequisites, dummy_tickets.clone(), &channel, 0.0005)?;
 
         assert_eq!(
             dummy_tickets, filtered_tickets,
             "empty prerequisites must not filter anything"
+        );
+        Ok(())
+    }
+
+    #[async_std::test]
+    async fn test_aggregation_prerequisites_should_filter_out_tickets_with_lower_than_min_win_prob(
+    ) -> anyhow::Result<()> {
+        let prerequisites = AggregationPrerequisites::default();
+        assert_eq!(None, prerequisites.min_unaggregated_ratio);
+        assert_eq!(None, prerequisites.min_ticket_count);
+
+        let channel = ChannelEntry::new(
+            BOB.public().to_address(),
+            ALICE.public().to_address(),
+            BalanceType::HOPR.balance(u32::MAX),
+            2.into(),
+            ChannelStatus::Open,
+            4_u32.into(),
+        );
+
+        let dummy_tickets = vec![dummy_ticket_model(channel.get_id(), 1, 1, 1)];
+
+        let filtered_tickets = filter_satisfying_ticket_models(prerequisites, dummy_tickets.clone(), &channel, 0.0006)?;
+
+        assert!(
+            filtered_tickets.is_empty(),
+            "must filter out tickets with lower win prob"
         );
         Ok(())
     }
@@ -1983,7 +2022,7 @@ mod tests {
             .map(|i| dummy_ticket_model(channel.get_id(), i as u64, 1, 1))
             .collect();
 
-        let filtered_tickets = filter_satisfying_ticket_models(prerequisites, dummy_tickets.clone(), &channel)?;
+        let filtered_tickets = filter_satisfying_ticket_models(prerequisites, dummy_tickets.clone(), &channel, 0.0005)?;
 
         assert_eq!(
             100,
@@ -2025,7 +2064,7 @@ mod tests {
             .map(|i| dummy_ticket_model(channel.get_id(), i as u64, 1, 1))
             .collect();
 
-        let filtered_tickets = filter_satisfying_ticket_models(prerequisites, dummy_tickets.clone(), &channel)?;
+        let filtered_tickets = filter_satisfying_ticket_models(prerequisites, dummy_tickets.clone(), &channel, 0.0005)?;
 
         assert!(
             filtered_tickets.is_empty(),
@@ -2059,7 +2098,7 @@ mod tests {
             .map(|i| dummy_ticket_model(channel.get_id(), i as u64, 1, 1))
             .collect();
 
-        let filtered_tickets = filter_satisfying_ticket_models(prerequisites, dummy_tickets.clone(), &channel)?;
+        let filtered_tickets = filter_satisfying_ticket_models(prerequisites, dummy_tickets.clone(), &channel, 0.0005)?;
 
         assert!(
             filtered_tickets.is_empty(),
@@ -2092,7 +2131,7 @@ mod tests {
             .map(|i| dummy_ticket_model(channel.get_id(), i as u64, 1, 1))
             .collect();
 
-        let filtered_tickets = filter_satisfying_ticket_models(prerequisites, dummy_tickets.clone(), &channel)?;
+        let filtered_tickets = filter_satisfying_ticket_models(prerequisites, dummy_tickets.clone(), &channel, 0.0005)?;
 
         assert!(!filtered_tickets.is_empty(), "must not return empty");
         assert_eq!(dummy_tickets, filtered_tickets, "return all tickets");
@@ -2123,7 +2162,7 @@ mod tests {
             .map(|i| dummy_ticket_model(channel.get_id(), i as u64, 1, 1))
             .collect();
 
-        let filtered_tickets = filter_satisfying_ticket_models(prerequisites, dummy_tickets.clone(), &channel)?;
+        let filtered_tickets = filter_satisfying_ticket_models(prerequisites, dummy_tickets.clone(), &channel, 0.0005)?;
 
         assert!(!filtered_tickets.is_empty(), "must not return empty");
         assert_eq!(dummy_tickets, filtered_tickets, "return all tickets");
@@ -2154,7 +2193,7 @@ mod tests {
             .map(|i| dummy_ticket_model(channel.get_id(), i as u64, 1, 1))
             .collect();
 
-        let filtered_tickets = filter_satisfying_ticket_models(prerequisites, dummy_tickets.clone(), &channel)?;
+        let filtered_tickets = filter_satisfying_ticket_models(prerequisites, dummy_tickets.clone(), &channel, 0.0005)?;
 
         assert!(!filtered_tickets.is_empty(), "must not return empty");
         assert_eq!(dummy_tickets, filtered_tickets, "return all tickets");
@@ -2185,7 +2224,7 @@ mod tests {
             .map(|i| dummy_ticket_model(channel.get_id(), i as u64, 1, 1))
             .collect();
 
-        let filtered_tickets = filter_satisfying_ticket_models(prerequisites, dummy_tickets.clone(), &channel)?;
+        let filtered_tickets = filter_satisfying_ticket_models(prerequisites, dummy_tickets.clone(), &channel, 0.0005)?;
 
         assert!(!filtered_tickets.is_empty(), "must not return empty");
         assert_eq!(dummy_tickets, filtered_tickets, "return all tickets");
@@ -2217,7 +2256,7 @@ mod tests {
             .collect();
         dummy_tickets[0].index_offset = 2; // Make this ticket aggregated
 
-        let filtered_tickets = filter_satisfying_ticket_models(prerequisites, dummy_tickets.clone(), &channel)?;
+        let filtered_tickets = filter_satisfying_ticket_models(prerequisites, dummy_tickets.clone(), &channel, 0.0005)?;
 
         assert!(filtered_tickets.is_empty(), "must return empty");
         Ok(())
@@ -2243,7 +2282,7 @@ mod tests {
         // Single aggregated ticket exceeding the min_unaggregated_ratio
         let dummy_tickets = vec![dummy_ticket_model(channel.get_id(), 1, 2, 110)];
 
-        let filtered_tickets = filter_satisfying_ticket_models(prerequisites, dummy_tickets.clone(), &channel)?;
+        let filtered_tickets = filter_satisfying_ticket_models(prerequisites, dummy_tickets.clone(), &channel, 0.0005)?;
 
         assert!(filtered_tickets.is_empty(), "must return empty");
         Ok(())


### PR DESCRIPTION
Floats representing winning probability were compared in the Sqlite3 DB using their binary representations, which was incorrect, as they should be compared as floats.