### PR TITLE
Fix smoke test execution

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -153,6 +153,10 @@ jobs:
     timeout-minutes: 10
     env:
       needs_nix_setup: true
+    outputs:
+      base-port: ${{ steps.find_base_port.outputs.base-port }}
+      snapshot-name: ${{ steps.find_base_port.outputs.snapshot-name }}
+      snapshot-dir: ${{ steps.find_base_port.outputs.snapshot-dir }}
     if: github.event.pull_request.draft == false
     steps:
       - name: Harden Runner
@@ -171,8 +175,8 @@ jobs:
         uses: hoprnet/hopr-workflows/actions/setup-gcp@72b6f30b6d0e2fa7298034156f503f2a2bd0f9c6 # master
         with:
           google-credentials: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
-          login-artifact-registry: 'false'
-          install-sdk: 'true'
+          login-artifact-registry: "false"
+          install-sdk: "true"
 
       - name: Install Nix
         if: env.needs_nix_setup == 'true'
@@ -188,25 +192,35 @@ jobs:
         env:
           USER: runner
 
-      - name: Download snapshot
+      - name: Find base port
+        id: find_base_port
+        run: |
+          base_port=$(./tests/find_port.py --min-port 3000 --max-port 4000 --skip 30)
+          echo "output_base-port=${base_port}" >> "$GITHUB_OUTPUT"
+          echo "output_snapshot-name="snapshot-${base_port}" >> "$GITHUB_OUTPUT"
+          echo "output_snapshot-dir="/tmp/hopr-localcluster/snapshot-${base_port}" >> "$GITHUB_OUTPUT"
+
+      - name: Download ${{ steps.find_base_port.outputs.snapshot-name }}
         id: download-snapshot
         if: ${{ !env.ACT }}
         run: |
-          mkdir -p /tmp/hopr-localcluster/snapshot
-          gcloud storage rsync gs://hoprnet-test-artifacts/snapshot /tmp/hopr-localcluster/snapshot --recursive
+          mkdir -p "${{ steps.find_base_port.outputs.snapshot-dir }}"
+          gcloud storage rsync gs://hoprnet-test-artifacts/snapshot "${{ steps.find_base_port_outputs.snapshot-dir }}" --recursive
         continue-on-error: true
 
-      - name: Check snapshot
-        run: ls -lR /tmp/hopr-localcluster/snapshot || echo "no snapshot found"
+      - name: Check ${{ steps.find_base_port.outputs.snapshot-name }}
+        run: ls -lR ${{ steps.find_base_port.outputs.snapshot-dir }} || echo "no snapshot found"
 
       - name: Run smoke tests hopli
-        run: nix develop -L .#citest -c uv run -m pytest tests/test_hopli.py
+        run: nix develop -L .#citest -c uv run --frozen -m pytest tests/test_hopli.py
+        env:
+          HOPR_SMOKETEST_BASE_PORT: ${{ steps.find_base_port.outputs.base-port }}
 
-      - name: Upload snapshot
+      - name: Upload ${{ steps.find_base_port.outputs.snapshot-name }}
         uses: google-github-actions/upload-cloud-storage@7c6e11cb7291594c5dfe0bc1dd9cd905e31e600c # v2.2.2
         if: ${{ !env.ACT && always() && steps.download-snapshot.outcome != 'success' }}
         with:
-          path: /tmp/hopr-localcluster/snapshot
+          path: ${{ steps.find_base_port.outputs.snapshot-dir }}
           destination: hoprnet-test-artifacts/
           gzip: false
 
@@ -265,8 +279,8 @@ jobs:
         uses: hoprnet/hopr-workflows/actions/setup-gcp@72b6f30b6d0e2fa7298034156f503f2a2bd0f9c6 # master
         with:
           google-credentials: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
-          login-artifact-registry: 'false'
-          install-sdk: 'true'
+          login-artifact-registry: "false"
+          install-sdk: "true"
 
       - name: Install Nix
         if: env.needs_nix_setup == 'true'
