### PR TITLE
fix(rest-api): Include swagger-ui in debug builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,7 +203,24 @@ tokio-util = { version = "0.7.16", default-features = false, features = [
   "compat",
 ] }
 tokio-retry = "0.3.0"
+tokio-stream = { version = "0.1.17", features = ["net"] }
+tower-http = { version = "0.6.6", features = [
+  "validate-request",
+  "compression-full",
+  "cors",
+  "trace",
+  "sensitive-headers",
+] }
 tower = { version = "0.5.2", default-features = false, features = ["util"] }
+oas3 = "0.19.0"
+urlencoding = "2.1.3"
+utoipa = { version = "5.4.0" }
+utoipa-scalar = { version = "0.3.0", features = ["axum"] }
+utoipa-swagger-ui = { version = "9.0.2", features = [
+  "axum",
+  "vendored",
+  "debug-embed",
+] }
 tracing = { version = "0.1.41" }
 tracing-subscriber = { version = "0.3.20", features = [
   "env-filter",

--- a/hoprd/rest-api/Cargo.toml
+++ b/hoprd/rest-api/Cargo.toml
@@ -44,20 +44,14 @@ serde_with = { workspace = true }
 smart-default = { workspace = true }
 strum = { workspace = true }
 tokio = { workspace = true }
-tokio-stream = { version = "0.1.17", features = ["net"] }
 tower = { workspace = true }
-tower-http = { version = "0.6.6", features = [
-  "validate-request",
-  "compression-full",
-  "cors",
-  "trace",
-  "sensitive-headers",
-] }
+tokio-stream = { workspace = true }
+tower-http = { workspace = true }
 tracing = { workspace = true }
-urlencoding = "2.1.3"
-utoipa = { version = "5.4.0" }
-utoipa-scalar = { version = "0.3.0", features = ["axum"] }
-utoipa-swagger-ui = { version = "9.0.2", features = ["axum", "vendored"] }
+urlencoding = { workspace = true }
+utoipa = { workspace = true }
+utoipa-scalar = { workspace = true }
+utoipa-swagger-ui = { workspace = true }
 validator = { workspace = true }
 
 hopr-async-runtime = { workspace = true, features = ["runtime-tokio"] }
@@ -70,7 +64,7 @@ hopr-platform = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
-oas3 = "0.19.0"
+oas3 = { workspace = true }
 test-log = { workspace = true }
 
 hopr-transport-session = { workspace = true }


### PR DESCRIPTION
Fixes #7518 

By default swagger-ui is only included in release builds. 