### PR TITLE
tests: Fix per-test teardown

### DIFF
--- a/sdk/python/localcluster/constants.py
+++ b/sdk/python/localcluster/constants.py
@@ -19,7 +19,7 @@ PORT_BASE = 3000
 
 SUITE_NAME = "hopr-localcluster"
 MAIN_DIR = Path("/tmp").joinpath(SUITE_NAME)
-CONTRACTS_DIR = Path(os.path.dirname(__file__)).joinpath("../../../ethereum/contracts")
+CONTRACTS_DIR = Path(__file__).parent.joinpath("../../../ethereum/contracts")
 
 ANVIL_FOLDER_NAME = "anvil"
 ANVIL_FOLDER = MAIN_DIR.joinpath(ANVIL_FOLDER_NAME)

--- a/sdk/python/localcluster/constants.py
+++ b/sdk/python/localcluster/constants.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pathlib import Path
 
 logging.basicConfig(format="%(asctime)s %(message)s")
@@ -18,10 +19,11 @@ PORT_BASE = 3000
 
 SUITE_NAME = "hopr-localcluster"
 MAIN_DIR = Path("/tmp").joinpath(SUITE_NAME)
+CONTRACTS_DIR = os.path.join(os.path.dirname(__file__), "../../../ethereum/contracts")
 
 ANVIL_FOLDER_NAME = "anvil"
 ANVIL_FOLDER = MAIN_DIR.joinpath(ANVIL_FOLDER_NAME)
 
 ANVIL_CONFIG_FILE = ANVIL_FOLDER.joinpath("anvil.cfg")
 
-CONTRACTS_ADDRESSES = PWD.joinpath("ethereum", "contracts", "contracts-addresses.json")
+CONTRACTS_ADDRESSES = Path(CONTRACTS_DIR).joinpath("contracts-addresses.json")

--- a/sdk/python/localcluster/constants.py
+++ b/sdk/python/localcluster/constants.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from pathlib import Path
 
 logging.basicConfig(format="%(asctime)s %(message)s")
@@ -19,7 +18,7 @@ PORT_BASE = 3000
 
 SUITE_NAME = "hopr-localcluster"
 MAIN_DIR = Path("/tmp").joinpath(SUITE_NAME)
-CONTRACTS_DIR = Path(__file__).parent.joinpath("../../../ethereum/contracts")
+CONTRACTS_DIR = PWD.joinpath("ethereum/contracts")
 
 ANVIL_FOLDER_NAME = "anvil"
 ANVIL_FOLDER = MAIN_DIR.joinpath(ANVIL_FOLDER_NAME)

--- a/sdk/python/localcluster/constants.py
+++ b/sdk/python/localcluster/constants.py
@@ -19,11 +19,11 @@ PORT_BASE = 3000
 
 SUITE_NAME = "hopr-localcluster"
 MAIN_DIR = Path("/tmp").joinpath(SUITE_NAME)
-CONTRACTS_DIR = os.path.join(os.path.dirname(__file__), "../../../ethereum/contracts")
+CONTRACTS_DIR = Path(os.path.dirname(__file__)).joinpath("../../../ethereum/contracts")
 
 ANVIL_FOLDER_NAME = "anvil"
 ANVIL_FOLDER = MAIN_DIR.joinpath(ANVIL_FOLDER_NAME)
 
 ANVIL_CONFIG_FILE = ANVIL_FOLDER.joinpath("anvil.cfg")
 
-CONTRACTS_ADDRESSES = Path(CONTRACTS_DIR).joinpath("contracts-addresses.json")
+CONTRACTS_ADDRESSES = CONTRACTS_DIR.joinpath("contracts-addresses.json")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import asyncio
 import itertools
+from pathlib import Path
 import logging
 import os
 import random
@@ -78,7 +79,7 @@ def random_distinct_pairs_from(values: list, count: int):
 @pytest.fixture(scope="session")
 async def swarm7(request):
     # path is related to where the test is run. Most likely the root of the repo
-    params_path = os.path.join(os.path.dirname(__file__), "../sdk/python/localcluster.params.yml")
+    params_path = Path(__file__).parent.joinpath("../sdk/python/localcluster.params.yml")
     cluster, anvil = await localcluster.bringup(params_path, test_mode=True, fully_connected=False)
 
     yield cluster.nodes

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,5 @@
 import asyncio
 import itertools
-from pathlib import Path
 import logging
 import os
 import random
@@ -78,8 +77,7 @@ def random_distinct_pairs_from(values: list, count: int):
 
 @pytest.fixture(scope="session")
 async def swarm7(request):
-    # path is related to where the test is run. Most likely the root of the repo
-    params_path = Path(__file__).parent.joinpath("../sdk/python/localcluster.params.yml")
+    params_path = PWD.joinpath("sdk/python/localcluster.params.yml")
     cluster, anvil = await localcluster.bringup(params_path, test_mode=True, fully_connected=False)
 
     yield cluster.nodes

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -2,6 +2,7 @@
 minversion = 7.0
 
 asyncio_mode = auto
+asyncio_default_fixture_loop_scope = session
 
 addopts = -ra -q
 

--- a/tests/test_hopli.py
+++ b/tests/test_hopli.py
@@ -11,6 +11,7 @@ from sdk.python.localcluster.constants import (
     ANVIL_CONFIG_FILE,
     IDENTITY_PREFIX,
     CONTRACTS_ADDRESSES,
+    CONTRACTS_DIR,
     MAIN_DIR,
     NETWORK,
     PASSWORD,
@@ -25,8 +26,6 @@ FIXTURES_PREFIX_NEW = "hopr-node-new_"
 PASSWORD_NEW = "e2e-test-new"
 
 ANVIL_ENDPOINT = f"http://127.0.0.1:{PORT_BASE}"
-
-CONTRACTS_DIR = os.path.join(os.path.dirname(__file__), "../ethereum/contracts")
 
 
 def remove_identity(folder: Path, filename: str):

--- a/tests/test_hopli.py
+++ b/tests/test_hopli.py
@@ -26,6 +26,8 @@ PASSWORD_NEW = "e2e-test-new"
 
 ANVIL_ENDPOINT = f"http://127.0.0.1:{PORT_BASE}"
 
+CONTRACTS_DIR = os.path.join(os.path.dirname(__file__), "../ethereum/contracts")
+
 
 def remove_identity(folder: Path, filename: str):
     run(["rm", "-f", folder.joinpath(filename)], check=True, capture_output=True)
@@ -59,7 +61,7 @@ def faucet(private_key: str, hopr_amount: str, native_amount: str):
         "--identity-directory",
         MAIN_DIR,
         "--contracts-root",
-        "./ethereum/contracts",
+        CONTRACTS_DIR,
         "--hopr-amount",
         hopr_amount,
         "--native-amount",
@@ -87,7 +89,7 @@ def manager_deregister(private_key: str, node_addr: str):
             "--node-address",
             node_addr,
             "--contracts-root",
-            "./ethereum/contracts",
+            CONTRACTS_DIR,
             "--provider-url",
             ANVIL_ENDPOINT,
         ],
@@ -110,7 +112,7 @@ def manager_register(private_key: str, node_addr: str, safe_addr: str):
             "--network",
             NETWORK,
             "--contracts-root",
-            "./ethereum/contracts",
+            CONTRACTS_DIR,
             "--node-address",
             node_addr,
             "--safe-address",
@@ -139,7 +141,7 @@ def manager_force_sync(private_key: str, safes: str, eligibility: str):
             "--safe-address",
             safes,
             "--contracts-root",
-            "./ethereum/contracts",
+            CONTRACTS_DIR,
             "--eligibility",
             eligibility,
             "--provider-url",
@@ -239,7 +241,7 @@ def create_safe_module(extra_prefix: str, private_key: str, manager_private_key:
             "--identity-directory",
             MAIN_DIR.joinpath("test_hopli"),
             "--contracts-root",
-            "./ethereum/contracts",
+            CONTRACTS_DIR,
             "--allowance",
             "10.5",
             "--native-amount",
@@ -287,7 +289,7 @@ def migrate_safe_module(private_key: str, manager_private_key: str, safe: str, m
             "--identity-directory",
             MAIN_DIR.joinpath("test_hopli"),
             "--contracts-root",
-            "./ethereum/contracts",
+            CONTRACTS_DIR,
             "--safe-address",
             safe,
             "--module-address",
@@ -315,7 +317,7 @@ def manager_set_win_prob(private_key: str, win_prob: str):
             "--winning-probability",
             win_prob,
             "--contracts-root",
-            "./ethereum/contracts",
+            CONTRACTS_DIR,
             "--provider-url",
             ANVIL_ENDPOINT,
         ],
@@ -335,7 +337,7 @@ def get_win_prob():
             "--network",
             NETWORK,
             "--contracts-root",
-            "./ethereum/contracts",
+            CONTRACTS_DIR,
             "--provider-url",
             ANVIL_ENDPOINT,
         ],
@@ -343,86 +345,149 @@ def get_win_prob():
     )
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
-@pytest.mark.xfail(reason="race-conditions lead to incorrect balances on nodes")
-async def test_hopli_should_be_able_to_fund_nodes(peer: str, swarm7: dict[str, Node]):
-    private_key = load_private_key(ANVIL_CONFIG_FILE)
+@pytest.mark.usefixtures("swarm7_reset")
+class TestHopliWithSwarm:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
+    @pytest.mark.xfail(reason="race-conditions lead to incorrect balances on nodes")
+    async def test_hopli_should_be_able_to_fund_nodes(self, peer: str, swarm7: dict[str, Node]):
+        private_key = load_private_key(ANVIL_CONFIG_FILE)
 
-    balance_before = await swarm7[peer].api.balances()
-    logging.debug(f"balance_before of {peer} / {swarm7[peer].address}: {balance_before}")
+        balance_before = await swarm7[peer].api.balances()
+        logging.debug(f"balance_before of {peer} / {swarm7[peer].address}: {balance_before}")
 
-    # fund node with 1 HOPR token and 10 native token
-    faucet(private_key, "1.0", "10.0")
+        # fund node with 1 HOPR token and 10 native token
+        faucet(private_key, "1.0", "10.0")
 
-    balance_after = await swarm7[peer].api.balances()
-    logging.debug(f"balance_after of {peer} / {swarm7[peer].address}: {balance_after}")
+        balance_after = await swarm7[peer].api.balances()
+        logging.debug(f"balance_after of {peer} / {swarm7[peer].address}: {balance_after}")
 
-    # Check if `hopli faucet` funds node to the desired amount
-    # on the native token
-    if balance_before.native > 10 * 1e18:
-        assert balance_after.native == balance_before.native
-    else:
-        assert balance_after.native == int(10 * 1e18)
+        # Check if `hopli faucet` funds node to the desired amount
+        # on the native token
+        if balance_before.native > 10 * 1e18:
+            assert balance_after.native == balance_before.native
+        else:
+            assert balance_after.native == int(10 * 1e18)
 
-    # on the HOPR token
-    if balance_before.hopr > 1 * 1e18:
-        assert balance_after.hopr == balance_before.native
-    else:
-        assert balance_after.hopr == int(1 * 1e18)
+        # on the HOPR token
+        if balance_before.hopr > 1 * 1e18:
+            assert balance_after.hopr == balance_before.native
+        else:
+            assert balance_after.hopr == int(1 * 1e18)
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
+    async def test_hopli_should_be_able_to_deregister_nodes_and_register_it(self, peer: str, swarm7: dict[str, Node]):
+        private_key = load_private_key(ANVIL_CONFIG_FILE)
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
-async def test_hopli_should_be_able_to_deregister_nodes_and_register_it(peer: str, swarm7: dict[str, Node]):
-    private_key = load_private_key(ANVIL_CONFIG_FILE)
+        with open(CONTRACTS_ADDRESSES, "r") as file:
+            address_data: dict = json.load(file)
+            network_registry_contract = address_data["networks"][NETWORK]["addresses"]["network_registry"]
 
-    with open(CONTRACTS_ADDRESSES, "r") as file:
-        address_data: dict = json.load(file)
-        network_registry_contract = address_data["networks"][NETWORK]["addresses"]["network_registry"]
+        res_before = run_cast_cmd(
+            "call", [network_registry_contract, "nodeRegisterdToAccount(address)(address)", swarm7[peer].address]
+        )
 
-    res_before = run_cast_cmd(
-        "call", [network_registry_contract, "nodeRegisterdToAccount(address)(address)", swarm7[peer].address]
-    )
+        # check the returned value is address safe
+        assert res_before.stdout.decode("utf-8").split("\n")[0].lower() == swarm7[peer].safe_address.lower()
 
-    # check the returned value is address safe
-    assert res_before.stdout.decode("utf-8").split("\n")[0].lower() == swarm7[peer].safe_address.lower()
+        # remove node from the network registry
+        manager_deregister(private_key, swarm7[peer].address)
 
-    # remove node from the network registry
-    manager_deregister(private_key, swarm7[peer].address)
+        # Check if nodes are removed from the network
+        run_cast_cmd("code", [network_registry_contract])
+        res_after_deregster = run_cast_cmd(
+            "call", [network_registry_contract, "nodeRegisterdToAccount(address)(address)", swarm7[peer].address]
+        )
 
-    # Check if nodes are removed from the network
-    run_cast_cmd("code", [network_registry_contract])
-    res_after_deregster = run_cast_cmd(
-        "call", [network_registry_contract, "nodeRegisterdToAccount(address)(address)", swarm7[peer].address]
-    )
+        # check the returned value is address zero
+        assert (
+            res_after_deregster.stdout.decode("utf-8").split("\n")[0].lower()
+            == "0x0000000000000000000000000000000000000000"
+        )
 
-    # check the returned value is address zero
-    assert (
-        res_after_deregster.stdout.decode("utf-8").split("\n")[0].lower()
-        == "0x0000000000000000000000000000000000000000"
-    )
+        # register node to the network registry
+        manager_register(private_key, swarm7[peer].address, swarm7[peer].safe_address)
 
-    # register node to the network registry
-    manager_register(private_key, swarm7[peer].address, swarm7[peer].safe_address)
+        # Check if nodes are removed from the network
+        run_cast_cmd("code", [network_registry_contract])
+        res_after_register = run_cast_cmd(
+            "call", [network_registry_contract, "nodeRegisterdToAccount(address)(address)", swarm7[peer].address]
+        )
 
-    # Check if nodes are removed from the network
-    run_cast_cmd("code", [network_registry_contract])
-    res_after_register = run_cast_cmd(
-        "call", [network_registry_contract, "nodeRegisterdToAccount(address)(address)", swarm7[peer].address]
-    )
+        # check the returned value is address safe
+        assert res_after_register.stdout.decode("utf-8").split("\n")[0].lower() == swarm7[peer].safe_address.lower()
 
-    # check the returned value is address safe
-    assert res_after_register.stdout.decode("utf-8").split("\n")[0].lower() == swarm7[peer].safe_address.lower()
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
+    async def test_hopli_should_be_able_to_sync_eligibility_for_all_nodes(self, peer: str, swarm7: dict[str, Node]):
+        private_key = load_private_key(ANVIL_CONFIG_FILE)
 
+        # remove all the nodes from the network registry
+        manager_force_sync(private_key, swarm7[peer].safe_address, "true")
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
-async def test_hopli_should_be_able_to_sync_eligibility_for_all_nodes(peer: str, swarm7: dict[str, Node]):
-    private_key = load_private_key(ANVIL_CONFIG_FILE)
+    @pytest.mark.asyncio
+    async def test_hopli_should_be_able_to_create_safe_module(self, swarm7: dict[str, Node]):
+        manager_private_key = load_private_key(ANVIL_CONFIG_FILE)
+        private_key = load_private_key(ANVIL_CONFIG_FILE, 1)
+        extra_prefix = "two"
 
