### PR TITLE
feat: allow configuring the minimum acceptable incoming ticket price

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4915,7 +4915,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-hopr"
-version = "4.2.0"
+version = "4.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/hoprd/hoprd/example_cfg.yaml
+++ b/hoprd/hoprd/example_cfg.yaml
@@ -144,6 +144,11 @@ hopr:
     # Outgoing ticket winning probability.
     # Should not be lower than the minimum ticket winning probability set on-chain
     # outgoing_ticket_winning_prob: 1.0
+    #
+    # Minimum incoming ticket price.
+    # The value cannot be lower than the minimum network ticket price multiplied by the node's path position,
+    # and will default to that value whenever it is lower.
+    # min_incoming_ticket_price: "1 wxHOPR"
 
 # Session Entry/Exit IP forwarding configuration for this node
 # This applies whenever the node is an Exit node of a Session.

--- a/hoprd/hoprd/src/config.rs
+++ b/hoprd/hoprd/src/config.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashSet, net::SocketAddr, time::Duration};
 
 use hopr_lib::{
-    HoprProtocolConfig, SafeModule, WinningProbability,
+    HoprBalance, HoprProtocolConfig, SafeModule, WinningProbability,
     config::{
         HoprLibConfig, HoprPacketPipelineConfig, HostConfig, HostType, ProbeConfig, SessionGlobalConfig,
         TransportConfig,
@@ -160,6 +160,12 @@ pub struct UserHoprNetworkConfig {
     #[default(default_outgoing_ticket_winning_prob())]
     #[serde(default = "default_outgoing_ticket_winning_prob")]
     pub outgoing_ticket_winning_prob: Option<f64>,
+    /// Minimum incoming ticket price.
+    ///
+    /// The value cannot be lower than the minimum network ticket price multiplied by the node's path position,
+    /// and will default to that value whenever it is lower.
+    #[serde(default)]
+    pub min_incoming_ticket_price: Option<HoprBalance>,
 }
 
 /// Subset of the [`HoprLibConfig`] that is tuned to be user-facing and more user-friendly.
@@ -209,6 +215,7 @@ impl From<UserHoprLibConfig> for HoprLibConfig {
                             .network
                             .outgoing_ticket_winning_prob
                             .and_then(|v| WinningProbability::try_from_f64(v).ok()),
+                        min_incoming_ticket_price: value.network.min_incoming_ticket_price,
                         ..Default::default()
                     },
                     ..Default::default()

--- a/protocols/hopr/Cargo.toml
+++ b/protocols/hopr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-protocol-hopr"
-version = "4.2.0"
+version = "4.3.0"
 edition = "2024"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Contains implementation of the HOPR protocol as specified in RFC-0004 & RFC-0005"

--- a/protocols/hopr/src/codec/decoder.rs
+++ b/protocols/hopr/src/codec/decoder.rs
@@ -97,7 +97,8 @@ where
                 .await
                 .map_err(|e| HoprProtocolError::ResolverError(e.into()))?
                 .mul(U256::from(fwd.path_pos))
-        });
+        })
+        .max(self.cfg.min_incoming_ticket_price.unwrap_or_default());
 
         let remaining_balance = trace_timed!("unrealized_balance lookup", {
             incoming_channel.balance.sub(

--- a/protocols/hopr/src/codec/mod.rs
+++ b/protocols/hopr/src/codec/mod.rs
@@ -23,6 +23,18 @@ pub struct HoprCodecConfig {
         serde_as(as = "Option<serde_with::DisplayFromStr>")
     )]
     pub outgoing_ticket_price: Option<hopr_primitive_types::balance::HoprBalance>,
+    /// Optional minimum price of incoming tickets.
+    ///
+    /// The value cannot be lower than the default outgoing ticket price times the node's path position.
+    ///
+    /// If not set (default), the network default outgoing ticket price times the node's path position
+    /// will be used.
+    #[cfg_attr(
+        feature = "serde",
+        serde(default),
+        serde_as(as = "Option<serde_with::DisplayFromStr>")
+    )]
+    pub min_incoming_ticket_price: Option<hopr_primitive_types::balance::HoprBalance>,
     /// Optional probability of winning an outgoing ticket.
     ///
     /// If not set (default), the network default will be used, which is the minimum allowed winning probability in the

--- a/transport/protocol/tests/common/mod.rs
+++ b/transport/protocol/tests/common/mod.rs
@@ -159,6 +159,7 @@ pub async fn peer_setup_for(
 
         let codec_config = HoprCodecConfig {
             outgoing_ticket_price: Some(*DEFAULT_PRICE_PER_PACKET),
+            min_incoming_ticket_price: None,
             outgoing_win_prob: Some(WinningProbability::ALWAYS),
         };
 


### PR DESCRIPTION
When the new `min_incoming_ticket_price` is set, it allows overriding the default expected incoming ticket price (network ticket price * path position). The override happens only if higher than network ticket price * path position.

Closes #7771