### PR TITLE
tests: Simplify smoke test setup

### DIFF
--- a/sdk/python/localcluster/cluster.py
+++ b/sdk/python/localcluster/cluster.py
@@ -46,11 +46,11 @@ class Cluster:
         for node in self.nodes.values():
             assert node.create_local_safe(self.anvil_config)
 
-    async def shared_bringup(self, skip_funding: bool = False):
+    async def shared_bringup(self, log_tag: str = ""):
         logging.info("Setting up nodes with protocol config files")
         for node in self.nodes.values():
             logging.debug(f"Setting up {node}")
-            node.setup(PASSWORD, self.protocol_config, PWD)
+            node.setup(PASSWORD, self.protocol_config, PWD, log_tag)
 
         # WAIT FOR NODES TO BE UP
         logging.info(f"Waiting up to {GLOBAL_TIMEOUT}s for nodes to start up")
@@ -64,10 +64,6 @@ class Cluster:
         if not all(nodes_readyness):
             logging.critical("Not all nodes are started, interrupting setup")
             raise RuntimeError
-
-        if not skip_funding:
-            self.fund_nodes()
-            return
 
         # WAIT FOR NODES TO BE UP
         logging.info(f"Waiting up to {GLOBAL_TIMEOUT}s for nodes to be ready")
@@ -149,11 +145,6 @@ class Cluster:
         for f in MAIN_DIR.glob(f"{NODE_NAME_PREFIX}/*.id"):
             os.remove(f)
         logging.info(f"Removed '*.id' files in {MAIN_DIR} subfolders")
-
-        # Remove old logs
-        for f in MAIN_DIR.glob(f"{NODE_NAME_PREFIX}/*.log"):
-            os.remove(f)
-        logging.info(f"Removed '*.log' files in {MAIN_DIR} subfolders")
 
         # Copy new identity files
         for idx, node in enumerate(self.nodes.values(), start=1):

--- a/sdk/python/localcluster/node.py
+++ b/sdk/python/localcluster/node.py
@@ -167,7 +167,7 @@ class Node:
         logging.error(f"Failed to create safe for node {self.id}: {res.stdout} - {res.stderr}")
         return False
 
-    def setup(self, password: str, config_file: Path, dir: Path):
+    def setup(self, password: str, config_file: Path, dir: Path, log_tag: str):
         trace_telemetry = "true" if os.getenv("TRACE_TELEMETRY") is not None else "false"
         log_level = "trace" if os.getenv("TRACE_TELEMETRY") is not None else "debug"
 
@@ -176,14 +176,14 @@ class Node:
             "RUST_LOG": ",".join(
                 [
                     log_level,
-                    "libp2p_swarm=info",
+                    # "libp2p_swarm=info",
                     "multistream_select=info",
                     "isahc=error",
                     "sea_orm=warn",
                     "sqlx=warn",
                     "hyper_util=warn",
-                    "libp2p_tcp=info",
-                    "libp2p_dns=info",
+                    # "libp2p_tcp=info",
+                    # "libp2p_dns=info",
                     "hickory_resolver=warn",
                 ]
             ),
@@ -216,8 +216,9 @@ class Node:
         ]
         if self.cfg_file_path is not None:
             cmd += [f"--configurationFilePath={self.cfg_file_path}"]
+        log_file_name = f"hoprd.{log_tag}.log" if log_tag else "hoprd.log"
 
-        with open(self.dir.joinpath("hoprd.log"), "w") as log_file:
+        with open(self.dir.joinpath(log_file_name), "w") as log_file:
             self.proc = Popen(
                 cmd,
                 stdout=log_file,

--- a/sdk/python/localcluster/snapshot.py
+++ b/sdk/python/localcluster/snapshot.py
@@ -4,16 +4,6 @@ from pathlib import Path
 from .cluster import Cluster
 from .constants import ANVIL_FOLDER, ANVIL_FOLDER_NAME, NODE_NAME_PREFIX, logging
 
-EXPECTED_FILES_FOR_SNAPSHOT = [
-    "db/hopr_index.db",
-    "db/hopr_index.db-shm",
-    "db/hopr_index.db-wal",
-    "db/hopr_logs.db",
-    "db/hopr_logs.db-shm",
-    "db/hopr_logs.db-wal",
-]
-
-
 class Snapshot:
     def __init__(self, anvil_port: int, parent_dir: Path, cluster: Cluster):
         self.anvil_port = anvil_port
@@ -43,29 +33,30 @@ class Snapshot:
             target_dir = self.sdir.joinpath(f"{NODE_NAME_PREFIX}_{i+1}")
             db_target_dir = target_dir.joinpath("db/")
 
-            db_target_dir.mkdir(parents=True, exist_ok=True)
-
-            for file in EXPECTED_FILES_FOR_SNAPSHOT:
-                shutil.copy(source_dir.joinpath(file), db_target_dir)
-
             shutil.copy(source_dir.joinpath("./hoprd.id"), target_dir)
             shutil.copy(source_dir.joinpath("./.env"), target_dir)
 
     def reuse(self):
         logging.info("Re-using snapshot")
 
-        # remove all files and folder in self.dir which are not snapshot
+        # remove all files and folder in self.dir which are not snapshot and not
+        # logs
 
         for entry in self.parent_dir.glob("*"):
             if entry.is_dir():
-                if entry.name == f"snapshot-{self.anvil_port}":
-                    continue
-                shutil.rmtree(entry, ignore_errors=True)
-            else:
+                continue
+            elif not entry.name.endswith(".log"):
+                logging.debug(f"Removing file: {entry}")
                 entry.unlink(missing_ok=True)
 
         # copy snapshot files
         shutil.copytree(self.sdir, self.parent_dir, dirs_exist_ok=True)
+
+        # remove log files from snapshot dir
+        for entry in self.sdir.glob("*"):
+            if entry.name.endswith(".log"):
+                logging.debug(f"Removing log file from snapshot: {entry}")
+                entry.unlink(missing_ok=True)
 
     @property
     def usable(self):
@@ -78,7 +69,6 @@ class Snapshot:
 
         for i in range(self.cluster.size):
             node_dir = self.sdir.joinpath(f"{NODE_NAME_PREFIX}_{i+1}")
-            expected_files.extend([node_dir.joinpath(file) for file in EXPECTED_FILES_FOR_SNAPSHOT])
 
         for f in expected_files:
             if not f.exists():


### PR DESCRIPTION
The smoke tests no longer need to address the pre-existing DB, since it has been moved into a randomly generated directory to avoid clashes.