### PR TITLE
Follow Prometheus metrics naming convention

### DIFF
--- a/METRICS.md
+++ b/METRICS.md
@@ -49,7 +49,7 @@ scrape_configs:
 - `hopr_strategy_auto_funding_funding_count`: Count of initiated automatic fundings
 - `hopr_strategy_promiscuous_opened_channels_count`: Count of open channel decisions
 - `hopr_strategy_promiscuous_closed_channels_count`: Count of close channel decisions
-- `hopr_strategy_promiscuous_max_auto_channels_count`: Count of maximum number of channels managed by the strategy
+- `hopr_strategy_promiscuous_max_auto_channels`: Count of maximum number of channels managed by the strategy
 - `hopr_strategy_auto_redeem_redeem_count`: Count of initiated automatic redemptions
 - `hopr_strategy_aggregating_aggregation_count`: Count of initiated automatic aggregations
 - `hopr_transport_p2p_opened_connection_count`: Count of the currently active p2p connections as observed from the rust-libp2p events
@@ -69,7 +69,7 @@ scrape_configs:
 - `hopr_chain_actions_count`: Number of different chain actions and their results, keys: `action`, `result`
 - `hopr_indexer_contract_log_count`: Counts of different HOPR contract logs processed by the Indexer, keys: `contract`
 - `hopr_tickets_incoming_statistics`: Ticket statistics for channels with incoming tickets, keys: `channel`, `statistic`
-- `hopr_session_active_sessions_count`: Number of currently active HOPR sessions
+- `hopr_session_num_active_sessions`: Number of currently active HOPR sessions
 - `hopr_session_received_error_count`: Number of HOPR session errors received from an Exit node, keys: `kind`
 - `hopr_session_sent_error_count`: Number of HOPR session errors sent to an Entry node, keys: `kind`
 - `hopr_session_established_sessions_count`: Number of sessions that were successfully established as an Exit node

--- a/METRICS.md
+++ b/METRICS.md
@@ -49,7 +49,7 @@ scrape_configs:
 - `hopr_strategy_auto_funding_funding_count`: Count of initiated automatic fundings
 - `hopr_strategy_promiscuous_opened_channels_count`: Count of open channel decisions
 - `hopr_strategy_promiscuous_closed_channels_count`: Count of close channel decisions
-- `hopr_strategy_promiscuous_max_auto_channels`: Count of maximum number of channels managed by the strategy
+- `hopr_strategy_promiscuous_max_auto_channels_count`: Count of maximum number of channels managed by the strategy
 - `hopr_strategy_auto_redeem_redeem_count`: Count of initiated automatic redemptions
 - `hopr_strategy_aggregating_aggregation_count`: Count of initiated automatic aggregations
 - `hopr_transport_p2p_opened_connection_count`: Count of the currently active p2p connections as observed from the rust-libp2p events
@@ -67,13 +67,13 @@ scrape_configs:
 - `hopr_indexer_checksum`: Contains an unsigned integer that represents the low 32-bits of the Indexer checksum.
 - `hopr_indexer_data_source`: Current data source of the Indexer, keys: `source`
 - `hopr_chain_actions_count`: Number of different chain actions and their results, keys: `action`, `result`
-- `hopr_indexer_contract_log_counters`: Counts of different HOPR contract logs processed by the Indexer, keys: `contract`
+- `hopr_indexer_contract_log_count`: Counts of different HOPR contract logs processed by the Indexer, keys: `contract`
 - `hopr_tickets_incoming_statistics`: Ticket statistics for channels with incoming tickets, keys: `channel`, `statistic`
-- `hopr_session_num_active_sessions`: Number of currently active HOPR sessions
-- `hopr_session_received_error_counts`: Number of HOPR session errors received from an Exit node, keys: `kind`
-- `hopr_session_sent_error_counts`: Number of HOPR session errors sent to an Entry node, keys: `kind`
-- `hopr_session_established_sessions`: Number of sessions that were successfully established as an Exit node
-- `hopr_session_initiated_sessions`: Number of sessions that were successfully initiated as an Entry node
+- `hopr_session_active_sessions_count`: Number of currently active HOPR sessions
+- `hopr_session_received_error_count`: Number of HOPR session errors received from an Exit node, keys: `kind`
+- `hopr_session_sent_error_count`: Number of HOPR session errors sent to an Entry node, keys: `kind`
+- `hopr_session_established_sessions_count`: Number of sessions that were successfully established as an Exit node
+- `hopr_session_initiated_sessions_count`: Number of sessions that were successfully initiated as an Entry node
 - `hopr_session_hoprd_clients`: Number of clients connected at this Entry node, keys: `type`
 - `hopr_session_hoprd_target_connections`: Number of currently active HOPR session target connections from this Exit node, keys: `type`
 - `hopr_tickets_incoming_win_probability`: Observes the winning probabilities on incoming tickets, buckets: 0.0, 0.0001, 0.001, 0.01, 0.05, 0.1, 0.15, 0.25, 0.3, 0.5

