### PR TITLE
feat(chain-config): Add non-version-checked constructor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4540,7 +4540,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-config"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "hopr-chain-types",
  "hopr-primitive-types",
@@ -4896,7 +4896,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "alloy",
  "anyhow",
@@ -5469,7 +5469,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "async-lock 3.4.1",

--- a/hopr/chain-config/Cargo.toml
+++ b/hopr/chain-config/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-chain-config"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "HOPR library containing the network and protocols configuration and exposing it to other components"


### PR DESCRIPTION
This is needed for `blokli` since it follows a new version base.