### PR TITLE
Add customisable environment for test nodes

### DIFF
--- a/sdk/python/localcluster/cluster.py
+++ b/sdk/python/localcluster/cluster.py
@@ -3,6 +3,7 @@ import os
 import shutil
 from pathlib import Path
 from subprocess import run
+from typing import Optional
 
 from . import utils
 from .constants import (
@@ -21,7 +22,7 @@ GLOBAL_TIMEOUT = 90
 
 
 class Cluster:
-    def __init__(self, config: dict, anvil_config: Path, protocol_config: Path, use_nat: bool, exposed: bool):
+    def __init__(self, config: dict, anvil_config: Path, protocol_config: Path, use_nat: bool, exposed: bool, extra_env: Optional[dict] = None):
         self.anvil_config = anvil_config
         self.protocol_config = protocol_config
         self.use_nat = use_nat
@@ -31,7 +32,7 @@ class Cluster:
         for network_name, params in config["networks"].items():
             for alias, node in params["nodes"].items():
                 self.nodes[str(index)] = Node.fromConfig(
-                    index, alias, node, config["defaults"], network_name, use_nat, exposed
+                    index, alias, node, config["defaults"], network_name, use_nat, exposed, extra_env.get(alias, {}) if extra_env else {}
                 )
                 index += 1
 

--- a/sdk/python/localcluster/main_process.py
+++ b/sdk/python/localcluster/main_process.py
@@ -24,7 +24,7 @@ random.seed(SEED)
 
 
 async def bringup(
-    config: str, test_mode: bool = False, fully_connected: bool = False, use_nat: bool = False, exposed: bool = False
+    config: str, test_mode: bool = False, fully_connected: bool = False, use_nat: bool = False, exposed: bool = False, extra_env: Optional[dict] = None
 ) -> Optional[Tuple[Cluster, Anvil]]:
     logging.info(f"Using the random seed: {SEED}")
 
@@ -35,7 +35,7 @@ async def bringup(
     with open(config, "r") as f:
         config = yaml.safe_load(f)
 
-    cluster = Cluster(config, ANVIL_CONFIG_FILE, ANVIL_FOLDER.joinpath("protocol-config.json"), use_nat, exposed)
+    cluster = Cluster(config, ANVIL_CONFIG_FILE, ANVIL_FOLDER.joinpath("protocol-config.json"), use_nat, exposed, extra_env)
     anvil = Anvil(ANVIL_FOLDER.joinpath("anvil.log"), ANVIL_CONFIG_FILE, ANVIL_FOLDER.joinpath("anvil.state.json"))
 
     snapshot = Snapshot(PORT_BASE, MAIN_DIR, cluster)


### PR DESCRIPTION
Add new fixture that allows to set environment variables individually for each node in the test cluster via pytest parametrize.