### PR TITLE
fix(ci): Update macOS runners to macos-15

### DIFF
--- a/.github/workflows/build-binaries.yaml
+++ b/.github/workflows/build-binaries.yaml
@@ -35,10 +35,10 @@ on:
         type: choice
         options:
           - self-hosted-hoprnet-bigger
-          - macos-13
-          - macos-14
+          - macos-15-xlarge
+          - macos-15-intel
         required: true
-        description: 'GH Runner to use: macos-13=x86_64-darwin and macos-14=aarch64-darwin'
+        description: 'GH Runner to use: macos-15-xlarge=aarch64-darwin and macos-15-intel=x86_64-darwin'
       target:
         type: choice
         options:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,9 +69,9 @@ jobs:
           - name: aarch64-linux
             runner: self-hosted-hoprnet-bigger
           - name: aarch64-darwin
-            runner: macos-14 # M1 machine
+            runner: macos-15-xlarge # Uses Apple Silicon M2 hardware 5vCPU, 14GB RAM and 14GB SSD. 8-core GPU
           - name: x86_64-darwin
-            runner: macos-13 # Intel machine
+            runner: macos-15-intel # Uses Intel hardware 4vCPU, 14GB RAM and 14GB SSD
     name: ${{ matrix.binary }}-${{ matrix.target.name }}
     uses: ./.github/workflows/build-binaries.yaml
     with:


### PR DESCRIPTION
Replaces deprecated `macos-13` and `macos-14` runners with `macos-15-intel` and `macos-15-xlarge`.