### PR TITLE
feat(hoprd): Fix fmt usage on macOS

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,6 @@
 watch_file nix/*.nix
 watch_file rust-toolchain.toml
+watch_file rust-toolchain-nightly.toml
 use flake
 
 PATH_add .cargo/bin

--- a/flake.lock
+++ b/flake.lock
@@ -167,11 +167,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770570707,
-        "narHash": "sha256-+vkNUOcjsxONeUQCDqV5wQR4v8hsKXblBlPeSUzcxjk=",
+        "lastModified": 1771192249,
+        "narHash": "sha256-HU7V/HdlbRtnggV0LZGGYql+rCj0x3vQfzaU+sIbDJQ=",
         "owner": "hoprnet",
         "repo": "hopli",
-        "rev": "0be9d19053cac2037eeaac67337a52c03c2d339b",
+        "rev": "b05e25dd9b5cbc92377b7d06b465036a16804086",
         "type": "github"
       },
       "original": {
@@ -220,11 +220,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1770806083,
-        "narHash": "sha256-1+SdZMUM61Q/Wq/Zftnm8bV/LfugxDTfjTwx5FoRNqw=",
+        "lastModified": 1771301150,
+        "narHash": "sha256-Acmg3PJ8RoSbZ7ItvQA27G9kdMqj7pcFvqumQBfaqNc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d79dfb1c7f39e5e06d200aa2654f46d50ade2bde",
+        "rev": "39991f2e8c08bec259a7b17153ff081a3790efe4",
         "type": "github"
       },
       "original": {
@@ -236,11 +236,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1770807129,
-        "narHash": "sha256-zbyJMzPYPGJe/JWWpz/HvVAjqLuVjmxPas+IMuaLjYU=",
+        "lastModified": 1771314354,
+        "narHash": "sha256-k1wpOF8nE8aNyWhGRc89BDWAt6r6HyJP1ntXnC3nfkE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "4100faef51d187e69cfaefe2605db78015d2c22e",
+        "rev": "cef509e45653a28f4ab089b66ede8bacb3f473ad",
         "type": "github"
       },
       "original": {
@@ -295,11 +295,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770779462,
-        "narHash": "sha256-ykcXTKtV+dOaKlOidAj6dpewBHjni9/oy/6VKcqfzfY=",
+        "lastModified": 1771297684,
+        "narHash": "sha256-wieWskQxZLPlNXX06JEB0bMoS/ZYQ89xBzF0RL9lyLs=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "8a53b3ade61914cdb10387db991b90a3a6f3c441",
+        "rev": "755d3669699a7c62aef35af187d75dc2728cfd85",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain-nightly.toml
+++ b/rust-toolchain-nightly.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly-2026-01-08"
+channel = "nightly-2026-02-12"
 profile = "default"
 components = ["cargo", "clippy", "rust-src", "rustfmt"]


### PR DESCRIPTION
The different approaches are needed to make both the nightly devshell and `nix fmt` work.