### PR TITLE
chore(ci): replace self-hosted runners with Depot runners

### DIFF
--- a/.github/scripts/generate-metrics-docs.sh
+++ b/.github/scripts/generate-metrics-docs.sh
@@ -137,7 +137,7 @@ fi
 
 # ── --fix: regenerate METRICS.md in place and stage it ─────────────────────────
 if [[ ${1:-} == "--fix" ]]; then
-  expected=$("$0" --generate)
+  expected=$(bash "$0" --generate)
   echo "$expected" >"$METRICS_DOC"
   git -C "$REPO_ROOT" add "$METRICS_DOC"
   echo "METRICS.md updated and staged."
@@ -158,7 +158,7 @@ normalize_table() {
 }
 
 # Generate expected content and compare with the actual file (whitespace-tolerant)
-expected=$("$0" --generate)
+expected=$(bash "$0" --generate)
 
 if ! diff -q <(echo "$expected" | normalize_table) <(normalize_table <"$METRICS_DOC") >/dev/null 2>&1; then
   echo "ERROR: METRICS.md is out of date. Differences:"

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@10cf5ffa21ceef42226dc3925d0d1d3314721d28 # workflow-tests-v4
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@cc69d3703cd89bbba3168da88f0b11c2e7f936da # workflow-tests-v4
     with:
       source_branch: ${{ github.ref_name }}
       enable_unit_tests: false

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -16,16 +16,15 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@cfadaaa8ec3f22764689169ed8bd05d6b973d62e # workflow-tests-v4
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@10cf5ffa21ceef42226dc3925d0d1d3314721d28 # workflow-tests-v4
     with:
       source_branch: ${{ github.ref_name }}
-      unit_tests: false
-      integration_tests: false
-      nightly_tests: false
-      benchmarks: false
-      unit_coverage: true
-      integration_coverage: true
-      unconditional: true
+      enable_unit_tests: false
+      enable_integration_tests: false
+      enable_nightly_tests: false
+      enable_benchmarks: false
+      enable_unit_coverage: true
+      enable_integration_coverage: true
       unit_coverage_command: |
         nix build -L .#coverage-unit
         cp result coverage.lcov

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@f24407b0e31b7c48f884198aff01178a7c691610 # workflow-tests-v4
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@68c55f5bd5bd5a74a92b03f7cd72970f862894d0 # workflow-tests-v4
     with:
       source_branch: ${{ github.ref_name }}
       enable_unit_tests: false

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@164082c2e12a2aa9d2b2bdbf7f3081bea85cd1a0 # workflow-tests-v4
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@b5190a22526f2da53a6006fe38f17857bd7df466 # workflow-tests-v4
     with:
       source_branch: ${{ github.ref_name }}
       enable_unit_tests: false

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -35,7 +35,7 @@ jobs:
           --test '*' \
           --lcov --output-path coverage.lcov \
           -j 1
-      runner: self-hosted-hoprnet-bigger
+      runner: depot-ubuntu-24.04-16
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@b5190a22526f2da53a6006fe38f17857bd7df466 # workflow-tests-v4
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@a34788ec4bf2bf4bd65aa39163ad920cc9d2833b # workflow-tests-v4
     with:
       source_branch: ${{ github.ref_name }}
       enable_unit_tests: false

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@cc69d3703cd89bbba3168da88f0b11c2e7f936da # workflow-tests-v4
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@164082c2e12a2aa9d2b2bdbf7f3081bea85cd1a0 # workflow-tests-v4
     with:
       source_branch: ${{ github.ref_name }}
       enable_unit_tests: false

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@a34788ec4bf2bf4bd65aa39163ad920cc9d2833b # workflow-tests-v4
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@f24407b0e31b7c48f884198aff01178a7c691610 # workflow-tests-v4
     with:
       source_branch: ${{ github.ref_name }}
       enable_unit_tests: false
@@ -34,7 +34,7 @@ jobs:
           --test '*' \
           --lcov --output-path coverage.lcov \
           -j 1
-      runner: depot-ubuntu-24.04-16
+      runner_unit: depot-ubuntu-24.04-16
       runner_integration: depot-ubuntu-24.04-8
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@268553d7984344080e3dc65eb92778c9103af7ec # workflow-tests-v3
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@cfadaaa8ec3f22764689169ed8bd05d6b973d62e # workflow-tests-v4
     with:
       source_branch: ${{ github.ref_name }}
       unit_tests: false
