### PR TITLE
fix: Fixing different bugs on create release

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -17,11 +17,6 @@ on:
         type: string
   workflow_dispatch:
     inputs:
-      base_branch:
-        description: 'The base branch used for the release'
-        required: true
-        type: string
-        default: master
       head_branch:
         description: 'The head branch from which download artifacts'
         required: true
@@ -42,12 +37,26 @@ jobs:
           disable-sudo: true
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
+      - name: Set environment variables
+        id: vars
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+            echo "The workflow is triggered by other pipeline"
+            echo "base_branch=${{ inputs.base_branch }}"  | tee -a $GITHUB_OUTPUT
+            echo "head_branch=${{ inputs.head_branch }}"  | tee -a $GITHUB_OUTPUT
+          else
+            echo "The workflow is triggered manually"
+            echo "base_branch=${{ github.ref_name }}" | tee -a $GITHUB_OUTPUT
+            echo "head_branch=${{ github.event.inputs.head_branch }}" | tee -a $GITHUB_OUTPUT
+          fi
+
       - name: Checkout hoprnet repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0  # Required for tagging
-          token: ${{ secrets.GH_RUNNER_TOKEN }} Required as using via pull_request_target
-          ref: ${{ github.event.inputs.base_branch }}
+          fetch-depth: 0 # Required for tagging
+          # Using a PAT because this job can be invoked from `pull_request_target`
+          token: ${{ secrets.GH_RUNNER_TOKEN }}
+          ref: ${{ steps.vars.outputs.base_branch }}
 
       - name: Setup GCP
         id: gcp
@@ -73,7 +82,7 @@ jobs:
           else
             echo "prerelease=false" >> $GITHUB_OUTPUT
           fi
-          ./scripts/download-workflow-binaries.sh ${{ github.event.inputs.head_branch }}
+          ./scripts/download-workflow-binaries.sh ${{ steps.vars.outputs.head_branch }}
         env:
           GH_TOKEN: ${{ secrets.GH_RUNNER_TOKEN }}
 
@@ -90,7 +99,7 @@ jobs:
           git tag v${{ steps.setup.outputs.current_version }}
           git push origin v${{ steps.setup.outputs.current_version }}
 
-          declare base_branch=${{ github.event.inputs.base_branch }}
+          declare base_branch=${{ steps.vars.outputs.base_branch }}
           # Tag release name
           if [[ "${base_branch}" == "master" ]]; then
             release_name=${{ vars.BRANCH_MASTER_RELEASE_NAME }}

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -15,6 +15,17 @@ on:
         description: 'The head branch for the pull request'
         required: true
         type: string
+  workflow_dispatch:
+    inputs:
+      base_branch:
+        description: 'The base branch for the release'
+        required: true
+        type: string
+        default: master
+      head_branch:
+        description: 'The head branch from which download artifacts'
+        required: true
+        type: string
 
 concurrency:
   group: create-release
@@ -34,8 +45,9 @@ jobs:
       - name: Checkout hoprnet repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          persist-credentials: false
-          ref: ${{ inputs.base_branch }}
+          fetch-depth: 0  # Required for tagging
+          token: ${{ secrets.GH_RUNNER_TOKEN }} Required as using via pull_request_target
+          ref: ${{ github.event.inputs.base_branch }}
 
       - name: Setup GCP
         id: gcp
@@ -61,7 +73,7 @@ jobs:
           else
             echo "prerelease=false" >> $GITHUB_OUTPUT
           fi
-          ./scripts/download-workflow-binaries.sh ${{ inputs.head_branch }}
+          ./scripts/download-workflow-binaries.sh ${{ github.event.inputs.head_branch }}
         env:
           GH_TOKEN: ${{ secrets.GH_RUNNER_TOKEN }}
 
@@ -78,7 +90,7 @@ jobs:
           git tag v${{ steps.setup.outputs.current_version }}
           git push origin v${{ steps.setup.outputs.current_version }}
 
-          declare base_branch=${{ inputs.base_branch }}
+          declare base_branch=${{ github.event.inputs.base_branch }}
           # Tag release name
           if [[ "${base_branch}" == "master" ]]; then
             release_name=${{ vars.BRANCH_MASTER_RELEASE_NAME }}

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -18,7 +18,7 @@ on:
   workflow_dispatch:
     inputs:
       base_branch:
-        description: 'The base branch for the release'
+        description: 'The base branch used for the release'
         required: true
         type: string
         default: master

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -95,9 +95,13 @@ jobs:
       - name: Tag repository
         id: tag
         run: |
