### PR TITLE
fix(ci): Remove the python updates as they break compatibility of pluto

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,7 +11,6 @@
   "vulnerabilityAlerts": { "enabled": true },
   "semanticCommits": "enabled",
   "rangeStrategy": "bump",
-  
   "packageRules": [
     { "matchCategories": ["rust"], "enabled": true },
     { "matchCategories": ["docker"], "enabled": true, "pinDigests": true },

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,9 +11,14 @@
   "vulnerabilityAlerts": { "enabled": true },
   "semanticCommits": "enabled",
   "rangeStrategy": "bump",
+  
   "packageRules": [
     { "matchCategories": ["rust"], "enabled": true },
     { "matchCategories": ["docker"], "enabled": true, "pinDigests": true },
+    {
+      "matchPackageNames": ["python"],
+      "enabled": false
+    },
     {
       "matchPackageNames": [
         "serde_yaml",


### PR DESCRIPTION
This pull request updates the Renovate configuration file to adjust package rules for better dependency management.

Changes to Renovate configuration:

* [`.github/renovate.json`](diffhunk://#diff-f82f7d36a61d22f640c25bdb8b0435bf9cb38679d99d5f460753fa668ee7cdb3R14-R21): Added a new package rule to disable Renovate updates for Python packages by matching `python` in `matchPackageNames` and setting `enabled` to `false`.