### PR TITLE
feat: update blokli-client and use on-chain redeem stats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1560,7 +1560,7 @@ dependencies = [
 [[package]]
 name = "blokli-client"
 version = "0.23.0"
-source = "git+https://github.com/hoprnet/blokli?branch=lukas%2Fadd-redeem-stats-to-testing#ab2f5aed6daef7362d0ce29ba516a5de8a888596"
+source = "git+https://github.com/hoprnet/blokli?branch=lukas%2Fadd-redeem-stats-to-testing#2a1fcb8048ac65798cdb319a9052405ed1d4acb9"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1572,7 +1572,7 @@ dependencies = [
  "futures",
  "futures-time",
  "hex",
- "hopr-types 1.5.2",
+ "hopr-types 1.5.4",
  "indexmap 2.14.0",
  "parking_lot",
  "rand 0.9.2",
@@ -1740,9 +1740,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -5099,51 +5099,6 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "1.5.2"
-source = "git+https://github.com/hoprnet/hopr-types?branch=main#981e9c8b321c6c4cddcb8b9ce9eb8f04a53223b1"
-dependencies = [
- "aes",
- "aquamarine",
- "async-trait",
- "bigdecimal",
- "blake3",
- "chacha20 0.9.1",
- "chrono",
- "cipher",
- "ctr",
- "curve25519-dalek",
- "digest 0.10.7",
- "ed25519-dalek",
- "float-cmp",
- "generic-array 1.3.5",
- "hex",
- "hex-literal",
- "k256",
- "lazy_static",
- "libp2p-identity",
- "multiaddr",
- "num_enum",
- "poly1305",
- "primitive-types 0.14.0",
- "rand 0.10.0",
- "rayon",
- "regex",
- "secp256k1 0.31.1",
- "serde",
- "serde_bytes",
- "sha2",
- "sha3",
- "smart-default",
- "strum 0.28.0",
- "subtle",
- "thiserror 2.0.18",
- "tracing",
- "typenum",
- "zeroize",
-]
-
-[[package]]
-name = "hopr-types"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3efb3f42c72ab2b00945ba3bd581131a2679fb3f3672940828730d402d8733a3"
@@ -5180,6 +5135,51 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_with",
+ "sha2",
+ "sha3",
+ "smart-default",
+ "strum 0.28.0",
+ "subtle",
+ "thiserror 2.0.18",
+ "tracing",
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
+name = "hopr-types"
+version = "1.5.4"
+source = "git+https://github.com/hoprnet/hopr-types?branch=main#1aedd842f80316910cbb28b88a08da68d590b922"
+dependencies = [
+ "aes",
+ "aquamarine",
+ "async-trait",
+ "bigdecimal",
+ "blake3",
+ "chacha20 0.9.1",
+ "chrono",
+ "cipher",
+ "ctr",
+ "curve25519-dalek",
+ "digest 0.10.7",
+ "ed25519-dalek",
+ "float-cmp",
+ "generic-array 1.3.5",
+ "hex",
+ "hex-literal",
+ "k256",
+ "lazy_static",
+ "libp2p-identity",
+ "multiaddr",
+ "num_enum",
+ "poly1305",
+ "primitive-types 0.14.0",
+ "rand 0.10.0",
+ "rayon",
+ "regex",
+ "secp256k1 0.31.1",
+ "serde",
+ "serde_bytes",
  "sha2",
  "sha3",
  "smart-default",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1560,7 +1560,7 @@ dependencies = [
 [[package]]
 name = "blokli-client"
 version = "0.23.1"
-source = "git+https://github.com/hoprnet/blokli?branch=lukas%2Ffix-default-redeemed-stats#c593ba5d4e7f7b5b8bba7b955e518a9ee2505cf0"
+source = "git+https://github.com/hoprnet/blokli?branch=main#e17923466742921800f8da17258b83ba334149d8"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6024,9 +6024,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -10410,9 +10410,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -10423,9 +10423,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10433,9 +10433,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -10443,9 +10443,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -10456,9 +10456,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -10526,9 +10526,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.31"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9d22005bf31b018f31ef9ecadb5d2c39cf4f6acc8db0456f72c815f3d7f757"
+checksum = "f4e9e31d834fe25fe991b8884e4b9f0e59db4a97d86e05d1464d6899c013cd62"
 dependencies = [
  "alloy-primitives",
  "num_enum",
@@ -139,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c0dc44157867da82c469c13186015b86abef209bf0e41625e4b68bac61d728"
+checksum = "7f16daaf7e1f95f62c6c3bf8a3fc3d78b08ae9777810c0bb5e94966c7cd57ef0"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba4cdb42df3871cd6b346d6a938ec2ba69a9a0f49d1f82714bc5c48349268434"
+checksum = "118998d9015332ab1b4720ae1f1e3009491966a0349938a1f43ff45a8a4c6299"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -180,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca63b7125a981415898ffe2a2a696c83696c9c6bdb1671c8a912946bbd8e49e7"
+checksum = "7ac9e0c34dc6bce643b182049cdfcca1b8ce7d9c260cbdd561f511873b7e26cd"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -198,6 +198,7 @@ dependencies = [
  "futures-util",
  "serde_json",
  "thiserror 2.0.18",
+ "tracing",
 ]
 
 [[package]]
@@ -226,7 +227,7 @@ dependencies = [
  "itoa",
  "serde",
  "serde_json",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -282,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9f7ef09f21bd1e9cb8a686f168cb4a206646804567f0889eadb8dcc4c9288c8"
+checksum = "e6ef28c9fdad22d4eec52d894f5f2673a0895f1e5ef196734568e68c0f6caca8"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -301,14 +302,13 @@ dependencies = [
  "serde",
  "serde_with",
  "sha2",
- "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "alloy-genesis"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c9cf3b99f46615fbf7dc1add0c96553abb7bf88fc9ec70dfbe7ad0b47ba7fe8"
+checksum = "bbf9480307b09d22876efb67d30cadd9013134c21f3a17ec9f93fd7536d38024"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -346,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff42cd777eea61f370c0b10f2648a1c81e0b783066cd7269228aa993afd487f7"
+checksum = "422d110f1c40f1f8d0e5562b0b649c35f345fccb7093d9f02729943dcd1eef71"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -361,9 +361,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cbca04f9b410fdc51aaaf88433cbac761213905a65fe832058bcf6690585762"
+checksum = "7197a66d94c4de1591cdc16a9bcea5f8cccd0da81b865b49aef97b1b4016e0fa"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -387,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d6d15e069a8b11f56bef2eccbad2a873c6dd4d4c81d04dda29710f5ea52f04"
+checksum = "eb82711d59a43fdfd79727c99f270b974c784ec4eb5728a0d0d22f26716c87ef"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -400,9 +400,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091dc8117d84de3a9ac7ec97f2c4d83987e24d485b478d26aa1ec455d7d52f7d"
+checksum = "a9b2fda91b56bb08907cd44c5068130360e027e46a8c17612d386869fa7940be"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -433,7 +433,7 @@ dependencies = [
  "derive_more",
  "foldhash 0.2.0",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "k256",
  "keccak-asm",
@@ -449,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d181c8cc7cf4805d7e589bf4074d56d55064fa1a979f005a45a62b047616d870"
+checksum = "bf6b18b929ef1d078b834c3631e9c925177f3b23ddc6fa08a722d13047205876"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -478,7 +478,7 @@ dependencies = [
  "lru",
  "parking_lot",
  "pin-project",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -490,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e93e50f64a77ad9c5470bf2ad0ca02f228da70c792a8f06634801e202579f35e"
+checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -501,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce8849c74c9ca0f5a03da1c865e3eb6f768df816e67dd3721a398a8a7e398011"
+checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -512,9 +512,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2792758a93ae32a32e9047c843d536e1448044f78422d71bf7d7c05149e103f"
+checksum = "94fcc9604042ca80bd37aa5e232ea1cd851f337e31e2babbbb345bc0b1c30de3"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -522,7 +522,7 @@ dependencies = [
  "alloy-transport-http",
  "futures",
  "pin-project",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "tokio",
@@ -535,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bdcbf9dfd5eea8bfeb078b1d906da8cd3a39c4d4dbe7a628025648e323611f6"
+checksum = "4faad925d3a669ffc15f43b3deec7fbdf2adeb28a4d6f9cf4bc661698c0f8f4b"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -547,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a3100b76987c1b1dc81f3abe592b7edc29e92b1242067a69d65e0030b35cf9"
+checksum = "47df51bedb3e6062cb9981187a51e86d0d64a4de66eb0855e9efe6574b044ddf"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -559,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd720b63f82b457610f2eaaf1f32edf44efffe03ae25d537632e7d23e7929e1a"
+checksum = "3823026d1ed239a40f12364fac50726c8daf1b6ab8077a97212c5123910429ed"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -570,9 +570,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2dc411f13092f237d2bf6918caf80977fc2f51485f9b90cb2a2f956912c8c9"
+checksum = "59c095f92c4e1ff4981d89e9aa02d5f98c762a1980ab66bec49c44be11349da2"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -591,9 +591,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ce1e0dbf7720eee747700e300c99aac01b1a95bb93f493a01e78ee28bb1a37"
+checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -602,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2425c6f314522c78e8198979c8cbf6769362be4da381d4152ea8eefce383535d"
+checksum = "43f447aefab0f1c0649f71edc33f590992d4e122bc35fb9cdbbf67d4421ace85"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -617,9 +617,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ecb71ee53d8d9c3fa7bac17542c8116ebc7a9726c91b1bf333ec3d04f5a789"
+checksum = "f721f4bf2e4812e5505aaf5de16ef3065a8e26b9139ac885862d00b5a55a659a"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -655,7 +655,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -689,7 +689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6df77fea9d6a2a75c0ef8d2acbdfd92286cc599983d3175ccdc170d3433d249"
 dependencies = [
  "serde",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -706,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa186e560d523d196580c48bf00f1bf62e63041f28ecf276acc22f8b27bb9f53"
+checksum = "8098f965442a9feb620965ba4b4be5e2b320f4ec5a3fff6bfa9e1ff7ef42bed1"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -729,14 +729,14 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa501ad58dd20acddbfebc65b52e60f05ebf97c52fa40d1b35e91f5e2da0ad0e"
+checksum = "e8597d36d546e1dab822345ad563243ec3920e199322cb554ce56c8ef1a1e2e7"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
  "itertools 0.14.0",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "serde_json",
  "tower",
  "tracing",
@@ -745,13 +745,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-trie"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d7fd448ab0a017de542de1dcca7a58e7019fe0e7a34ed3f9543ebddf6aceffa"
+checksum = "3f14b5d9b2c2173980202c6ff470d96e7c5e202c65a9f67884ad565226df7fbb"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "arrayvec",
  "derive_more",
  "nybbles",
  "serde",
@@ -762,11 +761,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fa0c53e8c1e1ef4d01066b01c737fb62fc9397ab52c6e7bb5669f97d281b9bc"
+checksum = "d69722eddcdf1ce096c3ab66cf8116999363f734eb36fe94a148f4f71c85da84"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -789,28 +788,13 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "annotate-snippets"
-version = "0.12.13"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fc7650eedcb2fee505aad48491529e408f0e854c2d9f63eb86c1361b9b3f93"
+checksum = "92570a3f9c98e7e84df84b71d0965ac99b1871fcd75a3773a3bd1bad13f64cf7"
 dependencies = [
  "anstyle",
  "memchr",
  "unicode-width",
-]
-
-[[package]]
-name = "anstream"
-version = "0.6.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
-dependencies = [
- "anstyle",
- "anstyle-parse 0.2.7",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is_terminal_polyfill",
- "utf8parse",
 ]
 
 [[package]]
@@ -820,7 +804,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
- "anstyle-parse 1.0.0",
+ "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
@@ -830,18 +814,9 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
-dependencies = [
- "utf8parse",
-]
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
@@ -903,9 +878,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.8.2"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
 ]
@@ -1116,9 +1091,6 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "asn1-rs"
@@ -1247,9 +1219,9 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
 dependencies = [
  "async-io",
  "async-lock",
@@ -1379,7 +1351,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -1587,8 +1559,8 @@ dependencies = [
 
 [[package]]
 name = "blokli-client"
-version = "0.21.1"
-source = "git+https://github.com/hoprnet/blokli#f2c574f93d9beebbd66394bd35b8b47d7602c279"
+version = "0.23.0"
+source = "git+https://github.com/hoprnet/blokli?branch=lukas%2Fadd-redeem-stats-to-testing#ab2f5aed6daef7362d0ce29ba516a5de8a888596"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1600,8 +1572,8 @@ dependencies = [
  "futures",
  "futures-time",
  "hex",
- "hopr-types 1.4.1",
- "indexmap 2.13.0",
+ "hopr-types 1.5.2",
+ "indexmap 2.14.0",
  "parking_lot",
  "rand 0.9.2",
  "reqwest 0.12.28",
@@ -1637,19 +1609,20 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
 dependencies = [
  "borsh-derive",
+ "bytes",
  "cfg_aliases",
 ]
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0686c856aa6aac0c4498f936d7d6a02df690f614c03e4d906d1018062b5c5e2c"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
@@ -1746,9 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.6"
+version = "2.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a0f582957c24870b7bfd12bf562c40b4734b533cafbaf8ded31d6d85f462c01"
+checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
 dependencies = [
  "blst",
  "cc",
@@ -1767,9 +1740,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.56"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebf35691d1bfb0ac386a69bac2fde4dd276fb618cf8bf4f5318fe285e821bb2"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1903,7 +1876,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
- "anstream 1.0.0",
+ "anstream",
  "anstyle",
  "clap_lex",
  "strsim 0.11.1",
@@ -1923,9 +1896,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "clru"
@@ -1947,9 +1920,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compression-codecs"
@@ -2347,7 +2320,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50258ca274346aeee7e6cb180acb54fe1fa792fae36c196b82a6099cb06e4de0"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "lalrpop-util",
  "logos",
 ]
@@ -2376,16 +2349,6 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
-dependencies = [
- "darling_core 0.21.3",
- "darling_macro 0.21.3",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
@@ -2410,21 +2373,6 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "serde",
- "strsim 0.11.1",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_core"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
@@ -2432,6 +2380,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
+ "serde",
  "strsim 0.11.1",
  "syn 2.0.117",
 ]
@@ -2443,17 +2392,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.21.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
-dependencies = [
- "darling_core 0.21.3",
  "quote",
  "syn 2.0.117",
 ]
@@ -2840,20 +2778,20 @@ dependencies = [
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
 dependencies = [
  "log",
 ]
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
+version = "0.11.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
 dependencies = [
- "anstream 0.6.21",
+ "anstream",
  "anstyle",
  "env_filter",
  "log",
@@ -2931,9 +2869,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fastrlp"
@@ -3092,9 +3030,12 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "funty"
@@ -3400,7 +3341,7 @@ dependencies = [
  "gix-utils",
  "itoa",
  "thiserror 2.0.18",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -3481,7 +3422,7 @@ dependencies = [
  "smallvec",
  "thiserror 2.0.18",
  "unicode-bom",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -3728,7 +3669,7 @@ dependencies = [
  "itoa",
  "smallvec",
  "thiserror 2.0.18",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -3825,7 +3766,7 @@ dependencies = [
  "gix-utils",
  "maybe-async",
  "thiserror 2.0.18",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -3857,7 +3798,7 @@ dependencies = [
  "gix-validate",
  "memmap2",
  "thiserror 2.0.18",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -3980,7 +3921,7 @@ dependencies = [
  "gix-fs",
  "libc",
  "parking_lot",
- "signal-hook 0.4.3",
+ "signal-hook 0.4.4",
  "signal-hook-registry",
  "tempfile",
 ]
@@ -4118,7 +4059,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -4137,7 +4078,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -4206,6 +4147,17 @@ dependencies = [
  "foldhash 0.2.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -4355,9 +4307,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.5.2"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d39b7741d84acd7f74221d2fe0e47cc747170a02a0dd57a19efbd280edaf13d8"
+checksum = "81890a313ee4985ca61940b26a8f6750e16679ee9b09024ec5563cf8e9e7586d"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -4365,7 +4317,7 @@ dependencies = [
  "chrono",
  "futures",
  "futures-concurrency",
- "hopr-types 1.5.1",
+ "hopr-types 1.5.3",
  "libp2p-identity",
  "multiaddr",
  "serde",
@@ -4381,7 +4333,7 @@ dependencies = [
  "async-lock",
  "auto_impl",
  "futures",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "tokio",
 ]
 
@@ -4442,7 +4394,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4480,7 +4432,7 @@ dependencies = [
  "anyhow",
  "hex",
  "hopr-platform",
- "hopr-types 1.5.1",
+ "hopr-types 1.5.3",
  "insta",
  "scrypt",
  "serde",
@@ -4504,7 +4456,7 @@ dependencies = [
  "hex-literal",
  "hopr-crypto-sphinx",
  "hopr-parallelize",
- "hopr-types 1.5.1",
+ "hopr-types 1.5.3",
  "lazy_static",
  "mimalloc",
  "parameterized",
@@ -4518,15 +4470,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-crypto-random"
-version = "1.4.1"
-source = "git+https://github.com/hoprnet/hopr-types?branch=main#d434e0723575ed0ac0c01bc8d1800bacb3a31b61"
-dependencies = [
- "generic-array 1.3.5",
- "rand 0.10.0",
-]
-
-[[package]]
 name = "hopr-crypto-sphinx"
 version = "0.12.1"
 dependencies = [
@@ -4536,7 +4479,7 @@ dependencies = [
  "elliptic-curve",
  "generic-array 1.3.5",
  "hex",
- "hopr-types 1.5.1",
+ "hopr-types 1.5.3",
  "k256",
  "parameterized",
  "postcard",
@@ -4545,38 +4488,6 @@ dependencies = [
  "subtle",
  "thiserror 2.0.18",
  "typenum",
-]
-
-[[package]]
-name = "hopr-crypto-types"
-version = "1.4.1"
-source = "git+https://github.com/hoprnet/hopr-types?branch=main#d434e0723575ed0ac0c01bc8d1800bacb3a31b61"
-dependencies = [
- "aes",
- "blake3",
- "chacha20 0.9.1",
- "cipher",
- "ctr",
- "curve25519-dalek",
- "digest 0.10.7",
- "ed25519-dalek",
- "generic-array 1.3.5",
- "hex",
- "hopr-crypto-random",
- "hopr-primitive-types",
- "k256",
- "libp2p-identity",
- "poly1305",
- "primitive-types 0.14.0",
- "secp256k1 0.31.1",
- "serde",
- "serde_bytes",
- "sha2",
- "sha3",
- "subtle",
- "thiserror 2.0.18",
- "typenum",
- "zeroize",
 ]
 
 [[package]]
@@ -4615,29 +4526,6 @@ dependencies = [
  "smart-default",
  "tokio",
  "validator",
-]
-
-[[package]]
-name = "hopr-internal-types"
-version = "1.4.1"
-source = "git+https://github.com/hoprnet/hopr-types?branch=main#d434e0723575ed0ac0c01bc8d1800bacb3a31b61"
-dependencies = [
- "aquamarine",
- "async-trait",
- "hex",
- "hex-literal",
- "hopr-crypto-random",
- "hopr-crypto-types",
- "hopr-primitive-types",
- "multiaddr",
- "num_enum",
- "rayon",
- "serde",
- "serde_bytes",
- "smart-default",
- "strum 0.28.0",
- "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
@@ -4697,7 +4585,7 @@ dependencies = [
  "hex-literal",
  "hopr-api",
  "hopr-statistics",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "insta",
  "parking_lot",
  "petgraph",
@@ -4719,7 +4607,7 @@ dependencies = [
  "hickory-resolver",
  "hopr-async-runtime",
  "hopr-metrics",
- "hopr-types 1.5.1",
+ "hopr-types 1.5.3",
  "lazy_static",
  "libp2p-identity",
  "multiaddr",
@@ -4761,30 +4649,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-primitive-types"
-version = "1.4.1"
-source = "git+https://github.com/hoprnet/hopr-types?branch=main#d434e0723575ed0ac0c01bc8d1800bacb3a31b61"
-dependencies = [
- "bigdecimal",
- "chrono",
- "float-cmp",
- "hex",
- "lazy_static",
- "primitive-types 0.14.0",
- "regex",
- "serde",
- "serde_bytes",
- "sha3",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "hopr-protocol-app"
 version = "1.0.1"
 dependencies = [
  "anyhow",
  "hopr-crypto-packet",
- "hopr-types 1.5.1",
+ "hopr-types 1.5.3",
  "serde",
  "serde_bytes",
  "strum 0.28.0",
@@ -4842,15 +4712,15 @@ dependencies = [
  "futures",
  "futures-concurrency",
  "futures-time",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "hex-literal",
  "hopr-async-runtime",
  "hopr-crypto-packet",
  "hopr-metrics",
  "hopr-network-types",
  "hopr-protocol-app",
- "hopr-types 1.5.1",
- "indexmap 2.13.0",
+ "hopr-types 1.5.3",
+ "indexmap 2.14.0",
  "insta",
  "lazy_static",
  "mimalloc",
@@ -4943,7 +4813,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-ticket-manager"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4951,7 +4821,7 @@ dependencies = [
  "criterion",
  "dashmap",
  "futures",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "hopr-api",
  "hopr-chain-connector",
  "hopr-platform",
@@ -5025,7 +4895,7 @@ dependencies = [
  "futures-timer",
  "hopr-metrics",
  "hopr-transport-mixer",
- "hopr-types 1.5.1",
+ "hopr-types 1.5.3",
  "humantime-serde",
  "insta",
  "lazy_static",
@@ -5080,7 +4950,7 @@ dependencies = [
  "hopr-network-graph",
  "hopr-protocol-hopr",
  "hopr-statistics",
- "hopr-types 1.5.1",
+ "hopr-types 1.5.3",
  "lazy_static",
  "moka",
  "smart-default",
@@ -5190,7 +5060,7 @@ dependencies = [
  "hopr-protocol-session",
  "hopr-protocol-start",
  "hopr-transport-tag-allocator",
- "hopr-types 1.5.1",
+ "hopr-types 1.5.3",
  "humantime-serde",
  "insta",
  "lazy_static",
@@ -5229,19 +5099,54 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "1.4.1"
-source = "git+https://github.com/hoprnet/hopr-types?branch=main#d434e0723575ed0ac0c01bc8d1800bacb3a31b61"
+version = "1.5.2"
+source = "git+https://github.com/hoprnet/hopr-types?branch=main#981e9c8b321c6c4cddcb8b9ce9eb8f04a53223b1"
 dependencies = [
- "hopr-crypto-types",
- "hopr-internal-types",
- "hopr-primitive-types",
+ "aes",
+ "aquamarine",
+ "async-trait",
+ "bigdecimal",
+ "blake3",
+ "chacha20 0.9.1",
+ "chrono",
+ "cipher",
+ "ctr",
+ "curve25519-dalek",
+ "digest 0.10.7",
+ "ed25519-dalek",
+ "float-cmp",
+ "generic-array 1.3.5",
+ "hex",
+ "hex-literal",
+ "k256",
+ "lazy_static",
+ "libp2p-identity",
+ "multiaddr",
+ "num_enum",
+ "poly1305",
+ "primitive-types 0.14.0",
+ "rand 0.10.0",
+ "rayon",
+ "regex",
+ "secp256k1 0.31.1",
+ "serde",
+ "serde_bytes",
+ "sha2",
+ "sha3",
+ "smart-default",
+ "strum 0.28.0",
+ "subtle",
+ "thiserror 2.0.18",
+ "tracing",
+ "typenum",
+ "zeroize",
 ]
 
 [[package]]
 name = "hopr-types"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6084743d50e8aee75a629289f853c7cca1bd1db49e3942c292f11f7e6e7d9d0f"
+checksum = "3efb3f42c72ab2b00945ba3bd581131a2679fb3f3672940828730d402d8733a3"
 dependencies = [
  "aes",
  "anyhow",
@@ -5347,7 +5252,7 @@ dependencies = [
  "serde",
  "serde-saphyr",
  "serde_json",
- "signal-hook 0.4.3",
+ "signal-hook 0.4.4",
  "smart-default",
  "strum 0.28.0",
  "tempfile",
@@ -5433,7 +5338,7 @@ dependencies = [
  "hopr-builder",
  "hopr-chain-connector",
  "hopr-lib",
- "hopr-types 1.5.1",
+ "hopr-types 1.5.3",
  "hoprd",
  "hoprd-api",
  "hoprd-api-client",
@@ -5573,9 +5478,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -5588,7 +5493,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -5617,7 +5521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "rustls 0.23.37",
  "rustls-pki-types",
@@ -5644,7 +5548,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -5659,7 +5563,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -5679,7 +5583,7 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -5718,12 +5622,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -5731,9 +5636,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -5744,9 +5649,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -5758,15 +5663,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -5778,15 +5683,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -5875,7 +5780,7 @@ dependencies = [
  "futures",
  "http 1.4.0",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "log",
  "rand 0.9.2",
@@ -5963,12 +5868,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "rayon",
  "serde",
  "serde_core",
@@ -6000,14 +5905,15 @@ dependencies = [
 
 [[package]]
 name = "ipconfig"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "widestring",
- "windows-sys 0.48.0",
- "winreg",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6018,9 +5924,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.10"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -6061,9 +5967,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
@@ -6118,10 +6024,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -6152,9 +6060,9 @@ dependencies = [
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b646a74e746cd25045aa0fd42f4f7f78aa6d119380182c7e63a5593c4ab8df6f"
+checksum = "fa468878266ad91431012b3e5ef1bf9b170eab22883503a318d46857afa4579a"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -6192,9 +6100,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libm"
@@ -6546,7 +6454,7 @@ dependencies = [
  "rcgen",
  "ring",
  "rustls 0.23.37",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "thiserror 2.0.18",
  "x509-parser",
  "yasna",
@@ -6579,19 +6487,19 @@ dependencies = [
  "thiserror 2.0.18",
  "tracing",
  "yamux 0.12.1",
- "yamux 0.13.9",
+ "yamux 0.13.10",
 ]
 
 [[package]]
 name = "libredox"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -6602,9 +6510,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -6787,9 +6695,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi",
@@ -7017,9 +6925,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -7106,7 +7014,7 @@ dependencies = [
  "log",
  "once_cell",
  "regex",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "url",
@@ -7123,9 +7031,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 dependencies = [
  "critical-section",
  "portable-atomic",
@@ -7155,16 +7063,16 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8d427828b22ae1fff2833a03d8486c2c881367f1c336349f307f321e7f4d05"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -7200,9 +7108,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
@@ -7502,7 +7410,7 @@ checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "rayon",
  "serde",
  "serde_derive",
@@ -7616,9 +7524,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
 dependencies = [
  "portable-atomic",
 ]
@@ -7637,9 +7545,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -7827,7 +7735,7 @@ checksum = "de362a0477182f45accdbad4d43cd89a95a1db0a518a7c1ddf3e525e6896f0f0"
 dependencies = [
  "heck 0.5.0",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "openapiv3",
  "proc-macro2",
  "quote",
@@ -7884,9 +7792,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
@@ -8186,9 +8094,9 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "3.1.1"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef99362319c782aa4639ad3a306b64c3bb90e12874e99b8df124cb679d988611"
+checksum = "67f7f231ea7b1172b7ac00ccf96b1250f0fb5a16d5585836aa4ebc997df7cbde"
 dependencies = [
  "libc",
 ]
@@ -8204,9 +8112,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -8296,7 +8204,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-rustls 0.27.7",
  "hyper-tls",
  "hyper-util",
@@ -8335,7 +8243,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "js-sys",
  "log",
@@ -8530,9 +8438,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc-hex"
@@ -8555,7 +8463,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
- "semver 1.0.27",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -8602,7 +8510,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -8662,9 +8570,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -8726,9 +8634,9 @@ dependencies = [
 
 [[package]]
 name = "saphyr-parser-bw"
-version = "0.0.610"
+version = "0.0.611"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d643f5e972f17219245b82f038c22cd3c74320bb17c6e8f7e8537de268b1bc6"
+checksum = "67dec0c833db75dc98957956b303fe447ffc5eb13f2325ef4c2350f7f3aa69e3"
 dependencies = [
  "arraydeque",
  "smallvec",
@@ -8746,9 +8654,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -8939,9 +8847,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 dependencies = [
  "serde",
  "serde_core",
@@ -8968,9 +8876,9 @@ dependencies = [
 
 [[package]]
 name = "serde-saphyr"
-version = "0.0.22"
+version = "0.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546b4da4f679832602a8f8ab8ddc10b6b1d2e1a13b4f9dddcaee499436fa06ad"
+checksum = "09fbdfe7a27a1b1633dfc0c4c8e65940b8d819c5ddb9cca48ebc3223b00c8b14"
 dependencies = [
  "ahash",
  "annotate-snippets",
@@ -9106,7 +9014,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -9133,7 +9041,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -9220,9 +9128,9 @@ dependencies = [
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b31139435f327c93c6038ed350ae4588e2c70a13d50599509fee6349967ba35a"
+checksum = "59cbb88c189d6352cc8ae96a39d19c7ecad8f7330b29461187f2587fdc2988d5"
 dependencies = [
  "cc",
  "cfg-if",
@@ -9261,9 +9169,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b57709da74f9ff9f4a27dce9526eec25ca8407c45a7887243b031a58935fb8e"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -9291,9 +9199,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "similar"
@@ -9733,9 +9641,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -9753,9 +9661,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -9768,9 +9676,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.50.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
@@ -9795,9 +9703,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9873,32 +9781,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.25.4+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime",
  "toml_parser",
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -9915,7 +9823,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-timeout 0.5.2",
  "hyper-util",
  "percent-encoding",
@@ -9951,7 +9859,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -10124,7 +10032,7 @@ dependencies = [
  "quote",
  "regress",
  "schemars 0.8.22",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "syn 2.0.117",
@@ -10141,7 +10049,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "schemars 0.8.22",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "serde_tokenstream",
@@ -10214,9 +10122,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-width"
@@ -10295,7 +10203,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -10502,9 +10410,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -10515,23 +10423,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -10539,9 +10443,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -10552,9 +10456,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -10576,7 +10480,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -10602,8 +10506,8 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
- "semver 1.0.27",
+ "indexmap 2.14.0",
+ "semver 1.0.28",
 ]
 
 [[package]]
@@ -10622,9 +10526,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -10791,15 +10695,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -10823,21 +10718,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -10884,12 +10764,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -10902,12 +10776,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -10917,12 +10785,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10950,12 +10812,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -10965,12 +10821,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -10986,12 +10836,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -11001,12 +10845,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -11030,13 +10868,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
+name = "winnow"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
+ "memchr",
 ]
 
 [[package]]
@@ -11067,7 +10904,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -11098,7 +10935,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -11117,9 +10954,9 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
- "semver 1.0.27",
+ "semver 1.0.28",
  "serde",
  "serde_derive",
  "serde_json",
@@ -11129,9 +10966,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -11203,9 +11040,9 @@ dependencies = [
 
 [[package]]
 name = "yamux"
-version = "0.13.9"
+version = "0.13.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c650efd29044140aa63caaf80129996a9e2659a2ab7045a7e061807d02fc8549"
+checksum = "1991f6690292030e31b0144d73f5e8368936c58e45e7068254f7138b23b00672"
 dependencies = [
  "futures",
  "log",
@@ -11234,9 +11071,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -11245,9 +11082,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11257,18 +11094,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.41"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96e13bc581734df6250836c59a5f44f3c57db9f9acb9dc8e3eaabdaf6170254d"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.41"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3545ea9e86d12ab9bba9fcd99b54c1556fd3199007def5a03c375623d05fac1c"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11277,18 +11114,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11318,9 +11155,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -11329,9 +11166,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -11340,9 +11177,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11358,7 +11195,7 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "memchr",
  "zopfli",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,8 +1559,8 @@ dependencies = [
 
 [[package]]
 name = "blokli-client"
-version = "0.23.0"
-source = "git+https://github.com/hoprnet/blokli?branch=lukas%2Fadd-redeem-stats-to-testing#2a1fcb8048ac65798cdb319a9052405ed1d4acb9"
+version = "0.23.1"
+source = "git+https://github.com/hoprnet/blokli?branch=lukas%2Ffix-default-redeemed-stats#c593ba5d4e7f7b5b8bba7b955e518a9ee2505cf0"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -6454,7 +6454,7 @@ dependencies = [
  "rcgen",
  "ring",
  "rustls 0.23.37",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.11",
  "thiserror 2.0.18",
  "x509-parser",
  "yasna",
@@ -8510,7 +8510,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.11",
  "subtle",
  "zeroize",
 ]
@@ -8570,9 +8570,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ backon = { version = "1.6.0", default-features = false }
 base64 = "0.22.1"
 bimap = "0.6.3"
 bitvec = "1.0.1"
-blokli-client = { git = "https://github.com/hoprnet/blokli", branch = "lukas/fix-default-redeemed-stats" } # Always use the latest for now
+blokli-client = { git = "https://github.com/hoprnet/blokli", branch = "main" } # Always use the latest for now
 bloomfilter = { version = "3.0.1" }
 bytesize = { version = "2.3.1", features = ["serde"] }
 bytes = "1.11.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ backon = { version = "1.6.0", default-features = false }
 base64 = "0.22.1"
 bimap = "0.6.3"
 bitvec = "1.0.1"
-blokli-client = { git = "https://github.com/hoprnet/blokli", branch = "lukas/add-redeem-stats-to-testing" } # Always use the latest for now
+blokli-client = { git = "https://github.com/hoprnet/blokli", branch = "lukas/fix-default-redeemed-stats" } # Always use the latest for now
 bloomfilter = { version = "3.0.1" }
 bytesize = { version = "2.3.1", features = ["serde"] }
 bytes = "1.11.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ arrayvec = { version = "0.7.6" }
 assertables = "9.8.6"
 async-broadcast = "0.7.2"
 async-lock = "3.4.2"
-async-signal = "0.2.13"
+async-signal = "0.2.14"
 async-trait = "0.1.89"
 asynchronous-codec = { version = "0.7.0" }
 auto_impl = "1.3.0"
@@ -63,7 +63,7 @@ backon = { version = "1.6.0", default-features = false }
 base64 = "0.22.1"
 bimap = "0.6.3"
 bitvec = "1.0.1"
-blokli-client = { git = "https://github.com/hoprnet/blokli" } # Always use the latest for now
+blokli-client = { git = "https://github.com/hoprnet/blokli", branch = "lukas/add-redeem-stats-to-testing" } # Always use the latest for now
 bloomfilter = { version = "3.0.1" }
 bytesize = { version = "2.3.1", features = ["serde"] }
 bytes = "1.11.1"
@@ -94,7 +94,7 @@ futures-timer = "3.0.3"
 futures-time = "3.0.1"
 generic-array = "1.3.5"
 halfbrown = "0.4.0"
-hashbrown = "0.16.1"
+hashbrown = "0.17.0"
 hex = "0.4.3"
 hex-literal = "1.1.0"
 hickory-resolver = { version = "0.25.2", default-features = false, features = [
@@ -147,7 +147,7 @@ progenitor-client = "0.13.0"
 rayon = "1.11.0"
 rand = { version = "0.10.0", features = ["thread_rng"] }
 rand_distr = "0.6.0"
-redb = "3.1.1"
+redb = "4.0.0"
 regex = "1.12.3"
 reqwest = { version = "0.13.2", default-features = false, features = [
   "json",
@@ -164,9 +164,9 @@ serde_json = "1.0.149"
 serde_repr = "0.1.20"
 serde_with = { version = "3.18.0", features = ["base64"] }
 serde_urlencoded = "0.7.1"
-serde-saphyr = "0.0.22"
+serde-saphyr = "0.0.23"
 serial_test = "3.4.0"
-signal-hook = "0.4.3"
+signal-hook = "0.4.4"
 smart-default = "0.7.1"
 socket2 = "0.6.3"
 strum = { version = "0.28.0", features = ["derive"] }
@@ -177,7 +177,7 @@ test-log = { version = "0.2.19", features = ["trace"] }
 thiserror = "2.0.18"
 tikv-jemallocator = "0.6.1"
 tikv-jemalloc-ctl = { version = "0.6.1", features = ["stats"] }
-tokio = { version = "1.50.0", features = [
+tokio = { version = "1.51.1", features = [
   "rt-multi-thread",
   "macros",
   "tracing",
@@ -218,8 +218,8 @@ mimalloc = { version = "0.1.48", default-features = false, features = [
   "secure",
 ] }
 
-hopr-api = "1.5.2"
-hopr-types = { version = "1.5.1", features = ["use-bindings"] }
+hopr-api = "1.6.1"
+hopr-types = { version = "1.5.3", features = ["use-bindings"] }
 hopr-async-runtime = { path = "common/async-runtime" }
 hopr-crypto-keypair = { path = "crypto/keypair", default-features = false }
 hopr-crypto-packet = { path = "crypto/packet", default-features = false }

--- a/common/test-stubs/src/lib.rs
+++ b/common/test-stubs/src/lib.rs
@@ -250,7 +250,12 @@ impl ChainValues for StubChainApi {
         })
     }
 
-    // outgoing_ticket_values: uses default impl that calls minimum_ticket_price + minimum_incoming_ticket_win_prob
+    async fn redemption_stats<A: Into<Address> + Send>(&self, _: A) -> Result<RedemptionStats, Self::Error> {
+        Ok(RedemptionStats {
+            redeemed_count: 0,
+            redeemed_value: HoprBalance::zero(),
+        })
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/hopr/builder/tests/transport_tickets.rs
+++ b/hopr/builder/tests/transport_tickets.rs
@@ -3,6 +3,7 @@ use std::{ops::Mul, time::Duration};
 use anyhow::Context;
 use futures::{AsyncWriteExt, StreamExt, pin_mut};
 use futures_time::future::FutureExt as _;
+use hopr_api::chain::ChainValues;
 use hopr_builder::{
     hopr_lib::{HoprBalance, HoprLibError, UnitaryFloatOps},
     testing::{
@@ -145,7 +146,7 @@ async fn redeem_ticket_on_request(
 
     wait_until(
         || async {
-            let stats_before = mid.inner().ticket_statistics().await?;
+            let stats_before = mid.inner().ticket_statistics()?;
             Ok::<_, HoprLibError>(stats_before.unredeemed_value >= message_count.into())
         },
         Duration::from_secs(15),
@@ -153,17 +154,23 @@ async fn redeem_ticket_on_request(
     .await
     .context("failed to wait for: `stats_before.unredeemed_value > message_count.into()`")?;
 
-    let stats_before = mid.inner().ticket_statistics().await?;
+    let stats_before = mid
+        .connector
+        .redemption_stats(mid.inner().get_safe_config().safe_address)
+        .await?;
 
     mid.inner()
         .redeem_all_tickets(0)
         .await
         .context("failed to redeem tickets")?;
 
-    #[allow(deprecated)] // TODO: remove once blokli#237 is merged
+    let mid_connector = mid.connector.clone();
     wait_until(
         || async {
-            let stats_after = mid.inner().ticket_statistics().await?;
+            let stats_after = mid_connector
+                .redemption_stats(mid.inner().get_safe_config().safe_address)
+                .await
+                .map_err(HoprLibError::chain)?;
             Ok::<_, HoprLibError>(stats_after.redeemed_value > stats_before.redeemed_value)
         },
         Duration::from_secs(5),
@@ -198,7 +205,6 @@ async fn neglect_ticket_on_closing(
     let stats_after_reset = mid
         .inner()
         .ticket_statistics()
-        .await
         .context("failed to get ticket statistics")?;
 
     let funding_amount = ticket_price.mul(message_count + PROBING_OVERHEAD);
@@ -228,7 +234,7 @@ async fn neglect_ticket_on_closing(
     // background probing).
     wait_until(
         || async {
-            let stats = mid.inner().ticket_statistics().await?;
+            let stats = mid.inner().ticket_statistics()?;
             Ok::<_, HoprLibError>(
                 stats.unredeemed_value >= stats_after_reset.unredeemed_value + HoprBalance::from(message_count),
             )
@@ -242,7 +248,6 @@ async fn neglect_ticket_on_closing(
     let stats_before_close = mid
         .inner()
         .ticket_statistics()
-        .await
         .context("failed to get ticket statistics")?;
 
     fw_channel.try_close_channels_all_channels().await?;
@@ -250,7 +255,7 @@ async fn neglect_ticket_on_closing(
 
     wait_until(
         || async {
-            let stats_after = mid.inner().ticket_statistics().await?;
+            let stats_after = mid.inner().ticket_statistics()?;
             // After closing the test channels, neglected value must increase.
             // We use a delta check because background probing may have created
             // unredeemed tickets on other channels that remain open.
@@ -310,8 +315,12 @@ async fn relay_gets_less_tickets_if_sender_has_lower_win_prob(
     let stats_before = mid
         .inner()
         .ticket_statistics()
-        .await
         .context("failed to get ticket statistics")?;
+
+    let chain_stats_before = mid
+        .connector
+        .redemption_stats(mid.inner().get_safe_config().safe_address)
+        .await?;
 
     for _ in 1..=message_count {
         tokio::time::timeout(Duration::from_millis(500), session.write_all(&sent_data))
@@ -326,13 +335,17 @@ async fn relay_gets_less_tickets_if_sender_has_lower_win_prob(
         .await
         .context("failed to redeem tickets")?;
 
-    #[allow(deprecated)] // TODO: remove once blokli#237 is merged
+    let mid_connector = mid.connector.clone();
     wait_until(
         || async {
-            let stats_after = mid.inner().ticket_statistics().await?;
+            let stats_after = mid.inner().ticket_statistics()?;
+            let chain_stats_after = mid_connector
+                .redemption_stats(mid.inner().get_safe_config().safe_address)
+                .await
+                .map_err(HoprLibError::chain)?;
             Ok::<_, HoprLibError>(
                 stats_after.winning_tickets < stats_before.winning_tickets + message_count as u128
-                    && stats_after.redeemed_value > stats_before.redeemed_value,
+                    && chain_stats_after.redeemed_value > chain_stats_before.redeemed_value,
             )
         },
         Duration::from_secs(5),
@@ -425,8 +438,12 @@ async fn relay_with_win_prob_higher_than_min_win_prob_should_succeed(
     let stats_before = mid
         .inner()
         .ticket_statistics()
-        .await
         .context("failed to get ticket statistics")?;
+
+    let chain_stats_before = mid
+        .connector
+        .redemption_stats(mid.inner().get_safe_config().safe_address)
+        .await?;
 
     for _ in 1..=message_count {
         tokio::time::timeout(Duration::from_millis(500), session.write_all(&sent_data))
@@ -440,12 +457,16 @@ async fn relay_with_win_prob_higher_than_min_win_prob_should_succeed(
         .await
         .context("failed to redeem tickets")?;
 
-    #[allow(deprecated)] // TODO: remove once blokli#237 is merged
+    let mid_connector = mid.connector.clone();
     wait_until(
         || async {
-            let stats_after = mid.inner().ticket_statistics().await?;
+            let stats_after = mid.inner().ticket_statistics()?;
+            let chain_stats_after = mid_connector
+                .redemption_stats(mid.inner().get_safe_config().safe_address)
+                .await
+                .map_err(HoprLibError::chain)?;
             Ok::<_, HoprLibError>(
-                stats_after.redeemed_value > stats_before.redeemed_value
+                chain_stats_after.redeemed_value > chain_stats_before.redeemed_value
                     && stats_after.winning_tickets > stats_before.winning_tickets,
             )
         },

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -1373,8 +1373,7 @@ where
             )))
     }
 
-    // TODO: this method can be sync unless we allow querying of the redeemed value from Blokli
-    pub async fn ticket_statistics(&self) -> Result<ChannelStats, HoprLibError> {
+    pub fn ticket_statistics(&self) -> Result<ChannelStats, HoprLibError> {
         self.ticket_management()?
             .ticket_stats(None)
             .map_err(HoprLibError::ticket_manager)

--- a/hoprd/rest-api-client/src/codegen/mod.rs
+++ b/hoprd/rest-api-client/src/codegen/mod.rs
@@ -1179,7 +1179,6 @@ and indexer state.*/
     ///  "type": "object",
     ///  "required": [
     ///    "neglectedValue",
-    ///    "redeemedValue",
     ///    "rejectedValue",
     ///    "unredeemedValue",
     ///    "winningCount"
@@ -1188,12 +1187,6 @@ and indexer state.*/
     ///    "neglectedValue": {
     ///      "examples": [
     ///        "0 wxHOPR"
-    ///      ],
-    ///      "type": "string"
-    ///    },
-    ///    "redeemedValue": {
-    ///      "examples": [
-    ///        "100 wxHOPR"
     ///      ],
     ///      "type": "string"
     ///    },
@@ -1225,8 +1218,6 @@ and indexer state.*/
     pub struct NodeTicketStatisticsResponse {
         #[serde(rename = "neglectedValue")]
         pub neglected_value: ::std::string::String,
-        #[serde(rename = "redeemedValue")]
-        pub redeemed_value: ::std::string::String,
         #[serde(rename = "rejectedValue")]
         pub rejected_value: ::std::string::String,
         #[serde(rename = "unredeemedValue")]

--- a/hoprd/rest-api/src/tickets.rs
+++ b/hoprd/rest-api/src/tickets.rs
@@ -71,9 +71,6 @@ pub(crate) struct NodeTicketStatisticsResponse {
     #[schema(value_type = String, example = "20 wxHOPR")]
     unredeemed_value: HoprBalance,
     #[serde_as(as = "DisplayFromStr")]
-    #[schema(value_type = String,example = "100 wxHOPR")]
-    redeemed_value: HoprBalance,
-    #[serde_as(as = "DisplayFromStr")]
     #[schema(value_type = String,example = "0 wxHOPR")]
     neglected_value: HoprBalance,
     #[serde_as(as = "DisplayFromStr")]
@@ -86,8 +83,6 @@ impl From<ChannelStats> for NodeTicketStatisticsResponse {
         Self {
             winning_count: value.winning_tickets as u64,
             unredeemed_value: value.unredeemed_value,
-            #[allow(deprecated)] // TODO: remove once blokli#237 is merged
-            redeemed_value: value.redeemed_value,
             neglected_value: value.neglected_value,
             rejected_value: value.rejected_value,
         }

--- a/impls/connector/Cargo.toml
+++ b/impls/connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-chain-connector"
-version = "0.18.0"
+version = "0.19.0"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["HOPR Association <tech@hoprnet.org>"]

--- a/impls/connector/src/connector/mod.rs
+++ b/impls/connector/src/connector/mod.rs
@@ -172,11 +172,13 @@ where
             .round() as u32;
         let min_channels = (self
             .client
-            .count_channels(blokli_client::api::ChannelSelector {
+            .query_channel_stats(blokli_client::api::ChannelSelector {
                 filter: None,
                 status: Some(blokli_client::api::types::ChannelStatus::Open),
+                ..Default::default()
             })
-            .await? as f64
+            .await?
+            .count as f64
             * sync_quota)
             .round() as u32;
         tracing::debug!(min_accounts, min_channels, "connection thresholds");

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_announce_new_account_with_multiaddresses.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_announce_new_account_with_multiaddresses.snap
@@ -1,5 +1,5 @@
 ---
-source: chain/connector/src/connector/accounts.rs
+source: impls/connector/src/connector/accounts.rs
 expression: "*connector.client.snapshot()"
 ---
 accounts:
@@ -17,6 +17,7 @@ native_balances:
 token_balances: {}
 safe_allowances: {}
 deployed_safes: {}
+safe_redeem_stats: {}
 tx_counts:
   668430def9eacd2b5064acf85d73fb0b351a1c8c: 1
 channels: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_announce_new_account_without_multiaddresses.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_announce_new_account_without_multiaddresses.snap
@@ -1,5 +1,5 @@
 ---
-source: chain/connector/src/connector/accounts.rs
+source: impls/connector/src/connector/accounts.rs
 expression: "*connector.client.snapshot()"
 ---
 accounts:
@@ -16,6 +16,7 @@ native_balances:
 token_balances: {}
 safe_allowances: {}
 deployed_safes: {}
+safe_redeem_stats: {}
 tx_counts:
   668430def9eacd2b5064acf85d73fb0b351a1c8c: 1
 channels: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_reannounce_when_existing_account_has_same_multiaddresses.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_reannounce_when_existing_account_has_same_multiaddresses.snap
@@ -1,5 +1,5 @@
 ---
-source: chain/connector/src/connector/accounts.rs
+source: impls/connector/src/connector/accounts.rs
 expression: "*connector.client.snapshot()"
 ---
 accounts:
@@ -34,6 +34,7 @@ deployed_safes:
     chain_key: 668430def9eacd2b5064acf85d73fb0b351a1c8c
     module_address: 463977c851087dca6e69d488fbd69dbad3ffc7fe
     registered_nodes: []
+safe_redeem_stats: {}
 tx_counts: {}
 channels: {}
 chain_info:

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_register_any_safe_when_node_already_registered.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_register_any_safe_when_node_already_registered.snap
@@ -1,5 +1,5 @@
 ---
-source: chain/connector/src/connector/accounts.rs
+source: impls/connector/src/connector/accounts.rs
 expression: "*connector.client.snapshot()"
 ---
 accounts: {}
@@ -21,6 +21,7 @@ deployed_safes:
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: "1111111111111111111111111111111111111111"
     registered_nodes: []
+safe_redeem_stats: {}
 tx_counts: {}
 channels: {}
 chain_info:

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_register_safe_that_does_not_exist.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_register_safe_that_does_not_exist.snap
@@ -1,5 +1,5 @@
 ---
-source: chain/connector/src/connector/accounts.rs
+source: impls/connector/src/connector/accounts.rs
 expression: "*connector.client.snapshot()"
 ---
 accounts: {}
@@ -10,6 +10,7 @@ native_balances:
 token_balances: {}
 safe_allowances: {}
 deployed_safes: {}
+safe_redeem_stats: {}
 tx_counts: {}
 channels: {}
 chain_info:

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_reannounce_when_existing_account_has_no_multiaddresses.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_reannounce_when_existing_account_has_no_multiaddresses.snap
@@ -1,5 +1,5 @@
 ---
-source: chain/connector/src/connector/accounts.rs
+source: impls/connector/src/connector/accounts.rs
 expression: "*connector.client.snapshot()"
 ---
 accounts:
@@ -34,6 +34,7 @@ deployed_safes:
     chain_key: 668430def9eacd2b5064acf85d73fb0b351a1c8c
     module_address: 463977c851087dca6e69d488fbd69dbad3ffc7fe
     registered_nodes: []
+safe_redeem_stats: {}
 tx_counts:
   668430def9eacd2b5064acf85d73fb0b351a1c8c: 1
 channels: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_register_safe.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_register_safe.snap
@@ -1,5 +1,5 @@
 ---
-source: chain/connector/src/connector/accounts.rs
+source: impls/connector/src/connector/accounts.rs
 expression: "*connector.client.snapshot()"
 ---
 accounts: {}
@@ -16,6 +16,7 @@ deployed_safes:
     module_address: "1111111111111111111111111111111111111111"
     registered_nodes:
       - 668430def9eacd2b5064acf85d73fb0b351a1c8c
+safe_redeem_stats: {}
 tx_counts:
   668430def9eacd2b5064acf85d73fb0b351a1c8c: 1
 channels: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_register_safe_that_has_nodes_registered_already.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_register_safe_that_has_nodes_registered_already.snap
@@ -1,5 +1,5 @@
 ---
-source: chain/connector/src/connector/accounts.rs
+source: impls/connector/src/connector/accounts.rs
 expression: "*connector.client.snapshot()"
 ---
 accounts: {}
@@ -17,6 +17,7 @@ deployed_safes:
     registered_nodes:
       - bea83ba0fcee21da44a30c893f466e6bf0c29bbb
       - 668430def9eacd2b5064acf85d73fb0b351a1c8c
+safe_redeem_stats: {}
 tx_counts:
   668430def9eacd2b5064acf85d73fb0b351a1c8c: 1
 channels: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_withdraw.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_withdraw.snap
@@ -1,5 +1,5 @@
 ---
-source: chain/connector/src/connector/accounts.rs
+source: impls/connector/src/connector/accounts.rs
 expression: "*connector.client.snapshot()"
 ---
 accounts: {}
@@ -19,6 +19,7 @@ token_balances:
     balance: 990 wxHOPR
 safe_allowances: {}
 deployed_safes: {}
+safe_redeem_stats: {}
 tx_counts:
   668430def9eacd2b5064acf85d73fb0b351a1c8c: 2
 channels: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_close_incoming_channel.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_close_incoming_channel.snap
@@ -1,5 +1,5 @@
 ---
-source: chain/connector/src/connector/channels.rs
+source: impls/connector/src/connector/channels.rs
 expression: "*connector.client().snapshot()"
 ---
 accounts:
@@ -59,6 +59,7 @@ deployed_safes:
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+safe_redeem_stats: {}
 tx_counts:
   668430def9eacd2b5064acf85d73fb0b351a1c8c: 1
 channels:

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_finalize_channel_closure.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_finalize_channel_closure.snap
@@ -1,5 +1,5 @@
 ---
-source: chain/connector/src/connector/channels.rs
+source: impls/connector/src/connector/channels.rs
 expression: "*connector.client().snapshot()"
 ---
 accounts:
@@ -59,6 +59,7 @@ deployed_safes:
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+safe_redeem_stats: {}
 tx_counts:
   668430def9eacd2b5064acf85d73fb0b351a1c8c: 1
 channels:

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_fund_channel.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_fund_channel.snap
@@ -1,5 +1,5 @@
 ---
-source: chain/connector/src/connector/channels.rs
+source: impls/connector/src/connector/channels.rs
 expression: "*connector.client().snapshot()"
 ---
 accounts:
@@ -59,6 +59,7 @@ deployed_safes:
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+safe_redeem_stats: {}
 tx_counts:
   668430def9eacd2b5064acf85d73fb0b351a1c8c: 1
 channels:

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_initiate_channel_closure.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_initiate_channel_closure.snap
@@ -1,5 +1,5 @@
 ---
-source: chain/connector/src/connector/channels.rs
+source: impls/connector/src/connector/channels.rs
 expression: snapshot
 ---
 accounts:
@@ -59,6 +59,7 @@ deployed_safes:
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+safe_redeem_stats: {}
 tx_counts:
   668430def9eacd2b5064acf85d73fb0b351a1c8c: 1
 channels:

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_open_channel.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_open_channel.snap
@@ -1,5 +1,5 @@
 ---
-source: chain/connector/src/connector/channels.rs
+source: impls/connector/src/connector/channels.rs
 expression: "*connector.client().snapshot()"
 ---
 accounts:
@@ -59,6 +59,7 @@ deployed_safes:
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+safe_redeem_stats: {}
 tx_counts:
   668430def9eacd2b5064acf85d73fb0b351a1c8c: 1
 channels:

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__safe__tests__connector_should_query_existing_safe.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__safe__tests__connector_should_query_existing_safe.snap
@@ -1,5 +1,5 @@
 ---
-source: chain/connector/src/connector/safe.rs
+source: impls/connector/src/connector/safe.rs
 expression: "*connector.client.snapshot()"
 ---
 accounts: {}
@@ -15,6 +15,7 @@ deployed_safes:
     chain_key: 668430def9eacd2b5064acf85d73fb0b351a1c8c
     module_address: "1111111111111111111111111111111111111111"
     registered_nodes: []
+safe_redeem_stats: {}
 tx_counts: {}
 channels: {}
 chain_info:

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_on_closed_channel.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_on_closed_channel.snap
@@ -1,5 +1,5 @@
 ---
-source: chain/connector/src/connector/tickets.rs
+source: impls/connector/src/connector/tickets.rs
 expression: "*connector.client().snapshot()"
 ---
 accounts:
@@ -59,6 +59,7 @@ deployed_safes:
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+safe_redeem_stats: {}
 tx_counts:
   668430def9eacd2b5064acf85d73fb0b351a1c8c: 1
 channels:

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_on_non_existing_channel.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_on_non_existing_channel.snap
@@ -1,5 +1,5 @@
 ---
-source: chain/connector/src/connector/tickets.rs
+source: impls/connector/src/connector/tickets.rs
 expression: "*connector.client().snapshot()"
 ---
 accounts:
@@ -59,6 +59,7 @@ deployed_safes:
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+safe_redeem_stats: {}
 tx_counts: {}
 channels:
   e555945b137ef926702c021fa24104e2268de40641e63b8b747019b09e100802:

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_amount_higher_than_channel_stake.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_amount_higher_than_channel_stake.snap
@@ -1,5 +1,5 @@
 ---
-source: chain/connector/src/connector/tickets.rs
+source: impls/connector/src/connector/tickets.rs
 expression: "*connector.client().snapshot()"
 ---
 accounts:
@@ -59,6 +59,7 @@ deployed_safes:
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+safe_redeem_stats: {}
 tx_counts: {}
 channels:
   e555945b137ef926702c021fa24104e2268de40641e63b8b747019b09e100802:

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_old_index.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_old_index.snap
@@ -1,5 +1,5 @@
 ---
-source: chain/connector/src/connector/tickets.rs
+source: impls/connector/src/connector/tickets.rs
 expression: "*connector.client().snapshot()"
 ---
 accounts:
@@ -59,6 +59,7 @@ deployed_safes:
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+safe_redeem_stats: {}
 tx_counts: {}
 channels:
   e555945b137ef926702c021fa24104e2268de40641e63b8b747019b09e100802:

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_previous_epoch.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_previous_epoch.snap
@@ -1,5 +1,5 @@
 ---
-source: chain/connector/src/connector/tickets.rs
+source: impls/connector/src/connector/tickets.rs
 expression: "*connector.client().snapshot()"
 ---
 accounts:
@@ -59,6 +59,7 @@ deployed_safes:
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+safe_redeem_stats: {}
 tx_counts: {}
 channels:
   e555945b137ef926702c021fa24104e2268de40641e63b8b747019b09e100802:

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_redeem_ticket.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_redeem_ticket.snap
@@ -1,5 +1,5 @@
 ---
-source: chain/connector/src/connector/tickets.rs
+source: impls/connector/src/connector/tickets.rs
 expression: "*connector.client().snapshot()"
 ---
 accounts:
@@ -59,6 +59,11 @@ deployed_safes:
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+safe_redeem_stats:
+  "0101010101010101010101010101010101010101":
+    __typename: RedeemedStats
+    redeemed_amount: 0.000000000000000001 wxHOPR
+    redemption_count: "1"
 tx_counts:
   668430def9eacd2b5064acf85d73fb0b351a1c8c: 1
 channels:

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_redeem_ticket_and_increase_redeemed_stats.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_redeem_ticket_and_increase_redeemed_stats.snap
@@ -1,0 +1,98 @@
+---
+source: impls/connector/src/connector/tickets.rs
+expression: "*connector.client().snapshot()"
+---
+accounts:
+  1:
+    chain_key: 668430def9eacd2b5064acf85d73fb0b351a1c8c
+    keyid: 1
+    multi_addresses: []
+    packet_key: 3f6b51c1158631d57d2ecfe0cc49396de92be26bcea89b77cd60223f1023f1a0
+    safe_address: "0101010101010101010101010101010101010101"
+  2:
+    chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
+    keyid: 2
+    multi_addresses: []
+    packet_key: 4b8f66f9df296e7d7c2280d9c833c879297ee9d435d6e075d46fad5717211b72
+    safe_address: "0202020202020202020202020202020202020202"
+native_balances:
+  668430def9eacd2b5064acf85d73fb0b351a1c8c:
+    __typename: NativeBalance
+    balance: 0.999999999999999998 xDai
+  "0101010101010101010101010101010101010101":
+    __typename: NativeBalance
+    balance: 0 xDai
+  bea83ba0fcee21da44a30c893f466e6bf0c29bbb:
+    __typename: NativeBalance
+    balance: 1 xDai
+  "0202020202020202020202020202020202020202":
+    __typename: NativeBalance
+    balance: 0 xDai
+token_balances:
+  668430def9eacd2b5064acf85d73fb0b351a1c8c:
+    __typename: HoprBalance
+    balance: 0 wxHOPR
+  "0101010101010101010101010101010101010101":
+    __typename: HoprBalance
+    balance: 100.000000000000000002 wxHOPR
+  bea83ba0fcee21da44a30c893f466e6bf0c29bbb:
+    __typename: HoprBalance
+    balance: 0 wxHOPR
+  "0202020202020202020202020202020202020202":
+    __typename: HoprBalance
+    balance: 100 wxHOPR
+safe_allowances:
+  "0101010101010101010101010101010101010101":
+    __typename: SafeHoprAllowance
+    allowance: 10000000000000 wxHOPR
+  "0202020202020202020202020202020202020202":
+    __typename: SafeHoprAllowance
+    allowance: 10000000000000 wxHOPR
+deployed_safes:
+  "0101010101010101010101010101010101010101":
+    address: "0101010101010101010101010101010101010101"
+    chain_key: 668430def9eacd2b5064acf85d73fb0b351a1c8c
+    module_address: 463977c851087dca6e69d488fbd69dbad3ffc7fe
+    registered_nodes: []
+  "0202020202020202020202020202020202020202":
+    address: "0202020202020202020202020202020202020202"
+    chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
+    module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
+    registered_nodes: []
+safe_redeem_stats:
+  "0101010101010101010101010101010101010101":
+    __typename: RedeemedStats
+    redeemed_amount: 0.000000000000000002 wxHOPR
+    redemption_count: "2"
+tx_counts:
+  668430def9eacd2b5064acf85d73fb0b351a1c8c: 2
+channels:
+  e555945b137ef926702c021fa24104e2268de40641e63b8b747019b09e100802:
+    balance: 0.000000000000000008 wxHOPR
+    closure_time: ~
+    concrete_channel_id: e555945b137ef926702c021fa24104e2268de40641e63b8b747019b09e100802
+    destination: 1
+    epoch: 1
+    source: 2
+    status: OPEN
+    ticket_index: "3"
+chain_info:
+  channel_closure_grace_period: "300"
+  channel_dst: "0000000000000000000000000000000000000000000000000000000000000000"
+  block_number: 1
+  chain_id: 100
+  gas_price: "1000000000"
+  ledger_dst: "0000000000000000000000000000000000000000000000000000000000000000"
+  max_fee_per_gas: "3000000000"
+  max_priority_fee_per_gas: "100000000"
+  min_ticket_winning_probability: 1
+  key_binding_fee: 0.01 wxHOPR
+  safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
+  ticket_price: 1 wxHOPR
+  network: rotsee
+  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\"}"
+  expected_block_time: "5"
+  finality: "3"
+version: "1"
+health: OK
+active_txs: {}

--- a/impls/connector/src/connector/tickets.rs
+++ b/impls/connector/src/connector/tickets.rs
@@ -155,7 +155,7 @@ mod tests {
     use blokli_client::BlokliTestClient;
     use hex_literal::hex;
     use hopr_api::{
-        chain::{ChainWriteChannelOperations, ChainWriteTicketOperations},
+        chain::{ChainValues, ChainWriteChannelOperations, ChainWriteTicketOperations},
         types::primitive::prelude::*,
     };
 
@@ -245,6 +245,71 @@ mod tests {
         connector.redeem_ticket(ticket).await?.await?;
 
         insta::assert_yaml_snapshot!(*connector.client().snapshot());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn connector_should_redeem_ticket_and_increase_redeemed_stats() -> anyhow::Result<()> {
+        let blokli_client = prepare_client()?;
+
+        let mut connector = create_connector(blokli_client)?;
+        connector.connect().await?;
+
+        let hkc1 = ChainKeypair::from_secret(&hex!(
+            "e17fe86ce6e99f4806715b0c9412f8dad89334bf07f72d5834207a9d8f19d7f8"
+        ))?;
+        let hkc2 = ChainKeypair::from_secret(&hex!(
+            "492057cf93e99b31d2a85bc5e98a9c3aa0021feec52c227cc8170e8f7d047775"
+        ))?;
+
+        let ticket = TicketBuilder::default()
+            .counterparty(&ChainKeypair::from_secret(&PRIVATE_KEY_1)?)
+            .amount(1)
+            .index(1)
+            .channel_epoch(1)
+            .eth_challenge(
+                Challenge::from_hint_and_share(
+                    &HalfKeyChallenge::new(hkc1.public().as_ref()),
+                    &HalfKeyChallenge::new(hkc2.public().as_ref()),
+                )?
+                .to_ethereum_challenge(),
+            )
+            .build_signed(&ChainKeypair::from_secret(&PRIVATE_KEY_2)?, &Hash::default())?
+            .into_acknowledged(Response::from_half_keys(
+                &HalfKey::try_from(hkc1.secret().as_ref())?,
+                &HalfKey::try_from(hkc2.secret().as_ref())?,
+            )?)
+            .into_redeemable(&ChainKeypair::from_secret(&PRIVATE_KEY_1)?, &Hash::default())?;
+
+        connector.redeem_ticket(ticket).await?.await?;
+
+        let ticket = TicketBuilder::default()
+            .counterparty(&ChainKeypair::from_secret(&PRIVATE_KEY_1)?)
+            .amount(1)
+            .index(2)
+            .channel_epoch(1)
+            .eth_challenge(
+                Challenge::from_hint_and_share(
+                    &HalfKeyChallenge::new(hkc1.public().as_ref()),
+                    &HalfKeyChallenge::new(hkc2.public().as_ref()),
+                )?
+                .to_ethereum_challenge(),
+            )
+            .build_signed(&ChainKeypair::from_secret(&PRIVATE_KEY_2)?, &Hash::default())?
+            .into_acknowledged(Response::from_half_keys(
+                &HalfKey::try_from(hkc1.secret().as_ref())?,
+                &HalfKey::try_from(hkc2.secret().as_ref())?,
+            )?)
+            .into_redeemable(&ChainKeypair::from_secret(&PRIVATE_KEY_1)?, &Hash::default())?;
+
+        connector.redeem_ticket(ticket).await?.await?;
+
+        insta::assert_yaml_snapshot!(*connector.client().snapshot());
+
+        let stats = connector.redemption_stats([1u8; Address::SIZE]).await?;
+        assert_eq!(2, stats.redeemed_count);
+        assert_eq!(HoprBalance::from(2), stats.redeemed_value);
 
         Ok(())
     }

--- a/impls/connector/src/connector/tickets.rs
+++ b/impls/connector/src/connector/tickets.rs
@@ -46,8 +46,10 @@ where
                     ticket.ticket.channel_id().into(),
                 )),
                 status: None,
+                ..Default::default()
             })
             .await?
+            .channels
             .first()
             .cloned()
             .ok_or_else(|| {

--- a/impls/connector/src/connector/values.rs
+++ b/impls/connector/src/connector/values.rs
@@ -179,4 +179,20 @@ mod tests {
 
         Ok(())
     }
+
+    #[tokio::test]
+    async fn connector_should_retrieve_redeemed_stats() -> anyhow::Result<()> {
+        let blokli_client = BlokliTestStateBuilder::default()
+            .with_hopr_network_chain_info("rotsee")
+            .build_static_client();
+
+        let connector = create_connector(blokli_client)?;
+
+        let stats = connector.redemption_stats([1u8; Address::SIZE]).await?;
+
+        assert_eq!(0, stats.redeemed_count);
+        assert_eq!(HoprBalance::zero(), stats.redeemed_value);
+
+        Ok(())
+    }
 }

--- a/impls/connector/src/connector/values.rs
+++ b/impls/connector/src/connector/values.rs
@@ -1,9 +1,9 @@
 use std::time::Duration;
 
-use blokli_client::api::BlokliQueryClient;
+use blokli_client::api::{BlokliQueryClient, RedeemedStatsSelector};
 use futures::TryFutureExt;
 use hopr_api::{
-    chain::{ChainInfo, DomainSeparators},
+    chain::{ChainInfo, DomainSeparators, RedemptionStats},
     types::{internal::prelude::WinningProbability, primitive::prelude::*},
 };
 
@@ -11,7 +11,7 @@ use crate::{
     HoprBlockchainReader,
     connector::HoprBlockchainConnector,
     errors::ConnectorError,
-    utils::{ParsedChainInfo, model_to_chain_info},
+    utils::{ParsedChainInfo, model_to_chain_info, model_to_redeemed_stats},
 };
 
 pub(crate) const CHAIN_INFO_CACHE_KEY: u32 = 0;
@@ -79,6 +79,15 @@ where
 
     async fn chain_info(&self) -> Result<ChainInfo, Self::Error> {
         Ok(self.query_cached_chain_info().await?.info)
+    }
+
+    async fn redemption_stats<A: Into<Address> + Send>(&self, safe_addr: A) -> Result<RedemptionStats, Self::Error> {
+        let safe_addr = safe_addr.into();
+        model_to_redeemed_stats(
+            self.client
+                .query_redeemed_stats(RedeemedStatsSelector::SafeAddress(safe_addr.into()))
+                .await?,
+        )
     }
 }
 

--- a/impls/connector/src/connector/values.rs
+++ b/impls/connector/src/connector/values.rs
@@ -96,7 +96,7 @@ mod tests {
     use std::str::FromStr;
 
     use hopr_api::{
-        chain::ChainValues,
+        chain::{ChainValues, DeployedSafe},
         types::{
             crypto::prelude::*,
             internal::account::{AccountEntry, AccountType},
@@ -183,6 +183,12 @@ mod tests {
     #[tokio::test]
     async fn connector_should_retrieve_redeemed_stats() -> anyhow::Result<()> {
         let blokli_client = BlokliTestStateBuilder::default()
+            .with_deployed_safes([DeployedSafe {
+                address: [1u8; Address::SIZE].into(),
+                owner: [2u8; Address::SIZE].into(),
+                module: [3u8; Address::SIZE].into(),
+                registered_nodes: vec![],
+            }])
             .with_hopr_network_chain_info("rotsee")
             .build_static_client();
 

--- a/impls/connector/src/reader.rs
+++ b/impls/connector/src/reader.rs
@@ -1,16 +1,16 @@
 use std::time::Duration;
 
-use blokli_client::api::{BlokliQueryClient, BlokliSubscriptionClient};
+use blokli_client::api::{BlokliQueryClient, BlokliSubscriptionClient, RedeemedStatsSelector};
 use futures::{StreamExt, TryStreamExt};
 use futures_time::future::FutureExt as FuturesTimeExt;
 use hopr_api::{
-    chain::{ChainInfo, DeployedSafe, DomainSeparators, SafeSelector},
+    chain::{ChainInfo, DeployedSafe, DomainSeparators, RedemptionStats, SafeSelector},
     types::{internal::prelude::*, primitive::prelude::*},
 };
 
 use crate::{
     errors::ConnectorError,
-    utils::{model_to_chain_info, model_to_deployed_safe},
+    utils::{model_to_chain_info, model_to_deployed_safe, model_to_redeemed_stats},
 };
 
 /// A simplified version of [`HoprBlockchainConnector`](crate::HoprBlockchainConnector)
@@ -87,6 +87,15 @@ where
     async fn chain_info(&self) -> Result<ChainInfo, Self::Error> {
         let chain_info = self.0.query_chain_info().await?;
         Ok(model_to_chain_info(chain_info)?.info)
+    }
+
+    async fn redemption_stats<A: Into<Address> + Send>(&self, safe_addr: A) -> Result<RedemptionStats, Self::Error> {
+        let safe_addr = safe_addr.into();
+        model_to_redeemed_stats(
+            self.0
+                .query_redeemed_stats(RedeemedStatsSelector::SafeAddress(safe_addr.into()))
+                .await?,
+        )
     }
 }
 

--- a/impls/connector/src/reader.rs
+++ b/impls/connector/src/reader.rs
@@ -193,6 +193,12 @@ mod tests {
     #[tokio::test]
     async fn redeemed_stats() -> anyhow::Result<()> {
         let blokli_client = BlokliTestStateBuilder::default()
+            .with_deployed_safes([DeployedSafe {
+                address: [1u8; Address::SIZE].into(),
+                owner: [2u8; Address::SIZE].into(),
+                module: [3u8; Address::SIZE].into(),
+                registered_nodes: vec![],
+            }])
             .with_hopr_network_chain_info("rotsee")
             .build_static_client();
 

--- a/impls/connector/src/reader.rs
+++ b/impls/connector/src/reader.rs
@@ -182,3 +182,26 @@ where
             .into())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use hopr_api::chain::ChainValues;
+
+    use super::*;
+    use crate::testing::BlokliTestStateBuilder;
+
+    #[tokio::test]
+    async fn redeemed_stats() -> anyhow::Result<()> {
+        let blokli_client = BlokliTestStateBuilder::default()
+            .with_hopr_network_chain_info("rotsee")
+            .build_static_client();
+
+        let reader = HoprBlockchainReader::new(blokli_client);
+
+        let stats = reader.redemption_stats([1u8; Address::SIZE]).await?;
+        assert_eq!(0, stats.redeemed_count);
+        assert_eq!(HoprBalance::zero(), stats.redeemed_value);
+
+        Ok(())
+    }
+}

--- a/impls/connector/src/testing/emulator.rs
+++ b/impls/connector/src/testing/emulator.rs
@@ -1,6 +1,6 @@
 use std::{ops::Add, str::FromStr};
 
-use blokli_client::{BlokliTestState, BlokliTestStateMutator};
+use blokli_client::{BlokliTestState, BlokliTestStateMutator, api::types::RedeemedStats};
 use hopr_api::types::{
     chain::{ContractAddresses, ParsedHoprChainAction},
     internal::channels::generate_channel_id,
@@ -433,6 +433,36 @@ impl BlokliTestStateMutator for FullStateEmulator {
                     })?;
                     safe_balance.balance =
                         blokli_client::api::types::TokenValueString((balance + *ticket_amount).to_string());
+
+                    match state.safe_redeem_stats.entry(safe_addr.clone()) {
+                        Entry::Occupied(mut e) => {
+                            let stats = e.get_mut();
+                            let current_redeemed_amount: HoprBalance =
+                                stats.redeemed_amount.0.parse().map_err(|_| {
+                                    blokli_client::errors::ErrorKind::MockClientError(anyhow::anyhow!(
+                                        "failed to parse redeemed value on {safe_addr}"
+                                    ))
+                                })?;
+                            let current_redeemed_count: u64 = stats.redemption_count.0.parse().map_err(|_| {
+                                blokli_client::errors::ErrorKind::MockClientError(anyhow::anyhow!(
+                                    "failed to parse redemed count on {safe_addr}"
+                                ))
+                            })?;
+
+                            stats.redeemed_amount = blokli_client::api::types::TokenValueString(
+                                (current_redeemed_amount + *ticket_amount).to_string(),
+                            );
+                            stats.redemption_count =
+                                blokli_client::api::types::Uint64((current_redeemed_count + 1).to_string());
+                        }
+                        Entry::Vacant(v) => {
+                            v.insert(RedeemedStats {
+                                __typename: "RedeemedStats".to_string(),
+                                redeemed_amount: blokli_client::api::types::TokenValueString(ticket_amount.to_string()),
+                                redemption_count: blokli_client::api::types::Uint64("1".into()),
+                            });
+                        }
+                    }
 
                     tracing::debug!(%channel_id, %ticket_index, %safe_addr, "ticket redeemed into safe");
                 } else {

--- a/impls/connector/src/testing/emulator.rs
+++ b/impls/connector/src/testing/emulator.rs
@@ -445,7 +445,7 @@ impl BlokliTestStateMutator for FullStateEmulator {
                                 })?;
                             let current_redeemed_count: u64 = stats.redemption_count.0.parse().map_err(|_| {
                                 blokli_client::errors::ErrorKind::MockClientError(anyhow::anyhow!(
-                                    "failed to parse redemed count on {safe_addr}"
+                                    "failed to parse redeemed count on {safe_addr}"
                                 ))
                             })?;
 

--- a/impls/connector/src/utils.rs
+++ b/impls/connector/src/utils.rs
@@ -1,7 +1,7 @@
 use std::{str::FromStr, time::Duration};
 
 use hopr_api::{
-    chain::{ChainInfo, DeployedSafe, DomainSeparators},
+    chain::{ChainInfo, DeployedSafe, DomainSeparators, RedemptionStats},
     types::{
         chain::{chain_events::ChainEvent, payload::GasEstimation},
         crypto::types::Hash,
@@ -78,6 +78,23 @@ pub(crate) fn model_to_graph_entry(
         .build()?;
 
     Ok((src, dst, channel))
+}
+
+pub(crate) fn model_to_redeemed_stats(
+    model: blokli_client::api::types::RedeemedStats,
+) -> Result<RedemptionStats, ConnectorError> {
+    Ok(RedemptionStats {
+        redeemed_count: model
+            .redemption_count
+            .0
+            .parse()
+            .map_err(|_| ConnectorError::TypeConversion("invalid redemption count".into()))?,
+        redeemed_value: model
+            .redeemed_amount
+            .0
+            .parse()
+            .map_err(|_| ConnectorError::TypeConversion("invalid redeemed amount".into()))?,
+    })
 }
 
 pub(crate) fn model_to_ticket_params(

--- a/impls/strategy/src/snapshots/hopr_strategy__auto_funding__tests__auto_funding_strategy.snap
+++ b/impls/strategy/src/snapshots/hopr_strategy__auto_funding__tests__auto_funding_strategy.snap
@@ -1,5 +1,5 @@
 ---
-source: logic/strategy/src/auto_funding.rs
+source: impls/strategy/src/auto_funding.rs
 expression: "*snapshot.refresh()"
 ---
 accounts:
@@ -111,6 +111,7 @@ deployed_safes:
     chain_key: 68499f50ff68d523385dc60686069935d17d762a
     module_address: c6cf223b5fa5a0002e5f975453407134b848c312
     registered_nodes: []
+safe_redeem_stats: {}
 tx_counts:
   bea83ba0fcee21da44a30c893f466e6bf0c29bbb: 1
 channels:

--- a/logic/ticket-manager/Cargo.toml
+++ b/logic/ticket-manager/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-ticket-manager"
 description = "Manages outgoing ticket indices and incoming redeemable tickets"
-version = "0.3.0"
+version = "0.4.0"
 rust-version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/logic/ticket-manager/src/manager.rs
+++ b/logic/ticket-manager/src/manager.rs
@@ -487,7 +487,6 @@ where
     /// If the given `channel` does not exist, it returns zero statistics instead of an error.
     ///
     /// Apart from [`unredeemed_value`](ChannelStats), the statistics are not persistent.
-    #[allow(deprecated)] // TODO: remove once blokli#237 is merged
     fn ticket_stats(&self, channel: Option<&ChannelId>) -> Result<ChannelStats, TicketManagerError> {
         self.channel_tickets
             .0
@@ -507,14 +506,12 @@ where
                         .unwrap_or_default()
                         + stats.unredeemed_value,
                     rejected_value: queue.1.rejected_value + stats.rejected_value,
-                    redeemed_value: queue.1.redeemed_value + stats.redeemed_value,
                     neglected_value: queue.1.neglected_value + stats.neglected_value,
                 })
             })
     }
 }
 
-#[allow(deprecated)] // TODO: remove once blokli#237 is merged
 #[cfg(test)]
 mod tests {
     use std::ops::Sub;
@@ -575,7 +572,6 @@ mod tests {
                 winning_tickets: 1,
                 unredeemed_value: tickets[0].verified_ticket().amount,
                 rejected_value: HoprBalance::zero(),
-                redeemed_value: HoprBalance::zero(),
                 neglected_value: HoprBalance::zero(),
             },
             mgr.ticket_stats(Some(&channel.get_id()))?
@@ -588,7 +584,6 @@ mod tests {
                 winning_tickets: 2,
                 unredeemed_value: tickets[0].verified_ticket().amount + tickets[1].verified_ticket().amount,
                 rejected_value: HoprBalance::zero(),
-                redeemed_value: HoprBalance::zero(),
                 neglected_value: HoprBalance::zero(),
             },
             mgr.ticket_stats(Some(&channel.get_id()))?
@@ -802,7 +797,6 @@ mod tests {
                 winning_tickets: tickets.len() as u128,
                 unredeemed_value: unrealized_value_after,
                 rejected_value: HoprBalance::zero(),
-                redeemed_value: HoprBalance::zero(),
                 neglected_value: neglected.iter().map(|t| t.verified_ticket().amount).sum(),
             },
             mgr.ticket_stats(Some(&channel.get_id()))?
@@ -877,7 +871,6 @@ mod tests {
                 winning_tickets: tickets.len() as u128,
                 unredeemed_value: unrealized_value_after,
                 rejected_value: HoprBalance::zero(),
-                redeemed_value: HoprBalance::zero(),
                 neglected_value: neglected.iter().map(|t| t.verified_ticket().amount).sum(),
             },
             mgr.ticket_stats(Some(&channel.get_id()))?
@@ -925,7 +918,6 @@ mod tests {
                 winning_tickets: tickets.len() as u128,
                 unredeemed_value: expected_unrealized_value,
                 rejected_value: HoprBalance::zero(),
-                redeemed_value: HoprBalance::zero(),
                 neglected_value: HoprBalance::zero(),
             },
             mgr.ticket_stats(Some(&tickets[0].ticket.channel_id()))?
@@ -980,7 +972,6 @@ mod tests {
             stats.unredeemed_value
         );
         assert_eq!(HoprBalance::zero(), stats.rejected_value);
-        assert_eq!(HoprBalance::zero(), stats.redeemed_value);
 
         Ok(())
     }
@@ -1042,7 +1033,6 @@ mod tests {
                 winning_tickets: tickets_from_epoch_1.len() as u128 + 1,
                 unredeemed_value: new_unrealized_value,
                 rejected_value: HoprBalance::zero(),
-                redeemed_value: HoprBalance::zero(),
                 neglected_value: neglected.iter().map(|t| t.verified_ticket().amount).sum(),
             },
             mgr.ticket_stats(Some(&channel_id))?
@@ -1431,7 +1421,6 @@ mod tests {
                 winning_tickets: tickets.len() as u128,
                 unredeemed_value: HoprBalance::zero(),
                 rejected_value: HoprBalance::zero(),
-                redeemed_value: HoprBalance::zero(),
                 neglected_value: neglected.iter().map(|t| t.verified_ticket().amount).sum(),
             },
             mgr.ticket_stats(Some(&channel.get_id()))?
@@ -1446,7 +1435,6 @@ mod tests {
                 winning_tickets: tickets.len() as u128,
                 unredeemed_value: HoprBalance::zero(),
                 rejected_value: HoprBalance::zero(),
-                redeemed_value: tickets[0].verified_ticket().amount,
                 neglected_value: neglected
                     .iter()
                     .map(|t| t.verified_ticket().amount)

--- a/transport/api/tests/stubs/mod.rs
+++ b/transport/api/tests/stubs/mod.rs
@@ -189,6 +189,13 @@ impl ChainValues for StubChain {
             contract_addresses: Default::default(),
         })
     }
+
+    async fn redemption_stats<A: Into<Address> + Send>(&self, _: A) -> Result<RedemptionStats, Self::Error> {
+        Ok(RedemptionStats {
+            redeemed_count: 0,
+            redeemed_value: HoprBalance::zero(),
+        })
+    }
 }
 
 /// Stub network view satisfying `Net` trait bounds (never used before `run()`).


### PR DESCRIPTION
This PR removes the redeemed value tracking from the code completely and uses the Blokli redeemed ticket stats query in tests.

Proper emulation of RedeemedStats tracking has been added to the BlokliStateEmulator.

Some additional dependencies were updated.

Requires https://github.com/hoprnet/blokli/pull/301
Closes #7987 