-    # remove all the nodes from the network registry
-    manager_force_sync(private_key, swarm7[peer].safe_address, "true")
+        # READ CONTRACT ADDRESS
+        with open(CONTRACTS_ADDRESSES, "r") as file:
+            address_data: dict = json.load(file)
+            network_registry_contract_1 = address_data["networks"][NETWORK]["addresses"]["network_registry"]
+            # network_registry_contract_2 = address_data["networks"][NETWORK2]["addresses"]["network_registry"]
+
+        # create identity
+        new_identity(extra_prefix)
+
+        # read the identity
+        new_node = read_identity(extra_prefix, PASSWORD)
+
+        # create safe and module
+        safe_address, module_address = create_safe_module(extra_prefix, private_key, manager_private_key)
+        run_cast_cmd("balance", [new_node])
+        run_cast_cmd("code", [safe_address])
+        run_cast_cmd("code", [module_address])
+
+        # Check the node node is registered with the new safe
+        res_check_created_safe_registration = run_cast_cmd(
+            "call", [network_registry_contract_1, "nodeRegisterdToAccount(address)(address)", new_node]
+        )
+        res_registration = res_check_created_safe_registration.stdout.decode("utf-8").split("\n")[0].lower()
+        assert res_registration == safe_address.lower()
+
+        # Remove the created identity
+        remove_identity(MAIN_DIR.joinpath("test_hopli"), f"{FIXTURES_PREFIX_NEW}{extra_prefix}0.id")
+
+    @pytest.mark.asyncio
+    async def test_hopli_should_be_able_to_set_and_read_win_prob(self, swarm7: dict[str, Node]):
+        # READ CONTRACT ADDRESS
+        with open(CONTRACTS_ADDRESSES, "r") as file:
+            address_data: dict = json.load(file)
+            win_prob_oracle = address_data["networks"][NETWORK]["addresses"]["winning_probability_oracle"]
+
+        # get current win prob
+        get_win_prob()
+        old_win_prob = run_cast_cmd("call", [win_prob_oracle, "currentWinProb()()"])
+        logging.info("old_win_prob %s", old_win_prob.stdout.decode("utf-8").split("is")[0].split("\n")[0].lower())
+        assert (
+            old_win_prob.stdout.decode("utf-8").split("is")[0].split("\n")[0].lower()
+            == "0x00000000000000000000000000000000000000000000000000ffffffffffffff"
+        )
+
+        # set new win prob
+        private_key = load_private_key(ANVIL_CONFIG_FILE)
+        manager_set_win_prob(private_key, "0.5")
+
+        # get new win prob
+        get_win_prob()
+        new_win_prob = run_cast_cmd("call", [win_prob_oracle, "currentWinProb()()"])
+        logging.info("new_win_prob %s", new_win_prob.stdout.decode("utf-8").split("is")[0].split("\n")[0].lower())
+        assert (
+            new_win_prob.stdout.decode("utf-8").split("is")[0].split("\n")[0].lower()
+            == "0x000000000000000000000000000000000000000000000000007fffffffffffff"
+        )
 
 
 @pytest.mark.asyncio
@@ -445,68 +510,3 @@ async def test_hopli_create_update_read_identity():
 
     # Remove the created identity
     remove_identity(MAIN_DIR.joinpath("test_hopli"), f"{FIXTURES_PREFIX_NEW}{extra_prefix}0.id")
