### PR TITLE
feat: add configurable limits for transport packet handling and stream open timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5278,7 +5278,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-protocol"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "async-channel 2.3.1",

--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ On top of the default configuration options generated for the command line, the 
 - `HOPR_BALANCER_PID_D_GAIN` - derivative (D) gain for the PID controller in SURB balancer (default: `0.2`)
 - `HOPR_TEST_DISABLE_CHECKS` - the node is being run in test mode with some safety checks disabled (currently: minimum winning probability check)
 - `HOPR_CAPTURE_PACKETS` - allow capturing customized HOPR packet format to a PCAP file or to a `udpdump` host. Note that `hoprd` must be built with the `capture` feature.
+- `HOPR_TRANSPORT_MAX_CONCURRENT_PACKETS` - maximum number of concurrently processed incoming packets from all peers (default: 10)
+- `HOPR_TRANSPORT_STREAM_OPEN_TIMEOUT_MS` - maximum time (in milliseconds) to wait until a stream connection is established to a peer (default: 2000 ms)
 - `HOPRD_SESSION_PORT_RANGE` - allows restricting the port range (syntax: `start:end` inclusive) of Session listener automatic port selection (when port 0 is specified)
 - `HOPRD_NAT` - indicates whether the host is behind a NAT and sets transport-specific settings accordingly (default: `false`)
 

--- a/docs/changelog/changelog-3.0.0-rc.1.md
+++ b/docs/changelog/changelog-3.0.0-rc.1.md
@@ -116,5 +116,4 @@ What's changed
 * Remove database connection opening per-packet by @NumberFour8 in #6922
 * Introduce WinningProbability type by @NumberFour8 in #6921
 * ci: Cache used cargo packages in a crates.io proxy by @Teebor-Choka in #6902
-
-
+* ci: Add pluto build flag by @ausias-armesto in #7315

--- a/transport/protocol/Cargo.toml
+++ b/transport/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-protocol"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 license = "GPL-3.0-only"


### PR DESCRIPTION
Adds `HOPR_TRANSPORT_MAX_CONCURRENT_PACKETS` and `HOPR_TRANSPORT_STREAM_OPEN_TIMEOUT_MS` environment variables.

Closes #7304