### PR TITLE
deps: Update cargo dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1011,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389a099b34312839e16420d499a9cad9650541715937ffbdd40d36f49e77eeb3"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10400,9 +10400,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes 1.10.1",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,7 +1113,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tinyvec",
 ]
 
@@ -1424,7 +1424,7 @@ dependencies = [
  "hmac 0.12.1",
  "k256",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
 ]
 
@@ -1440,7 +1440,7 @@ dependencies = [
  "once_cell",
  "pbkdf2 0.12.2",
  "rand 0.8.5",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
 ]
 
@@ -1459,7 +1459,7 @@ dependencies = [
  "ripemd",
  "serde",
  "serde_derive",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3",
  "thiserror 1.0.69",
 ]
@@ -2233,7 +2233,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.6.4",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -2373,7 +2373,7 @@ dependencies = [
  "scrypt 0.10.0",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3",
  "thiserror 1.0.69",
  "uuid 0.8.2",
@@ -2616,7 +2616,7 @@ dependencies = [
  "eth-keystore",
  "ethers-core",
  "rand 0.8.5",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tracing",
 ]
@@ -4558,7 +4558,7 @@ dependencies = [
  "primitive-types",
  "serde",
  "serde_bytes",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3",
  "subtle",
  "thiserror 2.0.12",
@@ -6094,7 +6094,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "signature",
 ]
 
@@ -6264,7 +6264,7 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.5",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "thiserror 1.0.69",
  "tracing",
  "zeroize",
@@ -8541,7 +8541,7 @@ version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a2fcdc9f40c8dc2922842ca9add611ad19f332227fc651d015881ad1552bd9a"
 dependencies = [
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "walkdir",
 ]
 
@@ -8826,7 +8826,7 @@ dependencies = [
  "hmac 0.12.1",
  "pbkdf2 0.11.0",
  "salsa20",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -8837,7 +8837,7 @@ checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
 dependencies = [
  "pbkdf2 0.12.2",
  "salsa20",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -9367,9 +9367,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -9545,7 +9545,7 @@ dependencies = [
  "rand_core 0.6.4",
  "ring 0.17.14",
  "rustc_version 0.4.1",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle",
 ]
 
@@ -9657,7 +9657,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.12",
  "time 0.3.41",
@@ -9698,7 +9698,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -9745,7 +9745,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "sha1 0.10.6",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -9788,7 +9788,7 @@ dependencies = [
  "rust_decimal",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6253,9 +6253,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "257b5621d159b32282eac446bed6670c39c7dc68a200a992d8f056afa0066f6d"
+checksum = "fbb68ea10844211a59ce46230909fd0ea040e8a192454d4cc2ee0d53e12280eb"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -6265,7 +6265,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "sha2 0.10.9",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
  "tracing",
  "zeroize",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,9 +1308,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de45108900e1f9b9242f7f2e254aa3e2c029c921c258fe9e6b4217eeebd54288"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
  "axum-core 0.5.2",
  "base64 0.22.1",
@@ -848,7 +848,7 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
 dependencies = [
- "axum 0.8.3",
+ "axum 0.8.4",
  "axum-core 0.5.2",
  "bytes 1.10.1",
  "form_urlencoded",
@@ -5209,7 +5209,7 @@ version = "3.12.0"
 dependencies = [
  "anyhow",
  "async-lock 3.4.0",
- "axum 0.8.3",
+ "axum 0.8.4",
  "axum-extra",
  "base64 0.22.1",
  "const_format",
@@ -10891,7 +10891,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59559e1509172f6b26c1cdbc7247c4ddd1ac6560fe94b584f81ee489b141f719"
 dependencies = [
- "axum 0.8.3",
+ "axum 0.8.4",
  "serde",
  "serde_json",
  "utoipa",
@@ -10903,7 +10903,7 @@ version = "9.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29519b3c485df6b13f4478ac909a491387e9ef70204487c3b64b53749aec0be"
 dependencies = [
- "axum 0.8.3",
+ "axum 0.8.4",
  "base64 0.22.1",
  "mime_guess",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,7 +186,7 @@ tokio = { version = "1.44.2", features = [
   "macros",
   "tracing",
 ] }
-tokio-util = { version = "0.7.14", default-features = false, features = [
+tokio-util = { version = "0.7.15", default-features = false, features = [
   "codec",
   "compat",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,7 +107,7 @@ k256 = { version = "0.13.4", features = [
 ] }
 lazy_static = "1.5.0"
 libp2p = { version = "0.55.0" }
-libp2p-identity = { version = "0.2.10", features = [
+libp2p-identity = { version = "0.2.11", features = [
   "peerid",
   "ed25519",
   "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,7 @@ async-stream = "0.3.6"
 async-trait = "0.1.88"
 asynchronous-codec = { version = "0.7.0", features = ["cbor"] }
 atomic_enum = "0.3.0"
-axum = { version = "0.8.3", features = ["ws", "http2"] }
+axum = { version = "0.8.4", features = ["ws", "http2"] }
 axum-extra = { version = "0.10.1", features = ["query"] }
 backon = { version = "1.5.0", default-features = false }
 base64 = "0.22.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,7 @@ bloomfilter = { version = "3.0.1", features = ["serde"] }
 bytesize = { version = "2.0.1", features = ["serde"] }
 cbor4ii = { version = "1.0.0" }
 cfg-if = "1.0.0"
-chrono = { version = "0.4.40", default-features = false }
+chrono = { version = "0.4.41", default-features = false }
 clap = { version = "4.5.36", features = ["derive", "env", "string"] }
 const_format = "0.2.34"
 console-subscriber = "0.4.1"

--- a/crypto/types/Cargo.toml
+++ b/crypto/types/Cargo.toml
@@ -22,7 +22,7 @@ poly1305 = { version = "0.8.0" }
 primitive-types = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_bytes = { workspace = true, optional = true }
-sha2 = "0.10.8"
+sha2 = "0.10.9"
 sha3 = { workspace = true }
 subtle = { workspace = true }
 thiserror = { workspace = true }

--- a/crypto/types/Cargo.toml
+++ b/crypto/types/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 
 [dependencies]
 aes = "0.8.4"
-blake3 = "1.8.0"
+blake3 = "1.8.2"
 cipher = "0.4.4"
 chacha20 = "0.9.1"
 crypto_box = { version = "0.9.1", features = ["seal"] }


### PR DESCRIPTION
Update dependencies:
This pull request updates several dependencies across the project to their latest versions. These updates primarily focus on maintaining compatibility, improving security, and benefiting from upstream bug fixes.

### Dependency Updates in `Cargo.toml`:
* Updated the `axum` dependency from `0.8.3` to `0.8.4`, which includes improvements and bug fixes for web framework features like WebSocket and HTTP/2.
* Upgraded the `chrono` dependency from `0.4.40` to `0.4.41`, likely addressing minor bug fixes or improvements in the date and time library.
* Updated `libp2p-identity` from `0.2.10` to `0.2.11`, ensuring compatibility and enhancements in peer identity handling.
* Bumped `tokio-util` from `0.7.14` to `0.7.15`, improving utility features for the Tokio async runtime.

### Dependency Updates in `crypto/types/Cargo.toml`:
* Updated `blake3` from `1.8.0` to `1.8.2`, likely improving hashing performance or fixing bugs.
* Upgraded `sha2` from `0.10.8` to `0.10.9`, addressing potential security or performance improvements in the SHA-2 cryptographic hashing library.