-          # Tag semver
-          git tag v${{ steps.setup.outputs.current_version }}
-          git push origin v${{ steps.setup.outputs.current_version }}
+          # Check if tag exists remotely
+          if git ls-remote --tags origin "v${{ steps.setup.outputs.current_version }}" | grep -q "refs/tags/v${{ steps.setup.outputs.current_version }}"; then
+            echo "Tag v${{ steps.setup.outputs.current_version }} already exists - skipping"
+          else
+            git tag "v${{ steps.setup.outputs.current_version }}"
+            git push origin "v${{ steps.setup.outputs.current_version }}"
+          fi
 
           declare base_branch=${{ steps.vars.outputs.base_branch }}
           # Tag release name

--- a/.github/workflows/generate-dappnode-pr.yaml
+++ b/.github/workflows/generate-dappnode-pr.yaml
@@ -55,7 +55,8 @@ jobs:
             echo "source_repo=${{ github.repository }}" | tee -a $GITHUB_OUTPUT
             echo "source_branch=${{ github.ref_name }}" | tee -a $GITHUB_OUTPUT
           fi
-          if [[ "${{ github.event.inputs.network }}" == "dufour" ]]; then
+          network="${{ inputs.network || github.event.inputs.network }}"
+          if [[ "${network}" == "dufour" ]]; then
               echo "dappnode_repository=dappnode/DAppNodePackage-Hopr" | tee -a $GITHUB_OUTPUT
             else
               echo "dappnode_repository=dappnode/DAppNodePackage-Hopr-testnet" | tee -a $GITHUB_OUTPUT

--- a/.github/workflows/generate-dappnode-pr.yaml
+++ b/.github/workflows/generate-dappnode-pr.yaml
@@ -13,6 +13,19 @@ on:
       source_branch:
         required: true
         type: string
+      network:
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      network:
+        type: choice
+        options:
+          - rotsee
+          - dufour
+        required: true
+        description: 'Package network (rotsee: testnet, dufour: mainnet)'
+        default: rotsee
 
 concurrency:
   group: dappnode
@@ -30,12 +43,30 @@ jobs:
           disable-sudo: true
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
+      - name: Set environment variables
+        id: vars
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+            echo "The workflow is triggered by other pipeline"
+            echo "source_repo=${{ inputs.source_repo }}" | tee -a $GITHUB_OUTPUT
+            echo "source_branch=${{ inputs.source_branch }}"  | tee -a $GITHUB_OUTPUT
+          else
+            echo "The workflow is triggered manually"
+            echo "source_repo=${{ github.repository }}" | tee -a $GITHUB_OUTPUT
+            echo "source_branch=${{ github.ref_name }}" | tee -a $GITHUB_OUTPUT
+          fi
+          if [[ "${{ github.event.inputs.network }}" == "dufour" ]]; then
+              echo "dappnode_repository=dappnode/DAppNodePackage-Hopr" | tee -a $GITHUB_OUTPUT
+            else
+              echo "dappnode_repository=dappnode/DAppNodePackage-Hopr-testnet" | tee -a $GITHUB_OUTPUT
+            fi
+
       - name: Checkout hoprnet repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-          repository: ${{ inputs.source_repo }}
-          ref: ${{ inputs.source_branch }}
+          repository: ${{ steps.vars.outputs.source_repo }}
+          ref: ${{ steps.vars.outputs.source_branch }}
 
       - name: Setup GCP
         id: gcp
@@ -49,8 +80,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-          repository: dappnode/DAppNodePackage-Hopr
-          path: "./DAppNodePackage-Hopr"
+          repository: ${{ steps.vars.outputs.dappnode_repository }}
+          path: "./DAppNodePackage-Hopr-repo"
           token: ${{ secrets.GH_RUNNER_TOKEN }}
           ref: main
 
@@ -65,7 +96,7 @@ jobs:
           # Retrieve the Docker tag in the format "tag@version" for the current version
           docker_tag=$(gcloud artifacts docker tags list ${{ vars.DOCKER_IMAGE_REGISTRY }}/hoprd --filter=tag:${{ steps.setup.outputs.current_version }} --format="csv[no-heading](tag,version)" | grep "${{ steps.setup.outputs.current_version }}," | sed 's/,/@/')
           yq -i e ".services.node.build.args.UPSTREAM_VERSION |= \"${docker_tag}\"" docker-compose.yml