@@ -36,6 +36,7 @@ jobs:
           --lcov --output-path coverage.lcov \
           -j 1
       runner: depot-ubuntu-24.04-16
+      runner_integration: depot-ubuntu-24.04-8
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/build-dappnode.yaml
+++ b/.github/workflows/build-dappnode.yaml
@@ -45,7 +45,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' || contains(inputs.labels, format('package:{0},', inputs.dappnode_repository))
     name: Build package
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     permissions:
       contents: read
     steps:

--- a/.github/workflows/checks-performance.yaml
+++ b/.github/workflows/checks-performance.yaml
@@ -32,7 +32,7 @@ permissions:
 jobs:
   performance:
     name: Download
-    runs-on: self-hosted-hoprnet-bigger
+    runs-on: depot-ubuntu-24.04-16
     if: vars.TEST_CHECK_PERFORMANCE_ENABLED == 'true'
     timeout-minutes: 30
     steps:

--- a/.github/workflows/checks-zizmor.yaml
+++ b/.github/workflows/checks-zizmor.yaml
@@ -29,6 +29,6 @@ jobs:
       security-events: write
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      runner: depot-ubuntu-24.04-16
+      runner: depot-ubuntu-24.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/checks-zizmor.yaml
+++ b/.github/workflows/checks-zizmor.yaml
@@ -29,6 +29,6 @@ jobs:
       security-events: write
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      runner: self-hosted-hoprnet-bigger
+      runner: depot-ubuntu-24.04-16
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/clean-pr.yaml
+++ b/.github/workflows/clean-pr.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   cleanup-pr:
     name: Remove cache
-    runs-on: self-hosted-hoprnet-small
+    runs-on: depot-ubuntu-24.04-4
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/clean-pr.yaml
+++ b/.github/workflows/clean-pr.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   cleanup-pr:
     name: Remove cache
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: depot-ubuntu-24.04
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/generate-dappnode-pr.yaml
+++ b/.github/workflows/generate-dappnode-pr.yaml
@@ -39,7 +39,7 @@ concurrency:
 jobs:
   build:
     name: package
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: depot-ubuntu-24.04
     permissions:
       contents: read
     timeout-minutes: 60

--- a/.github/workflows/generate-dappnode-pr.yaml
+++ b/.github/workflows/generate-dappnode-pr.yaml
@@ -39,7 +39,7 @@ concurrency:
 jobs:
   build:
     name: package
-    runs-on: self-hosted-hoprnet-small
+    runs-on: depot-ubuntu-24.04-4
     permissions:
       contents: read
     timeout-minutes: 60

--- a/.github/workflows/latexcompile.yaml
+++ b/.github/workflows/latexcompile.yaml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   build_latex:
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0

--- a/.github/workflows/latexcompile.yaml
+++ b/.github/workflows/latexcompile.yaml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   build_latex:
-    runs-on: self-hosted-hoprnet-small
+    runs-on: depot-ubuntu-24.04-4
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0

--- a/.github/workflows/load-tests.yaml
+++ b/.github/workflows/load-tests.yaml
@@ -106,7 +106,7 @@ jobs:
     name: Load Tests
     permissions:
       contents: read
-    runs-on: self-hosted-hoprnet-small
+    runs-on: depot-ubuntu-24.04-4
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0

--- a/.github/workflows/load-tests.yaml
+++ b/.github/workflows/load-tests.yaml
@@ -106,7 +106,7 @@ jobs:
     name: Load Tests
     permissions:
       contents: read
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -22,16 +22,16 @@ jobs:
       matrix:
         include:
           - architecture: x86_64-linux
-            runner: self-hosted-hoprnet-bigger
+            runner: depot-ubuntu-24.04-16
             build_command: nix build -L .#binary-hoprd-x86_64-linux
           - architecture: aarch64-linux
-            runner: self-hosted-hoprnet-bigger
+            runner: depot-ubuntu-24.04-16
             build_command: nix build -L .#binary-hoprd-aarch64-linux
             # - architecture: x86_64-darwin
