### PR TITLE
fix(autofunding): switch autofunding strategy to less than or equal

### DIFF
--- a/logic/strategy/src/auto_funding.rs
+++ b/logic/strategy/src/auto_funding.rs
@@ -90,7 +90,7 @@ impl<A: ChainWriteChannelOperations + Send + Sync> SingularStrategy for AutoFund
         if let ChannelChange::Balance { right: new, .. } = change {
             if new.le(&self.cfg.min_stake_threshold) && channel.status == ChannelStatus::Open {
                 info!(%channel, balance = %channel.balance, threshold = %self.cfg.min_stake_threshold,
-                    "stake on channel is below threshold",
+                    "stake on channel at or below threshold",
                 );
 
                 #[cfg(all(feature = "prometheus", not(test)))]


### PR DESCRIPTION
This slight difference will weed out a potential edge case regarding channel funding on the edge client