### PR TITLE
Set the aggregation ticket threshold to the middle of configuration range

### DIFF
--- a/hoprd/hoprd/example_cfg.yaml
+++ b/hoprd/hoprd/example_cfg.yaml
@@ -84,7 +84,7 @@ hopr:
         # Number of acknowledged winning tickets in a channel that triggers the ticket aggregation
         # in that channel when exceeded.
         # This condition is independent of `unrealized_balance_ratio`.
-        aggregation_threshold: 100
+        aggregation_threshold: 250
         # Percentage of unrealized balance in unaggregated tickets in a channel
         # that triggers the ticket aggregation when exceeded.
         # The unrealized balance in this case is the proportion of the channel balance allocated in unredeemed unaggregated tickets.

--- a/logic/strategy/src/aggregating.rs
+++ b/logic/strategy/src/aggregating.rs
@@ -60,7 +60,7 @@ const MAX_AGGREGATABLE_TICKET_COUNT: u32 = hopr_db_sql::tickets::MAX_TICKETS_TO_
 
 #[inline]
 fn default_aggregation_threshold() -> Option<u32> {
-    Some(100)
+    Some(250)
 }
 
 #[inline]
@@ -82,7 +82,7 @@ pub struct AggregatingStrategyConfig {
     ///
     /// This condition is independent of `unrealized_balance_ratio`.
     ///
-    /// Default is 100.
+    /// Default is 250.
     #[validate(range(min = 2, max = MAX_AGGREGATABLE_TICKET_COUNT))]
     #[serde(default = "default_aggregation_threshold")]
     #[default(default_aggregation_threshold())]


### PR DESCRIPTION
Align the default value for ticket aggregation in the middle of the possible range.

The current aggregation value means, that e.g. for CT with p=1.0 and ticket price = 0.0015, given the maximum non-sloped off stake at 75k, the CT node will generate 1msg/5s.

1 aggregation request period = 250[msg] / 1/5[msg/s] = 1250s