### PR TITLE
gha: Fix merge workflow to not run on closed

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -66,6 +66,8 @@ jobs:
           - hopli
           - hoprd
     name: Build ${{ matrix.package }}
+    # only run build and tag if the PR is merged, not if its closed
+    if: github.event.pull_request.merged == true
     uses: ./.github/workflows/build-docker.yaml
     with:
       branch: ${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
Before even a closed PR would have been tagged as the latest docker image.