-        working-directory: "./DAppNodePackage-Hopr"
+        working-directory: "./DAppNodePackage-Hopr-repo"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
@@ -75,7 +106,7 @@ jobs:
           title: "Update to release ${{ steps.setup.outputs.current_version }}"
           body: "This pull request contains the changes needed to bump Hoprd to version ${{ steps.setup.outputs.current_version }}"
           branch: bot/update-${{ steps.setup.outputs.current_version }}
-          path: "./DAppNodePackage-Hopr"
+          path: "./DAppNodePackage-Hopr-repo"
           delete-branch: true
           assignees: ${{ github.actor }}
           reviewers: "ausias-armesto,tolbrino,NumberFour8,Teebor-Choka,QYuQianchen"

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -146,6 +146,7 @@ jobs:
     with:
       source_repo: ${{ github.event.pull_request.base.repo.full_name }}
       source_branch: ${{ github.event.pull_request.base.ref }}
+      network: dufour
     secrets: inherit
   docs:
     name: Docs

--- a/.github/workflows/open-release.yaml
+++ b/.github/workflows/open-release.yaml
@@ -54,9 +54,11 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
             echo "The workflow is triggered by other pipeline"
             echo "source_branch=${{ inputs.source_branch }}"  | tee -a $GITHUB_OUTPUT
+            echo "release_type=${{ inputs.release_type }}"  | tee -a $GITHUB_OUTPUT
           else
             echo "The workflow is triggered manually"
             echo "source_branch=${{ github.ref_name }}" | tee -a $GITHUB_OUTPUT
+            echo "release_type=${{ github.event.inputs.release_type }}" | tee -a $GITHUB_OUTPUT
           fi
 
       - name: Checkout hoprnet repository
@@ -68,7 +70,7 @@ jobs:
       - name: Bump Version
         id: bump
         run: |
-          next_version=$(./scripts/get-next-version.sh ${{ github.event.inputs.release_type }})
+          next_version=$(./scripts/get-next-version.sh ${{ steps.vars.outputs.release_type }})
           ./scripts/bump-version.sh ${next_version}
           echo "next_version=${next_version}" >> $GITHUB_OUTPUT
 
@@ -77,10 +79,10 @@ jobs:
         with:
           token: ${{ secrets.GH_RUNNER_TOKEN }}
           commit-message: "Bump to version ${{ steps.bump.outputs.next_version }}"
-          base: ${{ inputs.source_branch }}
+          base: ${{ steps.vars.outputs.source_branch }}
           title: "ci: Open release ${{ steps.bump.outputs.next_version }}"
           body: "The scope of this PR is to create the contents of the new release ${{ steps.bump.outputs.next_version }}"
-          branch: bot/open-${{ github.event.inputs.release_type }}-${{ steps.bump.outputs.next_version }}
+          branch: bot/open-${{ steps.vars.outputs.release_type }}-${{ steps.bump.outputs.next_version }}
           delete-branch: true
           draft: true
           assignees: ${{ github.actor }}
@@ -89,7 +91,7 @@ jobs:
       - name: Enable Auto Merge
         run: |
           git fetch
-          git checkout bot/open-${{ github.event.inputs.release_type }}-${{ steps.bump.outputs.next_version }}
+          git checkout bot/open-${{ steps.vars.outputs.release_type }}-${{ steps.bump.outputs.next_version }}
           gh pr edit --add-reviewer "hoprnet/hopr-development"
           gh pr ready
         env:

--- a/.github/workflows/open-release.yaml
+++ b/.github/workflows/open-release.yaml
@@ -16,9 +16,18 @@ on:
       release_type:
         required: true
         type: string
-    secrets:
-      GH_RUNNER_TOKEN:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: 'Type of the release to open'
         required: true
+        type: choice
+        options:
+          - Major
+          - Minor
+          - Patch
+          - ReleaseCandidate
+        default: Patch
 
 concurrency:
   group: open-release
@@ -38,16 +47,28 @@ jobs:
           disable-sudo: true
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
+
+      - name: Set environment variables
+        id: vars
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
+            echo "The workflow is triggered by other pipeline"
+            echo "source_branch=${{ inputs.source_branch }}"  | tee -a $GITHUB_OUTPUT
+          else
+            echo "The workflow is triggered manually"
+            echo "source_branch=${{ github.ref_name }}" | tee -a $GITHUB_OUTPUT
+          fi
+
       - name: Checkout hoprnet repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-          ref: "${{ inputs.source_branch }}"
