### PR TITLE
Fix the cache cleaning of multiaddresses on peer dial

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4565,7 +4565,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-p2p"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "async-std",

--- a/transport/p2p/Cargo.toml
+++ b/transport/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-p2p"
-version = "0.5.4"
+version = "0.5.5"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 license = "GPL-3.0-only"

--- a/transport/p2p/src/behavior/discovery.rs
+++ b/transport/p2p/src/behavior/discovery.rs
@@ -194,6 +194,10 @@ impl NetworkBehaviour for Behaviour {
                                 peer_id: peer,
                                 address: multiaddress.clone(),
                             });
+
+                            // the dial is important to create a first connection some time before the heartbeat mechanism
+                            // kicks in, otherwise the heartbeat is likely to fail on the first try due to dial and protocol
+                            // negotiation taking longer than the request response timeout
                             self.pending_events.push_back(ToSwarm::Dial { opts: DialOpts::peer_id(peer).addresses(multiaddresses).build()});
                         }
                     }

--- a/transport/p2p/src/behavior/discovery.rs
+++ b/transport/p2p/src/behavior/discovery.rs
@@ -4,7 +4,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use futures::stream::{BoxStream, Stream, StreamExt};
 use futures_concurrency::stream::Merge;
 use libp2p::{
-    swarm::{dummy::ConnectionHandler, CloseConnection, NetworkBehaviour, ToSwarm},
+    swarm::{dial_opts::DialOpts, dummy::ConnectionHandler, CloseConnection, NetworkBehaviour, ToSwarm},
     Multiaddr, PeerId,
 };
 
@@ -194,6 +194,7 @@ impl NetworkBehaviour for Behaviour {
                                 peer_id: peer,
                                 address: multiaddress.clone(),
                             });
+                            self.pending_events.push_back(ToSwarm::Dial { opts: DialOpts::peer_id(peer).addresses(multiaddresses).build()});
                         }
                     }
                 }

--- a/transport/p2p/src/behavior/discovery.rs
+++ b/transport/p2p/src/behavior/discovery.rs
@@ -20,9 +20,7 @@ pub enum DiscoveryInput {
 }
 
 #[derive(Debug)]
-pub enum Event {
-    NewPeerMultiddress(PeerId, Multiaddr),
-}
+pub enum Event {}
 
 pub struct Behaviour {
     me: PeerId,
@@ -33,6 +31,7 @@ pub struct Behaviour {
             <<Self as NetworkBehaviour>::ConnectionHandler as libp2p::swarm::ConnectionHandler>::FromBehaviour,
         >,
     >,
+    all_peers: HashMap<PeerId, Multiaddr>,
     allowed_peers: HashSet<PeerId>,
     connected_peers: HashMap<PeerId, usize>,
 }
@@ -53,6 +52,7 @@ impl Behaviour {
                     .merge()
                     .fuse(),
             ),
+            all_peers: HashMap::new(),
             pending_events: VecDeque::new(),
             allowed_peers: HashSet::new(),
             connected_peers: HashMap::new(),
@@ -113,6 +113,19 @@ impl NetworkBehaviour for Behaviour {
                     *v -= 1;
                 };
             }
+            libp2p::swarm::FromSwarm::DialFailure(failure) => {
+                // NOTE: libp2p swarm in the current version removes the (PeerId, Multiaddr) from the cache on a dial failure,
+                // therefore it needs to be readded back to the swarm on every dial failure, for now we want to mirror the entire
+                // announcement back to the swarm
+                if let Some(peer_id) = failure.peer_id {
+                    if let Some(multiaddress) = self.all_peers.get(&peer_id) {
+                        self.pending_events.push_back(ToSwarm::NewExternalAddrOfPeer {
+                            peer_id,
+                            address: multiaddress.clone(),
+                        });
+                    }
+                }
+            }
             _ => {}
         }
     }
