### PR TITLE
feat: add custom tx timeout multiplier for individual tx types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.16.0"
+version = "0.17.0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/chain/connector/Cargo.toml
+++ b/chain/connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-chain-connector"
-version = "0.16.0"
+version = "0.17.0"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["HOPR Association <tech@hoprnet.org>"]

--- a/chain/connector/src/connector/accounts.rs
+++ b/chain/connector/src/connector/accounts.rs
@@ -166,7 +166,7 @@ where
             .map_err(AnnouncementError::processing)?;
 
         Ok(self
-            .send_tx(tx_req)
+            .send_tx(tx_req, None)
             .map_err(AnnouncementError::processing)
             .await?
             .boxed())
@@ -181,7 +181,7 @@ where
 
         let tx_req = self.payload_generator.transfer(*recipient, balance)?;
 
-        Ok(self.send_tx(tx_req).await?.boxed())
+        Ok(self.send_tx(tx_req, None).await?.boxed())
     }
 
     async fn register_safe(
@@ -230,7 +230,7 @@ where
             .map_err(SafeRegistrationError::processing)?;
 
         Ok(self
-            .send_tx(tx_req)
+            .send_tx(tx_req, None)
             .map_err(SafeRegistrationError::processing)
             .await?
             .boxed())

--- a/chain/connector/src/connector/channels.rs
+++ b/chain/connector/src/connector/channels.rs
@@ -140,7 +140,7 @@ where
         let tx_req = self.payload_generator.fund_channel(*dst, amount)?;
         tracing::debug!( %dst, %amount, "opening channel");
 
-        Ok(self.send_tx(tx_req).await?.boxed())
+        Ok(self.send_tx(tx_req, None).await?.boxed())
     }
 
     async fn fund_channel<'a>(
@@ -159,7 +159,7 @@ where
         let tx_req = self.payload_generator.fund_channel(channel.destination, amount)?;
         tracing::debug!(%channel_id, %amount, "funding channel");
 
-        Ok(self.send_tx(tx_req).await?.boxed())
+        Ok(self.send_tx(tx_req, None).await?.boxed())
     }
 
     async fn close_channel<'a>(
@@ -204,7 +204,7 @@ where
             _ => return Err(ConnectorError::InvalidState("channel closure time has not elapsed")),
         };
 
-        Ok(self.send_tx(tx_req).await?.boxed())
+        Ok(self.send_tx(tx_req, None).await?.boxed())
     }
 }
 

--- a/chain/connector/src/connector/mod.rs
+++ b/chain/connector/src/connector/mod.rs
@@ -538,9 +538,12 @@ where
     async fn send_tx<'a>(
         &'a self,
         tx_req: P::TxRequest,
+        custom_tx_multiplier: Option<u32>,
     ) -> Result<impl Future<Output = Result<ChainReceipt, ConnectorError>> + Send + 'a, ConnectorError> {
         let chain_info = self.query_cached_chain_info().await?;
-        let tx_timeout = self.cfg.tx_timeout_multiplier.max(1) * chain_info.finality * chain_info.expected_block_time;
+        let tx_timeout = custom_tx_multiplier.unwrap_or(self.cfg.tx_timeout_multiplier).max(1)
+            * chain_info.finality
+            * chain_info.expected_block_time;
         Ok(self
             .sequencer
             .enqueue_transaction(tx_req, tx_timeout.max(MIN_TX_CONFIRM_TIMEOUT))

--- a/chain/connector/src/connector/safe.rs
+++ b/chain/connector/src/connector/safe.rs
@@ -58,6 +58,8 @@ where
     }
 }
 
+const DEPLOY_SAFE_CUSTOM_TX_TIMEOUT_MULTIPLIER: u32 = 8;
+
 #[async_trait::async_trait]
 impl<B, C, P> hopr_api::chain::ChainWriteSafeOperations for HoprBlockchainConnector<C, B, P, P::TxRequest>
 where
@@ -91,7 +93,10 @@ where
                 .deploy_safe(balance, &[admin], true, hopr_types::crypto_random::random_bytes())?;
         tracing::debug!(%balance, %admin, "deploying safe");
 
-        Ok(self.send_tx(tx_req).await?.boxed())
+        Ok(self
+            .send_tx(tx_req, DEPLOY_SAFE_CUSTOM_TX_TIMEOUT_MULTIPLIER.into())
+            .await?
+            .boxed())
     }
 }
 

--- a/chain/connector/src/connector/tickets.rs
+++ b/chain/connector/src/connector/tickets.rs
@@ -106,7 +106,7 @@ where
         match self.prepare_ticket_redeem_payload(ticket).await {
             Ok(tx_req) => {
                 Ok(self
-                    .send_tx(tx_req)
+                    .send_tx(tx_req, None)
                     .await
                     .map_err(|e| TicketRedeemError::ProcessingError(ticket.ticket, e))?
                     .map_err(move |tx_tracking_error|


### PR DESCRIPTION
Individual transactions my require different finalities.

Currently, different finality is used only for Safe deployment. Additional tweaking can be done later.