### PR TITLE
chore: unpin libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,7 @@ k256 = { version = "0.13.4", features = [
   "serde",
 ] }
 lazy_static = "1.5.0"
-libc = "0.2"
+libc = "0.2" # Intentionally unpinned to 0.2
 libp2p = { version = "0.56.0" }
 libp2p-identity = { version = "0.2.13", features = [
   "peerid",


### PR DESCRIPTION
This allows downstream libraries use their own version of libc 0.2