### PR TITLE
feat(ci): add pre-commit checks

### DIFF
--- a/.github/workflows/checks-pre-commit.yaml
+++ b/.github/workflows/checks-pre-commit.yaml
@@ -13,11 +13,11 @@ on:
         required: true
         type: string
 concurrency:
-  group: ${{ inputs.source_branch || github.ref_name }}-audit
+  group: ${{ inputs.source_branch || github.ref_name }}-pre-commit
   cancel-in-progress: true
 
 jobs:
-  cargo-audit:
+  pre-commit:
     name: Pre-commit
     runs-on: self-hosted-hoprnet-small
     steps:
@@ -47,4 +47,4 @@ jobs:
           USER: runner
 
       - name: Run Pre-commit
-        run: nix develop -c "pre-commit"
+        run: nix develop --command bash -c "pre-commit run --all-files --show-diff-on-failure"

--- a/.github/workflows/checks-pre-commit.yaml
+++ b/.github/workflows/checks-pre-commit.yaml
@@ -1,0 +1,50 @@
+---
+name: Pre-commit
+
+on:
+  merge_group:
+    types: [checks_requested]
+  workflow_call:
+    inputs:
+      source_repo:
+        required: true
+        type: string
+      source_branch:
+        required: true
+        type: string
+concurrency:
+  group: ${{ inputs.source_branch || github.ref_name }}-audit
+  cancel-in-progress: true
+
+jobs:
+  cargo-audit:
+    name: Pre-commit
+    runs-on: self-hosted-hoprnet-small
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
+        with:
+          disable-sudo: true
+          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+
+      - name: Checkout hoprnet repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          repository: ${{ inputs.source_repo }}
+          ref: ${{ inputs.source_branch }}
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@17fe5fb4a23ad6cbbe47d6b3f359611ad276644c # v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
+        with:
+          name: hoprnet
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+        env:
+          USER: runner
+
+      - name: Run Pre-commit
+        run: nix develop -c "pre-commit"

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -24,6 +24,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pre-commit:
+    name: Pre-commit
+    uses: ./.github/workflows/checks-pre-commit.yaml
+    with:
+      source_repo: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+      source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
+    secrets: inherit
+
   audit:
     name: Audit
     uses: ./.github/workflows/checks-audit.yaml


### PR DESCRIPTION
This pull request introduces a new pre-commit workflow to streamline checks before merging and integrates it into the existing `checks.yaml` workflow. The changes focus on defining the pre-commit workflow and ensuring it is properly linked and configured.

### New Pre-commit Workflow:

* [`.github/workflows/checks-pre-commit.yaml`](diffhunk://#diff-af487f6988a751c9f8f1a422777e3e09ded55b4d843883102510947b0afc9a1fR1-R50): Added a new pre-commit workflow that runs on `merge_group` events and uses self-hosted runners. It includes steps for hardening the runner, checking out the repository, installing Nix, setting up Cachix, and running pre-commit checks.

### Integration with Existing Workflow:

* [`.github/workflows/checks.yaml`](diffhunk://#diff-4af11422a4987e947e5a47adead7a30d32cdb2db82e2d3fe36f8e6cbe84d5ac5R27-R34): Integrated the pre-commit workflow into the main `checks.yaml` file by adding a new `pre-commit` job that uses the newly created `checks-pre-commit.yaml` workflow. It passes the source repository and branch as inputs and inherits secrets.