### PR TITLE
Make the allowlist of Session targets empty in default configs

### DIFF
--- a/deploy/compose/hoprd_data/hoprd.cfg.yaml
+++ b/deploy/compose/hoprd_data/hoprd.cfg.yaml
@@ -15,14 +15,13 @@ hopr:
         aggregate_on_channel_close: true
       - !AutoRedeeming
         redeem_only_aggregated: true
-        minimum_redeem_ticket_value: "1500000000000000000 HOPR"
+        minimum_redeem_ticket_value: "2500000000000000000 HOPR"
       - !ClosureFinalizer
-        max_closure_overdue: 3600
+        max_closure_overdue: 300
   chain:
     network: dufour
     provider: # NOTE: Fill in value. Using a local RPC provider, make sure to always include the http:// prefix, followed by the IP address or localhost.
     announce: true
-    check_unrealized_balance: true
     keep_logs: true
     fast_sync: true
   safe_module:
@@ -36,3 +35,5 @@ api:
   host:
     address: !IPv4 0.0.0.0
     port: 3001
+session_ip_forwarding:
+  target_allow_list: []

--- a/deploy/compose/hoprd_data/hoprd.cfg.yaml
+++ b/deploy/compose/hoprd_data/hoprd.cfg.yaml
@@ -35,5 +35,3 @@ api:
   host:
     address: !IPv4 0.0.0.0
     port: 3001
-session_ip_forwarding:
-  target_allow_list: []

--- a/hoprd/hoprd/example_cfg.yaml
+++ b/hoprd/hoprd/example_cfg.yaml
@@ -171,7 +171,7 @@ hopr:
         #
         # Does not attempt to finalize closure of channels that have been overdue for closure for more than
         # this number of seconds.
-        max_closure_overdue: 3600
+        max_closure_overdue: 300
 
   # Configuration of the heartbeat mechanism for probing
   # other nodes in the HOPR network.
@@ -304,14 +304,15 @@ inbox:
   excluded_tags: [0]
 # Session Entry/Exit IP forwarding configuration for this node
 # This applies whenever the node is an Exit node of a Session.
-session_ip_forwarding:
-  #
-  # List of IP address and port tuples (written as e.g.: "127.0.0.1:8080") which are allowed
-  # to be targets of incoming Sessions.
-  # If the value is not set, all targets are allowed (default).
-  # For targets specifying a DNS name, the DNS resolution is performed first before the list is matched.
-  # Production configuration should always use this allowlist, e.g.: target_allow_list: ["127.0.0.1:8080"]
-  target_allow_list: []
+# session_ip_forwarding:
+#
+# List of IP address and port tuples (written as e.g.: "127.0.0.1:8080") which are allowed
+# to be targets of incoming Sessions.
+# If the value is not set, all targets are allowed (default).
+# For targets specifying a DNS name, the DNS resolution is performed first before the list is matched.
+# Production configuration should always use this allowlist, e.g.: target_allow_list: ["127.0.0.1:8080"]
+# NOTE: if you don't wish your node to act as an Exit node, set this to []
+# target_allow_list: []
 #
 # If the target is on TCP protocol, the Exit node can try to reach it this number of times.
 # max_tcp_target_retries: 10

--- a/hoprd/hoprd/example_cfg.yaml
+++ b/hoprd/hoprd/example_cfg.yaml
@@ -304,14 +304,14 @@ inbox:
   excluded_tags: [0]
 # Session Entry/Exit IP forwarding configuration for this node
 # This applies whenever the node is an Exit node of a Session.
-# session_ip_forwarding:
-#
-# List of IP address and port tuples (written as e.g.: "127.0.0.1:8080") which are allowed
-# to be targets of incoming Sessions.
-# If the value is not set, all targets are allowed (default).
-# For targets specifying a DNS name, the DNS resolution is performed first before the list is matched.
-# Production configuration should always use this allowlist, e.g.: target_allow_list: ["127.0.0.1:8080"]
-# target_allow_list:
+session_ip_forwarding:
+  #
+  # List of IP address and port tuples (written as e.g.: "127.0.0.1:8080") which are allowed
+  # to be targets of incoming Sessions.
+  # If the value is not set, all targets are allowed (default).
+  # For targets specifying a DNS name, the DNS resolution is performed first before the list is matched.
+  # Production configuration should always use this allowlist, e.g.: target_allow_list: ["127.0.0.1:8080"]
+  target_allow_list: []
 #
 # If the target is on TCP protocol, the Exit node can try to reach it this number of times.
 # max_tcp_target_retries: 10

--- a/hoprd/hoprd/example_cfg.yaml
+++ b/hoprd/hoprd/example_cfg.yaml
@@ -304,15 +304,19 @@ inbox:
   excluded_tags: [0]
 # Session Entry/Exit IP forwarding configuration for this node
 # This applies whenever the node is an Exit node of a Session.
