### PR TITLE
fix: add missing columns to the NetworkPeer table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5119,7 +5119,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "async-lock 3.4.1",
  "async-trait",
@@ -5213,7 +5213,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-network"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4774,7 +4774,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-db-migration"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "hopr-internal-types",
  "hopr-primitive-types",

--- a/db/migration/Cargo.toml
+++ b/db/migration/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-db-migration"
 description = "Contains database migrations for a HOPR node database"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 publish = false
 homepage = "https://hoprnet.org/"

--- a/db/migration/src/lib.rs
+++ b/db/migration/src/lib.rs
@@ -30,6 +30,7 @@ mod m20250604_000027_index_initial_seed;
 mod m20250701_000028_peers_deprecate_fields;
 mod m20250709_000029_channels_add_corrupted_state;
 mod m20250808_000030_index_create_corrupted_channel;
+mod m20250909_000031_peer_store_add_indices;
 
 #[derive(PartialEq)]
 pub enum BackendType {
@@ -82,6 +83,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20250604_000027_index_initial_seed::Migration),
             Box::new(m20250709_000029_channels_add_corrupted_state::Migration),
             Box::new(m20250808_000030_index_create_corrupted_channel::Migration),
+            Box::new(m20250909_000031_peer_store_add_indices::Migration),
         ]
     }
 }
@@ -130,6 +132,7 @@ impl MigratorTrait for MigratorPeers {
             Box::new(m20250528_000023_peers_reset::Migration),
             Box::new(m20250603_000025_peers_reset::Migration),
             Box::new(m20250701_000028_peers_deprecate_fields::Migration(BackendType::SQLite)),
+            Box::new(m20250909_000031_peer_store_add_indices::Migration),
         ]
     }
 }

--- a/db/migration/src/m20250909_000031_peer_store_add_indices.rs
+++ b/db/migration/src/m20250909_000031_peer_store_add_indices.rs
@@ -3,9 +3,8 @@ use sea_orm_migration::prelude::*;
 #[derive(DeriveMigrationName)]
 pub struct Migration;
 
-const IDX_NAME_IGNORED_UNTIL: &str = "idx_ignored_until";
+const IDX_NAME_IGNORED: &str = "idx_ignored";
 const IDX_NAME_QUALITY: &str = "idx_quality";
-
 const IDX_NAME_LAST_SEEN: &str = "idx_last_seen";
 
 #[async_trait::async_trait]
@@ -17,7 +16,7 @@ impl MigrationTrait for Migration {
             .create_index(
                 Index::create()
                     .if_not_exists()
-                    .name(IDX_NAME_IGNORED_UNTIL)
+                    .name(IDX_NAME_IGNORED)
                     .table(NetworkPeer::Table)
                     .col((NetworkPeer::Ignored, IndexOrder::Asc))
                     .to_owned(),

--- a/db/migration/src/m20250909_000031_peer_store_add_indices.rs
+++ b/db/migration/src/m20250909_000031_peer_store_add_indices.rs
@@ -30,7 +30,7 @@ impl MigrationTrait for Migration {
                     .if_not_exists()
                     .name(IDX_NAME_LAST_SEEN)
                     .table(NetworkPeer::Table)
-                    .col((NetworkPeer::LastSeen, IndexOrder::Desc))
+                    .col((NetworkPeer::LastSeen, IndexOrder::Asc))
                     .to_owned(),
             )
             .await?;

--- a/db/migration/src/m20250909_000031_peer_store_add_indices.rs
+++ b/db/migration/src/m20250909_000031_peer_store_add_indices.rs
@@ -1,0 +1,71 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+const IDX_NAME_IGNORED_UNTIL: &str = "idx_ignored_until";
+const IDX_NAME_QUALITY: &str = "idx_quality";
+
+const IDX_NAME_LAST_SEEN: &str = "idx_last_seen";
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // The PacketKey column already has a UNIQUE constraint, which automatically creates an index.
+
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .name(IDX_NAME_IGNORED_UNTIL)
+                    .table(NetworkPeer::Table)
+                    .col((NetworkPeer::Ignored, IndexOrder::Asc))
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .name(IDX_NAME_LAST_SEEN)
+                    .table(NetworkPeer::Table)
+                    .col((NetworkPeer::LastSeen, IndexOrder::Desc))
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .if_not_exists()
+                    .name(IDX_NAME_QUALITY)
+                    .table(NetworkPeer::Table)
+                    .col((NetworkPeer::Quality, IndexOrder::Asc))
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(Index::drop().name(IDX_NAME_QUALITY).to_owned())
+            .await?;
+
+        manager
+            .drop_index(Index::drop().name(IDX_NAME_LAST_SEEN).to_owned())
+            .await?;
+
+        manager
+            .drop_index(Index::drop().name(IDX_NAME_IGNORED_UNTIL).to_owned())
+            .await
+    }
+}
+
+#[derive(DeriveIden)]
+pub(crate) enum NetworkPeer {
+    Table,
+    Ignored,
+    LastSeen,
+    Quality,
+}

--- a/db/migration/src/m20250909_000031_peer_store_add_indices.rs
+++ b/db/migration/src/m20250909_000031_peer_store_add_indices.rs
@@ -56,7 +56,7 @@ impl MigrationTrait for Migration {
             .await?;
 
         manager
-            .drop_index(Index::drop().name(IDX_NAME_IGNORED_UNTIL).to_owned())
+            .drop_index(Index::drop().name(IDX_NAME_IGNORED).to_owned())
             .await
     }
 }

--- a/db/sql/src/peers.rs
+++ b/db/sql/src/peers.rs
@@ -215,7 +215,6 @@ impl HoprDbPeersOperations for HoprDb {
     ) -> Result<BoxStream<'a, PeerStatus>> {
         let selector: WrappedPeerSelector = selector.into();
         let mut sub_stream = hopr_db_entity::network_peer::Entity::find()
-            // .filter(hopr_db_entity::network_peer::Column::Ignored.is_not_null())
             .filter(selector)
             .order_by(
                 network_peer::Column::LastSeen,
@@ -517,8 +516,12 @@ mod tests {
                 .await?;
         }
 
+        // The peers have by default current timestamp as LastSeen column when
+        // the `add_network_peer` method is called.
+        // Therefore, the `get_network_peers` must retrieve them in ascending order
+        // so that it later matches the `peers` vector in the assertion.
         let peers_from_db: Vec<PeerId> = db
-            .get_network_peers(Default::default(), false)
+            .get_network_peers(Default::default(), true)
             .await?
             .map(|s| s.id.1)
             .collect()

--- a/transport/api/Cargo.toml
+++ b/transport/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Implements the main HOPR transport interface for the core library"
 edition = "2021"

--- a/transport/api/src/network_notifier.rs
+++ b/transport/api/src/network_notifier.rs
@@ -72,8 +72,8 @@ where
         self.network
             .find_peers_to_ping(from_timestamp)
             .await
-            .unwrap_or_else(|e| {
-                tracing::error!(error = %e, "Failed to generate peers for the heartbeat procedure");
+            .unwrap_or_else(|error| {
+                tracing::error!(%error, "failed to generate peers for the heartbeat procedure");
                 vec![]
             })
     }

--- a/transport/network/Cargo.toml
+++ b/transport/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-network"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 license = "GPL-3.0-only"


### PR DESCRIPTION
Indices were missing on columns that are used often in WHERE clauses to query the `NetworkPeer` table.

The PR optimizes the code path of `find_peers_to_ping` which is called very often by the new probing mechanism.

Closes #7442