### PR TITLE
ci: Fix prefix match in dappnode action

### DIFF
--- a/.github/workflows/build-dappnode.yaml
+++ b/.github/workflows/build-dappnode.yaml
@@ -135,7 +135,7 @@ jobs:
       - name: Publish DappNode Package
         id: publish
         run: |
-          docker_tag=$(gcloud artifacts docker tags list "${{ vars.DOCKER_IMAGE_REGISTRY }}/hoprd" --filter="tag:${{ steps.setup.outputs.current_version }}" --format="csv[no-heading](tag,version)" | grep "${{ steps.setup.outputs.current_version }}," | sed 's/,/@/')
+          docker_tag=$(gcloud artifacts docker tags list "${{ vars.DOCKER_IMAGE_REGISTRY }}/hoprd" --filter="tag:${{ steps.setup.outputs.current_version }}" --format="csv[no-heading](tag,version)" | grep -F "${{ steps.setup.outputs.current_version }}," | sed 's/,/@/')
           yq -i e ".services.node.build.args.UPSTREAM_VERSION |= \"${docker_tag}\"" "./docker-compose.yml"
           npm install
           npx @dappnode/dappnodesdk publish patch  --provider "remote" --upload_to "ipfs" --verbose | tee build.log


### PR DESCRIPTION
The previous approach would also match `2.2.3-commit` which is not expected.