### PR TITLE
feat: add Wireshark dissector and custom capture format

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -83,8 +83,13 @@ jobs:
         id: options
         run: |
           nix_debug_option="-dev"
+          nix_profile_build="false"
           if [[ "${{ inputs.production }}" = "true" || -n "${GITHUB_PR_LABEL_DOCKER_PRODUCTION_BUILD}" ]]; then
             nix_debug_option=""
+            nix_profile_build="true"
+          fi
+          if [[ -n "${GITHUB_PR_LABEL_DOCKER_PROFILE_BUILD}" ]]; then
+            nix_profile_build="true"
           fi
           declare docker_tag docker_tag_pr docker_release_latest_tag
           if ${{ contains(steps.pr-labels.outputs.labels, ' release ') }}; then
@@ -93,6 +98,7 @@ jobs:
             echo "DOCKER_TAG=${docker_tag}" >> $GITHUB_OUTPUT
             echo "DOCKER_TAG_PR=${docker_tag_pr}" >> $GITHUB_OUTPUT
             echo "NIX_BUILD_TARGET=${{ inputs.package }}${nix_debug_option}-docker-build-and-upload" >> $GITHUB_OUTPUT
+            echo "NIX_BUILD_TARGET_PROFILE=${{ inputs.package }}-profile-docker-build-and-upload" >> $GITHUB_OUTPUT
           else
             next_version=$(./scripts/get-next-version.sh Build)
             ./scripts/bump-version.sh ${next_version}
@@ -101,6 +107,9 @@ jobs:
             echo "DOCKER_TAG=${docker_tag}" >> $GITHUB_OUTPUT
             echo "DOCKER_TAG_PR=${docker_tag_pr}" >> $GITHUB_OUTPUT
             echo "NIX_BUILD_TARGET=${{ inputs.package }}${nix_debug_option}-docker-build-and-upload" >> $GITHUB_OUTPUT
+            if [[ "${nix_profile_build}" = "true" ]]: then
+              echo "NIX_BUILD_TARGET_PROFILE=${{ inputs.package }}-profile-docker-build-and-upload" >> $GITHUB_OUTPUT
+            fi
           fi
           base_branch=${{ github.event.pull_request.base.ref }}
           if [ "${base_branch}" == "master" ]; then
@@ -143,6 +152,34 @@ jobs:
         env:
           GOOGLE_ACCESS_TOKEN: ${{ steps.gcp.outputs.access_token }}
           IMAGE_TARGET: ${{ vars.DOCKER_IMAGE_REGISTRY }}/${{ inputs.package }}:${{ steps.options.outputs.DOCKER_RELEASE_LATEST_TAG }}
+
+      - name: Build and push ${{ inputs.package }}-profile docker image - Commit
+        run: nix run -L .#${{ steps.options.outputs.NIX_BUILD_TARGET_PROFILE }}
+        if: steps.options.outputs.NIX_BUILD_TARGET_PROFILE != ''
+        env:
+          GOOGLE_ACCESS_TOKEN: ${{ steps.gcp.outputs.access_token }}
+          IMAGE_TARGET: ${{ vars.DOCKER_IMAGE_REGISTRY }}/${{ inputs.package }}:${{ steps.options.outputs.DOCKER_TAG }}-profile
+
+      - name: Build and push ${{ inputs.package }}-profile docker image - PR
+        run: nix run -L .#${{ steps.options.outputs.NIX_BUILD_TARGET_PROFILE }}
+        if: steps.options.outputs.NIX_BUILD_TARGET_PROFILE != ''
+        env:
+          GOOGLE_ACCESS_TOKEN: ${{ steps.gcp.outputs.access_token }}
+          IMAGE_TARGET: ${{ vars.DOCKER_IMAGE_REGISTRY }}/${{ inputs.package }}:${{ steps.options.outputs.DOCKER_TAG_PR }}-profile
+
+      - name: Build and push ${{ inputs.package }}-profile docker image - latest
+        run: nix run -L .#${{ steps.options.outputs.NIX_BUILD_TARGET_PROFILE }}
+        if: steps.options.outputs.NIX_BUILD_TARGET_PROFILE != '' && inputs.production && github.event.pull_request.base.ref == 'master'
+        env:
+          GOOGLE_ACCESS_TOKEN: ${{ steps.gcp.outputs.access_token }}
+          IMAGE_TARGET: ${{ vars.DOCKER_IMAGE_REGISTRY }}/${{ inputs.package }}:latest-profile
+
+      - name: Build and push ${{ inputs.package }} docker image - release-latest
+        run: nix run -L .#${{ steps.options.outputs.NIX_BUILD_TARGET_PROFILE }}
+        if: steps.options.outputs.NIX_BUILD_TARGET_PROFILE != '' && inputs.production && steps.options.outputs.DOCKER_RELEASE_LATEST_TAG != ''
+        env:
+          GOOGLE_ACCESS_TOKEN: ${{ steps.gcp.outputs.access_token }}
+          IMAGE_TARGET: ${{ vars.DOCKER_IMAGE_REGISTRY }}/${{ inputs.package }}:${{ steps.options.outputs.DOCKER_RELEASE_LATEST_TAG }}-profile
 
       - name: Trigger deploy workflow if needed
         if: (env.GITHUB_PR_LABEL_DEPLOY_NODES || inputs.production ) && contains(inputs.package,'hoprd') && vars.CONTINUOUS_DEPLOYMENT_ENABLED == 'true'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1595,30 +1595,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
-name = "bitcode"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf300f4aa6e66f3bdff11f1236a88c622fe47ea814524792240b4d554d9858ee"
-dependencies = [
- "arrayvec",
- "bitcode_derive",
- "bytemuck",
- "glam",
- "serde",
-]
-
-[[package]]
-name = "bitcode_derive"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42b6b4cb608b8282dc3b53d0f4c9ab404655d562674c682db7e6c0458cc83c23"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.103",
-]
-
-[[package]]
 name = "bitcoin-io"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1824,12 +1800,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "bytemuck"
-version = "1.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
 
 [[package]]
 name = "byteorder"
