### PR TITLE
docker: Fix missing SSL library in the image 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,10 +75,7 @@ chrono = { version = "0.4.41", default-features = false }
 clap = { version = "4.5.38", features = ["derive", "env", "string"] }
 const_format = "0.2.34"
 console-subscriber = "0.4.1"
-criterion = { version = "0.6.0", features = [
-  "async_tokio",
-  "html_reports",
-] }
+criterion = { version = "0.6.0", features = ["async_tokio", "html_reports"] }
 crossbeam-queue = "0.3.12"
 crossbeam-skiplist = "0.1.3"
 ctor = "0.4.2"

--- a/nix/docker-builder.nix
+++ b/nix/docker-builder.nix
@@ -1,23 +1,13 @@
-{ Cmd ? [ ]
-, Entrypoint
-, env ? [ ]
-, extraContents ? [ ]
-, name
-, pkgs
-}:
+{ Cmd ? [ ], Entrypoint, env ? [ ], extraContents ? [ ], name, pkgs }:
 let
-  contents = with pkgs; [
-    bash
-    cacert
-    coreutils
-    findutils
-    iana-etc
-    nettools
-  ] ++ extraContents;
+  libPath = pkgs.lib.makeLibraryPath [ pkgs.openssl ];
+  contents = with pkgs;
+    [ bash cacert coreutils findutils iana-etc nettools ] ++ extraContents;
   Env = [
     "NO_COLOR=true" # suppress colored log output
     # "RUST_LOG=info"   # 'info' level is set by default with some spamming components set to override
     "RUST_BACKTRACE=full"
+    "LD_LIBRARY_PATH=${libPath}"
   ] ++ env;
 in
 pkgs.dockerTools.buildLayeredImage {
@@ -25,7 +15,5 @@ pkgs.dockerTools.buildLayeredImage {
   tag = "latest";
   # breaks binary reproducibility, but makes usage easier
   created = "now";
-  config = {
-    inherit Cmd Entrypoint Env;
-  };
+  config = { inherit Cmd Entrypoint Env; };
 }


### PR DESCRIPTION
This pull request refactors the `nix/docker-builder.nix` file to improve readability and functionality by reorganizing code and adding a new library path. The most important changes include consolidating the parameter declaration, adding a library path for OpenSSL, and simplifying the `contents` array formatting.

### Refactoring and functionality improvements:

* Consolidated the parameter declaration into a single line for improved readability.
* Added a new `libPath` variable to include the OpenSSL library path, and updated the `Env` array to set the `LD_LIBRARY_PATH` environment variable. This ensures that the necessary libraries are available at runtime.
* Simplified the formatting of the `contents` array by combining elements into a single line, making the code more concise.