### PR TITLE
fix(hoprd): ensure CA bundle is exposed and set TMPDIR

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -283,6 +283,9 @@
               # default to hoprd
               exec /bin/hoprd "$@"
             fi
+
+            # ensure the temporary directory exists
+            mkdir -p ${"TMPDIR:-/app/.tmp"}
           '';
 
           # Man pages using nix-lib
@@ -305,7 +308,7 @@
             ];
             Entrypoint = [ "/bin/docker-entrypoint.sh" ];
             Cmd = [ "hoprd" ];
-            env = [ "TMPDIR=/app" ];
+            env = [ "TMPDIR=/app/.tmp" ];
           };
           hoprd-dev-docker = nixLib.mkDockerImage {
             name = "hoprd";
@@ -316,7 +319,7 @@
             ];
             Entrypoint = [ "/bin/docker-entrypoint.sh" ];
             Cmd = [ "hoprd" ];
-            env = [ "TMPDIR=/app" ];
+            env = [ "TMPDIR=/app/.tmp" ];
           };
           hoprd-profile-docker = nixLib.mkDockerImage {
             name = "hoprd";
@@ -328,7 +331,7 @@
             ++ profileDeps;
             Entrypoint = [ "/bin/docker-entrypoint.sh" ];
             Cmd = [ "hoprd" ];
-            env = [ "TMPDIR=/app" ];
+            env = [ "TMPDIR=/app/.tmp" ];
           };
 
           # Docker security scanning and SBOM generation using nix-lib


### PR DESCRIPTION
- Update the CA bundle path environment variable so that the node find them
- Set the `TMPDIR` environment variable so that blokli connector can store temp files without errors

Fixes #7677 
Fixes #7678 