### PR TITLE
fix: bump rustls-webpki and fix treefmt formatting

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -24,12 +24,12 @@ jobs:
           - architecture: aarch64-linux
             runner: self-hosted-hoprnet-bigger
             build_command: nix build -L .#binary-hoprd-aarch64-linux
-          # - architecture: x86_64-darwin
-          #   runner: macos-15-intel
-          #   build_command: nix build -L .#binary-hoprd-x86_64-darwin
-          # - architecture: aarch64-darwin
-          #   runner: macos-15-xlarge
-          #   build_command: nix build -L .#binary-hoprd-aarch64-darwin
+            # - architecture: x86_64-darwin
+            #   runner: macos-15-intel
+            #   build_command: nix build -L .#binary-hoprd-x86_64-darwin
+            # - architecture: aarch64-darwin
+            #   runner: macos-15-xlarge
+            #   build_command: nix build -L .#binary-hoprd-aarch64-darwin
     uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@build-binaries-v2
     permissions:
       contents: read

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2525,7 +2525,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -6595,7 +6595,7 @@ dependencies = [
  "rcgen",
  "ring",
  "rustls 0.23.37",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "thiserror 2.0.18",
  "x509-parser",
  "yasna",
@@ -8768,7 +8768,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -8828,9 +8828,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/flake.nix
+++ b/flake.nix
@@ -165,12 +165,11 @@
           fixUtoipaEmbedPaths =
             drv:
             drv.overrideAttrs (old: {
-              preBuild =
-                ''
-                  find target -name 'embed.rs' -path '*/utoipa-swagger-ui*/out/*' \
-                    -exec sed -i "s|/nix/var/nix/builds/[^/]*/source|$(pwd)|g" {} \;
-                ''
-                + (old.preBuild or "");
+              preBuild = ''
+                find target -name 'embed.rs' -path '*/utoipa-swagger-ui*/out/*' \
+                  -exec sed -i "s|/nix/var/nix/builds/[^/]*/source|$(pwd)|g" {} \;
+              ''
+              + (old.preBuild or "");
             });
 
           hoprdPackages = {
@@ -259,7 +258,6 @@
                 }
               )
             );
-
 
             hoprd-clippy = rust-builder-local.callPackage nixLib.mkRustPackage (
               projectBuildArgs // { runClippy = true; }


### PR DESCRIPTION
## Summary
- Bump `rustls-webpki` 0.103.9 -> 0.103.10 to resolve RUSTSEC-2026-0049 (CRL distribution point matching logic vulnerability)
- Fix `flake.nix` indentation in `fixUtoipaEmbedPaths` and remove extra blank line before `hoprd-clippy`
- Fix `merge.yaml` commented-out matrix entries indentation

These are pre-existing issues on master that cause audit and lint CI failures.

## Test plan
- [ ] Audit check passes (no `rustls-webpki` vulnerability)
- [ ] Lint check passes (`nix run .#check` succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)