### PR TITLE
fix(chain): Raise error on reverted transactions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4421,7 +4421,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-api"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "alloy",
  "async-channel 2.5.0",
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-rpc"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "alloy",
  "anyhow",

--- a/chain/api/Cargo.toml
+++ b/chain/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-chain-api"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Implements the main HOPR chain interface"
 edition = "2021"

--- a/chain/api/src/executors.rs
+++ b/chain/api/src/executors.rs
@@ -1,10 +1,6 @@
 use std::{marker::PhantomData, time::Duration};
 
-use alloy::{
-    network::ReceiptResponse,
-    providers::PendingTransaction,
-    rpc::types::{TransactionReceipt, TransactionRequest},
-};
+use alloy::{providers::PendingTransaction, rpc::types::TransactionRequest};
 use async_trait::async_trait;
 use futures::{FutureExt, future::Either, pin_mut};
 use hopr_async_runtime::prelude::sleep;
@@ -73,10 +69,7 @@ impl<Rpc: HoprRpcOperations> RpcEthereumClient<Rpc> {
     ///
     /// If the transaction yields a result before the timeout, the result value is returned.
     /// Otherwise, an [RpcError::Timeout] is returned and the transaction sending is aborted.
-    async fn post_tx_with_timeout_and_confirm(
-        &self,
-        tx: TransactionRequest,
-    ) -> hopr_chain_rpc::errors::Result<TransactionReceipt> {
+    async fn post_tx_with_timeout_and_confirm(&self, tx: TransactionRequest) -> hopr_chain_rpc::errors::Result<Hash> {
         let submit_tx = self.rpc.send_transaction_with_confirm(tx).fuse();
         let timeout = sleep(self.cfg.max_tx_submission_wait).fuse();
         pin_mut!(submit_tx, timeout);
@@ -101,8 +94,7 @@ impl<Rpc: HoprRpcOperations + Send + Sync> EthereumClient<TransactionRequest> fo
         &self,
         tx: TransactionRequest,
     ) -> hopr_chain_rpc::errors::Result<Hash> {
-        let receipt = self.post_tx_with_timeout_and_confirm(tx).await?;
-        Ok(receipt.transaction_hash().0.into())
+        self.post_tx_with_timeout_and_confirm(tx).await
     }
 }
 

--- a/chain/api/src/executors.rs
+++ b/chain/api/src/executors.rs
@@ -1,6 +1,10 @@
 use std::{marker::PhantomData, time::Duration};
 
-use alloy::{providers::PendingTransaction, rpc::types::TransactionRequest};
+use alloy::{
+    network::ReceiptResponse,
+    providers::PendingTransaction,
+    rpc::types::{TransactionReceipt, TransactionRequest},
+};
 use async_trait::async_trait;
 use futures::{FutureExt, future::Either, pin_mut};
 use hopr_async_runtime::prelude::sleep;
@@ -64,6 +68,24 @@ impl<Rpc: HoprRpcOperations> RpcEthereumClient<Rpc> {
             Either::Right(_) => Err(RpcError::Timeout),
         }
     }
+
+    /// Post a transaction with a specified timeout and await its confirmation.
+    ///
+    /// If the transaction yields a result before the timeout, the result value is returned.
+    /// Otherwise, an [RpcError::Timeout] is returned and the transaction sending is aborted.
+    async fn post_tx_with_timeout_and_confirm(
+        &self,
+        tx: TransactionRequest,
+    ) -> hopr_chain_rpc::errors::Result<TransactionReceipt> {
+        let submit_tx = self.rpc.send_transaction_with_confirm(tx).fuse();
+        let timeout = sleep(self.cfg.max_tx_submission_wait).fuse();
+        pin_mut!(submit_tx, timeout);
+
+        match futures::future::select(submit_tx, timeout).await {
+            Either::Left((res, _)) => res,
+            Either::Right(_) => Err(RpcError::Timeout),
+        }
+    }
 }
 
 #[async_trait]
@@ -79,7 +101,8 @@ impl<Rpc: HoprRpcOperations + Send + Sync> EthereumClient<TransactionRequest> fo
         &self,
         tx: TransactionRequest,
     ) -> hopr_chain_rpc::errors::Result<Hash> {
-        Ok(self.post_tx_with_timeout(tx).await?.await?.0.into())
+        let receipt = self.post_tx_with_timeout_and_confirm(tx).await?;
+        Ok(receipt.transaction_hash().0.into())
     }
 }
 

--- a/chain/rpc/Cargo.toml
+++ b/chain/rpc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-chain-rpc"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Abstraction over Ethereum RPC provider client"

--- a/chain/rpc/src/errors.rs
+++ b/chain/rpc/src/errors.rs
@@ -1,9 +1,9 @@
 use alloy::{
     contract::Error as AlloyContractError,
-    primitives::FixedBytes,
     providers::{MulticallError, PendingTransactionError},
     transports::{RpcError as AlloyRpcError, TransportErrorKind},
 };
