### PR TITLE
feat(runtime): make spawned tasks abortable through futures mechanism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4507,6 +4507,7 @@ name = "hopr-async-runtime"
 version = "0.1.1"
 dependencies = [
  "async-std",
+ "futures",
  "tokio",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4504,7 +4504,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-async-runtime"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "async-std",
  "futures",
@@ -4556,7 +4556,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-api"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "alloy",
  "async-channel 2.3.1",
@@ -5099,7 +5099,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "async-lock 3.4.0",
  "async-trait",
@@ -5259,7 +5259,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-probe"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5298,7 +5298,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-protocol"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",
@@ -5344,7 +5344,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "aquamarine",

--- a/chain/api/Cargo.toml
+++ b/chain/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-chain-api"
-version = "0.5.1"
+version = "0.6.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Implements the main HOPR chain interface"
 edition = "2021"

--- a/chain/api/src/lib.rs
+++ b/chain/api/src/lib.rs
@@ -15,7 +15,8 @@ use alloy::{
 };
 use config::ChainNetworkConfig;
 use executors::{EthereumTransactionExecutor, RpcEthereumClient, RpcEthereumClientConfig};
-use hopr_async_runtime::prelude::{JoinHandle, sleep, spawn};
+use futures::future::AbortHandle;
+use hopr_async_runtime::{prelude::sleep, spawn_as_abortable};
 use hopr_chain_actions::{
     ChainActions,
     action_queue::{ActionQueue, ActionQueueConfig},
@@ -241,12 +242,12 @@ impl<T: HoprDbAllOperations + Send + Sync + Clone + std::fmt::Debug + 'static> H
     ///
     /// This method will spawn the [`HoprChainProcess::Indexer`] and [`HoprChainProcess::OutgoingOnchainActionQueue`]
     /// processes and return join handles to the calling function.
-    pub async fn start(&self) -> errors::Result<HashMap<HoprChainProcess, JoinHandle<()>>> {
-        let mut processes: HashMap<HoprChainProcess, JoinHandle<()>> = HashMap::new();
+    pub async fn start(&self) -> errors::Result<HashMap<HoprChainProcess, AbortHandle>> {
+        let mut processes: HashMap<HoprChainProcess, AbortHandle> = HashMap::new();
 
         processes.insert(
             HoprChainProcess::OutgoingOnchainActionQueue,
-            spawn(self.action_queue.clone().start()),
+            spawn_as_abortable(self.action_queue.clone().start()),
         );
         processes.insert(
             HoprChainProcess::Indexer,
@@ -265,7 +266,6 @@ impl<T: HoprDbAllOperations + Send + Sync + Clone + std::fmt::Debug + 'static> H
             .start()
             .await?,
         );
-
         Ok(processes)
     }
 

--- a/common/async-runtime/Cargo.toml
+++ b/common/async-runtime/Cargo.toml
@@ -22,3 +22,4 @@ async-std = { version = "1.13.1", features = [
   "unstable",
 ], optional = true }
 tokio = { workspace = true, optional = true }
+futures = { workspace = true }

--- a/common/async-runtime/Cargo.toml
+++ b/common/async-runtime/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-async-runtime"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Feature-selected async executor for HOPR"

--- a/hopr/hopr-lib/tests/chain_integration_tests.rs
+++ b/hopr/hopr-lib/tests/chain_integration_tests.rs
@@ -6,7 +6,7 @@ use alloy::primitives::{B256, U256};
 use common::create_rpc_client_to_anvil_with_snapshot;
 use futures::{StreamExt, pin_mut};
 use hex_literal::hex;
-use hopr_async_runtime::prelude::{JoinHandle, cancel_join_handle, sleep, spawn};
+use hopr_async_runtime::{AbortHandle, prelude::sleep, spawn_as_abortable};
 use hopr_chain_actions::{
     ChainActions,
     action_queue::{ActionQueue, ActionQueueConfig},
@@ -73,7 +73,7 @@ struct ChainNode {
     db: HoprDb,
     actions: ChainActions<HoprDb>,
     _indexer: Indexer<TestRpc, ContractEventHandlers<HoprDb>, HoprDb>,
-    node_tasks: Vec<JoinHandle<()>>,
+    node_tasks: Vec<AbortHandle>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -128,13 +128,13 @@ async fn start_node_chain_logic(
 
     let mut node_tasks = Vec::new();
 
-    node_tasks.push(spawn(async move {
+    node_tasks.push(spawn_as_abortable(async move {
         action_queue.start().await;
     }));
 
     // Action state tracking
     let (sce_tx, sce_rx) = async_channel::unbounded();
-    node_tasks.push(spawn(async move {
+    node_tasks.push(spawn_as_abortable(async move {
         let rx = sce_rx.clone();
         pin_mut!(rx);
 
@@ -804,8 +804,8 @@ async fn integration_test_indexer() -> anyhow::Result<()> {
         "alice and bob must be at the same checksum"
     );
 
-    futures::future::join_all(alice_node.node_tasks.into_iter().map(cancel_join_handle)).await;
-    futures::future::join_all(bob_node.node_tasks.into_iter().map(cancel_join_handle)).await;
+    futures::future::join_all(alice_node.node_tasks.into_iter().map(|ah| async move { ah.abort() })).await;
+    futures::future::join_all(bob_node.node_tasks.into_iter().map(|ah| async move { ah.abort() })).await;
 
     Ok(())
 }

--- a/hoprd/hoprd/src/main.rs
+++ b/hoprd/hoprd/src/main.rs
@@ -2,8 +2,7 @@ use std::{collections::HashMap, fmt::Formatter, str::FromStr, sync::Arc};
 
 use async_lock::RwLock;
 use async_signal::{Signal, Signals};
-use futures::StreamExt;
-use hopr_async_runtime::prelude::{JoinHandle, cancel_join_handle, spawn};
+use futures::{StreamExt, future::AbortHandle};
 use hopr_lib::{HoprLibProcesses, ToHex};
 use hoprd::{cli::CliArgs, errors::HoprdError, exit::HoprServerIpForwardingReactor};
 use hoprd_api::{ListenerJoinHandles, RestApiParameters, serve_api};
@@ -106,9 +105,9 @@ fn init_logger() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 enum HoprdProcesses {
-    HoprLib(HoprLibProcesses, JoinHandle<()>),
+    HoprLib(HoprLibProcesses, AbortHandle),
     ListenerSockets(ListenerJoinHandles),
-    RestApi(JoinHandle<()>),
+    RestApi(AbortHandle),
 }
 
 // Manual implementation needed, since Strum does not support skipping arguments
@@ -218,20 +217,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let session_listener_sockets = Arc::new(RwLock::new(HashMap::new()));
 
         processes.push(HoprdProcesses::ListenerSockets(session_listener_sockets.clone()));
-        processes.push(HoprdProcesses::RestApi(spawn(async move {
-            if let Err(e) = serve_api(RestApiParameters {
-                listener: api_listener,
-                hoprd_cfg: node_cfg_value,
-                cfg: api_cfg,
-                hopr: node_clone,
-                session_listener_sockets,
-                default_session_listen_host: cfg.session_ip_forwarding.default_entry_listen_host,
-            })
-            .await
-            {
-                error!(error = %e, "the REST API server could not start")
-            }
-        })));
+
+        processes.push(HoprdProcesses::RestApi(hopr_async_runtime::spawn_as_abortable(
+            async move {
+                if let Err(e) = serve_api(RestApiParameters {
+                    listener: api_listener,
+                    hoprd_cfg: node_cfg_value,
+                    cfg: api_cfg,
+                    hopr: node_clone,
+                    session_listener_sockets,
+                    default_session_listen_host: cfg.session_ip_forwarding.default_entry_listen_host,
+                })
+                .await
+                {
+                    error!(error = %e, "the REST API server could not start")
+                }
+            },
+        )));
     }
 
     let (_hopr_socket, hopr_processes) = node
@@ -253,18 +255,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 info!("Received the INT signal... tearing down the node");
                 futures::stream::iter(processes)
                     .then(|process| async move {
-                        let mut join_handles: Vec<JoinHandle<()>> = Vec::new();
+                        let mut abort_handles: Vec<AbortHandle> = Vec::new();
                         info!("Stopping process '{process}'");
                         match process {
-                            HoprdProcesses::HoprLib(_, jh) | HoprdProcesses::RestApi(jh) => join_handles.push(jh),
-                            HoprdProcesses::ListenerSockets(jhs) => {
-                                join_handles.extend(jhs.write().await.drain().map(|(_, entry)| entry.jh));
+                            HoprdProcesses::HoprLib(_, ah) | HoprdProcesses::RestApi(ah) => abort_handles.push(ah),
+                            HoprdProcesses::ListenerSockets(ahs) => {
+                                abort_handles.extend(ahs.write().await.drain().map(|(_, entry)| entry.abort_handle));
                             }
                         }
-                        futures::stream::iter(join_handles)
+                        futures::stream::iter(abort_handles)
                     })
                     .flatten()
-                    .for_each_concurrent(None, cancel_join_handle)
+                    .for_each_concurrent(None, |ah| async move { ah.abort() })
                     .await;
 
                 info!("All processes stopped... emulating the default handler...");

--- a/hoprd/rest-api/src/session.rs
+++ b/hoprd/rest-api/src/session.rs
@@ -11,7 +11,7 @@ use axum::{
 };
 use axum_extra::extract::Query;
 use base64::Engine;
-use futures::{AsyncReadExt, AsyncWriteExt, SinkExt, StreamExt, TryStreamExt};
+use futures::{AsyncReadExt, AsyncWriteExt, SinkExt, StreamExt, TryStreamExt, future::AbortHandle};
 use futures_concurrency::stream::Merge;
 use hopr_lib::{
     Address, HoprSession, SESSION_PAYLOAD_SIZE, ServiceId, SessionCapabilities, SessionClientConfig, SessionTarget,
@@ -129,7 +129,7 @@ pub struct StoredSessionEntry {
     /// Return path used for the Session.
     pub return_path: RoutingOptions,
     /// The join handle for the Session processing.
-    pub jh: hopr_async_runtime::prelude::JoinHandle<()>,
+    pub abort_handle: AbortHandle,
 }
 
 #[repr(u8)]
@@ -631,44 +631,6 @@ pub(crate) async fn create_client(
             // For each new TCP connection coming to the listener,
             // open a Session with the same parameters
             let hopr = state.hopr.clone();
-            let jh = hopr_async_runtime::prelude::spawn(
-                tokio_stream::wrappers::TcpListenerStream::new(tcp_listener)
-                    .and_then(|sock| async { Ok((sock.peer_addr()?, sock)) })
-                    .for_each_concurrent(None, move |accepted_client| {
-                        let data = data.clone();
-                        let target = target.clone();
-                        let hopr = hopr.clone();
-                        async move {
-                            match accepted_client {
-                                Ok((sock_addr, stream)) => {
-                                    debug!(socket = ?sock_addr, "incoming TCP connection");
-                                    let session = match hopr.connect_to(dst, target, data).await {
-                                        Ok(s) => s,
-                                        Err(error) => {
-                                            error!(%error, "failed to establish session");
-                                            return;
-                                        }
-                                    };
-
-                                    debug!(
-                                        socket = ?sock_addr,
-                                        session_id = tracing::field::debug(*session.id()),
-                                        "new session for incoming TCP connection",
-                                    );
-
-                                    #[cfg(all(feature = "prometheus", not(test)))]
-                                    METRIC_ACTIVE_CLIENTS.increment(&["tcp"], 1.0);
-
-                                    bind_session_to_stream(session, stream, HOPR_TCP_BUFFER_SIZE).await;
-
-                                    #[cfg(all(feature = "prometheus", not(test)))]
-                                    METRIC_ACTIVE_CLIENTS.decrement(&["tcp"], 1.0);
-                                }
-                                Err(e) => error!(error = %e, "failed to accept connection"),
-                            }
-                        }
-                    }),
-            );
 
             state.open_listeners.write().await.insert(
                 ListenerId(protocol.into(), bound_host),
@@ -677,7 +639,44 @@ pub(crate) async fn create_client(
                     target: target_spec.clone(),
                     forward_path: args.forward_path.clone(),
                     return_path: args.return_path.clone(),
-                    jh,
+                    abort_handle: hopr_async_runtime::spawn_as_abortable(
+                        tokio_stream::wrappers::TcpListenerStream::new(tcp_listener)
+                            .and_then(|sock| async { Ok((sock.peer_addr()?, sock)) })
+                            .for_each_concurrent(None, move |accepted_client| {
+                                let data = data.clone();
+                                let target = target.clone();
+                                let hopr = hopr.clone();
+                                async move {
+                                    match accepted_client {
+                                        Ok((sock_addr, stream)) => {
+                                            debug!(socket = ?sock_addr, "incoming TCP connection");
+                                            let session = match hopr.connect_to(dst, target, data).await {
+                                                Ok(s) => s,
+                                                Err(error) => {
+                                                    error!(%error, "failed to establish session");
+                                                    return;
+                                                }
+                                            };
+
+                                            debug!(
+                                                socket = ?sock_addr,
+                                                session_id = tracing::field::debug(*session.id()),
+                                                "new session for incoming TCP connection",
+                                            );
+
+                                            #[cfg(all(feature = "prometheus", not(test)))]
+                                            METRIC_ACTIVE_CLIENTS.increment(&["tcp"], 1.0);
+
+                                            bind_session_to_stream(session, stream, HOPR_TCP_BUFFER_SIZE).await;
+
+                                            #[cfg(all(feature = "prometheus", not(test)))]
+                                            METRIC_ACTIVE_CLIENTS.decrement(&["tcp"], 1.0);
+                                        }
+                                        Err(e) => error!(error = %e, "failed to accept connection"),
+                                    }
+                                }
+                            }),
+                    ),
                 },
             );
             bound_host
@@ -717,7 +716,7 @@ pub(crate) async fn create_client(
                     target: target_spec.clone(),
                     forward_path: args.forward_path.clone(),
                     return_path: args.return_path.clone(),
-                    jh: hopr_async_runtime::prelude::spawn(async move {
+                    abort_handle: hopr_async_runtime::spawn_as_abortable(async move {
                         #[cfg(all(feature = "prometheus", not(test)))]
                         METRIC_ACTIVE_CLIENTS.increment(&["udp"], 1.0);
 
@@ -903,7 +902,7 @@ pub(crate) async fn close_client(
                 .remove(&bound_addr)
                 .ok_or((StatusCode::NOT_FOUND, ApiErrorStatus::InvalidInput))?;
 
-            hopr_async_runtime::prelude::cancel_join_handle(entry.jh).await;
+            entry.abort_handle.abort();
         }
     }
 

--- a/transport/api/Cargo.toml
+++ b/transport/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Implements the main HOPR transport interface for the core library"
 edition = "2021"

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -36,7 +36,7 @@ use futures::{
     channel::mpsc::{self, Sender, UnboundedReceiver, UnboundedSender, unbounded},
 };
 use helpers::PathPlanner;
-use hopr_async_runtime::prelude::{JoinHandle, spawn};
+use hopr_async_runtime::{AbortHandle, spawn_as_abortable};
 use hopr_crypto_packet::prelude::HoprPacket;
 pub use hopr_crypto_types::{
     keypairs::{ChainKeypair, Keypair, OffchainKeypair},
@@ -268,7 +268,7 @@ where
         on_incoming_data: UnboundedSender<ApplicationData>,
         discovery_updates: UnboundedReceiver<PeerDiscovery>,
         on_incoming_session: UnboundedSender<IncomingSession>,
-    ) -> crate::errors::Result<HashMap<HoprTransportProcess, JoinHandle<()>>> {
+    ) -> crate::errors::Result<HashMap<HoprTransportProcess, AbortHandle>> {
         let (mut internal_discovery_update_tx, internal_discovery_update_rx) =
             futures::channel::mpsc::unbounded::<PeerDiscovery>();
 
@@ -377,7 +377,7 @@ where
             }
         }
 
-        let mut processes: HashMap<HoprTransportProcess, JoinHandle<()>> = HashMap::new();
+        let mut processes: HashMap<HoprTransportProcess, AbortHandle> = HashMap::new();
 
         let ticket_agg_proc = TicketAggregationInteraction::new(self.db.clone(), me_onchain);
         let tkt_agg_writer = ticket_agg_proc.writer();
@@ -461,7 +461,7 @@ where
         let _mixing_process_before_sending_out =
             hopr_async_runtime::prelude::spawn(mixing_channel_rx.map(Ok).forward(wire_msg_tx));
 
-        processes.insert(HoprTransportProcess::Medium, spawn(transport_layer.run()));
+        processes.insert(HoprTransportProcess::Medium, spawn_as_abortable(transport_layer.run()));
 
         // -- msg-ack protocol over the wire transport
         let packet_cfg = PacketInteractionConfig {
@@ -539,7 +539,7 @@ where
         let smgr = self.smgr.clone();
         processes.insert(
             HoprTransportProcess::SessionsManagement(0),
-            spawn(async move {
+            spawn_as_abortable(async move {
                 let _the_process_should_not_end = StreamExt::filter_map(rx_from_probing, |(pseudonym, data)| {
                     let smgr = smgr.clone();
                     async move {

--- a/transport/probe/Cargo.toml
+++ b/transport/probe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-probe"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Probing mechanism of the discovered network topology"

--- a/transport/protocol/Cargo.toml
+++ b/transport/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-protocol"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 license = "GPL-3.0-only"

--- a/transport/session/Cargo.toml
+++ b/transport/session/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-session"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Session functionality providing session abstraction over the HOPR transport"


### PR DESCRIPTION
This pull request introduces a significant refactor across multiple modules to replace the use of `JoinHandle` with `AbortHandle` for managing asynchronous tasks. This change improves task cancellation capabilities and aligns the codebase with modern async patterns. The changes span several files and include updates to function signatures, imports, and task spawning logic.

### Key Changes by Theme:

#### Transition to `AbortHandle`:
* Replaced `JoinHandle` with `AbortHandle` in task management across multiple modules, including `chain/api`, `chain/indexer`, `hopr-lib`, `hoprd`, and `hoprd/rest-api`. This required updating function signatures, return types, and task storage structures. [[1]](diffhunk://#diff-1190b47adce276227437e510df3d3250d35e7857a9f26189ed07cd59291ae13dL244-R250) [[2]](diffhunk://#diff-062748e5c084f2b0e350d07a9361f260daf0176c7dfc98272c3b227a0ce82f8dL108-R111) [[3]](diffhunk://#diff-dd3e00deb7558c2678c6984b11fabc2f69ac770270c874cdcc65be5487cbfbf4L611-R612) [[4]](diffhunk://#diff-b4d76d2ca8cb825810502c755c62f98c6e9e784a5197c0d4fe93d9171be7914bL109-R110) [[5]](diffhunk://#diff-070aea0f31844b0c158d9e5fd8075d947936228402358bbb3ff7883e63bd2862L132-R132)

#### Task Spawning Updates:
* Introduced and utilized a new utility function `spawn_as_abortable` in `common/async-runtime` to spawn tasks with `AbortHandle` support. This function wraps tasks in an abortable future and returns the corresponding `AbortHandle`. [[1]](diffhunk://#diff-8266320150a43bfa8303dbd049d574659078054128820e6236cf026d216981f7L24-R33) [[2]](diffhunk://#diff-1190b47adce276227437e510df3d3250d35e7857a9f26189ed07cd59291ae13dL244-R250) [[3]](diffhunk://#diff-062748e5c084f2b0e350d07a9361f260daf0176c7dfc98272c3b227a0ce82f8dL262-R265) [[4]](diffhunk://#diff-dd3e00deb7558c2678c6984b11fabc2f69ac770270c874cdcc65be5487cbfbf4R886-R889)

#### Dependency and Import Adjustments:
* Added `futures` as a dependency in `Cargo.toml` to access `AbortHandle` and related utilities. Updated imports across files to include `AbortHandle` and remove `JoinHandle` where no longer needed. [[1]](diffhunk://#diff-a0adad16442f3dac318e8bd90680f9a2181b002bf13a48509188e43c29443082R25) [[2]](diffhunk://#diff-1190b47adce276227437e510df3d3250d35e7857a9f26189ed07cd59291ae13dL18-R19) [[3]](diffhunk://#diff-062748e5c084f2b0e350d07a9361f260daf0176c7dfc98272c3b227a0ce82f8dL6-R10)

#### Test and Integration Updates:
* Updated test logic in `chain_integration_tests.rs` to use `AbortHandle` for task management. Adjusted cleanup logic to call `.abort()` on `AbortHandle` instances instead of canceling `JoinHandle`. [[1]](diffhunk://#diff-320a81bd6fea66745ba2849fda034c003902c81d285ae94d24329a2aa5cab094L76-R76) [[2]](diffhunk://#diff-320a81bd6fea66745ba2849fda034c003902c81d285ae94d24329a2aa5cab094L807-R808)

#### REST API Session Management:
* Refactored session handling in `hoprd/rest-api/src/session.rs` to store `AbortHandle` in `StoredSessionEntry` instead of `JoinHandle`. Updated task spawning for session listeners to use `spawn_as_abortable`. [[1]](diffhunk://#diff-070aea0f31844b0c158d9e5fd8075d947936228402358bbb3ff7883e63bd2862L132-R132) [[2]](diffhunk://#diff-070aea0f31844b0c158d9e5fd8075d947936228402358bbb3ff7883e63bd2862L634-R642)

These changes collectively enhance the codebase's robustness and maintainability by adopting a more flexible and modern approach to asynchronous task management.