### PR TITLE
refactor: simplify channel operation between transport and session manager

### DIFF
--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -62,7 +62,7 @@ use hopr_transport_probe::{
     ping::{PingConfig, Pinger},
 };
 pub use hopr_transport_probe::{errors::ProbeError, ping::PingQueryReplier};
-use hopr_transport_protocol::processor::{MsgSender, PacketInteractionConfig, SendMsgInput};
+use hopr_transport_protocol::processor::PacketInteractionConfig;
 pub use hopr_transport_protocol::{PeerDiscovery, execute_on_tick};
 pub use hopr_transport_session as session;
 #[cfg(feature = "runtime-tokio")]
@@ -126,7 +126,6 @@ pub struct HoprTransport<Db, R> {
     resolver: R,
     ping: Arc<OnceLock<Pinger>>,
     network: Arc<Network<Db>>,
-    process_packet_send: Arc<OnceLock<MsgSender<Sender<SendMsgInput>>>>,
     path_planner: PathPlanner<Db, R, CurrentPathSelector>,
     my_multiaddresses: Vec<Multiaddr>,
     smgr: SessionManager<Sender<(DestinationRouting, ApplicationDataOut)>, Sender<IncomingSession>>,
@@ -153,8 +152,6 @@ where
         channel_graph: Arc<RwLock<hopr_path::channel_graph::ChannelGraph>>,
         my_multiaddresses: Vec<Multiaddr>,
     ) -> Self {
-        let process_packet_send = Arc::new(OnceLock::new());
-
         let me_peerid: PeerId = me.into();
         let me_chain_addr = me_onchain.public().to_address();
 
@@ -169,7 +166,6 @@ where
                 cfg.network.clone(),
                 db.clone(),
             )),