@@ -282,19 +296,21 @@ jobs:
         env:
           USER: runner
 
-      - name: Download snapshot
+      - name: Download ${{ jobs.tests-smoke-hopli.outputs.snapshot-name }}
         id: download-snapshot
         if: ${{ !env.ACT }}
         run: |
-          mkdir -p /tmp/hopr-localcluster/snapshot
-          gcloud storage rsync gs://hoprnet-test-artifacts/snapshot /tmp/hopr-localcluster/snapshot --recursive
+          mkdir -p "${{ jobs.tests-smoke-hopli.outputs.snapshot-dir }}"
+          gcloud storage rsync gs://hoprnet-test-artifacts/snapshot ${{ jobs.tests-smoke-hopli.outputs.snapshot-dir }} --recursive
         continue-on-error: true
 
-      - name: Check snapshot
-        run: ls -lR /tmp/hopr-localcluster/snapshot || echo "no snapshot found"
+      - name: Check ${{ jobs.tests-smoke-hopli.outputs.snapshot-name }}
+        run: ls -lR "${{ jobs.tests-smoke-hopli.outputs.snapshot-dir }}" || echo "no snapshot found"
 
       - name: Run smoke tests ${{ matrix.suite }}
-        run: nix develop -L .#citest -c uv run -m pytest tests/test_${{ matrix.suite }}.py
+        run: nix develop -L .#citest -c uv run --frozen -m pytest tests/test_${{ matrix.suite }}.py
+        env:
+          HOPR_SMOKETEST_BASE_PORT: ${{ jobs.tests-smoke-hopli.outputs.base-port }}
 
       - name: Compress test logs
         if: ${{ !env.ACT && always() }}

--- a/nix/ciShell.nix
+++ b/nix/ciShell.nix
@@ -22,6 +22,7 @@ let
     dive
 
     uv