-# session_ip_forwarding:
-#
-# List of IP address and port tuples (written as e.g.: "127.0.0.1:8080") which are allowed
-# to be targets of incoming Sessions.
-# If the value is not set, all targets are allowed (default).
-# For targets specifying a DNS name, the DNS resolution is performed first before the list is matched.
-# Production configuration should always use this allowlist, e.g.: target_allow_list: ["127.0.0.1:8080"]
-# NOTE: if you don't wish your node to act as an Exit node, set this to []
-# target_allow_list: []
+session_ip_forwarding:
+  #
+  # Indicates whether the allowlist in `target_allow_list` should be used.
+  # If set to `false`, all Session targets will be allowed.
+  use_target_allow_list: true
+  #
+  # List of IP address and port tuples (written as e.g.: "127.0.0.1:8080") which are allowed
+  # to be targets of incoming Sessions.
+  # This has effect only if `use_target_allow_list` is `true`.
+  # If left empty (default), the node will deny any Session target and will effectively not act as an Exit node.
+  # For targets specifying a DNS name, the DNS resolution is performed first before the list is matched.
+  # Production configuration should always use this allowlist, e.g.: target_allow_list: ["127.0.0.1:8080"]
+  target_allow_list: []
 #
 # If the target is on TCP protocol, the Exit node can try to reach it this number of times.
 # max_tcp_target_retries: 10

--- a/hoprd/hoprd/src/config.rs
+++ b/hoprd/hoprd/src/config.rs
@@ -378,20 +378,33 @@ fn default_max_tcp_target_retries() -> u32 {
     10
 }
 
