### PR TITLE
build: Close release 3.0.1

### DIFF
--- a/docs/changelog/changelog-3.0.1.md
+++ b/docs/changelog/changelog-3.0.1.md
@@ -2,13 +2,17 @@ What's changed
 
 ### 🚀 New Features
 
-* feat(ci): Add support for docker-compose healthchecks by @ausias-armesto in #7621
+* feat(hopr-lib): reorganize the API for easier edgli and gnosis_vpn-client usage by @Teebor-Choka in #7522
 * feat: add timeouts to channels, packet processing, improve channel capacity by @NumberFour8 in #7601
+* feat(ci): Add support for docker-compose healthchecks by @ausias-armesto in #7621
+* feat: increase gas parameter to cope with current onchain gas situation by @jeandemeusy in #7883
 
 
 ### 🐞 Fixes
 
-* fix(hopr-lib): backport network registry changes by @Teebor-Choka in #7564
 * fix(hoprd): incorrectly parsed configuration overrides by @Teebor-Choka in #7529
-
-
+* fix: verbose metrics by @ausias-armesto in #7553
+* fix(hopr-lib): backport network registry changes by @Teebor-Choka in #7564
+* fix(hopr-lib): cherry-pick wrong rotsee winprob contract address by @QYuQianchen in #7563
+* fix: Add support for network health checking into readiness and healthiness by @Teebor-Choka in #7597
+* fix: resetting ticket states by @NumberFour8 in #7619


### PR DESCRIPTION
This Pull requests contains all the required changes needed before releasing a new version.

- [ ] Assess that all CI checks have passed successfully and wait for the docker images builds to finish.
- [ ] Get the approval from at least 2 members
- [ ] Check that binary x86_64-linux works correctly by setting up a node on that architecture and platform
- [ ] Check that binary aarch64-linux works correctly by setting up a node on that architecture and platform
- [ ] Check that binary aarch64-darwin works correctly by setting up a node on that architecture and platform
- [ ] Check that binary x86_64-darwin works correctly by setting up a node on that architecture and platform
- [ ] Create a new baseline for load testing following [Load testing guide](https://github.com/hoprnet/hoprnet/blob/master/.processes/release.md#load-testing).
