### PR TITLE
fix: add security advisory exception for RUSTSEC-2026-0037 for quinn-proto

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -10,6 +10,7 @@ ignore = [
   "RUSTSEC-2025-0140", # `gix-date` stems from `vergen-gix` which has no new major release just yet
   "RUSTSEC-2025-0137", # `alloy` - held back until removed, see https://github.com/hoprnet/hoprnet/issues/7707
   "RUSTSEC-2026-0002", # `lru` warning, fixed once `libp2p` is updated and `alloy` removed, see #7707
+  "RUSTSEC-2026-0037", # `quinn-proto` in `libp2p-quic`
 ]
 informational_warnings = ["unmaintained"]
 severity_threshold = "low"


### PR DESCRIPTION
This pull request makes a minor update to the `.cargo/audit.toml` configuration file by adding a new security advisory to the list of ignored advisories. This helps prevent build failures due to known issues in dependencies that are not yet resolved upstream.

- Dependency audit configuration:
  * Added `RUSTSEC-2026-0037` (related to `quinn-proto` in `libp2p-quic`) to the ignored advisories list in `.cargo/audit.toml`.