### PR TITLE
fix: improve messages metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5190,7 +5190,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-protocol"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "async-channel 2.5.0",

--- a/transport/protocol/Cargo.toml
+++ b/transport/protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-protocol"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 license = "GPL-3.0-only"


### PR DESCRIPTION
Fixes the missing `forwarded` and `received` types of the packet_count metric. Also fixes the labels for another metric.