### PR TITLE
feat: update hopr-api crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4441,15 +4441,20 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
+ "chrono",
  "futures",
+ "hopr-chain-types",
  "hopr-crypto-packet",
  "hopr-crypto-types",
  "hopr-internal-types",
+ "hopr-network-types",
+ "hopr-platform",
  "hopr-primitive-types",
  "multiaddr",
+ "strum 0.27.2",
 ]
 
 [[package]]

--- a/common/api/Cargo.toml
+++ b/common/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-api"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Common HOPR-related high-level API traits used in the code base"
@@ -10,9 +10,14 @@ license = "GPL-3.0-only"
 
 [dependencies]
 async-trait = { workspace = true }
+chrono = { workspace = true }
 futures = { workspace = true }
 multiaddr = { workspace = true }
+strum = { workspace = true }
 hopr-internal-types = { workspace = true }
 hopr-primitive-types = { workspace = true }
+hopr-network-types = { workspace = true }
+hopr-chain-types = { workspace = true }
 hopr-crypto-packet = { workspace = true }
 hopr-crypto-types = { workspace = true }
+hopr-platform = { workspace = true }

--- a/common/api/src/chain/accounts.rs
+++ b/common/api/src/chain/accounts.rs
@@ -1,7 +1,7 @@
-use std::error::Error;
+use std::fmt::Formatter;
 
 use futures::{future::BoxFuture, stream::BoxStream};
-use hopr_crypto_types::prelude::OffchainPublicKey;
+use hopr_crypto_types::prelude::{OffchainKeypair, OffchainPublicKey};
 pub use hopr_internal_types::prelude::AccountEntry;
 use hopr_primitive_types::prelude::Address;
 pub use hopr_primitive_types::prelude::{Balance, Currency};
@@ -9,28 +9,51 @@ pub use multiaddr::Multiaddr;
 
 use crate::chain::ChainReceipt;
 
+/// Error that can occur when making a node announcement.
+///
+/// See [`ChainWriteAccountOperations::announce`]
+#[derive(Debug, strum::EnumIs, strum::EnumTryAs)]
+pub enum AnnouncementError<E> {
+    /// Special error when an account is already announced.
+    AlreadyAnnounced,
+    /// Error that can occur when processing an announcement.
+    ProcessingError(E),
+}
+
+impl<E: std::fmt::Display> std::fmt::Display for AnnouncementError<E> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AnnouncementError::AlreadyAnnounced => f.write_str("already announced"),
+            AnnouncementError::ProcessingError(e) => write!(f, "account processing error: {e}"),
+        }
+    }
+}
+
+impl<E: std::error::Error> std::error::Error for AnnouncementError<E> {}
+
 /// On-chain write operations regarding on-chain node accounts.
 #[async_trait::async_trait]
 pub trait ChainWriteAccountOperations {
-    type Error: Error + Send + Sync + 'static;
+    type Error: std::error::Error + Send + Sync + 'static;
 
     /// Announces transport key and list of multi addresses.
     async fn announce(
         &self,
         multiaddrs: &[Multiaddr],
-        key: &OffchainPublicKey,
-    ) -> Result<BoxFuture<'_, Result<ChainReceipt, Self::Error>>, Self::Error>;
+        key: &OffchainKeypair,
+    ) -> Result<BoxFuture<'_, Result<ChainReceipt, Self::Error>>, AnnouncementError<Self::Error>>;
 
     /// Withdraws native or token currency.
     async fn withdraw<C: Currency>(
         &self,
         balance: Balance<C>,
+        recipient: &Address,
     ) -> Result<BoxFuture<'_, Result<ChainReceipt, Self::Error>>, Self::Error>;
 
     /// Registers Safe address with the current node.
     async fn register_safe(
         &self,
-        safe_address: Address,
+        safe_address: &Address,
     ) -> Result<BoxFuture<'_, Result<ChainReceipt, Self::Error>>, Self::Error>;
 }
 
@@ -39,13 +62,16 @@ pub trait ChainWriteAccountOperations {
 /// See [`ChainReadAccountOperations::stream_accounts`].
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct AccountSelector {
+    /// Selects accounts that are announced with multi-addresses.
     pub public_only: bool,
+    /// Selects accounts bound with the given chain key.
+    pub chain_key: Option<Address>,
 }
 
 /// Chain operations that read on-chain node accounts.
 #[async_trait::async_trait]
 pub trait ChainReadAccountOperations {
-    type Error: Error + Send + Sync + 'static;
+    type Error: std::error::Error + Send + Sync + 'static;
 
     /// Returns the native or token currency balance of the current node's account.
     async fn node_balance<C: Currency>(&self) -> Result<Balance<C>, Self::Error>;
@@ -56,9 +82,24 @@ pub trait ChainReadAccountOperations {
     /// Returns the native or token currency Safe allowance.
     async fn safe_allowance<C: Currency>(&self) -> Result<Balance<C>, Self::Error>;
 
+    /// Returns account entry given the on-chain `address`.
+    async fn find_account_by_address(&self, address: &Address) -> Result<Option<AccountEntry>, Self::Error>;
+
+    /// Returns account entry given the off-chain `packet_key`.
+    async fn find_account_by_packet_key(
+        &self,
+        packet_key: &OffchainPublicKey,
+    ) -> Result<Option<AccountEntry>, Self::Error>;
+
+    /// Validates the node's Safe setup.
+    async fn check_node_safe_module_status(&self) -> Result<bool, Self::Error>;
+
+    /// Checks if the given safe address can be registered with the current node.
+    async fn can_register_with_safe(&self, safe_address: &Address) -> Result<bool, Self::Error>;
+
     /// Returns on-chain node accounts with the given [`AccountSelector`].
     async fn stream_accounts<'a>(
         &'a self,
         selector: AccountSelector,
-    ) -> Result<BoxStream<'a, Result<AccountEntry, Self::Error>>, Self::Error>;
+    ) -> Result<BoxStream<'a, AccountEntry>, Self::Error>;
 }