@@ -4159,12 +4129,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glam"
-version = "0.30.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50a99dbe56b72736564cfa4b85bf9a33079f16ae8b74983ab06af3b1a3696b11"
-
-[[package]]
 name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5280,7 +5244,6 @@ dependencies = [
  "anyhow",
  "async-stream",
  "async-trait",
- "bitcode",
  "futures",
  "futures-concurrency",
  "hex",
@@ -5340,6 +5303,7 @@ dependencies = [
  "hopr-transport-identity",
  "hopr-transport-mixer",
  "hopr-transport-packet",
+ "hopr-transport-probe",
  "lazy_static",
  "libp2p",
  "moka",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1838,6 +1838,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder_slice"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b294e30387378958e8bf8f4242131b930ea615ff81e8cac2440cea0a6013190"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2539,6 +2548,17 @@ name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "derive-into-owned"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d94d81e3819a7b06a8638f448bc6339371ca9b6076a99d4a43eece3c4c923"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5324,6 +5344,7 @@ dependencies = [
  "libp2p",
  "moka",
  "more-asserts",
+ "pcap-file",
  "rust-stream-ext-concurrent",
  "serde",
  "serde_with",
@@ -5335,6 +5356,7 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-test",
+ "uuid",
  "validator",
 ]
 
@@ -7448,6 +7470,17 @@ checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
  "hmac",
+]
+
+[[package]]
+name = "pcap-file"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc1f139757b058f9f37b76c48501799d12c9aa0aa4c0d4c980b062ee925d1b2"
+dependencies = [
+ "byteorder_slice",
+ "derive-into-owned",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5356,7 +5356,6 @@ dependencies = [
  "tokio-util",
  "tracing",
  "tracing-test",
- "uuid",
  "validator",
 ]
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ On top of the default configuration options generated for the command line, the 
 - `HOPR_BALANCER_PID_I_GAIN` - integral (I) gain for the PID controller in SURB balancer (default: `0.7`)
 - `HOPR_BALANCER_PID_D_GAIN` - derivative (D) gain for the PID controller in SURB balancer (default: `0.2`)
 - `HOPR_TEST_DISABLE_CHECKS` - the node is being run in test mode with some safety checks disabled (currently: minimum winning probability check)
+- `HOPR_CAPTURE_PACKETS` - allow capturing customized HOPR packet format to a PCAP file or to a `udpdump` host. Note that `hoprd` must be built with the `capture` feature.
 - `HOPRD_SESSION_PORT_RANGE` - allows restricting the port range (syntax: `start:end` inclusive) of Session listener automatic port selection (when port 0 is specified)
 - `HOPRD_NAT` - indicates whether the host is behind a NAT and sets transport-specific settings accordingly (default: `false`)
 

--- a/db/api/src/protocol.rs
+++ b/db/api/src/protocol.rs
@@ -89,7 +89,7 @@ impl std::fmt::Debug for OutgoingPacket {
         f.debug_struct("OutgoingPacket")
             .field("next_hop", &self.next_hop)
             .field("ack_challenge", &self.ack_challenge)
-            .finish()
+            .finish_non_exhaustive()
     }
 }
 

--- a/flake.nix
+++ b/flake.nix
@@ -199,8 +199,16 @@
           # also used for Docker image
           hoprd-x86_64-linux = rust-builder-x86_64-linux.callPackage ./nix/rust-package.nix hoprdBuildArgs;
           # also used for Docker image
+          hoprd-x86_64-linux-profile = rust-builder-x86_64-linux.callPackage ./nix/rust-package.nix (
+            hoprdBuildArgs // { cargoExtraArgs = "-F capture"; }
+          );
+          # also used for Docker image
           hoprd-x86_64-linux-dev = rust-builder-x86_64-linux.callPackage ./nix/rust-package.nix (
-            hoprdBuildArgs // { CARGO_PROFILE = "dev"; }
+            hoprdBuildArgs
+            // {
+              CARGO_PROFILE = "dev";
+              cargoExtraArgs = "-F capture";
+            }
           );
           hoprd-aarch64-linux = rust-builder-aarch64-linux.callPackage ./nix/rust-package.nix hoprdBuildArgs;
           hoprd-armv7l-linux = rust-builder-armv7l-linux.callPackage ./nix/rust-package.nix hoprdBuildArgs;
@@ -225,7 +233,11 @@
             hoprdBuildArgs // { runClippy = true; }
           );
           hoprd-dev = rust-builder-local.callPackage ./nix/rust-package.nix (
-            hoprdBuildArgs // { CARGO_PROFILE = "dev"; }
+            hoprdBuildArgs
+            // {
+              CARGO_PROFILE = "dev";
+              cargoExtraArgs = "-F capture";
+            }
           );
           # build candidate binary as static on Linux amd64 to get more test exposure specifically via smoke tests
           hoprd-candidate =
