### PR TITLE
refactor: move ticket and ack sending operations outside the main pipeline

### DIFF
--- a/db/api/src/protocol.rs
+++ b/db/api/src/protocol.rs
@@ -93,13 +93,14 @@ pub enum IncomingPacket {
         previous_hop: OffchainPublicKey,
         next_hop: OffchainPublicKey,
         data: Box<[u8]>,
+        /// Acknowledgement to be sent to the previous hop
         ack: VerifiedAcknowledgement,
     },
     /// The packet contains an acknowledgement of a delivered packet.
     Acknowledgement {
         packet_tag: PacketTag,
         previous_hop: OffchainPublicKey,
-        ack: VerifiedAcknowledgement,
+        ack: Acknowledgement,
     },
 }
 

--- a/db/api/src/protocol.rs
+++ b/db/api/src/protocol.rs
@@ -93,8 +93,8 @@ pub enum IncomingPacket {
         previous_hop: OffchainPublicKey,
         next_hop: OffchainPublicKey,
         data: Box<[u8]>,
-        /// Acknowledgement to be sent to the previous hop
-        ack: VerifiedAcknowledgement,
+        /// Acknowledgement payload to be sent to the previous hop
+        ack_key: HalfKey,
     },
     /// The packet contains an acknowledgement of a delivered packet.
     Acknowledgement {

--- a/db/sql/src/protocol.rs
+++ b/db/sql/src/protocol.rs
@@ -606,17 +606,12 @@ impl HoprDbProtocolOperations for HoprDb {
                         payload.extend_from_slice(fwd.outgoing.packet.as_ref());
                         payload.extend_from_slice(&fwd.outgoing.ticket.into_encoded());
 
-                        let keypair_clone = pkt_keypair.clone();
-                        let ack =
-                            spawn_fifo_blocking(move || VerifiedAcknowledgement::new(fwd.ack_key, &keypair_clone))
-                                .await;
-
                         Ok(IncomingPacket::Forwarded {
                             packet_tag: fwd.packet_tag,
                             previous_hop: fwd.previous_hop,
                             next_hop: fwd.outgoing.next_hop,
                             data: payload.into_boxed_slice(),
-                            ack,
+                            ack_key: fwd.ack_key,
                         })
                     }
                     Err(DbSqlError::TicketValidationError(boxed_error)) => {

--- a/transport/protocol/src/lib.rs
+++ b/transport/protocol/src/lib.rs
@@ -77,7 +77,7 @@ use std::collections::HashMap;
 
 use futures::{SinkExt, StreamExt};
 use hopr_async_runtime::spawn_as_abortable;
-use hopr_crypto_types::types::OffchainPublicKey;
+use hopr_crypto_types::types::{HalfKey, OffchainPublicKey};
 use hopr_db_api::protocol::{HoprDbProtocolOperations, IncomingPacket};
 use hopr_internal_types::{
     prelude::{Acknowledgement, HoprPseudonym},
@@ -100,7 +100,10 @@ pub type HoprBinaryCodec = crate::codec::FixedLengthCodec<HOPR_PACKET_SIZE>;
 pub const CURRENT_HOPR_MSG_PROTOCOL: &str = "/hopr/mix/1.0.0";
 
 pub const TICKET_ACK_BUFFER_SIZE: usize = 1_000_000;
-pub const NUM_CONCURRENT_ACK_PROCESSING: usize = 10;
+pub const NUM_CONCURRENT_TICKET_ACK_PROCESSING: usize = 10;
+
+pub const ACK_OUT_BUFFER_SIZE: usize = 1_000_000;
+pub const NUM_CONCURRENT_ACK_OUT_PROCESSING: usize = 10;
 
 #[cfg(all(feature = "prometheus", not(test)))]
 use hopr_metrics::metrics::{MultiCounter, SimpleCounter};
@@ -133,6 +136,10 @@ pub enum ProtocolProcesses {
     MsgIn,
     #[strum(to_string = "HOPR [msg] - egress")]
     MsgOut,
+    #[strum(to_string = "HOPR [ack] - egress")]
+    AckOut,
+    #[strum(to_string = "HOPR [ack] - ingress - ticket acknowledgement")]
+    TicketAck,
     #[strum(to_string = "HOPR [msg] - mixer")]
     Mixer,
     #[strum(to_string = "bloom filter persistence (periodic)")]
@@ -140,8 +147,6 @@ pub enum ProtocolProcesses {
     #[cfg(feature = "capture")]
     #[strum(to_string = "packet capture")]
     Capture,
-    #[strum(to_string = "HOPR [ack] ticket acknowledgement")]
-    TicketAck,
 }
 /// Processed indexer generated events.
 #[derive(Debug, Clone)]
@@ -195,9 +200,6 @@ where
     #[cfg(all(feature = "prometheus", not(test)))]
     {
         // Initialize the lazy statics here
-        // lazy_static::initialize(&METRIC_RECEIVED_ACKS);
-        // lazy_static::initialize(&METRIC_SENT_ACKS);
-        // lazy_static::initialize(&METRIC_TICKETS_COUNT);
         lazy_static::initialize(&METRIC_PACKET_COUNT);
         lazy_static::initialize(&METRIC_PACKET_COUNT_PER_PEER);
         lazy_static::initialize(&METRIC_REPLAYED_PACKET_COUNT);
@@ -251,14 +253,14 @@ where
         WrappedTagBloomFilter::new("no_tbf".into())
     };
 
-    let (ack_tx, ack_rx) =
+    let (ticket_ack_tx, ticket_ack_rx) =
         futures::channel::mpsc::channel::<(Acknowledgement, OffchainPublicKey)>(TICKET_ACK_BUFFER_SIZE);
 
     let db_clone = db.clone();
     processes.insert(
         ProtocolProcesses::TicketAck,
-        spawn_as_abortable!(ack_rx
-            .for_each_concurrent(NUM_CONCURRENT_ACK_PROCESSING, move |(ack, sender)| {
+        spawn_as_abortable!(ticket_ack_rx
+            .for_each_concurrent(NUM_CONCURRENT_TICKET_ACK_PROCESSING, move |(ack, sender)| {
                 let db = db_clone.clone();
                 async move {
                     if let Ok(verified) = hopr_parallelize::cpu::spawn_blocking(move || ack.verify(&sender)).await {
@@ -274,6 +276,75 @@ where
                     }
                 }
             }))
+    );
+
+    let (ack_out_tx, ack_out_rx) =
+        futures::channel::mpsc::channel::<(Option<HalfKey>, OffchainPublicKey)>(ACK_OUT_BUFFER_SIZE);
+
+    #[cfg(feature = "capture")]
+    let capture_clone = capture.clone();
+
+    let db_clone = db.clone();
+    let me_clone = me.clone();
+    let msg_to_send_tx = wire_msg.0.clone();
+    processes.insert(
+        ProtocolProcesses::AckOut,
+        spawn_as_abortable!(ack_out_rx.for_each_concurrent(
+            NUM_CONCURRENT_ACK_OUT_PROCESSING,
+            move |(maybe_ack_key, destination)| {
+                let db = db_clone.clone();
+                let me = me_clone.clone();
+                let mut msg_to_send_tx_clone = msg_to_send_tx.clone();
+
+                #[cfg(feature = "capture")]
+                let mut capture = capture_clone.clone();
+                async move {
+                    #[cfg(feature = "capture")]
+                    let (is_random, me_pub) = (
+                        maybe_ack_key.is_none(),
+                        *hopr_crypto_types::keypairs::Keypair::public(&me),
+                    );
+
+                    // Sign acknowledgement with the given half-key or generate a signed random one
+                    let ack = hopr_parallelize::cpu::spawn_blocking(move || {
+                        maybe_ack_key
+                            .map(|ack_key| VerifiedAcknowledgement::new(ack_key, &me))
+                            .unwrap_or_else(|| VerifiedAcknowledgement::random(&me))
+                    })
+                    .await;
+
+                    #[cfg(feature = "capture")]
+                    let captured_packet: capture::CapturedPacket = capture::PacketBeforeTransit::OutgoingAck {
+                        me: me_pub,
+                        ack,
+                        is_random,
+                        next_hop: destination,
+                    }
+                    .into();
+
+                    match db.to_send_no_ack(ack.leak().as_ref().into(), destination).await {
+                        Ok(ack_packet) => {
+                            let now = std::time::Instant::now();
+                            if msg_to_send_tx_clone
+                                .send((ack_packet.next_hop.into(), ack_packet.data))
+                                .await
+                                .is_err()
+                            {
+                                error!("failed to forward an acknowledgement to the transport layer");
+                            }
+                            let elapsed = now.elapsed();
+                            if elapsed.as_millis() > SLOW_OP_MS {
+                                warn!(?elapsed, " msg_to_send_tx.send on ack took too long");
+                            }
+
+                            #[cfg(feature = "capture")]
+                            let _ = capture.try_send(captured_packet);
+                        }
+                        Err(error) => tracing::error!(%error, "failed to create ack packet"),
+                    }
+                }
+            }
+        )),
     );
 
     let msg_processor_read = processor::PacketProcessor::new(db.clone(), packet_cfg);
@@ -338,9 +409,8 @@ where
         }),
     );
 
-    let msg_to_send_tx = wire_msg.0.clone();
-    let db_for_recv = db.clone();
-    let me_for_recv = me.clone();
+    let ack_out_tx_clone_1 = ack_out_tx.clone();
+    let ack_out_tx_clone_2 = ack_out_tx.clone();
 
     #[cfg(feature = "capture")]
     let capture_clone = capture.clone();
@@ -352,9 +422,7 @@ where
                 .1
                 .then_concurrent(move |(peer, data)| {
                     let msg_processor = msg_processor_read.clone();
-                    let db = db_for_recv.clone();
-                    let mut msg_to_send_tx = msg_to_send_tx.clone();
-                    let me = me.clone();
+                    let mut ack_out_tx = ack_out_tx_clone_1.clone();
 
                     trace!(%peer, "protocol message in");
 
@@ -391,37 +459,14 @@ where
                             };
 
                             // Send random signed acknowledgement to give feedback to the sender
-                            let ack = hopr_parallelize::cpu::spawn_fifo_blocking(move || VerifiedAcknowledgement::random(&me)).await;
-
-                            #[cfg(feature = "capture")]
-                            let captured_packet: capture::CapturedPacket = capture::PacketBeforeTransit::OutgoingAck {
-                                me: me_pub,
-                                next_hop: peer,
-                                ack,
-                                is_random: true,
-                            }.into();
-
-                            match db
-                                .to_send_no_ack(ack.leak().as_ref().into(), peer)
-                                .await {
-                                    Ok(ack_packet) => {
-                                        let now = std::time::Instant::now();
-                                        if msg_to_send_tx.send((
-                                                ack_packet.next_hop.into(),
-                                                ack_packet.data,
-                                            )).await.is_err() {
-                                            error!("failed to forward an acknowledgement for a failed packet recv to the transport layer");
-                                        }
-                                        let elapsed = now.elapsed();
-                                        if elapsed.as_millis() > SLOW_OP_MS {
-                                            warn!(?elapsed," msg_to_send_tx.send took too long");
-                                        }
-
-                                        #[cfg(feature = "capture")]
-                                        let _ = capture_clone.try_send(captured_packet);
-                                    },
-                                    Err(error) => tracing::error!(%error, "Failed to create random ack packet for a failed receive"),
-                                }
+                            let now = std::time::Instant::now();
+                            if let Err(error) = ack_out_tx.send((None, peer)).await {
+                                tracing::error!(%error, "failed to send ack to the egress queue");
+                            }
+                            let elapsed = now.elapsed();
+                            if elapsed.as_millis() > SLOW_OP_MS {
+                                warn!(%peer, ?elapsed, "ack_out.send on failed packet took too long");
+                            }
                         }
 
                         #[cfg(feature = "capture")]
@@ -466,13 +511,12 @@ where
                 })
                 .then_concurrent(move |packet| {
                     let mut msg_to_send_tx = wire_msg.0.clone();
-                    let db = db.clone();
-                    let me = me_for_recv.clone();
 
                     #[cfg(feature = "capture")]
                     let mut capture_clone = capture_clone.clone();
 
-                    let mut ack_tx_clone = ack_tx.clone();
+                    let mut ticket_ack_tx_clone = ticket_ack_tx.clone();
+                    let mut ack_out_tx = ack_out_tx_clone_2.clone();
                     async move {
 
                     match packet {
@@ -481,8 +525,9 @@ where
                             ack,
                             ..
                         } => {
+                            trace!(%previous_hop, "acknowledging ticket using received ack");
                             let now = std::time::Instant::now();
-                            if let Err(error) = ack_tx_clone.send((ack, previous_hop)).await {
+                            if let Err(error) = ticket_ack_tx_clone.send((ack, previous_hop)).await {
                                 tracing::error!(%error, "failed dispatching received acknowledgement to the ticket ack queue");
                             }
                             let elapsed = now.elapsed();
@@ -503,15 +548,14 @@ where
                         } => {
                             // Send acknowledgement back
                             trace!(%previous_hop, "acknowledging final packet back");
-                            let ack = hopr_parallelize::cpu::spawn_fifo_blocking(move || VerifiedAcknowledgement::new(ack_key, &me)).await;
-
-                            #[cfg(feature = "capture")]
-                            let captured_packet: capture::CapturedPacket = capture::PacketBeforeTransit::OutgoingAck {
-                                me: me_pub,
-                                next_hop: previous_hop,
-                                ack,
-                                is_random: false,
-                            }.into();
+                            let now = std::time::Instant::now();
+                            if let Err(error) = ack_out_tx.send((Some(ack_key), previous_hop)).await {
+                                tracing::error!(%error, "failed to send ack to the egress queue");
+                            }
+                            let elapsed = now.elapsed();
+                            if elapsed.as_millis() > SLOW_OP_MS {
+                                warn!(%previous_hop, ?elapsed, "ack_out.send on final packet took too long");
+                            }
 
                             #[cfg(all(feature = "prometheus", not(test)))]
                             {
@@ -519,26 +563,13 @@ where
                                 METRIC_PACKET_COUNT.increment(&["received"]);
                             }
 
-                            if let Ok(ack_packet) = db
-                                .to_send_no_ack(ack.leak().as_ref().into(), previous_hop)
-                                .await
-                                .inspect_err(|error| error!(%error, "failed to create ack packet for a received message"))
-                                {
-                                    if msg_to_send_tx.send((ack_packet.next_hop.into(), ack_packet.data)).await.is_err() {
-                                        error!("failed to send an acknowledgement for a received packet to the transport layer");
-                                    }
-
-                                    #[cfg(feature = "capture")]
-                                    let _ = capture_clone.try_send(captured_packet);
-                                }
-
-                                Some((sender, plain_text, signals))
+                            Some((sender, plain_text, signals))
                         }
                         IncomingPacket::Forwarded {
                             previous_hop,
                             next_hop,
                             data,
-                            ack,
+                            ack_key,
                             ..
                         } => {
                             // First, relay the packet to the next hop
@@ -570,31 +601,17 @@ where
                             #[cfg(feature = "capture")]
                             let _ = capture_clone.try_send(captured_packet);
 
-                            // And then send acknowledgement to the previous hop
-                            trace!(%previous_hop, %next_hop, "acknowledging forwarded packet back");
-                            #[cfg(feature = "capture")]
-                            let captured_packet: capture::CapturedPacket = capture::PacketBeforeTransit::OutgoingAck {
-                                me: me_pub,
-                                next_hop: previous_hop,
-                                ack,
-                                is_random: false,
-                            }.into();
-
-                            if let Ok(ack_packet) = db
-                                .to_send_no_ack(ack.leak().as_ref().into(), previous_hop)
-                                .await
-                                .inspect_err(|error| error!(%error, "failed to create ack packet for a relayed message"))
-                            {
-                                msg_to_send_tx
-                                    .send((ack_packet.next_hop.into(), ack_packet.data))
-                                    .await
-                                    .unwrap_or_else(|_| {
-                                        error!("failed to send an acknowledgement for a relayed packet to the transport layer");
-                                    });
-
-                                #[cfg(feature = "capture")]
-                                let _ = capture_clone.try_send(captured_packet);
+                             // Send acknowledgement back
+                            trace!(%previous_hop, "acknowledging forwarded packet back");
+                            let now = std::time::Instant::now();
+                            if let Err(error) = ack_out_tx.send((Some(ack_key), previous_hop)).await {
+                                tracing::error!(%error, "failed to send ack to the egress queue");
                             }
+                            let elapsed = now.elapsed();
+                            if elapsed.as_millis() > SLOW_OP_MS {
+                                warn!(%previous_hop, ?elapsed, "ack_out.send on forwarded packet took too long");
+                            }
+
                             None
                         }
                     }


### PR DESCRIPTION
This PR moves does the following optimizations:

- the Acknowledgement egress was moved to a standalone task, so that acknowledgement creation is not holding out passing incoming packets to the Application layer
- the Acknowledgement ingress was moved to a standalone task, so that lengthy operations, like acknowledging an unacknowledged ticket using the incoming acknowledgement, or verifying if a newly acknowledged ticket is a winning one, are not done inside the packet packet pipeline, potentially holding up incoming packets