-
-
-@pytest.mark.asyncio
-async def test_hopli_should_be_able_to_create_safe_module(swarm7: dict[str, Node]):
-    manager_private_key = load_private_key(ANVIL_CONFIG_FILE)
-    private_key = load_private_key(ANVIL_CONFIG_FILE, 1)
-    extra_prefix = "two"
-
-    # READ CONTRACT ADDRESS
-    with open(CONTRACTS_ADDRESSES, "r") as file:
-        address_data: dict = json.load(file)
-        network_registry_contract_1 = address_data["networks"][NETWORK]["addresses"]["network_registry"]
-        # network_registry_contract_2 = address_data["networks"][NETWORK2]["addresses"]["network_registry"]
-
-    # create identity
-    new_identity(extra_prefix)
-
-    # read the identity
-    new_node = read_identity(extra_prefix, PASSWORD)
-
-    # create safe and module
-    safe_address, module_address = create_safe_module(extra_prefix, private_key, manager_private_key)
-    run_cast_cmd("balance", [new_node])
-    run_cast_cmd("code", [safe_address])
-    run_cast_cmd("code", [module_address])
-
-    # Check the node node is registered with the new safe
-    res_check_created_safe_registration = run_cast_cmd(
-        "call", [network_registry_contract_1, "nodeRegisterdToAccount(address)(address)", new_node]
-    )
-    res_registration = res_check_created_safe_registration.stdout.decode("utf-8").split("\n")[0].lower()
-    assert res_registration == safe_address.lower()
-
-    # Remove the created identity
-    remove_identity(MAIN_DIR.joinpath("test_hopli"), f"{FIXTURES_PREFIX_NEW}{extra_prefix}0.id")
-
-
-@pytest.mark.asyncio
-async def test_hopli_should_be_able_to_set_and_read_win_prob():
-    # READ CONTRACT ADDRESS
-    with open(CONTRACTS_ADDRESSES, "r") as file:
-        address_data: dict = json.load(file)
-        win_prob_oracle = address_data["networks"][NETWORK]["addresses"]["winning_probability_oracle"]
-
-    # get current win prob
-    get_win_prob()
-    old_win_prob = run_cast_cmd("call", [win_prob_oracle, "currentWinProb()()"])
-    logging.info("old_win_prob %s", old_win_prob.stdout.decode("utf-8").split("is")[0].split("\n")[0].lower())
-    assert (
-        old_win_prob.stdout.decode("utf-8").split("is")[0].split("\n")[0].lower()
-        == "0x00000000000000000000000000000000000000000000000000ffffffffffffff"
-    )
-
-    # set new win prob
-    private_key = load_private_key(ANVIL_CONFIG_FILE)
-    manager_set_win_prob(private_key, "0.5")
-
-    # get new win prob
-    get_win_prob()
-    new_win_prob = run_cast_cmd("call", [win_prob_oracle, "currentWinProb()()"])
-    logging.info("new_win_prob %s", new_win_prob.stdout.decode("utf-8").split("is")[0].split("\n")[0].lower())
-    assert (
-        new_win_prob.stdout.decode("utf-8").split("is")[0].split("\n")[0].lower()
-        == "0x000000000000000000000000000000000000000000000000007fffffffffffff"
-    )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -37,70 +37,6 @@ from .utils import (
 PORT_BASE = 19000
 
 
-# NOTE: this test is first, ensuring that all tests following it have ensured connectivity and
-# correct ticket price from api
-@pytest.mark.asyncio
-async def test_hoprd_swarm_connectivity(swarm7: dict[str, Node]):
-    async def check_all_connected(me: Node, others: list[str]):
-        others2 = set(others)
-        while True:
-            current_peers = set([x.peer_id for x in await me.api.peers()])
-            if current_peers.intersection(others) == others2:
-                break
-            else:
-                assert current_peers.intersection(others2) == others2
-                await asyncio.sleep(0.5)
-
-    await asyncio.gather(
-        *[
-            asyncio.wait_for(
-                check_all_connected(swarm7[k], [swarm7[v].peer_id for v in barebone_nodes() if v != k]), 60.0
-            )
-            for k in barebone_nodes()
-        ]
-    )
-
-    ticket_price = await random.choice(list(swarm7.values())).api.ticket_price()
-    if ticket_price is not None:
-        global TICKET_PRICE_PER_HOP, AGGREGATED_TICKET_PRICE
-        TICKET_PRICE_PER_HOP = ticket_price.value
-        AGGREGATED_TICKET_PRICE = TICKET_AGGREGATION_THRESHOLD * TICKET_PRICE_PER_HOP
-    else:
-        print("Could not get ticket price from API, using default value")
-
-
-@pytest.mark.asyncio
-async def test_hoprd_protocol_check_balances_without_prior_tests(swarm7: dict[str, Node]):
-    for node in swarm7.values():
-        addr = await node.api.addresses()
-        assert re.match("^0x[0-9a-fA-F]{40}$", addr.native) is not None
-        balances = await node.api.balances()
-        assert int(balances.native) > 0
-        assert int(balances.safe_hopr) > 0
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
-async def test_hoprd_should_be_able_to_remove_existing_aliases(peer: str, swarm7: dict[str, Node]):
-    other_peers = barebone_nodes()
-    other_peers.remove(peer)
-
-    alice = swarm7[random.choice(other_peers)]
-
-    assert alice.address != swarm7[peer].address
-
-    assert await swarm7[peer].api.aliases_get_alias("Alice") is None
-    assert await swarm7[peer].api.aliases_set_alias("Alice", alice.address) is True
-    assert (await swarm7[peer].api.aliases_get_alias("Alice")).peer_id == alice.peer_id
-    assert (await swarm7[peer].api.aliases_get_alias("Alice", True)).address == alice.address.lower()
-
-    assert (await swarm7[peer].api.aliases_get_aliases())["Alice"] == alice.peer_id
-    assert (await swarm7[peer].api.aliases_get_aliases(True))["Alice"] == alice.address.lower()
-
-    assert await swarm7[peer].api.aliases_remove_alias("Alice")
-    assert await swarm7[peer].api.aliases_get_alias("Alice") is None
-
-
 @asynccontextmanager
 async def create_alias(alias, peer, api):
     """Ensure that the created alias is also released at the end of the test."""
@@ -111,293 +47,501 @@ async def create_alias(alias, peer, api):
         assert await api.aliases_remove_alias(alias)
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
-async def test_hoprd_should_not_be_able_to_set_multiple_aliases_to_a_single_peerid(peer: str, swarm7: dict[str, Node]):
-    other_peers = barebone_nodes()
-    other_peers.remove(peer)
+@pytest.mark.usefixtures("swarm7_reset")
+class TestIntegrationWithSwarm:
+    # NOTE: this test is first, ensuring that all tests following it have ensured connectivity and
+    # correct ticket price from api
+    @pytest.mark.asyncio
+    async def test_hoprd_swarm_connectivity(self, swarm7: dict[str, Node]):
+        async def check_all_connected(me: Node, others: list[str]):
+            others2 = set(others)
+            while True:
+                current_peers = set([x.peer_id for x in await me.api.peers()])
+                if current_peers.intersection(others) == others2:
+                    break
+                else:
+                    assert current_peers.intersection(others2) == others2
+                    await asyncio.sleep(0.5)
 
-    rufus_peer_id = swarm7[random.choice(other_peers)].peer_id
-    my_peer_id = swarm7[peer].peer_id
-    assert rufus_peer_id != my_peer_id
-
-    async with create_alias("Rufus", rufus_peer_id, swarm7[peer].api) as api:
-        assert await api.aliases_set_alias("Simon", rufus_peer_id) is False
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
-async def test_hoprd_should_contain_self_alias_automatically(peer: str, swarm7: dict[str, Node]):
-    assert (await swarm7[peer].api.aliases_get_alias("me")).peer_id == swarm7[peer].peer_id
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("src, dest", random_distinct_pairs_from(barebone_nodes(), count=PARAMETERIZED_SAMPLE_SIZE))
-async def test_hoprd_ping_should_work_between_nodes_in_the_same_network(src: str, dest: str, swarm7: dict[str, Node]):
-    response = await swarm7[src].api.ping(swarm7[dest].peer_id)
-
-    assert response is not None
-    assert int(response.latency) > 0, f"Non-0 round trip time expected, actual: '{int(response.latency)}'"
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
-async def test_hoprd_ping_to_self_should_fail(peer: str, swarm7: dict[str, Node]):
-    response = await swarm7[peer].api.ping(swarm7[peer].peer_id)
-
-    assert response is None, "Pinging self should fail"
-
-
-@pytest.mark.asyncio
-async def test_hoprd_ping_should_not_be_able_to_ping_nodes_not_present_in_the_registry_UNFINISHED(
-    swarm7: dict[str, Node],
-):
-    """
-    # log "Node 7 should not be able to talk to Node 1 (Node 7 is not in the register)"
-    # result=$(ping "${api7}" ${addr1} "TIMEOUT")
-    # log "-- ${result}"
-
-    # log "Node 1 should not be able to talk to Node 7 (Node 7 is not in the register)"
-    # result=$(ping "${api1}" ${addr7} "TIMEOUT")
-    # log "-- ${result}"
-    """
-    assert True
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("src, dest", random_distinct_pairs_from(barebone_nodes(), count=PARAMETERIZED_SAMPLE_SIZE))
-async def test_hoprd_should_be_able_to_send_0_hop_messages_without_open_channels(
-    src: str, dest: str, swarm7: dict[str, Node]
-):
-    message_count = int(TICKET_AGGREGATION_THRESHOLD / 10)
-
-    packets = [f"0 hop message #{i:08d}" for i in range(message_count)]
-    await send_and_receive_packets_with_pop(packets, src=swarm7[src], dest=swarm7[dest], path=[])
-
-    # Remove all messages so they do not interfere with the later tests
-    await swarm7[dest].api.messages_pop_all(None)
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("src, dest", random_distinct_pairs_from(barebone_nodes(), count=PARAMETERIZED_SAMPLE_SIZE))
-async def test_hoprd_should_fail_sending_a_message_that_is_too_large(src: str, dest: str, swarm7: dict[str, Node]):
-    maximum_payload_size = 500
-    random_tag = gen_random_tag()
-
-    packet = "0 hop message too large: " + "".join(
-        random.choices(string.ascii_uppercase + string.digits, k=maximum_payload_size)
-    )
-    assert await swarm7[src].api.send_message(swarm7[dest].peer_id, packet, [], random_tag) is None
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("src,dest", [tuple(shuffled(barebone_nodes())[:2]) for _ in range(PARAMETERIZED_SAMPLE_SIZE)])
-async def test_hoprd_api_channel_should_register_fund_increase_using_fund_endpoint(
-    src: str, dest: str, swarm7: dict[str, Node]
-):
-    # convert HOPR to weiHOPR
-    hopr_amount = OPEN_CHANNEL_FUNDING_VALUE_HOPR * 1e18
-
-    async with create_channel(swarm7[src], swarm7[dest], funding=TICKET_PRICE_PER_HOP) as channel:
-        balance_before = await swarm7[src].api.balances()
-        channel_before = await swarm7[src].api.get_channel(channel.id)
-
-        assert await swarm7[src].api.fund_channel(channel.id, hopr_amount)
-
-        channel_after = await swarm7[src].api.get_channel(channel.id)
-
-        # Updated channel balance is visible immediately
-        assert channel_after.balance - channel_before.balance == hopr_amount
-
-        # Wait until the safe balance has decreased
-        await asyncio.wait_for(
-            check_safe_balance(swarm7[src], balance_before.safe_hopr - hopr_amount),
-            20.0,
-        )
-
-        # Safe allowance can be checked too at this point
-        balance_after = await swarm7[src].api.balances()
-        assert balance_before.safe_hopr_allowance - balance_after.safe_hopr_allowance == hopr_amount
-
-        await asyncio.wait_for(check_native_balance_below(swarm7[src], balance_before.native), 20.0)
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("src,dest", [tuple(shuffled(barebone_nodes())[:2]) for _ in range(PARAMETERIZED_SAMPLE_SIZE)])
-async def test_reset_ticket_statistics_from_metrics(src: Node, dest: Node, swarm7: dict[str, Node]):
-    def count_metrics(metrics: str):
-        types = ["neglected", "redeemed", "rejected"]
-        count = 0
-        for line in metrics.splitlines():
-            count += (
-                line.startswith("hopr_tickets_incoming_statistics")
-                and any(t in line for t in types)
-                and line.split()[-1] != "0"
-            )
-        return count
-
-    async with create_channel(swarm7[src], swarm7[dest], funding=TICKET_PRICE_PER_HOP, close_from_dest=False):
-        await send_and_receive_packets_with_pop(
-            ["1 hop message to self"], src=swarm7[src], dest=swarm7[src], path=[swarm7[dest].peer_id]
-        )
-
-    assert count_metrics(await swarm7[dest].api.metrics()) != 0
-
-    await swarm7[dest].api.reset_tickets_statistics()
-
-    assert count_metrics(await swarm7[dest].api.metrics()) == 0
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("src,dest", [tuple(shuffled(barebone_nodes())[:2]) for _ in range(PARAMETERIZED_SAMPLE_SIZE)])
-async def test_hoprd_should_fail_sending_a_message_when_the_channel_is_out_of_funding(
-    src: str, dest: str, swarm7: dict[str, Node]
-):
-    """
-    # FIXME: The following part can be enabled once incoming channel closure is
-    # implemented.
-    #
-    # need to close the incoming side to not have to wait for the closure timeout
-    # api_close_channel "${second_node_id}" "${node_id}" "${second_node_api}" "${node_addr}" "incoming"
-
-    # only fund for 2 tickets
-    # channel_info=$(api_open_channel "${node_id}" "${second_node_id}" "${node_api}" "${second_node_addr}" "200")
-
-    # need to wait a little to allow the other side to index the channel open event
-    # sleep 10
-    # api_get_tickets_in_channel ${second_node_api} ${channel_id} "TICKETS_NOT_FOUND"
-    # for i in `seq 1 ${generated_tickets}`; do
-    #   log "PendingBalance in channel: Node ${node_id} send 1 hop message to self via node ${second_node_id}"
-    #   api_send_message "${node_api}" "${msg_tag}" "${peer_id}" \
-    #       "pendingbalance: hello, world 1 self" "${second_peer_id}"
-    # done
-
-    # seems like there's slight delay needed for tickets endpoint to return up to date tickets, \
-    #       probably because of blockchain sync delay
-    # sleep 5
-
-    # ticket_amount=$(api_get_tickets_in_channel ${second_node_api} ${channel_id} | jq '. | length')
-    # if [[ "${ticket_amount}" != "${generated_tickets}" ]]; then
-    #   msg "PendingBalance: Ticket amount ${ticket_amount} is different than expected ${generated_tickets}"
-    #   exit 1
-    # fi
-
-    # api_redeem_tickets_in_channel ${second_node_api} ${channel_id}
-    # sleep 5
-    # api_get_tickets_in_channel ${second_node_api} ${channel_id} "TICKETS_NOT_FOUND"
-    # api_close_channel "${node_id}" "${second_node_id}" "${node_api}" "${second_node_addr}" "outgoing"
-    """
-
-    message_count = 2
-
-    async with AsyncExitStack() as channels:
         await asyncio.gather(
             *[
-                channels.enter_async_context(
-                    create_channel(
-                        swarm7[i[0]], swarm7[i[1]], funding=message_count * TICKET_PRICE_PER_HOP, close_from_dest=False
-                    )
+                asyncio.wait_for(
+                    check_all_connected(swarm7[k], [swarm7[v].peer_id for v in barebone_nodes() if v != k]), 60.0
                 )
-                for i in [[src, dest]]
+                for k in barebone_nodes()
             ]
         )
 
-        packets = [f"Channel agg and redeem on 1-hop: {src} - {dest} - {src} #{i:08d}" for i in range(message_count)]
-        await send_and_receive_packets_with_pop(packets, src=swarm7[src], dest=swarm7[src], path=[swarm7[dest].peer_id])
+        ticket_price = await random.choice(list(swarm7.values())).api.ticket_price()
+        if ticket_price is not None:
+            global TICKET_PRICE_PER_HOP, AGGREGATED_TICKET_PRICE
+            TICKET_PRICE_PER_HOP = ticket_price.value
+            AGGREGATED_TICKET_PRICE = TICKET_AGGREGATION_THRESHOLD * TICKET_PRICE_PER_HOP
+        else:
+            print("Could not get ticket price from API, using default value")
 
-        # this message has no funding in the channel, but it still should be sent
-        assert await swarm7[src].api.send_message(
-            swarm7[src].peer_id, "THIS MSG IS NOT COVERED", [swarm7[dest].peer_id]
+    @pytest.mark.asyncio
+    async def test_hoprd_protocol_check_balances_without_prior_tests(self, swarm7: dict[str, Node]):
+        for node in swarm7.values():
+            addr = await node.api.addresses()
+            assert re.match("^0x[0-9a-fA-F]{40}$", addr.native) is not None
+            balances = await node.api.balances()
+            assert int(balances.native) > 0
+            assert int(balances.safe_hopr) > 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
+    async def test_hoprd_should_be_able_to_remove_existing_aliases(self, peer: str, swarm7: dict[str, Node]):
+        other_peers = barebone_nodes()
+        other_peers.remove(peer)
+
+        alice = swarm7[random.choice(other_peers)]
+
+        assert alice.address != swarm7[peer].address
+
+        assert await swarm7[peer].api.aliases_get_alias("Alice") is None
+        assert await swarm7[peer].api.aliases_set_alias("Alice", alice.address) is True
+        assert (await swarm7[peer].api.aliases_get_alias("Alice")).peer_id == alice.peer_id
+        assert (await swarm7[peer].api.aliases_get_alias("Alice", True)).address == alice.address.lower()
+
+        assert (await swarm7[peer].api.aliases_get_aliases())["Alice"] == alice.peer_id
+        assert (await swarm7[peer].api.aliases_get_aliases(True))["Alice"] == alice.address.lower()
+
+        assert await swarm7[peer].api.aliases_remove_alias("Alice")
+        assert await swarm7[peer].api.aliases_get_alias("Alice") is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
+    async def test_hoprd_should_not_be_able_to_set_multiple_aliases_to_a_single_peerid(
+        self, peer: str, swarm7: dict[str, Node]
+    ):
+        other_peers = barebone_nodes()
+        other_peers.remove(peer)
+
+        rufus_peer_id = swarm7[random.choice(other_peers)].peer_id
+        my_peer_id = swarm7[peer].peer_id
+        assert rufus_peer_id != my_peer_id
+
+        async with create_alias("Rufus", rufus_peer_id, swarm7[peer].api) as api:
+            assert await api.aliases_set_alias("Simon", rufus_peer_id) is False
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
+    async def test_hoprd_should_contain_self_alias_automatically(self, peer: str, swarm7: dict[str, Node]):
+        assert (await swarm7[peer].api.aliases_get_alias("me")).peer_id == swarm7[peer].peer_id
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("src, dest", random_distinct_pairs_from(barebone_nodes(), count=PARAMETERIZED_SAMPLE_SIZE))
+    async def test_hoprd_ping_should_work_between_nodes_in_the_same_network(
+        self, src: str, dest: str, swarm7: dict[str, Node]
+    ):
+        response = await swarm7[src].api.ping(swarm7[dest].peer_id)
+
+        assert response is not None
+        assert int(response.latency) > 0, f"Non-0 round trip time expected, actual: '{int(response.latency)}'"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
+    async def test_hoprd_ping_to_self_should_fail(self, peer: str, swarm7: dict[str, Node]):
+        response = await swarm7[peer].api.ping(swarm7[peer].peer_id)
+
+        assert response is None, "Pinging self should fail"
+
+    @pytest.mark.asyncio
+    async def test_hoprd_ping_should_not_be_able_to_ping_nodes_not_present_in_the_registry_UNFINISHED(
+        self,
+        swarm7: dict[str, Node],
+    ):
+        """
+        # log "Node 7 should not be able to talk to Node 1 (Node 7 is not in the register)"
+        # result=$(ping "${api7}" ${addr1} "TIMEOUT")
+        # log "-- ${result}"
+
+        # log "Node 1 should not be able to talk to Node 7 (Node 7 is not in the register)"
+        # result=$(ping "${api1}" ${addr7} "TIMEOUT")
+        # log "-- ${result}"
+        """
+        assert True
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("src, dest", random_distinct_pairs_from(barebone_nodes(), count=PARAMETERIZED_SAMPLE_SIZE))
+    async def test_hoprd_should_be_able_to_send_0_hop_messages_without_open_channels(
+        self, src: str, dest: str, swarm7: dict[str, Node]
+    ):
+        message_count = int(TICKET_AGGREGATION_THRESHOLD / 10)
+
+        packets = [f"0 hop message #{i:08d}" for i in range(message_count)]
+        await send_and_receive_packets_with_pop(packets, src=swarm7[src], dest=swarm7[dest], path=[])
+
+        # Remove all messages so they do not interfere with the later tests
+        await swarm7[dest].api.messages_pop_all(None)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("src, dest", random_distinct_pairs_from(barebone_nodes(), count=PARAMETERIZED_SAMPLE_SIZE))
+    async def test_hoprd_should_fail_sending_a_message_that_is_too_large(
+        self, src: str, dest: str, swarm7: dict[str, Node]
+    ):
+        maximum_payload_size = 500
+        random_tag = gen_random_tag()
+
+        packet = "0 hop message too large: " + "".join(
+            random.choices(string.ascii_uppercase + string.digits, k=maximum_payload_size)
+        )
+        assert await swarm7[src].api.send_message(swarm7[dest].peer_id, packet, [], random_tag) is None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "src,dest", [tuple(shuffled(barebone_nodes())[:2]) for _ in range(PARAMETERIZED_SAMPLE_SIZE)]
+    )
+    async def test_hoprd_api_channel_should_register_fund_increase_using_fund_endpoint(
+        self, src: str, dest: str, swarm7: dict[str, Node]
+    ):
+        # convert HOPR to weiHOPR
+        hopr_amount = OPEN_CHANNEL_FUNDING_VALUE_HOPR * 1e18
+
+        async with create_channel(swarm7[src], swarm7[dest], funding=TICKET_PRICE_PER_HOP) as channel:
+            balance_before = await swarm7[src].api.balances()
+            channel_before = await swarm7[src].api.get_channel(channel.id)
+
+            assert await swarm7[src].api.fund_channel(channel.id, hopr_amount)
+
+            channel_after = await swarm7[src].api.get_channel(channel.id)
+
+            # Updated channel balance is visible immediately
+            assert channel_after.balance - channel_before.balance == hopr_amount
+
+            # Wait until the safe balance has decreased
+            await asyncio.wait_for(
+                check_safe_balance(swarm7[src], balance_before.safe_hopr - hopr_amount),
+                20.0,
+            )
+
+            # Safe allowance can be checked too at this point
+            balance_after = await swarm7[src].api.balances()
+            assert balance_before.safe_hopr_allowance - balance_after.safe_hopr_allowance == hopr_amount
+
+            await asyncio.wait_for(check_native_balance_below(swarm7[src], balance_before.native), 20.0)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "src,dest", [tuple(shuffled(barebone_nodes())[:2]) for _ in range(PARAMETERIZED_SAMPLE_SIZE)]
+    )
+    async def test_reset_ticket_statistics_from_metrics(self, src: Node, dest: Node, swarm7: dict[str, Node]):
+        def count_metrics(metrics: str):
+            types = ["neglected", "redeemed", "rejected"]
+            count = 0
+            for line in metrics.splitlines():
+                count += (
+                    line.startswith("hopr_tickets_incoming_statistics")
+                    and any(t in line for t in types)
+                    and line.split()[-1] != "0"
+                )
+            return count
+
+        async with create_channel(swarm7[src], swarm7[dest], funding=TICKET_PRICE_PER_HOP, close_from_dest=False):
+            await send_and_receive_packets_with_pop(
+                ["1 hop message to self"], src=swarm7[src], dest=swarm7[src], path=[swarm7[dest].peer_id]
+            )
+
+        assert count_metrics(await swarm7[dest].api.metrics()) != 0
+
+        await swarm7[dest].api.reset_tickets_statistics()
+
+        assert count_metrics(await swarm7[dest].api.metrics()) == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "src,dest", [tuple(shuffled(barebone_nodes())[:2]) for _ in range(PARAMETERIZED_SAMPLE_SIZE)]
+    )
+    async def test_hoprd_should_fail_sending_a_message_when_the_channel_is_out_of_funding(
+        self, src: str, dest: str, swarm7: dict[str, Node]
+    ):
+        """
+        # FIXME: The following part can be enabled once incoming channel closure is
+        # implemented.
+        #
+        # need to close the incoming side to not have to wait for the closure timeout
+        # api_close_channel "${second_node_id}" "${node_id}" "${second_node_api}" "${node_addr}" "incoming"
+    
+        # only fund for 2 tickets
+        # channel_info=$(api_open_channel "${node_id}" "${second_node_id}" "${node_api}" "${second_node_addr}" "200")
+    
+        # need to wait a little to allow the other side to index the channel open event
+        # sleep 10
+        # api_get_tickets_in_channel ${second_node_api} ${channel_id} "TICKETS_NOT_FOUND"
+        # for i in `seq 1 ${generated_tickets}`; do
+        #   log "PendingBalance in channel: Node ${node_id} send 1 hop message to self via node ${second_node_id}"
+        #   api_send_message "${node_api}" "${msg_tag}" "${peer_id}" \
+        #       "pendingbalance: hello, world 1 self" "${second_peer_id}"
+        # done
+    
+        # seems like there's slight delay needed for tickets endpoint to return up to date tickets, \
+        #       probably because of blockchain sync delay
+        # sleep 5
+    
+        # ticket_amount=$(api_get_tickets_in_channel ${second_node_api} ${channel_id} | jq '. | length')
+        # if [[ "${ticket_amount}" != "${generated_tickets}" ]]; then
+        #   msg "PendingBalance: Ticket amount ${ticket_amount} is different than expected ${generated_tickets}"
+        #   exit 1
+        # fi
+    
+        # api_redeem_tickets_in_channel ${second_node_api} ${channel_id}
+        # sleep 5
+        # api_get_tickets_in_channel ${second_node_api} ${channel_id} "TICKETS_NOT_FOUND"
+        # api_close_channel "${node_id}" "${second_node_id}" "${node_api}" "${second_node_addr}" "outgoing"
+        """
+
+        message_count = 2
+
+        async with AsyncExitStack() as channels:
+            await asyncio.gather(
+                *[
+                    channels.enter_async_context(
+                        create_channel(
+                            swarm7[i[0]],
+                            swarm7[i[1]],
+                            funding=message_count * TICKET_PRICE_PER_HOP,
+                            close_from_dest=False,
+                        )
+                    )
+                    for i in [[src, dest]]
+                ]
+            )
+
+            packets = [
+                f"Channel agg and redeem on 1-hop: {src} - {dest} - {src} #{i:08d}" for i in range(message_count)
+            ]
+            await send_and_receive_packets_with_pop(
+                packets, src=swarm7[src], dest=swarm7[src], path=[swarm7[dest].peer_id]
+            )
+
+            # this message has no funding in the channel, but it still should be sent
+            assert await swarm7[src].api.send_message(
+                swarm7[src].peer_id, "THIS MSG IS NOT COVERED", [swarm7[dest].peer_id]
+            )
+
+            await asyncio.wait_for(
+                check_unredeemed_tickets_value(swarm7[dest], message_count * TICKET_PRICE_PER_HOP), 30.0
+            )
+
+            # we should see the last message as rejected
+            await asyncio.wait_for(check_rejected_tickets_value(swarm7[dest], 1), 120.0)
+
+            await asyncio.sleep(10)  # wait for aggregation to finish
+            assert await swarm7[dest].api.tickets_redeem()
+
+            await asyncio.wait_for(check_all_tickets_redeemed(swarm7[dest]), 120.0)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("src,dest", random_distinct_pairs_from(barebone_nodes(), count=PARAMETERIZED_SAMPLE_SIZE))
+    async def test_hoprd_should_be_able_to_open_and_close_channel_without_tickets(
+        self, src: str, dest: str, swarm7: dict[str, Node]
+    ):
+        async with create_channel(swarm7[src], swarm7[dest], OPEN_CHANNEL_FUNDING_VALUE_HOPR):
+            # the context manager handles opening and closing of the channel with verification, using counter-party address
+            assert True
+
+        async with create_channel(swarm7[src], swarm7[dest], OPEN_CHANNEL_FUNDING_VALUE_HOPR, use_peer_id=True):
+            # the context manager handles opening and closing of the channel with verification using counter-party peerID
+            assert True
+
+    # generate a 1-hop route with a node using strategies in the middle
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "route",
+        [
+            [
+                random.sample(barebone_nodes(), 1)[0],
+                random.sample(default_nodes(), 1)[0],
+                random.sample(barebone_nodes(), 1)[0],
+            ]
+            for _ in range(PARAMETERIZED_SAMPLE_SIZE)
+        ],
+    )
+    async def test_hoprd_default_strategy_automatic_ticket_aggregation_and_redeeming(
+        self, route, swarm7: dict[str, Node]
+    ):
+        ticket_count = int(TICKET_AGGREGATION_THRESHOLD)
+        src = route[0]
+        mid = route[1]
+        dest = route[-1]
+        channel_funding = ticket_count * TICKET_PRICE_PER_HOP
+
+        # create channel from src to mid, mid to dest does not need a channel
+        async with create_channel(swarm7[src], swarm7[mid], funding=channel_funding):
+            statistics_before = await swarm7[mid].api.get_tickets_statistics()
+            assert statistics_before is not None
+
+            packets = [f"Ticket aggregation test: #{i:08d}" for i in range(ticket_count)]
+            await send_and_receive_packets_with_pop(
+                packets, src=swarm7[src], dest=swarm7[dest], path=[swarm7[mid].peer_id]
+            )
+
+            # monitor that the node aggregates and redeems tickets until the aggregated value is reached
+            async def check_aggregate_and_redeem_tickets(api: HoprdAPI):
+                while True:
+                    statistics_now = await api.get_tickets_statistics()
+                    assert statistics_now is not None
+
+                    redeemed_value_diff = statistics_now.redeemed_value - statistics_before.redeemed_value
+
+                    # break out of the loop if the aggregated value is reached
+                    if redeemed_value_diff >= AGGREGATED_TICKET_PRICE:
+                        break
+                    else:
+                        await asyncio.sleep(0.1)
+
+            await asyncio.wait_for(check_aggregate_and_redeem_tickets(swarm7[mid].api), 120.0)
+
+    # FIXME: This test depends on side-effects and cannot be run on its own. It
+    # should be redesigned.
+    @pytest.mark.asyncio
+    async def test_hoprd_sanity_check_channel_status(self, swarm7: dict[str, Node]):
+        """
+        The bash integration-test.sh opens and closes channels that can be visible inside this test scope
+        """
+        alice_api = swarm7["1"].api
+
+        open_channels = await alice_api.all_channels(include_closed=False)
+        open_and_closed_channels = await alice_api.all_channels(include_closed=True)
+
+        assert len(open_and_closed_channels.all) >= len(open_channels.all), "Open and closed channels should be present"
+
+        statuses = [c.status for c in open_and_closed_channels.all]
+        assert (
+            ChannelStatus.Closed in statuses or ChannelStatus.PendingToClose in statuses
+        ), "Closed channels should be present"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
+    async def test_hoprd_check_native_withdraw(self, peer, swarm7: dict[str, Node]):
+        amount = "9876"
+        remaining_attempts = 10
+
+        before_balance = int((await swarm7[peer].api.balances()).safe_native)
+        await swarm7[peer].api.withdraw(amount, swarm7[peer].safe_address, "Native")
+
+        after_balance = before_balance
+        while remaining_attempts > 0:
+            after_balance = int((await swarm7[peer].api.balances()).safe_native)
+            if after_balance != before_balance:
+                break
+            await asyncio.sleep(0.5)
+            remaining_attempts -= 1
+
+        assert after_balance - before_balance == int(amount)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
+    async def test_hoprd_check_ticket_price_is_default(self, peer, swarm7: dict[str, Node]):
+        price = await swarm7[peer].api.ticket_price()
+
+        assert isinstance(price.value, int)
+        assert price.value > 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("tag", [random.randint(0, RESERVED_TAG_UPPER_BOUND) for _ in range(5)])
+    async def test_send_message_with_reserved_application_tag_should_fail(self, tag: int, swarm7: dict[str, Node]):
+        src, dest = random_distinct_pairs_from(barebone_nodes(), count=1)[0]
+
+        assert (
+            await swarm7[src].api.send_message(
+                swarm7[dest].peer_id, "This message should fail due to reserved tag", [], tag
+            )
+            is None
         )
 