--- a/common/api/src/chain/events.rs
+++ b/common/api/src/chain/events.rs
@@ -1,0 +1,8 @@
+pub use hopr_chain_types::chain_events::{ChainEventType, SignificantChainEvent};
+
+pub trait ChainEvents {
+    type Error: std::error::Error + Send + Sync;
+
+    /// Subscribe to on-chain events.
+    fn subscribe(&self) -> Result<impl futures::Stream<Item = SignificantChainEvent> + Send + 'static, Self::Error>;
+}

--- a/common/api/src/chain/keys.rs
+++ b/common/api/src/chain/keys.rs
@@ -10,13 +10,11 @@ use hopr_primitive_types::prelude::Address;
 #[async_trait::async_trait]
 pub trait ChainKeyOperations {
     type Error: Error + Send + Sync + 'static;
-    type Mapper: KeyIdMapper<HoprSphinxSuite, HoprSphinxHeaderSpec> + Clone;
+    type Mapper: KeyIdMapper<HoprSphinxSuite, HoprSphinxHeaderSpec> + Clone + Send + Sync + 'static;
     /// Translates [`Address`] into [`OffchainPublicKey`].
     async fn chain_key_to_packet_key(&self, chain: &Address) -> Result<Option<OffchainPublicKey>, Self::Error>;
     /// Translates [`OffchainPublicKey`] into [`Address`].
     async fn packet_key_to_chain_key(&self, packet: &OffchainPublicKey) -> Result<Option<Address>, Self::Error>;
-    /// Returns [mapper](KeyIdMapper) for offchain key IDs.
-    fn key_id_mapper(&self) -> Self::Mapper;
     /// Returns [mapper](KeyIdMapper) for offchain key IDs as a reference.
     fn key_id_mapper_ref(&self) -> &Self::Mapper;
 }

--- a/common/api/src/chain/mod.rs
+++ b/common/api/src/chain/mod.rs
@@ -1,11 +1,13 @@
 mod accounts;
 mod channels;
+mod events;
 mod keys;
 mod misc;
 mod tickets;
 
 pub use accounts::*;
 pub use channels::*;
+pub use events::*;
 pub use keys::*;
 pub use misc::*;
 pub use tickets::*;

--- a/common/api/src/chain/tickets.rs
+++ b/common/api/src/chain/tickets.rs
@@ -1,10 +1,10 @@
 use std::error::Error;
 
 use futures::future::BoxFuture;
-pub use hopr_internal_types::prelude::{RedeemableTicket, WinningProbability};
+pub use hopr_internal_types::prelude::{AcknowledgedTicket, WinningProbability};
 use hopr_primitive_types::balance::HoprBalance;
 
-use crate::chain::ChainReceipt;
+use crate::{chain::ChainReceipt, db::TicketSelector};
 
 /// On-chain write operations with tickets.
 #[async_trait::async_trait]
@@ -13,8 +13,14 @@ pub trait ChainWriteTicketOperations {
     /// Redeems a single ticket on-chain.
     async fn redeem_ticket(
         &self,
-        ticket: RedeemableTicket,
+        ticket: AcknowledgedTicket,
     ) -> Result<BoxFuture<'_, Result<ChainReceipt, Self::Error>>, Self::Error>;
+
+    /// Allows to batch-redeem multiple tickets on-chain.
+    async fn redeem_tickets_via_selector(
+        &self,
+        selector: TicketSelector,
+    ) -> Result<Vec<BoxFuture<'_, Result<ChainReceipt, Self::Error>>>, Self::Error>;
 }
 
 /// On-chain read operations with tickets.

--- a/common/api/src/db/mod.rs
+++ b/common/api/src/db/mod.rs
@@ -1,0 +1,12 @@
+mod peers;
+
+mod protocol;
+
+mod tickets;
+
+pub use peers::*;
+pub use protocol::*;
+pub use tickets::*;
+
+/// Shorthand for the `chrono` based timestamp type used in the database.
+pub type DbTimestamp = chrono::DateTime<chrono::Utc>;

