### PR TITLE
fix: point to the actual cert file

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -257,7 +257,7 @@
             fi
 
             # ensure the temporary directory exists
-            mkdir -p ${TMPDIR:-/app/.tmp}
+            mkdir -p $TMPDIR
 
             # if the default listen host has not been set by the user,
             # we will set it to the container's ip address


### PR DESCRIPTION
Fixes nix setup from #7679, which didn't exactly solve the CA certifact not found error, not the temp file path.
Tested with the generated image from the artifact registry.