### PR TITLE
Remove balance update on API query

### DIFF
--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -561,31 +561,6 @@ impl Hopr {
             .hopr_chain_api
             .get_safe_balance(self.cfg.safe_module.safe_address)
             .await?;
-
-        if WxHOPR::is::<C>() {
-            let my_db = self.db.clone();
-            let amount = safe_balance.amount();
-            self.db
-                .begin_transaction()
-                .await?
-                .perform(|tx| {
-                    Box::pin(async move {
-                        let db_safe_balance = my_db.get_safe_hopr_balance(Some(tx)).await?;
-                        if amount != db_safe_balance.amount() {
-                            warn!(
-                                %db_safe_balance,
-                                %amount,
-                                "Safe balance in the DB mismatches on chain balance"
-                            );
-                            my_db
-                                .set_safe_hopr_balance(Some(tx), HoprBalance::new_base(amount))
-                                .await?;
-                        }
-                        Ok::<_, DbSqlError>(())
-                    })
-                })
-                .await?;
-        }
         Ok(safe_balance)
     }
 


### PR DESCRIPTION
Balance update on mismatch on API query can cause database lock during Indexing or node operation, because it causes a write into the Index DB.