-        await asyncio.wait_for(check_unredeemed_tickets_value(swarm7[dest], message_count * TICKET_PRICE_PER_HOP), 30.0)
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("tag", [random.randint(0, RESERVED_TAG_UPPER_BOUND) for _ in range(5)])
+    async def test_inbox_operations_with_reserved_application_tag_should_fail(self, tag: int, swarm7: dict[str, Node]):
+        id = random.choice(barebone_nodes())
 
-        # we should see the last message as rejected
-        await asyncio.wait_for(check_rejected_tickets_value(swarm7[dest], 1), 120.0)
+        assert await swarm7[id].api.messages_pop(tag) is None
+        assert await swarm7[id].api.messages_peek(tag) is None
+        assert await swarm7[id].api.messages_peek(tag) is None
 
-        await asyncio.sleep(10)  # wait for aggregation to finish
-        assert await swarm7[dest].api.tickets_redeem()
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("src,dest", random_distinct_pairs_from(barebone_nodes(), count=PARAMETERIZED_SAMPLE_SIZE))
+    async def test_peeking_messages_with_timestamp(self, src: str, dest: str, swarm7: dict[str, Node]):
+        message_count = int(TICKET_AGGREGATION_THRESHOLD / 10)
+        split_index = int(message_count * 0.66)
 
-        await asyncio.wait_for(check_all_tickets_redeemed(swarm7[dest]), 120.0)
+        random_tag = gen_random_tag()
 
+        src_peer = swarm7[src]
+        dest_peer = swarm7[dest]
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("src,dest", random_distinct_pairs_from(barebone_nodes(), count=PARAMETERIZED_SAMPLE_SIZE))
-async def test_hoprd_should_be_able_to_open_and_close_channel_without_tickets(
-    src: str, dest: str, swarm7: dict[str, Node]
-):
-    async with create_channel(swarm7[src], swarm7[dest], OPEN_CHANNEL_FUNDING_VALUE_HOPR):
-        # the context manager handles opening and closing of the channel with verification, using counter-party address
-        assert True
+        packets = [f"0 hop message #{i:08d}" for i in range(message_count)]
+        for packet in packets[:split_index]:
+            await src_peer.api.send_message(dest_peer.peer_id, packet, [], random_tag)
 
-    async with create_channel(swarm7[src], swarm7[dest], OPEN_CHANNEL_FUNDING_VALUE_HOPR, use_peer_id=True):
-        # the context manager handles opening and closing of the channel with verification using counter-party peerID
-        assert True
+        await asyncio.sleep(2)
 
+        for packet in packets[split_index:]:
+            await src_peer.api.send_message(dest_peer.peer_id, packet, [], random_tag)
 
-# generate a 1-hop route with a node using strategies in the middle
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "route",
-    [
-        [
-            random.sample(barebone_nodes(), 1)[0],
-            random.sample(default_nodes(), 1)[0],
-            random.sample(barebone_nodes(), 1)[0],
-        ]
-        for _ in range(PARAMETERIZED_SAMPLE_SIZE)
-    ],
-)
-async def test_hoprd_default_strategy_automatic_ticket_aggregation_and_redeeming(route, swarm7: dict[str, Node]):
-    ticket_count = int(TICKET_AGGREGATION_THRESHOLD)
-    src = route[0]
-    mid = route[1]
-    dest = route[-1]
-    channel_funding = ticket_count * TICKET_PRICE_PER_HOP
+        await asyncio.wait_for(
+            check_received_packets_with_peek(dest_peer, packets, tag=random_tag, sort=True),
+            MULTIHOP_MESSAGE_SEND_TIMEOUT,
+        )
 
-    # create channel from src to mid, mid to dest does not need a channel
-    async with create_channel(swarm7[src], swarm7[mid], funding=channel_funding):
-        statistics_before = await swarm7[mid].api.get_tickets_statistics()
-        assert statistics_before is not None
+        packets = await dest_peer.api.messages_peek_all(random_tag)
+        timestamps = sorted([message.received_at for message in packets])
 
-        packets = [f"Ticket aggregation test: #{i:08d}" for i in range(ticket_count)]
-        await send_and_receive_packets_with_pop(packets, src=swarm7[src], dest=swarm7[dest], path=[swarm7[mid].peer_id])
+        # ts_for_query set right before (1ms before) the first message of the second batch.
+        # This is to ensure that the first message of the second batch will be returned by the query.
+        # It's a workaround, it should work properly without the -1, however randmly fails.
+        ts_for_query = timestamps[split_index] - 1
 
-        # monitor that the node aggregates and redeems tickets until the aggregated value is reached
-        async def check_aggregate_and_redeem_tickets(api: HoprdAPI):
-            while True:
-                statistics_now = await api.get_tickets_statistics()
-                assert statistics_now is not None
+        async def peek_the_messages():
+            packets = await dest_peer.api.messages_peek_all(random_tag, ts_for_query)
 
-                redeemed_value_diff = statistics_now.redeemed_value - statistics_before.redeemed_value
+            assert len(packets) == message_count - split_index
 
-                # break out of the loop if the aggregated value is reached
-                if redeemed_value_diff >= AGGREGATED_TICKET_PRICE:
-                    break
-                else:
-                    await asyncio.sleep(0.1)
+        await asyncio.wait_for(peek_the_messages(), MULTIHOP_MESSAGE_SEND_TIMEOUT)
 
-        await asyncio.wait_for(check_aggregate_and_redeem_tickets(swarm7[mid].api), 120.0)
+        # Remove all messages so they do not interfere with the later tests
+        await dest_peer.api.messages_pop_all(random_tag)
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("src,dest", random_distinct_pairs_from(barebone_nodes(), count=PARAMETERIZED_SAMPLE_SIZE))
+    async def test_send_message_return_timestamp(self, src: str, dest: str, swarm7: dict[str, Node]):
+        message_count = int(TICKET_AGGREGATION_THRESHOLD / 10)
+        random_tag = gen_random_tag()
 
-# FIXME: This test depends on side-effects and cannot be run on its own. It
-# should be redesigned.
-@pytest.mark.asyncio
-async def test_hoprd_sanity_check_channel_status(swarm7: dict[str, Node]):
-    """
-    The bash integration-test.sh opens and closes channels that can be visible inside this test scope
-    """
-    alice_api = swarm7["1"].api
+        src_peer = swarm7[src]
+        dest_peer = swarm7[dest]
 
-    open_channels = await alice_api.all_channels(include_closed=False)
-    open_and_closed_channels = await alice_api.all_channels(include_closed=True)
+        packets = [f"0 hop message #{i:08d}" for i in range(message_count)]
+        timestamps = []
+        for packet in packets:
+            res = await src_peer.api.send_message(dest_peer.peer_id, packet, [], random_tag)
+            timestamps.append(res.timestamp)
 
-    assert len(open_and_closed_channels.all) >= len(open_channels.all), "Open and closed channels should be present"
+        # Remove all messages so they do not interfere with the later tests
+        await dest_peer.api.messages_pop_all(random_tag)
 
-    statuses = [c.status for c in open_and_closed_channels.all]
-    assert (
-        ChannelStatus.Closed in statuses or ChannelStatus.PendingToClose in statuses
-    ), "Closed channels should be present"
+        assert len(timestamps) == message_count
+        assert timestamps == sorted(timestamps)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("src,dest", random_distinct_pairs_from(barebone_nodes(), count=PARAMETERIZED_SAMPLE_SIZE))
+    async def test_send_message_with_address_or_peer_id(self, src: str, dest: str, swarm7: dict[str, Node]):
+        message_count = int(TICKET_AGGREGATION_THRESHOLD / 10)
+        random_tag = gen_random_tag()
+
+        src_peer = swarm7[src]
+        dest_peer = swarm7[dest]
+
+        packets = [f"0 hop message #{i:08d}" for i in range(message_count)]
+        for packet in packets:
+            res = await src_peer.api.send_message(
+                random.choice([dest_peer.peer_id, dest_peer.address]), packet, [], random_tag
+            )
+            assert res is not None
+
+        # Remove all messages so they do not interfere with the later tests
+        await dest_peer.api.messages_pop_all(random_tag)
 
 
 @pytest.mark.asyncio
