### PR TITLE
fix(deps): Add python313 to `Pluto`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -471,6 +471,7 @@
               jq
               lsof
               plutoSrc
+              python313
               runtimeShellPackage
               solcDefault
               time


### PR DESCRIPTION
This PR fixes pluto.

It wasn't working anymore probably because of structural changes in the nix shells and their dependancies.