--- a/common/api/src/db/peers.rs
+++ b/common/api/src/db/peers.rs
@@ -1,0 +1,216 @@
+use std::time::{Duration, SystemTime};
+
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use hopr_crypto_types::prelude::{OffchainPublicKey, PeerId};
+use hopr_primitive_types::prelude::*;
+use multiaddr::Multiaddr;
+
+/// Actual origin.
+///
+/// First occurence of the peer in the network mechanism.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, strum::Display, strum::FromRepr)]
+#[repr(u8)]
+pub enum PeerOrigin {
+    #[strum(to_string = "node initialization")]
+    Initialization = 0,
+    #[strum(to_string = "network registry")]
+    NetworkRegistry = 1,
+    #[strum(to_string = "incoming connection")]
+    IncomingConnection = 2,
+    #[strum(to_string = "outgoing connection attempt")]
+    OutgoingConnection = 3,
+    #[strum(to_string = "strategy monitors existing channel")]
+    StrategyExistingChannel = 4,
+    #[strum(to_string = "strategy considers opening a channel")]
+    StrategyConsideringChannel = 5,
+    #[strum(to_string = "strategy decided to open new channel")]
+    StrategyNewChannel = 6,
+    #[strum(to_string = "manual ping")]
+    ManualPing = 7,
+    #[strum(to_string = "testing")]
+    Testing = 8,
+}
+
+/// Statistical observation related to peers in the network. Statistics on all peer entries stored
+/// by the network component.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct Stats {
+    /// Number of good-quality public nodes.
+    pub good_quality_public: u32,
+    /// Number of bad-quality public nodes.
+    pub bad_quality_public: u32,
+    /// Number of good-quality non-public nodes.
+    pub good_quality_non_public: u32,
+    /// Number of bad-quality non-public nodes.
+    pub bad_quality_non_public: u32,
+}
+
+// #[cfg(all(feature = "prometheus", not(test)))]
+impl Stats {
+    /// Returns count of all peers.
+    pub fn all_count(&self) -> usize {
+        self.good_quality_public as usize
+            + self.bad_quality_public as usize
+            + self.good_quality_non_public as usize
+            + self.bad_quality_non_public as usize
+    }
+}
+
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
+pub struct PeerSelector {
+    /// Lower and upper bounds (both inclusive) on last seen timestamp.
+    pub last_seen: (Option<SystemTime>, Option<SystemTime>),
+    /// Lower and upper bounds (both inclusive) on peer quality.
+    pub quality: (Option<f64>, Option<f64>),
+}
+
+impl PeerSelector {
+    pub fn with_last_seen_gte(mut self, lower_bound: SystemTime) -> Self {
+        self.last_seen.0 = Some(lower_bound);
+        self
+    }
+
+    pub fn with_last_seen_lte(mut self, upper_bound: SystemTime) -> Self {
+        self.last_seen.1 = Some(upper_bound);
+        self
+    }
+
+    pub fn with_quality_gte(mut self, lower_bound: f64) -> Self {
+        self.quality.0 = Some(lower_bound);
+        self
+    }
+
+    pub fn with_quality_lte(mut self, upper_bound: f64) -> Self {
+        self.quality.1 = Some(upper_bound);
+        self
+    }
+}
+
+/// Status of the peer as recorded by a network component.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PeerStatus {
+    pub id: (OffchainPublicKey, PeerId),
+    pub origin: PeerOrigin,
+    pub last_seen: SystemTime,
+    pub last_seen_latency: Duration,
+    pub heartbeats_sent: u64,
+    pub heartbeats_succeeded: u64,
+    pub backoff: f64,
+    /// Until when the peer should be ignored.
+    pub ignored_until: Option<SystemTime>,
+    pub multiaddresses: Vec<Multiaddr>,
+    // Should be public(crate) but the separation through traits does not allow direct SQL ORM serde
+    pub quality: f64,
+    // Should be public(crate) but the separation through traits does not allow direct SQL ORM serde
+    pub quality_avg: SingleSumSMA<f64>,
+}
+
+impl PeerStatus {
+    pub fn new(id: PeerId, origin: PeerOrigin, backoff: f64, quality_window: u32) -> PeerStatus {
+        PeerStatus {
+            id: (OffchainPublicKey::from_peerid(&id).expect("invalid peer id given"), id),
+            origin,
+            heartbeats_sent: 0,
+            heartbeats_succeeded: 0,
+            last_seen: SystemTime::UNIX_EPOCH,
+            last_seen_latency: Duration::default(),
+            ignored_until: None,
+            backoff,
+            quality: 0.0,
+            quality_avg: SingleSumSMA::new(quality_window as usize),
+            multiaddresses: vec![],
+        }
+    }
+
+    // Update both the immediate last quality and the average windowed quality
+    pub fn update_quality(&mut self, new_value: f64) {
+        debug_assert!(
+            (0.0f64..=1.0f64).contains(&new_value),
+            "quality failed to update with value outside the [0,1] range"
+        );
+
+        if (0.0f64..=1.0f64).contains(&new_value) {
+            self.quality = new_value;
+            self.quality_avg.push(new_value);
+        }
+    }
+
+    /// Gets the average quality of this peer
+    pub fn get_average_quality(&self) -> f64 {
+        self.quality_avg.average().unwrap_or_default()
+    }
+
+    /// Gets the immediate node quality
+    pub fn get_quality(&self) -> f64 {
+        self.quality
+    }
+
+    /// Determines whether the peer is ignored due to quality concerns, given the current time.
+    #[inline]
+    pub fn is_ignored(&self) -> bool {
+        let now = hopr_platform::time::current_time();
+        self.ignored_until
+            .is_some_and(|t| now.saturating_sub(t) == std::time::Duration::from_secs(0))
+    }
+}
+
+impl std::fmt::Display for PeerStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(
+            f,
+            "Entry: [id={}, origin={}, last seen on={:?}, quality={}, heartbeats sent={}, heartbeats succeeded={}, \
+             backoff={}]",
+            self.id.1,
+            self.origin,
+            self.last_seen,
+            self.quality,
+            self.heartbeats_sent,
+            self.heartbeats_succeeded,
+            self.backoff
+        )
+    }
+}
+
+#[async_trait]
+pub trait HoprDbPeersOperations {
+    type Error: std::error::Error + Send + Sync + 'static;
+    /// Adds a peer to the backend.
+    ///
+    /// Should fail if the given peer id already exists in the store.
+    async fn add_network_peer(
+        &self,
+        peer: &PeerId,
+        origin: PeerOrigin,
+        mas: Vec<Multiaddr>,
+        backoff: f64,
+        quality_window: u32,
+    ) -> Result<(), Self::Error>;
+
+    /// Removes the peer from the backend.
+    ///
+    /// Should fail if the given peer id does not exist.
+    async fn remove_network_peer(&self, peer: &PeerId) -> Result<(), Self::Error>;
+
+    /// Updates stored information about the peer.
+    /// Should fail if the peer does not exist in the store.
+    async fn update_network_peer(&self, new_status: PeerStatus) -> Result<(), Self::Error>;
+
+    /// Gets stored information about the peer.
+    ///
+    /// Should return `None` if such peer does not exist in the store.
+    async fn get_network_peer(&self, peer: &PeerId) -> Result<Option<PeerStatus>, Self::Error>;
+
+    /// Returns a stream of all stored peers, optionally matching the given [`PeerSelector`] filter.
+    ///
+    /// The `sort_last_seen_asc` indicates whether the results should be sorted in ascending
+    /// or descending order of the `last_seen` field.
+    async fn get_network_peers<'a>(
+        &'a self,
+        selector: PeerSelector,
+        sort_last_seen_asc: bool,
+    ) -> Result<BoxStream<'a, PeerStatus>, Self::Error>;
+
+    /// Returns the [statistics](Stats) on the stored peers.
+    async fn network_peer_stats(&self, quality_threshold: f64) -> Result<Stats, Self::Error>;
+}

