### PR TITLE
fix: set chain id on transaction signing and encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4501,7 +4501,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4539,7 +4539,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-types"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/chain/connector/Cargo.toml
+++ b/chain/connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-chain-connector"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Implementation of HOPR Chain APIs using Blokli client"

--- a/chain/types/Cargo.toml
+++ b/chain/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-chain-types"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Core-Ethereum-specific interaction with the backend database"

--- a/chain/types/src/parser.rs
+++ b/chain/types/src/parser.rs
@@ -281,7 +281,7 @@ mod tests {
         let safe_gen = SafePayloadGenerator::new(&cp, *CONTRACT_ADDRS, [1u8; Address::SIZE].into());
         let signed_tx = safe_gen
             .announce(ad, 10_u32.into())?
-            .sign_and_encode_to_eip2718(1, None, &cp)
+            .sign_and_encode_to_eip2718(1, 1, None, &cp)
             .await?;
 
         let (action, signer) =
@@ -305,7 +305,7 @@ mod tests {
         let basic_gen = BasicPayloadGenerator::new(cp.public().to_address(), *CONTRACT_ADDRS);
         let signed_tx = basic_gen
             .fund_channel([2u8; Address::SIZE].into(), 123_u32.into())?
-            .sign_and_encode_to_eip2718(1, None, &cp)
+            .sign_and_encode_to_eip2718(1, 1, None, &cp)
             .await?;
 
         let (action, signer) =
@@ -319,7 +319,7 @@ mod tests {
         let safe_gen = SafePayloadGenerator::new(&cp, *CONTRACT_ADDRS, [1u8; Address::SIZE].into());
         let signed_tx = safe_gen
             .fund_channel([2u8; Address::SIZE].into(), 123_u32.into())?
-            .sign_and_encode_to_eip2718(1, None, &cp)
+            .sign_and_encode_to_eip2718(1, 1, None, &cp)
             .await?;
 
         let (action, signer) =
@@ -340,7 +340,7 @@ mod tests {
         let basic_gen = BasicPayloadGenerator::new(cp.public().to_address(), *CONTRACT_ADDRS);
         let signed_tx = basic_gen
             .initiate_outgoing_channel_closure([2u8; Address::SIZE].into())?
-            .sign_and_encode_to_eip2718(1, None, &cp)
+            .sign_and_encode_to_eip2718(1, 1, None, &cp)
             .await?;
 
         let channel_id = generate_channel_id(&cp.public().to_address(), &[2u8; Address::SIZE].into());
@@ -353,7 +353,7 @@ mod tests {
         let safe_gen = SafePayloadGenerator::new(&cp, *CONTRACT_ADDRS, [1u8; Address::SIZE].into());
         let signed_tx = safe_gen
             .initiate_outgoing_channel_closure([2u8; Address::SIZE].into())?
-            .sign_and_encode_to_eip2718(1, None, &cp)
+            .sign_and_encode_to_eip2718(1, 1, None, &cp)
             .await?;
 
         let (action, signer) =
@@ -371,7 +371,7 @@ mod tests {
         let basic_gen = BasicPayloadGenerator::new(cp.public().to_address(), *CONTRACT_ADDRS);
         let signed_tx = basic_gen
             .finalize_outgoing_channel_closure([2u8; Address::SIZE].into())?
-            .sign_and_encode_to_eip2718(1, None, &cp)
+            .sign_and_encode_to_eip2718(1, 1, None, &cp)
             .await?;
 
         let channel_id = generate_channel_id(&cp.public().to_address(), &[2u8; Address::SIZE].into());
@@ -384,7 +384,7 @@ mod tests {
         let safe_gen = SafePayloadGenerator::new(&cp, *CONTRACT_ADDRS, [1u8; Address::SIZE].into());
         let signed_tx = safe_gen
             .finalize_outgoing_channel_closure([2u8; Address::SIZE].into())?
-            .sign_and_encode_to_eip2718(1, None, &cp)
+            .sign_and_encode_to_eip2718(1, 1, None, &cp)
             .await?;
 
         let (action, signer) =
@@ -402,7 +402,7 @@ mod tests {
         let basic_gen = BasicPayloadGenerator::new(cp.public().to_address(), *CONTRACT_ADDRS);
         let signed_tx = basic_gen
             .close_incoming_channel([2u8; Address::SIZE].into())?
-            .sign_and_encode_to_eip2718(1, None, &cp)
+            .sign_and_encode_to_eip2718(1, 1, None, &cp)
             .await?;
 
         let channel_id = generate_channel_id(&[2u8; Address::SIZE].into(), &cp.public().to_address());
@@ -415,7 +415,7 @@ mod tests {
         let safe_gen = SafePayloadGenerator::new(&cp, *CONTRACT_ADDRS, [1u8; Address::SIZE].into());
         let signed_tx = safe_gen
             .close_incoming_channel([2u8; Address::SIZE].into())?
-            .sign_and_encode_to_eip2718(1, None, &cp)
+            .sign_and_encode_to_eip2718(1, 1, None, &cp)
             .await?;
 
         let (action, signer) =
@@ -433,7 +433,7 @@ mod tests {
         let basic_gen = BasicPayloadGenerator::new(cp.public().to_address(), *CONTRACT_ADDRS);
         let signed_tx = basic_gen
             .register_safe_by_node([2u8; Address::SIZE].into())?
-            .sign_and_encode_to_eip2718(1, None, &cp)
+            .sign_and_encode_to_eip2718(1, 1, None, &cp)
             .await?;
 
         let (action, signer) =
@@ -447,7 +447,7 @@ mod tests {
         let safe_gen = SafePayloadGenerator::new(&cp, *CONTRACT_ADDRS, [1u8; Address::SIZE].into());
         let signed_tx = safe_gen
             .register_safe_by_node([2u8; Address::SIZE].into())?
-            .sign_and_encode_to_eip2718(1, None, &cp)
+            .sign_and_encode_to_eip2718(1, 1, None, &cp)
             .await?;
 
         let (action, signer) =
@@ -481,7 +481,7 @@ mod tests {
         let basic_gen = BasicPayloadGenerator::new(cp_2.public().to_address(), *CONTRACT_ADDRS);
         let signed_tx = basic_gen
             .redeem_ticket(ticket.clone())?
-            .sign_and_encode_to_eip2718(1, None, &cp_2)
+            .sign_and_encode_to_eip2718(1, 1, None, &cp_2)
             .await?;
 
         let (action, signer) =
@@ -499,7 +499,7 @@ mod tests {
         let safe_gen = SafePayloadGenerator::new(&cp_2, *CONTRACT_ADDRS, [1u8; Address::SIZE].into());
         let signed_tx = safe_gen
             .redeem_ticket(ticket.clone())?
-            .sign_and_encode_to_eip2718(1, None, &cp_2)
+            .sign_and_encode_to_eip2718(1, 1, None, &cp_2)
             .await?;
 
         let (action, signer) =
@@ -524,7 +524,7 @@ mod tests {
         let basic_gen = BasicPayloadGenerator::new(cp.public().to_address(), *CONTRACT_ADDRS);
         let signed_tx = basic_gen
             .transfer::<XDai>([2u8; Address::SIZE].into(), 123_u32.into())?
-            .sign_and_encode_to_eip2718(1, None, &cp)
+            .sign_and_encode_to_eip2718(1, 1, None, &cp)
             .await?;
 
         let (action, signer) =
@@ -538,7 +538,7 @@ mod tests {
         let safe_gen = SafePayloadGenerator::new(&cp, *CONTRACT_ADDRS, [1u8; Address::SIZE].into());
         let signed_tx = safe_gen
             .transfer::<XDai>([2u8; Address::SIZE].into(), 123_u32.into())?
-            .sign_and_encode_to_eip2718(1, None, &cp)
+            .sign_and_encode_to_eip2718(1, 1, None, &cp)
             .await?;
 
         let (action, signer) =
@@ -559,7 +559,7 @@ mod tests {
         let basic_gen = BasicPayloadGenerator::new(cp.public().to_address(), *CONTRACT_ADDRS);
         let signed_tx = basic_gen
             .transfer::<WxHOPR>([2u8; Address::SIZE].into(), 123_u32.into())?
-            .sign_and_encode_to_eip2718(1, None, &cp)
+            .sign_and_encode_to_eip2718(1, 1, None, &cp)
             .await?;
 
         let (action, signer) =
@@ -573,7 +573,7 @@ mod tests {
         let safe_gen = SafePayloadGenerator::new(&cp, *CONTRACT_ADDRS, [1u8; Address::SIZE].into());
         let signed_tx = safe_gen
             .transfer::<WxHOPR>([2u8; Address::SIZE].into(), 123_u32.into())?
-            .sign_and_encode_to_eip2718(1, None, &cp)
+            .sign_and_encode_to_eip2718(1, 1, None, &cp)
             .await?;
 
         let (action, signer) =

--- a/chain/types/src/payload/bindings_based.rs
+++ b/chain/types/src/payload/bindings_based.rs
@@ -62,6 +62,7 @@ impl SignableTransaction for TransactionRequest {
     async fn sign_and_encode_to_eip2718(
         self,
         nonce: u64,
+        chain_id: u64,
         max_gas: Option<GasEstimation>,
         chain_keypair: &ChainKeypair,
     ) -> payload::Result<Box<[u8]>> {
@@ -71,6 +72,7 @@ impl SignableTransaction for TransactionRequest {
             .into();
         let signed: TxEnvelope = self
             .nonce(nonce)
+            .with_chain_id(chain_id)
             .gas_limit(max_gas.gas_limit)
             .max_fee_per_gas(max_gas.max_fee_per_gas)
             .max_priority_fee_per_gas(max_gas.max_priority_fee_per_gas)
@@ -617,7 +619,7 @@ pub(crate) mod tests {
 
         let signed_tx = generator
             .announce(ad, 100_u32.into())?
-            .sign_and_encode_to_eip2718(2, None, &chain_key_0)
+            .sign_and_encode_to_eip2718(2, 1, None, &chain_key_0)
             .await?;
         insta::assert_snapshot!("announce_basic", hex::encode(signed_tx));
 
@@ -626,7 +628,7 @@ pub(crate) mod tests {
 
         let signed_tx = generator
             .announce(ad_reannounce, 0_u32.into())?
-            .sign_and_encode_to_eip2718(1, None, &chain_key_0)
+            .sign_and_encode_to_eip2718(1, 1, None, &chain_key_0)
             .await?;
         insta::assert_snapshot!("announce_safe", hex::encode(signed_tx.clone()));
 
@@ -643,7 +645,7 @@ pub(crate) mod tests {
         let generator = BasicPayloadGenerator::new((&chain_key_bob).into(), *CONTRACT_ADDRS);
         let redeem_ticket_tx = generator.redeem_ticket(acked_ticket.clone())?;
         let signed_tx = redeem_ticket_tx
-            .sign_and_encode_to_eip2718(1, None, &chain_key_bob)
+            .sign_and_encode_to_eip2718(1, 1, None, &chain_key_bob)
             .await?;
 
         insta::assert_snapshot!("redeem_ticket_basic", hex::encode(signed_tx));
@@ -662,7 +664,7 @@ pub(crate) mod tests {
             SafePayloadGenerator::new((&chain_key_bob).into(), *CONTRACT_ADDRS, [1u8; Address::SIZE].into());
         let redeem_ticket_tx = generator.redeem_ticket(acked_ticket)?;
         let signed_tx = redeem_ticket_tx
-            .sign_and_encode_to_eip2718(2, None, &chain_key_bob)
+            .sign_and_encode_to_eip2718(2, 1, None, &chain_key_bob)
             .await?;
 
         insta::assert_snapshot!("redeem_ticket_safe", hex::encode(signed_tx));
@@ -678,7 +680,7 @@ pub(crate) mod tests {
         let generator = BasicPayloadGenerator::new((&chain_key_alice).into(), *CONTRACT_ADDRS);
         let tx = generator.transfer((&chain_key_bob).into(), HoprBalance::from(100))?;
 
-        let signed_tx = tx.sign_and_encode_to_eip2718(1, None, &chain_key_bob).await?;
+        let signed_tx = tx.sign_and_encode_to_eip2718(1, 1, None, &chain_key_bob).await?;
 
         insta::assert_snapshot!("withdraw_basic", hex::encode(signed_tx));
 
@@ -686,7 +688,7 @@ pub(crate) mod tests {
             SafePayloadGenerator::new((&chain_key_alice).into(), *CONTRACT_ADDRS, [1u8; Address::SIZE].into());
         let tx = generator.transfer((&chain_key_bob).into(), HoprBalance::from(100))?;
 
-        let signed_tx = tx.sign_and_encode_to_eip2718(2, None, &chain_key_bob).await?;
+        let signed_tx = tx.sign_and_encode_to_eip2718(2, 1, None, &chain_key_bob).await?;
 
         insta::assert_snapshot!("withdraw_safe", hex::encode(signed_tx));
 

--- a/chain/types/src/payload/mod.rs
+++ b/chain/types/src/payload/mod.rs
@@ -58,6 +58,7 @@ pub trait SignableTransaction {
     async fn sign_and_encode_to_eip2718(
         self,
         nonce: u64,
+        chain_id: u64,
         max_gas: Option<GasEstimation>,
         chain_keypair: &ChainKeypair,
     ) -> Result<Box<[u8]>>;


### PR DESCRIPTION
Adds explicit `chain_id` to each transaction sent out to Blokli

Refs https://github.com/hoprnet/blokli/issues/134