### PR TITLE
feat: Automate deployment on Gnosis infrastructure 

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -7,7 +7,7 @@ on:
   pull_request:
     types:
       - closed
-      - synchronize
+      # - synchronize
 concurrency:
   group: merge-${{ github.event.pull_request.base.ref }}
   cancel-in-progress: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,23 +27,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  deploy-dev:
-    name: Deploy Gnosis Dev
-    runs-on: self-hosted-hoprnet-small
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - name: Restart Hoprd
-        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
-        with:
-          token: ${{ secrets.GNOSIS_GITHUB_WORKFLOW_TOKEN }}
-          repository: gnosis/gnosis_vpn-infrastructure
-          event-type: restart_hoprd
-          client-payload: |-
-            {
-              "environment": "dev"
-            }
   validate-pr-title:
     name: Validate title
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
Automates the deployment of the new docker build image in Gnosis infrastrcuture.
- On PR merge, it will restart the Gnosis dev environment triggering to pull the latest build
- On close release, it will restart the Gnosis staging environment triggering to pull the latest release.
- Fixes error handling in justfile
- Adds vault and ssh management