@@ -337,7 +349,7 @@
           hoprd-docker = import ./nix/docker-builder.nix (hoprdDockerArgs hoprd-x86_64-linux [ ]);
           hoprd-dev-docker = import ./nix/docker-builder.nix (hoprdDockerArgs hoprd-x86_64-linux-dev [ ]);
           hoprd-profile-docker = import ./nix/docker-builder.nix (
-            hoprdDockerArgs hoprd-x86_64-linux profileDeps
+            hoprdDockerArgs hoprd-x86_64-linux-profile profileDeps
           );
 
           hopliDockerArgs = package: deps: {

--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -35,6 +35,7 @@ prometheus = [
   "hopr-network-types/prometheus",
   "hopr-strategy/prometheus",
 ]
+capture = ["hopr-transport/capture"]
 
 [dependencies]
 alloy = { workspace = true, default-features = false, features = [

--- a/hoprd/hoprd/Cargo.toml
+++ b/hoprd/hoprd/Cargo.toml
@@ -40,6 +40,7 @@ telemetry = [
 ]
 transport-quic = ["hopr-lib/transport-quic"]
 explicit-path = ["hoprd-api/explicit-path"]
+capture = ["hopr-lib/capture"]
 # To use profiling:
 # 1. Set RUSTFLAGS="--cfg tokio_unstable" before building
 # 2. Enable the 'prof' feature: cargo build --feature prof

--- a/transport/api/Cargo.toml
+++ b/transport/api/Cargo.toml
@@ -35,6 +35,7 @@ prometheus = [
 ]
 mixer-stream = ["dep:rust-stream-ext-concurrent"]
 mixer-channel = []
+capture = ["hopr-transport-protocol/capture"]
 
 [dependencies]
 async-trait = { workspace = true }

--- a/transport/mixer/src/channel.rs
+++ b/transport/mixer/src/channel.rs
@@ -70,7 +70,7 @@ impl<T> Clone for TrackedChannel<T> {
 }
 
 /// Error returned by the [`Sender`].
-#[derive(Debug, thiserror::Error)]
+#[derive(Clone, Debug, thiserror::Error)]
 pub enum SenderError {
     /// The channel is closed due to receiver being dropped.
     #[error("Channel is closed")]

--- a/transport/probe/Cargo.toml
+++ b/transport/probe/Cargo.toml
@@ -20,7 +20,6 @@ runtime-tokio = ["hopr-async-runtime/runtime-tokio"]
 anyhow = { workspace = true }
 async-stream = { workspace = true }
 async-trait = { workspace = true }
-bitcode = { version = "0.6.6", features = ["serde"] }
 futures = { workspace = true }
 futures-concurrency = { workspace = true }
 hex = { workspace = true }

--- a/transport/probe/src/content.rs
+++ b/transport/probe/src/content.rs
@@ -1,22 +1,24 @@
-use anyhow::Context;
+use hopr_primitive_types::prelude::GeneralError;
 use hopr_transport_packet::prelude::{ApplicationData, ReservedTag, Tag};
 
 /// Serializable and deserializable enum for the probe message content
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, strum::EnumDiscriminants)]
+#[strum_discriminants(vis(pub(crate)))]
+#[strum_discriminants(derive(strum::FromRepr, strum::EnumCount), repr(u8))]
 pub enum NeighborProbe {
-    /// Ping message with a random nonce
-    Ping([u8; Self::SIZE]),
-    /// Pong message repliying to a specific nonce
-    Pong([u8; Self::SIZE]),
+    /// Ping message with random nonce
+    Ping([u8; Self::NONCE_SIZE]),
+    /// Pong message replying to a specific nonce
+    Pong([u8; Self::NONCE_SIZE]),
 }
 
 impl NeighborProbe {
-    pub const SIZE: usize = 32;
+    pub const NONCE_SIZE: usize = 32;
+    pub const SIZE: usize = 1 + Self::NONCE_SIZE;
 
     /// Returns the nonce of the message
     pub fn random_nonce() -> Self {
-        const SIZE: usize = NeighborProbe::SIZE;
-        Self::Ping(hopr_crypto_random::random_bytes::<SIZE>())
+        Self::Ping(hopr_crypto_random::random_bytes::<{ Self::NONCE_SIZE }>())
     }
 
     pub fn is_complement_to(&self, other: Self) -> bool {
@@ -24,6 +26,38 @@ impl NeighborProbe {
             (Self::Ping(nonce1), Self::Pong(nonce2)) => nonce1 == nonce2,
             (Self::Pong(nonce1), Self::Ping(nonce2)) => nonce1 == nonce2,
             _ => false,
+        }
+    }
+
+    pub fn to_bytes(self) -> Box<[u8]> {
+        let mut out = Vec::with_capacity(1 + Self::NONCE_SIZE);
+        out.push(NeighborProbeDiscriminants::from(&self) as u8);
+        out.extend_from_slice(self.as_ref());
+        out.into_boxed_slice()
+    }
+}
+
+impl<'a> TryFrom<&'a [u8]> for NeighborProbe {
+    type Error = GeneralError;
+
+    fn try_from(value: &'a [u8]) -> Result<Self, Self::Error> {
+        if value.len() == 1 + Self::NONCE_SIZE {
+            match NeighborProbeDiscriminants::from_repr(value[0])
+                .ok_or(GeneralError::ParseError("NeighborProbe.disc".into()))?
+            {
+                NeighborProbeDiscriminants::Ping => {
+                    Ok(Self::Ping((&value[1..]).try_into().map_err(|_| {
+                        GeneralError::ParseError("NeighborProbe.ping_nonce".into())
+                    })?))
+                }
+                NeighborProbeDiscriminants::Pong => {
+                    Ok(Self::Pong((&value[1..]).try_into().map_err(|_| {
+                        GeneralError::ParseError("NeighborProbe.pong_nonce".into())
+                    })?))
+                }
+            }
+        } else {
+            Err(GeneralError::ParseError("NeighborProbe.size".into()))
         }
     }
 }
@@ -37,48 +71,143 @@ impl std::fmt::Display for NeighborProbe {
     }
 }
 
-impl From<NeighborProbe> for [u8; NeighborProbe::SIZE] {
-    fn from(probe: NeighborProbe) -> Self {
-        match probe {
+impl AsRef<[u8]> for NeighborProbe {
+    fn as_ref(&self) -> &[u8] {
+        match self {
             NeighborProbe::Ping(nonce) | NeighborProbe::Pong(nonce) => nonce,
         }
     }
 }
 
 /// TODO: TBD as a separate task for network discovery
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct PathTelemetry {
-    id: [u8; 10],
-    path: [u8; 10],
-    timestamp: u128,
+    pub id: [u8; Self::ID_SIZE],
+    pub path: [u8; Self::PATH_SIZE],
+    pub timestamp: u128,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+impl PathTelemetry {
+    pub const ID_SIZE: usize = 10;
+    pub const PATH_SIZE: usize = 10;
+    pub const SIZE: usize = Self::ID_SIZE + Self::PATH_SIZE + size_of::<u128>();
+
+    pub fn to_bytes(self) -> Box<[u8]> {
+        let mut out = Vec::with_capacity(Self::SIZE);
+        out.extend_from_slice(&self.id);
+        out.extend_from_slice(&self.path);
+        out.extend_from_slice(&self.timestamp.to_be_bytes());
+        out.into_boxed_slice()
+    }
+}
+
+impl std::fmt::Display for PathTelemetry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "PathTelemetry(id: {}, path: {}, timestamp: {})",
+            hex::encode(self.id),
+            hex::encode(self.path),
+            self.timestamp
+        )
+    }
+}
+
+impl<'a> TryFrom<&'a [u8]> for PathTelemetry {
+    type Error = GeneralError;
+
+    fn try_from(value: &'a [u8]) -> Result<Self, Self::Error> {
+        if value.len() == Self::SIZE {
+            Ok(Self {
+                id: (&value[0..10])
+                    .try_into()
+                    .map_err(|_| GeneralError::ParseError("PathTelemetry.id".into()))?,
+                path: (&value[10..20])
+                    .try_into()
+                    .map_err(|_| GeneralError::ParseError("PathTelemetry.id".into()))?,
+                timestamp: u128::from_be_bytes(
+                    (&value[20..36])
+                        .try_into()
+                        .map_err(|_| GeneralError::ParseError("PathTelemetry.id".into()))?,
+                ),
+            })
+        } else {
+            Err(GeneralError::ParseError("PathTelemetry".into()))
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, strum::EnumDiscriminants, strum::Display)]
+#[strum_discriminants(vis(pub(crate)))]
+#[strum_discriminants(derive(strum::FromRepr, strum::EnumCount), repr(u8))]
 pub enum Message {
     Telemetry(PathTelemetry),
     Probe(NeighborProbe),
 }
 
-impl std::fmt::Display for Message {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl Message {
+    pub const VERSION: u8 = 1;
+
+    pub fn to_bytes(self) -> Box<[u8]> {
+        let mut out = Vec::<u8>::with_capacity(1 + NeighborProbe::SIZE.max(PathTelemetry::SIZE));
+        out.push(Self::VERSION);
+        out.push(MessageDiscriminants::from(&self) as u8);
+
         match self {
-            Message::Telemetry(telemetry) => write!(f, "Telemetry({:?})", telemetry),
-            Message::Probe(probe) => write!(f, "Probe({})", probe),
+            Message::Telemetry(telemetry) => out.extend(telemetry.to_bytes()),
+            Message::Probe(probe) => out.extend(probe.to_bytes()),
+        }
+
+        out.into_boxed_slice()
+    }
+}
+
+impl<'a> TryFrom<&'a [u8]> for Message {
+    type Error = GeneralError;
+
+    fn try_from(value: &'a [u8]) -> Result<Self, Self::Error> {
+        if value.is_empty() {
+            return Err(GeneralError::ParseError("Message.size".into()));
+        }
+
+        if value[0] != Self::VERSION {
+            return Err(GeneralError::ParseError("Message.version".into()));
+        }
+
+        match MessageDiscriminants::from_repr(value[1]).ok_or(GeneralError::ParseError("Message.disc".into()))? {
+            MessageDiscriminants::Telemetry => {
+                if value.len() == 2 + PathTelemetry::SIZE {
+                    Ok(Self::Telemetry(
+                        (&value[2..])
+                            .try_into()
+                            .map_err(|_| GeneralError::ParseError("Message.telemetry".into()))?,
+                    ))
+                } else {
+                    Err(GeneralError::ParseError("Message.telemetry.size".into()))?
+                }
+            }
+            MessageDiscriminants::Probe => {
+                if value.len() == 2 + NeighborProbe::SIZE {
+                    Ok(Self::Probe(
+                        (&value[2..])
+                            .try_into()
+                            .map_err(|_| GeneralError::ParseError("Message.probe".into()))?,
+                    ))
+                } else {
+                    Err(GeneralError::ParseError("Message.probe.size".into()))?
+                }
+            }
         }
     }
 }
 
-impl TryFrom<Message> for ApplicationData {
-    type Error = anyhow::Error;
-
-    fn try_from(message: Message) -> Result<Self, Self::Error> {
+impl From<Message> for ApplicationData {
+    fn from(message: Message) -> Self {
         let tag: Tag = ReservedTag::Ping.into();
-        Ok(ApplicationData {
+        ApplicationData {
             application_tag: tag,
-            plain_text: bitcode::serialize(&message)
-                .context("Failed to serialize message")?
-                .into_boxed_slice(),
-        })
+            plain_text: message.to_bytes(),
+        }
     }
 }
 
@@ -89,7 +218,7 @@ impl TryFrom<ApplicationData> for Message {
         let reserved_probe_tag: Tag = ReservedTag::Ping.into();
 
         if value.application_tag == reserved_probe_tag {
-            let message: Message = bitcode::deserialize(&value.plain_text).context("Failed to deserialize message")?;
+            let message: Message = value.plain_text.as_ref().try_into()?;
             Ok(message)
         } else {
             Err(anyhow::anyhow!("Non probing application tag found"))
@@ -106,35 +235,56 @@ mod tests {
     use super::*;
 
     #[test]
+    fn probe_message_should_serialize_and_deserialize() -> anyhow::Result<()> {
+        let m1 = Message::Probe(NeighborProbe::random_nonce());
+        let m2 = Message::try_from(m1.to_bytes().as_ref())?;
+
+        assert_eq!(m1, m2);
+
+        let m1 = Message::Telemetry(PathTelemetry {
+            id: hopr_crypto_random::random_bytes(),
+            path: hopr_crypto_random::random_bytes(),
+            timestamp: 1234567890,
+        });
+        let m2 = Message::try_from(m1.to_bytes().as_ref())?;
+
+        assert_eq!(m1, m2);
+        Ok(())
+    }
+
+    #[test]
     fn random_generation_of_a_neighbor_probe_produces_a_ping() {
         let ping = NeighborProbe::random_nonce();
         assert!(matches!(ping, NeighborProbe::Ping(_)));
     }
 
     #[test]
-    fn check_for_complement_works_for_ping_and_pong_with_the_same_nonce() {
+    fn check_for_complement_works_for_ping_and_pong_with_the_same_nonce() -> anyhow::Result<()> {
         let ping = NeighborProbe::random_nonce();
-        let pong = { NeighborProbe::Pong(ping.into()) };
+        let pong = { NeighborProbe::Pong(ping.as_ref().try_into()?) };
 
         assert!(ping.is_complement_to(pong));
+        Ok(())
     }
 
     #[test]
-    fn check_for_complement_fails_for_ping_and_pong_with_different_nonce() {
+    fn check_for_complement_fails_for_ping_and_pong_with_different_nonce() -> anyhow::Result<()> {
         let ping = NeighborProbe::random_nonce();
         let pong = {
-            let mut other: [u8; NeighborProbe::SIZE] = ping.into();
+            let mut other: [u8; NeighborProbe::NONCE_SIZE] = ping.as_ref().try_into()?;
             other[0] = other[0].wrapping_add(1); // Modify the first byte to ensure it's different
             NeighborProbe::Pong(other)
         };
 
         assert!(!ping.is_complement_to(pong));
+
+        Ok(())
     }
 
     #[test]
     fn check_that_at_least_one_surb_can_fit_into_the_payload_for_direct_probing() -> anyhow::Result<()> {
         let ping = NeighborProbe::random_nonce();
-        let as_data: ApplicationData = Message::Probe(ping).try_into()?;
+        let as_data: ApplicationData = Message::Probe(ping).into();
 
         assert_lt!(
             as_data.plain_text.len(),
@@ -151,7 +301,7 @@ mod tests {
             path: [1; 10],
             timestamp: current_time().as_unix_timestamp().as_millis(),
         };
-        let as_data: ApplicationData = Message::Telemetry(telemetry).try_into()?;
+        let as_data: ApplicationData = Message::Telemetry(telemetry).into();
 
         assert_lt!(
             as_data.plain_text.len(),

--- a/transport/protocol/Cargo.toml
+++ b/transport/protocol/Cargo.toml
@@ -9,9 +9,10 @@ license = "GPL-3.0-only"
 crate-type = ["rlib"]
 
 [features]
-default = []
+default = ["capture"]
 runtime-tokio = ["hopr-async-runtime/runtime-tokio"]
 prometheus = ["dep:hopr-metrics", "hopr-path/prometheus"]
+capture = ["dep:pcap-file", "dep:uuid"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -21,6 +22,7 @@ hex-literal = { workspace = true }
 lazy_static = { workspace = true }
 libp2p = { workspace = true, features = ["noise", "request-response"] }
 moka = { workspace = true }
+pcap-file = { version = "2.0.0", optional = true }
 rust-stream-ext-concurrent = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_with = { workspace = true }
@@ -48,6 +50,7 @@ hopr-primitive-types = { workspace = true }
 hopr-transport-bloom = { workspace = true, features = ["persistent"] }
 hopr-transport-identity = { workspace = true }
 hopr-transport-packet = { workspace = true }
+uuid = { workspace = true, features = ["v4"], optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/transport/protocol/Cargo.toml
+++ b/transport/protocol/Cargo.toml
@@ -62,6 +62,7 @@ more-asserts = { workspace = true }
 serial_test = { workspace = true }
 tracing-test = { workspace = true }
 hopr-transport-mixer = { workspace = true }
+hopr-transport-probe = { workspace = true }
 
 [[bench]]
 name = "protocol_throughput_emulated"

--- a/transport/protocol/Cargo.toml
+++ b/transport/protocol/Cargo.toml
@@ -9,10 +9,10 @@ license = "GPL-3.0-only"
 crate-type = ["rlib"]
 
 [features]
-default = ["capture"]
+default = []
 runtime-tokio = ["hopr-async-runtime/runtime-tokio"]
 prometheus = ["dep:hopr-metrics", "hopr-path/prometheus"]
-capture = ["dep:pcap-file", "dep:uuid"]
+capture = ["dep:pcap-file"]
 
 [dependencies]
 anyhow = { workspace = true }
@@ -50,7 +50,6 @@ hopr-primitive-types = { workspace = true }
 hopr-transport-bloom = { workspace = true, features = ["persistent"] }
 hopr-transport-identity = { workspace = true }
 hopr-transport-packet = { workspace = true }
-uuid = { workspace = true, features = ["v4"], optional = true }
 
 [dev-dependencies]
 tokio = { workspace = true }

--- a/transport/protocol/hopr.lua
+++ b/transport/protocol/hopr.lua
@@ -1,0 +1,349 @@
+-- HOPR Start Protocol Lua dissector
+
+local hopr_start = Proto("hopr_start", "HOPR Start Protocol")
+
+-- Start protocol fields
+local start_fields = {
+    version = ProtoField.uint8("hopr_start.version", "Version", base.DEC),
+    type = ProtoField.uint8("hopr_start.type", "Type", base.HEX, {
+        [0x00] = "StartSession",
+        [0x01] = "SessionEstablished",
+        [0x02] = "SessionError",
+        [0x03] = "CloseSession",
+        [0x04] = "KeepAlive"
+    }),
+
+    msg = ProtoField.bytes("hopr_start.message", "Bincode encoded message")
+}
+
+hopr_start.fields = start_fields
+
+-- Dissector function
+local function dissect_hopr_start(buffer, pinfo, tree)
+    local subtree = tree:add(hopr_start, buffer())
+
+    local offset = 0
+    subtree:add(start_fields.version, buffer(offset,1))
+    local version = buffer(offset, 1):uint()
+    offset = offset + 1
+
+    subtree:add(start_fields.type, buffer(offset,1))
+    local msg_type = buffer(offset, 1):uint()
+    offset = offset + 1
+
+    subtree:add(start_fields.msg, buffer(offset))
+end
+
+---------------------------------------------------------------------------------------
+
+-- HOPR Session Protocol Lua dissector
+
+local hopr_session = Proto("hopr_session", "HOPR Session Protocol")
+
+-- Session protocol fields
+local session_fields = {
+    version = ProtoField.uint8("hopr_session.version", "Version", base.DEC),
+    
+    type = ProtoField.uint8("hopr_session.type", "Type", base.HEX, {
+        [0x00] = "Segment",
+        [0x01] = "SegmentRequest",
+        [0x02] = "FrameAcknowledgements"
+    }),
+
+    len = ProtoField.uint16("hopr_session.len", "Message Length", base.DEC),
+
+    -- Segment fields
+    seg_frame_id = ProtoField.uint32("hopr_session.segment.frame_id", "Frame ID", base.DEC),
+    seg_idx = ProtoField.uint8("hopr_session.segment.seg_idx", "Segment Index", base.DEC),
+    seg_seq_len = ProtoField.uint8("hopr_session.segment.seq_len", "Sequence Length", base.DEC),
+    seg_data = ProtoField.bytes("hopr_session.segment.data", "Data"),
+
+    -- SegmentRequest fields
+    req_frame_id = ProtoField.uint32("hopr_session.segment_request.frame_id", "Frame ID", base.DEC),
+    req_missing = ProtoField.uint8("hopr_session.segment_request.missing_segments", "Missing Segments", base.DEC),
+
+    -- FrameAcknowledgement fields
+    ack_frame_id = ProtoField.uint32("hopr_session.frame_ack.frame_id", "Frame ID", base.DEC)
+}
+
+hopr_session.fields = session_fields
+
+
+-- Dissector function
+local function dissect_hopr_session(buffer, pinfo, tree)
+    local subtree = tree:add(hopr_session, buffer())
+
+    local offset = 0
+    subtree:add(session_fields.version, buffer(offset,1))
+    local version = buffer(offset,1):uint()
+    offset = offset + 1
+
+    subtree:add(session_fields.type, buffer(offset,1))
+    local msg_type = buffer(offset,1):uint()
+    offset = offset + 1
+
+    subtree:add(session_fields.len, buffer(offset,2))
+    local msg_len = buffer(offset,2):uint()
+    offset = offset + 2
+
+    -- Parse message based on type
+    if msg_type == 0x00 then
+        -- Segment
+        pinfo.cols.info:append(", Segment")
+        local seg_tree = subtree:add("Segment")
+        seg_tree:add(session_fields.seg_frame_id, buffer(offset,4))
+        seg_tree:add(session_fields.seg_idx, buffer(offset+4,1))
+        seg_tree:add(session_fields.seg_seq_len, buffer(offset+5,1))
+        local data_len = msg_len - 6
+        local data_buf = buffer(offset+6, data_len)
+
+        -- Call heuristic dissectors on Segment.data
+        -- This allows Wireshark to attempt to decode the payload inside Segment.data
+        local data_tvb = data_buf:tvb()
+
+        -- Get the heuristic dissector table for "data"
+        succ = DissectorTable.try_heuristics("udp", data_tvb, pinfo, seg_tree)
+        if not succ then
+            succ = DissectorTable.try_heuristics("tcp", data_tvb, pinfo, seg_tree)
+            if not succ then
+                -- Fallback: just add raw bytes if no heuristic table found
+                seg_tree:add(session_fields.seg_data, data_buf)
+            end
+        end
+    elseif msg_type == 0x01 then
+        -- SegmentRequest[]
+        pinfo.cols.info:append(", SegmentRequest")
+        local end_offset = offset + msg_len
+        local idx = 0
+        while offset < end_offset do
+            local frame_id = buffer(offset,4):uint()
+            if frame_id == 0 then 
+                break 
+            end
+
+            local req_tree = subtree:add("SegmentRequest["..idx.."]")
+            req_tree:add(session_fields.req_frame_id, frame_id)
+            req_tree:add(session_fields.req_missing, buffer(offset+4,1))
+            offset = offset + 5
+            idx = idx + 1
+        end
+    elseif msg_type == 0x02 then
+        -- FrameAcknowledgement[]
+        pinfo.cols.info:append(", FrameAcknowledgements")
+        local end_offset = offset + msg_len
+        local idx = 0
+        while offset < end_offset do
+            local frame_id = buffer(offset,4):uint()
+            if frame_id == 0 then 
+                break
+            end
+
+            local ack_tree = subtree:add("FrameAcknowledgement["..idx.."]")
+            ack_tree:add(session_fields.ack_frame_id, frame_id)
+            offset = offset + 4
+            idx = idx + 1
+        end
+    end
+
+    return 2 + msg_len
+end
+
+---------------------------------------------------------------------------------------
+
+-- HOPR Protocol Wireshark Lua Dissector
+
+local hopr_proto = Proto("hopr", "HOPR Protocol")
+
+
+-- HOPR Protocol fields
+local hopr_fields = {
+    type = ProtoField.uint8("hopr.type", "Packet Type", base.DEC, {
+        [0x00] = "Final",
+        [0x01] = "Forwarded",
+        [0x02] = "Outgoing",
+    }),
+
+    -- Common fields
+    packet_tag = ProtoField.bytes("hopr.packet_tag", "Packet Tag"),
+    previous_hop = ProtoField.bytes("hopr.previous_hop", "Previous Hop"),
+    previous_hop_peer_id = ProtoField.stringz("hopr.previous_hop_peer_id", "Previous Hop (Peer ID)"),
+    next_hop = ProtoField.bytes("hopr.next_hop", "Next Hop"),
+    next_hop_peer_id = ProtoField.stringz("hopr.next_hop_peer_id", "Next Hop (Peer ID)"),
+    data_len = ProtoField.uint16("hopr.data_len", "Data Length"),
+
+    -- FinalPacket specific
+    sender_pseudonym = ProtoField.bytes("hopr.final.sender_pseudonym", "Sender Pseudonym"),
+    ack_key = ProtoField.bytes("hopr.final.ack_key", "ACK Key"),
+
+    -- ForwardedPacket specific
+    acknowledgement = ProtoField.bytes("hopr.forwarded.ack", "Acknowledgement"),
+
+    -- OutgoingPacket specific
+    challenge = ProtoField.bytes("hopr.outgoing.challenge", "Challenge"),
+
+    -- ApplicationData
+    appdata_tag = ProtoField.uint64("hopr.appdata.tag", "Tag", base.HEX),
+    appdata_type = ProtoField.uint8("hopr.appdata.type", "Type", base.DEC, {
+        [0x00] = "Probe",
+        [0x01] = "Start",
+        [0x0f] = "Undefined",
+        [0x10] = "Session"
+    }),
+    appdata_data = ProtoField.bytes("hopr.appdata.data", "Data")
+}
+
+hopr_proto.fields = hopr_fields
+
+
+-- ApplicationData dissector
+local function dissect_appdata(buffer, tree, offset, data_len, pinfo)
+    local appdata_tree = tree:add("ApplicationData")
+
+    -- Tag (u64)
+    local tag_field = buffer(offset, 8)
+    local tag = tag_field:uint64()
+    appdata_tree:add(hopr_fields.appdata_tag, tag_field)
+    offset = offset + 8
+
+    -- Data (variable length)
+    if data_len > 0 then
+        local data_field = buffer(offset, data_len - 8)
+        if tag == UInt64(0) then
+            pinfo.cols.info:append(", Probe")
+            appdata_tree:add(hopr_fields.appdata_type, 0)
+        elseif tag == UInt64(1) then
+            pinfo.cols.info:append(", Start")
+            appdata_tree:add(hopr_fields.appdata_type, 1)
+            dissect_hopr_start(data_field, pinfo, appdata_tree)
+        elseif tag >= UInt64(16) then
+            pinfo.cols.info:append(", Session")
+            appdata_tree:add(hopr_fields.appdata_type, 16)
+            dissect_hopr_session(data_field, pinfo, appdata_tree)
+        else
+            pinfo.cols.info:append(", Unknown application tag")
+            appdata_tree:add(hopr_fields.appdata_type, 15)
+            appdata_tree:add(hopr_fields.appdata_data, data_field)
+        end
+        offset = offset + data_len - 8
+    end
+
+    return offset
+end
+
+-- Main dissector
+function hopr_proto.dissector(buffer, pinfo, tree)
+    local length = buffer:len()
+    if length < 1 then return end
+
+    pinfo.cols.protocol = "HOPR"
+    local offset = 0
+    local subtree = tree:add(hopr_proto, buffer(), "HOPR Protocol")
+
+    -- Packet Type (u8)
+    local pkt_type = buffer(offset, 1):uint()
+    subtree:add(hopr_fields.type, buffer(offset, 1))
+    offset = offset + 1
+
+    -- Process based on packet type
+    if pkt_type == 0 then -- FinalPacket
+        if length < 1 + 16 + 32 + 10 + 32 + 2 + 8 then
+            subtree:add_expert_info(PI_MALFORMED, PI_ERROR, "Packet too short for FinalPacket")
+            return
+        end
+        pinfo.cols.info:set("Incoming")
+
+        local final_tree = subtree:add("FinalPacket")
+        final_tree:add(hopr_fields.packet_tag, buffer(offset, 16))
+        offset = offset + 16
+
+        final_tree:add(hopr_fields.previous_hop, buffer(offset, 32))
+        offset = offset + 32
+
+        local prev_hop_peer_id = buffer(offset):stringz()
+        final_tree:add(hopr_fields.previous_hop_peer_id, prev_hop_peer_id)
+        pinfo.cols.src = prev_hop_peer_id
+
+        offset = offset + prev_hop_peer_id:len() + 1
+
+        final_tree:add(hopr_fields.sender_pseudonym, buffer(offset, 10))
+        offset = offset + 10
+
+        final_tree:add(hopr_fields.ack_key, buffer(offset, 32))
+        offset = offset + 32
+
+        local data_len_field = buffer(offset, 2)
+        local data_len = data_len_field:uint()
+        final_tree:add(hopr_fields.data_len, data_len_field)
+        offset = offset + 2
+
+        offset = dissect_appdata(buffer, final_tree, offset, data_len, pinfo)
+
+    elseif pkt_type == 1 then -- ForwardedPacket
+        if length < 1 + 16 + 32 + 32 + 96 then
+            subtree:add_expert_info(PI_MALFORMED, PI_ERROR, "Packet too short for ForwardedPacket")
+            return
+        end
+        pinfo.cols.info:set("Relayed")
+
+        local fwd_tree = subtree:add("ForwardedPacket")
+        fwd_tree:add(hopr_fields.packet_tag, buffer(offset, 16))
+        offset = offset + 16
+
+        fwd_tree:add(hopr_fields.previous_hop, buffer(offset, 32))
+        offset = offset + 32
+
+        local prev_hop_peer_id = buffer(offset):stringz()
+        fwd_tree:add(hopr_fields.previous_hop_peer_id, prev_hop_peer_id)
+        pinfo.cols.src = prev_hop_peer_id
+
+        offset = offset + prev_hop_peer_id:len() + 1
+
+
+        fwd_tree:add(hopr_fields.next_hop, buffer(offset, 32))
+        offset = offset + 32
+
+        local next_hop_peer_id = buffer(offset):stringz()
+        fwd_tree:add(hopr_fields.next_hop_peer_id, next_hop_peer_id)
+        pinfo.cols.dst = next_hop_peer_id
+
+        offset = offset + next_hop_peer_id:len() + 1
+
+
+        fwd_tree:add(hopr_fields.acknowledgement, buffer(offset, 96))
+        offset = offset + 96
+
+    elseif pkt_type == 2 then -- OutgoingPacket
+        if length < 1 + 32 + 33 + 2 + 8 then
+            subtree:add_expert_info(PI_MALFORMED, PI_ERROR, "Packet too short for OutgoingPacket")
+            return
+        end
+        pinfo.cols.info:set("Outgoing")
+
+        local out_tree = subtree:add("OutgoingPacket")
+        out_tree:add(hopr_fields.next_hop, buffer(offset, 32))
+        offset = offset + 32
+
+        local next_hop_peer_id = buffer(offset):stringz()
+        out_tree:add(hopr_fields.next_hop_peer_id, next_hop_peer_id)
+        pinfo.cols.dst = next_hop_peer_id
+
+        offset = offset + next_hop_peer_id:len() + 1
+
+        out_tree:add(hopr_fields.challenge, buffer(offset, 33))
+        offset = offset + 33
+
+        local data_len_field = buffer(offset, 2)
+        local data_len = data_len_field:uint()
+        out_tree:add(hopr_fields.data_len, data_len_field)
+        offset = offset + 2
+
+        offset = dissect_appdata(buffer, out_tree, offset, data_len, pinfo)
+
+    else
+        subtree:add_expert_info(PI_MALFORMED, PI_WARN, "Unknown packet type: " .. pkt_type)
+    end
+end
+
+-- Register dissector
+local ethertype_table = DissectorTable.get("ethertype")
+ethertype_table:add(0x1234, hopr_proto) 

--- a/transport/protocol/src/capture.rs
+++ b/transport/protocol/src/capture.rs
@@ -33,7 +33,7 @@ impl PcapPacketWriter {
 
         writer
             .write_pcapng_block(InterfaceDescriptionBlock {
-                linktype: DataLink::ETHERNET,
+                linktype: DataLink::USER0,
                 snaplen: 0,
                 options: vec![],
             })
@@ -161,6 +161,8 @@ fn encode_incoming_packet_capture(packet: &IncomingPacket) -> Box<[u8]> {
             out.push(PacketType::Final as u8);
             out.extend_from_slice(packet_tag);
             out.extend_from_slice(previous_hop.as_ref());
+            out.extend_from_slice(previous_hop.to_peerid_str().as_bytes());
+            out.push(0); // Add null terminator to the string
             out.extend_from_slice(sender.as_ref());
             out.extend_from_slice(ack_key.as_ref());
             out.extend_from_slice((plain_text.len() as u16).to_be_bytes().as_ref());
@@ -176,7 +178,11 @@ fn encode_incoming_packet_capture(packet: &IncomingPacket) -> Box<[u8]> {
             out.push(PacketType::Forwarded as u8);
             out.extend_from_slice(packet_tag);
             out.extend_from_slice(previous_hop.as_ref());
+            out.extend_from_slice(previous_hop.to_peerid_str().as_bytes());
+            out.push(0); // Add null terminator to the string
             out.extend_from_slice(next_hop.as_ref());
+            out.extend_from_slice(next_hop.to_peerid_str().as_bytes());
+            out.push(0); // Add null terminator to the string
             out.extend_from_slice(ack.as_ref());
             out.extend_from_slice((data.len() as u16).to_be_bytes().as_ref());
             out.extend_from_slice(data.as_ref());
@@ -189,9 +195,125 @@ fn encode_outgoing_packet_capture(packet: &OutgoingPacket) -> Box<[u8]> {
     let mut out = Vec::new();
     out.push(PacketType::Outgoing as u8);
     out.extend_from_slice(packet.next_hop.as_ref());
+    out.extend_from_slice(packet.next_hop.to_peerid_str().as_bytes());
+    out.push(0); // Add null terminator to the string
     out.extend_from_slice(packet.ack_challenge.as_ref());
     out.extend_from_slice((packet.data.len() as u16).to_be_bytes().as_ref());
     out.extend_from_slice(packet.data.as_ref());
 
     out.into_boxed_slice()
+}
+
+#[cfg(test)]
+mod tests {
+    use hex_literal::hex;
+    use hopr_crypto_random::Randomizable;
+    use hopr_crypto_types::prelude::{Keypair, OffchainKeypair, SimplePseudonym};
+    use hopr_crypto_types::types::HalfKey;
+    use hopr_internal_types::prelude::Acknowledgement;
+    use hopr_network_types::prelude::protocol::{FrameAcknowledgements, SegmentRequest, SessionMessage};
+    use hopr_network_types::prelude::{FrameInfo, Segment};
+    use hopr_transport_packet::prelude::ApplicationData;
+    use super::*;
+
+    #[tokio::test]
+    async fn test_file_capture() -> anyhow::Result<()> {
+        let mut pcap = PacketCapture::new_file(File::create("test.pcap")?)?;
+
+        let packet = IncomingPacket::Final {
+            packet_tag: hopr_crypto_random::random_bytes(),
+            previous_hop: *OffchainKeypair::random().public(),
+            sender: SimplePseudonym::random(),
+            plain_text: ApplicationData::new(10u64, &hex!("deadbeef")).to_bytes(),
+            ack_key: HalfKey::random(),
+        };
+
+        pcap.capture_incoming(&packet)?;
+
+        let msg = SessionMessage::<1000>::Segment(Segment {
+            frame_id: 1,
+            seq_idx: 0,
+            seq_len: 1,
+            data: Box::new(hex!("474554202f20485454502f312e310d0a486f73743a207777772e6578616d706c652e636f6d0d0a557365722d4167656e743a206375726c2f382e372e310d0a4163636570743a202a2f2a0d0a0d0a")),
+        });
+
+        let packet = IncomingPacket::Final {
+            packet_tag: hopr_crypto_random::random_bytes(),
+            previous_hop: *OffchainKeypair::random().public(),
+            sender: SimplePseudonym::random(),
+            plain_text: ApplicationData::new_from_owned(1024_u64, msg.into_encoded()).to_bytes(),
+            ack_key: HalfKey::random(),
+        };
+
+        pcap.capture_incoming(&packet)?;
+
+        let msg = SessionMessage::<1000>::Acknowledge(FrameAcknowledgements::from(vec![1,2,100]));
+
+        let packet = IncomingPacket::Final {
+            packet_tag: hopr_crypto_random::random_bytes(),
+            previous_hop: *OffchainKeypair::random().public(),
+            sender: SimplePseudonym::random(),
+            plain_text: ApplicationData::new_from_owned(1024_u64, msg.into_encoded()).to_bytes(),
+            ack_key: HalfKey::random(),
+        };
+
+        pcap.capture_incoming(&packet)?;
+
+        let msg = SessionMessage::<1000>::Request(SegmentRequest::from_iter([
+            FrameInfo {
+                frame_id: 15,
+                missing_segments: [0b10100001].into(),
+                total_segments: 8,
+                last_update: std::time::SystemTime::now(),
+            },
+            FrameInfo {
+                frame_id: 11,
+                missing_segments: [0b00100001].into(),
+                total_segments: 8,
+                last_update: std::time::SystemTime::now(),
+            }
+        ]));
+
+        let packet = IncomingPacket::Final {
+            packet_tag: hopr_crypto_random::random_bytes(),
+            previous_hop: *OffchainKeypair::random().public(),
+            sender: SimplePseudonym::random(),
+            plain_text: ApplicationData::new_from_owned(1024_u64, msg.into_encoded()).to_bytes(),
+            ack_key: HalfKey::random(),
+        };
+
+        pcap.capture_incoming(&packet)?;
+
+        let packet = IncomingPacket::Forwarded {
+            packet_tag: hopr_crypto_random::random_bytes(),
+            previous_hop: *OffchainKeypair::random().public(),
+            next_hop: *OffchainKeypair::random().public(),
+            data: Box::new([0x08]),
+            ack: Acknowledgement::random(&OffchainKeypair::random())
+        };
+
+        pcap.capture_incoming(&packet)?;
+
+        let packet = OutgoingPacket {
+            next_hop: *OffchainKeypair::random().public(),
+            ack_challenge: HalfKey::random().to_challenge(),
+            data: ApplicationData::new(0u64, &hex!("cafebabe01")).to_bytes(),
+        };
+
+        pcap.capture_outgoing(&packet)?;
+
+        let packet = OutgoingPacket {
+            next_hop: *OffchainKeypair::random().public(),
+            ack_challenge: HalfKey::random().to_challenge(),
+            data: ApplicationData::new(1u64, &hex!("0004babe02")).to_bytes(),
+        };
+
+        pcap.capture_outgoing(&packet)?;
+
+
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+        Ok(())
+    }
+
 }

--- a/transport/protocol/src/capture.rs
+++ b/transport/protocol/src/capture.rs
@@ -1,0 +1,170 @@
+use std::fs::File;
+
+use futures::{StreamExt, future::Either, pin_mut};
+use hopr_db_api::prelude::{IncomingPacket, OutgoingPacket};
+use hopr_primitive_types::errors::GeneralError;
+use pcap_file::{
+    DataLink,
+    pcapng::{
+        PcapNgWriter,
+        blocks::{
+            enhanced_packet::{EnhancedPacketBlock, EnhancedPacketOption},
+            interface_description::InterfaceDescriptionBlock,
+        },
+    },
+};
+use uuid::Uuid;
+
+use crate::HOPR_PACKET_SIZE;
+
+type CaptureSender = std::sync::Arc<std::sync::Mutex<futures::channel::mpsc::Sender<Either<Box<[u8]>, Box<[u8]>>>>>;
+
+#[derive(Clone, Debug)]
+pub(crate) struct PacketCapture {
+    capture_tx: CaptureSender,
+}
+
+impl Default for PacketCapture {
+    fn default() -> Self {
+        let (capture_tx, capture_rx) = futures::channel::mpsc::channel::<Either<Box<[u8]>, Box<[u8]>>>(20000);
+        hopr_async_runtime::prelude::spawn(async move {
+            match File::create_new(format!("{}.pcap", Uuid::new_v4()))
+                .and_then(|f| PcapNgWriter::new(f).map_err(std::io::Error::other))
+            {
+                Ok(pcap_writer) => {
+                    let pcap_writer = std::sync::Arc::new(std::sync::Mutex::new(pcap_writer));
+
+                    let pcap_writer_clone = pcap_writer.clone();
+                    hopr_async_runtime::prelude::spawn_blocking(move || {
+                        let _ = pcap_writer_clone
+                            .lock()
+                            .map_err(|_| std::io::Error::other("lock error"))
+                            .and_then(|mut w| {
+                                w.write_pcapng_block(InterfaceDescriptionBlock {
+                                    linktype: DataLink::ETHERNET,
+                                    snaplen: 0,
+                                    options: vec![],
+                                })
+                                .map_err(std::io::Error::other)
+                            });
+                    });
+
+                    pin_mut!(capture_rx);
+                    while let Some(packet) = capture_rx.next().await {
+                        let timestamp = std::time::SystemTime::now()
+                            .duration_since(std::time::SystemTime::UNIX_EPOCH)
+                            .unwrap();
+                        let block = match packet {
+                            Either::Left(outgoing) => EnhancedPacketBlock {
+                                interface_id: 0,
+                                timestamp,
+                                original_len: HOPR_PACKET_SIZE as u32,
+                                data: outgoing.into_vec().into(),
+                                options: vec![EnhancedPacketOption::Comment("outgoing".into())],
+                            },
+                            Either::Right(incoming) => EnhancedPacketBlock {
+                                interface_id: 0,
+                                timestamp,
+                                original_len: HOPR_PACKET_SIZE as u32,
+                                data: incoming.into_vec().into(),
+                                options: vec![EnhancedPacketOption::Comment("incoming".into())],
+                            },
+                        };
+
+                        let pcap_writer_clone = pcap_writer.clone();
+                        hopr_async_runtime::prelude::spawn_blocking(move || {
+                            let _ = pcap_writer_clone
+                                .lock()
+                                .map_err(|_| std::io::Error::other("lock error"))
+                                .and_then(|mut w| w.write_pcapng_block(block).map_err(std::io::Error::other));
+                        });
+                    }
+                }
+                Err(error) => tracing::error!(%error, "capture could not be created"),
+            }
+        });
+
+        Self {
+            capture_tx: std::sync::Arc::new(std::sync::Mutex::new(capture_tx)),
+        }
+    }
+}
+
+impl PacketCapture {
+    pub fn capture_incoming(&self, packet: &IncomingPacket) -> crate::errors::Result<()> {
+        Ok(self
+            .capture_tx
+            .lock()
+            .map_err(|_| GeneralError::NonSpecificError("capture: cannot lock".into()))
+            .and_then(|mut tx| {
+                tx.try_send(Either::Right(encode_incoming_packet_capture(packet)))
+                    .map_err(|_| GeneralError::NonSpecificError("capture: cannot send packet".into()))
+            })?)
+    }
+
+    pub fn capture_outgoing(&self, packet: &OutgoingPacket) -> crate::errors::Result<()> {
+        Ok(self
+            .capture_tx
+            .lock()
+            .map_err(|_| GeneralError::NonSpecificError("capture: cannot lock".into()))
+            .and_then(|mut tx| {
+                tx.try_send(Either::Left(encode_outgoing_packet_capture(packet)))
+                    .map_err(|_| GeneralError::NonSpecificError("capture: cannot send packet".into()))
+            })?)
+    }
+}
+
+#[repr(u8)]
+enum PacketType {
+    Final = 0,
+    Forwarded = 1,
+    Outgoing = 2,
+}
+
+fn encode_incoming_packet_capture(packet: &IncomingPacket) -> Box<[u8]> {
+    let mut out = Vec::new();
+    match packet {
+        IncomingPacket::Final {
+            packet_tag,
+            previous_hop,
+            sender,
+            plain_text,
+            ack_key,
+        } => {
+            out.push(PacketType::Final as u8);
+            out.extend_from_slice(packet_tag);
+            out.extend_from_slice(previous_hop.as_ref());
+            out.extend_from_slice(sender.as_ref());
+            out.extend_from_slice(ack_key.as_ref());
+            out.extend_from_slice((plain_text.len() as u16).to_be_bytes().as_ref());
+            out.extend_from_slice(plain_text.as_ref());
+        }
+        IncomingPacket::Forwarded {
+            packet_tag,
+            previous_hop,
+            next_hop,
+            data,
+            ack,
+        } => {
+            out.push(PacketType::Forwarded as u8);
+            out.extend_from_slice(packet_tag);
+            out.extend_from_slice(previous_hop.as_ref());
+            out.extend_from_slice(next_hop.as_ref());
+            out.extend_from_slice(ack.as_ref());
+            out.extend_from_slice((data.len() as u16).to_be_bytes().as_ref());
+            out.extend_from_slice(data.as_ref());
+        }
+    }
+    out.into_boxed_slice()
+}
+
+fn encode_outgoing_packet_capture(packet: &OutgoingPacket) -> Box<[u8]> {
+    let mut out = Vec::new();
+    out.push(PacketType::Outgoing as u8);
+    out.extend_from_slice(packet.next_hop.as_ref());
+    out.extend_from_slice(packet.ack_challenge.as_ref());
+    out.extend_from_slice((packet.data.len() as u16).to_be_bytes().as_ref());
+    out.extend_from_slice(packet.data.as_ref());
+
+    out.into_boxed_slice()
+}

--- a/transport/protocol/src/lib.rs
+++ b/transport/protocol/src/lib.rs
@@ -70,7 +70,7 @@ pub mod timer;
 #[cfg(feature = "capture")]
 mod capture;
 
-use std::{collections::HashMap, str::FromStr};
+use std::collections::HashMap;
 
 use futures::{SinkExt, StreamExt};
 use hopr_async_runtime::spawn_as_abortable;
@@ -191,6 +191,7 @@ where
 
     #[cfg(feature = "capture")]
     let capture = {
+        use std::str::FromStr;
         let writer: Box<dyn capture::PacketWriter + Send + 'static> =
             if let Ok(desc) = std::env::var("HOPR_CAPTURE_PACKETS") {
                 if let Ok(udp_writer) = std::net::SocketAddr::from_str(&desc)

--- a/transport/protocol/src/lib.rs
+++ b/transport/protocol/src/lib.rs
@@ -66,6 +66,10 @@ pub mod processor;
 pub mod stream;
 
 pub mod timer;
+
+#[cfg(feature = "capture")]
+mod capture;
+
 use std::collections::HashMap;
 
 use futures::{SinkExt, StreamExt};

--- a/transport/protocol/src/lib.rs
+++ b/transport/protocol/src/lib.rs
@@ -199,7 +199,7 @@ where
                     .and_then(capture::UdpPacketDump::new)
                 {
                     Box::new(udp_writer)
-                } else if let Ok(pcap_writer) = std::fs::File::open(&desc).and_then(capture::PcapPacketWriter::new) {
+                } else if let Ok(pcap_writer) = std::fs::File::create(&desc).and_then(capture::PcapPacketWriter::new) {
                     Box::new(pcap_writer)
                 } else {
                     error!(desc, "failed to create packet capture: invalid socket address or file");


### PR DESCRIPTION
Allows capturing HOPR packets in custom format, which can be dissected via Wireshark.

1. build `hoprd` with the `capture` feature (`cargo b --features capture`)
2. run `hoprd` with `HOPR_CAPTURE_PACKETS=capture-file.pcap`
3. install dissector from `transport/protocol/hopr.lua` into `$HOME/.local/lib/wireshark/plugins/`
4. once `hoprd` terminates, open `capture-file.pcap` in Wireshark

Alternatively, `HOPR_CAPTURE_PACKETS` can specify a UDP socket for `udpdump` (also supported by Wireshark), e.g.: `HOPR_CAPTURE_PACKETS=127.0.0.1:5555` 