### PR TITLE
deps: Remove surf and surf-governor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -176,8 +176,6 @@ sqlx = { version = "0.8.5", default-features = false, features = [
 ] }
 strum = { version = "0.27.1", features = ["derive"] }
 subtle = "2.6.1"
-surf = { version = "2.3.2" }
-surf-governor = { version = "0.2.0" }
 tempfile = "3.20.0"
 test-log = { version = "0.2.17", features = ["trace"] }
 thiserror = "2.0.12"

--- a/hoprd/hoprd/src/main.rs
+++ b/hoprd/hoprd/src/main.rs
@@ -38,7 +38,6 @@ fn init_logger() -> Result<(), Box<dyn std::error::Error>> {
             .add_directive("libp2p_dns=info".parse()?)
             .add_directive("multistream_select=info".parse()?)
             .add_directive("isahc=error".parse()?)
-            .add_directive("surf::middleware::logger::native=error".parse()?)
             .add_directive("sea_orm=warn".parse()?)
             .add_directive("sqlx=warn".parse()?)
             .add_directive("hyper_util=warn".parse()?),


### PR DESCRIPTION
This pull request removes references to the `surf` library and its related components from the project. The changes involve cleaning up dependencies and adjusting logging configurations accordingly.

### Dependency cleanup:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L179-L180): Removed the `surf` and `surf-governor` dependencies from the project. These libraries are no longer used.

### Logging configuration update:

* [`hoprd/hoprd/src/main.rs`](diffhunk://#diff-b4d76d2ca8cb825810502c755c62f98c6e9e784a5197c0d4fe93d9171be7914bL41): Removed the logging directive for `surf::middleware::logger::native` in the `init_logger` function, as the `surf` library has been removed.