### PR TITLE
chore: update rand to 0.10.0

### DIFF
--- a/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_announce_new_account_with_multiaddresses.snap
+++ b/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_announce_new_account_with_multiaddresses.snap
@@ -30,7 +30,7 @@ chain_info:
   key_binding_fee: 0.01 wxHOPR
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
-  network: jura
+  network: rotsee
   contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\"}"
   expected_block_time: "5"
   finality: "8"

--- a/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_announce_new_account_without_multiaddresses.snap
+++ b/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_announce_new_account_without_multiaddresses.snap
@@ -29,7 +29,7 @@ chain_info:
   key_binding_fee: 0.01 wxHOPR
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
-  network: jura
+  network: rotsee
   contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\"}"
   expected_block_time: "5"
   finality: "8"

--- a/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_reannounce_when_existing_account_has_same_multiaddresses.snap
+++ b/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_reannounce_when_existing_account_has_same_multiaddresses.snap
@@ -46,7 +46,7 @@ chain_info:
   key_binding_fee: 0.01 wxHOPR
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
-  network: jura
+  network: rotsee
   contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\"}"
   expected_block_time: "5"
   finality: "8"

--- a/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_register_any_safe_when_node_already_registered.snap
+++ b/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_register_any_safe_when_node_already_registered.snap
@@ -33,7 +33,7 @@ chain_info:
   key_binding_fee: 0.01 wxHOPR
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
-  network: jura
+  network: rotsee
   contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\"}"
   expected_block_time: "5"
   finality: "8"

--- a/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_register_safe_that_does_not_exist.snap
+++ b/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_register_safe_that_does_not_exist.snap
@@ -22,7 +22,7 @@ chain_info:
   key_binding_fee: 0.01 wxHOPR
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
-  network: jura
+  network: rotsee
   contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\"}"
   expected_block_time: "5"
   finality: "8"

--- a/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_reannounce_when_existing_account_has_no_multiaddresses.snap
+++ b/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_reannounce_when_existing_account_has_no_multiaddresses.snap
@@ -47,7 +47,7 @@ chain_info:
   key_binding_fee: 0.01 wxHOPR
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
-  network: jura
+  network: rotsee
   contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\"}"
   expected_block_time: "5"
   finality: "8"

--- a/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_register_safe.snap
+++ b/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_register_safe.snap
@@ -29,7 +29,7 @@ chain_info:
   key_binding_fee: 0.01 wxHOPR
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
-  network: jura
+  network: rotsee
   contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\"}"
   expected_block_time: "5"
   finality: "8"

--- a/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_register_safe_that_has_nodes_registered_already.snap
+++ b/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_register_safe_that_has_nodes_registered_already.snap
@@ -30,7 +30,7 @@ chain_info:
   key_binding_fee: 0.01 wxHOPR
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
-  network: jura
+  network: rotsee
   contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\"}"
   expected_block_time: "5"
   finality: "8"

--- a/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_withdraw.snap
+++ b/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_withdraw.snap
@@ -32,7 +32,7 @@ chain_info:
   key_binding_fee: 0.01 wxHOPR
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
-  network: jura
+  network: rotsee
   contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\"}"
   expected_block_time: "5"
   finality: "8"

--- a/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_close_incoming_channel.snap
+++ b/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_close_incoming_channel.snap
@@ -81,7 +81,7 @@ chain_info:
   key_binding_fee: 0.01 wxHOPR
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
-  network: jura
+  network: rotsee
   contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\"}"
   expected_block_time: "5"
   finality: "8"

--- a/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_finalize_channel_closure.snap
+++ b/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_finalize_channel_closure.snap
@@ -81,7 +81,7 @@ chain_info:
   key_binding_fee: 0.01 wxHOPR
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
-  network: jura
+  network: rotsee
   contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\"}"
   expected_block_time: "5"
   finality: "8"

--- a/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_fund_channel.snap
+++ b/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_fund_channel.snap
@@ -81,7 +81,7 @@ chain_info:
   key_binding_fee: 0.01 wxHOPR
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
-  network: jura
+  network: rotsee
   contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\"}"
   expected_block_time: "5"
   finality: "8"

