### PR TITLE
nix: Full reformat according to RFC 166

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,8 +8,7 @@
     rust-overlay.url = "github:oxalica/rust-overlay/master";
     crane.url = "github:ipetkov/crane/v0.20.1";
     # pin it to a version which we are compatible with
-    foundry.url =
-      "github:shazow/foundry.nix/e50e7787af1b79b44680f309c94df4a71d529514";
+    foundry.url = "github:shazow/foundry.nix/e50e7787af1b79b44680f309c94df4a71d529514";
     # use change to add solc 0.8.24
     solc.url = "github:hoprnet/solc.nix/tb/20240129-solc-0.8.24";
     pre-commit.url = "github:cachix/pre-commit-hooks.nix";
@@ -27,31 +26,43 @@
   };
 
   outputs =
-    { self
-    , nixpkgs
-    , flake-utils
-    , flake-parts
-    , rust-overlay
-    , crane
-    , foundry
-    , solc
-    , pre-commit
-    , ...
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      flake-parts,
+      rust-overlay,
+      crane,
+      foundry,
+      solc,
+      pre-commit,
+      ...
     }@inputs:
     flake-parts.lib.mkFlake { inherit inputs; } {
-      imports =
-        [ inputs.treefmt-nix.flakeModule inputs.flake-root.flakeModule ];
-      perSystem = { config, lib, system, ... }:
+      imports = [
+        inputs.treefmt-nix.flakeModule
+        inputs.flake-root.flakeModule
+      ];
+      perSystem =
+        {
+          config,
+          lib,
+          system,
+          ...
+        }:
         let
           rev = toString (self.shortRev or self.dirtyShortRev);
           fs = lib.fileset;
           localSystem = system;
-          overlays = [ (import rust-overlay) foundry.overlay solc.overlay ];
+          overlays = [
+            (import rust-overlay)
+            foundry.overlay
+            solc.overlay
+          ];
           pkgs = import nixpkgs { inherit localSystem overlays; };
           buildPlatform = pkgs.stdenv.buildPlatform;
           solcDefault = solc.mkDefault pkgs pkgs.solc_0_8_19;
-          craneLib = (crane.mkLib pkgs).overrideToolchain
-            (p: p.rust-bin.stable.latest.default);
+          craneLib = (crane.mkLib pkgs).overrideToolchain (p: p.rust-bin.stable.latest.default);
           hoprdCrateInfoOriginal = craneLib.crateNameFromCargoToml {
             cargoToml = ./hopr/hopr-lib/Cargo.toml;
           };
@@ -59,9 +70,9 @@
             pname = "hoprd";
             # normalize the version to not include any suffixes so the cache
             # does not get busted
-            version = pkgs.lib.strings.concatStringsSep "."
-              (pkgs.lib.lists.take 3
-                (builtins.splitVersion hoprdCrateInfoOriginal.version));
+            version = pkgs.lib.strings.concatStringsSep "." (
+              pkgs.lib.lists.take 3 (builtins.splitVersion hoprdCrateInfoOriginal.version)
+            );
           };
           depsSrc = fs.toSource {
             root = ./.;
@@ -90,42 +101,91 @@
           };
 
           rust-builder-local = import ./nix/rust-builder.nix {
-            inherit nixpkgs rust-overlay crane foundry solc localSystem;
+            inherit
+              nixpkgs
+              rust-overlay
+              crane
+              foundry
+              solc
+              localSystem
+              ;
           };
 
           rust-builder-local-nightly = import ./nix/rust-builder.nix {
-            inherit nixpkgs rust-overlay crane foundry solc localSystem;
+            inherit
+              nixpkgs
+              rust-overlay
+              crane
+              foundry
+              solc
+              localSystem
+              ;
             useRustNightly = true;
           };
 
           rust-builder-x86_64-linux = import ./nix/rust-builder.nix {
-            inherit nixpkgs rust-overlay crane foundry solc localSystem;
+            inherit
+              nixpkgs
+              rust-overlay
+              crane
+              foundry
+              solc
+              localSystem
+              ;
             crossSystem = pkgs.lib.systems.examples.musl64;
             isCross = true;
             isStatic = true;
           };
 
           rust-builder-x86_64-darwin = import ./nix/rust-builder.nix {
-            inherit nixpkgs rust-overlay crane foundry solc localSystem;
+            inherit
+              nixpkgs
+              rust-overlay
+              crane
+              foundry
+              solc
+              localSystem
+              ;
             crossSystem = pkgs.lib.systems.examples.x86_64-darwin;
             isCross = true;
           };
 
           rust-builder-aarch64-linux = import ./nix/rust-builder.nix {
-            inherit nixpkgs rust-overlay crane foundry solc localSystem;
+            inherit
+              nixpkgs
+              rust-overlay
+              crane
+              foundry
+              solc
+              localSystem
+              ;
             crossSystem = pkgs.lib.systems.examples.aarch64-multiplatform-musl;
             isCross = true;
             isStatic = true;
           };
 
           rust-builder-aarch64-darwin = import ./nix/rust-builder.nix {
-            inherit nixpkgs rust-overlay crane foundry solc localSystem;
+            inherit
+              nixpkgs
+              rust-overlay
+              crane
+              foundry
+              solc
+              localSystem
+              ;
             crossSystem = pkgs.lib.systems.examples.aarch64-darwin;
             isCross = true;
           };
 
           rust-builder-armv7l-linux = import ./nix/rust-builder.nix {
-            inherit nixpkgs rust-overlay crane foundry solc localSystem;
+            inherit
+              nixpkgs
+              rust-overlay
+              crane
+              foundry
+              solc
+              localSystem
+              ;
             crossSystem = pkgs.lib.systems.examples.armv7l-hf-multiplatform;
             isCross = true;
           };
