### PR TITLE
feat(jemalloc): Enable profiling in jemalloc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -226,3 +226,4 @@ deploy/nfpm/*.1.gz
 **/*.pcap
 ~/.cargo/advisory-db
 ~/.cargo/advisory-db..lock
+jeprof-pull-*/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,8 +204,15 @@ opt-level = 1
 codegen-units = 1
 lto = "fat"
 panic = "abort"
-strip = true
 opt-level = 3
+strip = true
+
+# memory profiling profile — inherits release optimizations but preserves debug symbols
+# for jeprof symbol resolution
+[profile.memprof]
+inherits = "release"
+debug = 2
+strip = false
 
 # uses extended debug symbols for profiling but does not harm benchmarking performance
 [profile.bench]

--- a/protocols/session/src/socket/mod.rs
+++ b/protocols/session/src/socket/mod.rs
@@ -88,14 +88,29 @@ enum WriteState {
 /// behavior (see [`AcknowledgementState`](ack_state::AcknowledgementState))
 ///
 /// The constant argument `C` specifies the MTU in bytes of the underlying transport.
-#[pin_project::pin_project]
-pub struct SessionSocket<const C: usize, S> {
+#[pin_project::pin_project(PinnedDrop)]
+pub struct SessionSocket<const C: usize, S: SocketState<C>> {
     state: S,
     // This is where upstream writes the to-be-segmented frame data to
     upstream_frames_in: Pin<Box<dyn futures::io::AsyncWrite + Send>>,
     // This is where upstream reads the reconstructed frame data from
     downstream_frames_out: Pin<Box<dyn futures::io::AsyncRead + Send>>,
     write_state: WriteState,
+}
+
+// Ensure `state.stop()` runs even if the socket is dropped without
+// `poll_close` (e.g. its owning task was aborted). Without this, the
+// detached tasks spawned in `SocketState::run` keep their own channel
+// senders and never terminate, pinning the FrameInspector, ring-buffer,
+// and ack buffers per leaked session.
+#[pin_project::pinned_drop]
+impl<const C: usize, S: SocketState<C>> PinnedDrop for SessionSocket<C, S> {
+    fn drop(self: Pin<&mut Self>) {
+        let this = self.project();
+        if let Err(error) = this.state.stop() {
+            tracing::debug!(%error, "state.stop on SessionSocket drop failed");
+        }
+    }
 }
 
 impl<const C: usize> SessionSocket<C, Stateless<C>> {

--- a/protocols/session/src/socket/state.rs
+++ b/protocols/session/src/socket/state.rs
@@ -246,6 +246,12 @@ mod tests {
             .once()
             .in_sequence(&mut alice_seq)
             .return_once(|_| Ok::<_, SessionError>(()));
+        // PinnedDrop on SessionSocket calls state.stop() again on drop.
+        alice_state
+            .expect_stop()
+            .once()
+            .in_sequence(&mut alice_seq)
+            .return_once(|| Ok::<_, SessionError>(()));
 
         let mut bob_seq = mockall::Sequence::new();
         let mut bob_state = MockSockState::new();
@@ -289,6 +295,12 @@ mod tests {
             .once()
             .in_sequence(&mut bob_seq)
             .return_once(|_| Ok::<_, SessionError>(()));
+        // PinnedDrop on SessionSocket calls state.stop() again on drop.
+        bob_state
+            .expect_stop()
+            .once()
+            .in_sequence(&mut bob_seq)
+            .return_once(|| Ok::<_, SessionError>(()));
 
         let (alice, bob) = setup_alice_bob::<MTU>(
             FaultyNetworkConfig {

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -219,6 +219,19 @@ impl HoprSessionConfigurator {
             .update_surb_balancer_config(&self.id, config)
             .await?)
     }
+
+    /// Explicitly closes the underlying Session in the [`SessionManager`].
+    ///
+    /// Returns `true` if the session was found and closed, `false` if it was
+    /// already gone (or the manager is dropped). Frees the per-session state
+    /// (frame reassembly buffers, control channels, …) immediately rather than
+    /// waiting for the manager's idle-timeout eviction.
+    pub async fn close(&self) -> bool {
+        match self.smgr.upgrade() {
+            Some(smgr) => smgr.close_session(&self.id).await,
+            None => false,
+        }
+    }
 }
 
 /// Interface into the physical transport mechanism allowing all off-chain HOPR-related tasks on

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -957,6 +957,24 @@ where
         self.sessions.iter().map(|(k, _)| *k).collect()
     }
 
+    /// Explicitly closes the session with the given `id`.
+    ///
+    /// Removes the entry from the internal session cache, closes the data channel,
+    /// and aborts any auxiliary tasks. Returns `true` if a session was found and
+    /// closed, `false` otherwise.
+    ///
+    /// This avoids waiting for the idle timeout (`time_to_idle`) or the LRU
+    /// capacity bound to evict the entry, which is the desired behaviour when
+    /// the caller (e.g. REST `DELETE /session`) knows the session is finished.
+    pub async fn close_session(&self, id: &SessionId) -> bool {
+        if let Some(slot) = self.sessions.remove(id).await {
+            close_session(*id, slot, ClosureReason::Eviction);
+            true
+        } else {
+            false
+        }
+    }
+
     /// Updates the configuration of the SURB balancer on the given [`SessionId`].
     ///
     /// Returns an error if the Session with the given `id` does not exist, or


### PR DESCRIPTION
This only enables the code to be compiled in. No runtime overhead unless profiling is explicitly enabled through `MALLOC_CONF`, off by default.

Refs #7857