### PR TITLE
fix: incorrect nonce length in safe deployment code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4564,7 +4564,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-types"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/chain/connector/src/connector/mod.rs
+++ b/chain/connector/src/connector/mod.rs
@@ -224,7 +224,7 @@ where
             // Stream of Account events (Announcements)
             let graph_clone = graph.clone();
             let account_stream = account_stream
-                .inspect_ok(|entry| tracing::trace!(?entry, "new account entry"))
+                .inspect_ok(|entry| tracing::trace!(?entry, "new account event"))
                 .map_err(ConnectorError::from)
                 .try_filter_map(|account| futures::future::ready(model_to_account_entry(account).map(Some)))
                 .and_then(move |account| {
@@ -262,7 +262,7 @@ where
             // Stream of channel graph updates
             let channel_stream = channel_stream
                 .map_err(ConnectorError::from)
-                .inspect_ok(|entry| tracing::trace!(?entry, "new graph entry"))
+                .inspect_ok(|entry| tracing::trace!(?entry, "new graph event"))
                 .try_filter_map(|graph_event| futures::future::ready(model_to_graph_entry(graph_event).map(Some)))
                 .and_then(move |(src, dst, channel)| {
                     let graph = graph.clone();

--- a/chain/types/Cargo.toml
+++ b/chain/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-chain-types"
-version = "0.13.0"
+version = "0.14.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2021"
 description = "Core-Ethereum-specific interaction with the backend database"

--- a/chain/types/src/payload/bindings_based.rs
+++ b/chain/types/src/payload/bindings_based.rs
@@ -304,7 +304,7 @@ impl PayloadGenerator for BasicPayloadGenerator {
         balance: HoprBalance,
         admins: &[Address],
         include_node: bool,
-        nonce: [u8; 64],
+        nonce: [u8; 32],
     ) -> crate::payload::Result<Self::TxRequest> {
         const DEFAULT_CAPABILITY_PERMISSIONS: &str = "010103030303030303030303";
         let nonce = U256::from_be_slice(&nonce);
@@ -572,7 +572,7 @@ impl PayloadGenerator for SafePayloadGenerator {
         _: HoprBalance,
         _: &[Address],
         _: bool,
-        _: [u8; 64],
+        _: [u8; 32],
     ) -> crate::payload::Result<Self::TxRequest> {
         Err(InvalidState("cannot deploy Safe from SafePayloadGenerator"))
     }

--- a/chain/types/src/payload/mod.rs
+++ b/chain/types/src/payload/mod.rs
@@ -117,7 +117,7 @@ pub trait PayloadGenerator {
         balance: HoprBalance,
         admins: &[Address],
         include_node: bool,
-        nonce: [u8; 64],
+        nonce: [u8; 32],
     ) -> Result<Self::TxRequest>;
 }
 


### PR DESCRIPTION
The random nonce length was invalid (64 instead of 32 bytes)