@@ -136,55 +196,51 @@
             cargoToml = ./hoprd/hoprd/Cargo.toml;
           };
 
-          hoprd = rust-builder-local.callPackage ./nix/rust-package.nix
-            hoprdBuildArgs;
+          hoprd = rust-builder-local.callPackage ./nix/rust-package.nix hoprdBuildArgs;
           # also used for Docker image
-          hoprd-x86_64-linux =
-            rust-builder-x86_64-linux.callPackage ./nix/rust-package.nix
-              hoprdBuildArgs;
+          hoprd-x86_64-linux = rust-builder-x86_64-linux.callPackage ./nix/rust-package.nix hoprdBuildArgs;
           # also used for Docker image
-          hoprd-x86_64-linux-dev =
-            rust-builder-x86_64-linux.callPackage ./nix/rust-package.nix
-              (hoprdBuildArgs // { CARGO_PROFILE = "dev"; });
-          hoprd-aarch64-linux =
-            rust-builder-aarch64-linux.callPackage ./nix/rust-package.nix
-              hoprdBuildArgs;
-          hoprd-armv7l-linux =
-            rust-builder-armv7l-linux.callPackage ./nix/rust-package.nix
-              hoprdBuildArgs;
+          hoprd-x86_64-linux-dev = rust-builder-x86_64-linux.callPackage ./nix/rust-package.nix (
+            hoprdBuildArgs // { CARGO_PROFILE = "dev"; }
+          );
+          hoprd-aarch64-linux = rust-builder-aarch64-linux.callPackage ./nix/rust-package.nix hoprdBuildArgs;
+          hoprd-armv7l-linux = rust-builder-armv7l-linux.callPackage ./nix/rust-package.nix hoprdBuildArgs;
           # CAVEAT: must be built from a darwin system
-          hoprd-x86_64-darwin =
-            rust-builder-x86_64-darwin.callPackage ./nix/rust-package.nix
-              hoprdBuildArgs;
+          hoprd-x86_64-darwin = rust-builder-x86_64-darwin.callPackage ./nix/rust-package.nix hoprdBuildArgs;
           # CAVEAT: must be built from a darwin system
-          hoprd-aarch64-darwin =
-            rust-builder-aarch64-darwin.callPackage ./nix/rust-package.nix
-              hoprdBuildArgs;
+          hoprd-aarch64-darwin = rust-builder-aarch64-darwin.callPackage ./nix/rust-package.nix hoprdBuildArgs;
 
-          hopr-test = rust-builder-local.callPackage ./nix/rust-package.nix
-            (hoprdBuildArgs // { runTests = true; });
+          hopr-test = rust-builder-local.callPackage ./nix/rust-package.nix (
+            hoprdBuildArgs // { runTests = true; }
+          );
 
-          hopr-test-nightly =
-            rust-builder-local-nightly.callPackage ./nix/rust-package.nix
-              (hoprdBuildArgs // {
-                runTests = true;
-                cargoExtraArgs = "-Z panic-abort-tests";
-              });
+          hopr-test-nightly = rust-builder-local-nightly.callPackage ./nix/rust-package.nix (
+            hoprdBuildArgs
+            // {
+              runTests = true;
+              cargoExtraArgs = "-Z panic-abort-tests";
+            }
+          );
 
