### PR TITLE
tests: Divide by the win_prob to get the correct expected value

### DIFF
--- a/tests/test_win_prob.py
+++ b/tests/test_win_prob.py
@@ -115,7 +115,7 @@ class TestWinProbWithSwarm:
                 # Wait for at least some tickets to become acknowledged
                 await asyncio.wait_for(
                     check_unredeemed_tickets_value(
-                        swarm7[relay], statistics_before.unredeemed_value + ticket_count * ticket_price
+                        swarm7[relay], statistics_before.unredeemed_value + (ticket_count * ticket_price / Decimal(win_prob))
                     ),
                     30.0,
                 )


### PR DESCRIPTION
Fix the win_prob smoke test to properly divide by the probability to get the correct incentive.