### PR TITLE
toolchain: Update Rust to 1.87

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,10 +75,7 @@ chrono = { version = "0.4.41", default-features = false }
 clap = { version = "4.5.38", features = ["derive", "env", "string"] }
 const_format = "0.2.34"
 console-subscriber = "0.4.1"
-criterion = { version = "0.6.0", features = [
-  "async_tokio",
-  "html_reports",
-] }
+criterion = { version = "0.6.0", features = ["async_tokio", "html_reports"] }
 crossbeam-queue = "0.3.12"
 crossbeam-skiplist = "0.1.3"
 ctor = "0.4.2"

--- a/flake.lock
+++ b/flake.lock
@@ -189,11 +189,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743906877,
-        "narHash": "sha256-Thah1oU8Vy0gs9bh5QhNcQh1iuQiowMnZPbrkURonZA=",
+        "lastModified": 1747622321,
+        "narHash": "sha256-W0dYIWgsUu6rvOJRtKLhKskkv0VhQhJYGNIq+gGUc8g=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9d00c6b69408dd40d067603012938d9fbe95cfcd",
+        "rev": "bd030fd9983f7fddf87be1c64aa3064c8afa24c4",
         "type": "github"
       },
       "original": {

--- a/logic/path/src/channel_graph.rs
+++ b/logic/path/src/channel_graph.rs
@@ -174,7 +174,6 @@ impl<T> From<Result<Duration, T>> for NodeScoreUpdate {
 ///
 /// When a node reaches zero [quality](Node) and there are no edges (channels) containing this node,
 /// it is removed from the graph entirely.
-
 #[cfg_attr(feature = "serde", cfg_eval::cfg_eval, serde_with::serde_as)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug)]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.86"
+channel = "1.87"
 profile = "default"
 components = ["cargo", "clippy", "rust-src"]


### PR DESCRIPTION
This pull request includes two minor updates to the Rust project configuration files. The changes involve formatting improvements and updating the Rust toolchain version.

Configuration updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L78-R78): Reformatted the `criterion` dependency to place all features on a single line for consistency.
* [`rust-toolchain.toml`](diffhunk://#diff-2b1bde2cf3a858b7bf7424cb8bcbf01f35b94dc80b925d9432cbab3319ca9b4eL2-R2): Updated the Rust toolchain version from `1.86` to `1.87`.

Fix linting and formatting issues in `master`.