--- a/common/api/src/db/protocol.rs
+++ b/common/api/src/db/protocol.rs
@@ -1,0 +1,192 @@
+use std::fmt::Formatter;
+
+pub use hopr_crypto_packet::{
+    HoprSurb,
+    prelude::{HoprSenderId, PacketSignals},
+};
+use hopr_crypto_types::prelude::*;
+use hopr_internal_types::prelude::*;
+use hopr_network_types::prelude::{ResolvedTransportRouting, SurbMatcher};
+use hopr_primitive_types::balance::HoprBalance;
+
+use crate::chain::{ChainKeyOperations, ChainMiscOperations, ChainReadChannelOperations, ChainReadTicketOperations};
+
+/// Contains a SURB found in the SURB ring buffer via [`HoprDbProtocolOperations::find_surb`].
+#[derive(Debug)]
+pub struct FoundSurb {
+    /// Complete sender ID of the SURB.
+    pub sender_id: HoprSenderId,
+    /// The SURB itself.
+    pub surb: HoprSurb,
+    /// Number of SURBs remaining in the ring buffer with the same pseudonym.
+    pub remaining: usize,
+}
+
+/// Configuration for the SURB cache.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd)]
+pub struct SurbCacheConfig {
+    /// Size of the SURB ring buffer per pseudonym.
+    pub rb_capacity: usize,
+    /// Threshold for the number of SURBs in the ring buffer, below which it is
+    /// considered low ("SURB distress").
+    pub distress_threshold: usize,
+}
+
+/// Error that can occur when processing an incoming packet.
+#[derive(Debug, strum::EnumIs, strum::EnumTryAs)]
+pub enum IncomingPacketError<E> {
+    /// Packet is not decodable.
+    ///
+    /// Such errors are fatal and therefore the packet cannot be acknowledged.
+    Undecodable(E),
+    /// Packet is decodable but cannot be processed due to other reasons.
+    ///
+    /// Such errors are protocol-related and packets must be acknowledged.
+    ProcessingError(E),
+}
+
+impl<E: std::fmt::Display> std::fmt::Display for IncomingPacketError<E> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IncomingPacketError::Undecodable(e) => write!(f, "undecodable packet: {e}"),
+            IncomingPacketError::ProcessingError(e) => write!(f, "packet processing error: {e}"),
+        }
+    }
+}
+
+impl<E: std::error::Error> std::error::Error for IncomingPacketError<E> {}
+
+/// Trait defining all DB functionality needed by a packet/acknowledgement processing pipeline.
+#[async_trait::async_trait]
+pub trait HoprDbProtocolOperations {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Processes the acknowledgements for the pending tickets
+    ///
+    /// There are three cases:
+    /// 1. There is an unacknowledged ticket and we are awaiting a half key.
+    /// 2. We were the creator of the packet, hence we do not wait for any half key
+    /// 3. The acknowledgement is unexpected and stems from a protocol bug or an attacker
+    async fn handle_acknowledgement<R>(
+        &self,
+        ack: VerifiedAcknowledgement,
+        chain_resolver: &R,
+    ) -> Result<(), Self::Error>
+    where
+        R: ChainReadChannelOperations + ChainReadTicketOperations + ChainMiscOperations + Send + Sync;
+
+    /// Attempts to find SURB and its ID given the [`SurbMatcher`].
+    async fn find_surb(&self, matcher: SurbMatcher) -> Result<FoundSurb, Self::Error>;
+
+    /// Returns the SURB cache configuration.
+    fn get_surb_config(&self) -> SurbCacheConfig;
+
+    /// Process the data into an outgoing packet that is not going to be acknowledged.
+    async fn to_send_no_ack<R>(
+        &self,
+        data: Box<[u8]>,
+        destination: OffchainPublicKey,
+        resolver: &R,
+    ) -> Result<OutgoingPacket, Self::Error>
+    where
+        R: ChainKeyOperations + ChainMiscOperations + Send + Sync;
+
+    /// Process the data into an outgoing packet
+    async fn to_send<R>(
+        &self,
+        data: Box<[u8]>,
+        routing: ResolvedTransportRouting,
+        outgoing_ticket_win_prob: Option<WinningProbability>,
+        outgoing_ticket_price: Option<HoprBalance>,
+        signals: PacketSignals,
+        resolver: &R,
+    ) -> Result<OutgoingPacket, Self::Error>
+    where
+        R: ChainReadChannelOperations
+            + ChainReadTicketOperations
+            + ChainKeyOperations
+            + ChainMiscOperations
+            + Send
+            + Sync;
+
+    /// Process the incoming packet into data
+    #[allow(clippy::wrong_self_convention)]
+    async fn from_recv<R>(
+        &self,
+        data: Box<[u8]>,
+        pkt_keypair: &OffchainKeypair,
+        sender: OffchainPublicKey,
+        outgoing_ticket_win_prob: Option<WinningProbability>,
+        outgoing_ticket_price: Option<HoprBalance>,
+        resolver: &R,
+    ) -> Result<IncomingPacket, IncomingPacketError<Self::Error>>
+    where
+        R: ChainReadChannelOperations
+            + ChainReadTicketOperations
+            + ChainKeyOperations
+            + ChainMiscOperations
+            + Send
+            + Sync;
+}
+
+/// Contains some miscellaneous information about a received packet.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct AuxiliaryPacketInfo {
+    /// Packet signals that the packet carried.
+    ///
+    /// Zero if no signal flags were specified.
+    pub packet_signals: PacketSignals,
+    /// Number of SURBs that the packet carried.
+    pub num_surbs: usize,
+}
+
+#[allow(clippy::large_enum_variant)] // TODO: Uses too large objects
+pub enum IncomingPacket {
+    /// Packet is intended for us
+    Final {
+        packet_tag: PacketTag,
+        previous_hop: OffchainPublicKey,
+        sender: HoprPseudonym,
+        plain_text: Box<[u8]>,
+        ack_key: HalfKey,
+        info: AuxiliaryPacketInfo,
+    },
+    /// Packet must be forwarded
+    Forwarded {
+        packet_tag: PacketTag,
+        previous_hop: OffchainPublicKey,
+        next_hop: OffchainPublicKey,
+        data: Box<[u8]>,
+        /// Acknowledgement payload to be sent to the previous hop
+        ack_key: HalfKey,
+    },
+    /// The packet contains an acknowledgement of a delivered packet.
+    Acknowledgement {
+        packet_tag: PacketTag,
+        previous_hop: OffchainPublicKey,
+        ack: Acknowledgement,
+    },
+}
+
+/// Packet that is being sent out by us
+pub struct OutgoingPacket {
+    pub next_hop: OffchainPublicKey,
+    pub ack_challenge: HalfKeyChallenge,
+    pub data: Box<[u8]>,
+}
+
+impl std::fmt::Debug for OutgoingPacket {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("OutgoingPacket")
+            .field("next_hop", &self.next_hop)
+            .field("ack_challenge", &self.ack_challenge)
+            .finish_non_exhaustive()
+    }
+}
+
+#[allow(clippy::large_enum_variant)] // TODO: Uses too large objects
+pub enum ResolvedAcknowledgement {
+    Sending(VerifiedAcknowledgement),
+    RelayingWin(AcknowledgedTicket),
+    RelayingLoss(Hash),
+}

