### PR TITLE
feat: make both thread pools configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5457,6 +5457,7 @@ dependencies = [
  "home",
  "hopr-lib",
  "hopr-metrics",
+ "hopr-parallelize",
  "hoprd-api",
  "lazy_static",
  "opentelemetry",

--- a/README.md
+++ b/README.md
@@ -260,6 +260,9 @@ On top of the default configuration options generated for the command line, the 
 - `HOPRD_SESSION_ENTRY_UDP_RX_PARALLELISM` - sets the number of UDP listening sockets for UDP sessions on Entry node (defaults to number of CPU cores)
 - `HOPRD_SESSION_EXIT_UDP_RX_PARALLELISM` - sets the number of UDP listening sockets for UDP sessions on Exit node (defaults to number of CPU cores)
 - `HOPRD_NAT` - indicates whether the host is behind a NAT and sets transport-specific settings accordingly (default: `false`)
+- `HOPRD_NUM_CPU_THREADS` - sets the number of threads for CPU-bound tasks (default: number of CPU cores / 2)
+- `HOPRD_NUM_IO_THREADS` - sets the number of threads for IO-bound tasks (default: number of CPU cores / 2)
+- `HOPRD_THREAD_STACK_SIZE` - sets the thread stack size (default: 10 MB)
 
 ### Example execution
 

--- a/common/parallelize/src/lib.rs
+++ b/common/parallelize/src/lib.rs
@@ -24,9 +24,17 @@
 //!
 //! More information about parallization, execution and executors can be found in an excellent blog post [here](https://ryhl.io/blog/async-what-is-blocking/).
 
-/// Module for real thread pool based parallelization of CPU heavy blocking workloads.
+/// Module for real thread pool-based parallelization of CPU heavy blocking workloads.
 pub mod cpu {
     pub use rayon;
+
+    /// Initialize a `rayon` CPU thread pool with the given number of threads.
+    pub fn init_thread_pool(num_threads: usize) {
+        rayon::ThreadPoolBuilder::new()
+            .num_threads(num_threads)
+            .build_global()
+            .unwrap();
+    }
 
     /// Spawn an awaitable non-blocking execution of the given blocking function on a `rayon` CPU thread pool.
     ///

--- a/hoprd/hoprd/Cargo.toml
+++ b/hoprd/hoprd/Cargo.toml
@@ -91,6 +91,7 @@ hopr-lib = { workspace = true, features = [
 ] }
 hoprd-api = { workspace = true }
 hopr-metrics = { workspace = true, optional = true }
+hopr-parallelize = { workspace = true }
 lazy_static = { workspace = true, optional = true }
 
 # Target-specific dependencies for memory allocators

--- a/hoprd/hoprd/src/main.rs
+++ b/hoprd/hoprd/src/main.rs
@@ -140,8 +140,51 @@ impl std::fmt::Debug for HoprdProcesses {
     }
 }
 
-#[cfg_attr(feature = "runtime-tokio", tokio::main)]
-async fn main() -> Result<(), Box<dyn std::error::Error>> {
+#[cfg(not(feature = "runtime-tokio"))]
+compile_error!("The 'runtime-tokio' feature must be enabled");
+
+#[cfg(feature = "runtime-tokio")]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Divide the available CPU parallelism by 2,
+    // since we want to use half of the available threads for IO-bound and half for CPU-bound tasks
+    let avail_parallelism = std::thread::available_parallelism().ok().map(|v| v.get() / 2);
+
+    hopr_parallelize::cpu::init_thread_pool(
+        std::env::var("HOPRD_NUM_CPU_THREADS")
+            .ok()
+            .and_then(|v| usize::from_str(&v).ok())
+            .or(avail_parallelism)
+            .ok_or(anyhow::anyhow!(
+                "Could not determine the number of IO threads to use. Please set the HOPRD_NUM_CPU_THREADS \
+                 environment variable."
+            ))?,
+    );
+
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .worker_threads(
+            std::env::var("HOPRD_NUM_IO_THREADS")
+                .ok()
+                .and_then(|v| usize::from_str(&v).ok())
+                .or(avail_parallelism)
+                .ok_or(anyhow::anyhow!(
+                    "Could not determine the number of IO threads to use. Please set the HOPRD_NUM_IO_THREADS \
+                     environment variable."
+                ))?,
+        )
+        .thread_name("hoprd")
+        .thread_stack_size(
+            std::env::var("HOPRD_THREAD_STACK_SIZE")
+                .ok()
+                .and_then(|v| usize::from_str(&v).ok())
+                .unwrap_or(10 * 1024 * 1024),
+        )
+        .build()?
+        .block_on(main_inner())
+}
+
+#[cfg(feature = "runtime-tokio")]
+async fn main_inner() -> Result<(), Box<dyn std::error::Error>> {
     init_logger()?;
 
     #[cfg(all(target_os = "linux", feature = "jemalloc-stats"))]


### PR DESCRIPTION
By default, the thread pool sizes are half of the number of available CPUs.