@@ -427,140 +571,3 @@ async def test_hoprd_strategy_UNFINISHED():
     # test_strategy_setting ${api4}
     """
     assert True
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
-async def test_hoprd_check_native_withdraw(peer, swarm7: dict[str, Node]):
-    amount = "9876"
-    remaining_attempts = 10
-
-    before_balance = int((await swarm7[peer].api.balances()).safe_native)
-    await swarm7[peer].api.withdraw(amount, swarm7[peer].safe_address, "Native")
-
-    after_balance = before_balance
-    while remaining_attempts > 0:
-        after_balance = int((await swarm7[peer].api.balances()).safe_native)
-        if after_balance != before_balance:
-            break
-        await asyncio.sleep(0.5)
-        remaining_attempts -= 1
-
-    assert after_balance - before_balance == int(amount)
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
-async def test_hoprd_check_ticket_price_is_default(peer, swarm7: dict[str, Node]):
-    price = await swarm7[peer].api.ticket_price()
-
-    assert isinstance(price.value, int)
-    assert price.value > 0
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("tag", [random.randint(0, RESERVED_TAG_UPPER_BOUND) for _ in range(5)])
-async def test_send_message_with_reserved_application_tag_should_fail(tag: int, swarm7: dict[str, Node]):
-    src, dest = random_distinct_pairs_from(barebone_nodes(), count=1)[0]
-
-    assert (
-        await swarm7[src].api.send_message(
-            swarm7[dest].peer_id, "This message should fail due to reserved tag", [], tag
-        )
-        is None
-    )
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("tag", [random.randint(0, RESERVED_TAG_UPPER_BOUND) for _ in range(5)])
-async def test_inbox_operations_with_reserved_application_tag_should_fail(tag: int, swarm7: dict[str, Node]):
-    id = random.choice(barebone_nodes())
-
-    assert await swarm7[id].api.messages_pop(tag) is None
-    assert await swarm7[id].api.messages_peek(tag) is None
-    assert await swarm7[id].api.messages_peek(tag) is None
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("src,dest", random_distinct_pairs_from(barebone_nodes(), count=PARAMETERIZED_SAMPLE_SIZE))
-async def test_peeking_messages_with_timestamp(src: str, dest: str, swarm7: dict[str, Node]):
-    message_count = int(TICKET_AGGREGATION_THRESHOLD / 10)
-    split_index = int(message_count * 0.66)
-
-    random_tag = gen_random_tag()
-
-    src_peer = swarm7[src]
-    dest_peer = swarm7[dest]
-
-    packets = [f"0 hop message #{i:08d}" for i in range(message_count)]
-    for packet in packets[:split_index]:
-        await src_peer.api.send_message(dest_peer.peer_id, packet, [], random_tag)
-
-    await asyncio.sleep(2)
-
-    for packet in packets[split_index:]:
-        await src_peer.api.send_message(dest_peer.peer_id, packet, [], random_tag)
-
-    await asyncio.wait_for(
-        check_received_packets_with_peek(dest_peer, packets, tag=random_tag, sort=True), MULTIHOP_MESSAGE_SEND_TIMEOUT
-    )
-
-    packets = await dest_peer.api.messages_peek_all(random_tag)
-    timestamps = sorted([message.received_at for message in packets])
-
-    # ts_for_query set right before (1ms before) the first message of the second batch.
-    # This is to ensure that the first message of the second batch will be returned by the query.
-    # It's a workaround, it should work properly without the -1, however randmly fails.
-    ts_for_query = timestamps[split_index] - 1
-
-    async def peek_the_messages():
-        packets = await dest_peer.api.messages_peek_all(random_tag, ts_for_query)
-
-        assert len(packets) == message_count - split_index
-
-    await asyncio.wait_for(peek_the_messages(), MULTIHOP_MESSAGE_SEND_TIMEOUT)
-
-    # Remove all messages so they do not interfere with the later tests
-    await dest_peer.api.messages_pop_all(random_tag)
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("src,dest", random_distinct_pairs_from(barebone_nodes(), count=PARAMETERIZED_SAMPLE_SIZE))
-async def test_send_message_return_timestamp(src: str, dest: str, swarm7: dict[str, Node]):
-    message_count = int(TICKET_AGGREGATION_THRESHOLD / 10)
-    random_tag = gen_random_tag()
-
-    src_peer = swarm7[src]
-    dest_peer = swarm7[dest]
-
-    packets = [f"0 hop message #{i:08d}" for i in range(message_count)]
-    timestamps = []
-    for packet in packets:
-        res = await src_peer.api.send_message(dest_peer.peer_id, packet, [], random_tag)
-        timestamps.append(res.timestamp)
-
-    # Remove all messages so they do not interfere with the later tests
-    await dest_peer.api.messages_pop_all(random_tag)
-
-    assert len(timestamps) == message_count
-    assert timestamps == sorted(timestamps)
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("src,dest", random_distinct_pairs_from(barebone_nodes(), count=PARAMETERIZED_SAMPLE_SIZE))
-async def test_send_message_with_address_or_peer_id(src: str, dest: str, swarm7: dict[str, Node]):
-    message_count = int(TICKET_AGGREGATION_THRESHOLD / 10)
-    random_tag = gen_random_tag()
-
-    src_peer = swarm7[src]
-    dest_peer = swarm7[dest]
-
-    packets = [f"0 hop message #{i:08d}" for i in range(message_count)]
-    for packet in packets:
-        res = await src_peer.api.send_message(
-            random.choice([dest_peer.peer_id, dest_peer.address]), packet, [], random_tag
-        )
-        assert res is not None
-
-    # Remove all messages so they do not interfere with the later tests
-    await dest_peer.api.messages_pop_all(random_tag)

--- a/tests/test_redeeming.py
+++ b/tests/test_redeeming.py
@@ -24,178 +24,203 @@ from .utils import (
 PORT_BASE = 19000
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("peer", barebone_nodes())
-async def test_hoprd_should_not_have_unredeemed_tickets_without_sending_messages(peer: str, swarm7: dict[str, Node]):
-    statistics = await swarm7[peer].api.get_tickets_statistics()
+@pytest.mark.usefixtures("swarm7_reset")
+class TestRedeemingWithSwarm:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("peer", barebone_nodes())
+    async def test_hoprd_should_not_have_unredeemed_tickets_without_sending_messages(
+        self, peer: str, swarm7: dict[str, Node]
+    ):
+        statistics = await swarm7[peer].api.get_tickets_statistics()
 
-    assert statistics.unredeemed_value == 0
+        assert statistics.unredeemed_value == 0
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "src,dest", [tuple(shuffled(barebone_nodes())[:2]) for _ in range(PARAMETERIZED_SAMPLE_SIZE)]
+    )
+    async def test_hoprd_api_should_redeem_tickets_in_channel_using_redeem_endpoint(
+        self, src: str, dest: str, swarm7: dict[str, Node]
+    ):
+        message_count = 2
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("src,dest", [tuple(shuffled(barebone_nodes())[:2]) for _ in range(PARAMETERIZED_SAMPLE_SIZE)])
-async def test_hoprd_api_should_redeem_tickets_in_channel_using_redeem_endpoint(
-    src: str, dest: str, swarm7: dict[str, Node]
-):
-    message_count = 2
+        async with create_channel(
+            swarm7[src], swarm7[dest], funding=message_count * TICKET_PRICE_PER_HOP, close_from_dest=False
+        ) as channel:
+            packets = [f"Channel redeem on 1-hop: {src} - {dest} - {src} #{i:08d}" for i in range(message_count)]
 
-    async with create_channel(
-        swarm7[src], swarm7[dest], funding=message_count * TICKET_PRICE_PER_HOP, close_from_dest=False
-    ) as channel:
-        packets = [f"Channel redeem on 1-hop: {src} - {dest} - {src} #{i:08d}" for i in range(message_count)]
+            await send_and_receive_packets_with_pop(
+                packets, src=swarm7[src], dest=swarm7[src], path=[swarm7[dest].peer_id]
+            )
 
-        await send_and_receive_packets_with_pop(packets, src=swarm7[src], dest=swarm7[src], path=[swarm7[dest].peer_id])
+            await asyncio.wait_for(
+                check_unredeemed_tickets_value(swarm7[dest], message_count * TICKET_PRICE_PER_HOP), 30.0
+            )
 
-        await asyncio.wait_for(check_unredeemed_tickets_value(swarm7[dest], message_count * TICKET_PRICE_PER_HOP), 30.0)
+            async def channel_redeem_tickets(api: HoprdAPI, channel: str):
+                while True:
+                    if await api.channel_redeem_tickets(channel):
+                        break
+                    else:
+                        await asyncio.sleep(0.5)
 
-        async def channel_redeem_tickets(api: HoprdAPI, channel: str):
-            while True:
-                if await api.channel_redeem_tickets(channel):
-                    break
-                else:
-                    await asyncio.sleep(0.5)
+            await asyncio.wait_for(channel_redeem_tickets(swarm7[dest].api, channel.id), 20.0)
 
-        await asyncio.wait_for(channel_redeem_tickets(swarm7[dest].api, channel.id), 20.0)
+            await asyncio.wait_for(check_all_tickets_redeemed(swarm7[dest]), 120.0)
 
-        await asyncio.wait_for(check_all_tickets_redeemed(swarm7[dest]), 120.0)
+            assert await swarm7[dest].api.channel_get_tickets(channel) == []
 
-        assert await swarm7[dest].api.channel_get_tickets(channel) == []
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "src,dest", [tuple(shuffled(barebone_nodes())[:2]) for _ in range(PARAMETERIZED_SAMPLE_SIZE)]
+    )
+    async def test_hoprd_should_create_redeemable_tickets_on_routing_in_1_hop_to_self_scenario(
+        self, src: str, dest: str, swarm7: dict[str, Node]
+    ):
+        # send 90% of messages before ticket aggregation would kick in
+        message_count = int(TICKET_AGGREGATION_THRESHOLD / 10 * 9)
 
+        async with create_channel(
+            swarm7[src], swarm7[dest], funding=message_count * TICKET_PRICE_PER_HOP, close_from_dest=False
+        ) as channel:
+            # ensure ticket stats are what we expect before starting
+            statistics_before = await swarm7[dest].api.get_tickets_statistics()
+            assert statistics_before.unredeemed_value == 0
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("src,dest", [tuple(shuffled(barebone_nodes())[:2]) for _ in range(PARAMETERIZED_SAMPLE_SIZE)])
-async def test_hoprd_should_create_redeemable_tickets_on_routing_in_1_hop_to_self_scenario(
-    src: str, dest: str, swarm7: dict[str, Node]
-):
-    # send 90% of messages before ticket aggregation would kick in
-    message_count = int(TICKET_AGGREGATION_THRESHOLD / 10 * 9)
-
-    async with create_channel(
-        swarm7[src], swarm7[dest], funding=message_count * TICKET_PRICE_PER_HOP, close_from_dest=False
-    ) as channel:
-        # ensure ticket stats are what we expect before starting
-        statistics_before = await swarm7[dest].api.get_tickets_statistics()
-        assert statistics_before.unredeemed_value == 0
-
-        packets = [
-            f"1 hop message to self: {src} - {dest} - {src} #{i:08d} of #{message_count:08d}"
-            for i in range(message_count)
-        ]
-        await send_and_receive_packets_with_pop(
-            packets, src=swarm7[src], dest=swarm7[src], path=[swarm7[dest].peer_id], timeout=60.0
-        )
-
-        await asyncio.wait_for(check_unredeemed_tickets_value(swarm7[dest], message_count * TICKET_PRICE_PER_HOP), 30.0)
-
-        # ensure ticket stats are updated after messages are sent
-        statistics_after = await swarm7[dest].api.get_tickets_statistics()
-
-        unredeemed_value = statistics_after.unredeemed_value - statistics_before.unredeemed_value
-
-        assert statistics_after.redeemed_value == statistics_before.redeemed_value
-        assert unredeemed_value == (len(packets) * TICKET_PRICE_PER_HOP)
-
-        assert await swarm7[dest].api.channel_redeem_tickets(channel.id)
-
-        await asyncio.wait_for(check_all_tickets_redeemed(swarm7[dest]), 120.0)
-
-        # ensure ticket stats are updated after redemption
-        statistics_after_redemption = await swarm7[dest].api.get_tickets_statistics()
-        assert (statistics_after_redemption.redeemed_value - statistics_after.redeemed_value) == (
-            len(packets) * TICKET_PRICE_PER_HOP
-        )
-        assert statistics_after_redemption.unredeemed_value == 0
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("src,dest", [tuple(shuffled(barebone_nodes())[:2]) for _ in range(PARAMETERIZED_SAMPLE_SIZE)])
-async def test_hoprd_should_aggregate_and_redeem_tickets_in_channel_on_api_request(
-    src: str, dest: str, swarm7: dict[str, Node]
-):
-    message_count = 2
-
-    async with create_channel(swarm7[src], swarm7[dest], funding=message_count * TICKET_PRICE_PER_HOP) as channel:
-        packets = [f"Channel agg and redeem on 1-hop: {src} - {dest} - {src} #{i:08d}" for i in range(message_count)]
-        await send_and_receive_packets_with_pop(packets, src=swarm7[src], dest=swarm7[src], path=[swarm7[dest].peer_id])
-
-        await asyncio.wait_for(check_unredeemed_tickets_value(swarm7[dest], message_count * TICKET_PRICE_PER_HOP), 30.0)
-
-        ticket_statistics = await swarm7[dest].api.get_tickets_statistics()
-        assert ticket_statistics.unredeemed_value == 2 * TICKET_PRICE_PER_HOP
-
-        await asyncio.wait_for(swarm7[dest].api.channels_aggregate_tickets(channel.id), 20.0)
-
-        ticket_statistics = await swarm7[dest].api.get_tickets_statistics()
-        assert ticket_statistics.unredeemed_value == 2 * TICKET_PRICE_PER_HOP
-
-        assert await swarm7[dest].api.channel_redeem_tickets(channel.id)
-
-        await asyncio.wait_for(check_all_tickets_redeemed(swarm7[dest]), 120.0)
-
-        ticket_statistics = await swarm7[dest].api.get_tickets_statistics()
-        assert ticket_statistics.unredeemed_value == 0
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "route",
-    [shuffled(barebone_nodes())[:3] for _ in range(PARAMETERIZED_SAMPLE_SIZE)],
-    # + [shuffled(nodes())[:5] for _ in range(PARAMETERIZED_SAMPLE_SIZE)],
-)
-async def test_hoprd_should_create_redeemable_tickets_on_routing_in_general_n_hop(route, swarm7: dict[str, Node]):
-    message_count = int(TICKET_AGGREGATION_THRESHOLD / 10)
-
-    async with AsyncExitStack() as channels:
-        await asyncio.gather(
-            *[
-                channels.enter_async_context(
-                    create_channel(swarm7[route[i]], swarm7[route[i + 1]], funding=message_count * TICKET_PRICE_PER_HOP)
-                )
-                for i in range(len(route) - 1)
+            packets = [
+                f"1 hop message to self: {src} - {dest} - {src} #{i:08d} of #{message_count:08d}"
+                for i in range(message_count)
             ]
-        )
+            await send_and_receive_packets_with_pop(
+                packets, src=swarm7[src], dest=swarm7[src], path=[swarm7[dest].peer_id], timeout=60.0
+            )
 
-        packets = [f"General n-hop over {route} message #{i:08d}" for i in range(message_count)]
-        await send_and_receive_packets_with_pop(
-            packets,
-            src=swarm7[route[0]],
-            dest=swarm7[route[-1]],
-            path=[swarm7[x].peer_id for x in route[1:-1]],
-        )
+            await asyncio.wait_for(
+                check_unredeemed_tickets_value(swarm7[dest], message_count * TICKET_PRICE_PER_HOP), 30.0
+            )
 
-        await asyncio.wait_for(
-            check_unredeemed_tickets_value(swarm7[route[1]], message_count * TICKET_PRICE_PER_HOP), 30.0
-        )
+            # ensure ticket stats are updated after messages are sent
+            statistics_after = await swarm7[dest].api.get_tickets_statistics()
 
-        # wait for aggregation to finish before redeeming
-        await asyncio.sleep(10)
-        assert await swarm7[route[1]].api.tickets_redeem()
+            unredeemed_value = statistics_after.unredeemed_value - statistics_before.unredeemed_value
 
-        await asyncio.wait_for(check_all_tickets_redeemed(swarm7[route[1]]), 120.0)
+            assert statistics_after.redeemed_value == statistics_before.redeemed_value
+            assert unredeemed_value == (len(packets) * TICKET_PRICE_PER_HOP)
 
+            assert await swarm7[dest].api.channel_redeem_tickets(channel.id)
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("route", [shuffled(barebone_nodes())[:3] for _ in range(PARAMETERIZED_SAMPLE_SIZE)])
-async def test_hoprd_should_be_able_to_close_open_channels_with_unredeemed_tickets(route, swarm7: dict[str, Node]):
-    ticket_count = 2
+            await asyncio.wait_for(check_all_tickets_redeemed(swarm7[dest]), 120.0)
 
-    async with AsyncExitStack() as channels:
-        await asyncio.gather(
-            *[
-                channels.enter_async_context(
-                    create_channel(swarm7[route[i]], swarm7[route[i + 1]], funding=ticket_count * TICKET_PRICE_PER_HOP)
-                )
-                for i in range(len(route) - 1)
+            # ensure ticket stats are updated after redemption
+            statistics_after_redemption = await swarm7[dest].api.get_tickets_statistics()
+            assert (statistics_after_redemption.redeemed_value - statistics_after.redeemed_value) == (
+                len(packets) * TICKET_PRICE_PER_HOP
+            )
+            assert statistics_after_redemption.unredeemed_value == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "src,dest", [tuple(shuffled(barebone_nodes())[:2]) for _ in range(PARAMETERIZED_SAMPLE_SIZE)]
+    )
+    async def test_hoprd_should_aggregate_and_redeem_tickets_in_channel_on_api_request(
+        self, src: str, dest: str, swarm7: dict[str, Node]
+    ):
+        message_count = 2
+
+        async with create_channel(swarm7[src], swarm7[dest], funding=message_count * TICKET_PRICE_PER_HOP) as channel:
+            packets = [
+                f"Channel agg and redeem on 1-hop: {src} - {dest} - {src} #{i:08d}" for i in range(message_count)
             ]
-        )
+            await send_and_receive_packets_with_pop(
+                packets, src=swarm7[src], dest=swarm7[src], path=[swarm7[dest].peer_id]
+            )
 
-        packets = [f"Channel unredeemed check: #{i:08d}" for i in range(ticket_count)]
-        await send_and_receive_packets_with_pop(
-            packets, src=swarm7[route[0]], dest=swarm7[route[-1]], path=[swarm7[route[1]].peer_id]
-        )
+            await asyncio.wait_for(
+                check_unredeemed_tickets_value(swarm7[dest], message_count * TICKET_PRICE_PER_HOP), 30.0
+            )
 
-        await asyncio.wait_for(
-            check_unredeemed_tickets_value(swarm7[route[1]], ticket_count * TICKET_PRICE_PER_HOP), 30.0
-        )
+            ticket_statistics = await swarm7[dest].api.get_tickets_statistics()
+            assert ticket_statistics.unredeemed_value == 2 * TICKET_PRICE_PER_HOP
 
-        # NOTE: will be closed on context manager exit
+            await asyncio.wait_for(swarm7[dest].api.channels_aggregate_tickets(channel.id), 20.0)
+
+            ticket_statistics = await swarm7[dest].api.get_tickets_statistics()
+            assert ticket_statistics.unredeemed_value == 2 * TICKET_PRICE_PER_HOP
+
+            assert await swarm7[dest].api.channel_redeem_tickets(channel.id)
+
+            await asyncio.wait_for(check_all_tickets_redeemed(swarm7[dest]), 120.0)
+
+            ticket_statistics = await swarm7[dest].api.get_tickets_statistics()
+            assert ticket_statistics.unredeemed_value == 0
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "route",
+        [shuffled(barebone_nodes())[:3] for _ in range(PARAMETERIZED_SAMPLE_SIZE)],
+        # + [shuffled(nodes())[:5] for _ in range(PARAMETERIZED_SAMPLE_SIZE)],
+    )
+    async def test_hoprd_should_create_redeemable_tickets_on_routing_in_general_n_hop(
+        self, route, swarm7: dict[str, Node]
+    ):
+        message_count = int(TICKET_AGGREGATION_THRESHOLD / 10)
+
+        async with AsyncExitStack() as channels:
+            await asyncio.gather(
+                *[
+                    channels.enter_async_context(
+                        create_channel(
+                            swarm7[route[i]], swarm7[route[i + 1]], funding=message_count * TICKET_PRICE_PER_HOP
+                        )
+                    )
+                    for i in range(len(route) - 1)
+                ]
+            )
+
+            packets = [f"General n-hop over {route} message #{i:08d}" for i in range(message_count)]
+            await send_and_receive_packets_with_pop(
+                packets,
+                src=swarm7[route[0]],
+                dest=swarm7[route[-1]],
+                path=[swarm7[x].peer_id for x in route[1:-1]],
+            )
+
+            await asyncio.wait_for(
+                check_unredeemed_tickets_value(swarm7[route[1]], message_count * TICKET_PRICE_PER_HOP), 30.0
+            )
+
+            # wait for aggregation to finish before redeeming
+            await asyncio.sleep(10)
+            assert await swarm7[route[1]].api.tickets_redeem()
+
+            await asyncio.wait_for(check_all_tickets_redeemed(swarm7[route[1]]), 120.0)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("route", [shuffled(barebone_nodes())[:3] for _ in range(PARAMETERIZED_SAMPLE_SIZE)])
+    async def test_hoprd_should_be_able_to_close_open_channels_with_unredeemed_tickets(
+        self, route, swarm7: dict[str, Node]
+    ):
+        ticket_count = 2
+
+        async with AsyncExitStack() as channels:
+            await asyncio.gather(
+                *[
+                    channels.enter_async_context(
+                        create_channel(
+                            swarm7[route[i]], swarm7[route[i + 1]], funding=ticket_count * TICKET_PRICE_PER_HOP
+                        )
+                    )
+                    for i in range(len(route) - 1)
+                ]
+            )
+
+            packets = [f"Channel unredeemed check: #{i:08d}" for i in range(ticket_count)]
+            await send_and_receive_packets_with_pop(
+                packets, src=swarm7[route[0]], dest=swarm7[route[-1]], path=[swarm7[route[1]].peer_id]
+            )
+
+            await asyncio.wait_for(
+                check_unredeemed_tickets_value(swarm7[route[1]], ticket_count * TICKET_PRICE_PER_HOP), 30.0
+            )
+
+            # NOTE: will be closed on context manager exit

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -7,31 +7,31 @@ from sdk.python.localcluster.node import Node
 from tests.conftest import nodes_with_auth
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("peer", random.sample(nodes_with_auth(), 1))
-async def test_hoprd_rest_api_should_reject_connection_without_any_auth(swarm7: dict[str, Node], peer: str):
-    url = f"http://{swarm7[peer].host_addr}:{swarm7[peer].api_port}/api/v3/node/version"
+@pytest.mark.usefixtures("swarm7_reset")
+class TestRestApiWithSwarm:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("peer", random.sample(nodes_with_auth(), 1))
+    async def test_hoprd_rest_api_should_reject_connection_without_any_auth(self, swarm7: dict[str, Node], peer: str):
+        url = f"http://{swarm7[peer].host_addr}:{swarm7[peer].api_port}/api/v3/node/version"
 
-    async with aiohttp.ClientSession() as s:
-        assert (await s.get(url)).status == 401
+        async with aiohttp.ClientSession() as s:
+            assert (await s.get(url)).status == 401
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("peer", random.sample(nodes_with_auth(), 1))
+    async def test_hoprd_rest_api_should_reject_connection_with_invalid_token(self, peer: str, swarm7: dict[str, Node]):
+        url = f"http://{swarm7[peer].host_addr}:{swarm7[peer].api_port}/api/v3/node/version"
+        invalid_token = swarm7[peer].api_token.swapcase()
+        headers = {"X-Auth-Token": invalid_token}
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("peer", random.sample(nodes_with_auth(), 1))
-async def test_hoprd_rest_api_should_reject_connection_with_invalid_token(peer: str, swarm7: dict[str, Node]):
-    url = f"http://{swarm7[peer].host_addr}:{swarm7[peer].api_port}/api/v3/node/version"
-    invalid_token = swarm7[peer].api_token.swapcase()
-    headers = {"X-Auth-Token": invalid_token}
+        async with aiohttp.ClientSession(headers=headers) as s:
+            assert (await s.get(url)).status == 401
 
-    async with aiohttp.ClientSession(headers=headers) as s:
-        assert (await s.get(url)).status == 401
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("peer", random.sample(nodes_with_auth(), 1))
+    async def test_hoprd_rest_api_should_accept_connection_with_valid_token(self, peer: str, swarm7: dict[str, Node]):
+        url = f"http://{swarm7[peer].host_addr}:{swarm7[peer].api_port}/api/v3/node/version"
+        headers = {"X-Auth-Token": swarm7[peer].api_token}
 
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("peer", random.sample(nodes_with_auth(), 1))
-async def test_hoprd_rest_api_should_accept_connection_with_valid_token(peer: str, swarm7: dict[str, Node]):
-    url = f"http://{swarm7[peer].host_addr}:{swarm7[peer].api_port}/api/v3/node/version"
-    headers = {"X-Auth-Token": swarm7[peer].api_token}
-
-    async with aiohttp.ClientSession(headers=headers) as s:
-        assert (await s.get(url)).status == 200
+        async with aiohttp.ClientSession(headers=headers) as s:
+            assert (await s.get(url)).status == 200

--- a/tests/test_websocket_api.py
+++ b/tests/test_websocket_api.py
@@ -23,171 +23,196 @@ DEFAULT_ARGS = [
 ]
 
 
-@pytest.mark.parametrize("src,dest", random_distinct_pairs_from(nodes_with_auth(), count=1))
-def test_hoprd_websocket_api_should_reject_a_connection_without_a_valid_token(
-    src: str, dest: str, swarm7: dict[str, Node]
-):
-    with closing(websocket.WebSocket()) as ws:
-        try:
+@pytest.mark.usefixtures("swarm7_reset")
+class TestWebsocketWithSwarm:
+    @pytest.mark.parametrize("src,dest", random_distinct_pairs_from(nodes_with_auth(), count=1))
+    def test_hoprd_websocket_api_should_reject_a_connection_without_a_valid_token(
+        self, src: str, dest: str, swarm7: dict[str, Node]
+    ):
+        with closing(websocket.WebSocket()) as ws:
+            try:
+                url = to_ws_url(
+                    swarm7[src].host_addr,
+                    swarm7[src].api_port,
+                    args=DEFAULT_ARGS + [("destination", f"{swarm7[dest].peer_id}")],
+                )
+                ws.connect(url)
+            except websocket.WebSocketBadStatusException as e:
+                assert "401 Unauthorized" in str(e)
+            else:
+                pytest.fail("Should fail with 401 Unauthorized")
+
+    @pytest.mark.parametrize("src,dest", random_distinct_pairs_from(nodes_with_auth(), count=1))
+    def test_hoprd_websocket_api_should_reject_a_connection_with_an_invalid_token(
+        self, src: str, dest: str, swarm7: dict[str, Node]
+    ):
+        with closing(websocket.WebSocket()) as ws:
+            try:
+                url = to_ws_url(
+                    swarm7[src].host_addr,
+                    swarm7[src].api_port,
+                    args=DEFAULT_ARGS + [("destination", f"{swarm7[dest].peer_id}")],
+                )
+                ws.connect(url, header={"X-Auth-Token": "InvAliD_toKeN"})
+            except websocket.WebSocketBadStatusException as e:
+                assert "401 Unauthorized" in str(e)
+            else:
+                pytest.fail("Should fail with 401 Unauthorized")
+
+    @pytest.mark.parametrize("src,dest", random_distinct_pairs_from(nodes_with_auth(), count=1))
+    def test_hoprd_websocket_api_should_not_accept_a_connection_with_an_invalid_token_passed_as_query_param(
+        self, src: str, dest: str, swarm7: dict[str, Node]
+    ):
+        with closing(websocket.WebSocket()) as ws:
+            try:
+                url = to_ws_url(
+                    swarm7[src].host_addr,
+                    swarm7[src].api_port,
+                    args=[("apiToken", "InvAlid_Token")] + DEFAULT_ARGS + [("destination", f"{swarm7[dest].peer_id}")],
+                )
+                ws.connect(url)
+            except websocket.WebSocketBadStatusException as e:
+                assert "401 Unauthorized" in str(e)
+            else:
+                pytest.fail("Should fail with 401 Unauthorized")
+
+    @pytest.mark.parametrize("src,dest", random_distinct_pairs_from(nodes_with_auth(), count=1))
+    def test_hoprd_websocket_api_should_reject_a_connection_with_an_invalid_bearer_token(
+        self, src: str, dest: str, swarm7: dict[str, Node]
+    ):
+        with closing(websocket.WebSocket()) as ws:
+            try:
+                url = to_ws_url(
+                    swarm7[src].host_addr,
+                    swarm7[src].api_port,
+                    args=DEFAULT_ARGS + [("destination", f"{swarm7[dest].peer_id}")],
+                )
+                ws.connect(url, header={"Authorization": "Bearer InvAliD_toKeN"})
+            except websocket.WebSocketBadStatusException as e:
+                assert "401 Unauthorized" in str(e)
+            else:
+                pytest.fail("Should fail with 401 Unauthorized")
+
+    @pytest.mark.parametrize("src,dest", random_distinct_pairs_from(nodes_with_auth(), count=1))
+    def test_hoprd_websocket_api_should_accept_a_connection_with_a_valid_token(
+        self, src: str, dest: str, swarm7: dict[str, Node]
+    ):
+        with closing(websocket.WebSocket()) as ws:
             url = to_ws_url(
                 swarm7[src].host_addr,
                 swarm7[src].api_port,
                 args=DEFAULT_ARGS + [("destination", f"{swarm7[dest].peer_id}")],
             )
-            ws.connect(url)
-        except websocket.WebSocketBadStatusException as e:
-            assert "401 Unauthorized" in str(e)
-        else:
-            pytest.fail("Should fail with 401 Unauthorized")
+            ws.connect(url, header={"X-Auth-Token": swarm7[src].api_token})
 
+        time.sleep(0.5)
 
-@pytest.mark.parametrize("src,dest", random_distinct_pairs_from(nodes_with_auth(), count=1))
-def test_hoprd_websocket_api_should_reject_a_connection_with_an_invalid_token(
-    src: str, dest: str, swarm7: dict[str, Node]
-):
-    with closing(websocket.WebSocket()) as ws:
-        try:
+    @pytest.mark.xfail(
+        reason="This test is expected to fail due to a bug in the axum code, where the query is not parsed for the token"
+    )
+    @pytest.mark.parametrize("src,dest", random_distinct_pairs_from(nodes_with_auth(), count=1))
+    def test_hoprd_websocket_api_should_accept_a_connection_with_a_query_param_passed_valid_token(
+        self, src: str, dest: str, swarm7: dict[str, Node]
+    ):
+        with closing(websocket.WebSocket()) as ws:
             url = to_ws_url(
                 swarm7[src].host_addr,
                 swarm7[src].api_port,
-                args=DEFAULT_ARGS + [("destination", f"{swarm7[dest].peer_id}")],
-            )
-            ws.connect(url, header={"X-Auth-Token": "InvAliD_toKeN"})
-        except websocket.WebSocketBadStatusException as e:
-            assert "401 Unauthorized" in str(e)
-        else:
-            pytest.fail("Should fail with 401 Unauthorized")
-
-
-@pytest.mark.parametrize("src,dest", random_distinct_pairs_from(nodes_with_auth(), count=1))
-def test_hoprd_websocket_api_should_not_accept_a_connection_with_an_invalid_token_passed_as_query_param(
-    src: str, dest: str, swarm7: dict[str, Node]
-):
-    with closing(websocket.WebSocket()) as ws:
-        try:
-            url = to_ws_url(
-                swarm7[src].host_addr,
-                swarm7[src].api_port,
-                args=[("apiToken", "InvAlid_Token")] + DEFAULT_ARGS + [("destination", f"{swarm7[dest].peer_id}")],
-            )
-            ws.connect(url)
-        except websocket.WebSocketBadStatusException as e:
-            assert "401 Unauthorized" in str(e)
-        else:
-            pytest.fail("Should fail with 401 Unauthorized")
-
-
-@pytest.mark.parametrize("src,dest", random_distinct_pairs_from(nodes_with_auth(), count=1))
-def test_hoprd_websocket_api_should_reject_a_connection_with_an_invalid_bearer_token(
-    src: str, dest: str, swarm7: dict[str, Node]
-):
-    with closing(websocket.WebSocket()) as ws:
-        try:
-            url = to_ws_url(
-                swarm7[src].host_addr,
-                swarm7[src].api_port,
-                args=DEFAULT_ARGS + [("destination", f"{swarm7[dest].peer_id}")],
-            )
-            ws.connect(url, header={"Authorization": "Bearer InvAliD_toKeN"})
-        except websocket.WebSocketBadStatusException as e:
-            assert "401 Unauthorized" in str(e)
-        else:
-            pytest.fail("Should fail with 401 Unauthorized")
-
-
-@pytest.mark.parametrize("src,dest", random_distinct_pairs_from(nodes_with_auth(), count=1))
-def test_hoprd_websocket_api_should_accept_a_connection_with_a_valid_token(
-    src: str, dest: str, swarm7: dict[str, Node]
-):
-    with closing(websocket.WebSocket()) as ws:
-        url = to_ws_url(
-            swarm7[src].host_addr,
-            swarm7[src].api_port,
-            args=DEFAULT_ARGS + [("destination", f"{swarm7[dest].peer_id}")],
-        )
-        ws.connect(url, header={"X-Auth-Token": swarm7[src].api_token})
-
-    time.sleep(0.5)
-
-
-@pytest.mark.xfail(
-    reason="This test is expected to fail due to a bug in the axum code, where the query is not parsed for the token"
-)
-@pytest.mark.parametrize("src,dest", random_distinct_pairs_from(nodes_with_auth(), count=1))
-def test_hoprd_websocket_api_should_accept_a_connection_with_a_query_param_passed_valid_token(
-    src: str, dest: str, swarm7: dict[str, Node]
-):
-    with closing(websocket.WebSocket()) as ws:
-        url = to_ws_url(
-            swarm7[src].host_addr,
-            swarm7[src].api_port,
-            args=[("apiToken", swarm7[src].api_token)] + DEFAULT_ARGS + [("destination", f"{swarm7[dest].peer_id}")],
-        )
-        ws.connect(url)
-
-    time.sleep(0.5)
-
-
-@pytest.mark.parametrize("src,dest", random_distinct_pairs_from(nodes_with_auth(), count=1))
-def test_hoprd_websocket_api_should_accept_a_connection_with_a_valid_bearer_token(
-    src: str, dest: str, swarm7: dict[str, Node]
-):
-    with closing(websocket.WebSocket()) as ws:
-        url = to_ws_url(
-            swarm7[src].host_addr,
-            swarm7[src].api_port,
-            args=DEFAULT_ARGS + [("destination", f"{swarm7[dest].peer_id}")],
-        )
-        ws.connect(url, header={"Authorization": "Bearer " + swarm7[src].api_token})
-
-    time.sleep(0.5)
-
-
-@pytest.mark.parametrize("src,dest", random_distinct_pairs_from(nodes_with_auth(), count=1))
-def test_hoprd_websocket_api_should_reject_connection_on_invalid_path(src: str, dest: str, swarm7: dict[str, Node]):
-    ws = websocket.WebSocket()
-    try:
-        url = to_ws_url(
-            swarm7[src].host_addr,
-            f"{swarm7[src].api_port}/defIniteLY_InVAliD_paTh",
-            args=DEFAULT_ARGS + [("destination", f"{swarm7[dest].peer_id}")],
-        )
-        ws.connect(url, header={"X-Auth-Token": swarm7[src].api_token})
-    except websocket.WebSocketBadStatusException as e:
-        assert "404 Not Found" in str(e)
-    else:
-        pytest.fail("Should fail with 404 Not Found")
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("src,dest", random_distinct_pairs_from(nodes_with_auth(), count=1))
-async def test_websocket_send_receive_messages(src: str, dest: str, swarm7: dict[str, Node]):
-    message_target_count = 10
-
-    with EchoServer(SocketType.TCP, STANDARD_MTU_SIZE) as server:
-        async with connect(
-            to_ws_url(
-                swarm7[src].host_addr,
-                swarm7[src].api_port,
-                args=[("target", f"127.0.0.1:{server.port}")]
+                args=[("apiToken", swarm7[src].api_token)]
                 + DEFAULT_ARGS
                 + [("destination", f"{swarm7[dest].peer_id}")],
-            ),
-            additional_headers=[("X-Auth-Token", swarm7[src].api_token)],
-        ) as ws:
-            for i in range(message_target_count):
-                body = f"hello msg #{i} from peer {swarm7[src].peer_id} to peer {swarm7[dest].peer_id}"
+            )
+            ws.connect(url)
 
-                await ws.send(body.encode())
+        time.sleep(0.5)
 
-                try:
-                    msg = await asyncio.wait_for(ws.recv(), timeout=5)
-                except Exception:
-                    pytest.fail(f"Timeout when receiving msg {i} from {src} to {dest}")
-                assert body == msg.decode(), "sent data content should be identical"
+    @pytest.mark.parametrize("src,dest", random_distinct_pairs_from(nodes_with_auth(), count=1))
+    def test_hoprd_websocket_api_should_accept_a_connection_with_a_valid_bearer_token(
+        self, src: str, dest: str, swarm7: dict[str, Node]
+    ):
+        with closing(websocket.WebSocket()) as ws:
+            url = to_ws_url(
+                swarm7[src].host_addr,
+                swarm7[src].api_port,
+                args=DEFAULT_ARGS + [("destination", f"{swarm7[dest].peer_id}")],
+            )
+            ws.connect(url, header={"Authorization": "Bearer " + swarm7[src].api_token})
 
+        time.sleep(0.5)
 
-# ==== DEPRECATED BELOW
+    @pytest.mark.parametrize("src,dest", random_distinct_pairs_from(nodes_with_auth(), count=1))
+    def test_hoprd_websocket_api_should_reject_connection_on_invalid_path(
+        self, src: str, dest: str, swarm7: dict[str, Node]
+    ):
+        ws = websocket.WebSocket()
+        try:
+            url = to_ws_url(
+                swarm7[src].host_addr,
+                f"{swarm7[src].api_port}/defIniteLY_InVAliD_paTh",
+                args=DEFAULT_ARGS + [("destination", f"{swarm7[dest].peer_id}")],
+            )
+            ws.connect(url, header={"X-Auth-Token": swarm7[src].api_token})
+        except websocket.WebSocketBadStatusException as e:
+            assert "404 Not Found" in str(e)
+        else:
+            pytest.fail("Should fail with 404 Not Found")
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("src,dest", random_distinct_pairs_from(nodes_with_auth(), count=1))
+    async def test_websocket_send_receive_messages(self, src: str, dest: str, swarm7: dict[str, Node]):
+        message_target_count = 10
+
+        with EchoServer(SocketType.TCP, STANDARD_MTU_SIZE) as server:
+            async with connect(
+                to_ws_url(
+                    swarm7[src].host_addr,
+                    swarm7[src].api_port,
+                    args=[("target", f"127.0.0.1:{server.port}")]
+                    + DEFAULT_ARGS
+                    + [("destination", f"{swarm7[dest].peer_id}")],
+                ),
+                additional_headers=[("X-Auth-Token", swarm7[src].api_token)],
+            ) as ws:
+                for i in range(message_target_count):
+                    body = f"hello msg #{i} from peer {swarm7[src].peer_id} to peer {swarm7[dest].peer_id}"
+
+                    await ws.send(body.encode())
+
+                    try:
+                        msg = await asyncio.wait_for(ws.recv(), timeout=5)
+                    except Exception:
+                        pytest.fail(f"Timeout when receiving msg {i} from {src} to {dest}")
+                    assert body == msg.decode(), "sent data content should be identical"
+
+    # ==== DEPRECATED BELOW
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("src,dest", random_distinct_pairs_from(nodes_with_auth(), count=1))
+    async def test_websocket_send_receive_messages_DEPRECATED(
+        self, src: str, dest: str, swarm7: dict[str, Node], ws_connections
+    ):
+        tag = random.randint(30000, 60000)
+
+        message_target_count = 10
+
+        for i in range(message_target_count):
+            body = f"hello msg {i} from peer {swarm7[src].peer_id} to peer {swarm7[dest].peer_id}"
+
+            # we test direct messaging only
+            msg = {
+                "body": body,
+                "destination": random.choice([swarm7[dest].peer_id, swarm7[dest].address]),
+                "path": [],
+                "tag": tag,
+            }
+
+            await ws_connections[src].send(json.dumps(msg))
+
+            try:
+                msg = await asyncio.wait_for(ws_connections[dest].recv(), timeout=5)
+            except Exception:
+                pytest.fail(f"Timeout when receiving msg {i} from {src} to {dest}")
+            assert re.match(f".*{body}.*$", msg)
 
 
 def to_ws_url_deprecated(host, port):
@@ -215,30 +240,3 @@ async def ws_connections(swarm7: dict[str, Node]):
         ) as ws4,
     ):
         yield {"1": ws1, "2": ws2, "3": ws3, "4": ws4}
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize("src,dest", random_distinct_pairs_from(nodes_with_auth(), count=1))
-async def test_websocket_send_receive_messages_DEPRECATED(src: str, dest: str, swarm7: dict[str, Node], ws_connections):
-    tag = random.randint(30000, 60000)
-
-    message_target_count = 10
-
-    for i in range(message_target_count):
-        body = f"hello msg {i} from peer {swarm7[src].peer_id} to peer {swarm7[dest].peer_id}"
-
-        # we test direct messaging only
-        msg = {
-            "body": body,
-            "destination": random.choice([swarm7[dest].peer_id, swarm7[dest].address]),
-            "path": [],
-            "tag": tag,
-        }
-
-        await ws_connections[src].send(json.dumps(msg))
-
-        try:
-            msg = await asyncio.wait_for(ws_connections[dest].recv(), timeout=5)
-        except Exception:
-            pytest.fail(f"Timeout when receiving msg {i} from {src} to {dest}")
-        assert re.match(f".*{body}.*$", msg)

--- a/tests/test_win_prob.py
+++ b/tests/test_win_prob.py
@@ -3,12 +3,7 @@ import random
 
 import pytest
 
-from sdk.python.localcluster.constants import (
-    ANVIL_CONFIG_FILE,
-    NETWORK,
-    PORT_BASE,
-    TICKET_PRICE_PER_HOP,
-)
+from sdk.python.localcluster.constants import ANVIL_CONFIG_FILE, NETWORK, PORT_BASE, TICKET_PRICE_PER_HOP, CONTRACTS_DIR
 from sdk.python.localcluster.node import Node
 from sdk.python.localcluster.utils import load_private_key
 
@@ -35,7 +30,7 @@ def set_minimum_winning_probability_in_network(private_key: str, win_prob: float
         "--network",
         NETWORK,
         "--contracts-root",
-        "./ethereum/contracts",
+        CONTRACTS_DIR,
         "--winning-probability",
         str(win_prob),
         "--provider-url",
@@ -44,320 +39,326 @@ def set_minimum_winning_probability_in_network(private_key: str, win_prob: float
     run_hopli_cmd(cmd, custom_env)
 
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
-async def test_hoprd_check_min_incoming_ticket_win_prob_is_default(peer, swarm7: dict[str, Node]):
-    win_prob = await swarm7[peer].api.ticket_min_win_prob()
+@pytest.mark.usefixtures("swarm7_reset")
+class TestWinProbWithSwarm:
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("peer", random.sample(barebone_nodes(), 1))
+    async def test_hoprd_check_min_incoming_ticket_win_prob_is_default(self, peer, swarm7: dict[str, Node]):
+        win_prob = await swarm7[peer].api.ticket_min_win_prob()
 
-    assert win_prob is not None
-    assert 0.0 <= round(win_prob.value, 5) <= 1.0
+        assert win_prob is not None
+        assert 0.0 <= round(win_prob.value, 5) <= 1.0
 
-    private_key = load_private_key(ANVIL_CONFIG_FILE)
+        private_key = load_private_key(ANVIL_CONFIG_FILE)
 
-    new_win_prob = win_prob.value / 2
-    set_minimum_winning_probability_in_network(private_key, new_win_prob)
+        new_win_prob = win_prob.value / 2
+        set_minimum_winning_probability_in_network(private_key, new_win_prob)
 
-    try:
-        await asyncio.wait_for(check_min_incoming_win_prob_eq(swarm7[peer], new_win_prob), timeout=20.0)
-    finally:
-        # Restore the winning probability regardless of the outcome
-        set_minimum_winning_probability_in_network(private_key, win_prob.value)
+        try:
+            await asyncio.wait_for(check_min_incoming_win_prob_eq(swarm7[peer], new_win_prob), timeout=20.0)
+        finally:
+            # Restore the winning probability regardless of the outcome
+            set_minimum_winning_probability_in_network(private_key, win_prob.value)
 
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "route",
-    [
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "route",
         [
-            *random.sample(nodes_with_lower_outgoing_win_prob(), 1),
-            *random.sample(barebone_nodes(), 2),
-        ]
-        for _ in range(PARAMETERIZED_SAMPLE_SIZE)
-    ],
-)
-async def test_hoprd_should_relay_packets_with_lower_win_prob_then_agg_and_redeem_them(route, swarm7: dict[str, Node]):
-    ticket_count = 100
-    win_prob = 0.1
-    win_ticket_tolerance = 0.1
+            [
+                *random.sample(nodes_with_lower_outgoing_win_prob(), 1),
+                *random.sample(barebone_nodes(), 2),
+            ]
+            for _ in range(PARAMETERIZED_SAMPLE_SIZE)
+        ],
+    )
+    async def test_hoprd_should_relay_packets_with_lower_win_prob_then_agg_and_redeem_them(
+        self, route, swarm7: dict[str, Node]
+    ):
+        ticket_count = 100
+        win_prob = 0.1
+        win_ticket_tolerance = 0.1
 
-    src = route[0]
-    relay = route[1]
-    dest = route[-1]
+        src = route[0]
+        relay = route[1]
+        dest = route[-1]
 
-    private_key = load_private_key(ANVIL_CONFIG_FILE)
+        private_key = load_private_key(ANVIL_CONFIG_FILE)
 
-    set_minimum_winning_probability_in_network(private_key, win_prob)
-    await asyncio.wait_for(check_min_incoming_win_prob_eq(swarm7[relay], win_prob), 10.0)
+        set_minimum_winning_probability_in_network(private_key, win_prob)
+        await asyncio.wait_for(check_min_incoming_win_prob_eq(swarm7[relay], win_prob), 10.0)
 
-    try:
-        async with create_channel(
-            swarm7[src], swarm7[relay], funding=2 * ticket_count * TICKET_PRICE_PER_HOP / win_prob
-        ) as channel:
-            # ensure ticket stats are what we expect before starting
-            statistics_before = await swarm7[relay].api.get_tickets_statistics()
-
-            # the destination should receive all the packets
-            await swarm7[dest].api.messages_pop_all(None)
-            packets = [f"Lower ticket win probability check: #{i:08d}" for i in range(ticket_count)]
-            await send_and_receive_packets_with_pop(
-                packets, src=swarm7[src], dest=swarm7[dest], path=[swarm7[relay].peer_id]
-            )
-
-            # the value of redeemable tickets on the relay should not go above the given threshold
-            ticket_statistics = await swarm7[relay].api.get_tickets_statistics()
-            new_tickets_value = ticket_statistics.unredeemed_value - statistics_before.unredeemed_value
-            winning_count = ticket_statistics.winning_count - statistics_before.winning_count
-            assert new_tickets_value > 0
-            assert abs(winning_count - ticket_count * win_prob) <= win_ticket_tolerance * ticket_count
-
-            await asyncio.wait_for(swarm7[relay].api.channels_aggregate_tickets(channel.id), 20.0)
-
-            assert await swarm7[relay].api.channel_redeem_tickets(channel.id)
-            await asyncio.wait_for(check_all_tickets_redeemed(swarm7[relay]), 120.0)
-
-            # The tickets can get successfully redeemed on that channel
-            ticket_statistics = await swarm7[relay].api.get_tickets_statistics()
-            assert ticket_statistics.unredeemed_value == 0
-            assert ticket_statistics.redeemed_value - statistics_before.redeemed_value == new_tickets_value
-    finally:
-        # Always return winning probability to 1.0 even if the test failed
-        set_minimum_winning_probability_in_network(private_key, 1.0)
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "route",
-    [
-        [
-            *random.sample(nodes_with_lower_outgoing_win_prob(), 1),
-            *random.sample(barebone_nodes(), 2),
-        ]
-        for _ in range(PARAMETERIZED_SAMPLE_SIZE)
-    ],
-)
-async def test_hoprd_should_reject_unredeemed_tickets_with_lower_win_prob_when_min_bound_increases(
-    route, swarm7: dict[str, Node]
-):
-    ticket_count = 100
-    win_prob = 0.1
-    win_ticket_tolerance = 0.1
-
-    src = route[0]
-    relay = route[1]
-    dest = route[-1]
-
-    private_key = load_private_key(ANVIL_CONFIG_FILE)
-
-    set_minimum_winning_probability_in_network(private_key, win_prob)
-    await asyncio.wait_for(check_min_incoming_win_prob_eq(swarm7[relay], win_prob), 10.0)
-
-    try:
-        async with create_channel(
-            swarm7[src], swarm7[relay], funding=2 * ticket_count * TICKET_PRICE_PER_HOP / win_prob
-        ):
-            # ensure ticket stats are what we expect before starting
-            statistics_before = await swarm7[relay].api.get_tickets_statistics()
-            unredeemed_value_before = statistics_before.unredeemed_value
-            rejected_value_before = statistics_before.rejected_value
-
-            # the destination should receive all the packets
-            await swarm7[dest].api.messages_pop_all(None)
-            packets = [f"Lowering ticket win probability check: #{i:08d}" for i in range(ticket_count)]
-            await send_and_receive_packets_with_pop(
-                packets, src=swarm7[src], dest=swarm7[dest], path=[swarm7[relay].peer_id]
-            )
-
-            # the value of redeemable tickets on the relay should not go above the given threshold
-            ticket_statistics = await swarm7[relay].api.get_tickets_statistics()
-            unredeemed_value_1 = ticket_statistics.unredeemed_value
-            winning_count = ticket_statistics.winning_count - statistics_before.winning_count
-            rejected_value = ticket_statistics.rejected_value
-            assert unredeemed_value_1 - unredeemed_value_before > 0
-            assert abs(winning_count - ticket_count * win_prob) <= win_ticket_tolerance * ticket_count
-            assert rejected_value - rejected_value_before == 0
-
-            # Now if we increase the minimum winning probability, the relayer should
-            # reject all the unredeemed tickets
-            set_minimum_winning_probability_in_network(private_key, win_prob * 2)
-            await asyncio.wait_for(check_min_incoming_win_prob_eq(swarm7[relay], win_prob * 2), 10.0)
-
-            ticket_statistics = await swarm7[relay].api.get_tickets_statistics()
-            unredeemed_value_2 = ticket_statistics.unredeemed_value
-            rejected_value = ticket_statistics.rejected_value
-            assert rejected_value - rejected_value_before == unredeemed_value_1
-            assert unredeemed_value_2 - unredeemed_value_before == 0
-
-    finally:
-        # Always return winning probability to 1.0 even if the test failed
-        set_minimum_winning_probability_in_network(private_key, 1.0)
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "route",
-    [
-        [
-            *random.sample(nodes_with_lower_outgoing_win_prob(), 1),
-            *random.sample(barebone_nodes(), 3),
-        ]
-        for _ in range(PARAMETERIZED_SAMPLE_SIZE)
-    ],
-)
-async def test_hoprd_should_relay_with_increased_win_prob(route, swarm7: dict[str, Node]):
-    ticket_count = 100
-    win_prob = 0.1
-    win_ticket_tolerance = 0.1
-
-    src = route[0]
-    relay_1 = route[1]
-    relay_2 = route[2]
-    dest = route[-1]
-
-    private_key = load_private_key(ANVIL_CONFIG_FILE)
-
-    set_minimum_winning_probability_in_network(private_key, win_prob)
-    await asyncio.wait_for(check_min_incoming_win_prob_eq(swarm7[relay_1], win_prob), 10.0)
-
-    try:
-        async with create_channel(
-            swarm7[src], swarm7[relay_1], funding=2 * ticket_count * TICKET_PRICE_PER_HOP / win_prob
-        ):
+        try:
             async with create_channel(
-                swarm7[relay_1], swarm7[relay_2], funding=2 * ticket_count * TICKET_PRICE_PER_HOP / win_prob
-            ):
+                swarm7[src], swarm7[relay], funding=2 * ticket_count * TICKET_PRICE_PER_HOP / win_prob
+            ) as channel:
                 # ensure ticket stats are what we expect before starting
-                statistics_before_1 = await swarm7[relay_1].api.get_tickets_statistics()
-                unredeemed_value_before_1 = statistics_before_1.unredeemed_value
-
-                statistics_before_2 = await swarm7[relay_2].api.get_tickets_statistics()
-                unredeemed_value_before_2 = statistics_before_2.unredeemed_value
+                statistics_before = await swarm7[relay].api.get_tickets_statistics()
 
                 # the destination should receive all the packets
                 await swarm7[dest].api.messages_pop_all(None)
-                packets = [f"Relaying ticket win probability check: #{i:08d}" for i in range(ticket_count)]
+                packets = [f"Lower ticket win probability check: #{i:08d}" for i in range(ticket_count)]
                 await send_and_receive_packets_with_pop(
-                    packets, src=swarm7[src], dest=swarm7[dest], path=[swarm7[relay_1].peer_id, swarm7[relay_2].peer_id]
+                    packets, src=swarm7[src], dest=swarm7[dest], path=[swarm7[relay].peer_id]
                 )
 
-                # the value of redeemable tickets on the first relay should not go above the given threshold
-                ticket_statistics = await swarm7[relay_1].api.get_tickets_statistics()
-                unredeemed_value_1 = ticket_statistics.unredeemed_value
-                winning_count_1 = ticket_statistics.winning_count - statistics_before_1.winning_count
-                assert unredeemed_value_1 - unredeemed_value_before_1 > 0
-                assert abs(winning_count_1 - ticket_count * win_prob) <= win_ticket_tolerance * ticket_count
+                # the value of redeemable tickets on the relay should not go above the given threshold
+                ticket_statistics = await swarm7[relay].api.get_tickets_statistics()
+                new_tickets_value = ticket_statistics.unredeemed_value - statistics_before.unredeemed_value
+                winning_count = ticket_statistics.winning_count - statistics_before.winning_count
+                assert new_tickets_value > 0
+                assert abs(winning_count - ticket_count * win_prob) <= win_ticket_tolerance * ticket_count
 
-                # however, since the first relay sends tickets with win probability = 1,
-                # the second relay must get all the tickets as winning
-                ticket_statistics = await swarm7[relay_2].api.get_tickets_statistics()
-                unredeemed_value_2 = ticket_statistics.unredeemed_value
-                winning_count_2 = ticket_statistics.winning_count - statistics_before_2.winning_count
-                assert unredeemed_value_2 - unredeemed_value_before_2 > 0
-                assert winning_count_2 == ticket_count
-    finally:
-        # Always return winning probability to 1.0 even if the test failed
-        set_minimum_winning_probability_in_network(private_key, 1.0)
+                await asyncio.wait_for(swarm7[relay].api.channels_aggregate_tickets(channel.id), 20.0)
 
+                assert await swarm7[relay].api.channel_redeem_tickets(channel.id)
+                await asyncio.wait_for(check_all_tickets_redeemed(swarm7[relay]), 120.0)
 
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "route",
-    [
+                # The tickets can get successfully redeemed on that channel
+                ticket_statistics = await swarm7[relay].api.get_tickets_statistics()
+                assert ticket_statistics.unredeemed_value == 0
+                assert ticket_statistics.redeemed_value - statistics_before.redeemed_value == new_tickets_value
+        finally:
+            # Always return winning probability to 1.0 even if the test failed
+            set_minimum_winning_probability_in_network(private_key, 1.0)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "route",
         [
-            *random.sample(barebone_nodes(), 1),
-            *random.sample(nodes_with_lower_outgoing_win_prob(), 1),
-            *random.sample(barebone_nodes(), 1),
-        ]
-        for _ in range(PARAMETERIZED_SAMPLE_SIZE)
-    ],
-)
-async def test_hoprd_should_relay_packets_with_higher_than_min_win_prob(route, swarm7: dict[str, Node]):
-    ticket_count = 10
-    win_prob = 0.1
+            [
+                *random.sample(nodes_with_lower_outgoing_win_prob(), 1),
+                *random.sample(barebone_nodes(), 2),
+            ]
+            for _ in range(PARAMETERIZED_SAMPLE_SIZE)
+        ],
+    )
+    async def test_hoprd_should_reject_unredeemed_tickets_with_lower_win_prob_when_min_bound_increases(
+        self, route, swarm7: dict[str, Node]
+    ):
+        ticket_count = 100
+        win_prob = 0.1
+        win_ticket_tolerance = 0.1
 
-    src = route[0]
-    relay = route[1]
-    dest = route[-1]
+        src = route[0]
+        relay = route[1]
+        dest = route[-1]
 
-    private_key = load_private_key(ANVIL_CONFIG_FILE)
+        private_key = load_private_key(ANVIL_CONFIG_FILE)
 
-    set_minimum_winning_probability_in_network(private_key, win_prob)
-    await asyncio.wait_for(check_min_incoming_win_prob_eq(swarm7[relay], win_prob), 10.0)
+        set_minimum_winning_probability_in_network(private_key, win_prob)
+        await asyncio.wait_for(check_min_incoming_win_prob_eq(swarm7[relay], win_prob), 10.0)
 
-    try:
-        async with create_channel(
-            swarm7[src], swarm7[relay], funding=2 * ticket_count * TICKET_PRICE_PER_HOP / win_prob
-        ):
+        try:
+            async with create_channel(
+                swarm7[src], swarm7[relay], funding=2 * ticket_count * TICKET_PRICE_PER_HOP / win_prob
+            ):
+                # ensure ticket stats are what we expect before starting
+                statistics_before = await swarm7[relay].api.get_tickets_statistics()
+                unredeemed_value_before = statistics_before.unredeemed_value
+                rejected_value_before = statistics_before.rejected_value
+
+                # the destination should receive all the packets
+                await swarm7[dest].api.messages_pop_all(None)
+                packets = [f"Lowering ticket win probability check: #{i:08d}" for i in range(ticket_count)]
+                await send_and_receive_packets_with_pop(
+                    packets, src=swarm7[src], dest=swarm7[dest], path=[swarm7[relay].peer_id]
+                )
+
+                # the value of redeemable tickets on the relay should not go above the given threshold
+                ticket_statistics = await swarm7[relay].api.get_tickets_statistics()
+                unredeemed_value_1 = ticket_statistics.unredeemed_value
+                winning_count = ticket_statistics.winning_count - statistics_before.winning_count
+                rejected_value = ticket_statistics.rejected_value
+                assert unredeemed_value_1 - unredeemed_value_before > 0
+                assert abs(winning_count - ticket_count * win_prob) <= win_ticket_tolerance * ticket_count
+                assert rejected_value - rejected_value_before == 0
+
+                # Now if we increase the minimum winning probability, the relayer should
+                # reject all the unredeemed tickets
+                set_minimum_winning_probability_in_network(private_key, win_prob * 2)
+                await asyncio.wait_for(check_min_incoming_win_prob_eq(swarm7[relay], win_prob * 2), 10.0)
+
+                ticket_statistics = await swarm7[relay].api.get_tickets_statistics()
+                unredeemed_value_2 = ticket_statistics.unredeemed_value
+                rejected_value = ticket_statistics.rejected_value
+                assert rejected_value - rejected_value_before == unredeemed_value_1
+                assert unredeemed_value_2 - unredeemed_value_before == 0
+
+        finally:
+            # Always return winning probability to 1.0 even if the test failed
+            set_minimum_winning_probability_in_network(private_key, 1.0)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "route",
+        [
+            [
+                *random.sample(nodes_with_lower_outgoing_win_prob(), 1),
+                *random.sample(barebone_nodes(), 3),
+            ]
+            for _ in range(PARAMETERIZED_SAMPLE_SIZE)
+        ],
+    )
+    async def test_hoprd_should_relay_with_increased_win_prob(self, route, swarm7: dict[str, Node]):
+        ticket_count = 100
+        win_prob = 0.1
+        win_ticket_tolerance = 0.1
+
+        src = route[0]
+        relay_1 = route[1]
+        relay_2 = route[2]
+        dest = route[-1]
+
+        private_key = load_private_key(ANVIL_CONFIG_FILE)
+
+        set_minimum_winning_probability_in_network(private_key, win_prob)
+        await asyncio.wait_for(check_min_incoming_win_prob_eq(swarm7[relay_1], win_prob), 10.0)
+
+        try:
+            async with create_channel(
+                swarm7[src], swarm7[relay_1], funding=2 * ticket_count * TICKET_PRICE_PER_HOP / win_prob
+            ):
+                async with create_channel(
+                    swarm7[relay_1], swarm7[relay_2], funding=2 * ticket_count * TICKET_PRICE_PER_HOP / win_prob
+                ):
+                    # ensure ticket stats are what we expect before starting
+                    statistics_before_1 = await swarm7[relay_1].api.get_tickets_statistics()
+                    unredeemed_value_before_1 = statistics_before_1.unredeemed_value
+
+                    statistics_before_2 = await swarm7[relay_2].api.get_tickets_statistics()
+                    unredeemed_value_before_2 = statistics_before_2.unredeemed_value
+
+                    # the destination should receive all the packets
+                    await swarm7[dest].api.messages_pop_all(None)
+                    packets = [f"Relaying ticket win probability check: #{i:08d}" for i in range(ticket_count)]
+                    await send_and_receive_packets_with_pop(
+                        packets,
+                        src=swarm7[src],
+                        dest=swarm7[dest],
+                        path=[swarm7[relay_1].peer_id, swarm7[relay_2].peer_id],
+                    )
+
+                    # the value of redeemable tickets on the first relay should not go above the given threshold
+                    ticket_statistics = await swarm7[relay_1].api.get_tickets_statistics()
+                    unredeemed_value_1 = ticket_statistics.unredeemed_value
+                    winning_count_1 = ticket_statistics.winning_count - statistics_before_1.winning_count
+                    assert unredeemed_value_1 - unredeemed_value_before_1 > 0
+                    assert abs(winning_count_1 - ticket_count * win_prob) <= win_ticket_tolerance * ticket_count
+
+                    # however, since the first relay sends tickets with win probability = 1,
+                    # the second relay must get all the tickets as winning
+                    ticket_statistics = await swarm7[relay_2].api.get_tickets_statistics()
+                    unredeemed_value_2 = ticket_statistics.unredeemed_value
+                    winning_count_2 = ticket_statistics.winning_count - statistics_before_2.winning_count
+                    assert unredeemed_value_2 - unredeemed_value_before_2 > 0
+                    assert winning_count_2 == ticket_count
+        finally:
+            # Always return winning probability to 1.0 even if the test failed
+            set_minimum_winning_probability_in_network(private_key, 1.0)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "route",
+        [
+            [
+                *random.sample(barebone_nodes(), 1),
+                *random.sample(nodes_with_lower_outgoing_win_prob(), 1),
+                *random.sample(barebone_nodes(), 1),
+            ]
+            for _ in range(PARAMETERIZED_SAMPLE_SIZE)
+        ],
+    )
+    async def test_hoprd_should_relay_packets_with_higher_than_min_win_prob(self, route, swarm7: dict[str, Node]):
+        ticket_count = 10
+        win_prob = 0.1
+
+        src = route[0]
+        relay = route[1]
+        dest = route[-1]
+
+        private_key = load_private_key(ANVIL_CONFIG_FILE)
+
+        set_minimum_winning_probability_in_network(private_key, win_prob)
+        await asyncio.wait_for(check_min_incoming_win_prob_eq(swarm7[relay], win_prob), 10.0)
+
+        try:
+            async with create_channel(
+                swarm7[src], swarm7[relay], funding=2 * ticket_count * TICKET_PRICE_PER_HOP / win_prob
+            ):
+                # ensure ticket stats are what we expect before starting
+                statistics_before = await swarm7[relay].api.get_tickets_statistics()
+                unredeemed_value_before = statistics_before.unredeemed_value
+                rejected_value_before = statistics_before.rejected_value
+
+                # the destination should receive all the packets
+                await swarm7[dest].api.messages_pop_all(None)
+                packets = [f"Standard ticket win probability check: #{i:08d}" for i in range(ticket_count)]
+                await send_and_receive_packets_with_pop(
+                    packets, src=swarm7[src], dest=swarm7[dest], path=[swarm7[relay].peer_id]
+                )
+
+                # in this case, the relay has tickets for all the packets, because the source sends them with win prob = 1
+                ticket_statistics = await swarm7[relay].api.get_tickets_statistics()
+                unredeemed_value = ticket_statistics.unredeemed_value
+                rejected_value = ticket_statistics.rejected_value
+                assert unredeemed_value - unredeemed_value_before == TICKET_PRICE_PER_HOP * ticket_count
+                assert ticket_statistics.winning_count - statistics_before.winning_count == ticket_count
+                assert rejected_value - rejected_value_before == 0
+
+                # at this point the tickets become neglected, since the channel will be closed
+        finally:
+            # Always return winning probability to 1.0 even if the test failed
+            set_minimum_winning_probability_in_network(private_key, 1.0)
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "route",
+        [
+            [
+                *random.sample(nodes_with_lower_outgoing_win_prob(), 1),
+                *random.sample(barebone_nodes(), 2),
+            ]
+            for _ in range(PARAMETERIZED_SAMPLE_SIZE)
+        ],
+    )
+    async def test_hoprd_should_not_accept_tickets_with_lower_than_min_win_prob(self, route, swarm7: dict[str, Node]):
+        ticket_count = 10
+
+        src = route[0]
+        relay = route[1]
+        dest = route[-1]
+
+        async with create_channel(swarm7[src], swarm7[relay], funding=ticket_count * TICKET_PRICE_PER_HOP):
             # ensure ticket stats are what we expect before starting
             statistics_before = await swarm7[relay].api.get_tickets_statistics()
             unredeemed_value_before = statistics_before.unredeemed_value
             rejected_value_before = statistics_before.rejected_value
 
-            # the destination should receive all the packets
+            # sent out all packets at from source
             await swarm7[dest].api.messages_pop_all(None)
-            packets = [f"Standard ticket win probability check: #{i:08d}" for i in range(ticket_count)]
-            await send_and_receive_packets_with_pop(
-                packets, src=swarm7[src], dest=swarm7[dest], path=[swarm7[relay].peer_id]
+            packets = [f"Rejected ticket win probability check: #{i:08d}" for i in range(ticket_count)]
+            random_tag = gen_random_tag()
+
+            for packet in packets:
+                assert await swarm7[src].api.send_message(
+                    swarm7[dest].peer_id, packet, [swarm7[relay].peer_id], random_tag
+                )
+
+            # wait until the relay rejects all the tickets
+            await asyncio.wait_for(
+                check_rejected_tickets_value(
+                    swarm7[relay], rejected_value_before + ticket_count * TICKET_PRICE_PER_HOP
+                ),
+                30.0,
             )
 
-            # in this case, the relay has tickets for all the packets, because the source sends them with win prob = 1
+            # unredeemed value should not change on the relay
             ticket_statistics = await swarm7[relay].api.get_tickets_statistics()
-            unredeemed_value = ticket_statistics.unredeemed_value
-            rejected_value = ticket_statistics.rejected_value
-            assert unredeemed_value - unredeemed_value_before == TICKET_PRICE_PER_HOP * ticket_count
-            assert ticket_statistics.winning_count - statistics_before.winning_count == ticket_count
-            assert rejected_value - rejected_value_before == 0
+            assert ticket_statistics.unredeemed_value == unredeemed_value_before
+            assert ticket_statistics.winning_count == statistics_before.winning_count
 
-            # at this point the tickets become neglected, since the channel will be closed
-    finally:
-        # Always return winning probability to 1.0 even if the test failed
-        set_minimum_winning_probability_in_network(private_key, 1.0)
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "route",
-    [
-        [
-            *random.sample(nodes_with_lower_outgoing_win_prob(), 1),
-            *random.sample(barebone_nodes(), 2),
-        ]
-        for _ in range(PARAMETERIZED_SAMPLE_SIZE)
-    ],
-)
-async def test_hoprd_should_not_accept_tickets_with_lower_than_min_win_prob(route, swarm7: dict[str, Node]):
-    ticket_count = 10
-
-    src = route[0]
-    relay = route[1]
-    dest = route[-1]
-
-    async with create_channel(swarm7[src], swarm7[relay], funding=ticket_count * TICKET_PRICE_PER_HOP):
-        # ensure ticket stats are what we expect before starting
-        statistics_before = await swarm7[relay].api.get_tickets_statistics()
-        unredeemed_value_before = statistics_before.unredeemed_value
-        rejected_value_before = statistics_before.rejected_value
-
-        # sent out all packets at from source
-        await swarm7[dest].api.messages_pop_all(None)
-        packets = [f"Rejected ticket win probability check: #{i:08d}" for i in range(ticket_count)]
-        random_tag = gen_random_tag()
-
-        for packet in packets:
-            assert await swarm7[src].api.send_message(swarm7[dest].peer_id, packet, [swarm7[relay].peer_id], random_tag)
-
-        # wait until the relay rejects all the tickets
-        await asyncio.wait_for(
-            check_rejected_tickets_value(swarm7[relay], rejected_value_before + ticket_count * TICKET_PRICE_PER_HOP),
-            30.0,
-        )
-
-        # unredeemed value should not change on the relay
-        ticket_statistics = await swarm7[relay].api.get_tickets_statistics()
-        assert ticket_statistics.unredeemed_value == unredeemed_value_before
-        assert ticket_statistics.winning_count == statistics_before.winning_count
-
-        # in this case, the destination receives nothing, because the relayer will not relay packets
-        # with win prob lower than 1
-        messages = await swarm7[dest].api.messages_peek_all(random_tag)
-        assert messages is not None
-        assert len(messages) == 0
+            # in this case, the destination receives nothing, because the relayer will not relay packets
+            # with win prob lower than 1
+            messages = await swarm7[dest].api.messages_peek_all(random_tag)
+            assert messages is not None
+            assert len(messages) == 0


### PR DESCRIPTION
This change is needed to add alternative swarm7 fixture implementations. 

- The original swarm7 is executed per test session instead of per module, reducing test runtime when executing multiple test modules.
- The teardown fixture is  used selectively on test classes which are explicitly using swarm7. This allows test suites which use alternative swarm7 implementations to not use that teardown fixture.

Refs #6908 