### PR TITLE
fix(tests): update localcluster parameters and adjust test configuration

### DIFF
--- a/sdk/python/localcluster.test.params.yml
+++ b/sdk/python/localcluster.test.params.yml
@@ -21,6 +21,6 @@ networks:
       - config_file: 'default.cfg.yaml'
         identity_path: './sdk/identities/hopr-node_5.id'
         host: localhost
-      - config_file: 'default.cfg.yaml'
+      - config_file: 'barebone-lower-win-prob.cfg.yaml'
         identity_path: './sdk/identities/hopr-node_6.id'
         host: '127.0.0.1'

--- a/sdk/python/localcluster.test.params.yml
+++ b/sdk/python/localcluster.test.params.yml
@@ -5,17 +5,17 @@ defaults:
 networks:
   anvil-localhost:
     nodes:
-      - config_file: 'default.cfg.yaml'
+      - config_file: 'barebone.cfg.yaml'
         identity_path: './sdk/identities/hopr-node_1.id'
         host: localhost
-      - config_file: 'default.cfg.yaml'
+      - config_file: 'barebone.cfg.yaml'
         identity_path: './sdk/identities/hopr-node_2.id'
         host: '127.0.0.1'
         api_token: ~
-      - config_file: 'default.cfg.yaml'
+      - config_file: 'barebone.cfg.yaml'
         identity_path: './sdk/identities/hopr-node_3.id'
         host: localhost
-      - config_file: 'default.cfg.yaml'
+      - config_file: 'barebone.cfg.yaml'
         identity_path: './sdk/identities/hopr-node_4.id'
         host: '127.0.0.1'
       - config_file: 'default.cfg.yaml'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,7 +94,7 @@ async def base_port(request):
 
 @pytest.fixture(scope="session")
 async def swarm7(request, base_port):
-    params_path = PWD.joinpath("sdk/python/localcluster.params.yml")
+    params_path = PWD.joinpath("sdk/python/localcluster.test.params.yml")
     try:
         cluster, anvil = await localcluster.bringup(
             params_path, test_mode=True, fully_connected=False, use_nat=False, base_port=base_port

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 2
-requires-python = ">=3.13, <3.14"
+requires-python = "==3.13.*"
 
 [options]
 exclude-newer = "2025-07-18T00:00:00Z"
@@ -637,11 +637,11 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "pytest", specifier = ">=8.3.3" },
-    { name = "pytest-asyncio", specifier = ">=0.24.0" },
+    { name = "pytest-asyncio", specifier = ">=1.1.0" },
     { name = "pytest-timeout", specifier = ">=2.3.1" },
     { name = "requests", specifier = ">=2.32.3" },
     { name = "websocket-client", specifier = ">=1.5.1" },
-    { name = "websockets", specifier = ">=13.1" },
+    { name = "websockets", specifier = ">=15.0.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
This PR splits the behavior of the localcluster into two modes, wether it's being used as a standalone module, or within the smoketests:
- standalone mode: all node have the same config
- smoketests: the nodes uses the custom configs with different probabilities and strategies