### PR TITLE
chore(hopr-lib): lower some logs to more realistic values

### DIFF
--- a/transport/network/src/network.rs
+++ b/transport/network/src/network.rs
@@ -198,7 +198,7 @@ where
         {
             let stats = self.db.network_peer_stats(self.cfg.quality_bad_threshold).await?;
             self.refresh_metrics(&stats);
-            tracing::info!(
+            tracing::trace!(
                 health = %health_from_stats(&stats, self.am_i_public),
                 trigger = "peer removal",
                 "Network health updated"
@@ -272,7 +272,7 @@ where
             {
                 let stats = self.db.network_peer_stats(self.cfg.quality_bad_threshold).await?;
                 self.refresh_metrics(&stats);
-                tracing::info!(
+                tracing::trace!(
                     health = %health_from_stats(&stats, self.am_i_public),
                     trigger = "peer update",
                     "Network health updated"


### PR DESCRIPTION
This pull request makes a minor change to the logging level in the `network.rs` file. The log statements for network health updates triggered by peer removal and peer update events have been changed from `info` to `trace` level to reduce log verbosity.