### PR TITLE
chore(hopr-lib): adapt interfaces for more ergonomy in edgli and external usage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4609,6 +4609,7 @@ name = "hopr-chain-api"
 version = "0.7.1"
 dependencies = [
  "alloy",
+ "anyhow",
  "async-channel 2.5.0",
  "async-trait",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4992,7 +4992,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.0"
+version = "3.1.0"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5266,7 +5266,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.13.4"
+version = "0.14.0"
 dependencies = [
  "async-lock 3.4.1",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5571,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd"
-version = "4.0.0"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "async-lock 3.4.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,9 +102,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67031be093311a96afdd146fb5de209ceaf0f347f2284ed71902368cd15a77ff"
+checksum = "7f6cfe35f100bc496007c9a00f90b88bdf565f1421d4c707c9f07e0717e2aaad"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -138,9 +138,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cd9d29a6a0bb8d4832ff7685dcbb430011b832f2ccec1af9571a0e75c1f7e9c"
+checksum = "59094911f05dbff1cf5b29046a00ef26452eccc8d47136d50a47c0cf22f00c85"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -159,14 +159,14 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce038cb325f9a85a10fb026fb1b70cb8c62a004d85d22f8516e5d173e3eec612"
+checksum = "903cb8f728107ca27c816546f15be38c688df3c381d7bd1a4a9f215effc1ddb4"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -178,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a376305e5c3b3285e84a553fa3f9aee4f5f0e1b0aad4944191b843cd8228788d"
+checksum = "03df5cb3b428ac96b386ad64c11d5c6e87a5505682cf1fbd6f8f773e9eda04f6"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -195,7 +195,7 @@ dependencies = [
  "futures",
  "futures-util",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -237,7 +237,7 @@ dependencies = [
  "alloy-rlp",
  "crc",
  "serde",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -261,14 +261,14 @@ dependencies = [
  "alloy-rlp",
  "k256",
  "serde",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "alloy-eips"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bfec530782b30151e2564edf3c900f1fa6852128b7a993e458e8e3815d8b915"
+checksum = "ac7f1c9a1ccc7f3e03c36976455751a6166a4f0d2d2c530c3f87dfe7d0cdc836"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -283,14 +283,14 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956e6a23eb880dd93123e8ebea028584325b9af22f991eec2c499c54c277c073"
+checksum = "1421f6c9d15e5b86afbfe5865ca84dea3b9f77173a0963c1a2ee4e626320ada9"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -327,24 +327,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be436893c0d1f7a57d1d8f1b6b9af9db04174468410b7e6e1d1893e78110a3bc"
+checksum = "65f763621707fa09cece30b73ecc607eb43fd7a72451fe3b46f645b905086926"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
  "http",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tracing",
 ]
 
 [[package]]
 name = "alloy-network"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f18959e1a1b40e05578e7a705f65ff4e6b354e38335da4b33ccbee876bde7c26"
+checksum = "2f59a869fa4b4c3a7f08b1c8cb79aec61c29febe6e24a24fe0fcfded8a9b5703"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -363,14 +363,14 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1da0037ac546c0cae2eb776bed53687b7bbf776f4e7aa2fea0b8b89e734c319b"
+checksum = "46e9374c667c95c41177602ebe6f6a2edd455193844f011d973d374b65501b38"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -381,9 +381,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd89c9e72e62d95b51be0b92468282526b37d3d1015f5e31069a35c2e020872f"
+checksum = "d392c130f3d4a325c913348351395efb16d197da1d07c2de3a2f7876d9d981ee"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -395,7 +395,7 @@ dependencies = [
  "rand 0.8.5",
  "serde_json",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tracing",
  "url",
 ]
@@ -429,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca97e31bc05bd6d4780254fbb60b16d33b3548d1c657a879fffb0e7ebb642e9"
+checksum = "77818b7348bd5486491a5297579dbfe5f706a81f8e1f5976393025f1e22a7c7d"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -461,7 +461,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "url",
@@ -492,9 +492,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbeeeffa0bb7e95cb79f2b4b46b591763afeccfa9a797183c1b192377ffb6fac"
+checksum = "2430d5623e428dd012c6c2156ae40b7fe638d6fca255e3244e0fba51fa698e93"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -515,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21fe4c370b9e733d884ffd953eb6d654d053b1b22e26ffd591ef597a9e2bc49"
+checksum = "e9e131624d08a25cfc40557041e7dc42e1182fa1153e7592d120f769a1edce56"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -527,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb44412ed075c19d37698f33213b83f0bf8ccc2d4e928527f2622555a31723de"
+checksum = "d65e3266095e6d8e8028aab5f439c6b8736c5147314f7e606c61597e014cb8a0"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65423baf6af0ff356e254d7824b3824aa34d8ca9bd857a4e298f74795cc4b69d"
+checksum = "07429a1099cd17227abcddb91b5e38c960aaeb02a6967467f5bb561fbe716ac6"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -550,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "848f8ea4063bed834443081d77f840f31075f68d0d49723027f5a209615150bf"
+checksum = "db46b0901ee16bbb68d986003c66dcb74a12f9d9b3c44f8e85d51974f2458f0f"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -566,14 +566,14 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "alloy-serde"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19c3835bdc128f2f3418f5d6c76aec63a245d72973e0eaacc9720aa0787225c5"
+checksum = "5413814be7a22fbc81e0f04a2401fcc3eb25e56fd53b04683e8acecc6e1fe01b"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -582,9 +582,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42084a7b455ef0b94ed201b7494392a759c3e20faac2d00ded5d5762fcf71dee"
+checksum = "53410a18a61916e2c073a6519499514e027b01e77eeaf96acd1df7cf96ef6bb2"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -592,14 +592,14 @@ dependencies = [
  "either",
  "elliptic-curve",
  "k256",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6312ccc048a4a88aed7311fc448a2e23da55c60c2b3b6dcdb794f759d02e49d7"
+checksum = "e6006c4cbfa5d08cadec1fcabea6cb56dc585a30a9fce40bcf81e307d6a71c8e"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -608,7 +608,7 @@ dependencies = [
  "async-trait",
  "k256",
  "rand 0.8.5",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -686,9 +686,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f77fa71f6dad3aa9b97ab6f6e90f257089fb9eaa959892d153a1011618e2d6"
+checksum = "d94ee404368a3d9910dfe61b203e888c6b0e151a50e147f95da8baff9f9c7763"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -700,7 +700,7 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tower 0.5.2",
  "tracing",
@@ -710,9 +710,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab1a5d0f5dd5e07187a4170bdcb7ceaff18b1133cd6b8585bc316ab442cd78a"
+checksum = "a2f8a6338d594f6c6481292215ee8f2fd7b986c80aba23f3f44e761a8658de78"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -741,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc79013f9ac3a8ddeb60234d43da09e6d6abfc1c9dd29d3fe97adfbece3f4a08"
+checksum = "e64c09ec565a90ed8390d82aa08cd3b22e492321b96cb4a3d4f58414683c9e2f"
 dependencies = [
  "alloy-primitives",
  "darling 0.21.3",
@@ -1068,7 +1068,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "time",
 ]
 
@@ -1130,9 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9611ec0b6acea03372540509035db2f7f1e9f04da5d27728436fa994033c00a0"
+checksum = "5a89bce6054c720275ac2432fbba080a66a2106a44a1b804553930ca6909f4e0"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -1455,11 +1455,11 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
 dependencies = [
- "axum-core 0.5.2",
+ "axum-core 0.5.5",
  "base64 0.22.1",
  "bytes",
  "form_urlencoded",
@@ -1475,8 +1475,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
@@ -1512,9 +1511,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.5.2"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1523,7 +1522,6 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
@@ -1532,12 +1530,12 @@ dependencies = [
 
 [[package]]
 name = "axum-extra"
-version = "0.10.1"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
+checksum = "9963ff19f40c6102c76756ef0a46004c0d58957d87259fc9208ff8441c12ab96"
 dependencies = [
- "axum 0.8.4",
- "axum-core 0.5.2",
+ "axum 0.8.6",
+ "axum-core 0.5.5",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -1547,12 +1545,12 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "serde",
+ "serde_core",
  "serde_html_form",
  "serde_path_to_error",
- "tower 0.5.2",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2064,9 +2062,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.30"
+version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "485abf41ac0c8047c07c87c72c8fb3eb5197f6e9d7ded615dfd1a00ae00a0f64"
+checksum = "ef8a506ec4b81c460798f572caead636d57d3d7e940f998160f52bd254bf2d23"
 dependencies = [
  "brotli",
  "compression-core",
@@ -3465,7 +3463,7 @@ dependencies = [
  "parking_lot",
  "signal-hook",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3478,7 +3476,7 @@ dependencies = [
  "gix-date",
  "gix-utils 0.2.0",
  "itoa",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "winnow",
 ]
 
@@ -3495,7 +3493,7 @@ dependencies = [
  "gix-trace",
  "kstring",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "unicode-bom",
 ]
 
@@ -3505,7 +3503,7 @@ version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1db9765c69502650da68f0804e3dc2b5f8ccc6a2d104ca6c85bc40700d37540"
 dependencies = [
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3514,7 +3512,7 @@ version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b1f1d8764958699dc764e3f727cef280ff4d1bd92c107bbf8acd85b30c1bd6f"
 dependencies = [
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3540,7 +3538,7 @@ dependencies = [
  "gix-chunk",
  "gix-hash 0.17.0",
  "memmap2",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3559,7 +3557,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "unicode-bom",
  "winnow",
 ]
@@ -3574,7 +3572,7 @@ dependencies = [
  "bstr",
  "gix-path",
  "libc",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3586,7 +3584,7 @@ dependencies = [
  "bstr",
  "itoa",
  "jiff",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3610,7 +3608,7 @@ dependencies = [
  "gix-traverse",
  "gix-worktree",
  "imara-diff",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3630,7 +3628,7 @@ dependencies = [
  "gix-trace",
  "gix-utils 0.2.0",
  "gix-worktree",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3646,7 +3644,7 @@ dependencies = [
  "gix-path",
  "gix-ref",
  "gix-sec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3663,7 +3661,7 @@ dependencies = [
  "libc",
  "once_cell",
  "prodash",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "walkdir",
 ]
 
@@ -3697,7 +3695,7 @@ dependencies = [
  "gix-trace",
  "gix-utils 0.2.0",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3711,7 +3709,7 @@ dependencies = [
  "gix-features 0.41.1",
  "gix-path",
  "gix-utils 0.2.0",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3725,7 +3723,7 @@ dependencies = [
  "gix-features 0.42.1",
  "gix-path",
  "gix-utils 0.3.0",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3749,7 +3747,7 @@ dependencies = [
  "faster-hex 0.9.0",
  "gix-features 0.41.1",
  "sha1-checked",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3761,7 +3759,7 @@ dependencies = [
  "faster-hex 0.10.0",
  "gix-features 0.42.1",
  "sha1-checked",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3813,7 +3811,7 @@ dependencies = [
  "memmap2",
  "rustix 0.38.44",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3824,7 +3822,7 @@ checksum = "570f8b034659f256366dc90f1a24924902f20acccd6a15be96d44d1269e7a796"
 dependencies = [
  "gix-tempfile",
  "gix-utils 0.3.0",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3844,7 +3842,7 @@ dependencies = [
  "gix-validate 0.9.4",
  "itoa",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "winnow",
 ]
 
@@ -3866,7 +3864,7 @@ dependencies = [
  "gix-quote",
  "parking_lot",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3884,7 +3882,7 @@ dependencies = [
  "gix-path",
  "memmap2",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3896,7 +3894,7 @@ dependencies = [
  "bstr",
  "faster-hex 0.9.0",
  "gix-trace",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3908,7 +3906,7 @@ dependencies = [
  "bstr",
  "faster-hex 0.9.0",
  "gix-trace",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3922,7 +3920,7 @@ dependencies = [
  "gix-validate 0.10.0",
  "home",
  "once_cell",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3937,7 +3935,7 @@ dependencies = [
  "gix-config-value",
  "gix-glob",
  "gix-path",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3955,7 +3953,7 @@ dependencies = [
  "gix-transport",
  "gix-utils 0.2.0",
  "maybe-async",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "winnow",
 ]
 
@@ -3967,7 +3965,7 @@ checksum = "1b005c550bf84de3b24aa5e540a23e6146a1c01c7d30470e35d75a12f827f969"
 dependencies = [
  "bstr",
  "gix-utils 0.2.0",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -3987,7 +3985,7 @@ dependencies = [
  "gix-utils 0.2.0",
  "gix-validate 0.9.4",
  "memmap2",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "winnow",
 ]
 
@@ -4002,7 +4000,7 @@ dependencies = [
  "gix-revision",
  "gix-validate 0.9.4",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4020,7 +4018,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "gix-trace",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4035,7 +4033,7 @@ dependencies = [
  "gix-hashtable",
  "gix-object",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4059,7 +4057,7 @@ dependencies = [
  "bstr",
  "gix-hash 0.17.0",
  "gix-lock",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4082,7 +4080,7 @@ dependencies = [
  "gix-pathspec",
  "gix-worktree",
  "portable-atomic",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4097,7 +4095,7 @@ dependencies = [
  "gix-pathspec",
  "gix-refspec",
  "gix-url",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4135,7 +4133,7 @@ dependencies = [
  "gix-quote",
  "gix-sec",
  "gix-url",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4152,7 +4150,7 @@ dependencies = [
  "gix-object",
  "gix-revwalk",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4165,7 +4163,7 @@ dependencies = [
  "gix-features 0.41.1",
  "gix-path",
  "percent-encoding",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "url",
 ]
 
@@ -4197,7 +4195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34b5f1253109da6c79ed7cf6e1e38437080bb6d704c76af14c93e2f255234084"
 dependencies = [
  "bstr",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4207,7 +4205,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77b9e00cacde5b51388d28ed746c493b18a6add1f19b5e01d686b3b9ece66d4d"
 dependencies = [
  "bstr",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -4449,7 +4447,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "socket2 0.5.10",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tinyvec",
  "tokio",
  "tracing",
@@ -4472,7 +4470,7 @@ dependencies = [
  "rand 0.9.2",
  "resolv-conf",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
 ]
@@ -4528,7 +4526,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tikv-jemallocator",
  "tokio",
  "tracing",
@@ -4601,7 +4599,7 @@ dependencies = [
  "serde",
  "smart-default",
  "test-log",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
 ]
@@ -4629,7 +4627,7 @@ dependencies = [
  "serde_with",
  "smart-default",
  "strum 0.27.2",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "url",
@@ -4647,7 +4645,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "strum 0.27.2",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "validator",
 ]
 
@@ -4688,7 +4686,7 @@ dependencies = [
  "sysinfo",
  "tempfile",
  "test-log",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
 ]
@@ -4727,7 +4725,7 @@ dependencies = [
  "smart-default",
  "tempfile",
  "test-log",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tower 0.5.2",
  "tracing",
@@ -4752,7 +4750,7 @@ dependencies = [
  "multiaddr",
  "serde",
  "strum 0.27.2",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tracing",
 ]
 
@@ -4770,7 +4768,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tracing",
  "typenum",
  "uuid",
@@ -4798,7 +4796,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "strum 0.27.2",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tikv-jemallocator",
  "tokio",
  "tracing",
@@ -4832,7 +4830,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "subtle",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "typenum",
 ]
 
@@ -4867,7 +4865,7 @@ dependencies = [
  "sha2",
  "sha3",
  "subtle",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tikv-jemallocator",
  "typenum",
  "zeroize",
@@ -4889,7 +4887,7 @@ dependencies = [
  "multiaddr",
  "num_enum",
  "strum 0.27.2",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tracing",
 ]
 
@@ -4908,7 +4906,7 @@ dependencies = [
  "sea-orm",
  "sea-orm-cli",
  "sea-orm-migration",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
 ]
 
@@ -4963,7 +4961,7 @@ dependencies = [
  "smart-default",
  "sqlx",
  "strum 0.27.2",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "validator",
@@ -4988,7 +4986,7 @@ dependencies = [
  "serde_bytes",
  "smart-default",
  "strum 0.27.2",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tracing",
 ]
 
@@ -5043,7 +5041,7 @@ dependencies = [
  "smart-default",
  "strum 0.27.2",
  "test-log",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -5087,7 +5085,7 @@ dependencies = [
  "socket2 0.6.0",
  "strum 0.27.2",
  "test-log",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-util",
  "tracing",
@@ -5126,7 +5124,7 @@ dependencies = [
  "serde_with",
  "smart-default",
  "strum 0.27.2",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
 ]
@@ -5135,7 +5133,7 @@ dependencies = [
 name = "hopr-platform"
 version = "0.2.1"
 dependencies = [
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -5155,7 +5153,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "sha3",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -5168,7 +5166,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "strum 0.27.2",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -5207,7 +5205,7 @@ dependencies = [
  "smart-default",
  "strum 0.27.2",
  "test-log",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tikv-jemallocator",
  "tokio",
  "tokio-util",
@@ -5225,7 +5223,7 @@ dependencies = [
  "serde",
  "serde_cbor_2",
  "strum 0.27.2",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -5258,7 +5256,7 @@ dependencies = [
  "smart-default",
  "strum 0.27.2",
  "test-log",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "validator",
@@ -5303,7 +5301,7 @@ dependencies = [
  "smart-default",
  "strum 0.27.2",
  "temp-env",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tracing",
  "uuid",
  "validator",
@@ -5328,7 +5326,7 @@ dependencies = [
  "anyhow",
  "libp2p-identity",
  "multiaddr",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -5347,7 +5345,7 @@ dependencies = [
  "more-asserts",
  "rust-stream-ext-concurrent",
  "smart-default",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "tracing-test",
@@ -5375,7 +5373,7 @@ dependencies = [
  "serde_with",
  "smart-default",
  "strum 0.27.2",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "validator",
@@ -5402,7 +5400,7 @@ dependencies = [
  "libp2p-stream",
  "more-asserts",
  "rand 0.8.5",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "tracing-test",
@@ -5440,7 +5438,7 @@ dependencies = [
  "serde_with",
  "smart-default",
  "strum 0.27.2",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "tracing-test",
@@ -5491,7 +5489,7 @@ dependencies = [
  "serial_test",
  "smart-default",
  "strum 0.27.2",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-util",
  "tracing",
@@ -5532,7 +5530,7 @@ dependencies = [
  "smart-default",
  "strum 0.27.2",
  "test-log",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tikv-jemallocator",
  "tokio",
  "tracing",
@@ -5565,7 +5563,7 @@ dependencies = [
  "more-asserts",
  "rust-stream-ext-concurrent",
  "serial_test",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "tracing-test",
@@ -5596,7 +5594,7 @@ dependencies = [
  "smart-default",
  "tempfile",
  "test-log",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "tokio",
@@ -5613,7 +5611,7 @@ name = "hoprd-api"
 version = "4.2.2"
 dependencies = [
  "anyhow",
- "axum 0.8.4",
+ "axum 0.8.6",
  "axum-extra",
  "base64 0.22.1",
  "bytesize",
@@ -6382,7 +6380,7 @@ dependencies = [
  "multiaddr",
  "pin-project",
  "rw-stream-sink",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -6416,7 +6414,7 @@ dependencies = [
  "quick-protobuf-codec",
  "rand 0.8.5",
  "rand_core 0.6.4",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tracing",
  "web-time",
 ]
@@ -6451,7 +6449,7 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.5",
  "rw-stream-sink",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tracing",
  "unsigned-varint 0.8.0",
  "web-time",
@@ -6487,7 +6485,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "sha2",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tracing",
  "zeroize",
 ]
@@ -6528,7 +6526,7 @@ dependencies = [
  "rand 0.8.5",
  "snow",
  "static_assertions",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tracing",
  "x25519-dalek",
  "zeroize",
@@ -6551,7 +6549,7 @@ dependencies = [
  "ring",
  "rustls",
  "socket2 0.5.10",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
 ]
@@ -6650,7 +6648,7 @@ dependencies = [
  "ring",
  "rustls",
  "rustls-webpki",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "x509-parser",
  "yasna",
 ]
@@ -6679,7 +6677,7 @@ dependencies = [
  "either",
  "futures",
  "libp2p-core",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tracing",
  "yamux 0.12.1",
  "yamux 0.13.6",
@@ -7123,7 +7121,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -7438,7 +7436,7 @@ dependencies = [
  "futures-sink",
  "js-sys",
  "pin-project-lite",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tracing",
 ]
 
@@ -7468,7 +7466,7 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "reqwest",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tonic 0.13.1",
 ]
@@ -7498,7 +7496,7 @@ dependencies = [
  "percent-encoding",
  "rand 0.9.2",
  "serde_json",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
 ]
@@ -7673,15 +7671,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "21e0a3a33733faeaf8651dfee72dd0f388f0c8e5ad496a3478fa5a922f49cfa8"
 dependencies = [
  "memchr",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "ucd-trie",
 ]
 
 [[package]]
 name = "petgraph"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54acf3a685220b533e437e264e4d932cfbdc4cc7ec0cd232ed73c08d03b8a7ca"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
@@ -8035,7 +8033,7 @@ dependencies = [
  "memchr",
  "parking_lot",
  "protobuf",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -8153,7 +8151,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.6.0",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tracing",
  "web-time",
@@ -8174,7 +8172,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tinyvec",
  "tracing",
  "web-time",
@@ -8923,7 +8921,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "strum 0.26.3",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "time",
  "tracing",
  "url",
@@ -9030,7 +9028,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.106",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -9176,9 +9174,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.227"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80ece43fc6fbed4eb5392ab50c07334d3e577cbf40997ee896fe7af40bba4245"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -9216,18 +9214,18 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.227"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a576275b607a2c86ea29e410193df32bc680303c82f31e275bbfcafe8b33be5"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.227"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51e694923b8824cf0e9b382adf0f60d4e05f348f357b38833a3fa5ed7c2ede04"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9637,7 +9635,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -9721,7 +9719,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tracing",
  "whoami",
 ]
@@ -9759,7 +9757,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tracing",
  "whoami",
 ]
@@ -9784,7 +9782,7 @@ dependencies = [
  "serde",
  "serde_urlencoded",
  "sqlx-core",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tracing",
  "url",
 ]
@@ -10013,11 +10011,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.17",
 ]
 
 [[package]]
@@ -10033,9 +10031,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10245,9 +10243,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -10554,9 +10552,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -10565,7 +10563,7 @@ dependencies = [
  "log",
  "rand 0.9.2",
  "sha1",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "utf-8",
 ]
 
@@ -10761,7 +10759,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59559e1509172f6b26c1cdbc7247c4ddd1ac6560fe94b584f81ee489b141f719"
 dependencies = [
- "axum 0.8.4",
+ "axum 0.8.6",
  "serde",
  "serde_json",
  "utoipa",
@@ -10773,7 +10771,7 @@ version = "9.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
 dependencies = [
- "axum 0.8.4",
+ "axum 0.8.6",
  "base64 0.22.1",
  "mime_guess",
  "regex",
@@ -11636,7 +11634,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "time",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ members = [
 ]
 
 [workspace.dependencies]
-alloy = { version = "=1.0.36", default-features = false, features = [
+alloy = { version = "=1.0.37", default-features = false, features = [
   "essentials",
   "json-rpc",
   "node-bindings",
@@ -60,7 +60,7 @@ alloy = { version = "=1.0.36", default-features = false, features = [
 anyhow = "1.0.100"
 aquamarine = "0.6.0"
 arrayvec = { version = "0.7.6", features = ["serde"] }
-async-compression = "0.4.31"
+async-compression = "0.4.32"
 async-channel = "2.5.0"
 async-lock = "3.4.1"
 async-signal = "0.2.13"
@@ -69,8 +69,8 @@ async-tar = "0.5.0"
 async-trait = "0.1.89"
 asynchronous-codec = { version = "0.7.0", features = ["cbor"] }
 atomic_enum = "0.3.0"
-axum = { version = "0.8.4", features = ["ws", "http2"] }
-axum-extra = { version = "0.10.1", features = ["query"] }
+axum = { version = "0.8.6", features = ["ws", "http2"] }
+axum-extra = { version = "0.10.3", features = ["query"] }
 backon = { version = "1.5.2", default-features = false }
 base64 = "0.22.1"
 bigdecimal = "0.4.8"
@@ -136,7 +136,7 @@ temp-env = "0.3.6"
 parameterized = "2.0.0"
 parking_lot = "0.12.4"
 pcap-file = "2.0.0"
-petgraph = { version = "0.8.2", features = ["serde-1"] }
+petgraph = { version = "0.8.3", features = ["serde-1"] }
 pid = "4.0.0"
 pin-project = "1.1.10"
 primitive-types = { version = "0.14.0", features = ["serde"] }
@@ -170,7 +170,7 @@ sea-query-binder = { version = "0.7.0", default-features = false, features = [
   "sqlx-sqlite",
 ] }
 semver = "1.0.27"
-serde = { version = "1.0.227", features = ["derive"] }
+serde = { version = "1.0.228", features = ["derive"] }
 serde_bytes = "0.11.19"
 serde_cbor_2 = "0.13.0"
 serde_json = "1.0.145"
@@ -192,7 +192,7 @@ subtle = "2.6.1"
 sysinfo = "0.37"
 tempfile = "3.23.0"
 test-log = { version = "0.2.18", features = ["trace"] }
-thiserror = "2.0.16"
+thiserror = "2.0.17"
 tokio = { version = "1.47.1", features = [
   "rt-multi-thread",
   "macros",

--- a/chain/api/Cargo.toml
+++ b/chain/api/Cargo.toml
@@ -24,6 +24,9 @@ prometheus = [
   "hopr-db-sql/prometheus",
 ]
 
+[build-dependencies]
+anyhow = { workspace = true }
+
 [dependencies]
 alloy = { workspace = true, default-features = false, features = [
   "essentials",

--- a/chain/api/build.rs
+++ b/chain/api/build.rs
@@ -1,27 +1,26 @@
 use std::{env, fs, path::Path};
 
-fn main() {
-    let out_dir = env::var("OUT_DIR").unwrap();
+use anyhow::Context;
+
+const CONFIG_FILE_PATH: &str = "../../hopr/chain-config/data/protocol-config.json";
+
+fn main() -> anyhow::Result<()> {
+    let out_dir = env::var("OUT_DIR").context("OUT_DIR environment variable should be set")?;
     let dest_path = Path::new(&out_dir).join("protocol-config.json");
 
-    // Copy the protocol-config.json from the chain-config crate
-    let config_path = Path::new("../../hopr/chain-config/data/protocol-config.json");
+    let config_path = Path::new(CONFIG_FILE_PATH);
 
-    if config_path.exists() {
-        fs::copy(config_path, &dest_path).expect("Failed to copy protocol-config.json to OUT_DIR");
+    if !config_path.exists() {
+        return Err(anyhow::anyhow!(
+            "protocol-config.json not found at expected path: {:?}",
+            config_path
+        ));
     } else {
-        // Fallback: create a minimal config if the file doesn't exist
-        // This handles the case where the relative path structure is different
-        println!("cargo:warning=protocol-config.json not found at expected path, creating minimal config");
-
-        let minimal_config = r#"{
-            "networks": {},
-            "chains": {}
-        }"#;
-
-        fs::write(&dest_path, minimal_config).expect("Failed to write minimal protocol-config.json");
+        fs::copy(config_path, &dest_path).context("Failed to copy protocol-config.json to OUT_DIR")?;
     }
 
     // Tell Cargo to rerun this build script if the config file changes
-    println!("cargo:rerun-if-changed=../../hopr/chain-config/data/protocol-config.json");
+    println!("cargo:rerun-if-changed={CONFIG_FILE_PATH}");
+
+    Ok(())
 }

--- a/chain/api/build.rs
+++ b/chain/api/build.rs
@@ -1,0 +1,27 @@
+use std::{env, fs, path::Path};
+
+fn main() {
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest_path = Path::new(&out_dir).join("protocol-config.json");
+
+    // Copy the protocol-config.json from the chain-config crate
+    let config_path = Path::new("../../hopr/chain-config/data/protocol-config.json");
+
+    if config_path.exists() {
+        fs::copy(config_path, &dest_path).expect("Failed to copy protocol-config.json to OUT_DIR");
+    } else {
+        // Fallback: create a minimal config if the file doesn't exist
+        // This handles the case where the relative path structure is different
+        println!("cargo:warning=protocol-config.json not found at expected path, creating minimal config");
+
+        let minimal_config = r#"{
+            "networks": {},
+            "chains": {}
+        }"#;
+
+        fs::write(&dest_path, minimal_config).expect("Failed to write minimal protocol-config.json");
+    }
+
+    // Tell Cargo to rerun this build script if the config file changes
+    println!("cargo:rerun-if-changed=../../hopr/chain-config/data/protocol-config.json");
+}

--- a/chain/api/src/config.rs
+++ b/chain/api/src/config.rs
@@ -250,7 +250,8 @@ pub struct ProtocolsConfig {
 
 impl Default for ProtocolsConfig {
     fn default() -> Self {
-        Self::from_str(include_str!("../../../hopr/chain-config/data/protocol-config.json"))
+        // Use the embedded protocol config from build time
+        Self::from_str(include_str!(concat!(env!("OUT_DIR"), "/protocol-config.json")))
             .expect("bundled protocol config should be always valid")
     }
 }

--- a/chain/api/src/lib.rs
+++ b/chain/api/src/lib.rs
@@ -81,9 +81,15 @@ pub async fn can_register_with_safe<Rpc: HoprRpcOperations>(
 pub async fn wait_for_funds<Rpc: HoprRpcOperations>(
     address: Address,
     min_balance: XDaiBalance,
+    suggested_balance: XDaiBalance,
     max_delay: Duration,
     rpc: &Rpc,
 ) -> Result<()> {
+    info!(
+        %address, suggested_minimum_balance = %suggested_balance,
+        "Node about to start, checking for funds",
+    );
+
     let multiplier = 1.05;
     let mut current_delay = Duration::from_secs(2).min(max_delay);
 

--- a/chain/api/src/lib.rs
+++ b/chain/api/src/lib.rs
@@ -98,7 +98,7 @@ pub async fn wait_for_funds<Rpc: HoprRpcOperations>(
                     warn!("still unfunded, trying again soon");
                 }
             }
-            Err(e) => error!(error = %e, "failed to fetch balance from the chain"),
+            Err(error) => error!(%error, "failed to fetch balance from the chain"),
         }
 
         sleep(current_delay).await;

--- a/db/entity/build.rs
+++ b/db/entity/build.rs
@@ -149,7 +149,6 @@ fn main() -> anyhow::Result<()> {
                 if file_name.ends_with(".rs") && file_name != "mod.rs" {
                     let module_name = file_name.trim_end_matches(".rs");
                     mod_content.push_str(&format!("pub mod {};\n", module_name));
-                    mod_content.push_str(&format!("pub use {}::*;\n", module_name));
                 }
             }
         }

--- a/db/entity/src/codegen/mod.rs
+++ b/db/entity/src/codegen/mod.rs
@@ -1,1 +1,5 @@
-pub mod sqlite;
+#[cfg(feature = "sqlite")]
+pub mod sqlite {
+    // Include the generated SQLite entities from OUT_DIR
+    include!(concat!(env!("OUT_DIR"), "/codegen/sqlite/mod.rs"));
+}

--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-lib"
-version = "4.0.0"
+version = "3.1.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "HOPR library containing the entire functionality importable without the HOPRd daemon"

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -64,7 +64,7 @@ pub mod prelude {
             prelude::ForeignDataMode,
             udp::{ConnectedUdpStream, UdpStreamParallelism},
         },
-        transport::OffchainPublicKey,
+        transport::{OffchainPublicKey, socket::HoprSocket},
         types::primitive::prelude::Address,
     };
 }
@@ -81,11 +81,7 @@ use std::{
 use async_lock::RwLock;
 pub use async_trait::async_trait;
 use errors::{HoprLibError, HoprStatusError};
-use futures::{
-    FutureExt, SinkExt, StreamExt,
-    channel::mpsc::{Receiver, Sender, channel},
-    future::AbortHandle,
-};
+use futures::{FutureExt, SinkExt, StreamExt, channel::mpsc::channel, future::AbortHandle};
 use hopr_async_runtime::prelude::{sleep, spawn};
 pub use hopr_chain_actions::errors::ChainActionsError;
 use hopr_chain_actions::{channels::ChannelActions, node::NodeActions, redeem::TicketRedeemActions};
@@ -158,42 +154,6 @@ lazy_static::lazy_static! {
         "Node on-chain and off-chain addresses",
         &["peerid", "address", "safe_address", "module_address"]
     ).unwrap();
-}
-
-/// Represents the socket behavior of the hopr-lib spawned [`Hopr`] object.
-///
-/// Provides a read and write stream for Hopr socket recognized data formats.
-pub struct HoprSocket {
-    rx: Receiver<ApplicationDataIn>,
-    tx: Sender<ApplicationDataIn>,
-}
-
-impl Default for HoprSocket {
-    fn default() -> Self {
-        let channel_capacity = std::env::var("HOPR_INTERNAL_RAW_SOCKET_LIKE_CHANNEL_CAPACITY")
-            .ok()
-            .and_then(|s| s.trim().parse::<usize>().ok())
-            .filter(|&c| c > 0)
-            .unwrap_or(16_384);
-
-        debug!(capacity = channel_capacity, "Creating HoprSocket channel");
-        let (tx, rx) = channel::<ApplicationDataIn>(channel_capacity);
-        Self { rx, tx }
-    }
-}
-
-impl HoprSocket {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    pub fn reader(self) -> Receiver<ApplicationDataIn> {
-        self.rx
-    }
-
-    pub fn writer(&self) -> Sender<ApplicationDataIn> {
-        self.tx.clone()
-    }
 }
 
 /// HOPR main object providing the entire HOPR node functionality
@@ -443,6 +403,16 @@ impl Hopr {
             .unwrap_or(self.chain_cfg.chain.default_provider.clone())
     }
 
+    pub async fn wait_for_funds(&self) -> errors::Result<()> {
+        Ok(wait_for_funds(
+            self.me_onchain(),
+            *MIN_NATIVE_BALANCE,
+            Duration::from_secs(200),
+            self.hopr_chain_api.rpc(),
+        )
+        .await?)
+    }
+
     #[inline]
     fn is_public(&self) -> bool {
         self.cfg.chain.announce
@@ -453,7 +423,16 @@ impl Hopr {
     >(
         &self,
         #[cfg(feature = "session-server")] serve_handler: T,
-    ) -> errors::Result<(HoprSocket, HashMap<state::HoprLibProcesses, AbortHandle>)> {
+    ) -> errors::Result<(
+        hopr_transport::socket::HoprSocket<
+            futures::channel::mpsc::Receiver<ApplicationDataIn>,
+            futures::channel::mpsc::Sender<(
+                hopr_transport::ApplicationDataOut,
+                hopr_network_types::types::DestinationRouting,
+            )>,
+        >,
+        HashMap<state::HoprLibProcesses, AbortHandle>,
+    )> {
         self.error_if_not_in_state(
             state::HoprState::Uninitialized,
             "Cannot start the hopr node multiple times".into(),
@@ -465,14 +444,6 @@ impl Hopr {
         );
 
         let mut processes: HashMap<state::HoprLibProcesses, AbortHandle> = HashMap::new();
-
-        wait_for_funds(
-            self.me_onchain(),
-            *MIN_NATIVE_BALANCE,
-            Duration::from_secs(200),
-            self.hopr_chain_api.rpc(),
-        )
-        .await?;
 
         info!("Starting the node...");
 
@@ -781,9 +752,6 @@ impl Hopr {
             );
         }
 
-        let socket = HoprSocket::new();
-        let transport_output_tx = socket.writer();
-
         // notifier on acknowledged ticket reception
         let multi_strategy_ack_ticket = self.multistrategy.clone();
 
@@ -864,12 +832,11 @@ impl Hopr {
             );
         }
 
-        for (id, proc) in self
+        let (hopr_socket, transport_processes) = self
             .transport_api
-            .run(&self.me_chain, transport_output_tx, indexer_peer_update_rx, session_tx)
-            .await?
-            .into_iter()
-        {
+            .run(&self.me_chain, indexer_peer_update_rx, session_tx)
+            .await?;
+        for (id, proc) in transport_processes.into_iter() {
             processes.insert(id.into(), proc);
         }
 
@@ -951,7 +918,7 @@ impl Hopr {
             1.0,
         );
 
-        Ok((socket, processes))
+        Ok((hopr_socket, processes))
     }
 
     // p2p transport =========

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -403,16 +403,6 @@ impl Hopr {
             .unwrap_or(self.chain_cfg.chain.default_provider.clone())
     }
 
-    pub async fn wait_for_funds(&self) -> errors::Result<()> {
-        Ok(wait_for_funds(
-            self.me_onchain(),
-            *MIN_NATIVE_BALANCE,
-            Duration::from_secs(200),
-            self.hopr_chain_api.rpc(),
-        )
-        .await?)
-    }
-
     #[inline]
     fn is_public(&self) -> bool {
         self.cfg.chain.announce
@@ -438,10 +428,14 @@ impl Hopr {
             "Cannot start the hopr node multiple times".into(),
         )?;
 
-        info!(
-            address = %self.me_onchain(), minimum_balance = %*SUGGESTED_NATIVE_BALANCE,
-            "Node is not started, please fund this node",
-        );
+        wait_for_funds(
+            self.me_onchain(),
+            *MIN_NATIVE_BALANCE,
+            *SUGGESTED_NATIVE_BALANCE,
+            Duration::from_secs(200),
+            self.hopr_chain_api.rpc(),
+        )
+        .await?;
 
         let mut processes: HashMap<state::HoprLibProcesses, AbortHandle> = HashMap::new();
 

--- a/hoprd/hoprd/Cargo.toml
+++ b/hoprd/hoprd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd"
-version = "4.0.0"
+version = "3.1.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "HOPR node executable."

--- a/hoprd/hoprd/src/main.rs
+++ b/hoprd/hoprd/src/main.rs
@@ -256,7 +256,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         processes.push(HoprdProcesses::RestApi(abort_handle));
     }
 
-    node.wait_for_funds().await?;
     let (_hopr_socket, hopr_processes) = node
         .run(HoprServerIpForwardingReactor::new(
             hopr_keys.packet_key.clone(),

--- a/hoprd/hoprd/src/main.rs
+++ b/hoprd/hoprd/src/main.rs
@@ -256,6 +256,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         processes.push(HoprdProcesses::RestApi(abort_handle));
     }
 
+    node.wait_for_funds().await?;
     let (_hopr_socket, hopr_processes) = node
         .run(HoprServerIpForwardingReactor::new(
             hopr_keys.packet_key.clone(),

--- a/transport/api/Cargo.toml
+++ b/transport/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport"
-version = "0.13.4"
+version = "0.14.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Implements the main HOPR transport interface for the core library"
 edition = "2021"

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -23,6 +23,8 @@ pub mod network_notifier;
 /// Objects used and possibly exported by the crate for re-use for transport functionality
 pub mod proxy;
 
+pub mod socket;
+
 use std::{
     collections::{HashMap, HashSet},
     sync::{Arc, OnceLock},
@@ -33,7 +35,7 @@ use async_lock::RwLock;
 use constants::MAXIMUM_MSG_OUTGOING_BUFFER_SIZE;
 use futures::{
     FutureExt, SinkExt, StreamExt,
-    channel::mpsc::{SendError, Sender, channel},
+    channel::mpsc::{Sender, channel},
 };
 use helpers::PathPlanner;
 use hopr_async_runtime::{AbortHandle, prelude::spawn, spawn_as_abortable};
@@ -99,7 +101,10 @@ pub use crate::{
     config::HoprTransportConfig,
     helpers::{PeerEligibility, TicketStatistics},
 };
-use crate::{constants::SESSION_INITIATION_TIMEOUT_BASE, errors::HoprTransportError, helpers::run_packet_planner};
+use crate::{
+    constants::SESSION_INITIATION_TIMEOUT_BASE, errors::HoprTransportError, helpers::run_packet_planner,
+    socket::HoprSocket,
+};
 
 pub const APPLICATION_TAG_RANGE: std::ops::Range<Tag> = Tag::APPLICATION_TAG_RANGE;
 
@@ -281,16 +286,23 @@ where
     /// processes and return join handles to the calling function. These processes are not started immediately but
     /// are waiting for a trigger from this piece of code.
     #[allow(clippy::too_many_arguments)]
-    pub async fn run<S1, S2>(
+    pub async fn run<S>(
         &self,
         me_onchain: &ChainKeypair,
-        on_incoming_data: S1,
-        discovery_updates: S2,
+        discovery_updates: S,
         on_incoming_session: Sender<IncomingSession>,
-    ) -> crate::errors::Result<HashMap<HoprTransportProcess, AbortHandle>>
+    ) -> crate::errors::Result<(
+        HoprSocket<
+            futures::channel::mpsc::Receiver<ApplicationDataIn>,
+            futures::channel::mpsc::Sender<(
+                hopr_protocol_app::prelude::ApplicationDataOut,
+                hopr_transport_session::DestinationRouting,
+            )>,
+        >,
+        HashMap<HoprTransportProcess, AbortHandle>,
+    )>
     where
-        S1: futures::Sink<ApplicationDataIn, Error = SendError> + Send + 'static,
-        S2: futures::Stream<Item = PeerDiscovery> + Send + 'static,
+        S: futures::Stream<Item = PeerDiscovery> + Send + 'static,
     {
         info!("Loading initial peers from the storage");
         let mut addresses: HashSet<Multiaddr> = HashSet::new();
@@ -582,6 +594,42 @@ where
                 .filter(|&c| c > 0)
                 .unwrap_or(16_384);
 
+        let (on_incoming_data_tx, on_incoming_data_rx) =
+            channel::<ApplicationDataIn>(msg_protocol_bidirectional_channel_capacity);
+
+        let (bridge_tx, bridge_rx) =
+            channel::<(ApplicationDataOut, DestinationRouting)>(msg_protocol_bidirectional_channel_capacity);
+
+        let pp = self.path_planner.clone();
+        spawn(
+            bridge_rx
+                .filter_map(move |(data, routing)| {
+                    let pp = pp.clone();
+
+                    async move {
+                        pp.resolve_routing(data.data.total_len(), usize::MAX, routing)
+                            .await
+                            .map(|(routing, _size)| {
+                                let (tx, _rx) = futures::channel::oneshot::channel::<
+                                    std::result::Result<(), hopr_crypto_packet::errors::PacketError>,
+                                >();
+                                (data, routing, tx.into())
+                            })
+                            .ok()
+                    }
+                })
+                .map(Ok)
+                .forward(external_msg_send.clone())
+                .inspect(|_| {
+                    tracing::warn!(
+                        task = "transport -> bridge -> protocol",
+                        "long-running background task finished"
+                    )
+                }),
+        );
+
+        let hopr_socket: crate::socket::HoprSocket<_, _> = (on_incoming_data_rx, bridge_tx).into();
+
         debug!(
             capacity = msg_protocol_bidirectional_channel_capacity,
             "Creating protocol bidirectional channel"
@@ -696,7 +744,7 @@ where
                     }
                 })
                 .map(Ok)
-                .forward(on_incoming_data)
+                .forward(on_incoming_data_tx)
                 .inspect(|_| tracing::warn!(
                     task = %HoprTransportProcess::SessionsManagement(0),
                     "long-running background task finished"
@@ -704,7 +752,7 @@ where
             ),
         );
 
-        Ok(processes)
+        Ok((hopr_socket, processes))
     }
 
     pub fn ticket_aggregator(&self) -> Arc<dyn TicketAggregatorTrait + Send + Sync + 'static> {

--- a/transport/api/src/socket.rs
+++ b/transport/api/src/socket.rs
@@ -1,0 +1,42 @@
+use futures::{Sink, Stream};
+use hopr_protocol_app::prelude::{ApplicationDataIn, ApplicationDataOut};
+use hopr_transport_session::DestinationRouting;
+
+/// Represents the socket behavior of the hopr-lib spawned [`Hopr`] object.
+///
+/// HOPR socket aims to mimic a simple socket like write and read behavior for unstructured
+/// communication without the advanced session properties.
+///
+/// Typical use cases might be low level UDP based protocols that can wrap the HOPR socket
+/// without needing the advanced session functionality.
+pub struct HoprSocket<T, U> {
+    rx: T,
+    tx: U,
+}
+
+impl<T, U> From<(T, U)> for HoprSocket<T, U>
+where
+    T: Stream<Item = ApplicationDataIn> + Send + 'static,
+    U: Sink<(ApplicationDataOut, DestinationRouting)> + Send + Clone + 'static,
+{
+    fn from(value: (T, U)) -> Self {
+        Self {
+            rx: value.0,
+            tx: value.1,
+        }
+    }
+}
+
+impl<T, U> HoprSocket<T, U>
+where
+    T: Stream<Item = ApplicationDataIn> + Send + 'static,
+    U: Sink<(ApplicationDataOut, DestinationRouting)> + Send + Clone + 'static,
+{
+    pub fn reader(self) -> T {
+        self.rx
+    }
+
+    pub fn writer(&self) -> U {
+        self.tx.clone()
+    }
+}


### PR DESCRIPTION
This pull request introduces several dependency updates and a significant refactor of the HOPR socket interface to improve modularity and flexibility in the transport layer. The main focus is on decoupling the socket implementation from the core library and moving it into the transport layer, making it more generic and adaptable for different use cases.

**Key changes:**

### Transport Layer Refactor

* Moved the `HoprSocket` struct from `hopr-lib` to a new module `transport/api/src/socket.rs`, and refactored it to be generic over any `Stream` and `Sink` types for improved flexibility.

### Dependency Updates
* Bumped the version of `hopr-transport` to `0.14.0` and downgraded `hopr-lib` to version `3.1.0`.
