### PR TITLE
fix: rejected ticket metric

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4821,7 +4821,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-db-sql"
-version = "0.18.3"
+version = "0.18.4"
 dependencies = [
  "anyhow",
  "async-lock 3.4.1",

--- a/db/sql/Cargo.toml
+++ b/db/sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-db-sql"
-version = "0.18.3"
+version = "0.18.4"
 edition = "2021"
 description = "Contains SQL DB functionality implementing the DB API traits to be used by other crates in the code base"
 homepage = "https://hoprnet.org/"

--- a/db/sql/src/tickets.rs
+++ b/db/sql/src/tickets.rs
@@ -1395,19 +1395,19 @@ mod tests {
         init_db_with_tickets_and_channel(db, count_tickets, None, 1.0).await
     }
 
-    async fn init_db_with_low_winn_prob_tickets(
+    async fn init_db_with_low_win_prob_tickets(
         db: &HoprDb,
         count_tickets: u64,
-        winn_prob: f64,
+        win_prob: f64,
     ) -> anyhow::Result<(ChannelEntry, Vec<AcknowledgedTicket>)> {
-        init_db_with_tickets_and_channel(db, count_tickets, None, winn_prob).await
+        init_db_with_tickets_and_channel(db, count_tickets, None, win_prob).await
     }
 
     async fn init_db_with_tickets_and_channel(
         db: &HoprDb,
         count_tickets: u64,
         channel_ticket_index: Option<u32>,
-        winn_prob: f64,
+        win_prob: f64,
     ) -> anyhow::Result<(ChannelEntry, Vec<AcknowledgedTicket>)> {
         let channel = ChannelEntry::new(
             BOB.public().to_address(),
@@ -1421,7 +1421,7 @@ mod tests {
         db.upsert_channel(None, channel).await?;
 
         let tickets: Vec<AcknowledgedTicket> = (0..count_tickets)
-            .map(|i| generate_random_ack_ticket(&BOB, &ALICE, i, 1, winn_prob))
+            .map(|i| generate_random_ack_ticket(&BOB, &ALICE, i, 1, win_prob))
             .collect::<anyhow::Result<Vec<AcknowledgedTicket>>>()?;
 
         let db_clone = db.clone();
@@ -1640,11 +1640,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_mark_unsaved_low_winn_prob_ticket_rejected() -> anyhow::Result<()> {
+    async fn test_mark_unsaved_low_win_prob_ticket_rejected() -> anyhow::Result<()> {
         let db = HoprDb::new_in_memory(ALICE.clone()).await?;
-        let winn_prob: f64 = 0.25;
+        let win_prob: f64 = 0.25;
 
-        let tickets = init_db_with_low_winn_prob_tickets(&db, 10, winn_prob).await?.1;
+        let tickets = init_db_with_low_win_prob_tickets(&db, 10, win_prob).await?.1;
 
         assert!(!tickets.is_empty(), "tickets must be present");
 
@@ -1663,7 +1663,7 @@ mod tests {
         let stats = db.get_ticket_statistics(None).await?;
         let sum_all_tickets: HoprBalance = tickets.iter().map(|t| t.verified_ticket().amount).sum();
 
-        assert_eq!(sum_all_tickets.mul_f64(winn_prob)?, stats.rejected_value);
+        assert_eq!(sum_all_tickets.mul_f64(win_prob)?, stats.rejected_value);
         assert_eq!(
             stats,
             db.get_ticket_statistics(Some(*CHANNEL_ID)).await?,

--- a/db/sql/src/tickets.rs
+++ b/db/sql/src/tickets.rs
@@ -423,7 +423,11 @@ impl HoprDbTicketOperations for HoprDb {
 
     async fn mark_unsaved_ticket_rejected(&self, ticket: &Ticket) -> Result<()> {
         let channel_id = ticket.channel_id;
-        let amount = ticket.amount;
+        let amount = ticket
+            .amount
+            .mul_f64(ticket.win_prob().as_f64())
+            .map_err(DbSqlError::from)?;
+
         Ok(self
             .ticket_manager
             .with_write_locked_db(|tx| {
@@ -1388,13 +1392,22 @@ mod tests {
         db: &HoprDb,
         count_tickets: u64,
     ) -> anyhow::Result<(ChannelEntry, Vec<AcknowledgedTicket>)> {
-        init_db_with_tickets_and_channel(db, count_tickets, None).await
+        init_db_with_tickets_and_channel(db, count_tickets, None, 1.0).await
+    }
+
+    async fn init_db_with_low_winn_prob_tickets(
+        db: &HoprDb,
+        count_tickets: u64,
+        winn_prob: f64,
+    ) -> anyhow::Result<(ChannelEntry, Vec<AcknowledgedTicket>)> {
+        init_db_with_tickets_and_channel(db, count_tickets, None, winn_prob).await
     }
 
     async fn init_db_with_tickets_and_channel(
         db: &HoprDb,
         count_tickets: u64,
         channel_ticket_index: Option<u32>,
+        winn_prob: f64,
     ) -> anyhow::Result<(ChannelEntry, Vec<AcknowledgedTicket>)> {
         let channel = ChannelEntry::new(
             BOB.public().to_address(),
@@ -1408,7 +1421,7 @@ mod tests {
         db.upsert_channel(None, channel).await?;
 
         let tickets: Vec<AcknowledgedTicket> = (0..count_tickets)
-            .map(|i| generate_random_ack_ticket(&BOB, &ALICE, i, 1, 1.0))
+            .map(|i| generate_random_ack_ticket(&BOB, &ALICE, i, 1, winn_prob))
             .collect::<anyhow::Result<Vec<AcknowledgedTicket>>>()?;
 
         let db_clone = db.clone();
@@ -1617,6 +1630,40 @@ mod tests {
 
         let stats = db.get_ticket_statistics(None).await?;
         assert_eq!(ticket.verified_ticket().amount, stats.rejected_value);
+        assert_eq!(
+            stats,
+            db.get_ticket_statistics(Some(*CHANNEL_ID)).await?,
+            "per channel stats must be same"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_mark_unsaved_low_winn_prob_ticket_rejected() -> anyhow::Result<()> {
+        let db = HoprDb::new_in_memory(ALICE.clone()).await?;
+        let winn_prob: f64 = 0.25;
+
+        let tickets = init_db_with_low_winn_prob_tickets(&db, 10, winn_prob).await?.1;
+
+        assert!(!tickets.is_empty(), "tickets must be present");
+
+        let stats = db.get_ticket_statistics(None).await?;
+        assert_eq!(HoprBalance::zero(), stats.rejected_value);
+        assert_eq!(
+            stats,
+            db.get_ticket_statistics(Some(*CHANNEL_ID)).await?,
+            "per channel stats must be same"
+        );
+
+        for ticket in tickets.iter() {
+            db.mark_unsaved_ticket_rejected(ticket.verified_ticket()).await?;
+        }
+
+        let stats = db.get_ticket_statistics(None).await?;
+        let sum_all_tickets: HoprBalance = tickets.iter().map(|t| t.verified_ticket().amount).sum();
+
+        assert_eq!(sum_all_tickets.mul_f64(winn_prob)?, stats.rejected_value);
         assert_eq!(
             stats,
             db.get_ticket_statistics(Some(*CHANNEL_ID)).await?,
@@ -3418,7 +3465,7 @@ mod tests {
         const COUNT_TICKETS: u64 = 2;
 
         // we set up the channel to have ticket index 1, and ensure that fix does not trigger
-        let (..) = init_db_with_tickets_and_channel(&db, COUNT_TICKETS, Some(1u32)).await?;
+        let (..) = init_db_with_tickets_and_channel(&db, COUNT_TICKETS, Some(1u32), 1.0).await?;
 
         // mark the first ticket as being redeemed
         let mut ticket = hopr_db_entity::ticket::Entity::find()

--- a/tests/test_win_prob.py
+++ b/tests/test_win_prob.py
@@ -385,8 +385,6 @@ class TestWinProbWithSwarm:
         ):
             # ensure ticket stats are what we expect before starting
             statistics_before = await swarm7[mid].api.get_tickets_statistics()
-            unredeemed_value_before = statistics_before.unredeemed_value
-            rejected_value_before = statistics_before.rejected_value
 
             was_active = False
             try:
@@ -404,13 +402,13 @@ class TestWinProbWithSwarm:
 
                 # wait until the relay rejects the session establishment packet
                 await asyncio.wait_for(
-                    check_rejected_tickets_value(swarm7[mid], rejected_value_before + ticket_price / win_prob),
+                    check_rejected_tickets_value(swarm7[mid], statistics_before.rejected_value + ticket_price),
                     30.0,
                 )
 
                 # unredeemed value should not change on the relay
                 ticket_statistics = await swarm7[mid].api.get_tickets_statistics()
-                assert ticket_statistics.unredeemed_value == unredeemed_value_before
+                assert ticket_statistics.unredeemed_value == statistics_before.unredeemed_value
                 assert ticket_statistics.winning_count == statistics_before.winning_count
 
             assert was_active is False


### PR DESCRIPTION
The rejected metric was considering each rejected ticket as a possibly winning ticket. This made the metric grow to a massive number now that the ticket value is 10wxHOPR.

This PR account each rejected ticket as a ticket worth the ticket price, not value.

This should be further improved in 4.0 with https://github.com/hoprnet/hoprnet/issues/7520