+use hopr_crypto_types::prelude::Hash;
 /// Errors produced by this crate and other error-related types.
 use thiserror::Error;
 
@@ -32,7 +32,7 @@ pub enum RpcError {
     PendingTransactionError(#[from] PendingTransactionError),
 
     #[error("transaction with hash {0} failed on-chain")]
-    TransactionFailed(FixedBytes<32>),
+    TransactionFailed(Hash),
 
     #[error("filter does not contain any criteria")]
     FilterIsEmpty,

--- a/chain/rpc/src/errors.rs
+++ b/chain/rpc/src/errors.rs
@@ -1,5 +1,6 @@
 use alloy::{
     contract::Error as AlloyContractError,
+    primitives::FixedBytes,
     providers::{MulticallError, PendingTransactionError},
     transports::{RpcError as AlloyRpcError, TransportErrorKind},
 };
@@ -29,6 +30,9 @@ pub enum RpcError {
 
     #[error(transparent)]
     PendingTransactionError(#[from] PendingTransactionError),
+
+    #[error("transaction with hash {0} failed on-chain")]
+    TransactionFailed(FixedBytes<32>),
 
     #[error("filter does not contain any criteria")]
     FilterIsEmpty,

--- a/chain/rpc/src/lib.rs
+++ b/chain/rpc/src/lib.rs
@@ -18,7 +18,11 @@ use std::{
     time::Duration,
 };
 
-use alloy::{primitives::B256, providers::PendingTransaction, rpc::types::TransactionRequest};
+use alloy::{
+    primitives::B256,
+    providers::PendingTransaction,
+    rpc::types::{TransactionReceipt, TransactionRequest},
+};
 use async_trait::async_trait;
 use errors::LogConversionError;
 use futures::Stream;
@@ -292,8 +296,11 @@ pub trait HoprRpcOperations {
     /// Retrieves the on-chain status of node, safe, and module.
     async fn check_node_safe_module_status(&self, node_address: Address) -> Result<NodeSafeModuleStatus>;
 
-    /// Sends transaction to the RPC provider.
+    /// Sends transaction to the RPC provider, does not await confirmation.
     async fn send_transaction(&self, tx: TransactionRequest) -> Result<PendingTransaction>;
+
+    /// Sends transaction to the RPC provider, awaits confirmation.
+    async fn send_transaction_with_confirm(&self, tx: TransactionRequest) -> Result<TransactionReceipt>;
 }
 
 /// Structure containing filtered logs that all belong to the same block.

--- a/chain/rpc/src/lib.rs
+++ b/chain/rpc/src/lib.rs
@@ -18,11 +18,7 @@ use std::{
     time::Duration,
 };
 
-use alloy::{
-    primitives::B256,
-    providers::PendingTransaction,
-    rpc::types::{TransactionReceipt, TransactionRequest},
-};
+use alloy::{primitives::B256, providers::PendingTransaction, rpc::types::TransactionRequest};
 use async_trait::async_trait;
 use errors::LogConversionError;
 use futures::Stream;
@@ -300,7 +296,7 @@ pub trait HoprRpcOperations {
     async fn send_transaction(&self, tx: TransactionRequest) -> Result<PendingTransaction>;
 
     /// Sends transaction to the RPC provider, awaits confirmation.
-    async fn send_transaction_with_confirm(&self, tx: TransactionRequest) -> Result<TransactionReceipt>;
+    async fn send_transaction_with_confirm(&self, tx: TransactionRequest) -> Result<Hash>;
 }
 
 /// Structure containing filtered logs that all belong to the same block.

--- a/chain/rpc/src/rpc.rs
+++ b/chain/rpc/src/rpc.rs
@@ -16,7 +16,7 @@ use alloy::{
     },
     rpc::{
         client::RpcClient,
-        types::{Block, TransactionRequest},
+        types::{Block, TransactionReceipt, TransactionRequest},
     },
     signers::local::PrivateKeySigner,
     sol,
@@ -411,13 +411,30 @@ impl<R: HttpRequestor + 'static + Clone> HoprRpcOperations for RpcOperations<R> 
     async fn send_transaction(&self, tx: TransactionRequest) -> Result<PendingTransaction> {
         let sent_tx = self.provider.send_transaction(tx).await?;
 
-        let receipt = sent_tx
+        let pending_tx = sent_tx
             .with_required_confirmations(self.cfg.finality as u64)
             .register()
             .await
             .map_err(RpcError::PendingTransactionError)?;
 
-        Ok(receipt)
+        Ok(pending_tx)
+    }
+
+    async fn send_transaction_with_confirm(&self, tx: TransactionRequest) -> Result<TransactionReceipt> {
+        let sent_tx = self.provider.send_transaction(tx).await?;
+
+        let receipt = sent_tx
+            .with_required_confirmations(self.cfg.finality as u64)
+            .get_receipt()
+            .await
+            .map_err(RpcError::PendingTransactionError)?;
+
+        if receipt.status() {
+            Ok(receipt)
+        } else {
+            // Transaction failed, raise an error
+            Err(RpcError::TransactionFailed(receipt.transaction_hash))
+        }
     }
 }
 
@@ -567,11 +584,15 @@ mod tests {
         let balance_1: XDaiBalance = rpc.get_xdai_balance((&chain_key_0).into()).await?;
         assert!(balance_1.amount().gt(&0.into()), "balance must be greater than 0");
 
-        // Send 1 ETH to some random address
-        let tx = create_native_transfer::<Ethereum>(*RANDY, U256::from(1000000_u32));
-        let tx_hash = rpc.send_transaction(tx).await?;
+        // Test 1: Send 1 ETH to some random address, do not wait for confirmation
+        let tx_1 = create_native_transfer::<Ethereum>(*RANDY, U256::from(1000000_u32));
+        let tx_hash = rpc.send_transaction(tx_1).await?;
 
         wait_until_tx(tx_hash, Duration::from_secs(8)).await;
+
+        // Test 2: Send 1 ETH to some random address, wait for confirmation
+        let tx_2 = create_native_transfer::<Ethereum>(*RANDY, U256::from(1000000_u32));
+        let _receipt = rpc.send_transaction_with_confirm(tx_2).await?;
 
         Ok(())
     }

--- a/chain/rpc/src/rpc.rs
+++ b/chain/rpc/src/rpc.rs
@@ -432,13 +432,15 @@ impl<R: HttpRequestor + 'static + Clone> HoprRpcOperations for RpcOperations<R> 
             .await
             .map_err(RpcError::PendingTransactionError)?;
 
+        let tx_hash = Hash::from(receipt.transaction_hash.0);
+
         // Check the transaction status. `status()` returns `true` for successful transactions
         // and `false` for failed or reverted transactions.
         if receipt.status() {
-            Ok(Hash::from(receipt.transaction_hash.0))
+            Ok(tx_hash)
         } else {
             // Transaction failed, raise an error
-            Err(RpcError::TransactionFailed(Hash::from(receipt.transaction_hash.0)))
+            Err(RpcError::TransactionFailed(tx_hash))
         }
     }
 }

--- a/chain/rpc/src/rpc.rs
+++ b/chain/rpc/src/rpc.rs
@@ -429,6 +429,8 @@ impl<R: HttpRequestor + 'static + Clone> HoprRpcOperations for RpcOperations<R> 
             .await
             .map_err(RpcError::PendingTransactionError)?;
 
+        // Check the transaction status. `status()` returns `true` for successful transactions
+        // and `false` for failed or reverted transactions.
         if receipt.status() {
             Ok(receipt)
         } else {

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -1335,13 +1335,9 @@ impl Hopr {
     pub async fn withdraw_tokens(&self, recipient: Address, amount: HoprBalance) -> errors::Result<Hash> {
         self.error_if_not_in_state(HoprState::Running, "Node is not ready for on-chain operations".into())?;
 
-        Ok(self
-            .hopr_chain_api
-            .actions_ref()
-            .withdraw(recipient, amount)
-            .await?
-            .await?
-            .tx_hash)
+        let awaiter = self.hopr_chain_api.actions_ref().withdraw(recipient, amount).await?;
+
+        Ok(awaiter.await?.tx_hash)
     }
 
     /// Withdraw on-chain native assets to a given address
@@ -1350,13 +1346,13 @@ impl Hopr {
     pub async fn withdraw_native(&self, recipient: Address, amount: XDaiBalance) -> errors::Result<Hash> {
         self.error_if_not_in_state(HoprState::Running, "Node is not ready for on-chain operations".into())?;
 
-        Ok(self
+        let awaiter = self
             .hopr_chain_api
             .actions_ref()
             .withdraw_native(recipient, amount)
-            .await?
-            .await?
-            .tx_hash)
+            .await?;
+
+        Ok(awaiter.await?.tx_hash)
     }
 
     pub async fn open_channel(&self, destination: &Address, amount: HoprBalance) -> errors::Result<OpenChannelResult> {
@@ -1378,13 +1374,13 @@ impl Hopr {
     pub async fn fund_channel(&self, channel_id: &Hash, amount: HoprBalance) -> errors::Result<Hash> {
         self.error_if_not_in_state(HoprState::Running, "Node is not ready for on-chain operations".into())?;
 
-        Ok(self
+        let awaiter = self
             .hopr_chain_api
             .actions_ref()
             .fund_channel(*channel_id, amount)
-            .await?
-            .await
-            .map(|confirm| confirm.tx_hash)?)
+            .await?;
+
+        Ok(awaiter.await?.tx_hash)
     }
 
     pub async fn close_channel(


### PR DESCRIPTION
Fixes #7342 

The previous approach would wait for on-chain confirmations, but not check the status of the transaction. This has been changed such that if the status if failed, an explicit error is raised.