### PR TITLE
fix: default tx confirm timeout in hoprd

### DIFF
--- a/hoprd/hoprd/src/main.rs
+++ b/hoprd/hoprd/src/main.rs
@@ -279,7 +279,7 @@ async fn main_inner() -> anyhow::Result<()> {
     let mut chain_connector = create_trustful_hopr_blokli_connector(
         &hopr_keys.chain_key,
         BlockchainConnectorConfig {
-            tx_confirm_timeout: std::time::Duration::from_secs(30),
+            tx_confirm_timeout: std::time::Duration::from_secs(90),
             connection_timeout: std::time::Duration::from_mins(1),
         },
         BlokliClient::new(


### PR DESCRIPTION
As in title.
Fixes https://github.com/hoprnet/hoprnet/issues/7766
Fixes https://linear.app/hoprnet/issue/HOP-601/cannot-open-channel