### PR TITLE
fix(hopr-lib): decrease the amount of connections to 1 on the index db

### DIFF
--- a/db/sql/Cargo.toml
+++ b/db/sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-db-sql"
-version = "0.14.3"
+version = "0.14.4"
 edition = "2021"
 description = "Contains SQL DB functionality implementing the DB API traits to be used by other crates in the code base"
 homepage = "https://hoprnet.org/"

--- a/db/sql/src/db.rs
+++ b/db/sql/src/db.rs
@@ -82,7 +82,7 @@ impl HoprDb {
         // Indexer database
         let index = PoolOptions::new()
             .min_connections(0)
-            .max_connections(30)
+            .max_connections(1)
             .connect_with(cfg_template.clone().filename(directory.join(SQL_DB_INDEX_FILE_NAME)))
             .await
             .map_err(|e| crate::errors::DbSqlError::Construction(e.to_string()))?;

--- a/db/sql/src/db.rs
+++ b/db/sql/src/db.rs
@@ -82,7 +82,7 @@ impl HoprDb {
         // Indexer database
         let index = PoolOptions::new()
             .min_connections(0)
-            .max_connections(1)
+            .max_connections(1) // single connection to avoid DB lock issues by serializing all operations
             .connect_with(cfg_template.clone().filename(directory.join(SQL_DB_INDEX_FILE_NAME)))
             .await
             .map_err(|e| crate::errors::DbSqlError::Construction(e.to_string()))?;
@@ -90,10 +90,10 @@ impl HoprDb {
         // Peers database
         let peers = PoolOptions::new()
             .min_connections(0) // Default is 0
+            .max_connections(300) // Default is 10
             .acquire_timeout(Duration::from_secs(60)) // Default is 30
             .idle_timeout(Some(Duration::from_secs(10 * 60))) // This is the default
             .max_lifetime(Some(Duration::from_secs(30 * 60))) // This is the default
-            .max_connections(300) // Default is 10
             .connect_with(cfg_template.clone().filename(directory.join(SQL_DB_PEERS_FILE_NAME)))
             .await
             .map_err(|e| crate::errors::DbSqlError::Construction(e.to_string()))?;


### PR DESCRIPTION
This pull request modifies database connection settings in the `HoprDb` implementation to address potential database lock issues and optimize connection management. The key changes involve adjusting the `max_connections` parameter for the indexer and peers databases.

### Database connection configuration updates:

* [`db/sql/src/db.rs`](diffhunk://#diff-8486b4d107ff48d05d4b876721cafc2d92649ae60b14ee2e16f3d8f3bd506899L85-L96): Reduced `max_connections` for the indexer database from 30 to 1 to avoid database lock issues by serializing all operations.
* [`db/sql/src/db.rs`](diffhunk://#diff-8486b4d107ff48d05d4b876721cafc2d92649ae60b14ee2e16f3d8f3bd506899L85-L96): Adjusted the `max_connections` for the peers database to ensure it is explicitly set to 300, maintaining the previous behavior but clarifying the configuration.