--- a/chain/indexer/src/handlers.rs
+++ b/chain/indexer/src/handlers.rs
@@ -34,7 +34,7 @@ use crate::errors::{CoreEthereumIndexerError, Result};
 lazy_static::lazy_static! {
     static ref METRIC_INDEXER_LOG_COUNTERS: hopr_metrics::MultiCounter =
         hopr_metrics::MultiCounter::new(
-            "hopr_indexer_contract_log_counters",
+            "hopr_indexer_contract_log_count",
             "Counts of different HOPR contract logs processed by the Indexer",
             &["contract"]
     ).unwrap();

--- a/logic/strategy/src/promiscuous.rs
+++ b/logic/strategy/src/promiscuous.rs
@@ -56,7 +56,7 @@ lazy_static::lazy_static! {
     static ref METRIC_COUNT_CLOSURES: SimpleCounter =
         SimpleCounter::new("hopr_strategy_promiscuous_closed_channels_count", "Count of close channel decisions").unwrap();
     static ref METRIC_MAX_AUTO_CHANNELS: SimpleGauge =
-        SimpleGauge::new("hopr_strategy_promiscuous_max_auto_channels", "Count of maximum number of channels managed by the strategy").unwrap();
+        SimpleGauge::new("hopr_strategy_promiscuous_max_auto_channels_count", "Count of maximum number of channels managed by the strategy").unwrap();
 }
 
 /// A decision made by the Promiscuous strategy on each tick,

--- a/logic/strategy/src/promiscuous.rs
+++ b/logic/strategy/src/promiscuous.rs
@@ -56,7 +56,7 @@ lazy_static::lazy_static! {
     static ref METRIC_COUNT_CLOSURES: SimpleCounter =
         SimpleCounter::new("hopr_strategy_promiscuous_closed_channels_count", "Count of close channel decisions").unwrap();
     static ref METRIC_MAX_AUTO_CHANNELS: SimpleGauge =
-        SimpleGauge::new("hopr_strategy_promiscuous_max_auto_channels_count", "Count of maximum number of channels managed by the strategy").unwrap();
+        SimpleGauge::new("hopr_strategy_promiscuous_max_auto_channels", "Count of maximum number of channels managed by the strategy").unwrap();
 }
 
 /// A decision made by the Promiscuous strategy on each tick,

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -19,7 +19,7 @@ use crate::{IncomingSession, Session, SessionClientConfig, SessionId};
 #[cfg(all(feature = "prometheus", not(test)))]
 lazy_static::lazy_static! {
     static ref METRIC_ACTIVE_SESSIONS: hopr_metrics::SimpleGauge = hopr_metrics::SimpleGauge::new(
-        "hopr_session_active_sessions_count",
+        "hopr_session_num_active_sessions",
         "Number of currently active HOPR sessions"
     ).unwrap();
     static ref METRIC_NUM_ESTABLISHED_SESSIONS: hopr_metrics::SimpleCounter = hopr_metrics::SimpleCounter::new(

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -19,24 +19,24 @@ use crate::{IncomingSession, Session, SessionClientConfig, SessionId};
 #[cfg(all(feature = "prometheus", not(test)))]
 lazy_static::lazy_static! {
     static ref METRIC_ACTIVE_SESSIONS: hopr_metrics::SimpleGauge = hopr_metrics::SimpleGauge::new(
-        "hopr_session_num_active_sessions",
+        "hopr_session_active_sessions_count",
         "Number of currently active HOPR sessions"
     ).unwrap();
     static ref METRIC_NUM_ESTABLISHED_SESSIONS: hopr_metrics::SimpleCounter = hopr_metrics::SimpleCounter::new(
-        "hopr_session_established_sessions",
+        "hopr_session_established_sessions_count",
         "Number of sessions that were successfully established as an Exit node"
     ).unwrap();
     static ref METRIC_NUM_INITIATED_SESSIONS: hopr_metrics::SimpleCounter = hopr_metrics::SimpleCounter::new(
-        "hopr_session_initiated_sessions",
+        "hopr_session_initiated_sessions_count",
         "Number of sessions that were successfully initiated as an Entry node"
     ).unwrap();
     static ref METRIC_RECEIVED_SESSION_ERRS: hopr_metrics::MultiCounter = hopr_metrics::MultiCounter::new(
-        "hopr_session_received_error_counts",
+        "hopr_session_received_error_count",
         "Number of HOPR session errors received from an Exit node",
         &["kind"]
     ).unwrap();
     static ref METRIC_SENT_SESSION_ERRS: hopr_metrics::MultiCounter = hopr_metrics::MultiCounter::new(
-        "hopr_session_sent_error_counts",
+        "hopr_session_sent_error_count",
         "Number of HOPR session errors sent to an Entry node",
         &["kind"]
     ).unwrap();


### PR DESCRIPTION
To follow Prometheus metrics naming conventions, each counter should end in `_total`, `_sum`, `_bucket` or `_count`.

The following metrics have been renamed:
- ~`hopr_strategy_promiscuous_max_auto_channels` -> `hopr_strategy_promiscuous_max_auto_channels_count`~
- ~`hopr_session_num_active_sessions` -> `hopr_session_active_sessions_count`~
- `hopr_session_established_sessions` -> `hopr_session_established_sessions_count`
- `hopr_session_initiated_sessions` -> `hopr_session_initiated_sessions_count`
- `hopr_session_received_error_counts` -> `hopr_session_received_error_count`
- `hopr_session_sent_error_counts` -> `hopr_session_sent_error_count`
- `hopr_indexer_contract_log_counters` -> `hopr_indexer_contract_log_count`

There's an open PR https://github.com/hoprnet/gitops/pull/263 to update the Grafana dashboards accordingly. This PR should only be merged once we migrate the HOPRd hosted nodes to 3.0