### PR TITLE
fix(indexer): key-binding errors

### DIFF
--- a/chain/indexer/src/handlers.rs
+++ b/chain/indexer/src/handlers.rs
@@ -135,7 +135,7 @@ where
                 // safeguard against empty multiaddrs, skip
                 if address_announcement.baseMultiaddr.is_empty() {
                     warn!(
-                        address = ?address_announcement.node,
+                        address = %address_announcement.node,
                         "encountered empty multiaddress announcement",
                     );
                     return Ok(None);
@@ -163,8 +163,8 @@ where
             }
             HoprAnnouncementsEvents::KeyBinding(key_binding) => {
                 debug!(
-                    address = ?key_binding.chain_key,
-                    public_key = ?key_binding.ed25519_pub_key.0,
+                    address = %key_binding.chain_key,
+                    public_key = %key_binding.ed25519_pub_key,
                     "on_announcement_event: KeyBinding",
                 );
                 match KeyBinding::from_parts(

--- a/db/sql/src/cache.rs
+++ b/db/sql/src/cache.rs
@@ -247,8 +247,10 @@ impl CacheKeyMapper {
                     Ok(())
                 }
             }
-            // This should never happen.
-            (Entry::Vacant(_v_id), Entry::Occupied(v_key)) => {
+            // This only happens on re-announcements:
+            // The re-announcement uses the same packet key and chain-key, but the block number (published at)
+            // is different, and therefore the id_entry will be vacant.
+            (Entry::Vacant(_), Entry::Occupied(v_key)) => {
                 tracing::debug!(
                     "attempt to insert key {key} with key-id {id} failed because key is already set as {}",
                     v_key.get()
@@ -256,7 +258,7 @@ impl CacheKeyMapper {
                 Err(DbSqlError::LogicalError("inconsistent key-id binding".into()))
             }
             // This should never happen.
-            (Entry::Occupied(v_id), Entry::Vacant(_v_key)) => {
+            (Entry::Occupied(v_id), Entry::Vacant(_)) => {
                 tracing::debug!(
                     "attempt to insert key {key} with key-id {id} failed because key-id is already set as {}",
                     v_id.get()


### PR DESCRIPTION
Fixes errors like `logical error: inconsistent key-id binding`, caused by re-announcements.

Now the key-id binding is inserted only when the announcement is made for the first time, as subsequent updates of key-binding are not necessary.