-            process_packet_send,
             path_planner: PathPlanner::new(
                 me_chain_addr,
                 db.clone(),
@@ -334,11 +330,6 @@ where
 
         let (external_msg_send, external_msg_rx) =
             channel::<(ApplicationDataOut, ResolvedTransportRouting)>(MAXIMUM_MSG_OUTGOING_BUFFER_SIZE);
-
-        self.process_packet_send
-            .clone()
-            .set(MsgSender::new(external_msg_send.clone()))
-            .expect("must set the packet processing writer only once");
 
         // -- transport medium
         let mixer_cfg = build_mixer_cfg_from_env();
@@ -555,7 +546,7 @@ where
         let probe = Probe::new((*self.me.public(), self.me_address), self.cfg.probe);
         for (k, v) in probe
             .continuously_scan(
-                (external_msg_send, rx_from_protocol),
+                (external_msg_send.clone(), rx_from_protocol),
                 manual_ping_rx,
                 network_notifier::ProbeNetworkInteractions::new(
                     self.network.clone(),
@@ -583,13 +574,7 @@ where
             .expect("must set the ticket aggregation writer only once");
 
         // -- session management
-        let packet_planner = run_packet_planner(
-            self.path_planner.clone(),
-            self.process_packet_send
-                .get()
-                .cloned()
-                .expect("packet sender must be set"),
-        );
+        let packet_planner = run_packet_planner(self.path_planner.clone(), external_msg_send);
 
         self.smgr
             .start(packet_planner, on_incoming_session)

--- a/transport/protocol/benches/protocol_throughput_emulated.rs
+++ b/transport/protocol/benches/protocol_throughput_emulated.rs
@@ -2,7 +2,7 @@
 mod common;
 use common::{PEERS, PEERS_CHAIN, create_dbs, create_minimal_topology, random_packets_of_count, resolve_mock_path};
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use futures::StreamExt;
+use futures::{SinkExt, StreamExt};
 use hopr_crypto_packet::prelude::HoprPacket;
 use hopr_crypto_random::Randomizable;
 use hopr_crypto_types::keypairs::Keypair;
@@ -10,7 +10,7 @@ use hopr_internal_types::prelude::*;
 use hopr_network_types::prelude::ResolvedTransportRouting;
 use hopr_primitive_types::prelude::HoprBalance;
 use hopr_protocol_app::prelude::{ApplicationDataIn, ApplicationDataOut};
-use hopr_transport_protocol::processor::{MsgSender, PacketInteractionConfig};
+use hopr_transport_protocol::processor::PacketInteractionConfig;
 use libp2p::PeerId;
 
 use crate::common::IndexerDbChainWrapper;
@@ -88,7 +88,6 @@ pub fn protocol_throughput_sender(c: &mut Criterion) {
                         .await
                         .expect("path must be constructible");
 
-                        let sender = MsgSender::new(api_send_tx);
                         let routing = ResolvedTransportRouting::Forward {
                             pseudonym: HoprPseudonym::random(),
                             forward_path: path,
@@ -98,12 +97,12 @@ pub fn protocol_throughput_sender(c: &mut Criterion) {
                         let count = packets.len();
                         futures::stream::iter(packets)
                             .map(|packet| {
-                                let sender = sender.clone();
+                                let mut sender = api_send_tx.clone();
                                 let path = routing.clone();
 
                                 async move {
                                     sender
-                                        .send_packet(ApplicationDataOut::with_no_packet_info(packet), path.clone())
+                                        .send((ApplicationDataOut::with_no_packet_info(packet), path.clone()))
                                         .await
                                 }
                             })

--- a/transport/protocol/src/processor.rs
+++ b/transport/protocol/src/processor.rs
@@ -1,10 +1,8 @@
-use futures::{Sink, SinkExt};
 use hopr_api::{
     chain::{ChainKeyOperations, ChainReadChannelOperations, ChainValues},
     db::{HoprDbProtocolOperations, IncomingPacket, IncomingPacketError, OutgoingPacket},
 };
 pub use hopr_crypto_packet::errors::PacketError;
-use hopr_crypto_packet::errors::PacketError::TransportError;
 use hopr_crypto_types::prelude::*;
 use hopr_internal_types::prelude::*;
 use hopr_network_types::prelude::ResolvedTransportRouting;
@@ -108,39 +106,6 @@ where
     /// Creates a new instance given the DB and configuration.
     pub fn new(db: Db, resolver: R, cfg: PacketInteractionConfig) -> Self {
         Self { db, resolver, cfg }
-    }
-}
-
-pub type SendMsgInput = (ApplicationDataOut, ResolvedTransportRouting);
-
-#[derive(Debug, Clone)]
-pub struct MsgSender<T>
-where
-    T: Sink<SendMsgInput> + Send + Sync + Clone + 'static + std::marker::Unpin,
-{
-    tx: T,
-}
-
-impl<T> MsgSender<T>
-where
-    T: Sink<SendMsgInput> + Send + Sync + Clone + 'static + std::marker::Unpin,
-{
-    pub fn new(tx: T) -> Self {
-        Self { tx }
-    }
-
-    /// Pushes a new packet into processing.
-    #[tracing::instrument(level = "trace", skip(self, data))]
-    pub async fn send_packet(
-        &self,
-        data: ApplicationDataOut,
-        routing: ResolvedTransportRouting,
-    ) -> Result<(), PacketError> {
-        self.tx
-            .clone()
-            .send((data, routing))
-            .await
-            .map_err(|_| TransportError("failed to send a message".into()))
     }
 }
 

--- a/transport/protocol/tests/common/mod.rs
+++ b/transport/protocol/tests/common/mod.rs
@@ -25,7 +25,7 @@ use hopr_path::{ChainPath, Path, PathAddressResolver, ValidatedPath, channel_gra
 use hopr_primitive_types::prelude::*;
 use hopr_protocol_app::prelude::*;
 use hopr_transport_mixer::config::MixerConfig;
-use hopr_transport_protocol::processor::{MsgSender, PacketInteractionConfig};
+use hopr_transport_protocol::processor::PacketInteractionConfig;
 use lazy_static::lazy_static;
 use libp2p::{Multiaddr, PeerId};
 use tokio::time::timeout;
@@ -464,7 +464,7 @@ pub async fn send_relay_receive_channel_of_n_peers(
     let pseudonym = HoprPseudonym::random();
     let mut sent_packet_count = 0;
     for test_msg in test_msgs.iter().take(packet_count) {
-        let sender = MsgSender::new(apis[0].0.clone());
+        let mut sender = apis[0].0.clone();
         let routing = ResolvedTransportRouting::Forward {
             pseudonym,
             forward_path: packet_path.clone(),
@@ -472,7 +472,7 @@ pub async fn send_relay_receive_channel_of_n_peers(
         };
 
         sender
-            .send_packet(ApplicationDataOut::with_no_packet_info(test_msg.clone()), routing)
+            .send((ApplicationDataOut::with_no_packet_info(test_msg.clone()), routing))
             .await?;
 
         sent_packet_count += 1;


### PR DESCRIPTION
Removed `MsgSender` to layer to simplify the pipeline <-> session delivery