### PR TITLE
fix: Incompatible attributes in new 'Setup Gcp' workflow action

### DIFF
--- a/.github/workflows/build-dappnode.yaml
+++ b/.github/workflows/build-dappnode.yaml
@@ -92,9 +92,9 @@ jobs:
         id: gcp
         uses: hoprnet/hopr-workflows/actions/setup-gcp@644d936de4e1c8f5c50ba50f8526209455c28b4a # master
         with:
-          google-credentials: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
-          login-artifact-registry: 'false'
-          install-sdk: 'true'
+          google_credentials: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
+          login_artifact_registry: 'false'
+          install_sdk: 'true'
 
       - name: Setup Node.js
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -60,9 +60,9 @@ jobs:
         id: gcp
         uses: hoprnet/hopr-workflows/actions/setup-gcp@644d936de4e1c8f5c50ba50f8526209455c28b4a # master
         with:
-          google-credentials: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
-          login-artifact-registry: 'true'
-          install-sdk: 'false'
+          google_credentials: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
+          login_artifact_registry: 'true'
+          install_sdk: 'false'
 
       - name: Install Nix
         if: env.needs_nix_setup == true

--- a/.github/workflows/clean-pr.yaml
+++ b/.github/workflows/clean-pr.yaml
@@ -31,9 +31,9 @@ jobs:
         id: gcp
         uses: hoprnet/hopr-workflows/actions/setup-gcp@644d936de4e1c8f5c50ba50f8526209455c28b4a # master
         with:
-          google-credentials: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
-          login-artifact-registry: 'true'
-          install-sdk: 'true'
+          google_credentials: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
+          login_artifact_registry: 'true'
+          install_sdk: 'true'
 
       - name: Cleanup Github pipeline cache
         run: |

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -59,9 +59,9 @@ jobs:
         id: gcp
         uses: hoprnet/hopr-workflows/actions/setup-gcp@644d936de4e1c8f5c50ba50f8526209455c28b4a # master
         with:
-          google-credentials: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
-          login-artifact-registry: 'true'
-          install-sdk: 'true'
+          google_credentials: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
+          login_artifact_registry: 'true'
+          install_sdk: 'true'
 
       - name: Log in to Docker Hub
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0

--- a/.github/workflows/deploy-nodes.yaml
+++ b/.github/workflows/deploy-nodes.yaml
@@ -39,10 +39,10 @@ jobs:
         id: gcp
         uses: hoprnet/hopr-workflows/actions/setup-gcp@644d936de4e1c8f5c50ba50f8526209455c28b4a # master
         with:
-          google-credentials: ${{ secrets.GCP_SA_TERRAFORM_JSON }}
-          login-artifact-registry: 'true'
-          install-sdk: 'true'
-          login-gke: 'true'
+          google_credentials: ${{ secrets.GCP_SA_TERRAFORM_JSON }}
+          login_artifact_registry: 'true'
+          install_sdk: 'true'
+          login_gke: 'true'
           project: hopr-staging
 
       - name: Set environment variables

--- a/.github/workflows/generate-dappnode-pr.yaml
+++ b/.github/workflows/generate-dappnode-pr.yaml
@@ -73,9 +73,9 @@ jobs:
         id: gcp
         uses: hoprnet/hopr-workflows/actions/setup-gcp@644d936de4e1c8f5c50ba50f8526209455c28b4a # master
         with:
-          google-credentials: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
-          login-artifact-registry: 'false'
-          install-sdk: 'true'
+          google_credentials: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
+          login_artifact_registry: 'false'
+          install_sdk: 'true'
 
       - name: Checkout DAppNodePackage-Hopr
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/load-tests.yaml
+++ b/.github/workflows/load-tests.yaml
@@ -123,10 +123,10 @@ jobs:
         id: gcp
         uses: hoprnet/hopr-workflows/actions/setup-gcp@644d936de4e1c8f5c50ba50f8526209455c28b4a # master
         with:
-          google-credentials: ${{ secrets.GCP_SA_TERRAFORM_JSON }}
-          login-artifact-registry: 'false'
-          install-sdk: 'true'
-          login-gke: 'true'
+          google_credentials: ${{ secrets.GCP_SA_TERRAFORM_JSON }}
+          login_artifact_registry: 'false'
+          install_sdk: 'true'
+          login_gke: 'true'
           project: hopr-staging
       - name: Set environment variables
         run: |

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -50,9 +50,9 @@ jobs:
         id: gcp
         uses: hoprnet/hopr-workflows/actions/setup-gcp@644d936de4e1c8f5c50ba50f8526209455c28b4a # master
         with:
-          google-credentials: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
-          login-artifact-registry: 'false'
-          install-sdk: 'true'
+          google_credentials: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
+          login_artifact_registry: 'false'
+          install_sdk: 'true'
 
       - name: Download artifacts from parent workflow run
         id: download

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -37,9 +37,9 @@ jobs:
         id: gcp
         uses: hoprnet/hopr-workflows/actions/setup-gcp@644d936de4e1c8f5c50ba50f8526209455c28b4a # master
         with:
-          google-credentials: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
-          login-artifact-registry: 'true'
-          install-sdk: 'true'
+          google_credentials: ${{ secrets.GOOGLE_HOPRASSOCIATION_CREDENTIALS_REGISTRY }}
+          login_artifact_registry: 'true'
+          install_sdk: 'true'
 
       - name: Tag docker images with release name
         run: |


### PR DESCRIPTION
This fixes the attributes names for the reused action `Setup GCP` which now uses underscore instead of dash. 

The pipelines won't work until we fix this. There is no option to test this change as the current workflows on `main` uses `pull_request_target` and therefore uses the worfklow definition at `main` which is incorrect.