### PR TITLE
Delete closed foreign channels from the database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,7 +1289,7 @@ dependencies = [
 
 [[package]]
 name = "chain-indexer"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-db-sql"
-version = "0.11.3"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-lock 3.4.0",

--- a/chain/indexer/Cargo.toml
+++ b/chain/indexer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "chain-indexer"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Core-Ethereum-specific interaction with the backend database"

--- a/common/internal-types/src/channels.rs
+++ b/common/internal-types/src/channels.rs
@@ -59,6 +59,9 @@ pub enum ChannelDirection {
     Outgoing = 1,
 }
 
+/// Alias for the [`Hash`] representing a channel ID.
+pub type ChannelId = Hash;
+
 /// Overall description of a channel
 #[derive(Copy, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ChannelEntry {
@@ -68,7 +71,7 @@ pub struct ChannelEntry {
     pub ticket_index: U256,
     pub status: ChannelStatus,
     pub channel_epoch: U256,
-    id: Hash,
+    id: ChannelId,
 }
 
 impl ChannelEntry {
@@ -93,7 +96,7 @@ impl ChannelEntry {
     }
 
     /// Generates the channel ID using the source and destination address
-    pub fn get_id(&self) -> Hash {
+    pub fn get_id(&self) -> ChannelId {
         self.id
     }
 

--- a/db/sql/Cargo.toml
+++ b/db/sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-db-sql"
-version = "0.11.3"
+version = "0.12.0"
 edition = "2021"
 description = "Contains SQL DB functionality implementing the DB API traits to be used by other crates in the code base"
 homepage = "https://hoprnet.org/"


### PR DESCRIPTION
Foreign channels (the ones where the running node is not source nor destination) do not need to be kept in the database once they are closed.

To be merged after: #6739 

Fixes #6880 