### PR TITLE
fix: remove rusttls dependency from sea-orm and sqlx dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4649,7 +4649,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-db-entity"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -4675,7 +4675,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-db-node"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-lock",
@@ -9455,9 +9455,9 @@ dependencies = [
  "indexmap 2.13.0",
  "log",
  "memchr",
+ "native-tls",
  "once_cell",
  "percent-encoding",
- "rustls 0.23.36",
  "serde",
  "serde_json",
  "sha2",
@@ -9467,7 +9467,6 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
- "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -10807,24 +10806,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.26.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
-dependencies = [
- "webpki-roots 1.0.5",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bed680863276c63889429bfd6cab3b99943659923822de1c8a39c49e4d722c"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/db/entity/Cargo.toml
+++ b/db/entity/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-db-entity"
 description = "Contains all HOPR database entities"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 homepage = "https://hoprnet.org/"
 repository = "https://github.com/hoprnet/hoprnet"
@@ -10,9 +10,9 @@ license = "GPL-3.0-only"
 [features]
 default = ["sqlite"]
 runtime-tokio = [
-  "sea-orm/runtime-tokio-rustls",
-  "sea-orm-cli/runtime-tokio-rustls",
-  "sea-orm-migration/runtime-tokio-rustls",
+  "sea-orm/runtime-tokio-native-tls",
+  "sea-orm-cli/runtime-tokio-native-tls",
+  "sea-orm-migration/runtime-tokio-native-tls",
 ]
 sqlite = []
 

--- a/db/node/Cargo.toml
+++ b/db/node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-db-node"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Contains SQL Node DB functionality implementing the DB API traits"
 homepage = "https://hoprnet.org/"
@@ -14,8 +14,8 @@ runtime-tokio = [
   "hopr-db-entity/runtime-tokio",
   "hopr-db-migration/runtime-tokio",
   "sea-orm/runtime-tokio",
-  "sea-orm/runtime-tokio-rustls",
-  "sqlx/runtime-tokio-rustls",
+  "sea-orm/runtime-tokio-native-tls",
+  "sqlx/runtime-tokio-native-tls",
   "sqlx/runtime-tokio",
 ]
 prometheus = ["dep:lazy_static", "dep:hopr-metrics"]


### PR DESCRIPTION
Since using SqlLite, no TLS is needed at all, and apparently the native option makes it for the CI easier to build.