### PR TITLE
fix: prevent dropped chain events from negative caching and subscribe race

### DIFF
--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -1234,17 +1234,18 @@ where
 
         let channel_id = generate_channel_id(&self.me_onchain(), destination);
 
-        let confirm_awaiter = self
-            .chain_api
-            .open_channel(destination, amount)
-            .await
-            .map_err(HoprLibError::chain)?;
-
+        // Subscribe to chain events BEFORE sending the transaction to avoid
+        // a race where the event is broadcast before the subscriber activates.
         let (event_awaiter, event_abort) = self.spawn_wait_for_on_chain_event(
             format!("open channel to {destination} ({channel_id})"),
             move |event| matches!(event, ChainEvent::ChannelOpened(c) if c.get_id() == &channel_id),
             ON_CHAIN_RESOLUTION_EVENT_TIMEOUT,
         )?;
+
+        let confirm_awaiter = self.chain_api.open_channel(destination, amount).await.map_err(|e| {
+            event_abort.abort();
+            HoprLibError::chain(e)
+        })?;
 
         let tx_hash = confirm_awaiter.await.map_err(|e| {
             event_abort.abort();
@@ -1262,17 +1263,18 @@ where
 
         let channel_id = *channel_id;
 
-        let confirm_awaiter = self
-            .chain_api
-            .fund_channel(&channel_id, amount)
-            .await
-            .map_err(HoprLibError::chain)?;
-
+        // Subscribe to chain events BEFORE sending the transaction to avoid
+        // a race where the event is broadcast before the subscriber activates.
         let (event_awaiter, event_abort) = self.spawn_wait_for_on_chain_event(
             format!("fund channel {channel_id}"),
             move |event| matches!(event, ChainEvent::ChannelBalanceIncreased(c, a) if c.get_id() == &channel_id && a == &amount),
             ON_CHAIN_RESOLUTION_EVENT_TIMEOUT
         )?;
+
+        let confirm_awaiter = self.chain_api.fund_channel(&channel_id, amount).await.map_err(|e| {
+            event_abort.abort();
+            HoprLibError::chain(e)
+        })?;
 
         let res = confirm_awaiter.await.map_err(|e| {
             event_abort.abort();
@@ -1290,12 +1292,8 @@ where
 
         let channel_id = *channel_id;
 
-        let confirm_awaiter = self
-            .chain_api
-            .close_channel(&channel_id)
-            .await
-            .map_err(HoprLibError::chain)?;
-
+        // Subscribe to chain events BEFORE sending the transaction to avoid
+        // a race where the event is broadcast before the subscriber activates.
         let (event_awaiter, event_abort) = self.spawn_wait_for_on_chain_event(
             format!("close channel {channel_id}"),
             move |event| {
@@ -1304,6 +1302,11 @@ where
             },
             ON_CHAIN_RESOLUTION_EVENT_TIMEOUT,
         )?;
+
+        let confirm_awaiter = self.chain_api.close_channel(&channel_id).await.map_err(|e| {
+            event_abort.abort();
+            HoprLibError::chain(e)
+        })?;
 
         let tx_hash = confirm_awaiter.await.map_err(|e| {
             event_abort.abort();


### PR DESCRIPTION
## Summary

Refs #8000

- **Subscribe-before-transaction race**: Ported fix from PR #7963 — in `open_channel`, `fund_channel`, and `close_channel_by_id`, the chain event subscriber is set up before sending the transaction. Early chain API failures now abort the event waiter to avoid leaking stray tasks.