### PR TITLE
fix: correct comment for data field in CLI arguments

### DIFF
--- a/hoprd/hoprd/src/cli.rs
+++ b/hoprd/hoprd/src/cli.rs
@@ -65,7 +65,7 @@ pub struct CliArgs {
     )]
     pub identity: Option<String>,
 
-    // Identity details
+    // Data directory
     #[arg(
         long,
         env = "HOPRD_DATA",


### PR DESCRIPTION
Line 59: // Identity details - for the identity field (path to the identification file)
Line 68: // Data directory - for the data field (directory for storing data)