### PR TITLE
fix(hopr-lib): consider network registry enabled state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4924,7 +4924,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-db-sql"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "anyhow",
  "async-lock 3.4.1",

--- a/chain/indexer/src/handlers.rs
+++ b/chain/indexer/src/handlers.rs
@@ -1801,6 +1801,8 @@ mod tests {
         };
         let handlers = init_handlers(clonable_rpc_operations, db.clone());
 
+        db.set_network_registry_enabled(None, true).await?;
+
         let encoded_data = ().abi_encode();
 
         let registered_log = SerializableLog {
@@ -1850,6 +1852,8 @@ mod tests {
         };
         let handlers = init_handlers(clonable_rpc_operations, db.clone());
 
+        db.set_network_registry_enabled(None, true).await?;
+
         let registered_log = SerializableLog {
             address: handlers.addresses.network_registry,
             topics: vec![
@@ -1897,6 +1901,8 @@ mod tests {
             inner: Arc::new(rpc_operations),
         };
         let handlers = init_handlers(clonable_rpc_operations, db.clone());
+
+        db.set_network_registry_enabled(None, true).await?;
 
         db.set_access_in_network_registry(None, *SELF_CHAIN_ADDRESS, true)
             .await?;
@@ -1948,6 +1954,8 @@ mod tests {
             inner: Arc::new(rpc_operations),
         };
         let handlers = init_handlers(clonable_rpc_operations, db.clone());
+
+        db.set_network_registry_enabled(None, true).await?;
 
         db.set_access_in_network_registry(None, *SELF_CHAIN_ADDRESS, true)
             .await?;

--- a/db/sql/Cargo.toml
+++ b/db/sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-db-sql"
-version = "0.18.4"
+version = "0.18.5"
 edition = "2021"
 description = "Contains SQL DB functionality implementing the DB API traits to be used by other crates in the code base"
 homepage = "https://hoprnet.org/"

--- a/db/sql/src/registry.rs
+++ b/db/sql/src/registry.rs
@@ -164,7 +164,7 @@ mod tests {
     use hopr_primitive_types::prelude::Address;
     use lazy_static::lazy_static;
 
-    use crate::{db::HoprDb, registry::HoprDbRegistryOperations};
+    use crate::{db::HoprDb, info::HoprDbInfoOperations, registry::HoprDbRegistryOperations};
 
     lazy_static! {
         static ref ADDR_1: Address = "4331eaa9542b6b034c43090d9ec1c2198758dbc3"
@@ -178,6 +178,8 @@ mod tests {
     #[tokio::test]
     async fn test_network_registry_db() -> anyhow::Result<()> {
         let db = HoprDb::new_in_memory(ChainKeypair::random()).await?;
+
+        db.set_network_registry_enabled(None, true).await?;
 
         assert!(!db.is_allowed_in_network_registry(None, &ADDR_1.as_ref()).await?);
         assert!(!db.is_allowed_in_network_registry(None, &ADDR_2.as_ref()).await?);


### PR DESCRIPTION
This pull request updates the logic for checking network registry entries by adding a feature flag based on the `chain_info` table. Now, registry checks are only enforced if the registry is enabled in the database.

**Feature flag for registry checks:**

* Added a check for `network_registry_enabled` in the `chain_info` table using the `SINGULAR_TABLE_FIXED_ID` constant to determine if registry checks should be performed (`db/sql/src/registry.rs`). [[1]](diffhunk://#diff-307b47d05b1001c0e493e30b6552516316d42a9db14fde34a9dcd3308b5a30b7L2-R8) [[2]](diffhunk://#diff-307b47d05b1001c0e493e30b6552516316d42a9db14fde34a9dcd3308b5a30b7R86-R102)
* If the registry is not enabled, the check always returns `true`, effectively bypassing the network registry validation (`db/sql/src/registry.rs`).

## Note
Fixes #7536