### PR TITLE
chore: update blokli-client to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ebac8ff9c2f07667e1803dc777304337e160ce5153335beb45e8ec0751808"
+checksum = "ff8c665521d11efbb11d5e5c5d63971426bb63df00d24545baf97e7f3dc91c0c"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -1586,8 +1586,8 @@ dependencies = [
 
 [[package]]
 name = "blokli-client"
-version = "0.10.1"
-source = "git+https://github.com/hoprnet/blokli?rev=3fe92b5#3fe92b5023e063f6af59bf171388f27239bdf197"
+version = "0.11.0"
+source = "git+https://github.com/hoprnet/blokli?rev=d2be82c#d2be82c581d40a06f6e5b8d61733f41a635526d2"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -8225,16 +8225,14 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.24"
+version = "0.12.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
+checksum = "b6eff9328d40131d43bd911d42d79eb6a47312002a4daefc9e37f17e74a7701a"
 dependencies = [
- "async-compression",
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
- "futures-util",
  "h2 0.4.12",
  "http 1.4.0",
  "http-body 1.0.1",
@@ -8256,7 +8254,6 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-native-tls",
- "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
@@ -9348,9 +9345,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "similar"
@@ -10230,9 +10227,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf146f99d442e8e68e585f5d798ccd3cad9a7835b917e09728880a862706456"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
  "async-compression",
  "bitflags 2.10.0",
@@ -10241,6 +10238,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
+ "http-body-util",
  "iri-string",
  "mime",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ bigdecimal = "0.4.9"
 bimap = "0.6.3"
 bincode = { version = "2.0.1", features = ["serde"] }
 bitvec = "1.0.1"
-blokli-client = { git = "https://github.com/hoprnet/blokli", rev = "3fe92b5", version = "0.10.1" }
+blokli-client = { git = "https://github.com/hoprnet/blokli", rev = "d2be82c", version = "0.11.0" }
 bloomfilter = { version = "3.0.1", features = ["serde"] }
 bytesize = { version = "2.3.1", features = ["serde"] }
 bytes = "1.11.0"

--- a/chain/connector/src/connector/tickets.rs
+++ b/chain/connector/src/connector/tickets.rs
@@ -28,7 +28,9 @@ where
         let channel = self
             .client
             .query_channels(blokli_client::api::ChannelSelector {
-                filter: blokli_client::api::ChannelFilter::ChannelId(ticket.ticket.channel_id().into()),
+                filter: Some(blokli_client::api::ChannelFilter::ChannelId(
+                    ticket.ticket.channel_id().into(),
+                )),
                 status: None,
             })
             .await?

--- a/chain/connector/src/lib.rs
+++ b/chain/connector/src/lib.rs
@@ -122,6 +122,7 @@ pub async fn init_blokli_connector(
             provider.as_deref().unwrap_or(DEFAULT_BLOKLI_URL).parse()?,
             blokli_client::BlokliClientConfig {
                 timeout: std::time::Duration::from_secs(5),
+                stream_reconnect_timeout: std::time::Duration::from_secs(30),
             },
         ),
         safe_module_address,


### PR DESCRIPTION
As in title.

The new version contains important bug fixes. 