### PR TITLE
ci: Fix log upload

### DIFF
--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -45,13 +45,18 @@ jobs:
           disable-sudo: false
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
+      - name: Checkout hoprnet repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
       - name: Setup GCP
         id: gcp
         uses: hoprnet/hopr-workflows/actions/setup-gcp@72b6f30b6d0e2fa7298034156f503f2a2bd0f9c6 # master
         with:
           google-credentials: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
-          login-artifact-registry: 'true'
-          install-sdk: 'true'
+          login-artifact-registry: "true"
+          install-sdk: "true"
 
       - name: Install Nix
         if: env.needs_nix_setup == 'true'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -225,10 +225,15 @@ jobs:
         working-directory: "/tmp"
         run: |
           # Copy all the logs to a directory to avoid log file changes and simplify tar command
-          test_name=test-smoke-${{ matrix.suite }}-${{ github.run_id }}-${{ github.run_number }}
+          test_name=test-smoke-hopli-${{ github.run_id }}-${{ github.run_number }}
           mkdir -p ${test_name}
-          cp hopr-localcluster/hopr-node_*/*.log ${test_name}/ || echo "no files to copy"
-          cp hopr-localcluster/anvil/*.log ${test_name}/ || echo "no files to copy"
+
+          # Copy files, delete all but the log files
+          cp -r hopr-localcluster/hopr-node_* ${test_name}/ || echo "no files to copy"
+          find ${test_name}/ -type f ! -name "hoprd.log" -delete
+          cp hopr-localcluster/anvil/anvil.log ${test_name}/ || echo "no files to copy"
+
+          # Create tarball and upload to GCP
           tar -czvf ${test_name}.tgz ${test_name}/
           gcloud storage cp ${test_name}.tgz gs://hoprnet-test-logs/pr-${{ github.event.pull_request.number }}/
 
@@ -324,7 +329,12 @@ jobs:
           # Copy all the logs to a directory to avoid log file changes and simplify tar command
           test_name=test-smoke-${{ matrix.suite }}-${{ github.run_id }}-${{ github.run_number }}
           mkdir -p ${test_name}
-          cp hopr-localcluster/hopr-node_*/*.log ${test_name}/ || echo "no files to copy"
-          cp hopr-localcluster/anvil/*.log ${test_name}/ || echo "no files to copy"
+
+          # Copy files, delete all but the log files
+          cp -r hopr-localcluster/hopr-node_* ${test_name}/ || echo "no files to copy"
+          find ${test_name}/ -type f ! -name "hoprd.log" -delete
+          cp hopr-localcluster/anvil/anvil.log ${test_name}/ || echo "no files to copy"
+
+          # Create tarball and upload to GCP
           tar -czvf ${test_name}.tgz ${test_name}/
           gcloud storage cp ${test_name}.tgz gs://hoprnet-test-logs/pr-${{ github.event.pull_request.number }}/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -55,8 +55,7 @@ jobs:
           USER: runner
 
       - name: Run unit tests
-        run: |
-          nix build -L .#hopr-test
+        run: nix build -L .#hopr-test
 
   tests-unit-nightly:
     runs-on: self-hosted-hoprnet-bigger
@@ -232,6 +231,12 @@ jobs:
           tar -czvf ${test_path}.tgz ${test_path}
         working-directory: "/tmp"
 
+      - name: Find tmp folder path
+        id: find-tmp-path
+        run: |
+          tmp_path=$(realpath --relative-to="$(pwd)" "/tmp")
+          echo "tmp-path=${tmp_path}" >> "$GITHUB_OUTPUT"
+
       - name: Upload test logs
         uses: google-github-actions/upload-cloud-storage@7c6e11cb7291594c5dfe0bc1dd9cd905e31e600c # v2.2.2
         if: ${{ !env.ACT && always() }}
@@ -337,11 +342,17 @@ jobs:
           tar -czvf ${test_path}.tgz ${test_path}
         working-directory: "/tmp"
 
+      - name: Find tmp folder path
+        id: find-tmp-path
+        run: |
+          tmp_path=$(realpath --relative-to="$(pwd)" "/tmp")
+          echo "tmp-path=${tmp_path}" >> "$GITHUB_OUTPUT"
+
       - name: Upload test logs
         uses: google-github-actions/upload-cloud-storage@7c6e11cb7291594c5dfe0bc1dd9cd905e31e600c # v2.2.2
         if: ${{ !env.ACT && always() }}
         with:
-          path: /tmp/
+          path: ${{ steps.find-tmp-path.outputs.tmp-path }}
           glob: "test-smoke-*"
           parent: false
           destination: hoprnet-test-logs/pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -220,31 +220,17 @@ jobs:
           destination: hoprnet-test-artifacts/
           gzip: false
 
-      - name: Compress test logs
+      - name: Compress and upload test logs
         if: ${{ !env.ACT && always() }}
+        working-directory: "/tmp"
         run: |
           # Copy all the logs to a directory to avoid log file changes and simplify tar command
-          test_path=/tmp/test-smoke-hopli-${{ github.run_id }}-${{ github.run_number }}
-          mkdir -p ${test_path}
-          cp -r /tmp/hopr-smoke-test/test_hopli/*.log ${test_path} || echo "no files to copy"
-          cd ${test_path}
-          tar -czvf ${test_path}.tgz ${test_path}
-        working-directory: "/tmp"
-
-      - name: Find tmp folder path
-        id: find-tmp-path
-        run: |
-          tmp_path=$(realpath --relative-to="$(pwd)" "/tmp")
-          echo "tmp-path=${tmp_path}" >> "$GITHUB_OUTPUT"
-
-      - name: Upload test logs
-        uses: google-github-actions/upload-cloud-storage@7c6e11cb7291594c5dfe0bc1dd9cd905e31e600c # v2.2.2
-        if: ${{ !env.ACT && always() }}
-        with:
-          path: /tmp/
-          glob: "test-smoke-*"
-          parent: false
-          destination: hoprnet-test-logs/pr-${{ github.event.pull_request.number }}
+          test_name=test-smoke-${{ matrix.suite }}-${{ github.run_id }}-${{ github.run_number }}
+          mkdir -p ${test_name}
+          cp hopr-localcluster/hopr-node_*/*.log ${test_name}/ || echo "no files to copy"
+          cp hopr-localcluster/anvil/*.log ${test_name}/ || echo "no files to copy"
+          tar -czvf ${test_name}.tgz ${test_name}/
+          gcloud storage cp ${test_name}.tgz gs://hoprnet-test-logs/pr-${{ github.event.pull_request.number }}/
 
   tests-smoke:
     runs-on: self-hosted-hoprnet-bigger
@@ -331,28 +317,14 @@ jobs:
           destination: hoprnet-test-artifacts/
           gzip: false
 
-      - name: Compress test logs
+      - name: Compress and upload test logs
         if: ${{ !env.ACT && always() }}
+        working-directory: "/tmp"
         run: |
           # Copy all the logs to a directory to avoid log file changes and simplify tar command
-          test_path=/tmp/test-smoke-${{ matrix.suite }}-${{ github.run_id }}-${{ github.run_number }}
-          mkdir -p ${test_path}
-          cp -r /tmp/hopr-smoke-test/test_${{ matrix.suite }}/*.log ${test_path} || echo "no files to copy"
-          cd ${test_path}
-          tar -czvf ${test_path}.tgz ${test_path}
-        working-directory: "/tmp"
-
-      - name: Find tmp folder path
-        id: find-tmp-path
-        run: |
-          tmp_path=$(realpath --relative-to="$(pwd)" "/tmp")
-          echo "tmp-path=${tmp_path}" >> "$GITHUB_OUTPUT"
-
-      - name: Upload test logs
-        uses: google-github-actions/upload-cloud-storage@7c6e11cb7291594c5dfe0bc1dd9cd905e31e600c # v2.2.2
-        if: ${{ !env.ACT && always() }}
-        with:
-          path: ${{ steps.find-tmp-path.outputs.tmp-path }}
-          glob: "test-smoke-*"
-          parent: false
-          destination: hoprnet-test-logs/pr-${{ github.event.pull_request.number }}
+          test_name=test-smoke-${{ matrix.suite }}-${{ github.run_id }}-${{ github.run_number }}
+          mkdir -p ${test_name}
+          cp hopr-localcluster/hopr-node_*/*.log ${test_name}/ || echo "no files to copy"
+          cp hopr-localcluster/anvil/*.log ${test_name}/ || echo "no files to copy"
+          tar -czvf ${test_name}.tgz ${test_name}/
+          gcloud storage cp ${test_name}.tgz gs://hoprnet-test-logs/pr-${{ github.event.pull_request.number }}/

--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -7,10 +7,10 @@ env:
 on:
   workflow_dispatch: # allows manual triggering
   schedule:
-    - cron: '0 0 * * 0' # runs weekly on Sunday at 00:00
+    - cron: "0 0 * * 0" # runs weekly on Sunday at 00:00
 
 permissions:
-  contents: read
+  contents: write
   issues: write
   pull-requests: write
 

--- a/hopr/hopr-lib/data/protocol-config.json
+++ b/hopr/hopr-lib/data/protocol-config.json
@@ -55,7 +55,7 @@
       "max_block_range": 1000,
       "tags": ["etherscan"],
       "tx_polling_interval": 3000,
-      "version_range": "2.*||3.*"
+      "version_range": ">=2.0.0, <4.0.0"
     },
     "rotsee": {
       "addresses": {
@@ -77,7 +77,7 @@
       "max_block_range": 1000,
       "tags": ["etherscan"],
       "tx_polling_interval": 3000,
-      "version_range": "2.*||3.*"
+      "version_range": ">=2.0.0, <4.0.0"
     }
   }
 }

--- a/hopr/hopr-lib/data/protocol-config.json
+++ b/hopr/hopr-lib/data/protocol-config.json
@@ -55,29 +55,7 @@
       "max_block_range": 1000,
       "tags": ["etherscan"],
       "tx_polling_interval": 3000,
-      "version_range": "2.*"
-    },
-    "monte_rosa": {
-      "addresses": {
-        "announcements": "0x0000000000000000000000000000000000000000",
-        "channels": "0xFaBeE463f31E39eC8952bBfB4490C41103bf573e",
-        "module_implementation": "0x0000000000000000000000000000000000000000",
-        "network_registry": "0x819E6a81e1e3f96CF1ac9200477C2d09c676959D",
-        "network_registry_proxy": "0xcA9B1bC189F977B2A9217598D0300d956b6a719f",
-        "node_safe_registry": "0x0000000000000000000000000000000000000000",
-        "node_stake_v2_factory": "0x0000000000000000000000000000000000000000",
-        "ticket_price_oracle": "0x0000000000000000000000000000000000000000",
-        "winning_probability_oracle": "0x0000000000000000000000000000000000000000",
-        "token": "0x66225dE86Cac02b32f34992eb3410F59DE416698"
-      },
-      "chain": "xdai",
-      "confirmations": 8,
-      "environment_type": "production",
-      "indexer_start_block_number": 24097267,
-      "max_block_range": 1000,
-      "tags": ["etherscan"],
-      "tx_polling_interval": 3000,
-      "version_range": "1.89||1.90||1.91||1.92||1.93"
+      "version_range": "2.*||3.*"
     },
     "rotsee": {
       "addresses": {
@@ -99,7 +77,7 @@
       "max_block_range": 1000,
       "tags": ["etherscan"],
       "tx_polling_interval": 3000,
-      "version_range": "2.*"
+      "version_range": "2.*||3.*"
     }
   }
 }


### PR DESCRIPTION
- Fixed upload of log files to GCP for every smoke test suite
- Fixed permission problem in flake update GHA workflow
- Fixed missing Git checkout in cleanup GHA workflow
- Fixed protocol config to allow 3.x nodes in Rotsee and Dufour networks, also removed obsolete Monte Rosa network