### PR TITLE
protocol: Bump heartbeat protocol version to disallow connections to previous versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4764,7 +4764,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-p2p"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/transport/p2p/Cargo.toml
+++ b/transport/p2p/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-p2p"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 license = "GPL-3.0-only"

--- a/transport/p2p/src/constants.rs
+++ b/transport/p2p/src/constants.rs
@@ -2,7 +2,7 @@
 pub const HOPR_SWARM_IDLE_CONNECTION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(300); // 5 minutes
 
 /// P2P protocol identifiers
-pub(crate) const HOPR_HEARTBEAT_PROTOCOL_V_0_1_0: &str = "/hopr/heartbeat/0.1.0";
+pub(crate) const HOPR_HEARTBEAT_PROTOCOL_V_0_2_0: &str = "/hopr/heartbeat/0.2.0";
 
 // Swarm configuration
 /// The maximum number of concurrently dialed (outbound) peers.

--- a/transport/p2p/src/lib.rs
+++ b/transport/p2p/src/lib.rs
@@ -42,7 +42,7 @@ use hopr_transport_network::network::NetworkTriggeredEvent;
 use hopr_transport_network::ping::PingQueryReplier;
 use hopr_transport_protocol::PeerDiscovery;
 
-use crate::constants::HOPR_HEARTBEAT_PROTOCOL_V_0_1_0;
+use crate::constants::HOPR_HEARTBEAT_PROTOCOL_V_0_2_0;
 
 pub const MSG_ACK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 pub const NAT_SERVER_PROBE_INTERVAL: std::time::Duration = std::time::Duration::from_secs(30);
@@ -137,7 +137,7 @@ impl HoprNetworkBehavior {
             heartbeat_generator: behavior::heartbeat::Behaviour::new(heartbeat_requests),
             heartbeat: libp2p::request_response::cbor::Behaviour::<Ping, Pong>::new(
                 [(
-                    StreamProtocol::new(HOPR_HEARTBEAT_PROTOCOL_V_0_1_0),
+                    StreamProtocol::new(HOPR_HEARTBEAT_PROTOCOL_V_0_2_0),
                     libp2p::request_response::ProtocolSupport::Full,
                 )],
                 libp2p::request_response::Config::default().with_request_timeout(hb_timeout),

--- a/transport/p2p/src/swarm.rs
+++ b/transport/p2p/src/swarm.rs
@@ -17,7 +17,7 @@ use hopr_transport_network::{network::NetworkTriggeredEvent, ping::PingQueryRepl
 use hopr_transport_protocol::{config::ProtocolConfig, PeerDiscovery};
 
 use crate::{constants, errors::Result, HoprNetworkBehavior};
-use crate::{HoprNetworkBehaviorEvent, Ping, Pong};
+use crate::{HoprNetworkBehaviorEvent, Ping, Pong, HOPR_HEARTBEAT_PROTOCOL_V_0_2_0};
 
 #[cfg(all(feature = "prometheus", not(test)))]
 use hopr_metrics::metrics::SimpleGauge;
@@ -204,7 +204,7 @@ impl HoprSwarm {
             select! {
                 event = swarm.select_next_some() => match event {
                     SwarmEvent::Behaviour(HoprNetworkBehaviorEvent::Heartbeat(event)) => {
-                        let _span = tracing::span!(tracing::Level::DEBUG, "swarm protocol", protocol = "/hopr/heartbeat/0.1.0");
+                        let _span = tracing::span!(tracing::Level::DEBUG, "swarm protocol", protocol = HOPR_HEARTBEAT_PROTOCOL_V_0_2_0);
                         match event {
                             libp2p::request_response::Event::<Ping,Pong>::Message {
                                 peer,


### PR DESCRIPTION
If the heartbeat protocol remained unchanged, a v2 release would collide with the current implementation on the `msg/ack` protocol level within the same network.

Heartbeat maps the current network to usable peers. If v2 peers (`singapore`) can't connect to the latest release due to protocol version changes, they discard v3 peers from the usability mapping. Conversely, the latest nodes attempt to probe v2 nodes but fail to register them for message sending due to protocol differences.