### PR TITLE
Improve the tag organization for v3 packet payload format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5336,7 +5336,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "aquamarine",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5245,6 +5245,7 @@ dependencies = [
  "hopr-crypto-packet",
  "serde",
  "serde_bytes",
+ "strum 0.27.1",
  "thiserror 2.0.12",
 ]
 

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -78,7 +78,7 @@ pub use hopr_transport::{
     ApplicationData, HalfKeyChallenge, Health, IncomingSession as HoprIncomingSession, Keypair, Multiaddr,
     OffchainKeypair as HoprOffchainKeypair, PeerId, PingQueryReplier, ProbeError, SESSION_PAYLOAD_SIZE, SendMsg,
     ServiceId, Session as HoprSession, SessionCapability, SessionClientConfig, SessionId as HoprSessionId,
-    SessionTarget, SurbBalancerConfig, Tag, TicketStatistics, USABLE_PAYLOAD_CAPACITY_FOR_SESSION,
+    SessionTarget, SurbBalancerConfig, Tag, TicketStatistics,
     config::{HostConfig, HostType, looks_like_domain},
     errors::{HoprTransportError, NetworkingError, ProtocolError},
 };

--- a/hopr/hopr-lib/tests/session_integration_tests.rs
+++ b/hopr/hopr-lib/tests/session_integration_tests.rs
@@ -31,7 +31,7 @@ impl SendMsg for BufferingMsgSender {
 #[tokio::test]
 async fn udp_session_bridging() -> anyhow::Result<()> {
     let dst: Address = (&ChainKeypair::random()).into();
-    let id = SessionId::new(1u64.into(), HoprPseudonym::random());
+    let id = SessionId::new(1u64, HoprPseudonym::random());
     let (_tx, rx) = futures::channel::mpsc::unbounded();
     let (buffer_tx, mut buffer_rx) = futures::channel::mpsc::unbounded();
 
@@ -89,7 +89,7 @@ async fn udp_session_bridging() -> anyhow::Result<()> {
 #[tokio::test]
 async fn udp_session_bridging_with_segmentation() -> anyhow::Result<()> {
     let dst: Address = (&ChainKeypair::random()).into();
-    let id = SessionId::new(1u64.into(), HoprPseudonym::random());
+    let id = SessionId::new(1u64, HoprPseudonym::random());
     let (_tx, rx) = futures::channel::mpsc::unbounded();
     let (buffer_tx, mut buffer_rx) = futures::channel::mpsc::unbounded();
 
@@ -133,10 +133,7 @@ async fn udp_session_bridging_with_segmentation() -> anyhow::Result<()> {
                 .await?
                 .expect("must have data");
             if let Some(msg) =
-                SessionMessage::<{ hopr_transport_session::USABLE_PAYLOAD_CAPACITY_FOR_SESSION }>::try_from(
-                    read.as_ref(),
-                )?
-                .try_as_segment()
+                SessionMessage::<{ ApplicationData::PAYLOAD_SIZE }>::try_from(read.as_ref())?.try_as_segment()
             {
                 recv_buf.extend_from_slice(&msg.data);
             }

--- a/hopr/hopr-lib/tests/session_integration_tests.rs
+++ b/hopr/hopr-lib/tests/session_integration_tests.rs
@@ -31,7 +31,7 @@ impl SendMsg for BufferingMsgSender {
 #[tokio::test]
 async fn udp_session_bridging() -> anyhow::Result<()> {
     let dst: Address = (&ChainKeypair::random()).into();
-    let id = SessionId::new(hopr_lib::Tag(1), HoprPseudonym::random());
+    let id = SessionId::new(1u64.into(), HoprPseudonym::random());
     let (_tx, rx) = futures::channel::mpsc::unbounded();
     let (buffer_tx, mut buffer_rx) = futures::channel::mpsc::unbounded();
 
@@ -89,7 +89,7 @@ async fn udp_session_bridging() -> anyhow::Result<()> {
 #[tokio::test]
 async fn udp_session_bridging_with_segmentation() -> anyhow::Result<()> {
     let dst: Address = (&ChainKeypair::random()).into();
-    let id = SessionId::new(hopr_lib::Tag(1), HoprPseudonym::random());
+    let id = SessionId::new(1u64.into(), HoprPseudonym::random());
     let (_tx, rx) = futures::channel::mpsc::unbounded();
     let (buffer_tx, mut buffer_rx) = futures::channel::mpsc::unbounded();
 

--- a/hoprd/rest-api/src/prometheus.rs
+++ b/hoprd/rest-api/src/prometheus.rs
@@ -1,8 +1,10 @@
 use axum::{extract::Request, middleware::Next, response::Response};
-use hopr_lib::AsUnixTimestamp;
 #[cfg(all(feature = "prometheus", not(test)))]
-use hopr_metrics::metrics::{MultiCounter, MultiHistogram, SimpleGauge};
-use hopr_platform::time::native::current_time;
+use {
+    hopr_lib::AsUnixTimestamp,
+    hopr_metrics::metrics::{MultiCounter, MultiHistogram, SimpleGauge},
+    hopr_platform::time::native::current_time,
+};
 
 #[cfg(all(feature = "prometheus", not(test)))]
 lazy_static::lazy_static! {

--- a/hoprd/rest-api/src/session.rs
+++ b/hoprd/rest-api/src/session.rs
@@ -1062,7 +1062,7 @@ mod tests {
     -> anyhow::Result<()> {
         let (tx, rx) = futures::channel::mpsc::unbounded::<Box<[u8]>>();
 
-        let session_id = hopr_lib::HoprSessionId::new(4567u64.into(), HoprPseudonym::random());
+        let session_id = hopr_lib::HoprSessionId::new(4567u64, HoprPseudonym::random());
         let peer: hopr_lib::Address = "0x5112D584a1C72Fc250176B57aEba5fFbbB287D8F".parse()?;
         let session = hopr_lib::HoprSession::new(
             session_id,
@@ -1108,7 +1108,7 @@ mod tests {
     -> anyhow::Result<()> {
         let (tx, rx) = futures::channel::mpsc::unbounded::<Box<[u8]>>();
 
-        let session_id = hopr_lib::HoprSessionId::new(4567u64.into(), HoprPseudonym::random());
+        let session_id = hopr_lib::HoprSessionId::new(4567u64, HoprPseudonym::random());
         let peer: hopr_lib::Address = "0x5112D584a1C72Fc250176B57aEba5fFbbB287D8F".parse()?;
         let session = hopr_lib::HoprSession::new(
             session_id,
@@ -1127,11 +1127,11 @@ mod tests {
         tokio::task::spawn(bind_session_to_stream(
             session,
             udp_listener,
-            hopr_lib::USABLE_PAYLOAD_CAPACITY_FOR_SESSION,
+            ApplicationData::PAYLOAD_SIZE,
         ));
 
         let mut udp_stream = ConnectedUdpStream::builder()
-            .with_buffer_size(hopr_lib::USABLE_PAYLOAD_CAPACITY_FOR_SESSION)
+            .with_buffer_size(ApplicationData::PAYLOAD_SIZE)
             .with_queue_size(HOPR_UDP_QUEUE_SIZE)
             .with_counterparty(listen_addr)
             .build(("127.0.0.1", 0))

--- a/hoprd/rest-api/src/session.rs
+++ b/hoprd/rest-api/src/session.rs
@@ -1062,7 +1062,7 @@ mod tests {
     -> anyhow::Result<()> {
         let (tx, rx) = futures::channel::mpsc::unbounded::<Box<[u8]>>();
 
-        let session_id = hopr_lib::HoprSessionId::new(hopr_lib::Tag(4567), HoprPseudonym::random());
+        let session_id = hopr_lib::HoprSessionId::new(4567u64.into(), HoprPseudonym::random());
         let peer: hopr_lib::Address = "0x5112D584a1C72Fc250176B57aEba5fFbbB287D8F".parse()?;
         let session = hopr_lib::HoprSession::new(
             session_id,
@@ -1108,7 +1108,7 @@ mod tests {
     -> anyhow::Result<()> {
         let (tx, rx) = futures::channel::mpsc::unbounded::<Box<[u8]>>();
 
-        let session_id = hopr_lib::HoprSessionId::new(hopr_lib::Tag(4567), HoprPseudonym::random());
+        let session_id = hopr_lib::HoprSessionId::new(4567u64.into(), HoprPseudonym::random());
         let peer: hopr_lib::Address = "0x5112D584a1C72Fc250176B57aEba5fFbbB287D8F".parse()?;
         let session = hopr_lib::HoprSession::new(
             session_id,

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -64,7 +64,6 @@ use hopr_transport_p2p::{
     HoprSwarm,
     swarm::{TicketAggregationRequestType, TicketAggregationResponseType},
 };
-use hopr_transport_packet::prelude::*;
 pub use hopr_transport_packet::prelude::{ApplicationData, Tag};
 use hopr_transport_probe::{
     DbProxy, Probe,
@@ -99,7 +98,7 @@ pub use crate::{
 };
 use crate::{constants::SESSION_INITIATION_TIMEOUT_BASE, errors::HoprTransportError};
 
-pub const USABLE_TAG_RANGE: std::ops::Range<Tag> = Tag::USABLE_RANGE;
+pub const APPLICATION_TAG_RANGE: std::ops::Range<Tag> = Tag::APPLICATION_TAG_RANGE;
 
 #[cfg(any(
     all(feature = "mixer-channel", feature = "mixer-stream"),
@@ -246,9 +245,7 @@ where
             process_ticket_aggregate: Arc::new(OnceLock::new()),
             smgr: SessionManager::new(SessionManagerConfig {
                 // TODO(v3.1): Use the entire range of tags properly
-                //
-                // session_tag_range: Tag::USABLE_RANGE,
-                session_tag_range: (Tag(16)..Tag(65535)),
+                session_tag_range: (16..65535),
                 initiation_timeout_base: SESSION_INITIATION_TIMEOUT_BASE,
                 idle_timeout: cfg.session.idle_timeout,
                 balancer_sampling_interval: cfg.session.balancer_sampling_interval,
@@ -629,18 +626,11 @@ where
     }
 
     #[tracing::instrument(level = "info", skip(self, msg), fields(uuid = uuid::Uuid::new_v4().to_string()))]
-    pub async fn send_message(
-        &self,
-        msg: Box<[u8]>,
-        routing: DestinationRouting,
-        application_tag: Tag,
-    ) -> errors::Result<()> {
-        let tag: ResolvedTag = application_tag.into();
-
-        if let ResolvedTag::Reserved(reserved_tag) = tag {
+    pub async fn send_message(&self, msg: Box<[u8]>, routing: DestinationRouting, tag: Tag) -> errors::Result<()> {
+        if let Tag::Reserved(reserved_tag) = tag {
             return Err(HoprTransportError::Api(format!(
                 "Application tag must not from range: {:?}, but was {reserved_tag:?}",
-                Tag::USABLE_RANGE
+                Tag::APPLICATION_TAG_RANGE
             )));
         }
 
@@ -651,7 +641,7 @@ where
             )));
         }
 
-        let app_data = ApplicationData::new_from_owned(application_tag, msg);
+        let app_data = ApplicationData::new_from_owned(tag, msg);
         let routing = self.path_planner.resolve_routing(app_data.len(), routing).await?;
 
         // Here we do not use msg_sender directly,

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -79,8 +79,7 @@ use hopr_transport_protocol::{
 pub use hopr_transport_session::transfer_session;
 pub use hopr_transport_session::{
     Capability as SessionCapability, IncomingSession, SESSION_PAYLOAD_SIZE, ServiceId, Session, SessionClientConfig,
-    SessionId, SessionTarget, SurbBalancerConfig, USABLE_PAYLOAD_CAPACITY_FOR_SESSION, errors::TransportSessionError,
-    traits::SendMsg,
+    SessionId, SessionTarget, SurbBalancerConfig, errors::TransportSessionError, traits::SendMsg,
 };
 use hopr_transport_session::{DispatchResult, SessionManager, SessionManagerConfig};
 use hopr_transport_ticket_aggregation::{

--- a/transport/packet/Cargo.toml
+++ b/transport/packet/Cargo.toml
@@ -16,6 +16,7 @@ serde = ["dep:serde", "dep:serde_bytes"]
 hex = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_bytes = { workspace = true, optional = true }
+strum = { workspace = true }
 thiserror = { workspace = true }
 
 hopr-crypto-packet = { workspace = true }

--- a/transport/packet/src/errors.rs
+++ b/transport/packet/src/errors.rs
@@ -4,6 +4,9 @@ use thiserror::Error;
 pub enum PacketError {
     #[error("error while decoding message: {0}")]
     DecodingError(String),
+
+    #[error("tag error: {0}")]
+    TagError(String),
 }
 
 pub type Result<T> = core::result::Result<T, PacketError>;

--- a/transport/packet/src/lib.rs
+++ b/transport/packet/src/lib.rs
@@ -2,5 +2,5 @@ pub mod errors;
 pub mod v1;
 
 pub mod prelude {
-    pub use crate::v1::{ApplicationData, CustomTag, ReservedTag, ResolvedTag, Tag};
+    pub use crate::v1::{ApplicationData, ReservedTag, Tag};
 }

--- a/transport/packet/src/v1.rs
+++ b/transport/packet/src/v1.rs
@@ -6,19 +6,11 @@ use strum::IntoEnumIterator;
 #[repr(u64)]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, strum::EnumIter)]
 pub enum ReservedTag {
-    /// Request to initiate a new session.
-    SessionStart = 0,
-    /// Confirmation that a new session has been established by the counterparty.
-    SessionEstablished = 1,
-    /// Counterparty could not establish a new session due to an error.
-    SessionError = 2,
-    /// Counterparty has closed the session.
-    SessionClose = 3,
-    /// A ping message to keep the session alive.
-    SessionKeepAlive = 4,
-
     /// Ping traffic for 0-hop detection.
-    Ping = ReservedTag::Undefined as u64 - 1,
+    Ping = 0,
+
+    /// Commands associated with session start protocol regarding session initiation.
+    SessionStart = 1,
 
     /// Undefined catch all.
     Undefined = 15,
@@ -203,7 +195,7 @@ mod tests {
 
     #[test]
     fn tag_should_be_obtainable_as_reserved_when_created_from_a_reserved_range() {
-        let reserved_tag = ReservedTag::SessionStart as u64;
+        let reserved_tag = ReservedTag::Ping as u64;
 
         assert_eq!(Tag::from(reserved_tag), Tag::Reserved(reserved_tag));
     }

--- a/transport/packet/src/v1.rs
+++ b/transport/packet/src/v1.rs
@@ -1,173 +1,120 @@
-use std::{
-    fmt::Formatter,
-    ops::{Add, Range, Sub},
-};
+use std::{fmt::Formatter, ops::Range};
 
-/// Tags are represented by 8 bytes ([`u64`]`).
-///
-/// [`u64`] should offer enough space to even avoid collisions and tag attacks.
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Tag(pub u64);
+use strum::IntoEnumIterator;
 
-/// The tag appended to the application data packet to identify the application target.
-impl Tag {
-    pub const MAX: Tag = Tag(u64::MAX);
-    pub const SIZE: usize = size_of::<u64>();
-    /// Tag range usable by external applications of the library.
-    pub const USABLE_RANGE: Range<Tag> = ReservedTag::UPPER_BOUND..CustomTag::UPPER_BOUND;
+/// List of all reserved application tags for the protocol.
+#[repr(u64)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, strum::EnumIter)]
+pub enum ReservedTag {
+    /// Request to initiate a new session.
+    SessionStart = 0,
+    /// Confirmation that a new session has been established by the counterparty.
+    SessionEstablished = 1,
+    /// Counterparty could not establish a new session due to an error.
+    SessionError = 2,
+    /// Counterparty has closed the session.
+    SessionClose = 3,
+    /// A ping message to keep the session alive.
+    SessionKeepAlive = 4,
 
-    pub const fn new(tag: u64) -> Self {
-        Self(tag)
-    }
+    /// Ping traffic for 0-hop detection.
+    Ping = ReservedTag::Undefined as u64 - 1,
 
-    pub fn from_be_bytes(bytes: [u8; Self::SIZE]) -> Self {
-        Self(u64::from_be_bytes(bytes))
-    }
+    /// Undefined catch all.
+    Undefined = 15,
+}
 
-    pub fn to_be_bytes(&self) -> [u8; Self::SIZE] {
-        self.0.to_be_bytes()
+impl ReservedTag {
+    /// The range of reserved tags
+    pub fn range() -> Range<u64> {
+        0..(Self::iter().max().unwrap_or(Self::Undefined) as u64 + 1)
     }
 }
 
+impl From<ReservedTag> for Tag {
+    fn from(tag: ReservedTag) -> Self {
+        (tag as u64).into()
+    }
+}
+
+/// Tags are represented by 8 bytes ([`u64`]`).
+///
+/// [`u64`] should offer enough space to avoid collisions and tag attacks.
+// #[repr(u64)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Tag {
+    Reserved(u64),
+    Application(u64),
+}
+
+impl Tag {
+    /// Application tag range for external usage
+    pub const APPLICATION_TAG_RANGE: Range<Self> =
+        (Self::Application(ReservedTag::Undefined as u64 + 1))..Self::Application(Self::MAX);
+    pub const MAX: u64 = u64::MAX;
+    pub const SIZE: usize = size_of::<u64>();
+
+    pub fn from_be_bytes(bytes: [u8; Self::SIZE]) -> Self {
+        let tag = u64::from_be_bytes(bytes);
+        tag.into()
+    }
+
+    pub fn to_be_bytes(&self) -> [u8; Self::SIZE] {
+        match self {
+            Tag::Reserved(tag) | Tag::Application(tag) => tag.to_be_bytes(),
+        }
+    }
+
+    pub fn as_u64(&self) -> u64 {
+        match self {
+            Tag::Reserved(tag) | Tag::Application(tag) => *tag,
+        }
+    }
+}
+
+impl<T: Into<u64>> From<T> for Tag {
+    fn from(tag: T) -> Self {
+        let tag: u64 = tag.into();
+
+        if ReservedTag::range().contains(&tag) {
+            Tag::Reserved(
+                ReservedTag::iter()
+                    .find(|&t| t as u64 == tag)
+                    .unwrap_or(ReservedTag::Undefined) as u64,
+            )
+        } else {
+            Tag::Application(tag)
+        }
+    }
+}
+
+#[cfg(feature = "serde")]
 impl serde::Serialize for Tag {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
-        serializer.serialize_u64(self.0)
+        match self {
+            Tag::Reserved(tag) | Tag::Application(tag) => serializer.serialize_u64(*tag),
+        }
     }
 }
 
+#[cfg(feature = "serde")]
 impl<'a> serde::Deserialize<'a> for Tag {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'a>,
     {
         let value = u64::deserialize(deserializer)?;
-        Ok(Self(value))
-    }
-}
 
-impl Add for Tag {
-    type Output = Self;
-
-    fn add(self, other: Self) -> Self::Output {
-        Self(self.0 + other.0)
-    }
-}
-
-impl Sub for Tag {
-    type Output = Self;
-
-    fn sub(self, other: Self) -> Self::Output {
-        Self(self.0 - other.0)
+        Ok(value.into())
     }
 }
 
 impl std::fmt::Display for Tag {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Tag({})", self.0)
-    }
-}
-
-impl From<u64> for Tag {
-    fn from(value: u64) -> Self {
-        Self(value)
-    }
-}
-
-impl From<u32> for Tag {
-    fn from(value: u32) -> Self {
-        Self(value as u64)
-    }
-}
-
-impl From<u8> for Tag {
-    fn from(value: u8) -> Self {
-        Self(value as u64)
-    }
-}
-
-impl PartialEq<u64> for Tag {
-    fn eq(&self, other: &u64) -> bool {
-        self.0 == *other
-    }
-}
-
-impl PartialOrd<u64> for Tag {
-    fn partial_cmp(&self, other: &u64) -> Option<std::cmp::Ordering> {
-        self.0.partial_cmp(other)
-    }
-}
-
-/// Resolved tag type with translated tag annotation.
-///
-/// The resolved tag covers the entire range of tags and a tag is always representable by it.
-#[repr(u64)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum ResolvedTag {
-    Reserved(ReservedTag),
-    Custom(CustomTag),
-}
-
-impl From<ResolvedTag> for Tag {
-    fn from(tag: ResolvedTag) -> Self {
-        match tag {
-            ResolvedTag::Reserved(reserved_tag) => reserved_tag.into(),
-            ResolvedTag::Custom(custom_tag) => custom_tag.0,
-        }
-    }
-}
-
-impl From<Tag> for ResolvedTag {
-    fn from(tag: Tag) -> Self {
-        if tag < ReservedTag::UPPER_BOUND {
-            match tag.0 {
-                x if x == ReservedTag::SessionInit as u64 => ResolvedTag::Reserved(ReservedTag::SessionInit),
-                x if x == ReservedTag::Ping as u64 => ResolvedTag::Reserved(ReservedTag::Ping),
-                _ => ResolvedTag::Reserved(ReservedTag::Undefined),
-            }
-        } else {
-            ResolvedTag::Custom(CustomTag(tag))
-        }
-    }
-}
-
-/// List of all reserved application tags for the protocol.
-#[repr(u64)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-
-pub enum ReservedTag {
-    /// Opening a new session.
-    SessionInit = 0,
-    /// Ping traffic for 0-hop detection.
-    Ping = 14,
-    /// Undefined catch all.
-    Undefined = Self::UPPER_BOUND.0 - 1,
-}
-
-impl ReservedTag {
-    /// The upper limit value for the session reserved tag range.
-    pub const UPPER_BOUND: Tag = Tag(1 << 4); // 16
-}
-
-impl From<ReservedTag> for Tag {
-    fn from(tag: ReservedTag) -> Self {
-        Self(tag as u64)
-    }
-}
-
-/// Tags used for application data labeling only.
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub struct CustomTag(Tag);
-
-impl CustomTag {
-    pub const UPPER_BOUND: Tag = Tag(u64::MAX);
-}
-
-impl From<CustomTag> for Tag {
-    fn from(tag: CustomTag) -> Self {
-        tag.0
+        write!(f, "Tag({})", self.as_u64())
     }
 }
 
@@ -190,9 +137,9 @@ impl ApplicationData {
         }
     }
 
-    pub fn new_from_owned(application_tag: Tag, plain_text: Box<[u8]>) -> Self {
+    pub fn new_from_owned<T: Into<Tag>>(tag: T, plain_text: Box<[u8]>) -> Self {
         Self {
-            application_tag,
+            application_tag: tag.into(),
             plain_text,
         }
     }
@@ -218,9 +165,7 @@ impl std::fmt::Display for ApplicationData {
 }
 
 impl ApplicationData {
-    const TAG_SIZE: usize = size_of::<Tag>();
-
-    // minimum size
+    const TAG_SIZE: usize = Tag::SIZE;
 
     pub fn from_bytes(data: &[u8]) -> crate::errors::Result<Self> {
         if data.len() >= Self::TAG_SIZE {
@@ -248,6 +193,41 @@ impl ApplicationData {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn reserved_tag_v1_range_is_stable() {
+        let range = ReservedTag::range();
+        assert_eq!(range.start, 0);
+        assert_eq!(range.count(), 16); // 0 to 15 inclusive
+    }
+
+    #[test]
+    fn tag_should_be_obtainable_as_reserved_when_created_from_a_reserved_range() {
+        let reserved_tag = ReservedTag::SessionStart as u64;
+
+        assert_eq!(Tag::from(reserved_tag), Tag::Reserved(reserved_tag));
+    }
+
+    #[test]
+    fn tag_should_be_obtainable_as_undefined_reserved_when_created_from_an_undefined_value_in_reserved_range() {
+        let reserved_tag_without_assignment = 7u64;
+
+        assert_eq!(
+            Tag::from(reserved_tag_without_assignment),
+            Tag::Reserved(ReservedTag::Undefined as u64)
+        );
+    }
+
+    #[test]
+    fn v1_format_is_binary_stable() -> anyhow::Result<()> {
+        let original = ApplicationData::new(10u64, &[0_u8, 1_u8]);
+        let reserialized = ApplicationData::from_bytes(&original.to_bytes())?;
+        let reserialized = ApplicationData::from_bytes(&reserialized.to_bytes())?;
+
+        assert_eq!(original, reserialized);
+
+        Ok(())
+    }
 
     #[test]
     fn test_application_data() -> anyhow::Result<()> {

--- a/transport/probe/src/probe.rs
+++ b/transport/probe/src/probe.rs
@@ -9,7 +9,7 @@ use hopr_internal_types::protocol::HoprPseudonym;
 use hopr_network_types::types::{ResolvedTransportRouting, SurbMatcher, ValidatedPath};
 use hopr_platform::time::native::current_time;
 use hopr_primitive_types::{prelude::Address, traits::AsUnixTimestamp};
-use hopr_transport_packet::prelude::{ApplicationData, ReservedTag, Tag};
+use hopr_transport_packet::prelude::{ApplicationData, ReservedTag};
 use hopr_transport_protocol::processor::{PacketError, PacketSendFinalizer};
 use libp2p_identity::PeerId;
 
@@ -229,7 +229,7 @@ impl Probe {
 
                 async move {
                     // TODO(v3.1): compare not only against ping tag, but also against telemetry that will be occuring on random tags
-                    if data.application_tag == Tag::from(ReservedTag::Ping) {
+                    if data.application_tag == ReservedTag::Ping.into() {
                         let message: anyhow::Result<Message> = data.try_into().context("failed to convert data into message");
 
                         match message {
@@ -289,6 +289,7 @@ mod tests {
     use async_trait::async_trait;
     use futures::future::BoxFuture;
     use hopr_crypto_types::keypairs::{ChainKeypair, Keypair, OffchainKeypair};
+    use hopr_transport_packet::prelude::Tag;
 
     use super::*;
 
@@ -665,7 +666,7 @@ mod tests {
             let mut from_probing_up_rx = iface.from_probing_up_rx;
 
             let expected_data = ApplicationData {
-                application_tag: Tag::MAX,
+                application_tag: Tag::MAX.into(),
                 plain_text: b"Hello, this is a test message!".to_vec().into_boxed_slice(),
             };
 

--- a/transport/session/Cargo.toml
+++ b/transport/session/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-session"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Session functionality providing session abstraction over the HOPR transport"

--- a/transport/session/src/errors.rs
+++ b/transport/session/src/errors.rs
@@ -34,6 +34,9 @@ pub enum TransportSessionError {
     #[error("received data for an unregistered session")]
     UnknownData,
 
+    #[error("session establishment protocol error: {0}")]
+    StartProtocolError(String),
+
     #[error(transparent)]
     Manager(#[from] SessionManagerError),
 

--- a/transport/session/src/errors.rs
+++ b/transport/session/src/errors.rs
@@ -8,9 +8,6 @@ pub enum TransportSessionError {
     #[error("connection timed out")]
     Timeout,
 
-    #[error("application tag from disallowed range")]
-    Tag,
-
     #[error("incorrect data size")]
     PayloadSize,
 

--- a/transport/session/src/lib.rs
+++ b/transport/session/src/lib.rs
@@ -17,17 +17,18 @@ pub use balancer::SurbBalancerConfig;
 use hopr_internal_types::prelude::HoprPseudonym;
 use hopr_network_types::prelude::state::{SessionFeature, SessionSocket};
 pub use hopr_network_types::types::*;
+use hopr_transport_packet::prelude::ApplicationData;
 pub use manager::{DispatchResult, MIN_BALANCER_SAMPLING_INTERVAL, SessionManager, SessionManagerConfig};
 #[cfg(feature = "runtime-tokio")]
 pub use types::transfer_session;
-pub use types::{IncomingSession, ServiceId, Session, SessionId, SessionTarget, USABLE_PAYLOAD_CAPACITY_FOR_SESSION};
+pub use types::{IncomingSession, ServiceId, Session, SessionId, SessionTarget};
 
 // TODO: resolve this in #7145
 #[cfg(not(feature = "serde"))]
 compile_error!("The `serde` feature currently must be enabled, see #7145");
 
 /// Number of bytes that can be sent in a single Session protocol payload.
-pub const SESSION_PAYLOAD_SIZE: usize = SessionSocket::<USABLE_PAYLOAD_CAPACITY_FOR_SESSION>::PAYLOAD_CAPACITY;
+pub const SESSION_PAYLOAD_SIZE: usize = SessionSocket::<{ ApplicationData::PAYLOAD_SIZE }>::PAYLOAD_CAPACITY;
 
 /// Capabilities of a session.
 #[repr(u8)]

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -15,7 +15,7 @@ use hopr_crypto_random::Randomizable;
 use hopr_internal_types::prelude::HoprPseudonym;
 use hopr_network_types::prelude::*;
 use hopr_primitive_types::prelude::Address;
-use hopr_transport_packet::prelude::{ApplicationData, Tag};
+use hopr_transport_packet::prelude::{ApplicationData, ReservedTag, Tag};
 use tracing::{debug, error, info, trace, warn};
 
 use crate::{
@@ -63,8 +63,8 @@ pub struct SessionManagerConfig {
     ///
     /// Default is 16..1024.
     #[doc(hidden)]
-    #[default(_code = "16u64.into()..1024u64.into()")]
-    pub session_tag_range: Range<Tag>,
+    #[default(_code = "16u64..1024u64")]
+    pub session_tag_range: Range<u64>,
 
     /// The base timeout for initiation of Session initiation.
     ///
@@ -295,9 +295,6 @@ fn initiation_timeout_max_one_way(base: Duration, hops: usize) -> Duration {
     base * (hops as u32)
 }
 
-/// The Minimum Session tag due to Start-protocol messages.
-pub const MIN_SESSION_TAG_RANGE_RESERVATION: Tag = Tag::new(16u64);
-
 /// Smallest possible interval for balancer sampling.
 pub const MIN_BALANCER_SAMPLING_INTERVAL: Duration = Duration::from_millis(100);
 
@@ -305,9 +302,10 @@ impl<S: SendMsg + Clone + Send + Sync + 'static> SessionManager<S> {
     /// Creates a new instance given the `PeerId` and [config](SessionManagerConfig).
     pub fn new(mut cfg: SessionManagerConfig) -> Self {
         // Accommodate the lower bound if too low.
-        if cfg.session_tag_range.start < MIN_SESSION_TAG_RANGE_RESERVATION {
-            let diff = MIN_SESSION_TAG_RANGE_RESERVATION - cfg.session_tag_range.start;
-            cfg.session_tag_range = MIN_SESSION_TAG_RANGE_RESERVATION..cfg.session_tag_range.end + diff;
+        let min_session_tag_range_reservation = ReservedTag::range().end;
+        if cfg.session_tag_range.start < min_session_tag_range_reservation {
+            let diff = min_session_tag_range_reservation - cfg.session_tag_range.start;
+            cfg.session_tag_range = min_session_tag_range_reservation..cfg.session_tag_range.end + diff;
         }
 
         #[cfg(all(feature = "prometheus", not(test)))]
@@ -319,8 +317,8 @@ impl<S: SendMsg + Clone + Send + Sync + 'static> SessionManager<S> {
             session_initiations: moka::future::Cache::builder()
                 .max_capacity(
                     std::ops::Range {
-                        start: cfg.session_tag_range.start.0,
-                        end: cfg.session_tag_range.end.0,
+                        start: cfg.session_tag_range.start,
+                        end: cfg.session_tag_range.end,
                     }
                     .count() as u64,
                 )
@@ -703,14 +701,14 @@ impl<S: SendMsg + Clone + Send + Sync + 'static> SessionManager<S> {
         pseudonym: HoprPseudonym,
         data: ApplicationData,
     ) -> crate::errors::Result<DispatchResult> {
-        if (0..self.cfg.session_tag_range.start.0).contains(&data.application_tag.0) {
+        if (0..self.cfg.session_tag_range.start).contains(&data.application_tag.as_u64()) {
             // This is a Start protocol message, so we handle it
-            trace!(tag = data.application_tag.0, "dispatching Start protocol message");
+            trace!(tag = %data.application_tag, "dispatching Start protocol message");
             return self
                 .handle_start_protocol_message(pseudonym, data)
                 .await
                 .map(|_| DispatchResult::Processed);
-        } else if self.cfg.session_tag_range.contains(&data.application_tag) {
+        } else if self.cfg.session_tag_range.contains(&data.application_tag.as_u64()) {
             let session_id = SessionId::new(data.application_tag, pseudonym);
 
             return if let Some(session_data) = self.sessions.get(&session_id).await {
@@ -761,12 +759,12 @@ impl<S: SendMsg + Clone + Send + Sync + 'static> SessionManager<S> {
                         // NOTE: It is allowed to insert sessions using the same tag
                         // but different pseudonyms because the SessionId is different.
                         let next_tag: Tag = match sid {
-                            Some(session_id) => ((session_id.tag().0 + 1) % self.cfg.session_tag_range.end.0)
-                                .max(self.cfg.session_tag_range.start.0)
+                            Some(session_id) => ((session_id.tag().as_u64() + 1) % self.cfg.session_tag_range.end)
+                                .max(self.cfg.session_tag_range.start)
                                 .into(),
                             None => hopr_crypto_random::random_integer(
-                                self.cfg.session_tag_range.start.0,
-                                Some(self.cfg.session_tag_range.end.0),
+                                self.cfg.session_tag_range.start,
+                                Some(self.cfg.session_tag_range.end),
                             )
                             .into(),
                         };
@@ -1340,7 +1338,7 @@ mod tests {
         let bob_peer: Address = (&ChainKeypair::random()).into();
 
         let cfg = SessionManagerConfig {
-            session_tag_range: 16u64.into()..17u64.into(), // Slot for exactly one session
+            session_tag_range: 16u64..17u64, // Slot for exactly one session
             ..Default::default()
         };
 

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -303,7 +303,7 @@ impl<S: SendMsg + Clone + Send + Sync + 'static> SessionManager<S> {
     pub fn new(mut cfg: SessionManagerConfig) -> Self {
         let min_session_tag_range_reservation = ReservedTag::range().end;
         debug_assert!(
-            min_session_tag_range_reservation > StartProtocol::<SessionId>::START_PROTOCOL_MESSAGE_TAG as u64,
+            min_session_tag_range_reservation > StartProtocol::<SessionId>::START_PROTOCOL_MESSAGE_TAG.as_u64(),
             "invalid tag reservation range"
         );
 
@@ -706,7 +706,7 @@ impl<S: SendMsg + Clone + Send + Sync + 'static> SessionManager<S> {
         pseudonym: HoprPseudonym,
         data: ApplicationData,
     ) -> crate::errors::Result<DispatchResult> {
-        if data.application_tag == StartProtocol::<SessionId>::START_PROTOCOL_MESSAGE_TAG.into() {
+        if data.application_tag == StartProtocol::<SessionId>::START_PROTOCOL_MESSAGE_TAG {
             // This is a Start protocol message, so we handle it
             trace!(tag = %data.application_tag, "dispatching Start protocol message");
             return self

--- a/transport/session/src/types.rs
+++ b/transport/session/src/types.rs
@@ -70,7 +70,8 @@ pub struct SessionId {
 }
 
 impl SessionId {
-    pub fn new(tag: Tag, pseudonym: HoprPseudonym) -> Self {
+    pub fn new<T: Into<Tag>>(tag: T, pseudonym: HoprPseudonym) -> Self {
+        let tag = tag.into();
         let mut cached = format!("{pseudonym}:{tag}");
         cached.truncate(MAX_SESSION_ID_STR_LEN);
 
@@ -137,7 +138,8 @@ impl<'de> serde::Deserialize<'de> for SessionId {
                 A: de::SeqAccess<'de>,
             {
                 Ok(SessionId::new(
-                    seq.next_element()?.ok_or_else(|| de::Error::invalid_length(0, &self))?,
+                    seq.next_element::<Tag>()?
+                        .ok_or_else(|| de::Error::invalid_length(0, &self))?,
                     seq.next_element()?.ok_or_else(|| de::Error::invalid_length(1, &self))?,
                 ))
             }
@@ -146,13 +148,13 @@ impl<'de> serde::Deserialize<'de> for SessionId {
             where
                 V: de::MapAccess<'de>,
             {
-                let mut tag = None;
-                let mut pseudonym = None;
+                let mut tag: Option<Tag> = None;
+                let mut pseudonym: Option<HoprPseudonym> = None;
                 while let Some(key) = map.next_key()? {
                     match key {
                         Field::Tag => {
                             if tag.is_some() {
-                                return Err(de::Error::duplicate_field("tx_tag"));
+                                return Err(de::Error::duplicate_field("tag"));
                             }
                             tag = Some(map.next_value()?);
                         }
@@ -203,10 +205,6 @@ impl Hash for SessionId {
         self.pseudonym.hash(state);
     }
 }
-
-/// Payload capacity of a HOPR packet usable by the Session protocol.
-// TODO: Move this into ApplicationData
-pub const USABLE_PAYLOAD_CAPACITY_FOR_SESSION: usize = HoprPacket::PAYLOAD_SIZE - size_of::<Tag>();
 
 /// Helper trait to allow Box aliasing
 trait AsyncReadWrite: futures::AsyncWrite + futures::AsyncRead + Send {}
@@ -294,7 +292,7 @@ impl Session {
 
             Self {
                 id,
-                inner: Box::pin(SessionSocket::<USABLE_PAYLOAD_CAPACITY_FOR_SESSION>::new(
+                inner: Box::pin(SessionSocket::<{ ApplicationData::PAYLOAD_SIZE }>::new(
                     id,
                     inner_session,
                     cfg,
@@ -486,11 +484,11 @@ impl futures::AsyncWrite for InnerSession {
         self.tx_buffer.clear();
         self.tx_bytes = 0;
 
-        for i in 0..(buf.len() / USABLE_PAYLOAD_CAPACITY_FOR_SESSION
-            + ((buf.len() % USABLE_PAYLOAD_CAPACITY_FOR_SESSION != 0) as usize))
+        for i in
+            0..(buf.len() / ApplicationData::PAYLOAD_SIZE + ((buf.len() % ApplicationData::PAYLOAD_SIZE != 0) as usize))
         {
-            let start = i * USABLE_PAYLOAD_CAPACITY_FOR_SESSION;
-            let end = ((i + 1) * USABLE_PAYLOAD_CAPACITY_FOR_SESSION).min(buf.len());
+            let start = i * ApplicationData::PAYLOAD_SIZE;
+            let end = ((i + 1) * ApplicationData::PAYLOAD_SIZE).min(buf.len());
 
             let payload = ApplicationData::new(tag, &buf[start..end]);
             let sender = self.tx.clone();
@@ -605,7 +603,7 @@ where
     // 1) If Session protocol is used for segmentation, we need to buffer up data at MAX_WRITE_SIZE.
     // 2) Otherwise, the bare session implements chunking, therefore, data can be written with arbitrary sizes.
     let into_session_len = if session.capabilities().contains(&Capability::Segmentation) {
-        max_buffer.min(SessionSocket::<USABLE_PAYLOAD_CAPACITY_FOR_SESSION>::MAX_WRITE_SIZE)
+        max_buffer.min(SessionSocket::<{ ApplicationData::PAYLOAD_SIZE }>::MAX_WRITE_SIZE)
     } else {
         max_buffer
     };
@@ -667,7 +665,7 @@ mod tests {
     #[test]
     fn session_should_identify_with_its_own_id() -> anyhow::Result<()> {
         let addr: Address = (&ChainKeypair::random()).into();
-        let id = SessionId::new(1u64.into(), HoprPseudonym::random());
+        let id = SessionId::new(1u64, HoprPseudonym::random());
         let (_tx, rx) = futures::channel::mpsc::unbounded();
         let mock = MockSendMsg::new();
 
@@ -686,7 +684,7 @@ mod tests {
     #[tokio::test]
     async fn session_should_read_data_in_one_swoop_if_the_buffer_is_sufficiently_large() -> anyhow::Result<()> {
         let addr: Address = (&ChainKeypair::random()).into();
-        let id = SessionId::new(1u64.into(), HoprPseudonym::random());
+        let id = SessionId::new(1u64, HoprPseudonym::random());
         let (tx, rx) = futures::channel::mpsc::unbounded();
         let mock = MockSendMsg::new();
 
@@ -718,7 +716,7 @@ mod tests {
     async fn session_should_read_data_in_multiple_rounds_if_the_buffer_is_not_sufficiently_large() -> anyhow::Result<()>
     {
         let addr: Address = (&ChainKeypair::random()).into();
-        let id = SessionId::new(1u64.into(), HoprPseudonym::random());
+        let id = SessionId::new(1u64, HoprPseudonym::random());
         let (tx, rx) = futures::channel::mpsc::unbounded();
         let mock = MockSendMsg::new();
 
@@ -755,7 +753,7 @@ mod tests {
     #[tokio::test]
     async fn session_should_write_data_on_forward_path() -> anyhow::Result<()> {
         let addr: Address = (&ChainKeypair::random()).into();
-        let id = SessionId::new(1u64.into(), HoprPseudonym::random());
+        let id = SessionId::new(1u64, HoprPseudonym::random());
         let (_tx, rx) = futures::channel::mpsc::unbounded();
         let mut mock = MockSendMsg::new();
 
@@ -785,7 +783,7 @@ mod tests {
 
     #[tokio::test]
     async fn session_should_write_data_on_return_path() -> anyhow::Result<()> {
-        let id = SessionId::new(1u64.into(), HoprPseudonym::random());
+        let id = SessionId::new(1u64, HoprPseudonym::random());
         let (_tx, rx) = futures::channel::mpsc::unbounded();
         let mut mock = MockSendMsg::new();
 
@@ -816,10 +814,10 @@ mod tests {
     #[tokio::test]
     async fn session_should_chunk_the_data_if_without_segmentation_the_write_size_is_greater_than_the_usable_mtu_size()
     -> anyhow::Result<()> {
-        const TO_SEND: usize = USABLE_PAYLOAD_CAPACITY_FOR_SESSION * 2 + 10;
+        const TO_SEND: usize = ApplicationData::PAYLOAD_SIZE * 2 + 10;
 
         let addr: Address = (&ChainKeypair::random()).into();
-        let id = SessionId::new(1u64.into(), HoprPseudonym::random());
+        let id = SessionId::new(1u64, HoprPseudonym::random());
         let (_tx, rx) = futures::channel::mpsc::unbounded();
         let mut mock = MockSendMsg::new();
 


### PR DESCRIPTION
Changes to the packet structure in the tag section and reserved tag allocation:
- [x] packet: Improve the tag representation
- [x] Compress v3 tag usage to minimize the session allocated space