+fn just_true() -> bool {
+    true
+}
+
 /// Configuration of the Exit node (see [`HoprServerIpForwardingReactor`]) and the Entry node.
 #[serde_as]
 #[derive(
     Clone, Debug, Eq, PartialEq, smart_default::SmartDefault, serde::Deserialize, serde::Serialize, validator::Validate,
 )]
 pub struct SessionIpForwardingConfig {
-    /// If specified, enforces only the given target addresses (after DNS resolution).
-    /// If `None` is specified, allows all targets.
+    /// Controls whether allowlisting should be done via `target_allow_list`.
+    /// If set to `false`, the node will act as an Exit node for any target.
     ///
-    /// Defaults to `None`.
+    /// Defaults to `true`.
+    #[serde(default = "just_true")]
+    #[default(true)]
+    pub use_target_allow_list: bool,
+
+    /// Enforces only the given target addresses (after DNS resolution).
+    ///
+    /// This is used only if `use_target_allow_list` is set to `true`.
+    /// If left empty (and `use_target_allow_list` is `true`), the node will not act as an Exit node.
+    ///
+    /// Defaults to empty.
     #[serde(default)]
-    #[default(None)]
-    #[serde_as(as = "Option<HashSet<serde_with::DisplayFromStr>>")]
-    pub target_allow_list: Option<HashSet<SocketAddr>>,
+    #[serde_as(as = "HashSet<serde_with::DisplayFromStr>")]
+    pub target_allow_list: HashSet<SocketAddr>,
 
     /// Delay between retries in seconds to reach a TCP target.
     ///

--- a/hoprd/hoprd/src/exit.rs
+++ b/hoprd/hoprd/src/exit.rs
@@ -30,17 +30,14 @@ impl HoprServerIpForwardingReactor {
     }
 
     fn all_ips_allowed(&self, addrs: &[SocketAddr]) -> bool {
-        for addr in addrs {
-            if !self
-                .cfg
-                .target_allow_list
-                .as_ref()
-                .map_or(true, |allowlist| allowlist.contains(addr))
-            {
-                tracing::error!(%addr, "address not allowed by the target allow list, denying the target");
-                return false;
+        if self.cfg.use_target_allow_list {
+            for addr in addrs {
+                if !self.cfg.target_allow_list.contains(addr) {
+                    tracing::error!(%addr, "address not allowed by the target allow list, denying the target");
+                    return false;
+                }
+                tracing::debug!(%addr, "address allowed by the target allow list, accepting the target");
             }
-            tracing::debug!(%addr, "address allowed by the target allow list, accepting the target");
         }
         true
     }

--- a/hoprd/hoprd/src/exit.rs
+++ b/hoprd/hoprd/src/exit.rs
@@ -30,12 +30,19 @@ impl HoprServerIpForwardingReactor {
     }
 
     fn all_ips_allowed(&self, addrs: &[SocketAddr]) -> bool {
-        addrs.iter().all(|addr| {
-            self.cfg
+        for addr in addrs {
+            if !self
+                .cfg
                 .target_allow_list
                 .as_ref()
-                .map_or(true, |list| list.contains(addr))
-        })
+                .map_or(true, |allowlist| allowlist.contains(addr))
+            {
+                tracing::error!(%addr, "address not allowed by the target allow list, denying the target");
+                return false;
+            }
+            tracing::debug!(%addr, "address allowed by the target allow list, accepting the target");
+        }
+        true
     }
 }
 

--- a/hoprd/hoprd/src/main.rs
+++ b/hoprd/hoprd/src/main.rs
@@ -323,7 +323,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (hopr_socket, hopr_processes) = node
         .run(HoprServerIpForwardingReactor::new(
             hopr_keys.packet_key.clone(),
-            Default::default(),
+            cfg.session_ip_forwarding,
         ))
         .await?;
 

--- a/logic/strategy/src/channel_finalizer.rs
+++ b/logic/strategy/src/channel_finalizer.rs
@@ -31,7 +31,7 @@ lazy_static::lazy_static! {
 
 #[inline]
 fn default_max_closure_overdue() -> Duration {
-    Duration::from_secs(3600)
+    Duration::from_secs(300)
 }
 
 /// Contains configuration of the [ClosureFinalizerStrategy].
@@ -41,7 +41,7 @@ pub struct ClosureFinalizerStrategyConfig {
     /// Do not attempt to finalize closure of channels that have
     /// been overdue for closure for more than this period.
     ///
-    /// Default is 3600 seconds.
+    /// Default is 300 seconds.
     #[serde_as(as = "DurationSeconds<u64>")]
     #[serde(default = "default_max_closure_overdue")]
     #[default(default_max_closure_overdue())]

--- a/sdk/barebone-lower-win-prob.cfg.yaml
+++ b/sdk/barebone-lower-win-prob.cfg.yaml
@@ -18,3 +18,5 @@ hopr:
     outgoing_ticket_winning_prob: 0.1
     heartbeat:
       timeout: 5
+session_ip_forwarding:
+  use_target_allow_list: false

--- a/sdk/barebone-lower-win-prob.cfg.yaml
+++ b/sdk/barebone-lower-win-prob.cfg.yaml
@@ -18,5 +18,5 @@ hopr:
     outgoing_ticket_winning_prob: 0.1
     heartbeat:
       timeout: 5
-session_ip_forwarding:
-  use_target_allow_list: false
+  session_ip_forwarding:
+    use_target_allow_list: false

--- a/sdk/barebone-lower-win-prob.cfg.yaml
+++ b/sdk/barebone-lower-win-prob.cfg.yaml
@@ -18,5 +18,5 @@ hopr:
     outgoing_ticket_winning_prob: 0.1
     heartbeat:
       timeout: 5
-  session_ip_forwarding:
-    use_target_allow_list: false
+session_ip_forwarding:
+  use_target_allow_list: false

--- a/sdk/barebone.cfg.yaml
+++ b/sdk/barebone.cfg.yaml
@@ -18,4 +18,6 @@ hopr:
     heartbeat:
       timeout: 5
     outgoing_ticket_winning_prob: 1.0
+session_ip_forwarding:
+  use_target_allow_list: false
 

--- a/sdk/barebone.cfg.yaml
+++ b/sdk/barebone.cfg.yaml
@@ -18,6 +18,6 @@ hopr:
     heartbeat:
       timeout: 5
     outgoing_ticket_winning_prob: 1.0
-  session_ip_forwarding:
-    use_target_allow_list: false
+session_ip_forwarding:
+  use_target_allow_list: false
 

--- a/sdk/barebone.cfg.yaml
+++ b/sdk/barebone.cfg.yaml
@@ -18,6 +18,6 @@ hopr:
     heartbeat:
       timeout: 5
     outgoing_ticket_winning_prob: 1.0
-session_ip_forwarding:
-  use_target_allow_list: false
+  session_ip_forwarding:
+    use_target_allow_list: false
 

--- a/sdk/default.cfg.yaml
+++ b/sdk/default.cfg.yaml
@@ -27,5 +27,5 @@ hopr:
     heartbeat:
       timeout: 5
     outgoing_ticket_winning_prob: 1.0
-session_ip_forwarding:
-  use_target_allow_list: false
+  session_ip_forwarding:
+    use_target_allow_list: false

--- a/sdk/default.cfg.yaml
+++ b/sdk/default.cfg.yaml
@@ -27,3 +27,5 @@ hopr:
     heartbeat:
       timeout: 5
     outgoing_ticket_winning_prob: 1.0
+session_ip_forwarding:
+  use_target_allow_list: false

--- a/sdk/default.cfg.yaml
+++ b/sdk/default.cfg.yaml
@@ -27,5 +27,5 @@ hopr:
     heartbeat:
       timeout: 5
     outgoing_ticket_winning_prob: 1.0
-  session_ip_forwarding:
-    use_target_allow_list: false
+session_ip_forwarding:
+  use_target_allow_list: false


### PR DESCRIPTION
Per default, nodes should not be acting as Exit nodes (receive Sessions), unless some list of allowed targets is specified. This has been reflected in all default configs.
Note that this change does not affect Service-type Sessions, such as the ones used by the CT. These will always be allowed to be opened.

Also corrected other defaults in the config.