### PR TITLE
Use bench without the testing feature

### DIFF
--- a/common/network-types/Cargo.toml
+++ b/common/network-types/Cargo.toml
@@ -22,7 +22,6 @@ runtime-tokio = [
   "hickory-resolver/tokio-runtime",
 ]
 prometheus = ["dep:lazy_static", "dep:hopr-metrics"]
-testing = []
 
 [dependencies]
 aquamarine = { workspace = true }

--- a/common/network-types/benches/session.rs
+++ b/common/network-types/benches/session.rs
@@ -1,3 +1,7 @@
+#[allow(unused)]
+#[path = "../src/session/utils.rs"]
+mod utils;
+
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use futures::{AsyncReadExt, AsyncWriteExt};
 use hopr_network_types::prelude::state::{SessionConfig, SessionSocket};
@@ -5,10 +9,7 @@ use hopr_network_types::utils::DuplexIO;
 use rand::{thread_rng, Rng};
 use std::collections::HashSet;
 
-#[cfg(not(feature = "testing"))]
-compile_error!("Must specify the 'testing' feature");
-
-use hopr_network_types::prelude::{FaultyNetwork, FaultyNetworkConfig};
+use utils::{FaultyNetwork, FaultyNetworkConfig};
 
 /// This MTU is based on the current MTU size in HOPR 2.2
 const MTU: usize = 466;

--- a/common/network-types/src/session/mod.rs
+++ b/common/network-types/src/session/mod.rs
@@ -24,6 +24,3 @@ pub mod state;
 mod utils;
 
 pub use frame::{Frame, FrameId, FrameInfo, FrameReassembler, Segment, SegmentId};
-
-#[cfg(feature = "testing")]
-pub use utils::{FaultyNetwork, FaultyNetworkConfig};


### PR DESCRIPTION
This pull request refactors the handling of the `FaultyNetwork` and `FaultyNetworkConfig` utilities by consolidating their usage and removing conditional compilation for the `testing` feature. The changes streamline the codebase and improve maintainability.

### Refactoring and Code Simplification:

* [`common/network-types/benches/session.rs`](diffhunk://#diff-b0c2fda04b5b34fbd454b1d7ac033ee816c410c842ce05d2240ce7df49a0cbb0R1-R12): Introduced a new `mod utils` declaration with an explicit path to `utils.rs`, allowing the `FaultyNetwork` and `FaultyNetworkConfig` utilities to be used without conditional compilation. Removed the `compile_error!` macro that enforced the presence of the `testing` feature.

* [`common/network-types/src/session/mod.rs`](diffhunk://#diff-ce43aec550149c6fe980dbc6205afb04e8228b355863a135a22459b840b5647dL27-L29): Removed the conditional `#[cfg(feature = "testing")]` export of `FaultyNetwork` and `FaultyNetworkConfig`, as these utilities are now consistently imported via the `utils` module.