@@ -151,6 +164,13 @@ impl NetworkBehaviour for Behaviour {
                 PeerDiscovery::Allow(peer) => {
                     debug!(peer = %peer, "p2p - discovery - Network registry allow");
                     let _ = self.allowed_peers.insert(peer);
+
+                    if let Some(multiaddress) = self.all_peers.get(&peer) {
+                        self.pending_events.push_back(ToSwarm::NewExternalAddrOfPeer {
+                            peer_id: peer,
+                            address: multiaddress.clone(),
+                        });
+                    }
                 }
                 PeerDiscovery::Ban(peer) => {
                     debug!(peer = %peer, "p2p - discovery - Network registry ban");
@@ -167,9 +187,13 @@ impl NetworkBehaviour for Behaviour {
                 PeerDiscovery::Announce(peer, multiaddresses) => {
                     if peer != self.me {
                         debug!(peer = %peer, addresses = tracing::field::debug(&multiaddresses), "p2p - discovery - Announcement");
-                        for multiaddress in multiaddresses.into_iter() {
-                            self.pending_events
-                                .push_back(ToSwarm::GenerateEvent(Event::NewPeerMultiddress(peer, multiaddress)));
+                        if let Some(multiaddress) = multiaddresses.last() {
+                            self.all_peers.insert(peer, multiaddress.clone());
+
+                            self.pending_events.push_back(ToSwarm::NewExternalAddrOfPeer {
+                                peer_id: peer,
+                                address: multiaddress.clone(),
+                            });
                         }
                     }
                 }

--- a/transport/p2p/src/lib.rs
+++ b/transport/p2p/src/lib.rs
@@ -84,8 +84,9 @@ pub struct HoprNetworkBehavior {
         Vec<legacy::AcknowledgedTicket>,
         std::result::Result<legacy::Ticket, String>,
     >,
-    // WARNING: order is important, this must be the last member, because the request_response components
-    // remove the peer from its address, and the discovery readds that.
+    // WARNING: the order of struct members is important, `discovery` must be the last member,
+    // because the request_response components remove the peer from its peer store after a failed
+    // dial operation and the discovery mechanism is responsible for populating all peer stores.
     discovery: behavior::discovery::Behaviour,
 }
 

--- a/transport/p2p/src/lib.rs
+++ b/transport/p2p/src/lib.rs
@@ -75,7 +75,6 @@ pub struct Pong(pub ControlMessage, pub String);
 #[derive(NetworkBehaviour)]
 #[behaviour(to_swarm = "HoprNetworkBehaviorEvent")]
 pub struct HoprNetworkBehavior {
-    discovery: behavior::discovery::Behaviour,
     heartbeat_generator: behavior::heartbeat::Behaviour,
     ticket_aggregation_behavior: behavior::ticket_aggregation::Behaviour,
     pub heartbeat: libp2p::request_response::cbor::Behaviour<Ping, Pong>,
@@ -85,6 +84,9 @@ pub struct HoprNetworkBehavior {
         Vec<legacy::AcknowledgedTicket>,
         std::result::Result<legacy::Ticket, String>,
     >,
+    // WARNING: order is important, this must be the last member, because the request_response components
+    // remove the peer from its address, and the discovery readds that.
+    discovery: behavior::discovery::Behaviour,
 }
 
 impl Debug for HoprNetworkBehavior {

--- a/transport/p2p/src/swarm.rs
+++ b/transport/p2p/src/swarm.rs
@@ -624,7 +624,7 @@ impl HoprSwarmWithProcessors {
                     } => {
                         debug!(peer = tracing::field::debug(peer_id), connection_id = %connection_id, transport="libp2p", "dialing")
                     }
-                    _ => error!(transport="libp2p", "unimplemented message type in p2p processing chain encountered")
+                    _ => trace!(transport="libp2p", "unimplemented message type in p2p processing chain encountered")
                 }
             }
         }

--- a/transport/p2p/src/swarm.rs
+++ b/transport/p2p/src/swarm.rs
@@ -498,21 +498,7 @@ impl HoprSwarmWithProcessors {
                         }
                     }
                     SwarmEvent::Behaviour(HoprNetworkBehaviorEvent::KeepAlive(_)) => {}
-                    SwarmEvent::Behaviour(HoprNetworkBehaviorEvent::Discovery(event)) => {
-                        let _span = tracing::span!(tracing::Level::DEBUG, "swarm behavior", behavior="discovery");
-
-                        trace!(event = tracing::field::debug(&event), "Received a discovery event");
-                        match event {
-                            crate::behavior::discovery::Event::NewPeerMultiddress(peer, multiaddress) => {
-                                info!(%peer, address = %multiaddress, "New record");
-                                swarm.add_peer_address(peer, multiaddress.clone());
-
-                                if let Err(e) = swarm.dial(peer) {
-                                    error!(%peer, address = %multiaddress, error = %e, "Failed to dial the peer");
-                                }
-                            },
-                        }
-                    }
+                    SwarmEvent::Behaviour(HoprNetworkBehaviorEvent::Discovery(_)) => {}
                     SwarmEvent::Behaviour(HoprNetworkBehaviorEvent::TicketAggregationBehavior(event)) => {
                         let _span = tracing::span!(tracing::Level::DEBUG, "swarm behavior", behavior="ticket aggregation");
 


### PR DESCRIPTION
As identified by @tolbrino the swarm voids the cache for the peer id that failed to dial, causing the multiaddress to be further unknown for redials, causing an incremental decline in peer connectability.

To solve this, the node now holds the entire announced peer list and on failed dials reinserts the multiaddress for a peer that failed to be dialed.

Closes #6869 