+    python313
   ];
   shellPackages = packages ++ extraPackages;
   cleanArgs = removeAttrs args [

--- a/nix/testShell.nix
+++ b/nix/testShell.nix
@@ -24,6 +24,7 @@ let
   '' + shellHook;
   packages = with pkgs; [
     uv
+    python313
     solcDefault
     foundry-bin
   ];

--- a/sdk/python/localcluster/cluster.py
+++ b/sdk/python/localcluster/cluster.py
@@ -67,7 +67,7 @@ class Cluster:
 
         if not skip_funding:
             self.fund_nodes()
-            # return
+            return
 
         # WAIT FOR NODES TO BE UP
         logging.info(f"Waiting up to {GLOBAL_TIMEOUT}s for nodes to be ready")

--- a/sdk/python/localcluster/main_process.py
+++ b/sdk/python/localcluster/main_process.py
@@ -71,18 +71,16 @@ async def bringup(
         # wait before contract deployments are finalized
         await asyncio.sleep(2.5)
 
-        # FIXME: This breaks the random base port approach since nodes will make announcements using different port.
-        # Skipping for now until a better approach is found.
         # BRING UP NODES (with funding)
-        # await cluster.shared_bringup(skip_funding=False)
+        await cluster.shared_bringup(skip_funding=False)
 
         anvil.kill()
-        # cluster.clean_up()
+        cluster.clean_up()
 
         # delay to ensure anvil is stopped and state file closed
         await asyncio.sleep(1)
 
-        snapshot.create(ANVIL_FOLDER.joinpath("anvil.state.json"))
+        snapshot.create()
 
     snapshot.reuse()
 
@@ -97,7 +95,7 @@ async def bringup(
 
     # BRING UP NODES (without funding)
     try:
-        await cluster.shared_bringup(skip_funding=False)
+        await cluster.shared_bringup(skip_funding=True)
     except asyncio.TimeoutError as e:
         logging.error(f"Timeout error: {e}")
         return cluster, anvil

--- a/sdk/python/localcluster/node.py
+++ b/sdk/python/localcluster/node.py
@@ -74,6 +74,7 @@ class Node:
         self.api_port: int = 0
         self.p2p_port: int = 0
         self.anvil_port: int = 0
+        self.tokio_console_port: int = 0
 
         self.prepare()
 
@@ -85,8 +86,11 @@ class Node:
         self.dir = MAIN_DIR.joinpath(f"{NODE_NAME_PREFIX}_{self.id}")
         self.cfg_file_path = MAIN_DIR.joinpath(self.cfg_file)
         self.anvil_port = self.base_port
-        self.api_port = self.base_port + (self.id * 2)
+        self.api_port = self.base_port + (self.id * 3)
         self.p2p_port = self.api_port + 1
+        self.tokio_console_port = self.p2p_port + 1
+
+        logging.info(f"Node {self.id} ports: api {self.api_port}, p2p {self.p2p_port}, anvil {self.anvil_port}, tokio console {self.tokio_console_port}")
 
     def load_addresses(self):
         loaded_env = load_env_file(self.dir.joinpath(".env"))
@@ -179,7 +183,7 @@ class Node:
             "HOPR_TEST_DISABLE_CHECKS": "true",
             "HOPRD_USE_OPENTELEMETRY": trace_telemetry,
             "OTEL_SERVICE_NAME": f"hoprd-{self.p2p_port}",
-            "TOKIO_CONSOLE_BIND": f"localhost:{self.p2p_port+100}",
+            "TOKIO_CONSOLE_BIND": f"localhost:{self.tokio_console_port}",
             "HOPRD_NAT": "true" if self.use_nat else "false",
         }
         loaded_env = load_env_file(self.dir.joinpath(".env"))

--- a/sdk/python/localcluster/node.py
+++ b/sdk/python/localcluster/node.py
@@ -90,7 +90,9 @@ class Node:
         self.p2p_port = self.api_port + 1
         self.tokio_console_port = self.p2p_port + 1
 
-        logging.info(f"Node {self.id} ports: api {self.api_port}, p2p {self.p2p_port}, anvil {self.anvil_port}, tokio console {self.tokio_console_port}")
+        logging.info(
+            f"Node {self.id} ports: api {self.api_port}, p2p {self.p2p_port}, anvil {self.anvil_port}, tokio console {self.tokio_console_port}"
+        )
 
     def load_addresses(self):
         loaded_env = load_env_file(self.dir.joinpath(".env"))

--- a/sdk/python/localcluster/snapshot.py
+++ b/sdk/python/localcluster/snapshot.py
@@ -20,8 +20,8 @@ class Snapshot:
         self.parent_dir = parent_dir
         self.cluster = cluster
 
-    def create(self, anvil_file: Path):
-        logging.info("Taking snapshot")
+    def create(self):
+        logging.info(f"Taking snapshot (anvil port: {self.anvil_port}")
 
         # delete old snapshot
         shutil.rmtree(self.sdir, ignore_errors=True)
@@ -45,10 +45,8 @@ class Snapshot:
 
             db_target_dir.mkdir(parents=True, exist_ok=True)
 
-            # FIXME: This breaks the random base port approach since nodes will make announcements using different port.
-            # Skipping for now until a better approach is found.
-            # for file in EXPECTED_FILES_FOR_SNAPSHOT:
-            #   shutil.copy(source_dir.joinpath(file), db_target_dir)
+            for file in EXPECTED_FILES_FOR_SNAPSHOT:
+                shutil.copy(source_dir.joinpath(file), db_target_dir)
 
             shutil.copy(source_dir.joinpath("./hoprd.id"), target_dir)
             shutil.copy(source_dir.joinpath("./.env"), target_dir)
@@ -60,7 +58,7 @@ class Snapshot:
 
         for entry in self.parent_dir.glob("*"):
             if entry.is_dir():
-                if entry.name == "snapshot":
+                if entry.name == f"snapshot-{self.anvil_port}":
                     continue
                 shutil.rmtree(entry, ignore_errors=True)
             else:
@@ -78,11 +76,9 @@ class Snapshot:
             self.sdir.joinpath("default.cfg.yaml"),
         ]
 
-        # FIXME: This breaks the random base port approach since nodes will make announcements using different port.
-        # Skipping for now until a better approach is found.
-        # for i in range(self.cluster.size):
-        #     node_dir = self.sdir.joinpath(f"{NODE_NAME_PREFIX}_{i+1}")
-        #     expected_files.extend([node_dir.joinpath(file) for file in EXPECTED_FILES_FOR_SNAPSHOT])
+        for i in range(self.cluster.size):
+            node_dir = self.sdir.joinpath(f"{NODE_NAME_PREFIX}_{i+1}")
+            expected_files.extend([node_dir.joinpath(file) for file in EXPECTED_FILES_FOR_SNAPSHOT])
 
         for f in expected_files:
             if not f.exists():
@@ -93,4 +89,4 @@ class Snapshot:
 
     @property
     def sdir(self):
-        return self.parent_dir.joinpath("snapshot")
+        return self.parent_dir.joinpath(f"snapshot-{self.anvil_port}")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,7 @@ from subprocess import PIPE, STDOUT, CalledProcessError, Popen
 
 import pytest
 
+from utils import find_available_port_block
 from sdk.python import localcluster
 from sdk.python.localcluster.constants import PWD
 from sdk.python.localcluster.node import Node
@@ -78,7 +79,13 @@ def random_distinct_pairs_from(values: list, count: int):
 
 @pytest.fixture(scope="session")
 async def base_port(request):
-    base_port = find_available_port_block(12000, 13000, 20)
+    base_port_env = os.environ.get("HOPR_SMOKETEST_BASE_PORT")
+
+    if base_port_env is None:
+        base_port = find_available_port_block(3000, 4000, 30)
+    else:
+        base_port = int(base_port_env)
+
     if base_port is None:
         pytest.fail("No available base port found")
     logging.info(f"Using base port: {base_port}")
@@ -90,7 +97,7 @@ async def swarm7(request, base_port):
     params_path = PWD.joinpath("sdk/python/localcluster.params.yml")
     try:
         cluster, anvil = await localcluster.bringup(
-            params_path, test_mode=True, fully_connected=False, use_nat=False, base_port=base_port
+            params_path, test_mode=True, fully_connected=False, use_nat=True, base_port=base_port
         )
 
         yield cluster.nodes
@@ -132,71 +139,3 @@ def run_hopli_cmd(cmd: list[str], custom_env):
     retcode = proc.wait()
     if retcode:
         raise CalledProcessError(retcode, cmd)
-
-
-def find_available_port_block(min_port=9000, max_port=9980, skip=20, block_size=None):
-    """
-    Find a randomly selected available port on localhost within the specified range,
-    checking only every nth port based on the skip parameter, and ensuring that
-    a contiguous block of ports following the found port are also available.
-
-    Args:
-        min_port (int): The minimum port number to check (inclusive)
-        max_port (int): The maximum port number to check (inclusive)
-        skip (int): Check only every nth port (e.g. skip=2 checks every second port)
-        block_size (int, optional): Number of consecutive ports that must be free.
-                                   If None, defaults to the same value as skip.
-
-    Returns:
-        int: The starting port number of an available block, or None if no suitable block found
-    """
-    # Ensure skip is at least 0
-    skip = max(0, skip)
-
-    # If block_size is not specified, use the same value as skip
-    if block_size is None:
-        block_size = skip
-
-    # Adjust max_port to ensure we can fit a block of ports at the end
-    adjusted_max = max_port - block_size + 1
-
-    # Create a list of potential starting ports in the specified range, applying the skip
-    potential_starts = list(range(min_port, adjusted_max + 1, skip))
-
-    # Randomize the port order
-    random.shuffle(potential_starts)
-
-    # Variable to store our result
-    result = None
-
-    for start_port in potential_starts:
-        # Check if all ports in the block are available
-        block_available = True
-
-        # Store open sockets temporarily to prevent others from taking the ports while we're checking
-        temp_sockets = []
-
-        # Check each port in the block
-        for offset in range(block_size):
-            port = start_port + offset
-
-            # Skip checking if port is beyond the max_port
-            if port > max_port:
-                block_available = False
-                break
-
-            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-                # connect_ex returns 0 if the connection succeeds,
-                # and a non-zero error code otherwise
-                if s.connect_ex(("127.0.0.1", port)) == 0:
-                    # Port is in use
-                    block_available = False
-                    break
-
-        # If all ports in the block are available, set the result
-        if block_available:
-            result = start_port
-            break  # Exit the loop once we find a valid block
-
-    # Return the starting port of the available block, or None if not found
-    return result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from subprocess import PIPE, STDOUT, CalledProcessError, Popen
 
 import pytest
 
-from utils import find_available_port_block
+from .find_port import find_available_port_block
 from sdk.python import localcluster
 from sdk.python.localcluster.constants import PWD
 from sdk.python.localcluster.node import Node

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import random
+import socket
 from contextlib import asynccontextmanager
 
 from sdk.python.api.channelstatus import ChannelStatus
@@ -185,3 +186,70 @@ async def send_and_receive_packets_with_peek(
     await asyncio.wait_for(check_received_packets_with_peek(dest, packets, tag=random_tag, sort=True), timeout)
 
     return random_tag
+
+def find_available_port_block(min_port=9000, max_port=9980, skip=20, block_size=None):
+    """
+    Find a randomly selected available port on localhost within the specified range,
+    checking only every nth port based on the skip parameter, and ensuring that
+    a contiguous block of ports following the found port are also available.
+
+    Args:
+        min_port (int): The minimum port number to check (inclusive)
+        max_port (int): The maximum port number to check (inclusive)
+        skip (int): Check only every nth port (e.g. skip=2 checks every second port)
+        block_size (int, optional): Number of consecutive ports that must be free.
+                                   If None, defaults to the same value as skip.
+
+    Returns:
+        int: The starting port number of an available block, or None if no suitable block found
+    """
+    # Ensure skip is at least 0
+    skip = max(0, skip)
+
+    # If block_size is not specified, use the same value as skip
+    if block_size is None:
+        block_size = skip
+
+    # Adjust max_port to ensure we can fit a block of ports at the end
+    adjusted_max = max_port - block_size + 1
+
+    # Create a list of potential starting ports in the specified range, applying the skip
+    potential_starts = list(range(min_port, adjusted_max + 1, skip))
+
+    # Randomize the port order
+    random.shuffle(potential_starts)
+
+    # Variable to store our result
+    result = None
+
+    for start_port in potential_starts:
+        # Check if all ports in the block are available
+        block_available = True
+
+        # Store open sockets temporarily to prevent others from taking the ports while we're checking
+        temp_sockets = []
+
+        # Check each port in the block
+        for offset in range(block_size):
+            port = start_port + offset
+
+            # Skip checking if port is beyond the max_port
+            if port > max_port:
+                block_available = False
+                break
+
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                # connect_ex returns 0 if the connection succeeds,
+                # and a non-zero error code otherwise
+                if s.connect_ex(("127.0.0.1", port)) == 0:
+                    # Port is in use
+                    block_available = False
+                    break
+
+        # If all ports in the block are available, set the result
+        if block_available:
+            result = start_port
+            break  # Exit the loop once we find a valid block
+
+    # Return the starting port of the available block, or None if not found
+    return result


### PR DESCRIPTION
Re-enable the use of snapshots. However, snapshots are now base port specific, thus also the CI workflows have been adapted to use base port specific snapshots.