### PR TITLE
db: Fix ticket aggregation balance threshold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4270,7 +4270,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-db-sql"
-version = "0.12.1"
+version = "0.12.2"
 dependencies = [
  "anyhow",
  "async-lock 3.4.0",

--- a/db/sql/Cargo.toml
+++ b/db/sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-db-sql"
-version = "0.12.1"
+version = "0.12.2"
 edition = "2021"
 description = "Contains SQL DB functionality implementing the DB API traits to be used by other crates in the code base"
 homepage = "https://hoprnet.org/"

--- a/db/sql/src/tickets.rs
+++ b/db/sql/src/tickets.rs
@@ -2261,7 +2261,7 @@ mod tests {
     }
 
     #[async_std::test]
-    async fn test_aggregation_prerequisites_must_return_empty_when_minimum_only_aggregated_ratio_is_met(
+    async fn test_aggregation_prerequisites_must_return_tickets_when_minimum_incl_aggregated_ratio_is_met(
     ) -> anyhow::Result<()> {
         const TICKET_COUNT: usize = 90;
 
@@ -2287,7 +2287,7 @@ mod tests {
 
         let filtered_tickets = filter_satisfying_ticket_models(prerequisites, dummy_tickets.clone(), &channel, 0.0005)?;
 
-        assert!(filtered_tickets.is_empty(), "must return empty");
+        assert_eq!(filtered_tickets.len(), TICKET_COUNT);
         Ok(())
     }
 


### PR DESCRIPTION
During the aggregation check values of previously aggregated tickets are now also taken into account. This is fine since there is a safe-guard which ensures that the number of aggregated tickets must be more than 1.

Refs #6926 