### PR TITLE
nix: Add missing lld to shell

### DIFF
--- a/nix/mkShell.nix
+++ b/nix/mkShell.nix
@@ -24,6 +24,7 @@ let
     gnumake
     gnuplot
     jq
+    llvmPackages.bintools
     lsof
     mold
     openssl


### PR DESCRIPTION
The linker was missing in the shell when needed on Darwin.