### PR TITLE
fix: end correctly the socket and processes once the entire UDP connection is dropped

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4908,7 +4908,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-network-types"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "arrayvec",

--- a/common/network-types/Cargo.toml
+++ b/common/network-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-network-types"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Contains types used for networking over the HOPR protocol"
 edition = "2021"

--- a/common/network-types/src/udp.rs
+++ b/common/network-types/src/udp.rs
@@ -53,7 +53,7 @@ lazy_static::lazy_static! {
 /// multiple sockets with `SO_REUSEADDR` and spin parallel tasks that will coordinate data and
 /// transmission retrieval using these sockets. This is driven by RX/TX MPMC queues, which are
 /// per-default unbounded (see [queue size](UdpStreamBuilder::with_queue_size) for details).
-#[pin_project::pin_project]
+#[pin_project::pin_project(PinnedDrop)]
 pub struct ConnectedUdpStream {
     socket_handles: Vec<tokio::task::JoinHandle<()>>,
     #[pin]
@@ -660,6 +660,15 @@ impl tokio::io::AsyncWrite for ConnectedUdpStream {
                 "udp stream is closed",
             )))
         }
+    }
+}
+
+#[pin_project::pinned_drop]
+impl PinnedDrop for ConnectedUdpStream {
+    fn drop(self: Pin<&mut Self>) {
+        self.project().socket_handles.iter().for_each(|handle| {
+            handle.abort();
+        })
     }
 }
 

--- a/common/network-types/src/udp.rs
+++ b/common/network-types/src/udp.rs
@@ -666,6 +666,7 @@ impl tokio::io::AsyncWrite for ConnectedUdpStream {
 #[pin_project::pinned_drop]
 impl PinnedDrop for ConnectedUdpStream {
     fn drop(self: Pin<&mut Self>) {
+        debug!(binding = ?self.bound_to,"dropping ConnectedUdpStream");
         self.project().socket_handles.iter().for_each(|handle| {
             handle.abort();
         })

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -192,8 +192,8 @@ pub struct SessionManagerConfig {
     /// The actual timeout is adjusted according to the number of hops for that Session:
     /// `t = initiation_time_out_base * (num_forward_hops + num_return_hops + 2)`
     ///
-    /// Default is 5 seconds.
-    #[default(Duration::from_secs(5))]
+    /// Default is 500 milliseconds.
+    #[default(Duration::from_millis(500))]
     pub initiation_timeout_base: Duration,
 
     /// Timeout for Session to be closed due to inactivity.


### PR DESCRIPTION
As in title.

When `ConnectedUdpStream` was not closed properly via `shutdown` it would leak the UDP socket and not terminate the running processes, effectively causing the process to run OOM when many Sessions were used over time. 

Closes #7450
Refs #7449