--- a/common/api/src/db/tickets.rs
+++ b/common/api/src/db/tickets.rs
@@ -1,0 +1,351 @@
+use std::{
+    collections::HashSet,
+    fmt::{Display, Formatter},
+    ops::{Bound, RangeBounds},
+    sync::{Arc, atomic::AtomicU64},
+};
+
+use futures::stream::BoxStream;
+use hopr_crypto_types::prelude::*;
+use hopr_internal_types::prelude::*;
+use hopr_primitive_types::prelude::*;
+
+/// Allows selecting a range of ticket indices in [TicketSelector].
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum TicketIndexSelector {
+    /// Selects no ticket index specifically.
+    /// This makes the [TicketSelector] less restrictive.
+    #[default]
+    None,
+    /// Selects a single ticket with the given index.
+    Single(u64),
+    /// Selects multiple tickets with the given indices.
+    Multiple(HashSet<u64>),
+    /// Selects multiple tickets with indices within the given range.
+    Range((Bound<u64>, Bound<u64>)),
+}
+
+impl Display for TicketIndexSelector {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match &self {
+            TicketIndexSelector::None => write!(f, ""),
+            TicketIndexSelector::Single(idx) => write!(f, "with index {idx}"),
+            TicketIndexSelector::Multiple(indices) => write!(f, "with indices {indices:?}"),
+            TicketIndexSelector::Range((lb, ub)) => write!(f, "with indices in {lb:?}..{ub:?}"),
+        }
+    }
+}
+
+/// Allows selecting tickets via [`HoprDbTicketOperations`].
+#[derive(Clone, Debug)]
+pub struct TicketSelector {
+    /// Channel ID and Epoch pairs.
+    pub channel_identifiers: Vec<(Hash, U256)>,
+    /// If given, will select ticket(s) with the given indices
+    /// in the given channel and epoch.
+    ///
+    /// See [`TicketIndexSelector`] for possible options.
+    pub index: TicketIndexSelector,
+    /// If given, the tickets are further restricted to the ones with a winning probability
+    /// in this range.
+    pub win_prob: (Bound<WinningProbability>, Bound<WinningProbability>),
+    /// If given, the tickets are further restricted to the ones with an amount
+    /// in this range.
+    pub amount: (Bound<HoprBalance>, Bound<HoprBalance>),
+    /// Further restriction to tickets with the given state.
+    pub state: Option<AcknowledgedTicketStatus>,
+    /// Further restrict to only aggregated tickets.
+    pub only_aggregated: bool,
+}
+
+impl Display for TicketSelector {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        let out = format!(
+            "ticket selector in {:?} {}{}{}{}{}",
+            self.channel_identifiers,
+            self.index,
+            self.state
+                .map(|state| format!(" in state {state}"))
+                .unwrap_or("".into()),
+            if self.only_aggregated { " only aggregated" } else { "" },
+            match &self.win_prob {
+                (Bound::Unbounded, Bound::Unbounded) => "".to_string(),
+                bounds => format!(" with winning probability in {bounds:?}"),
+            },
+            match &self.amount {
+                (Bound::Unbounded, Bound::Unbounded) => "".to_string(),
+                bounds => format!(" with amount in {bounds:?}"),
+            },
+        );
+        write!(f, "{}", out.trim())
+    }
+}
+
+impl TicketSelector {
+    /// Create a new ticket selector given the `channel_id` and `epoch`.
+    pub fn new<T: Into<U256>>(channel_id: Hash, epoch: T) -> Self {
+        Self {
+            channel_identifiers: vec![(channel_id, epoch.into())],
+            index: TicketIndexSelector::None,
+            win_prob: (Bound::Unbounded, Bound::Unbounded),
+            amount: (Bound::Unbounded, Bound::Unbounded),
+            state: None,
+            only_aggregated: false,
+        }
+    }
+
+    /// Allows matching tickets on multiple channels by adding the given
+    /// `channel_id` and `epoch` to the selector.
+    ///
+    /// This also nullifies any prior effect of any prior calls to [`TicketSelector::with_index`] or
+    /// [`TicketSelector::with_index_range`]
+    /// as ticket indices cannot be matched over multiple channels.
+    pub fn also_on_channel<T: Into<U256>>(self, channel_id: Hash, epoch: T) -> Self {
+        let mut ret = self.clone();
+        ret.index = TicketIndexSelector::None;
+        ret.channel_identifiers.push((channel_id, epoch.into()));
+        ret
+    }
+
+    /// Sets the selector to match only tickets on the given `channel_id` and `epoch`.
+    ///
+    /// This nullifies any prior calls to [`TicketSelector::also_on_channel`].
+    pub fn just_on_channel<T: Into<U256>>(self, channel_id: Hash, epoch: T) -> Self {
+        let mut ret = self.clone();
+        ret.channel_identifiers = vec![(channel_id, epoch.into())];
+        ret
+    }
+
+    /// Checks if this selector operates only on a single channel.
+    ///
+    /// This will return `false` if [`TicketSelector::also_on_channel`] was called, and neither
+    /// the [`TicketSelector::with_index`] nor [`TicketSelector::with_index_range`] were
+    /// called subsequently.
+    pub fn is_single_channel(&self) -> bool {
+        self.channel_identifiers.len() == 1
+    }
+
+    /// If `false` is returned, the selector can fetch more than a single ticket.
+    pub fn is_unique(&self) -> bool {
+        self.is_single_channel()
+            && (matches!(&self.index, TicketIndexSelector::Single(_))
+                || matches!(&self.index, TicketIndexSelector::Multiple(indices) if indices.len() == 1))
+    }
+
+    /// Returns this instance with a ticket index set.
+    ///
+    /// This method can be called multiple times to select multiple tickets.
+    /// If [`TicketSelector::with_index_range`] was previously called, it will be replaced.
+    /// If [`TicketSelector::also_on_channel`] was previously called, its effect will be nullified.
+    pub fn with_index(mut self, index: u64) -> Self {
+        self.channel_identifiers.truncate(1);
+        self.index = match self.index {
+            TicketIndexSelector::None | TicketIndexSelector::Range(_) => TicketIndexSelector::Single(index),
+            TicketIndexSelector::Single(existing) => {
+                TicketIndexSelector::Multiple(HashSet::from_iter([existing, index]))
+            }
+            TicketIndexSelector::Multiple(mut existing) => {
+                existing.insert(index);
+                TicketIndexSelector::Multiple(existing)
+            }
+        };
+        self
+    }
+
+    /// Returns this instance with a ticket index upper bound set.
+    /// If [`TicketSelector::with_index`] was previously called, it will be replaced.
+    /// If [`TicketSelector::also_on_channel`] was previously called, its effect will be nullified.
+    pub fn with_index_range<T: RangeBounds<u64>>(mut self, index_bound: T) -> Self {
+        self.channel_identifiers.truncate(1);
+        self.index = TicketIndexSelector::Range((index_bound.start_bound().cloned(), index_bound.end_bound().cloned()));
+        self
+    }
+
+    /// Returns this instance with a ticket state set.
+    pub fn with_state(mut self, state: AcknowledgedTicketStatus) -> Self {
+        self.state = Some(state);
+        self
+    }
+
+    /// Returns this instance without a ticket state set.
+    pub fn with_no_state(mut self) -> Self {
+        self.state = None;
+        self
+    }
+
+    /// Returns this instance with `only_aggregated` flag value.
+    pub fn with_aggregated_only(mut self, only_aggregated: bool) -> Self {
+        self.only_aggregated = only_aggregated;
+        self
+    }
+
+    /// Returns this instance with a winning probability range bounds set.
+    pub fn with_winning_probability<T: RangeBounds<WinningProbability>>(mut self, range: T) -> Self {
+        self.win_prob = (range.start_bound().cloned(), range.end_bound().cloned());
+        self
+    }
+
+    /// Returns this instance with the ticket amount range bounds set.
+    pub fn with_amount<T: RangeBounds<HoprBalance>>(mut self, range: T) -> Self {
+        self.amount = (range.start_bound().cloned(), range.end_bound().cloned());
+        self
+    }
+}
+
+impl From<&AcknowledgedTicket> for TicketSelector {
+    fn from(value: &AcknowledgedTicket) -> Self {
+        Self {
+            channel_identifiers: vec![(
+                value.verified_ticket().channel_id,
+                value.verified_ticket().channel_epoch.into(),
+            )],
+            index: TicketIndexSelector::Single(value.verified_ticket().index),
+            win_prob: (Bound::Unbounded, Bound::Unbounded),
+            amount: (Bound::Unbounded, Bound::Unbounded),
+            state: Some(value.status),
+            only_aggregated: value.verified_ticket().index_offset > 1,
+        }
+    }
+}
+
+impl From<&RedeemableTicket> for TicketSelector {
+    fn from(value: &RedeemableTicket) -> Self {
+        Self {
+            channel_identifiers: vec![(
+                value.verified_ticket().channel_id,
+                value.verified_ticket().channel_epoch.into(),
+            )],
+            index: TicketIndexSelector::Single(value.verified_ticket().index),
+            win_prob: (Bound::Unbounded, Bound::Unbounded),
+            amount: (Bound::Unbounded, Bound::Unbounded),
+            state: None,
+            only_aggregated: value.verified_ticket().index_offset > 1,
+        }
+    }
+}
+
+impl From<&ChannelEntry> for TicketSelector {
+    fn from(value: &ChannelEntry) -> Self {
+        Self {
+            channel_identifiers: vec![(value.get_id(), value.channel_epoch)],
+            index: TicketIndexSelector::None,
+            win_prob: (Bound::Unbounded, Bound::Unbounded),
+            amount: (Bound::Unbounded, Bound::Unbounded),
+            state: None,
+            only_aggregated: false,
+        }
+    }
+}
+
+impl From<ChannelEntry> for TicketSelector {
+    fn from(value: ChannelEntry) -> Self {
+        TicketSelector::from(&value)
+    }
+}
+
+/// Different markers for unredeemed tickets.
+/// See [`HoprDbTicketOperations::mark_tickets_as`] for usage.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, strum::Display)]
+#[strum(serialize_all = "lowercase")]
+pub enum TicketMarker {
+    Redeemed,
+    Rejected,
+    Neglected,
+}
+
+/// Database operations for tickets.
+#[async_trait::async_trait]
+pub trait HoprDbTicketOperations {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Retrieve acknowledged winning tickets, according to the given `selector`.
+    ///
+    /// If no selector is given, streams tickets in all channels.
+    async fn stream_tickets<'c>(
+        &'c self,
+        selector: Option<TicketSelector>,
+    ) -> Result<BoxStream<'c, AcknowledgedTicket>, Self::Error>;
+
+    /// Marks tickets as the given [`TicketMarker`], removing them from the DB and updating the
+    /// ticket statistics for each ticket's channel.
+    ///
+    /// Returns the number of marked tickets.
+    async fn mark_tickets_as(&self, selector: TicketSelector, mark_as: TicketMarker) -> Result<usize, Self::Error>;
+
+    /// Updates the ticket statistics according to the fact that the given ticket has
+    /// been rejected by the packet processing pipeline.
+    ///
+    /// This ticket is not yet stored in the ticket DB;
+    /// therefore, only the statistics in the corresponding channel are updated.
+    async fn mark_unsaved_ticket_rejected(&self, ticket: &Ticket) -> Result<(), Self::Error>;
+
+    /// Updates [state](AcknowledgedTicketStatus) of the tickets matching the given `selector`.
+    ///
+    /// Returns the updated tickets in the new state.
+    async fn update_ticket_states_and_fetch<'a>(
+        &'a self,
+        selector: TicketSelector,
+        new_state: AcknowledgedTicketStatus,
+    ) -> Result<BoxStream<'a, AcknowledgedTicket>, Self::Error>;
+
+    /// Updates [state](AcknowledgedTicketStatus) of the tickets matching the given `selector`.
+    async fn update_ticket_states(
+        &self,
+        selector: TicketSelector,
+        new_state: AcknowledgedTicketStatus,
+    ) -> Result<usize, Self::Error>;
+
+    /// Retrieves the ticket statistics for the given channel.
+    ///
+    /// If no channel is given, it retrieves aggregate ticket statistics for all channels.
+    async fn get_ticket_statistics(&self, channel_id: Option<Hash>) -> Result<ChannelTicketStatistics, Self::Error>;
+
+    /// Resets the ticket statistics about neglected, rejected, and redeemed tickets.
+    async fn reset_ticket_statistics(&self) -> Result<(), Self::Error>;
+
+    /// Counts the tickets matching the given `selector` and their total value.
+    ///
+    /// The optional transaction `tx` must be in the database.
+    async fn get_tickets_value(&self, selector: TicketSelector) -> Result<(usize, HoprBalance), Self::Error>;
+
+    /// Sets the stored outgoing ticket index to `index`, only if the currently stored value
+    /// is less than `index`. This ensures the stored value can only be growing.
+    ///
+    /// Returns the old value.
+    ///
+    /// If the entry is not yet present for the given ID, it is initialized to 0.
+    async fn compare_and_set_outgoing_ticket_index(&self, channel_id: Hash, index: u64) -> Result<u64, Self::Error>;
+
+    /// Resets the outgoing ticket index to 0 for the given channel id.
+    ///
+    /// Returns the old value before reset.
+    ///
+    /// If the entry is not yet present for the given ID, it is initialized to 0.
+    async fn reset_outgoing_ticket_index(&self, channel_id: Hash) -> Result<u64, Self::Error>;
+
+    /// Increments the outgoing ticket index in the given channel ID and returns the value before incrementing.
+    ///
+    /// If the entry is not yet present for the given ID, it is initialized to 0 and incremented.
+    async fn increment_outgoing_ticket_index(&self, channel_id: Hash) -> Result<u64, Self::Error>;
+
+    /// Gets the current outgoing ticket index for the given channel id.
+    ///
+    /// If the entry is not yet present for the given ID, it is initialized to 0.
+    async fn get_outgoing_ticket_index(&self, channel_id: Hash) -> Result<Arc<AtomicU64>, Self::Error>;
+
+    /// Compares outgoing ticket indices in the cache with the stored values
+    /// and updates the stored value where changed.
+    ///
+    /// Returns the number of updated ticket indices.
+    async fn persist_outgoing_ticket_indices(&self) -> Result<usize, Self::Error>;
+}
+
+/// Can contain ticket statistics for a channel or aggregated ticket statistics for all channels.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
+pub struct ChannelTicketStatistics {
+    pub winning_tickets: u128,
+    pub neglected_value: HoprBalance,
+    pub redeemed_value: HoprBalance,
+    pub unredeemed_value: HoprBalance,
+    pub rejected_value: HoprBalance,
+}

