### PR TITLE
fix: prevent tainting the unack tickets cache predictor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.22"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8c665521d11efbb11d5e5c5d63971426bb63df00d24545baf97e7f3dc91c0c"
+checksum = "35d744058a9daa51a8cf22a3009607498fcf82d3cf4c5444dd8056cdf651f471"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -1586,8 +1586,8 @@ dependencies = [
 
 [[package]]
 name = "blokli-client"
-version = "0.11.0"
-source = "git+https://github.com/hoprnet/blokli?rev=d2be82c#d2be82c581d40a06f6e5b8d61733f41a635526d2"
+version = "0.11.1"
+source = "git+https://github.com/hoprnet/blokli?rev=b08b1f1#b08b1f15f503c0b2dda1caa04c5f7547a29e3784"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4918,7 +4918,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-hopr"
-version = "4.0.0"
+version = "4.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5728,9 +5728,9 @@ checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -5742,9 +5742,9 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
@@ -6319,9 +6319,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3104e13b51e4711ff5738caa1fb54467c8604c2e94d607e27745bcf709068774"
+checksum = "f0c7892c221730ba55f7196e98b0b8ba5e04b4155651736036628e9f73ed6fc3"
 dependencies = [
  "bs58",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ bigdecimal = "0.4.9"
 bimap = "0.6.3"
 bincode = { version = "2.0.1", features = ["serde"] }
 bitvec = "1.0.1"
-blokli-client = { git = "https://github.com/hoprnet/blokli", rev = "d2be82c", version = "0.11.0" }
+blokli-client = { git = "https://github.com/hoprnet/blokli", rev = "b08b1f1", version = "0.11.1" }
 bloomfilter = { version = "3.0.1", features = ["serde"] }
 bytesize = { version = "2.3.1", features = ["serde"] }
 bytes = "1.11.0"

--- a/hopr/hopr-lib/src/testing/mod.rs
+++ b/hopr/hopr-lib/src/testing/mod.rs
@@ -1,3 +1,7 @@
+use std::future::Future;
+
+use futures::{StreamExt, TryFutureExt, TryStreamExt};
+use futures_time::future::FutureExt as FuturesTimeExt;
 use hopr_chain_connector::{
     HoprBlockchainSafeConnector,
     testing::{BlokliTestClient, FullStateEmulator},
@@ -8,3 +12,27 @@ pub mod fixtures;
 pub mod hopr;
 
 type TestingConnector = std::sync::Arc<HoprBlockchainSafeConnector<BlokliTestClient<FullStateEmulator>>>;
+
+/// Waits until either the given async `predicate` returns true or the `timeout` is reached.
+///
+/// The predicate is sampled 10 times inside the `timeout` period, but not faster than every 100ms (for timeouts < 1s).
+pub async fn wait_until<F, Fut, E>(predicate: F, timeout: std::time::Duration) -> anyhow::Result<()>
+where
+    F: Fn() -> Fut,
+    Fut: Future<Output = Result<bool, E>>,
+    E: std::error::Error + Send + Sync + 'static,
+{
+    if !predicate().await? {
+        futures_time::stream::interval(futures_time::time::Duration::from(
+            (timeout / 10).max(std::time::Duration::from_millis(100)),
+        ))
+        .map(Ok)
+        .try_skip_while(|_| predicate().and_then(|v| futures::future::ok(!v)))
+        .take(1)
+        .collect::<Vec<_>>()
+        .timeout(futures_time::time::Duration::from(timeout))
+        .await?;
+    }
+
+    Ok(())
+}

--- a/hopr/hopr-lib/tests/chain_operations-size3.rs
+++ b/hopr/hopr-lib/tests/chain_operations-size3.rs
@@ -89,7 +89,7 @@ async fn channel_funding_should_be_visible_in_channel_stake(cluster: &ClusterGua
         .await
         .context("failed to retrieve channel by id")?;
 
-    assert_eq!(updated_channel.balance, funding_amount.mul(2));
+    assert!(updated_channel.balance >= funding_amount.mul(2));
 
     channel.try_close_channels_all_channels().await?;
 

--- a/protocols/hopr/Cargo.toml
+++ b/protocols/hopr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-protocol-hopr"
-version = "4.0.0"
+version = "4.0.1"
 edition = "2024"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Contains implementation of the HOPR protocol as specified in RFC-0004 & RFC-0005"

--- a/transport/protocol/src/pipeline.rs
+++ b/transport/protocol/src/pipeline.rs
@@ -453,7 +453,7 @@ async fn start_incoming_ack_pipeline<AckIn, T, TEvt>(
                         }
                     }
                     Ok(_) => {
-                        tracing::warn!("acknowledgement batch could not acknowledge any ticket");
+                        tracing::debug!("acknowledgement batch could not acknowledge any ticket");
                     }
                     Err(TicketAcknowledgementError::UnexpectedAcknowledgement) => {
                         // Unexpected acknowledgements naturally happen


### PR DESCRIPTION
- During the check for possibility that peer may send us an acknowledgement, the cache predictor was tainted, allowing the entries not to expire. Now the check is done first using `contains_key` which does not affect the popularity estimator.

- E2E tests were enhanced with the `wait_until` function

- `blokli_client` was updated to 0.11.1