### PR TITLE
fix(hopr-lib): backport network registry changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4924,7 +4924,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-db-sql"
-version = "0.18.4"
+version = "0.18.5"
 dependencies = [
  "anyhow",
  "async-lock 3.4.1",

--- a/chain/indexer/src/handlers.rs
+++ b/chain/indexer/src/handlers.rs
@@ -1801,6 +1801,8 @@ mod tests {
         };
         let handlers = init_handlers(clonable_rpc_operations, db.clone());
 
+        db.set_network_registry_enabled(None, true).await?;
+
         let encoded_data = ().abi_encode();
 
         let registered_log = SerializableLog {
@@ -1850,6 +1852,8 @@ mod tests {
         };
         let handlers = init_handlers(clonable_rpc_operations, db.clone());
 
+        db.set_network_registry_enabled(None, true).await?;
+
         let registered_log = SerializableLog {
             address: handlers.addresses.network_registry,
             topics: vec![
@@ -1897,6 +1901,8 @@ mod tests {
             inner: Arc::new(rpc_operations),
         };
         let handlers = init_handlers(clonable_rpc_operations, db.clone());
+
+        db.set_network_registry_enabled(None, true).await?;
 
         db.set_access_in_network_registry(None, *SELF_CHAIN_ADDRESS, true)
             .await?;
@@ -1948,6 +1954,8 @@ mod tests {
             inner: Arc::new(rpc_operations),
         };
         let handlers = init_handlers(clonable_rpc_operations, db.clone());
+
+        db.set_network_registry_enabled(None, true).await?;
 
         db.set_access_in_network_registry(None, *SELF_CHAIN_ADDRESS, true)
             .await?;

--- a/db/sql/Cargo.toml
+++ b/db/sql/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-db-sql"
-version = "0.18.4"
+version = "0.18.5"
 edition = "2021"
 description = "Contains SQL DB functionality implementing the DB API traits to be used by other crates in the code base"
 homepage = "https://hoprnet.org/"


### PR DESCRIPTION
This pull request consists of dependency updates, metrics schema changes, and improvements to registry logic and UDP metrics handling. The most significant changes include updating multiple Rust dependencies, refactoring UDP packet length metrics to simplify their structure, and enhancing the database registry logic to respect a global enable/disable flag. Additionally, several metrics definitions were clarified or renamed for better consistency, and minor improvements were made to progress reporting and hex parsing.

**Dependency Updates:**
* Updated several Rust dependencies in `Cargo.toml` files across the workspace, including `alloy`, `anyhow`, `async-compression`, `clap`, `moka`, `primitive-types`, `regex`, `serde`, `serde_bytes`, `serde_with`, and `tempfile`, to their latest patch versions for improved stability and security. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L52-R63) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L86-R86) [[3]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L127-R127) [[4]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L142-R147) [[5]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L173-R178) [[6]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L193-R193)

**Metrics Refactoring:**
* Changed UDP ingress and egress packet length metrics in `common/network-types/src/udp.rs` from `MultiHistogram` (with `counterparty` label) to `SimpleHistogram` (no labels), and updated all usages accordingly. This simplifies metrics collection and aligns with updated documentation. [[1]](diffhunk://#diff-29e32d2bac7d960590a2d0903ac97c7548b12e227645bcb84b923da25e2a6151L21-R31) [[2]](diffhunk://#diff-29e32d2bac7d960590a2d0903ac97c7548b12e227645bcb84b923da25e2a6151L445-R443) [[3]](diffhunk://#diff-29e32d2bac7d960590a2d0903ac97c7548b12e227645bcb84b923da25e2a6151L560-R558)
* Updated metric definitions in `METRICS.md` to remove or rename keys for several metrics, such as removing `counterparty` from UDP packet length metrics and replacing `endpoint` with `path` for HTTP API metrics. [[1]](diffhunk://#diff-084e22197f10daf7e3d2ca334cba42860c294d78b61b9d7abe665f83a8cd136fL56-R55) [[2]](diffhunk://#diff-084e22197f10daf7e3d2ca334cba42860c294d78b61b9d7abe665f83a8cd136fL72-R70) [[3]](diffhunk://#diff-084e22197f10daf7e3d2ca334cba42860c294d78b61b9d7abe665f83a8cd136fL82-R81)

**Registry Logic Improvements:**
* Enhanced the registry access logic in `db/sql/src/registry.rs` to check the global `network_registry_enabled` flag before validating access, defaulting to enabled if not set. This ensures registry checks respect the global enable/disable status.
* Updated tests in both `chain/indexer/src/handlers.rs` and `db/sql/src/registry.rs` to set the `network_registry_enabled` flag before performing registry access operations, ensuring correct test behavior. [[1]](diffhunk://#diff-f240d1186612677decf950b9aad4c50ac9e6f11af589fce4178888478b6755a8R1804-R1805) [[2]](diffhunk://#diff-f240d1186612677decf950b9aad4c50ac9e6f11af589fce4178888478b6755a8R1855-R1856) [[3]](diffhunk://#diff-f240d1186612677decf950b9aad4c50ac9e6f11af589fce4178888478b6755a8R1905-R1906) [[4]](diffhunk://#diff-f240d1186612677decf950b9aad4c50ac9e6f11af589fce4178888478b6755a8R1958-R1959) [[5]](diffhunk://#diff-307b47d05b1001c0e493e30b6552516316d42a9db14fde34a9dcd3308b5a30b7L157-R167)

**Minor Improvements:**
* Improved progress reporting in `chain/indexer/src/snapshot/download.rs` and hex string parsing in `common/primitive-types/src/traits.rs` by using the `is_multiple_of` method for clarity and correctness. [[1]](diffhunk://#diff-464d568851d929aa9359540578c0af19a5de75b5b2560549b988b03a0075ac6cL249-R249) [[2]](diffhunk://#diff-a9187f85c8bbba861bc1e83c0eec86845e986ebdbb0ec8051248126faf724698L69-R69)

**Version Bumps:**
* Bumped crate versions in `chain/indexer/Cargo.toml`, `common/network-types/Cargo.toml`, `common/primitive-types/Cargo.toml`, and `db/sql/Cargo.toml` to reflect the latest changes. [[1]](diffhunk://#diff-2b1e23a0dd9b3e7e6f5908fda37b104a05c3422daeceb8ce83af462b06f9fcf9L3-R3) [[2]](diffhunk://#diff-74e5e06ce863cf65b4c984618a26780a976505ef4398d92a79d73b9ae88016acL3-R3) [[3]](diffhunk://#diff-146fc3c3ab5e63bd1dd471a6977269fa9462b27dd642cdaa3980d20e9b195bd2L3-R3) [[4]](diffhunk://#diff-626a002025135f5c4717c7be90c4778bdd5b11dbfcdc4165b42e139525534123L3-R3)