--- a/common/api/src/lib.rs
+++ b/common/api/src/lib.rs
@@ -1,5 +1,8 @@
 /// On-chain operations-related API traits.
 pub mod chain;
+/// Node database related API traits.
+pub mod db;
 
-pub use hopr_crypto_types::prelude::OffchainPublicKey;
+pub use hopr_crypto_types::prelude::{OffchainPublicKey, PeerId};
 pub use hopr_primitive_types::prelude::Address;
+pub use multiaddr::Multiaddr;

--- a/common/internal-types/src/channels.rs
+++ b/common/internal-types/src/channels.rs
@@ -6,9 +6,10 @@ use std::{
 use hopr_crypto_types::prelude::*;
 use hopr_primitive_types::prelude::*;
 
-/// Describes status of a channel
-#[derive(Copy, Clone, Debug, smart_default::SmartDefault, strum::Display)]
+#[derive(Copy, Clone, Debug, smart_default::SmartDefault, strum::Display, strum::EnumDiscriminants)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[strum_discriminants(vis(pub))]
+#[strum_discriminants(derive(strum::FromRepr, strum::EnumCount), repr(i8))]
 #[strum(serialize_all = "PascalCase")]
 pub enum ChannelStatus {
     /// The channel is closed.
@@ -288,10 +289,8 @@ mod tests {
     };
 
     use hex_literal::hex;
-    use hopr_crypto_types::prelude::*;
-    use hopr_primitive_types::prelude::*;
 
-    use crate::channels::{ChannelEntry, ChannelStatus, generate_channel_id};
+    use super::*;
 
     lazy_static::lazy_static! {
         static ref ALICE: ChainKeypair = ChainKeypair::from_secret(&hex!("492057cf93e99b31d2a85bc5e98a9c3aa0021feec52c227cc8170e8f7d047775")).expect("lazy static keypair should be constructible");
@@ -318,6 +317,19 @@ mod tests {
         assert_eq!(
             "PendingToClose",
             ChannelStatus::PendingToClose(SystemTime::now()).to_string()
+        );
+    }
+
+    #[test]
+    fn channel_status_repr_compat() {
+        assert_eq!(ChannelStatusDiscriminants::Open as i8, i8::from(ChannelStatus::Open));
+        assert_eq!(
+            ChannelStatusDiscriminants::Closed as i8,
+            i8::from(ChannelStatus::Closed)
+        );
+        assert_eq!(
+            ChannelStatusDiscriminants::PendingToClose as i8,
+            i8::from(ChannelStatus::PendingToClose(SystemTime::now()))
         );
     }
 


### PR DESCRIPTION
This PR adds Node DB APIs to `hopr-api` crate and updates the Chain APIs.

Since the APIs are not being used in 3.0, the PR can be merged into `master`.

Prerequisite for #7507