--- a/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_initiate_channel_closure.snap
+++ b/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_initiate_channel_closure.snap
@@ -81,7 +81,7 @@ chain_info:
   key_binding_fee: 0.01 wxHOPR
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
-  network: jura
+  network: rotsee
   contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\"}"
   expected_block_time: "5"
   finality: "8"

--- a/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_open_channel.snap
+++ b/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_open_channel.snap
@@ -81,7 +81,7 @@ chain_info:
   key_binding_fee: 0.01 wxHOPR
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
-  network: jura
+  network: rotsee
   contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\"}"
   expected_block_time: "5"
   finality: "8"

--- a/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__safe__tests__connector_should_query_existing_safe.snap
+++ b/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__safe__tests__connector_should_query_existing_safe.snap
@@ -27,7 +27,7 @@ chain_info:
   key_binding_fee: 0.01 wxHOPR
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
-  network: jura
+  network: rotsee
   contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\"}"
   expected_block_time: "5"
   finality: "8"

--- a/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_on_closed_channel.snap
+++ b/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_on_closed_channel.snap
@@ -81,7 +81,7 @@ chain_info:
   key_binding_fee: 0.01 wxHOPR
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
-  network: jura
+  network: rotsee
   contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\"}"
   expected_block_time: "5"
   finality: "8"

--- a/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_on_non_existing_channel.snap
+++ b/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_on_non_existing_channel.snap
@@ -80,7 +80,7 @@ chain_info:
   key_binding_fee: 0.01 wxHOPR
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
-  network: jura
+  network: rotsee
   contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\"}"
   expected_block_time: "5"
   finality: "8"

--- a/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_amount_higher_than_channel_stake.snap
+++ b/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_amount_higher_than_channel_stake.snap
@@ -80,7 +80,7 @@ chain_info:
   key_binding_fee: 0.01 wxHOPR
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
-  network: jura
+  network: rotsee
   contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\"}"
   expected_block_time: "5"
   finality: "8"

--- a/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_old_index.snap
+++ b/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_old_index.snap
@@ -80,7 +80,7 @@ chain_info:
   key_binding_fee: 0.01 wxHOPR
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
-  network: jura
+  network: rotsee
   contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\"}"
   expected_block_time: "5"
   finality: "8"

--- a/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_previous_epoch.snap
+++ b/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_previous_epoch.snap
@@ -80,7 +80,7 @@ chain_info:
   key_binding_fee: 0.01 wxHOPR
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
-  network: jura
+  network: rotsee
   contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\"}"
   expected_block_time: "5"
   finality: "8"

--- a/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_redeem_ticket.snap
+++ b/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_redeem_ticket.snap
@@ -81,7 +81,7 @@ chain_info:
   key_binding_fee: 0.01 wxHOPR
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
-  network: jura
+  network: rotsee
   contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\"}"
   expected_block_time: "5"
   finality: "8"

--- a/chain/connector/src/testing/mod.rs
+++ b/chain/connector/src/testing/mod.rs
@@ -256,6 +256,7 @@ impl BlokliTestStateBuilder {
     #[must_use]
     pub fn with_chain_info(mut self, info: ChainInfo) -> Self {
         self.0.chain_info.chain_id = info.chain_id as i32;
+        self.0.chain_info.network = info.hopr_network_name;
         self.0.chain_info.contract_addresses = blokli_client::api::types::ContractAddressMap(
             serde_json::to_string(&info.contract_addresses).expect("failed to serialize contract addresses"),
         );
@@ -268,6 +269,7 @@ impl BlokliTestStateBuilder {
     #[must_use]
     pub fn with_hopr_network_chain_info(mut self, name: &str) -> Self {
         let (chain_id, addrs) = contract_addresses_for_network(name).expect("network name not found");
+        self.0.chain_info.network = name.to_string();
         self.0.chain_info.contract_addresses = blokli_client::api::types::ContractAddressMap(
             serde_json::to_string(&addrs).expect("failed to serialize contract addresses"),
         );

--- a/justfile
+++ b/justfile
@@ -85,4 +85,4 @@ test:
     cargo clippy --workspace --all-targets -- -D warnings
     echo ""
     echo "==> Running unit & integration tests..."
-    cargo test
+    cargo test --test '*' -- --test-threads=1


### PR DESCRIPTION
- updates the `rand` crate to 0.10.0
- removes sealing feature that requires old crypto_box version (dependent on older version of `rand`)

Refs #7172