### PR TITLE
Fixed an incorrect calculation of Tag size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5245,7 +5245,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-packet"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "hex",

--- a/crypto/packet/src/lib.rs
+++ b/crypto/packet/src/lib.rs
@@ -77,11 +77,6 @@ pub type HoprReplyOpener = (types::HoprSurbId, ReplyOpener);
 /// The calculation here is based on the fact that libp2p Stream over QUIC
 /// leaves space for 1460 bytes in the packet payload.
 ///
-/// The value of 1021 bytes has been chosen so that the Session protocol
-/// has exactly 1000 bytes for effective payload:
-/// - the Session protocol has a current overhead of 13 bytes
-/// - Tag requires 8 bytes
-///
 /// **DO NOT USE this value for calculations outside of this crate: use `HoprPacket::PAYLOAD_SIZE` instead!**
 pub(crate) const PAYLOAD_SIZE_INT: usize = 1021;
 
@@ -101,8 +96,8 @@ mod tests {
         );
 
         assert!(
-            hopr_packet_len < 1492 - 32, // 32 bytes was measured as the libp2p QUIC overhead
-            "HOPR packet {hopr_packet_len} must fit within a layer 4 packet with libp2p overhead"
+            hopr_packet_len <= 1492 - 32, // 32 bytes was measured as the libp2p QUIC overhead
+            "HOPR packet of {hopr_packet_len} bytes must fit within a layer 4 packet with libp2p overhead"
         );
     }
 

--- a/transport/packet/Cargo.toml
+++ b/transport/packet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-packet"
-version = "3.0.0"
+version = "3.0.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 license = "GPL-3.0-only"

--- a/transport/packet/src/v1.rs
+++ b/transport/packet/src/v1.rs
@@ -120,7 +120,7 @@ pub struct ApplicationData {
 }
 
 impl ApplicationData {
-    pub const PAYLOAD_SIZE: usize = hopr_crypto_packet::prelude::HoprPacket::PAYLOAD_SIZE - size_of::<Tag>();
+    pub const PAYLOAD_SIZE: usize = hopr_crypto_packet::prelude::HoprPacket::PAYLOAD_SIZE - Tag::SIZE;
 
     pub fn new<T: Into<Tag>>(application_tag: T, plain_text: &[u8]) -> Self {
         Self {

--- a/transport/session/src/types.rs
+++ b/transport/session/src/types.rs
@@ -48,8 +48,7 @@ const fn max_decimal_digits_for_n_bytes(n: usize) -> usize {
 }
 
 // Enough to fit HoprPseudonym in hex (with 0x prefix), delimiter and tag number
-const MAX_SESSION_ID_STR_LEN: usize =
-    2 + 2 * HoprPseudonym::SIZE + 1 + max_decimal_digits_for_n_bytes(size_of::<Tag>());
+const MAX_SESSION_ID_STR_LEN: usize = 2 + 2 * HoprPseudonym::SIZE + 1 + max_decimal_digits_for_n_bytes(Tag::SIZE);
 
 /// Unique ID of a specific Session in a certain direction.
 ///


### PR DESCRIPTION
Tag size was calculated incorrectly by using the `size_of` function, which returns the size of the enum, instead of the actual representation bound to `u64` (8 bytes)