### PR TITLE
fix(nix): add CA certifactes to docker image

### DIFF
--- a/nix/docker-builder.nix
+++ b/nix/docker-builder.nix
@@ -10,8 +10,8 @@
 }:
 let
   libPath = pkgs.lib.makeLibraryPath [ pkgs.openssl ];
-  caBundlePath = "/etc/ssl/certs/ca-bundle.crt";
-  caCertsDir = "/etc/ssl/certs";
+  caBundlePath = "${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt";
+  caCertsDir = "${pkgs.cacert}/etc/ssl/certs";
   contents =
     with pkgs;
     [


### PR DESCRIPTION
CA certifactes are missing in the docker image, leading into failing https requests.