-          hoprd-clippy = rust-builder-local.callPackage ./nix/rust-package.nix
-            (hoprdBuildArgs // { runClippy = true; });
-          hoprd-dev = rust-builder-local.callPackage ./nix/rust-package.nix
-            (hoprdBuildArgs // { CARGO_PROFILE = "dev"; });
+          hoprd-clippy = rust-builder-local.callPackage ./nix/rust-package.nix (
+            hoprdBuildArgs // { runClippy = true; }
+          );
+          hoprd-dev = rust-builder-local.callPackage ./nix/rust-package.nix (
+            hoprdBuildArgs // { CARGO_PROFILE = "dev"; }
+          );
           # build candidate binary as static on Linux amd64 to get more test exposure specifically via smoke tests
           hoprd-candidate =
             if buildPlatform.isLinux && buildPlatform.isx86_64 then
-              rust-builder-x86_64-linux.callPackage ./nix/rust-package.nix
-                (hoprdBuildArgs // { CARGO_PROFILE = "candidate"; })
+              rust-builder-x86_64-linux.callPackage ./nix/rust-package.nix (
+                hoprdBuildArgs // { CARGO_PROFILE = "candidate"; }
+              )
             else
-              rust-builder-local.callPackage ./nix/rust-package.nix
-                (hoprdBuildArgs // { CARGO_PROFILE = "candidate"; });
-          hoprd-bench = rust-builder-local.callPackage ./nix/rust-package.nix
-            (hoprdBuildArgs // { runBench = true; });
+              rust-builder-local.callPackage ./nix/rust-package.nix (
+                hoprdBuildArgs // { CARGO_PROFILE = "candidate"; }
+              );
+          hoprd-bench = rust-builder-local.callPackage ./nix/rust-package.nix (
+            hoprdBuildArgs // { runBench = true; }
+          );
 
           hopliBuildArgs = {
             inherit src depsSrc rev;
@@ -195,43 +251,36 @@
             '';
           };
 
-          hopli = rust-builder-local.callPackage ./nix/rust-package.nix
-            hopliBuildArgs;
+          hopli = rust-builder-local.callPackage ./nix/rust-package.nix hopliBuildArgs;
           # also used for Docker image
-          hopli-x86_64-linux =
-            rust-builder-x86_64-linux.callPackage ./nix/rust-package.nix
-              hopliBuildArgs;
+          hopli-x86_64-linux = rust-builder-x86_64-linux.callPackage ./nix/rust-package.nix hopliBuildArgs;
           # also used for Docker image
-          hopli-x86_64-linux-dev =
-            rust-builder-x86_64-linux.callPackage ./nix/rust-package.nix
-              (hopliBuildArgs // { CARGO_PROFILE = "dev"; });
-          hopli-aarch64-linux =
-            rust-builder-aarch64-linux.callPackage ./nix/rust-package.nix
-              hopliBuildArgs;
-          hopli-armv7l-linux =
-            rust-builder-armv7l-linux.callPackage ./nix/rust-package.nix
-              hopliBuildArgs;
+          hopli-x86_64-linux-dev = rust-builder-x86_64-linux.callPackage ./nix/rust-package.nix (
+            hopliBuildArgs // { CARGO_PROFILE = "dev"; }
+          );
+          hopli-aarch64-linux = rust-builder-aarch64-linux.callPackage ./nix/rust-package.nix hopliBuildArgs;
+          hopli-armv7l-linux = rust-builder-armv7l-linux.callPackage ./nix/rust-package.nix hopliBuildArgs;
           # CAVEAT: must be built from a darwin system
-          hopli-x86_64-darwin =
-            rust-builder-x86_64-darwin.callPackage ./nix/rust-package.nix
-              hopliBuildArgs;
+          hopli-x86_64-darwin = rust-builder-x86_64-darwin.callPackage ./nix/rust-package.nix hopliBuildArgs;
           # CAVEAT: must be built from a darwin system
-          hopli-aarch64-darwin =
-            rust-builder-aarch64-darwin.callPackage ./nix/rust-package.nix
-              hopliBuildArgs;
+          hopli-aarch64-darwin = rust-builder-aarch64-darwin.callPackage ./nix/rust-package.nix hopliBuildArgs;
 
-          hopli-clippy = rust-builder-local.callPackage ./nix/rust-package.nix
-            (hopliBuildArgs // { runClippy = true; });
-          hopli-dev = rust-builder-local.callPackage ./nix/rust-package.nix
-            (hopliBuildArgs // { CARGO_PROFILE = "dev"; });
+          hopli-clippy = rust-builder-local.callPackage ./nix/rust-package.nix (
+            hopliBuildArgs // { runClippy = true; }
+          );
+          hopli-dev = rust-builder-local.callPackage ./nix/rust-package.nix (
+            hopliBuildArgs // { CARGO_PROFILE = "dev"; }
+          );
           # build candidate binary as static on Linux amd64 to get more test exposure specifically via smoke tests
           hopli-candidate =
             if buildPlatform.isLinux && buildPlatform.isx86_64 then
-              rust-builder-x86_64-linux.callPackage ./nix/rust-package.nix
-                (hopliBuildArgs // { CARGO_PROFILE = "candidate"; })
+              rust-builder-x86_64-linux.callPackage ./nix/rust-package.nix (
+                hopliBuildArgs // { CARGO_PROFILE = "candidate"; }
+              )
             else
-              rust-builder-local.callPackage ./nix/rust-package.nix
-                (hopliBuildArgs // { CARGO_PROFILE = "candidate"; });
+              rust-builder-local.callPackage ./nix/rust-package.nix (
+                hopliBuildArgs // { CARGO_PROFILE = "candidate"; }
+              );
 
           profileDeps = with pkgs; [
             gdb
@@ -241,38 +290,37 @@
             valgrind
           ];
 
-          dockerHoprdEntrypoint =
-            pkgs.writeShellScriptBin "docker-entrypoint.sh" ''
-              set -euo pipefail
+          dockerHoprdEntrypoint = pkgs.writeShellScriptBin "docker-entrypoint.sh" ''
+            set -euo pipefail
 
-              # if the default listen host has not been set by the user,
-              # we will set it to the container's ip address
-              # defaulting to random port
+            # if the default listen host has not been set by the user,
+            # we will set it to the container's ip address
+            # defaulting to random port
 
-              listen_host="''${HOPRD_DEFAULT_SESSION_LISTEN_HOST:-}"
-              listen_host_preset_ip="''${listen_host%%:*}"
-              listen_host_preset_port="''${listen_host#*:}"
+            listen_host="''${HOPRD_DEFAULT_SESSION_LISTEN_HOST:-}"
+            listen_host_preset_ip="''${listen_host%%:*}"
+            listen_host_preset_port="''${listen_host#*:}"
 
-              if [ -z "''${listen_host_preset_ip:-}" ]; then
-                listen_host_ip="$(hostname -i)"
+            if [ -z "''${listen_host_preset_ip:-}" ]; then
+              listen_host_ip="$(hostname -i)"
 
-                if [ -z "''${listen_host_preset_port:-}" ]; then
-                  listen_host="''${listen_host_ip}:0"
-                else
-                  listen_host="''${listen_host_ip}:''${listen_host_preset_port}"
-                fi
-              fi
-
-              export HOPRD_DEFAULT_SESSION_LISTEN_HOST="''${listen_host}"
-
-              if [ -n "''${1:-}" ] && [ -f "/bin/''${1:-}" ] && [ -x "/bin/''${1:-}" ]; then
-                # allow execution of auxiliary commands
-                exec "$@"
+              if [ -z "''${listen_host_preset_port:-}" ]; then
+                listen_host="''${listen_host_ip}:0"
               else
-                # default to hoprd
-                exec /bin/hoprd "$@"
+                listen_host="''${listen_host_ip}:''${listen_host_preset_port}"
               fi
-            '';
+            fi
+
+            export HOPRD_DEFAULT_SESSION_LISTEN_HOST="''${listen_host}"
+
+            if [ -n "''${1:-}" ] && [ -f "/bin/''${1:-}" ] && [ -x "/bin/''${1:-}" ]; then
+              # allow execution of auxiliary commands
+              exec "$@"
+            else
+              # default to hoprd
+              exec /bin/hoprd "$@"
+            fi
+          '';
 
           # FIXME: the docker image built is not working on macOS arm platforms
           # and will simply lead to a non-working image. Likely, some form of
@@ -280,16 +328,18 @@
           hoprdDockerArgs = package: deps: {
             inherit pkgs;
             name = "hoprd";
-            extraContents = [ dockerHoprdEntrypoint package ] ++ deps;
+            extraContents = [
+              dockerHoprdEntrypoint
+              package
+            ] ++ deps;
             Entrypoint = [ "/bin/docker-entrypoint.sh" ];
             Cmd = [ "hoprd" ];
           };
-          hoprd-docker = import ./nix/docker-builder.nix
-            (hoprdDockerArgs hoprd-x86_64-linux [ ]);
-          hoprd-dev-docker = import ./nix/docker-builder.nix
-            (hoprdDockerArgs hoprd-x86_64-linux-dev [ ]);
-          hoprd-profile-docker = import ./nix/docker-builder.nix
-            (hoprdDockerArgs hoprd-x86_64-linux profileDeps);
+          hoprd-docker = import ./nix/docker-builder.nix (hoprdDockerArgs hoprd-x86_64-linux [ ]);
+          hoprd-dev-docker = import ./nix/docker-builder.nix (hoprdDockerArgs hoprd-x86_64-linux-dev [ ]);
+          hoprd-profile-docker = import ./nix/docker-builder.nix (
+            hoprdDockerArgs hoprd-x86_64-linux profileDeps
+          );
 
           hopliDockerArgs = package: deps: {
             inherit pkgs;
@@ -301,12 +351,11 @@
               "HOPLI_CONTRACTS_ROOT=${package}/ethereum/contracts"
             ];
           };
-          hopli-docker = import ./nix/docker-builder.nix
-            (hopliDockerArgs hopli-x86_64-linux [ ]);
-          hopli-dev-docker = import ./nix/docker-builder.nix
-            (hopliDockerArgs hopli-x86_64-linux-dev [ ]);
-          hopli-profile-docker = import ./nix/docker-builder.nix
-            (hopliDockerArgs hopli-x86_64-linux profileDeps);
+          hopli-docker = import ./nix/docker-builder.nix (hopliDockerArgs hopli-x86_64-linux [ ]);
+          hopli-dev-docker = import ./nix/docker-builder.nix (hopliDockerArgs hopli-x86_64-linux-dev [ ]);
+          hopli-profile-docker = import ./nix/docker-builder.nix (
+            hopliDockerArgs hopli-x86_64-linux profileDeps
+          );
 
           anvilSrc = fs.toSource {
             root = ./.;
@@ -320,10 +369,8 @@
               ./Makefile
               (fs.fileFilter (file: file.hasExt "sol") ./vendor/solidity)
               (fs.fileFilter (file: file.hasExt "sol") ./ethereum/contracts/src)
-              (fs.fileFilter (file: file.hasExt "sol")
-                ./ethereum/contracts/script)
-              (fs.fileFilter (file: file.hasExt "sol")
-                ./ethereum/contracts/test)
+              (fs.fileFilter (file: file.hasExt "sol") ./ethereum/contracts/script)
+              (fs.fileFilter (file: file.hasExt "sol") ./ethereum/contracts/test)
             ];
           };
           anvil-docker = pkgs.dockerTools.buildLayeredImage {
@@ -376,8 +423,15 @@
               ${pkgs.foundry-bin}/bin/forge build --root /ethereum/contracts
             '';
             config = {
-              Cmd = [ "/bin/tini" "--" "bash" "/scripts/run-local-anvil.sh" ];
-              ExposedPorts = { "8545/tcp" = { }; };
+              Cmd = [
+                "/bin/tini"
+                "--"
+                "bash"
+                "/scripts/run-local-anvil.sh"
+              ];
+              ExposedPorts = {
+                "8545/tcp" = { };
+              };
             };
           };
           plutoSrc = fs.toSource {
@@ -397,10 +451,8 @@
               ./Makefile
               (fs.fileFilter (file: file.hasExt "sol") ./vendor/solidity)
               (fs.fileFilter (file: file.hasExt "sol") ./ethereum/contracts/src)
-              (fs.fileFilter (file: file.hasExt "sol")
-                ./ethereum/contracts/script)
-              (fs.fileFilter (file: file.hasExt "sol")
-                ./ethereum/contracts/test)
+              (fs.fileFilter (file: file.hasExt "sol") ./ethereum/contracts/script)
+              (fs.fileFilter (file: file.hasExt "sol") ./ethereum/contracts/test)
             ];
           };
           hopr-pluto = pkgs.dockerTools.buildLayeredImage {
@@ -463,7 +515,12 @@
 
             '';
             config = {
-              Cmd = [ "/bin/tini" "--" "bash" "/scripts/run-local-cluster.sh" ];
+              Cmd = [
+                "/bin/tini"
+                "--"
+                "bash"
+                "/scripts/run-local-cluster.sh"
+              ];
               ExposedPorts = {
                 "8545/tcp" = { };
                 "3001-3006/tcp" = { };
@@ -472,7 +529,8 @@
             };
           };
 
-          dockerImageUploadScript = image:
+          dockerImageUploadScript =
+            image:
             pkgs.writeShellScriptBin "docker-image-upload" ''
               set -eu
               OCI_ARCHIVE="$(nix build --no-link --print-out-paths ${image})"
@@ -498,18 +556,19 @@
           hopli-profile-docker-build-and-upload = flake-utils.lib.mkApp {
             drv = dockerImageUploadScript hopli-profile-docker;
           };
-          hopr-pluto-docker-build-and-upload =
-            flake-utils.lib.mkApp { drv = dockerImageUploadScript hopr-pluto; };
-          docs = rust-builder-local-nightly.callPackage ./nix/rust-package.nix
-            (hoprdBuildArgs // { buildDocs = true; });
+          hopr-pluto-docker-build-and-upload = flake-utils.lib.mkApp {
+            drv = dockerImageUploadScript hopr-pluto;
+          };
+          docs = rust-builder-local-nightly.callPackage ./nix/rust-package.nix (
+            hoprdBuildArgs // { buildDocs = true; }
+          );
           smoke-tests = pkgs.stdenv.mkDerivation {
             pname = "hoprd-smoke-tests";
             version = hoprdCrateInfo.version;
             src = fs.toSource {
               root = ./.;
               fileset = fs.unions [
-                (fs.fileFilter (file: file.hasExt "sol")
-                  ./ethereum/contracts/src)
+                (fs.fileFilter (file: file.hasExt "sol") ./ethereum/contracts/src)
                 ./tests
                 ./scripts
                 ./sdk/python
@@ -550,20 +609,45 @@
             tools = pkgs;
           };
           devShell = import ./nix/devShell.nix {
-            inherit pkgs config crane pre-commit-check solcDefault;
+            inherit
+              pkgs
+              config
+              crane
+              pre-commit-check
+              solcDefault
+              ;
           };
           ciShell = import ./nix/ciShell.nix { inherit pkgs config crane; };
           testShell = import ./nix/testShell.nix {
-            inherit pkgs config crane solcDefault;
+            inherit
+              pkgs
+              config
+              crane
+              solcDefault
+              ;
           };
           ciTestShell = import ./nix/ciTestShell.nix {
-            inherit pkgs config crane solcDefault;
+            inherit
+              pkgs
+              config
+              crane
+              solcDefault
+              ;
             hoprd = hoprd-candidate;
             hopli = hopli-candidate;
           };
           docsShell = import ./nix/devShell.nix {
-            inherit pkgs config crane pre-commit-check solcDefault;
-            extraPackages = with pkgs; [ html-tidy pandoc ];
+            inherit
+              pkgs
+              config
+              crane
+              pre-commit-check
+              solcDefault
+              ;
+            extraPackages = with pkgs; [
+              html-tidy
+              pandoc
+            ];
             useRustNightly = true;
           };
           run-check = flake-utils.lib.mkApp {
@@ -582,7 +666,10 @@
           run-audit = flake-utils.lib.mkApp {
             drv = pkgs.writeShellApplication {
               name = "audit";
-              runtimeInputs = [ pkgs.cargo pkgs.cargo-audit ];
+              runtimeInputs = [
+                pkgs.cargo
+                pkgs.cargo-audit
+              ];
               text = ''
                 cargo audit
               '';
@@ -656,8 +743,10 @@
             ];
 
             programs.yamlfmt.enable = true;
-            settings.formatter.yamlfmt.includes =
-              [ ".github/labeler.yml" ".github/workflows/*.yaml" ];
+            settings.formatter.yamlfmt.includes = [
+              ".github/labeler.yml"
+              ".github/workflows/*.yaml"
+            ];
             # trying setting from https://github.com/google/yamlfmt/blob/main/docs/config-file.md
             settings.formatter.yamlfmt.settings = {
               formatter.type = "basic";
@@ -668,13 +757,20 @@
             };
 
             programs.prettier.enable = true;
-            settings.formatter.prettier.includes =
-              [ "*.md" "*.json" "ethereum/contracts/README.md" ];
-            settings.formatter.prettier.excludes =
-              [ "ethereum/contracts/*" "*.yml" "*.yaml" ];
-
+            settings.formatter.prettier.includes = [
+              "*.md"
+              "*.json"
+              "ethereum/contracts/README.md"
+            ];
+            settings.formatter.prettier.excludes = [
+              "ethereum/contracts/*"
+              "*.yml"
+              "*.yaml"
+            ];
             programs.rustfmt.enable = true;
-            programs.nixpkgs-fmt.enable = true;
+            # using the official Nixpkgs formatting
+            # see  # https://github.com/NixOS/rfcs/blob/master/rfcs/0166-nix-formatting.md
+            programs.nixfmt.enable = true;
             programs.taplo.enable = true;
             programs.ruff-format.enable = true;
 
@@ -722,10 +818,20 @@
           };
 
           packages = {
-            inherit hoprd hoprd-dev hoprd-docker hoprd-dev-docker
-              hoprd-profile-docker;
-            inherit hopli hopli-dev hopli-docker hopli-dev-docker
-              hopli-profile-docker;
+            inherit
+              hoprd
+              hoprd-dev
+              hoprd-docker
+              hoprd-dev-docker
+              hoprd-profile-docker
+              ;
+            inherit
+              hopli
+              hopli-dev
+              hopli-docker
+              hopli-dev-docker
+              hopli-profile-docker
+              ;
             inherit hoprd-candidate hopli-candidate;
             inherit hopr-test hopr-test-nightly;
             inherit anvil-docker hopr-pluto;
@@ -750,7 +856,11 @@
           formatter = config.treefmt.build.wrapper;
         };
       # platforms which are supported as build environments
-      systems =
-        [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
     };
 }

--- a/nix/cargo-bench.nix
+++ b/nix/cargo-bench.nix
@@ -1,20 +1,25 @@
-{ mkCargoDerivation
+{
+  mkCargoDerivation,
 }:
 
-{ cargoArtifacts
+{
+  cargoArtifacts,
 
-, ...
+  ...
 }@origArgs:
 let
   args = builtins.removeAttrs origArgs [
     "cargoExtraArgs"
   ];
 in
-mkCargoDerivation (args // {
-  inherit cargoArtifacts;
-  pnameSuffix = "-bench";
+mkCargoDerivation (
+  args
+  // {
+    inherit cargoArtifacts;
+    pnameSuffix = "-bench";
 
-  buildPhaseCargoCommand = "cargo bench --locked";
+    buildPhaseCargoCommand = "cargo bench --locked";
 
-  nativeBuildInputs = (args.nativeBuildInputs or [ ]);
-})
+    nativeBuildInputs = (args.nativeBuildInputs or [ ]);
+  }
+)

--- a/nix/ciShell.nix
+++ b/nix/ciShell.nix
@@ -1,6 +1,7 @@
-{ pkgs
-, extraPackages ? [ ]
-, ...
+{
+  pkgs,
+  extraPackages ? [ ],
+  ...
 }@args:
 let
   mkShell = import ./mkShell.nix { };
@@ -29,6 +30,9 @@ let
     "extraPackages"
   ];
 in
-mkShell (cleanArgs // {
-  inherit shellPackages;
-})
+mkShell (
+  cleanArgs
+  // {
+    inherit shellPackages;
+  }
+)

--- a/nix/ciTestShell.nix
+++ b/nix/ciTestShell.nix
@@ -1,8 +1,9 @@
-{ pkgs
-, extraPackages ? [ ]
-, hoprd
-, hopli
-, ...
+{
+  pkgs,
+  extraPackages ? [ ],
+  hoprd,
+  hopli,
+  ...
 }@args:
 let
   packages = with pkgs; [
@@ -14,6 +15,9 @@ let
     "hopli"
   ];
 in
-import ./testShell.nix (cleanArgs // {
-  extraPackages = packages ++ extraPackages;
-})
+import ./testShell.nix (
+  cleanArgs
+  // {
+    extraPackages = packages ++ extraPackages;
+  }
+)

--- a/nix/devShell.nix
+++ b/nix/devShell.nix
@@ -1,8 +1,9 @@
-{ pkgs
-, extraPackages ? [ ]
-, pre-commit-check
-, solcDefault
-, ...
+{
+  pkgs,
+  extraPackages ? [ ],
+  pre-commit-check,
+  solcDefault,
+  ...
 }@args:
 let
   shellHook = ''
@@ -14,6 +15,9 @@ let
     "pre-commit-check"
   ];
 in
-import ./testShell.nix (cleanArgs // {
-  inherit shellHook shellPackages;
-})
+import ./testShell.nix (
+  cleanArgs
+  // {
+    inherit shellHook shellPackages;
+  }
+)

--- a/nix/docker-builder.nix
+++ b/nix/docker-builder.nix
@@ -1,8 +1,24 @@
-{ Cmd ? [ ], Entrypoint, env ? [ ], extraContents ? [ ], name, pkgs }:
+{
+  Cmd ? [ ],
+  Entrypoint,
+  env ? [ ],
+  extraContents ? [ ],
+  name,
+  pkgs,
+}:
 let
   libPath = pkgs.lib.makeLibraryPath [ pkgs.openssl ];
-  contents = with pkgs;
-    [ bash cacert coreutils findutils iana-etc nettools ] ++ extraContents;
+  contents =
+    with pkgs;
+    [
+      bash
+      cacert
+      coreutils
+      findutils
+      iana-etc
+      nettools
+    ]
+    ++ extraContents;
   Env = [
     "NO_COLOR=true" # suppress colored log output
     # "RUST_LOG=info"   # 'info' level is set by default with some spamming components set to override

--- a/nix/rust-builder.nix
+++ b/nix/rust-builder.nix
@@ -1,35 +1,46 @@
-{ crane
-, crossSystem ? localSystem
-, foundry
-, isCross ? false
-, isStatic ? false
-, localSystem
-, nixpkgs
-, rust-overlay
-, solc
-, useRustNightly ? false
+{
+  crane,
+  crossSystem ? localSystem,
+  foundry,
+  isCross ? false,
+  isStatic ? false,
+  localSystem,
+  nixpkgs,
+  rust-overlay,
+  solc,
+  useRustNightly ? false,
 }@args:
-let crossSystem0 = crossSystem;
-in let
+let
+  crossSystem0 = crossSystem;
+in
+let
   # the foundry overlay uses the hostPlatform, so we need to use a
   # localSystem-only pkgs to get the correct architecture
   pkgsLocal = import nixpkgs {
     localSystem = args.localSystem;
-    overlays = [ foundry.overlay rust-overlay.overlays.default solc.overlay ];
+    overlays = [
+      foundry.overlay
+      rust-overlay.overlays.default
+      solc.overlay
+    ];
   };
 
   localSystem = pkgsLocal.lib.systems.elaborate args.localSystem;
   crossSystem =
-    let system = pkgsLocal.lib.systems.elaborate crossSystem0;
-    in if crossSystem0 == null
-      || pkgsLocal.lib.systems.equals system localSystem then
+    let
+      system = pkgsLocal.lib.systems.elaborate crossSystem0;
+    in
+    if crossSystem0 == null || pkgsLocal.lib.systems.equals system localSystem then
       localSystem
     else
       system;
 
   pkgs = import nixpkgs {
     inherit localSystem crossSystem;
-    overlays = [ rust-overlay.overlays.default solc.overlay ];
+    overlays = [
+      rust-overlay.overlays.default
+      solc.overlay
+    ];
   };
 
   # `buildPlatform` is the local host platform
@@ -39,9 +50,7 @@ in let
 
   foundryBin = pkgsLocal.foundry-bin;
 
-  envCase = triple:
-    pkgsLocal.lib.strings.toUpper
-      (builtins.replaceStrings [ "-" ] [ "_" ] triple);
+  envCase = triple: pkgsLocal.lib.strings.toUpper (builtins.replaceStrings [ "-" ] [ "_" ] triple);
 
   solcDefault = solc.mkDefault pkgs pkgs.pkgsBuildHost.solc_0_8_19;
 
@@ -56,8 +65,9 @@ in let
       p: p.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default)
     else
       p:
-      (p.pkgsBuildHost.rust-bin.fromRustupToolchainFile
-        ../rust-toolchain.toml).override { targets = [ cargoTarget ]; };
+      (p.pkgsBuildHost.rust-bin.fromRustupToolchainFile ../rust-toolchain.toml).override {
+        targets = [ cargoTarget ];
+      };
 
   craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchainFun;
 
@@ -66,16 +76,16 @@ in let
 
   buildEnvBase = {
     CARGO_BUILD_TARGET = cargoTarget;
-    "CARGO_TARGET_${envCase cargoTarget}_LINKER" =
-      "${pkgs.stdenv.cc.targetPrefix}cc";
+    "CARGO_TARGET_${envCase cargoTarget}_LINKER" = "${pkgs.stdenv.cc.targetPrefix}cc";
     HOST_CC = "${pkgs.stdenv.cc.nativePrefix}cc";
     CARGO_BUILD_RUSTFLAGS = "-C link-arg=-fuse-ld=${linker}";
   };
   buildEnvStatic =
-    if isStatic then {
-      CARGO_BUILD_RUSTFLAGS =
-        "${buildEnvBase.CARGO_BUILD_RUSTFLAGS} -C target-feature=+crt-static";
-    } else
+    if isStatic then
+      {
+        CARGO_BUILD_RUSTFLAGS = "${buildEnvBase.CARGO_BUILD_RUSTFLAGS} -C target-feature=+crt-static";
+      }
+    else
       { };
 
   buildEnv = buildEnvBase // buildEnvStatic;
@@ -84,19 +94,34 @@ in
 {
   # inherit rustToolchain;
 
-  callPackage = (package: args:
+  callPackage = (
+    package: args:
     let
-      crate = pkgs.callPackage package
-        (args // { inherit foundryBin solcDefault craneLib isCross isStatic; });
-      # Override the derivation to add cross-compilation environment variables.
+      crate = pkgs.callPackage package (
+        args
+        // {
+          inherit
+            foundryBin
+            solcDefault
+            craneLib
+            isCross
+            isStatic
+            ;
+        }
+      );
     in
-    crate.overrideAttrs (previous:
-      buildEnv // {
+    # Override the derivation to add cross-compilation environment variables.
+    crate.overrideAttrs (
+      previous:
+      buildEnv
+      // {
         # We also have to override the `cargoArtifacts` derivation with the same changes.
         cargoArtifacts =
           if previous.cargoArtifacts != null then
             previous.cargoArtifacts.overrideAttrs (previous: buildEnv)
           else
             null;
-      }));
+      }
+    )
+  );
 }

--- a/nix/testShell.nix
+++ b/nix/testShell.nix
@@ -1,27 +1,32 @@
-{ pkgs
-, extraPackages ? [ ]
-, solcDefault
-, shellHook ? ""
-, ...
+{
+  pkgs,
+  extraPackages ? [ ],
+  solcDefault,
+  shellHook ? "",
+  ...
 }@args:
 let
   mkShell = import ./mkShell.nix { };
-  finalShellHook = ''
-    if ! grep -q "solc = \"${solcDefault}/bin/solc\"" ethereum/contracts/foundry.toml; then
-      echo "solc = \"${solcDefault}/bin/solc\""
-      echo "Generating foundry.toml file!"
-      sed "s|# solc = .*|solc = \"${solcDefault}/bin/solc\"|g" \
-        ethereum/contracts/foundry.in.toml >| \
-        ethereum/contracts/foundry.toml
-    else
-      echo "foundry.toml file already exists!"
-    fi
-  '' + ''
-    uv sync --frozen
-    unset SOURCE_DATE_EPOCH
-  '' + pkgs.lib.optionalString pkgs.stdenv.isLinux ''
-    autoPatchelf ./.venv
-  '' + shellHook;
+  finalShellHook =
+    ''
+      if ! grep -q "solc = \"${solcDefault}/bin/solc\"" ethereum/contracts/foundry.toml; then
+        echo "solc = \"${solcDefault}/bin/solc\""
+        echo "Generating foundry.toml file!"
+        sed "s|# solc = .*|solc = \"${solcDefault}/bin/solc\"|g" \
+          ethereum/contracts/foundry.in.toml >| \
+          ethereum/contracts/foundry.toml
+      else
+        echo "foundry.toml file already exists!"
+      fi
+    ''
+    + ''
+      uv sync --frozen
+      unset SOURCE_DATE_EPOCH
+    ''
+    + pkgs.lib.optionalString pkgs.stdenv.isLinux ''
+      autoPatchelf ./.venv
+    ''
+    + shellHook;
   packages = with pkgs; [
     uv
     python313
@@ -35,7 +40,10 @@ let
     "shellHook"
   ];
 in
-mkShell (cleanArgs // {
-  inherit shellPackages;
-  shellHook = finalShellHook;
-})
+mkShell (
+  cleanArgs
+  // {
+    inherit shellPackages;
+    shellHook = finalShellHook;
+  }
+)


### PR DESCRIPTION
This pull request refactors multiple Nix files to improve code readability and maintainability by adopting a consistent formatting style. The changes primarily involve restructuring function arguments, reformatting lists, and improving indentation. Additionally, some minor logic adjustments and cleanups were made to streamline the code.

### General Refactoring and Formatting:
* Updated function argument definitions across all modified files to use a consistent inline object format instead of a mix of destructured and inline styles. This change improves readability and aligns with common Nix conventions. (`nix/cargo-bench.nix` - [[1]](diffhunk://#diff-2e576ca04cdc311f97e3619ce90c45ec70e7d53e6170c41045697223c62cf889L1-R25) `nix/ciShell.nix` - [[2]](diffhunk://#diff-e2b1cc06fb4e986ed68bd96ae1ad461d8cba80219bae109c09cbfbed51696e93L1-R4) `nix/ciTestShell.nix` - [[3]](diffhunk://#diff-a6a0eea64d997f52d5817e147873516af013d7ce9eab247d7728c6e52ee63857L1-R6) `nix/devShell.nix` - [[4]](diffhunk://#diff-b2e0388cca8a6e70427cfd30c940805830231c65f4a16ee177944553e65d04f0L1-R6) `nix/docker-builder.nix` - [[5]](diffhunk://#diff-d713e6aeb3aba5d4d7830fb2b36f236ef03336c65c7b85f56c66f7aa84e58577L1-R21) `nix/mkShell.nix` - [[6]](diffhunk://#diff-752d0fd4b5e4e869e73b3d6595c90ab223165d9d05b313ccd3f6da6558ea788dL3-R23) `nix/rust-builder.nix` - [[7]](diffhunk://#diff-e6d1fdf69580149a5e1ca677e574a38ec6801a9ef0030e8a87ff0cda25fe3d2bL1-R43) `nix/rust-package.nix` - [[8]](diffhunk://#diff-ddb90233e19f19be4cba88e3a2de97470eef8a4628cbb184f1d2d40df3b443b6L1-R27) `nix/testShell.nix` - [[9]](diffhunk://#diff-8c24d44470b8ff447664f6c19883951182e3ad0ac0539462dd5ecafd9a832996L1-R11)

### Logic Adjustments:
* Simplified conditional expressions and list concatenations to reduce unnecessary complexity and improve clarity. For example:
  - Adjusted the handling of `useRustNightly` in `nix/mkShell.nix` and `nix/rust-builder.nix` to improve readability. (`[[1]](diffhunk://#diff-752d0fd4b5e4e869e73b3d6595c90ab223165d9d05b313ccd3f6da6558ea788dL3-R23)`, `[[2]](diffhunk://#diff-e6d1fdf69580149a5e1ca677e574a38ec6801a9ef0030e8a87ff0cda25fe3d2bL59-R70)`)
  - Streamlined the logic for setting up Darwin-specific build inputs in `nix/rust-package.nix`. (`[[1]](diffhunk://#diff-ddb90233e19f19be4cba88e3a2de97470eef8a4628cbb184f1d2d40df3b443b6L47-R50)`, `[[2]](diffhunk://#diff-ddb90233e19f19be4cba88e3a2de97470eef8a4628cbb184f1d2d40df3b443b6L93-R118)`)

### Consistent Formatting of Lists and Attributes:
* Reformatted long lists and attribute sets to place each item on a separate line for better readability. This change is particularly noticeable in files like `nix/docker-builder.nix`, `nix/rust-package.nix`, and `nix/rust-builder.nix`. (`[[1]](diffhunk://#diff-d713e6aeb3aba5d4d7830fb2b36f236ef03336c65c7b85f56c66f7aa84e58577L1-R21)`, `[[2]](diffhunk://#diff-ddb90233e19f19be4cba88e3a2de97470eef8a4628cbb184f1d2d40df3b443b6L93-R118)`, `[[3]](diffhunk://#diff-e6d1fdf69580149a5e1ca677e574a38ec6801a9ef0030e8a87ff0cda25fe3d2bL69-R88)`)

### Improvements to Shell Hooks:
* Refactored shell hook logic in `nix/testShell.nix` to improve readability and ensure consistent formatting for multi-line strings. (`[nix/testShell.nixL19-R29](diffhunk://#diff-8c24d44470b8ff447664f6c19883951182e3ad0ac0539462dd5ecafd9a832996L19-R29)`)

### Cleanup of Redundant Code:
* Removed unnecessary parentheses and redundant attributes in several files, such as `nix/rust-builder.nix` and `nix/rust-package.nix`, to streamline the code. (`[[1]](diffhunk://#diff-e6d1fdf69580149a5e1ca677e574a38ec6801a9ef0030e8a87ff0cda25fe3d2bL42-R53)`, `[[2]](diffhunk://#diff-ddb90233e19f19be4cba88e3a2de97470eef8a4628cbb184f1d2d40df3b443b6L154-R172)`)