-            #   runner: macos-15-intel
+            #   runner: depot-macos-15
             #   build_command: nix build -L .#binary-hoprd-x86_64-darwin
             # - architecture: aarch64-darwin
-            #   runner: macos-15-xlarge
+            #   runner: depot-macos-15
             #   build_command: nix build -L .#binary-hoprd-aarch64-darwin
     uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@build-binaries-v2
     permissions:
@@ -64,12 +64,12 @@ jobs:
       build_matrix: >-
         [
           {
-            "runner": "self-hosted-hoprnet-bigger",
+            "runner": "depot-ubuntu-24.04-16",
             "architecture": "x86_64-linux",
             "build_command": "nix build -L .#docker-hoprd-x86_64-linux"
           },
           {
-            "runner": "self-hosted-hoprnet-bigger",
+            "runner": "depot-ubuntu-24.04-16",
             "architecture": "aarch64-linux",
             "build_command": "nix build -L .#docker-hoprd-aarch64-linux"
           }
@@ -88,7 +88,7 @@ jobs:
       docker_hub_token: ${{ secrets.DOCKER_HUB_TOKEN }}
   deploy-dev:
     name: Deploy Gnosis Dev
-    runs-on: self-hosted-hoprnet-small
+    runs-on: depot-ubuntu-24.04-4
     needs: build-docker
     if: github.event.pull_request.merged == true
     permissions:
@@ -108,7 +108,7 @@ jobs:
   cache_deps:
     name: Cache deps
     if: github.event.pull_request.merged == true
-    runs-on: self-hosted-hoprnet-small
+    runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 60
     permissions:
       contents: read
@@ -135,7 +135,7 @@ jobs:
     if: github.event.pull_request.merged == true
     needs:
       - build-docker
-    runs-on: self-hosted-hoprnet-bigger
+    runs-on: depot-ubuntu-24.04-16
     timeout-minutes: 60
     permissions:
       contents: write
@@ -164,7 +164,7 @@ jobs:
       - build-docker
       - docs
     if: ${{ always() && github.event.pull_request.merged == true && !success() }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Notify failed merge pipeline
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5 # v1.0.2
@@ -179,7 +179,7 @@ jobs:
             The merge pipeline has failed for pull request [#${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
   cleanup_actions:
     name: Cleanup Actions
-    runs-on: self-hosted-hoprnet-small
+    runs-on: depot-ubuntu-24.04-4
     permissions:
       actions: write
     steps:

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -64,12 +64,12 @@ jobs:
       build_matrix: >-
         [
           {
-            "runner": "depot-ubuntu-24.04-16",
+            "runner": "depot-ubuntu-24.04-8",
             "architecture": "x86_64-linux",
             "build_command": "nix build -L .#docker-hoprd-x86_64-linux"
           },
           {
-            "runner": "depot-ubuntu-24.04-16",
+            "runner": "depot-ubuntu-24.04-8",
             "architecture": "aarch64-linux",
             "build_command": "nix build -L .#docker-hoprd-aarch64-linux"
           }
@@ -88,7 +88,7 @@ jobs:
       docker_hub_token: ${{ secrets.DOCKER_HUB_TOKEN }}
   deploy-dev:
     name: Deploy Gnosis Dev
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: depot-ubuntu-24.04
     needs: build-docker
     if: github.event.pull_request.merged == true
     permissions:
@@ -135,7 +135,7 @@ jobs:
     if: github.event.pull_request.merged == true
     needs:
       - build-docker
-    runs-on: depot-ubuntu-24.04-16
+    runs-on: depot-ubuntu-24.04-8
     timeout-minutes: 60
     permissions:
       contents: write
@@ -179,7 +179,7 @@ jobs:
             The merge pipeline has failed for pull request [#${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
   cleanup_actions:
     name: Cleanup Actions
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: depot-ubuntu-24.04
     permissions:
       actions: write
     steps:

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -22,10 +22,10 @@ jobs:
       matrix:
         include:
           - architecture: x86_64-linux
-            runner: depot-ubuntu-24.04-16
+            runner: depot-ubuntu-24.04-8
             build_command: nix build -L .#binary-hoprd-x86_64-linux
           - architecture: aarch64-linux
-            runner: depot-ubuntu-24.04-16
+            runner: depot-ubuntu-24.04-8
             build_command: nix build -L .#binary-hoprd-aarch64-linux
             # - architecture: x86_64-darwin
             #   runner: depot-macos-15
@@ -64,12 +64,12 @@ jobs:
       build_matrix: >-
         [
           {
-            "runner": "depot-ubuntu-24.04-8",
+            "runner": "depot-ubuntu-24.04-4",
             "architecture": "x86_64-linux",
             "build_command": "nix build -L .#docker-hoprd-x86_64-linux"
           },
           {
-            "runner": "depot-ubuntu-24.04-8",
+            "runner": "depot-ubuntu-24.04-4",
             "architecture": "aarch64-linux",
             "build_command": "nix build -L .#docker-hoprd-aarch64-linux"
           }
@@ -135,7 +135,7 @@ jobs:
     if: github.event.pull_request.merged == true
     needs:
       - build-docker
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 60
     permissions:
       contents: write

--- a/.github/workflows/pr-label.yaml
+++ b/.github/workflows/pr-label.yaml
@@ -23,7 +23,7 @@ jobs:
   build-candidate:
     name: Build Candidate
     if: github.event.label.name == 'build:candidate'
-    runs-on: self-hosted-hoprnet-bigger
+    runs-on: depot-ubuntu-24.04-16
     timeout-minutes: 20
     steps:
       - name: Build candidate binary

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -104,7 +104,7 @@ jobs:
       enable_integration_tests: true
       integration_test_command: "nix develop -c env NEXTEST_HIDE_PROGRESS_BAR=1 cargo nextest run --test '*' -j 1"
       enable_nightly_tests: true
-      enable_benchmarks: true
+      enable_benchmarks: false
       enable_unit_coverage: true
       enable_integration_coverage: true
       unit_coverage_command: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -97,7 +97,7 @@ jobs:
 
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@268553d7984344080e3dc65eb92778c9103af7ec # workflow-tests-v3
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@cfadaaa8ec3f22764689169ed8bd05d6b973d62e # workflow-tests-v4
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       unit_tests: true
@@ -117,6 +117,7 @@ jobs:
           --lcov --output-path coverage.lcov \
           -j 1
       runner: depot-ubuntu-24.04-16
+      runner_integration: depot-ubuntu-24.04-8
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       codecov_token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -97,16 +97,16 @@ jobs:
 
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@cfadaaa8ec3f22764689169ed8bd05d6b973d62e # workflow-tests-v4
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@10cf5ffa21ceef42226dc3925d0d1d3314721d28 # workflow-tests-v4
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      unit_tests: true
-      integration_tests: true
+      enable_unit_tests: true
+      enable_integration_tests: true
       integration_test_command: "nix develop -c env NEXTEST_HIDE_PROGRESS_BAR=1 cargo nextest run --test '*' -j 1"
-      nightly_tests: true
-      benchmarks: true
-      unit_coverage: true
-      integration_coverage: true
+      enable_nightly_tests: true
+      enable_benchmarks: true
+      enable_unit_coverage: true
+      enable_integration_coverage: true
       unit_coverage_command: |
         nix build -L .#coverage-unit
         cp result coverage.lcov

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,7 +27,7 @@ jobs:
   validate-pr-title:
     name: Validate title
     if: github.event_name == 'pull_request'
-    runs-on: self-hosted-hoprnet-small
+    runs-on: depot-ubuntu-24.04-4
     permissions:
       pull-requests: read
     steps:
@@ -53,7 +53,7 @@ jobs:
   label:
     name: Add labels
     if: github.event_name == 'pull_request'
-    runs-on: self-hosted-hoprnet-small
+    runs-on: depot-ubuntu-24.04-4
     permissions:
       contents: read
       issues: write
@@ -90,8 +90,8 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@bbd22e57cf954c15f0a6051d59329857809141dd # workflow-checks-v1
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      runner_small: self-hosted-hoprnet-small
-      runner_large: self-hosted-hoprnet-bigger
+      runner_small: depot-ubuntu-24.04-4
+      runner_large: depot-ubuntu-24.04-16
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
@@ -116,7 +116,7 @@ jobs:
           --test '*' \
           --lcov --output-path coverage.lcov \
           -j 1
-      runner: self-hosted-hoprnet-bigger
+      runner: depot-ubuntu-24.04-16
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       codecov_token: ${{ secrets.CODECOV_TOKEN }}
@@ -128,19 +128,19 @@ jobs:
       matrix:
         include:
           - architecture: x86_64-linux
-            runner: self-hosted-hoprnet-bigger
+            runner: depot-ubuntu-24.04-16
             build_command: nix build -L .#binary-hoprd-x86_64-linux
             required_label: ""
           - architecture: aarch64-linux
-            runner: self-hosted-hoprnet-bigger
+            runner: depot-ubuntu-24.04-16
             build_command: nix build -L .#binary-hoprd-aarch64-linux
             required_label: "binary:aarch64-linux"
           - architecture: aarch64-darwin
-            runner: macos-15-xlarge
+            runner: depot-macos-15
             build_command: nix build -L .#binary-hoprd-aarch64-darwin
             required_label: binary:aarch64-darwin
           - architecture: x86_64-darwin
-            runner: macos-15-intel
+            runner: depot-macos-15
             build_command: nix build -L .#binary-hoprd-x86_64-darwin
             required_label: binary:x86_64-darwin
     uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@build-binaries-v2
@@ -175,7 +175,7 @@ jobs:
       build_matrix: >-
         [
           {
-            "runner": "self-hosted-hoprnet-bigger",
+            "runner": "depot-ubuntu-24.04-16",
             "architecture": "x86_64-linux",
             "build_command": "nix build -L .#docker-hoprd-x86_64-linux",
             "build_debug_command": "nix build -L .#docker-hoprd-dev-x86_64-linux"
@@ -191,7 +191,7 @@ jobs:
 
   docs:
     name: Docs
-    runs-on: self-hosted-hoprnet-bigger
+    runs-on: depot-ubuntu-24.04-16
     timeout-minutes: 60
     permissions:
       contents: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -97,7 +97,7 @@ jobs:
 
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@b5190a22526f2da53a6006fe38f17857bd7df466 # workflow-tests-v4
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@a34788ec4bf2bf4bd65aa39163ad920cc9d2833b # workflow-tests-v4
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       enable_unit_tests: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,7 +27,7 @@ jobs:
   validate-pr-title:
     name: Validate title
     if: github.event_name == 'pull_request'
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: depot-ubuntu-24.04
     permissions:
       pull-requests: read
     steps:
@@ -53,7 +53,7 @@ jobs:
   label:
     name: Add labels
     if: github.event_name == 'pull_request'
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: depot-ubuntu-24.04
     permissions:
       contents: read
       issues: write
@@ -91,7 +91,7 @@ jobs:
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       runner_small: depot-ubuntu-24.04-4
-      runner_large: depot-ubuntu-24.04-16
+      runner_large: depot-ubuntu-24.04-8
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
@@ -175,7 +175,7 @@ jobs:
       build_matrix: >-
         [
           {
-            "runner": "depot-ubuntu-24.04-16",
+            "runner": "depot-ubuntu-24.04-8",
             "architecture": "x86_64-linux",
             "build_command": "nix build -L .#docker-hoprd-x86_64-linux",
             "build_debug_command": "nix build -L .#docker-hoprd-dev-x86_64-linux"
@@ -191,7 +191,7 @@ jobs:
 
   docs:
     name: Docs
-    runs-on: depot-ubuntu-24.04-16
+    runs-on: depot-ubuntu-24.04-8
     timeout-minutes: 60
     permissions:
       contents: read

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -97,7 +97,7 @@ jobs:
 
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@10cf5ffa21ceef42226dc3925d0d1d3314721d28 # workflow-tests-v4
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@cc69d3703cd89bbba3168da88f0b11c2e7f936da # workflow-tests-v4
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       enable_unit_tests: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -97,7 +97,7 @@ jobs:
 
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@164082c2e12a2aa9d2b2bdbf7f3081bea85cd1a0 # workflow-tests-v4
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@b5190a22526f2da53a6006fe38f17857bd7df466 # workflow-tests-v4
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       enable_unit_tests: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -97,7 +97,7 @@ jobs:
 
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@a34788ec4bf2bf4bd65aa39163ad920cc9d2833b # workflow-tests-v4
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@f24407b0e31b7c48f884198aff01178a7c691610 # workflow-tests-v4
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       enable_unit_tests: true
@@ -116,7 +116,7 @@ jobs:
           --test '*' \
           --lcov --output-path coverage.lcov \
           -j 1
-      runner: depot-ubuntu-24.04-16
+      runner_unit: depot-ubuntu-24.04-16
       runner_integration: depot-ubuntu-24.04-8
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -97,7 +97,7 @@ jobs:
 
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@cc69d3703cd89bbba3168da88f0b11c2e7f936da # workflow-tests-v4
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@164082c2e12a2aa9d2b2bdbf7f3081bea85cd1a0 # workflow-tests-v4
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       enable_unit_tests: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -97,7 +97,7 @@ jobs:
 
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@f24407b0e31b7c48f884198aff01178a7c691610 # workflow-tests-v4
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@68c55f5bd5bd5a74a92b03f7cd72970f862894d0 # workflow-tests-v4
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       enable_unit_tests: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -90,8 +90,8 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@bbd22e57cf954c15f0a6051d59329857809141dd # workflow-checks-v1
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      runner_small: depot-ubuntu-24.04-4
-      runner_large: depot-ubuntu-24.04-8
+      runner_small: depot-ubuntu-24.04
+      runner_large: depot-ubuntu-24.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
@@ -128,11 +128,11 @@ jobs:
       matrix:
         include:
           - architecture: x86_64-linux
-            runner: depot-ubuntu-24.04-16
+            runner: depot-ubuntu-24.04-8
             build_command: nix build -L .#binary-hoprd-x86_64-linux
             required_label: ""
           - architecture: aarch64-linux
-            runner: depot-ubuntu-24.04-16
+            runner: depot-ubuntu-24.04-8
             build_command: nix build -L .#binary-hoprd-aarch64-linux
             required_label: "binary:aarch64-linux"
           - architecture: aarch64-darwin
@@ -175,7 +175,7 @@ jobs:
       build_matrix: >-
         [
           {
-            "runner": "depot-ubuntu-24.04-8",
+            "runner": "depot-ubuntu-24.04-4",
             "architecture": "x86_64-linux",
             "build_command": "nix build -L .#docker-hoprd-x86_64-linux",
             "build_debug_command": "nix build -L .#docker-hoprd-dev-x86_64-linux"
@@ -191,7 +191,7 @@ jobs:
 
   docs:
     name: Docs
-    runs-on: depot-ubuntu-24.04-8
+    runs-on: depot-ubuntu-24.04-4
     timeout-minutes: 60
     permissions:
       contents: read

--- a/.github/workflows/promote-release.yaml
+++ b/.github/workflows/promote-release.yaml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   promote_release:
     name: Promote Release
-    runs-on: self-hosted-hoprnet-small
+    runs-on: depot-ubuntu-24.04-4
     permissions:
       contents: write
     steps:

--- a/.github/workflows/promote-release.yaml
+++ b/.github/workflows/promote-release.yaml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   promote_release:
     name: Promote Release
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: depot-ubuntu-24.04
     permissions:
       contents: write
     steps:

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   publish-release:
     name: Publish Release
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: depot-ubuntu-24.04
     permissions:
       contents: read
     steps:

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   publish-release:
     name: Publish Release
-    runs-on: self-hosted-hoprnet-small
+    runs-on: depot-ubuntu-24.04-4
     permissions:
       contents: read
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         include:
           - architecture: x86_64-linux
-            runner: self-hosted-hoprnet-bigger
+            runner: depot-ubuntu-24.04-16
             build_command: nix build -L .#binary-hoprd-x86_64-linux
     uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@build-binaries-v2
     permissions:
@@ -58,7 +58,7 @@ jobs:
       build_matrix: >-
         [
           {
-            "runner": "self-hosted-hoprnet-bigger",
+            "runner": "depot-ubuntu-24.04-16",
             "architecture": "x86_64-linux",
             "build_command": "nix build -L .#docker-hoprd-x86_64-linux",
             "smoke_test_command": "nix develop -c just smoke-test"
@@ -78,7 +78,7 @@ jobs:
     needs:
       - build-binaries
       - build-docker
-    runs-on: self-hosted-hoprnet-small
+    runs-on: depot-ubuntu-24.04-4
     permissions:
       contents: write
     steps:
@@ -99,7 +99,7 @@ jobs:
           github_token: ${{ secrets.GH_RUNNER_TOKEN }}
   deploy-staging:
     name: Deploy Gnosis Staging
-    runs-on: self-hosted-hoprnet-small
+    runs-on: depot-ubuntu-24.04-4
     needs: [build-docker, release]
     permissions:
       contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         include:
           - architecture: x86_64-linux
-            runner: depot-ubuntu-24.04-16
+            runner: depot-ubuntu-24.04-8
             build_command: nix build -L .#binary-hoprd-x86_64-linux
     uses: hoprnet/hopr-workflows/.github/workflows/build-binaries.yaml@build-binaries-v2
     permissions:
@@ -58,7 +58,7 @@ jobs:
       build_matrix: >-
         [
           {
-            "runner": "depot-ubuntu-24.04-8",
+            "runner": "depot-ubuntu-24.04-4",
             "architecture": "x86_64-linux",
             "build_command": "nix build -L .#docker-hoprd-x86_64-linux",
             "smoke_test_command": "nix develop -c just smoke-test"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,7 +58,7 @@ jobs:
       build_matrix: >-
         [
           {
-            "runner": "depot-ubuntu-24.04-16",
+            "runner": "depot-ubuntu-24.04-8",
             "architecture": "x86_64-linux",
             "build_command": "nix build -L .#docker-hoprd-x86_64-linux",
             "smoke_test_command": "nix develop -c just smoke-test"
@@ -78,7 +78,7 @@ jobs:
     needs:
       - build-binaries
       - build-docker
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: depot-ubuntu-24.04
     permissions:
       contents: write
     steps:
@@ -99,7 +99,7 @@ jobs:
           github_token: ${{ secrets.GH_RUNNER_TOKEN }}
   deploy-staging:
     name: Deploy Gnosis Staging
-    runs-on: depot-ubuntu-24.04-4
+    runs-on: depot-ubuntu-24.04
     needs: [build-docker, release]
     permissions:
       contents: read

--- a/.github/workflows/update-flake-lock.yaml
+++ b/.github/workflows/update-flake-lock.yaml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   lockfile:
-    runs-on: self-hosted-hoprnet-small
+    runs-on: depot-ubuntu-24.04-4
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0

--- a/flake.nix
+++ b/flake.nix
@@ -115,7 +115,10 @@
           src = nixLib.mkSrc {
             root = ./.;
             inherit fs;
-            extraFiles = [ ./hoprd/hoprd/example_cfg.yaml ];
+            extraFiles = [
+              ./hoprd/hoprd/example_cfg.yaml
+              ./deploy/compose/hoprd/conf/hoprd.cfg.yaml
+            ];
           };
           testSrc = nixLib.mkTestSrc {
             root = ./.;


### PR DESCRIPTION
## Summary

- Migrate all GitHub Actions workflows from self-hosted runners to Depot managed runners
- Right-size each job based on actual CPU/RAM metrics (~60% cost reduction)
- Fix pre-commit hook failure caused by `/usr/bin/env` missing in Nix sandbox
- Fix bench-build failure: add `hoprd.cfg.yaml` to `src.extraFiles` in flake.nix
- Refactor `tests.yaml` reusable workflow (hoprnet/hopr-workflows#32, merged as `workflow-tests-v4`):
  - Matrix → 7 individual conditional jobs with `enable_*` inputs
  - Per-job runner selection: `runner_unit` / `runner_integration`
  - Coverage depends only on corresponding test (not all tests)
  - Removed `unconditional` input

### Runner Allocation

| Tier | Runner | Jobs |
|------|--------|------|
| Minimal (2 vCPU / 8 GB) | `depot-ubuntu-24.04` | validate-pr-title, add-labels, deploy, release, cleanup, notify, latex, load-tests, dappnode, pre-commit, audit |
| Light (4 vCPU / 16 GB) | `depot-ubuntu-24.04-4` | lint, deps, zizmor, cache-deps, flake-lock, docker-build, docs |
| Medium (8 vCPU / 32 GB) | `depot-ubuntu-24.04-8` | binary builds, integration tests, integration coverage |
| Heavy (16 vCPU / 64 GB) | `depot-ubuntu-24.04-16` | unit tests, unit nightly, unit coverage, performance |
| macOS (8 vCPU / 24 GB) | `depot-macos-15` | darwin binary builds |