### PR TITLE
fix: remove ticket manager db connection per-packet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4656,7 +4656,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-db-sql"
-version = "0.14.4"
+version = "0.14.5"
 dependencies = [
  "anyhow",
  "async-lock 3.4.0",

--- a/crypto/packet/src/por.rs
+++ b/crypto/packet/src/por.rs
@@ -7,6 +7,7 @@ use hopr_crypto_types::{
     types::{Challenge, HalfKey, HalfKeyChallenge, Response},
 };
 use hopr_primitive_types::prelude::*;
+use tracing::instrument;
 
 use crate::errors::{PacketError, Result};
 
@@ -206,6 +207,7 @@ pub struct ProofOfRelayOutput {
 /// * `secret` shared secret with the creator of the packet
 /// * `pors` `ProofOfRelayString` as included within the packet
 /// * `challenge` the ticket challenge of the incoming ticket
+#[instrument(level = "trace", skip_all, err)]
 pub fn pre_verify(
     secret: &SharedSecret,
     pors: &ProofOfRelayString,

--- a/crypto/packet/src/validation.rs
+++ b/crypto/packet/src/validation.rs
@@ -1,12 +1,13 @@
 use hopr_crypto_types::types::Hash;
 use hopr_internal_types::prelude::*;
 use hopr_primitive_types::prelude::*;
-use tracing::debug;
+use tracing::{debug, instrument};
 
 use crate::errors::TicketValidationError;
 
 /// Performs validations of the given unacknowledged ticket and channel.
 /// This is a higher-level function, hence it is not in `hopr-internal-types` crate.
+#[instrument(level = "trace", skip_all, err)]
 pub fn validate_unacknowledged_ticket(
     ticket: Ticket,
     channel: &ChannelEntry,

--- a/db/sql/Cargo.toml
+++ b/db/sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-db-sql"
-version = "0.14.4"
+version = "0.14.5"
 edition = "2021"
 description = "Contains SQL DB functionality implementing the DB API traits to be used by other crates in the code base"
 homepage = "https://hoprnet.org/"

--- a/db/sql/src/channels.rs
+++ b/db/sql/src/channels.rs
@@ -5,6 +5,7 @@ use hopr_db_entity::{channel, conversions::channels::ChannelStatusUpdate, errors
 use hopr_internal_types::prelude::*;
 use hopr_primitive_types::prelude::*;
 use sea_orm::{ActiveModelTrait, ActiveValue::Set, ColumnTrait, EntityTrait, IntoActiveModel, QueryFilter};
+use tracing::instrument;
 
 use crate::{
     HoprDbGeneralModelOperations, OptTx,
@@ -256,6 +257,7 @@ impl HoprDbChannelOperations for HoprDb {
         Ok(ret)
     }
 
+    #[instrument(level = "trace", skip(self, tx), err)]
     async fn get_channel_by_parties<'a>(
         &'a self,
         tx: OptTx<'a>,
@@ -266,6 +268,7 @@ impl HoprDbChannelOperations for HoprDb {
         let fetch_channel = async move {
             let src_hex = src.to_hex();
             let dst_hex = dst.to_hex();
+            tracing::warn!(%src, %dst, "cache miss on get_channel_by_parties");
             self.nest_transaction(tx)
                 .await?
                 .perform(|tx| {

--- a/db/sql/src/info.rs
+++ b/db/sql/src/info.rs
@@ -326,6 +326,7 @@ impl HoprDbInfoOperations for HoprDb {
             .caches
             .single_values
             .try_get_with_by_ref(&CachedValueDiscriminants::IndexerDataCache, async move {
+                tracing::warn!("cache miss on get_indexer_data");
                 myself
                     .nest_transaction(tx)
                     .and_then(|op| {

--- a/db/sql/src/protocol.rs
+++ b/db/sql/src/protocol.rs
@@ -46,8 +46,11 @@ lazy_static::lazy_static! {
         MultiCounter::new("hopr_tickets_count", "Number of winning tickets", &["type"]).unwrap();
 }
 
+const SLOW_OP_MS: u128 = 150;
+
 impl HoprDb {
     /// Validates a ticket from a forwarded packet and replaces it with a new ticket for the next hop.
+    #[instrument(level = "trace", skip_all, err)]
     async fn validate_and_replace_ticket(
         &self,
         mut fwd: HoprForwardedPacket,
@@ -106,6 +109,7 @@ impl HoprDb {
         // so afterward we are sure the source of the `channel`
         // (which is equal to `previous_hop_addr`) has issued this
         // ticket.
+        let start = std::time::Instant::now();
         let verified_incoming_ticket = spawn_fifo_blocking(move || {
             validate_unacknowledged_ticket(
                 fwd.outgoing.ticket,
@@ -117,6 +121,9 @@ impl HoprDb {
             )
         })
         .await?;
+        if start.elapsed().as_millis() > SLOW_OP_MS {
+            warn!("validate_unacknowledged_ticket took {} ms", start.elapsed().as_millis());
+        }
 
         // We currently take the maximum of the win prob from the incoming ticket
         // and the one configured on this node.
@@ -169,7 +176,7 @@ impl HoprDb {
         Ok(fwd)
     }
 
-    #[instrument(level = "trace", skip(self, ack), err(Debug))]
+    #[instrument(level = "trace", skip(self, ack), err)]
     async fn validate_acknowledgement(
         &self,
         ack: &Acknowledgement,
@@ -495,7 +502,7 @@ impl HoprDbProtocolOperations for HoprDb {
         }
     }
 
-    #[tracing::instrument(level = "trace", skip(self, data, pkt_keypair, sender), fields(sender = %sender), err)]
+    #[tracing::instrument(level = "trace", skip_all, fields(sender = %sender), err)]
     async fn from_recv(
         &self,
         data: Box<[u8]>,
@@ -507,6 +514,7 @@ impl HoprDbProtocolOperations for HoprDb {
         let offchain_keypair = pkt_keypair.clone();
         let myself = self.clone();
 
+        let start = std::time::Instant::now();
         let packet = spawn_fifo_blocking(move || {
             HoprPacket::from_incoming(&data, &offchain_keypair, sender, &myself.caches.key_id_mapper, |p| {
                 myself.caches.pseudonym_openers.remove(p)
@@ -514,6 +522,13 @@ impl HoprDbProtocolOperations for HoprDb {
             .map_err(|e| DbSqlError::LogicalError(format!("failed to construct an incoming packet: {e}")))
         })
         .await?;
+        if start.elapsed().as_millis() > SLOW_OP_MS {
+            warn!(
+                peer = sender.to_peerid_str(),
+                "from_incoming took {} ms",
+                start.elapsed().as_millis()
+            );
+        }
 
         match packet {
             HoprPacket::Final(incoming) => {
@@ -566,10 +581,18 @@ impl HoprDbProtocolOperations for HoprDb {
                 })
             }
             HoprPacket::Forwarded(fwd) => {
-                match self
+                let start = std::time::Instant::now();
+                let validation_res = self
                     .validate_and_replace_ticket(*fwd, &self.chain_key, outgoing_ticket_win_prob, outgoing_ticket_price)
-                    .await
-                {
+                    .await;
+                if start.elapsed().as_millis() > SLOW_OP_MS {
+                    warn!(
+                        peer = sender.to_peerid_str(),
+                        "validate_and_replace_ticket took {} ms",
+                        start.elapsed().as_millis()
+                    );
+                }
+                match validation_res {
                     Ok(fwd) => {
                         let mut payload = Vec::with_capacity(HoprPacket::SIZE);
                         payload.extend_from_slice(fwd.outgoing.packet.as_ref());

--- a/db/sql/src/ticket_manager.rs
+++ b/db/sql/src/ticket_manager.rs
@@ -263,6 +263,7 @@ impl TicketManager {
             .caches
             .unrealized_value
             .try_get_with_by_ref(&(channel_id, channel_epoch), async move {
+                tracing::warn!(%channel_id, %channel_epoch, "cache miss on unrealized value");
                 OpenTransaction(
                     tickets_db
                         .begin_with_config(None, None)

--- a/db/sql/src/ticket_manager.rs
+++ b/db/sql/src/ticket_manager.rs
@@ -257,35 +257,34 @@ impl TicketManager {
         let channel_epoch = selector.channel_identifiers[0].1;
         let selector: WrappedTicketSelector = selector.into();
 
-        let transaction = OpenTransaction(
-            self.tickets_db
-                .begin_with_config(None, None)
-                .await
-                .map_err(crate::errors::DbSqlError::BackendError)?,
-            crate::TargetDb::Tickets,
-        );
-
+        let tickets_db = self.tickets_db.clone();
         let selector_clone = selector.clone();
         Ok(self
             .caches
             .unrealized_value
             .try_get_with_by_ref(&(channel_id, channel_epoch), async move {
-                transaction
-                    .perform(|tx| {
-                        Box::pin(async move {
-                            ticket::Entity::find()
-                                .filter(selector_clone)
-                                .stream(tx.as_ref())
-                                .await
-                                .map_err(crate::errors::DbSqlError::from)?
-                                .map_err(crate::errors::DbSqlError::from)
-                                .try_fold(HoprBalance::zero(), |value, t| async move {
-                                    Ok(value + HoprBalance::from_be_bytes(t.amount))
-                                })
-                                .await
-                        })
+                OpenTransaction(
+                    tickets_db
+                        .begin_with_config(None, None)
+                        .await
+                        .map_err(DbSqlError::BackendError)?,
+                    crate::TargetDb::Tickets,
+                )
+                .perform(|tx| {
+                    Box::pin(async move {
+                        ticket::Entity::find()
+                            .filter(selector_clone)
+                            .stream(tx.as_ref())
+                            .await
+                            .map_err(crate::errors::DbSqlError::from)?
+                            .map_err(crate::errors::DbSqlError::from)
+                            .try_fold(HoprBalance::zero(), |value, t| async move {
+                                Ok(value + HoprBalance::from_be_bytes(t.amount))
+                            })
+                            .await
                     })
-                    .await
+                })
+                .await
             })
             .await?)
     }

--- a/transport/protocol/src/lib.rs
+++ b/transport/protocol/src/lib.rs
@@ -334,7 +334,7 @@ where
                         let res = msg_processor.recv(&peer, data).await.map_err(move |e| (peer, e));
                         let elapsed = now.elapsed();
                         if elapsed.as_millis() > SLOW_OP_MS {
-                            warn!(?elapsed, "msg_processor.recv took too long");
+                            warn!(%peer, ?elapsed, "msg_processor.recv took too long");
                         }
 
                         // If there was an error caused by interpretation of the packet data,


### PR DESCRIPTION
The `TicketManager::unrealized_value()` method create a connection even on a cache-hit. This caused connections to be created per-packet, as this method is called in the hot-path.

This bug was present also on 2.x versions, possibly causing the Sessions to get stalled on higher throughputs.