### PR TITLE
deps: Fix inconsistent Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7590,7 +7590,7 @@ dependencies = [
  "asynchronous-codec",
  "bytes",
  "quick-protobuf",
- "thiserror 1.0.68",
+ "thiserror 1.0.69",
  "unsigned-varint 0.8.0",
 ]
 


### PR DESCRIPTION
1 dependency was incorrectly updated in #7131 . This PR fixes it.