### PR TITLE
feat(ci): Add support for docker-compose healthchecks

### DIFF
--- a/nix/docker-builder.nix
+++ b/nix/docker-builder.nix
@@ -21,6 +21,7 @@ let
       nettools
       gnugrep # Used for searching env variables
       gnutar # Used to extract the database files from the docker container
+      curl # Used in docker-compose for healthchecks
 
     ]
     ++ extraContents;


### PR DESCRIPTION
Adding support for docker-compose healthchecks require `curl` to be installed