### PR TITLE
Adjust default  maximum mixer delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ On top of the default configuration options generated for the command line, the 
 - `HOPR_INTERNAL_LIBP2P_SWARM_IDLE_TIMEOUT` - timeout for all idle libp2p swarm connections in seconds
 - `HOPR_INTERNAL_DB_PEERS_PERSISTENCE_AFTER_RESTART_IN_SECONDS` - cutoff duration from now to not retain the peers with older records in the peers database (e.g. after a restart)
 - `HOPR_INTERNAL_REST_API_MAX_CONCURRENT_WEBSOCKET_COUNT` - the maximum number of concurrent websocket opened through the REST API
+- `HOPR_INTERNAL_MIXER_PACKET_MAX_DELAY_MILLIS` - maximum mixer packet delay in milliseconds
 - `HOPR_TEST_DISABLE_CHECKS` - the node is being run in test mode with some safety checks disabled (currently: minimum winning probability check)
 - `ENV_WORKER_THREADS` - the number of environment worker threads for the tokio executor
 - `HOPRD_SESSION_PORT_RANGE` - allows restricting the port range (syntax: `start:end` inclusive) of Session listener automatic port selection (when port 0 is specified)

--- a/chain/rpc/src/rpc.rs
+++ b/chain/rpc/src/rpc.rs
@@ -832,7 +832,7 @@ mod tests {
             NetworkRegistryProxy::Dummy(e) => {
                 let _ = e.owner_add_account(cfg.safe_address.into()).send().await?.await?;
             }
-            NetworkRegistryProxy::Safe(e) => {}
+            NetworkRegistryProxy::Safe(_) => {}
         };
 
         let _ = rpc

--- a/transport/protocol/src/msg/mixer.rs
+++ b/transport/protocol/src/msg/mixer.rs
@@ -28,6 +28,11 @@ impl MixerConfig {
         }
     }
 
+    /// Returns the minimum and maximum delay.
+    pub fn delay_range(&self) -> (u64, u64) {
+        (self.min_delay.as_millis() as u64, self.max_delay.as_millis() as u64)
+    }
+
     /// Get a random delay duration from the specified minimum and maximum delay available
     /// inside the configuration.
     pub fn random_delay(&self) -> Duration {

--- a/transport/protocol/src/msg/mixer.rs
+++ b/transport/protocol/src/msg/mixer.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 pub struct MixerConfig {
     #[default(Duration::from_millis(0u64))]
     min_delay: Duration,
-    #[default(Duration::from_millis(200u64))]
+    #[default(Duration::from_millis(1u64))]
     max_delay: Duration,
     #[default = 10]
     pub metric_delay_window: u64,

--- a/transport/protocol/src/msg/mixer.rs
+++ b/transport/protocol/src/msg/mixer.rs
@@ -4,7 +4,7 @@ use std::time::Duration;
 pub struct MixerConfig {
     #[default(Duration::from_millis(0u64))]
     min_delay: Duration,
-    #[default(Duration::from_millis(1u64))]
+    #[default(Duration::from_millis(50u64))]
     max_delay: Duration,
     #[default = 10]
     pub metric_delay_window: u64,

--- a/transport/protocol/src/msg/mixer.rs
+++ b/transport/protocol/src/msg/mixer.rs
@@ -28,7 +28,7 @@ impl MixerConfig {
         }
     }
 
-    /// Returns the minimum and maximum delay.
+    /// Returns the minimum and maximum delay in milliseconds.
     pub fn delay_range(&self) -> (u64, u64) {
         (self.min_delay.as_millis() as u64, self.max_delay.as_millis() as u64)
     }

--- a/transport/protocol/src/msg/processor.rs
+++ b/transport/protocol/src/msg/processor.rs
@@ -18,7 +18,6 @@ use hopr_primitive_types::prelude::*;
 
 use super::packet::OutgoingPacket;
 use crate::bloom;
-use crate::msg::mixer::MixerConfig;
 
 lazy_static::lazy_static! {
     /// Fixed price per packet to 0.01 HOPR
@@ -316,7 +315,6 @@ impl MsgSender {
 pub struct PacketInteractionConfig {
     pub packet_keypair: OffchainKeypair,
     pub chain_keypair: ChainKeypair,
-    pub mixer: MixerConfig,
     pub outgoing_ticket_win_prob: Option<f64>,
     pub outgoing_ticket_price: Option<Balance>,
 }
@@ -331,7 +329,6 @@ impl PacketInteractionConfig {
         Self {
             packet_keypair: packet_keypair.clone(),
             chain_keypair: chain_keypair.clone(),
-            mixer: MixerConfig::default(),
             outgoing_ticket_win_prob,
             outgoing_ticket_price,
         }

--- a/transport/protocol/tests/msg_ack_workflows.rs
+++ b/transport/protocol/tests/msg_ack_workflows.rs
@@ -25,10 +25,7 @@ use hopr_db_sql::{
 use hopr_internal_types::prelude::*;
 use hopr_primitive_types::prelude::*;
 use hopr_transport_protocol::{
-    msg::{
-        mixer::MixerConfig,
-        processor::{MsgSender, PacketInteractionConfig, PacketSendFinalizer},
-    },
+    msg::processor::{MsgSender, PacketInteractionConfig, PacketSendFinalizer},
     DEFAULT_PRICE_PER_PACKET,
 };
 use tracing::debug;
@@ -208,7 +205,6 @@ async fn peer_setup_for(count: usize) -> anyhow::Result<(Vec<WireChannels>, Vec<
         let cfg = PacketInteractionConfig {
             packet_keypair: opk.clone(),
             chain_keypair: ock.clone(),
-            mixer: MixerConfig::default(), // TODO: unnecessary, can be removed
             outgoing_ticket_win_prob: Some(1.0),
             outgoing_ticket_price: Some(Balance::new(100, BalanceType::HOPR)),
         };


### PR DESCRIPTION
This PR changes the maximum mixer delay to 50 milliseconds and makes it configurable via new environment variable: `HOPR_INTERNAL_MIXER_PACKET_MAX_DELAY_MILLIS`