+          ref: "${{ steps.vars.outputs.source_branch }}"
 
       - name: Bump Version
         id: bump
         run: |
-          next_version=$(./scripts/get-next-version.sh ${{ inputs.release_type }})
+          next_version=$(./scripts/get-next-version.sh ${{ github.event.inputs.release_type }})
           ./scripts/bump-version.sh ${next_version}
           echo "next_version=${next_version}" >> $GITHUB_OUTPUT
 
@@ -59,7 +80,7 @@ jobs:
           base: ${{ inputs.source_branch }}
           title: "ci: Open release ${{ steps.bump.outputs.next_version }}"
           body: "The scope of this PR is to create the contents of the new release ${{ steps.bump.outputs.next_version }}"
-          branch: bot/open-${{ inputs.release_type }}-${{ steps.bump.outputs.next_version }}
+          branch: bot/open-${{ github.event.inputs.release_type }}-${{ steps.bump.outputs.next_version }}
           delete-branch: true
           draft: true
           assignees: ${{ github.actor }}
@@ -68,7 +89,7 @@ jobs:
       - name: Enable Auto Merge
         run: |
           git fetch
-          git checkout bot/open-${{ inputs.release_type }}-${{ steps.bump.outputs.next_version }}
+          git checkout bot/open-${{ github.event.inputs.release_type }}-${{ steps.bump.outputs.next_version }}
           gh pr edit --add-reviewer "hoprnet/hopr-development"
           gh pr ready
         env:

--- a/docs/changelog/changelog-3.0.0-rc.1.md
+++ b/docs/changelog/changelog-3.0.0-rc.1.md
@@ -118,5 +118,3 @@ What's changed
 * Add support for libp2p_stream into the swarm object by @Teebor-Choka in #6928
 * Remove database connection opening per-packet by @NumberFour8 in #6922
 * Introduce WinningProbability type by @NumberFour8 in #6921
-
-

--- a/docs/changelog/changelog-3.0.0-rc.1.md
+++ b/docs/changelog/changelog-3.0.0-rc.1.md
@@ -117,3 +117,5 @@ What's changed
 * Introduce WinningProbability type by @NumberFour8 in #6921
 * ci: Cache used cargo packages in a crates.io proxy by @Teebor-Choka in #6902
 * ci: Add pluto build flag by @ausias-armesto in #7315
+* fix: Using wrong branch when creating release by @ausias-armesto in #7317
+

--- a/docs/changelog/changelog-3.0.0-rc.1.md
+++ b/docs/changelog/changelog-3.0.0-rc.1.md
@@ -18,6 +18,8 @@ What's changed
 
 ### 🐞 Fixes
 
+* fix: Using wrong branch when creating release  by @ausias-armesto in #7317
+* fix(nix): hopli aarch64 build working and add man-page generation by @tolbrino in #7310
 * fix(ci): Port deploy_nodes changes by @tolbrino in #7305
 * fix(ci): comply with pre-commit by @Teebor-Choka in #7281
 * fix(ci): Fixing merge pipeline by @ausias-armesto in #7276
@@ -39,6 +41,7 @@ What's changed
 * Update documentation on Nodemanagement module by @QYuQianchen in #7028
 * Post-Providence smart contract features (tracker for v3.0) by @QYuQianchen in #7027
 * Protocol Feature: Return Path by @tolbrino in #4496
+* ci: Add pluto build flag by @ausias-armesto in #7315
 * feat: Add binary signatures and multiple os package improvements by @ausias-armesto in #7297
 * Remove balance update on API query by @NumberFour8 in #7252
 * tests: Fix randomly failing win_prob smoke test by @Teebor-Choka in #7230
@@ -115,7 +118,5 @@ What's changed
 * Add support for libp2p_stream into the swarm object by @Teebor-Choka in #6928
 * Remove database connection opening per-packet by @NumberFour8 in #6922
 * Introduce WinningProbability type by @NumberFour8 in #6921
-* ci: Cache used cargo packages in a crates.io proxy by @Teebor-Choka in #6902
-* ci: Add pluto build flag by @ausias-armesto in #7315
-* fix: Using wrong branch when creating release by @ausias-armesto in #7317
+
 


### PR DESCRIPTION
Fixes the following:
- Changes the github token used for tagging because when using pull_request_target it requires write permissions
- Adds manual execution to create-release and generate-dappnode-pr pipelines so they can be launched manually in case of failure.
- Add more robustness to git tag step