### PR TITLE
fix(api): update schema value types for max_surb_upstream and response buffer

### DIFF
--- a/hoprd/rest-api/Cargo.toml
+++ b/hoprd/rest-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd-api"
-version = "4.2.1"
+version = "4.2.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "API enabling developers to interact with a hoprd node programatically through HTTP REST API."

--- a/hoprd/rest-api/src/session.rs
+++ b/hoprd/rest-api/src/session.rs
@@ -464,7 +464,7 @@ pub(crate) struct SessionClientRequest {
     /// All syntaxes like "2 MB", "128 kiB", "3MiB" are supported. The value must be
     /// at least the size of 2 Session packet payloads.
     #[serde_as(as = "Option<DisplayFromStr>")]
-    #[schema(value_type = String)]
+    #[schema(value_type = Option<String>)]
     pub response_buffer: Option<bytesize::ByteSize>,
     /// The maximum throughput at which artificial SURBs might be generated and sent
     /// to the recipient of the Session.
@@ -475,7 +475,7 @@ pub(crate) struct SessionClientRequest {
     /// All syntaxes like "2 MBps", "1.2Mbps", "300 kb/s", "1.23 Mb/s" are supported.
     #[serde(default)]
     #[serde(with = "human_bandwidth::option")]
-    #[schema(value_type = String)]
+    #[schema(value_type = Option<String>)]
     pub max_surb_upstream: Option<human_bandwidth::re::bandwidth::Bandwidth>,
     /// How many Sessions to pool for clients.
     ///

--- a/hoprd/rest-api/src/session.rs
+++ b/hoprd/rest-api/src/session.rs
@@ -596,12 +596,12 @@ pub(crate) struct SessionClientResponse {
     /// to the recipient of the Session.    
     #[serde(default)]
     #[serde(with = "human_bandwidth::option")]
-    #[schema(value_type = String)]
+    #[schema(value_type = Option<String>)]
     pub max_surb_upstream: Option<human_bandwidth::re::bandwidth::Bandwidth>,
     /// The amount of response data the Session counterparty can deliver back to us, without us
     /// sending any SURBs to them.
     #[serde_as(as = "Option<DisplayFromStr>")]
-    #[schema(value_type = String)]
+    #[schema(value_type = Option<String>)]
     pub response_buffer: Option<bytesize::ByteSize>,
     /// How many Sessions to pool for clients.
     pub session_pool: Option<usize>,


### PR DESCRIPTION
Closes #7490 