### PR TITLE
refactor: move HoprSessionServer to hopr-api, bump hopr-api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,7 +833,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -844,7 +844,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2805,7 +2805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4284,7 +4284,7 @@ dependencies = [
 [[package]]
 name = "hopr-api"
 version = "1.8.0"
-source = "git+https://github.com/hoprnet/hopr-api?branch=kauki%2Frefactor%2Fnode%2Fhas-accessors#c248e60a5a25b98ea2a01b8dcf2bdca5bc34e60d"
+source = "git+https://github.com/hoprnet/hopr-api?branch=kauki%2Frefactor%2Fnode%2Fhas-accessors#4e7839d20e86e4aeb72639c7d146f8be5e651fe6"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -5489,7 +5489,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5884,7 +5884,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6847,7 +6847,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7814,7 +7814,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7851,7 +7851,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8419,7 +8419,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9154,7 +9154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9354,7 +9354,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10433,7 +10433,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,7 +833,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -844,7 +844,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2805,7 +2805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4284,7 +4284,7 @@ dependencies = [
 [[package]]
 name = "hopr-api"
 version = "1.8.0"
-source = "git+https://github.com/hoprnet/hopr-api?branch=kauki%2Frefactor%2Fnode%2Fhas-accessors#0723f3091f287e44787dbe1da4d00640520839a5"
+source = "git+https://github.com/hoprnet/hopr-api?branch=kauki%2Frefactor%2Fnode%2Fhas-accessors#c248e60a5a25b98ea2a01b8dcf2bdca5bc34e60d"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -5490,7 +5490,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5885,7 +5885,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6848,7 +6848,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7815,7 +7815,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7852,7 +7852,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8420,7 +8420,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9155,7 +9155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9355,7 +9355,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10434,7 +10434,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4284,7 +4284,7 @@ dependencies = [
 [[package]]
 name = "hopr-api"
 version = "1.8.0"
-source = "git+https://github.com/hoprnet/hopr-api?branch=kauki%2Frefactor%2Fnode%2Fhas-accessors#4e7839d20e86e4aeb72639c7d146f8be5e651fe6"
+source = "git+https://github.com/hoprnet/hopr-api?branch=kauki%2Frefactor%2Fnode%2Fhas-accessors#66740f046deea4f8984d8bcfcffef31b0dd34e19"
 dependencies = [
  "async-trait",
  "atomic_enum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,7 +833,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -844,7 +844,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2805,7 +2805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4284,7 +4284,7 @@ dependencies = [
 [[package]]
 name = "hopr-api"
 version = "1.8.0"
-source = "git+https://github.com/hoprnet/hopr-api?branch=kauki%2Frefactor%2Fnode%2Fhas-accessors#937abfab528e24c840c21033c0f72daf3a912391"
+source = "git+https://github.com/hoprnet/hopr-api?branch=kauki%2Frefactor%2Fnode%2Fhas-accessors#0723f3091f287e44787dbe1da4d00640520839a5"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -5490,7 +5490,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5885,7 +5885,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6848,7 +6848,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7815,7 +7815,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7852,7 +7852,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8420,7 +8420,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8751,7 +8751,7 @@ checksum = "09fbdfe7a27a1b1633dfc0c4c8e65940b8d819c5ddb9cca48ebc3223b00c8b14"
 dependencies = [
  "ahash",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "nohash-hasher",
@@ -9155,7 +9155,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9355,7 +9355,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10434,7 +10434,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,7 +833,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -844,7 +844,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2805,7 +2805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4283,8 +4283,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.8.0"
-source = "git+https://github.com/hoprnet/hopr-api?branch=kauki%2Frefactor%2Fnode%2Fhas-accessors#66740f046deea4f8984d8bcfcffef31b0dd34e19"
+version = "1.7.0"
+source = "git+https://github.com/hoprnet/hopr-api?branch=kauki%2Frefactor%2Fnode%2Fhas-accessors#a3818ba46d9f9b64dfc0436e85244360dcf2d14d"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -5489,7 +5489,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5884,7 +5884,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6847,7 +6847,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7814,7 +7814,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7851,7 +7851,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8419,7 +8419,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9154,7 +9154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9354,7 +9354,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10433,7 +10433,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4714,7 +4714,6 @@ dependencies = [
  "hopr-network-graph",
  "hopr-reference",
  "hopr-ticket-manager",
- "hopr-transport",
  "hopr-transport-p2p",
  "lazy_static",
  "opentelemetry-prometheus-text-exporter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,7 +833,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -844,7 +844,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2805,7 +2805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4284,7 +4284,7 @@ dependencies = [
 [[package]]
 name = "hopr-api"
 version = "1.7.0"
-source = "git+https://github.com/hoprnet/hopr-api?branch=kauki%2Frefactor%2Fnode%2Fhas-accessors#a3818ba46d9f9b64dfc0436e85244360dcf2d14d"
+source = "git+https://github.com/hoprnet/hopr-api?branch=kauki%2Frefactor%2Fnode%2Fhas-accessors#d21ea599499431283786604f1b3ea8a134562d62"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -5489,7 +5489,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5884,7 +5884,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6847,7 +6847,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7814,7 +7814,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7851,7 +7851,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8419,7 +8419,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -9154,7 +9154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9354,7 +9354,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -10433,7 +10433,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -833,7 +833,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -844,7 +844,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2805,7 +2805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4284,7 +4284,7 @@ dependencies = [
 [[package]]
 name = "hopr-api"
 version = "1.7.0"
-source = "git+https://github.com/hoprnet/hopr-api?branch=kauki%2Frefactor%2Fnode%2Fhas-accessors#d21ea599499431283786604f1b3ea8a134562d62"
+source = "git+https://github.com/hoprnet/hopr-api?branch=main#6d4b4efe23e45b63e13be1d21319f6ca4b8e7029"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -5489,7 +5489,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5884,7 +5884,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6847,7 +6847,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7814,7 +7814,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7851,7 +7851,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8419,7 +8419,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9154,7 +9154,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9354,7 +9354,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10433,7 +10433,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,7 +218,7 @@ mimalloc = { version = "0.1.48", default-features = false, features = [
   "secure",
 ] }
 
-hopr-api = { git = "https://github.com/hoprnet/hopr-api", branch = "kauki/refactor/node/has-accessors" }
+hopr-api = { git = "https://github.com/hoprnet/hopr-api", branch = "main" }
 hopr-types = { version = "1.5.3", features = ["use-bindings"] }
 hopr-async-runtime = { path = "common/async-runtime" }
 hopr-crypto-keypair = { path = "crypto/keypair", default-features = false }

--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -39,7 +39,7 @@ serde = [
   "hopr-transport/serde",
 ]
 session-client = ["hopr-api/node-session-client"]
-session-server = []
+session-server = ["hopr-api/node-session-server"]
 transport-announce-quic = ["hopr-transport/p2p-announce-quic"]
 
 # === utility features ===

--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -39,7 +39,7 @@ serde = [
   "hopr-transport/serde",
 ]
 session-client = ["hopr-api/node-session-client"]
-session-server = ["hopr-api/node-session-server"]
+session-server = []
 transport-announce-quic = ["hopr-transport/p2p-announce-quic"]
 
 # === utility features ===

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -14,6 +14,7 @@ use hopr_api::{
     tickets::{TicketFactory, TicketManagement},
     types::{
         chain::chain_events::ChainEvent,
+        internal::prelude::{ChannelDirection, ChannelStatus},
         primitive::prelude::{Address, UnitaryFloatOps},
     },
 };
@@ -417,12 +418,13 @@ where
             })?;
             tracing::info!(%safe_addr, "safe successfully registered with this node");
         }
-        Err(SafeRegistrationError::AlreadyRegistered(registered_safe)) if registered_safe == safe_addr => {
-            tracing::info!(%safe_addr, "this safe is already registered with this node");
-        }
-        Err(SafeRegistrationError::AlreadyRegistered(registered_safe)) if registered_safe != safe_addr => {
-            tracing::error!(%safe_addr, %registered_safe, "node registered with different safe");
-            return Err(HoprLibError::GeneralError("node registered with different safe".into()));
+        Err(SafeRegistrationError::AlreadyRegistered(registered_safe)) => {
+            if registered_safe == safe_addr {
+                tracing::info!(%safe_addr, "this safe is already registered with this node");
+            } else {
+                tracing::error!(%safe_addr, %registered_safe, "node registered with different safe");
+                return Err(HoprLibError::GeneralError("node registered with different safe".into()));
+            }
         }
         Err(error) => {
             tracing::error!(%safe_addr, %error, "safe registration failed");
@@ -433,7 +435,7 @@ where
     let multiaddresses_to_announce = if ctx.cfg.publish {
         transport_api.announceable_multiaddresses()
     } else {
-        Vec::with_capacity(0)
+        Vec::new()
     };
 
     multiaddresses_to_announce
@@ -562,10 +564,7 @@ where
 
                                 match keys {
                                     Ok(Some((from, to))) => {
-                                        let capacity = if matches!(
-                                            channel.status,
-                                            hopr_api::types::internal::prelude::ChannelStatus::Closed
-                                        ) {
+                                        let capacity = if matches!(channel.status, ChannelStatus::Closed) {
                                             None
                                         } else if let Ok(ticket_value) =
                                             ticket_price.read().div_f64(win_probability.read().as_f64())
@@ -771,7 +770,6 @@ macro_rules! impl_build_methods {
                         let chain = chain_for_neglect.clone();
                         let tmgr = tmgr_for_neglect.clone();
                         async move {
-                            use hopr_api::types::internal::prelude::ChannelDirection;
                             match closed_channel.direction(chain.me()) {
                                 Some(ChannelDirection::Incoming) => {
                                     match tmgr.neglect_tickets(closed_channel.get_id(), None) {

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -48,7 +48,7 @@ lazy_static::lazy_static! {
 /// Intermediate state produced by the shared initialization sequence.
 ///
 /// Holds all resources needed by the divergent `build_edge` / `build_full` finalization steps.
-struct PreBuiltNode<Chain, Graph, Net, NB, Ct> {
+struct PreHopr<Chain, Graph, Net, NB, Ct> {
     chain_id: ChainKeypair,
     transport_id: OffchainKeypair,
     cfg: HoprLibConfig,
@@ -409,7 +409,7 @@ where
     /// Shared initialization sequence for both edge and full node builds.
     async fn pre_build(
         mut self,
-    ) -> Result<PreBuiltNode<Chain, Graph, <NB as NetworkBuilder>::Network, NB, Ct>, HoprLibError> {
+    ) -> Result<PreHopr<Chain, Graph, <NB as NetworkBuilder>::Network, NB, Ct>, HoprLibError> {
         self.cfg.validate()?;
 
         let chain_api = self
@@ -620,7 +620,7 @@ where
         // === Chain → Graph event wiring ===
         // Subscribe to chain events and update the graph accordingly.
         // This runs as a background task for the lifetime of the node.
-        let mut processes = {
+        let processes = {
             let chain_events = chain_api
                 .subscribe_with_state_sync([StateSyncOptions::PublicAccounts, StateSyncOptions::OpenedChannels])
                 .map_err(HoprLibError::chain)?;
@@ -752,7 +752,7 @@ where
             processes
         };
 
-        Ok(PreBuiltNode {
+        Ok(PreHopr {
             chain_id,
             transport_id,
             cfg: self.cfg,

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -1,9 +1,10 @@
 use std::{convert::identity, sync::Arc, time::Duration};
 
 use futures::{FutureExt, StreamExt, channel::mpsc::channel};
-// Re-exports for downstream convenience
-pub use hopr_api::types::crypto::keypairs::Keypair;
-pub use hopr_api::types::crypto::prelude::{ChainKeypair, OffchainKeypair};
+pub use hopr_api::types::crypto::{
+    keypairs::Keypair,
+    prelude::{ChainKeypair, OffchainKeypair},
+};
 use hopr_api::{
     chain::{AnnouncementError, HoprChainApi, SafeRegistrationError, StateSyncOptions},
     ct::{CoverTrafficGeneration, ProbingTrafficGeneration},
@@ -45,23 +46,136 @@ lazy_static::lazy_static! {
     ).unwrap();
 }
 
-// ---------------------------------------------------------------------------
-// Session server attachment helper
-// ---------------------------------------------------------------------------
+/// Intermediate state produced by the shared initialization sequence.
+struct PreHopr<Chain, Graph, Net, NB, Ct> {
+    chain_id: ChainKeypair,
+    transport_id: OffchainKeypair,
+    cfg: HoprLibConfig,
+    state: Arc<AtomicHoprState>,
+    transport_api: HoprTransport<Chain, Graph, Net>,
+    chain_api: Chain,
+    ticket_event_subscribers: (
+        async_broadcast::Sender<TicketEvent>,
+        async_broadcast::InactiveReceiver<TicketEvent>,
+    ),
+    processes: AbortableList<HoprLibProcess>,
+    session_tx: futures::channel::mpsc::Sender<IncomingSession>,
+    cover_traffic: Ct,
+    network_builder: NB,
+}
 
-#[cfg(feature = "session-server")]
-fn attach_session_server<Srv>(
-    session_rx: futures::channel::mpsc::Receiver<IncomingSession>,
-    server: Srv,
-    processes: &mut AbortableList<HoprLibProcess>,
-) where
-    Srv: hopr_api::node::HoprSessionServer<Session = IncomingSession>,
-    Srv::Error: std::fmt::Display,
-{
-    tracing::debug!("attaching session server");
-    processes.insert(
-        HoprLibProcess::SessionServer,
-        hopr_async_runtime::spawn_as_abortable!(
+/// Abstract builder for the [`Hopr`] node object.
+///
+/// Provides two distinct build paths:
+///
+/// - [`build_edge`](HoprBuilder::build_edge) — standalone ticket factory, no ticket management
+/// - [`build_full`](HoprBuilder::build_full) — coupled ticket factory + ticket manager
+///
+/// # Type Parameters
+///
+/// - `Chain` — blockchain API ([`HoprChainApi`])
+/// - `Graph` — network graph ([`HoprGraphApi`])
+/// - `NB` — network builder factory ([`NetworkBuilder`])
+/// - `Ct` — cover traffic / probing ([`ProbingTrafficGeneration`] + [`CoverTrafficGeneration`])
+pub struct HoprBuilder<Chain = (), Graph = (), NB = (), Ct = ()> {
+    chain: Option<Chain>,
+    graph: Option<Graph>,
+    network_builder: Option<NB>,
+    cover_traffic: Option<Ct>,
+    identity: Option<(ChainKeypair, OffchainKeypair)>,
+    safe_and_module: Option<(Address, Address)>,
+    cfg: HoprLibConfig,
+    /// Pre-spawned session server: `(session_tx, abort_handle)`.
+    /// Created by [`with_session_server`](HoprBuilder::with_session_server).
+    /// Sessions are not emitted until transport starts during build, so
+    /// spawning the consumer early is safe.
+    #[cfg(feature = "session-server")]
+    session: Option<(
+        futures::channel::mpsc::Sender<IncomingSession>,
+        hopr_async_runtime::AbortHandle,
+    )>,
+}
+
+impl<Chain, Graph, NB, Ct> Default for HoprBuilder<Chain, Graph, NB, Ct> {
+    fn default() -> Self {
+        Self {
+            chain: None,
+            graph: None,
+            network_builder: None,
+            cover_traffic: None,
+            identity: None,
+            safe_and_module: None,
+            cfg: Default::default(),
+            #[cfg(feature = "session-server")]
+            session: None,
+        }
+    }
+}
+
+impl<Chain, Graph, NB, Ct> HoprBuilder<Chain, Graph, NB, Ct> {
+    /// Sets the chain API implementation.
+    pub fn with_chain_api(mut self, chain: Chain) -> Self {
+        self.chain = Some(chain);
+        self
+    }
+
+    /// Sets the network graph.
+    pub fn with_graph(mut self, graph: Graph) -> Self {
+        self.graph = Some(graph);
+        self
+    }
+
+    /// Sets the network builder (factory for P2P network).
+    pub fn with_network_builder(mut self, builder: NB) -> Self {
+        self.network_builder = Some(builder);
+        self
+    }
+
+    /// Sets the cover traffic and probing provider.
+    pub fn with_cover_traffic(mut self, ct: Ct) -> Self {
+        self.cover_traffic = Some(ct);
+        self
+    }
+
+    /// Sets the node's on-chain and off-chain identity.
+    pub fn with_identity(mut self, chain_key: &ChainKeypair, offchain_key: &OffchainKeypair) -> Self {
+        self.identity = Some((chain_key.clone(), offchain_key.clone()));
+        self
+    }
+
+    /// Sets the node Safe and module addresses.
+    pub fn with_safe_module(mut self, safe: &Address, module: &Address) -> Self {
+        self.safe_and_module = Some((*safe, *module));
+        self
+    }
+
+    /// Sets the [`HoprLibConfig`].
+    pub fn with_config(mut self, cfg: HoprLibConfig) -> Self {
+        self.cfg = cfg;
+        self
+    }
+
+    /// Attaches a session server for handling incoming sessions.
+    ///
+    /// Eagerly spawns the server task and creates the incoming session channel.
+    /// The spawned task blocks on the receiver until transport starts emitting
+    /// sessions during [`build_edge`](HoprBuilder::build_edge) or
+    /// [`build_full`](HoprBuilder::build_full).
+    #[cfg(feature = "session-server")]
+    pub fn with_session_server(
+        mut self,
+        server: impl hopr_api::node::HoprSessionServer<Session = IncomingSession, Error: std::fmt::Display>,
+    ) -> Self {
+        let incoming_session_capacity = std::env::var("HOPR_INTERNAL_SESSION_INCOMING_CAPACITY")
+            .ok()
+            .and_then(|s| s.trim().parse::<usize>().ok())
+            .filter(|&c| c > 0)
+            .unwrap_or(256);
+
+        let (session_tx, session_rx) = channel::<IncomingSession>(incoming_session_capacity);
+
+        tracing::debug!(capacity = incoming_session_capacity, "spawning session server");
+        let handle = hopr_async_runtime::spawn_as_abortable!(
             session_rx
                 .for_each_concurrent(None, move |session| {
                     let server = server.clone();
@@ -79,59 +193,16 @@ fn attach_session_server<Srv>(
                     task = %HoprLibProcess::SessionServer,
                     "long-running background task finished"
                 ))
-        ),
-    );
-}
+        );
 
-// ---------------------------------------------------------------------------
-// Builder core — shared across feature variants
-// ---------------------------------------------------------------------------
-
-/// Internal core holding builder fields common to all feature configurations.
-struct HoprBuilderCore<Chain, Graph, NB, Ct> {
-    chain: Option<Chain>,
-    graph: Option<Graph>,
-    network_builder: Option<NB>,
-    cover_traffic: Option<Ct>,
-    identity: Option<(ChainKeypair, OffchainKeypair)>,
-    safe_and_module: Option<(Address, Address)>,
-    cfg: HoprLibConfig,
-}
-
-impl<Chain, Graph, NB, Ct> Default for HoprBuilderCore<Chain, Graph, NB, Ct> {
-    fn default() -> Self {
-        Self {
-            chain: None,
-            graph: None,
-            network_builder: None,
-            cover_traffic: None,
-            identity: None,
-            safe_and_module: None,
-            cfg: Default::default(),
-        }
+        self.session = Some((session_tx, handle));
+        self
     }
 }
 
-/// Intermediate state produced by the shared initialization sequence.
-struct PreHopr<Chain, Graph, Net, NB, Ct> {
-    chain_id: ChainKeypair,
-    transport_id: OffchainKeypair,
-    cfg: HoprLibConfig,
-    state: Arc<AtomicHoprState>,
-    transport_api: HoprTransport<Chain, Graph, Net>,
-    chain_api: Chain,
-    ticket_event_subscribers: (
-        async_broadcast::Sender<TicketEvent>,
-        async_broadcast::InactiveReceiver<TicketEvent>,
-    ),
-    processes: AbortableList<HoprLibProcess>,
-    session_tx: futures::channel::mpsc::Sender<IncomingSession>,
-    session_rx: futures::channel::mpsc::Receiver<IncomingSession>,
-    cover_traffic: Ct,
-    network_builder: NB,
-}
+// === Build methods ===
 
-impl<Chain, Graph, NB, Ct> HoprBuilderCore<Chain, Graph, NB, Ct>
+impl<Chain, Graph, NB, Ct> HoprBuilder<Chain, Graph, NB, Ct>
 where
     Chain: HoprChainApi + Clone + Send + Sync + 'static,
     Graph: HoprGraphApi<HoprNodeId = hopr_api::OffchainPublicKey> + Clone + Send + Sync + 'static,
@@ -143,26 +214,224 @@ where
         hopr_api::network::NetworkView + NetworkStreamControl + Send + Sync + Clone + 'static,
     Ct: ProbingTrafficGeneration + CoverTrafficGeneration + Send + Sync + 'static,
 {
-    async fn pre_build(
-        mut self,
-    ) -> Result<PreHopr<Chain, Graph, <NB as NetworkBuilder>::Network, NB, Ct>, HoprLibError> {
-        self.cfg.validate()?;
+    /// Builds an edge (entry/exit) [`Hopr`] node.
+    pub async fn build_edge<TFact>(
+        self,
+        ticket_factory: TFact,
+    ) -> Result<Hopr<Chain, Graph, <NB as NetworkBuilder>::Network, ()>, HoprLibError>
+    where
+        TFact: TicketFactory + Clone + Send + Sync + 'static,
+    {
+        let pre = self.pre_build().await?;
 
-        let chain_api = self
-            .chain
-            .clone()
-            .ok_or(HoprLibError::BuilderError("missing chain API"))?;
-        let graph = self.graph.clone().ok_or(HoprLibError::BuilderError("missing graph"))?;
-        let (chain_id, transport_id) = self
-            .identity
-            .clone()
-            .ok_or(HoprLibError::BuilderError("missing identity"))?;
-        let cover_traffic = self
-            .cover_traffic
+        tracing::info!("starting transport for edge node");
+        let (_, transport_processes) = pre
+            .transport_api
+            .run(
+                pre.cover_traffic,
+                pre.network_builder,
+                futures::sink::drain(),
+                ticket_factory,
+                pre.session_tx,
+            )
+            .await?;
+
+        let mut processes = pre.processes;
+        processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
+
+        let hopr = Hopr {
+            chain_id: NodeOnchainIdentity {
+                node_address: pre.chain_id.public().to_address(),
+                safe_address: pre.cfg.safe_module.safe_address,
+                module_address: pre.cfg.safe_module.module_address,
+            },
+            cfg: pre.cfg,
+            state: pre.state.clone(),
+            ticket_event_subscribers: pre.ticket_event_subscribers,
+            transport_id: pre.transport_id,
+            transport_api: pre.transport_api,
+            chain_api: pre.chain_api,
+            processes,
+            ticket_manager: (),
+        };
+
+        hopr.state
+            .store(HoprState::Running, std::sync::atomic::Ordering::Relaxed);
+        tracing::info!(
+            id = %hopr.transport_id.public().to_peerid_str(),
+            version = constants::APP_VERSION,
+            "EDGE NODE STARTED AND RUNNING"
+        );
+
+        Ok(hopr)
+    }
+
+    /// Builds a full (relay) [`Hopr`] node.
+    pub async fn build_full<TMgr, TFact>(
+        self,
+        ticket_manager: TMgr,
+        ticket_factory: TFact,
+    ) -> Result<Hopr<Chain, Graph, <NB as NetworkBuilder>::Network, TMgr>, HoprLibError>
+    where
+        TMgr: TicketManagement + Clone + Send + Sync + 'static,
+        TFact: TicketFactory + Clone + Send + Sync + 'static,
+    {
+        let pre = self.pre_build().await?;
+        let mut processes = pre.processes;
+
+        // Ticket event processing
+        tracing::info!("starting ticket events processor");
+        let (tickets_tx, tickets_rx) = channel(8192);
+        let (tickets_rx_stream, tickets_handle) = futures::stream::abortable(tickets_rx);
+        processes.insert(HoprLibProcess::TicketEvents, tickets_handle);
+        let new_ticket_tx = pre.ticket_event_subscribers.0.clone();
+        let tmgr_clone = ticket_manager.clone();
+        spawn(
+            tickets_rx_stream
+                .for_each(move |event| {
+                    if let TicketEvent::WinningTicket(ticket) = &event
+                        && let Err(error) = tmgr_clone.insert_incoming_ticket(**ticket)
+                    {
+                        tracing::error!(%error, "failed to insert incoming ticket");
+                    }
+                    if let Err(error) = new_ticket_tx.try_broadcast(event) {
+                        tracing::error!(%error, "failed to broadcast ticket event");
+                    }
+                    futures::future::ready(())
+                })
+                .inspect(|_| {
+                    tracing::warn!(
+                        task = %HoprLibProcess::TicketEvents,
+                        "long-running background task finished"
+                    )
+                }),
+        );
+
+        // Channel closure → ticket neglect
+        {
+            let chain_for_neglect = pre.chain_api.clone();
+            let tmgr_for_neglect = ticket_manager.clone();
+            let events = pre.chain_api.subscribe().map_err(HoprLibError::chain)?;
+            let (neglect_handle, neglect_reg) = hopr_async_runtime::AbortHandle::new_pair();
+            spawn(
+                futures::stream::Abortable::new(
+                    events.filter_map(move |event| {
+                        futures::future::ready(match event {
+                            ChainEvent::ChannelClosed(ch) => Some(ch),
+                            _ => None,
+                        })
+                    }),
+                    neglect_reg,
+                )
+                .for_each(move |closed_channel| {
+                    let chain = chain_for_neglect.clone();
+                    let tmgr = tmgr_for_neglect.clone();
+                    async move {
+                        use hopr_api::types::internal::prelude::ChannelDirection;
+                        match closed_channel.direction(chain.me()) {
+                            Some(ChannelDirection::Incoming) => {
+                                match tmgr.neglect_tickets(closed_channel.get_id(), None) {
+                                    Ok(neglected) if !neglected.is_empty() => {
+                                        tracing::warn!(
+                                            num_neglected = neglected.len(),
+                                            %closed_channel,
+                                            "tickets on incoming closed channel were neglected"
+                                        );
+                                    }
+                                    Ok(_) => {}
+                                    Err(error) => {
+                                        tracing::error!(
+                                            %error, %closed_channel,
+                                            "failed to neglect tickets on closed channel"
+                                        );
+                                    }
+                                }
+                            }
+                            Some(ChannelDirection::Outgoing) => {}
+                            _ => {}
+                        }
+                    }
+                })
+                .inspect(|_| {
+                    tracing::warn!(
+                        task = %HoprLibProcess::ChannelEvents,
+                        "channel closure ticket neglect task finished"
+                    )
+                }),
+            );
+            processes.insert(HoprLibProcess::OutIndexSync, neglect_handle);
+        }
+
+        // Start transport
+        tracing::info!("starting transport for full node");
+        let (_, transport_processes) = pre
+            .transport_api
+            .run(
+                pre.cover_traffic,
+                pre.network_builder,
+                tickets_tx,
+                ticket_factory,
+                pre.session_tx,
+            )
+            .await?;
+        processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
+
+        let hopr = Hopr {
+            chain_id: NodeOnchainIdentity {
+                node_address: pre.chain_id.public().to_address(),
+                safe_address: pre.cfg.safe_module.safe_address,
+                module_address: pre.cfg.safe_module.module_address,
+            },
+            cfg: pre.cfg,
+            state: pre.state.clone(),
+            ticket_event_subscribers: pre.ticket_event_subscribers,
+            transport_id: pre.transport_id,
+            transport_api: pre.transport_api,
+            chain_api: pre.chain_api,
+            processes,
+            ticket_manager,
+        };
+
+        hopr.state
+            .store(HoprState::Running, std::sync::atomic::Ordering::Relaxed);
+
+        tracing::info!(
+            id = %hopr.transport_id.public().to_peerid_str(),
+            version = constants::APP_VERSION,
+            "FULL NODE STARTED AND RUNNING"
+        );
+
+        #[cfg(all(feature = "telemetry", not(test)))]
+        METRIC_HOPR_NODE_INFO.set(
+            &[
+                &hopr.transport_id.public().to_peerid_str(),
+                &hopr.chain_id.node_address.to_string(),
+                &hopr.chain_id.safe_address.to_string(),
+                &hopr.chain_id.module_address.to_string(),
+            ],
+            1.0,
+        );
+
+        Ok(hopr)
+    }
+
+    /// Shared initialization sequence for both build paths.
+    async fn pre_build(self) -> Result<PreHopr<Chain, Graph, <NB as NetworkBuilder>::Network, NB, Ct>, HoprLibError> {
+        let mut chain = self.chain;
+        let mut graph = self.graph;
+        let mut network_builder = self.network_builder;
+        let mut cover_traffic = self.cover_traffic;
+        let cfg = self.cfg;
+
+        cfg.validate()?;
+
+        let chain_api = chain.take().ok_or(HoprLibError::BuilderError("missing chain API"))?;
+        let graph = graph.take().ok_or(HoprLibError::BuilderError("missing graph"))?;
+        let (chain_id, transport_id) = self.identity.ok_or(HoprLibError::BuilderError("missing identity"))?;
+        let cover_traffic = cover_traffic
             .take()
             .ok_or(HoprLibError::BuilderError("missing cover traffic"))?;
-        let network_builder = self
-            .network_builder
+        let network_builder = network_builder
             .take()
             .ok_or(HoprLibError::BuilderError("missing network builder"))?;
 
@@ -170,8 +439,8 @@ where
             (&chain_id, &transport_id),
             chain_api.clone(),
             graph.clone(),
-            vec![(&self.cfg.host).try_into().map_err(HoprLibError::TransportError)?],
-            self.cfg.protocol.clone(),
+            vec![(&cfg.host).try_into().map_err(HoprLibError::TransportError)?],
+            cfg.protocol.clone(),
         )
         .map_err(HoprLibError::TransportError)?;
 
@@ -229,7 +498,7 @@ where
         }
 
         let network_min_ticket_price = chain_api.minimum_ticket_price().await.map_err(HoprLibError::chain)?;
-        let configured_ticket_price = self.cfg.protocol.packet.codec.outgoing_ticket_price;
+        let configured_ticket_price = cfg.protocol.packet.codec.outgoing_ticket_price;
         if configured_ticket_price.is_some_and(|c| c < network_min_ticket_price) {
             return Err(HoprLibError::GeneralError(format!(
                 "configured outgoing ticket price < network minimum: {configured_ticket_price:?} < \
@@ -241,7 +510,7 @@ where
             .minimum_incoming_ticket_win_prob()
             .await
             .map_err(HoprLibError::chain)?;
-        let configured_win_prob = self.cfg.protocol.packet.codec.outgoing_win_prob;
+        let configured_win_prob = cfg.protocol.packet.codec.outgoing_win_prob;
         if !std::env::var("HOPR_TEST_DISABLE_CHECKS").is_ok_and(|v| v.to_lowercase() == "true")
             && configured_win_prob.is_some_and(|c| c.approx_cmp(&network_min_win_prob).is_lt())
         {
@@ -258,7 +527,7 @@ where
             "Node information"
         );
 
-        let safe_addr = self.cfg.safe_module.safe_address;
+        let safe_addr = cfg.safe_module.safe_address;
         if me_onchain == safe_addr {
             return Err(HoprLibError::GeneralError(
                 "cannot use self as staking safe address".into(),
@@ -287,7 +556,7 @@ where
             }
         }
 
-        let multiaddresses_to_announce = if self.cfg.publish {
+        let multiaddresses_to_announce = if cfg.publish {
             transport_api.announceable_multiaddresses()
         } else {
             Vec::with_capacity(0)
@@ -335,17 +604,27 @@ where
 
         tracing::info!(%this_node_account, "node account is ready");
 
-        let incoming_session_capacity = std::env::var("HOPR_INTERNAL_SESSION_INCOMING_CAPACITY")
-            .ok()
-            .and_then(|s| s.trim().parse::<usize>().ok())
-            .filter(|&c| c > 0)
-            .unwrap_or(256);
+        // Session channel — use pre-spawned session server channel if available,
+        // otherwise create a dummy channel (sessions will be dropped).
+        let mut processes = AbortableList::<HoprLibProcess>::default();
 
-        let processes = AbortableList::<HoprLibProcess>::default();
-        let (session_tx, session_rx) = channel::<IncomingSession>(incoming_session_capacity);
+        #[cfg(feature = "session-server")]
+        let session_tx = if let Some((tx, handle)) = self.session {
+            processes.insert(HoprLibProcess::SessionServer, handle);
+            tx
+        } else {
+            let (tx, _rx) = channel::<IncomingSession>(1);
+            tx
+        };
 
-        // === Chain → Graph event wiring ===
-        let processes = {
+        #[cfg(not(feature = "session-server"))]
+        let session_tx = {
+            let (tx, _rx) = channel::<IncomingSession>(1);
+            tx
+        };
+
+        // Chain → Graph event wiring
+        {
             let chain_events = chain_api
                 .subscribe_with_state_sync([StateSyncOptions::PublicAccounts, StateSyncOptions::OpenedChannels])
                 .map_err(HoprLibError::chain)?;
@@ -469,586 +748,24 @@ where
                     "long-running background task finished"
                 )
             });
-            let mut processes = processes;
             processes.insert(
                 HoprLibProcess::ChannelEvents,
                 hopr_async_runtime::spawn_as_abortable!(proc),
             );
-            processes
-        };
+        }
 
         Ok(PreHopr {
             chain_id,
             transport_id,
-            cfg: self.cfg,
+            cfg,
             state: Arc::new(AtomicHoprState::new(HoprState::Uninitialized)),
             transport_api,
             chain_api,
             ticket_event_subscribers: (new_tickets_tx, new_tickets_rx.deactivate()),
             processes,
             session_tx,
-            session_rx,
             cover_traffic,
             network_builder,
         })
-    }
-}
-
-// ---------------------------------------------------------------------------
-// HoprBuilder — with session-server feature
-// ---------------------------------------------------------------------------
-
-#[cfg(feature = "session-server")]
-pub struct HoprBuilder<Chain = (), Graph = (), NB = (), Ct = (), Srv = ()> {
-    core: HoprBuilderCore<Chain, Graph, NB, Ct>,
-    session_server: Option<Srv>,
-}
-
-#[cfg(feature = "session-server")]
-impl<Chain, Graph, NB, Ct, Srv> Default for HoprBuilder<Chain, Graph, NB, Ct, Srv> {
-    fn default() -> Self {
-        Self {
-            core: Default::default(),
-            session_server: None,
-        }
-    }
-}
-
-#[cfg(feature = "session-server")]
-impl<Chain, Graph, NB, Ct, Srv> HoprBuilder<Chain, Graph, NB, Ct, Srv> {
-    pub fn with_chain_api(mut self, chain: Chain) -> Self {
-        self.core.chain = Some(chain);
-        self
-    }
-
-    pub fn with_graph(mut self, graph: Graph) -> Self {
-        self.core.graph = Some(graph);
-        self
-    }
-
-    pub fn with_network_builder(mut self, builder: NB) -> Self {
-        self.core.network_builder = Some(builder);
-        self
-    }
-
-    pub fn with_cover_traffic(mut self, ct: Ct) -> Self {
-        self.core.cover_traffic = Some(ct);
-        self
-    }
-
-    pub fn with_identity(mut self, chain_key: &ChainKeypair, offchain_key: &OffchainKeypair) -> Self {
-        self.core.identity = Some((chain_key.clone(), offchain_key.clone()));
-        self
-    }
-
-    pub fn with_safe_module(mut self, safe: &Address, module: &Address) -> Self {
-        self.core.safe_and_module = Some((*safe, *module));
-        self
-    }
-
-    pub fn with_config(mut self, cfg: HoprLibConfig) -> Self {
-        self.core.cfg = cfg;
-        self
-    }
-
-    /// Sets the session server for handling incoming sessions.
-    pub fn with_session_server(mut self, srv: Srv) -> Self {
-        self.session_server = Some(srv);
-        self
-    }
-}
-
-#[cfg(feature = "session-server")]
-impl<Chain, Graph, NB, Ct, Srv> HoprBuilder<Chain, Graph, NB, Ct, Srv>
-where
-    Chain: HoprChainApi + Clone + Send + Sync + 'static,
-    Graph: HoprGraphApi<HoprNodeId = hopr_api::OffchainPublicKey> + Clone + Send + Sync + 'static,
-    <Graph as hopr_api::graph::NetworkGraphTraverse>::Observed:
-        hopr_api::graph::traits::EdgeObservableRead + Send + 'static,
-    <Graph as hopr_api::graph::NetworkGraphWrite>::Observed: hopr_api::graph::traits::EdgeObservableWrite + Send,
-    NB: NetworkBuilder + Send + Sync + 'static,
-    <NB as NetworkBuilder>::Network:
-        hopr_api::network::NetworkView + NetworkStreamControl + Send + Sync + Clone + 'static,
-    Ct: ProbingTrafficGeneration + CoverTrafficGeneration + Send + Sync + 'static,
-    Srv: hopr_api::node::HoprSessionServer<Session = IncomingSession>,
-    <Srv as hopr_api::node::HoprSessionServer>::Error: std::fmt::Display,
-{
-    /// Builds an edge (entry/exit) [`Hopr`] node.
-    pub async fn build_edge<TFact>(
-        self,
-        ticket_factory: TFact,
-    ) -> Result<Hopr<Chain, Graph, <NB as NetworkBuilder>::Network, ()>, HoprLibError>
-    where
-        TFact: TicketFactory + Clone + Send + Sync + 'static,
-    {
-        let pre = self.core.pre_build().await?;
-
-        tracing::info!("starting transport for edge node");
-        let (_, transport_processes) = pre
-            .transport_api
-            .run(
-                pre.cover_traffic,
-                pre.network_builder,
-                futures::sink::drain(),
-                ticket_factory,
-                pre.session_tx,
-            )
-            .await?;
-
-        let mut processes = pre.processes;
-        processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
-
-        if let Some(server) = self.session_server {
-            attach_session_server(pre.session_rx, server, &mut processes);
-        }
-
-        let hopr = Hopr {
-            chain_id: NodeOnchainIdentity {
-                node_address: pre.chain_id.public().to_address(),
-                safe_address: pre.cfg.safe_module.safe_address,
-                module_address: pre.cfg.safe_module.module_address,
-            },
-            cfg: pre.cfg,
-            state: pre.state.clone(),
-            ticket_event_subscribers: pre.ticket_event_subscribers,
-            transport_id: pre.transport_id,
-            transport_api: pre.transport_api,
-            chain_api: pre.chain_api,
-            processes,
-            ticket_manager: (),
-        };
-
-        hopr.state
-            .store(HoprState::Running, std::sync::atomic::Ordering::Relaxed);
-        tracing::info!(
-            id = %hopr.transport_id.public().to_peerid_str(),
-            version = constants::APP_VERSION,
-            "EDGE NODE STARTED AND RUNNING"
-        );
-
-        Ok(hopr)
-    }
-
-    /// Builds a full (relay) [`Hopr`] node.
-    pub async fn build_full<TMgr, TFact>(
-        self,
-        ticket_manager: TMgr,
-        ticket_factory: TFact,
-    ) -> Result<Hopr<Chain, Graph, <NB as NetworkBuilder>::Network, TMgr>, HoprLibError>
-    where
-        TMgr: TicketManagement + Clone + Send + Sync + 'static,
-        TFact: TicketFactory + Clone + Send + Sync + 'static,
-    {
-        let pre = self.core.pre_build().await?;
-        let mut processes = pre.processes;
-
-        // Ticket event processing
-        tracing::info!("starting ticket events processor");
-        let (tickets_tx, tickets_rx) = channel(8192);
-        let (tickets_rx_stream, tickets_handle) = futures::stream::abortable(tickets_rx);
-        processes.insert(HoprLibProcess::TicketEvents, tickets_handle);
-        let new_ticket_tx = pre.ticket_event_subscribers.0.clone();
-        let tmgr_clone = ticket_manager.clone();
-        spawn(
-            tickets_rx_stream
-                .for_each(move |event| {
-                    if let TicketEvent::WinningTicket(ticket) = &event
-                        && let Err(error) = tmgr_clone.insert_incoming_ticket(**ticket)
-                    {
-                        tracing::error!(%error, "failed to insert incoming ticket");
-                    }
-                    if let Err(error) = new_ticket_tx.try_broadcast(event) {
-                        tracing::error!(%error, "failed to broadcast ticket event");
-                    }
-                    futures::future::ready(())
-                })
-                .inspect(|_| {
-                    tracing::warn!(
-                        task = %HoprLibProcess::TicketEvents,
-                        "long-running background task finished"
-                    )
-                }),
-        );
-
-        // Channel closure → ticket neglect
-        {
-            let chain_for_neglect = pre.chain_api.clone();
-            let tmgr_for_neglect = ticket_manager.clone();
-            let events = pre.chain_api.subscribe().map_err(HoprLibError::chain)?;
-            let (neglect_handle, neglect_reg) = hopr_async_runtime::AbortHandle::new_pair();
-            spawn(
-                futures::stream::Abortable::new(
-                    events.filter_map(move |event| {
-                        futures::future::ready(match event {
-                            ChainEvent::ChannelClosed(ch) => Some(ch),
-                            _ => None,
-                        })
-                    }),
-                    neglect_reg,
-                )
-                .for_each(move |closed_channel| {
-                    let chain = chain_for_neglect.clone();
-                    let tmgr = tmgr_for_neglect.clone();
-                    async move {
-                        use hopr_api::types::internal::prelude::ChannelDirection;
-                        match closed_channel.direction(chain.me()) {
-                            Some(ChannelDirection::Incoming) => {
-                                match tmgr.neglect_tickets(closed_channel.get_id(), None) {
-                                    Ok(neglected) if !neglected.is_empty() => {
-                                        tracing::warn!(
-                                            num_neglected = neglected.len(),
-                                            %closed_channel,
-                                            "tickets on incoming closed channel were neglected"
-                                        );
-                                    }
-                                    Ok(_) => {}
-                                    Err(error) => {
-                                        tracing::error!(
-                                            %error, %closed_channel,
-                                            "failed to neglect tickets on closed channel"
-                                        );
-                                    }
-                                }
-                            }
-                            Some(ChannelDirection::Outgoing) => {}
-                            _ => {}
-                        }
-                    }
-                })
-                .inspect(|_| {
-                    tracing::warn!(
-                        task = %HoprLibProcess::ChannelEvents,
-                        "channel closure ticket neglect task finished"
-                    )
-                }),
-            );
-            processes.insert(HoprLibProcess::OutIndexSync, neglect_handle);
-        }
-
-        // Start transport
-        tracing::info!("starting transport for full node");
-        let (_, transport_processes) = pre
-            .transport_api
-            .run(
-                pre.cover_traffic,
-                pre.network_builder,
-                tickets_tx,
-                ticket_factory,
-                pre.session_tx,
-            )
-            .await?;
-        processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
-
-        if let Some(server) = self.session_server {
-            attach_session_server(pre.session_rx, server, &mut processes);
-        }
-
-        let hopr = Hopr {
-            chain_id: NodeOnchainIdentity {
-                node_address: pre.chain_id.public().to_address(),
-                safe_address: pre.cfg.safe_module.safe_address,
-                module_address: pre.cfg.safe_module.module_address,
-            },
-            cfg: pre.cfg,
-            state: pre.state.clone(),
-            ticket_event_subscribers: pre.ticket_event_subscribers,
-            transport_id: pre.transport_id,
-            transport_api: pre.transport_api,
-            chain_api: pre.chain_api,
-            processes,
-            ticket_manager,
-        };
-
-        hopr.state
-            .store(HoprState::Running, std::sync::atomic::Ordering::Relaxed);
-
-        tracing::info!(
-            id = %hopr.transport_id.public().to_peerid_str(),
-            version = constants::APP_VERSION,
-            "FULL NODE STARTED AND RUNNING"
-        );
-
-        #[cfg(all(feature = "telemetry", not(test)))]
-        METRIC_HOPR_NODE_INFO.set(
-            &[
-                &hopr.transport_id.public().to_peerid_str(),
-                &hopr.chain_id.node_address.to_string(),
-                &hopr.chain_id.safe_address.to_string(),
-                &hopr.chain_id.module_address.to_string(),
-            ],
-            1.0,
-        );
-
-        Ok(hopr)
-    }
-}
-
-// ---------------------------------------------------------------------------
-// HoprBuilder — without session-server feature
-// ---------------------------------------------------------------------------
-
-#[cfg(not(feature = "session-server"))]
-pub struct HoprBuilder<Chain = (), Graph = (), NB = (), Ct = ()> {
-    core: HoprBuilderCore<Chain, Graph, NB, Ct>,
-}
-
-#[cfg(not(feature = "session-server"))]
-impl<Chain, Graph, NB, Ct> Default for HoprBuilder<Chain, Graph, NB, Ct> {
-    fn default() -> Self {
-        Self {
-            core: Default::default(),
-        }
-    }
-}
-
-#[cfg(not(feature = "session-server"))]
-impl<Chain, Graph, NB, Ct> HoprBuilder<Chain, Graph, NB, Ct> {
-    pub fn with_chain_api(mut self, chain: Chain) -> Self {
-        self.core.chain = Some(chain);
-        self
-    }
-
-    pub fn with_graph(mut self, graph: Graph) -> Self {
-        self.core.graph = Some(graph);
-        self
-    }
-
-    pub fn with_network_builder(mut self, builder: NB) -> Self {
-        self.core.network_builder = Some(builder);
-        self
-    }
-
-    pub fn with_cover_traffic(mut self, ct: Ct) -> Self {
-        self.core.cover_traffic = Some(ct);
-        self
-    }
-
-    pub fn with_identity(mut self, chain_key: &ChainKeypair, offchain_key: &OffchainKeypair) -> Self {
-        self.core.identity = Some((chain_key.clone(), offchain_key.clone()));
-        self
-    }
-
-    pub fn with_safe_module(mut self, safe: &Address, module: &Address) -> Self {
-        self.core.safe_and_module = Some((*safe, *module));
-        self
-    }
-
-    pub fn with_config(mut self, cfg: HoprLibConfig) -> Self {
-        self.core.cfg = cfg;
-        self
-    }
-}
-
-#[cfg(not(feature = "session-server"))]
-impl<Chain, Graph, NB, Ct> HoprBuilder<Chain, Graph, NB, Ct>
-where
-    Chain: HoprChainApi + Clone + Send + Sync + 'static,
-    Graph: HoprGraphApi<HoprNodeId = hopr_api::OffchainPublicKey> + Clone + Send + Sync + 'static,
-    <Graph as hopr_api::graph::NetworkGraphTraverse>::Observed:
-        hopr_api::graph::traits::EdgeObservableRead + Send + 'static,
-    <Graph as hopr_api::graph::NetworkGraphWrite>::Observed: hopr_api::graph::traits::EdgeObservableWrite + Send,
-    NB: NetworkBuilder + Send + Sync + 'static,
-    <NB as NetworkBuilder>::Network:
-        hopr_api::network::NetworkView + NetworkStreamControl + Send + Sync + Clone + 'static,
-    Ct: ProbingTrafficGeneration + CoverTrafficGeneration + Send + Sync + 'static,
-{
-    /// Builds an edge (entry/exit) [`Hopr`] node.
-    pub async fn build_edge<TFact>(
-        self,
-        ticket_factory: TFact,
-    ) -> Result<Hopr<Chain, Graph, <NB as NetworkBuilder>::Network, ()>, HoprLibError>
-    where
-        TFact: TicketFactory + Clone + Send + Sync + 'static,
-    {
-        let pre = self.core.pre_build().await?;
-
-        tracing::info!("starting transport for edge node");
-        let (_, transport_processes) = pre
-            .transport_api
-            .run(
-                pre.cover_traffic,
-                pre.network_builder,
-                futures::sink::drain(),
-                ticket_factory,
-                pre.session_tx,
-            )
-            .await?;
-
-        let mut processes = pre.processes;
-        processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
-
-        let hopr = Hopr {
-            chain_id: NodeOnchainIdentity {
-                node_address: pre.chain_id.public().to_address(),
-                safe_address: pre.cfg.safe_module.safe_address,
-                module_address: pre.cfg.safe_module.module_address,
-            },
-            cfg: pre.cfg,
-            state: pre.state.clone(),
-            ticket_event_subscribers: pre.ticket_event_subscribers,
-            transport_id: pre.transport_id,
-            transport_api: pre.transport_api,
-            chain_api: pre.chain_api,
-            processes,
-            ticket_manager: (),
-        };
-
-        hopr.state
-            .store(HoprState::Running, std::sync::atomic::Ordering::Relaxed);
-        tracing::info!(
-            id = %hopr.transport_id.public().to_peerid_str(),
-            version = constants::APP_VERSION,
-            "EDGE NODE STARTED AND RUNNING"
-        );
-
-        Ok(hopr)
-    }
-
-    /// Builds a full (relay) [`Hopr`] node.
-    pub async fn build_full<TMgr, TFact>(
-        self,
-        ticket_manager: TMgr,
-        ticket_factory: TFact,
-    ) -> Result<Hopr<Chain, Graph, <NB as NetworkBuilder>::Network, TMgr>, HoprLibError>
-    where
-        TMgr: TicketManagement + Clone + Send + Sync + 'static,
-        TFact: TicketFactory + Clone + Send + Sync + 'static,
-    {
-        let pre = self.core.pre_build().await?;
-        let mut processes = pre.processes;
-
-        // Ticket event processing
-        tracing::info!("starting ticket events processor");
-        let (tickets_tx, tickets_rx) = channel(8192);
-        let (tickets_rx_stream, tickets_handle) = futures::stream::abortable(tickets_rx);
-        processes.insert(HoprLibProcess::TicketEvents, tickets_handle);
-        let new_ticket_tx = pre.ticket_event_subscribers.0.clone();
-        let tmgr_clone = ticket_manager.clone();
-        spawn(
-            tickets_rx_stream
-                .for_each(move |event| {
-                    if let TicketEvent::WinningTicket(ticket) = &event
-                        && let Err(error) = tmgr_clone.insert_incoming_ticket(**ticket)
-                    {
-                        tracing::error!(%error, "failed to insert incoming ticket");
-                    }
-                    if let Err(error) = new_ticket_tx.try_broadcast(event) {
-                        tracing::error!(%error, "failed to broadcast ticket event");
-                    }
-                    futures::future::ready(())
-                })
-                .inspect(|_| {
-                    tracing::warn!(
-                        task = %HoprLibProcess::TicketEvents,
-                        "long-running background task finished"
-                    )
-                }),
-        );
-
-        // Channel closure → ticket neglect
-        {
-            let chain_for_neglect = pre.chain_api.clone();
-            let tmgr_for_neglect = ticket_manager.clone();
-            let events = pre.chain_api.subscribe().map_err(HoprLibError::chain)?;
-            let (neglect_handle, neglect_reg) = hopr_async_runtime::AbortHandle::new_pair();
-            spawn(
-                futures::stream::Abortable::new(
-                    events.filter_map(move |event| {
-                        futures::future::ready(match event {
-                            ChainEvent::ChannelClosed(ch) => Some(ch),
-                            _ => None,
-                        })
-                    }),
-                    neglect_reg,
-                )
-                .for_each(move |closed_channel| {
-                    let chain = chain_for_neglect.clone();
-                    let tmgr = tmgr_for_neglect.clone();
-                    async move {
-                        use hopr_api::types::internal::prelude::ChannelDirection;
-                        match closed_channel.direction(chain.me()) {
-                            Some(ChannelDirection::Incoming) => {
-                                match tmgr.neglect_tickets(closed_channel.get_id(), None) {
-                                    Ok(neglected) if !neglected.is_empty() => {
-                                        tracing::warn!(
-                                            num_neglected = neglected.len(),
-                                            %closed_channel,
-                                            "tickets on incoming closed channel were neglected"
-                                        );
-                                    }
-                                    Ok(_) => {}
-                                    Err(error) => {
-                                        tracing::error!(
-                                            %error, %closed_channel,
-                                            "failed to neglect tickets on closed channel"
-                                        );
-                                    }
-                                }
-                            }
-                            Some(ChannelDirection::Outgoing) => {}
-                            _ => {}
-                        }
-                    }
-                })
-                .inspect(|_| {
-                    tracing::warn!(
-                        task = %HoprLibProcess::ChannelEvents,
-                        "channel closure ticket neglect task finished"
-                    )
-                }),
-            );
-            processes.insert(HoprLibProcess::OutIndexSync, neglect_handle);
-        }
-
-        tracing::info!("starting transport for full node");
-        let (_, transport_processes) = pre
-            .transport_api
-            .run(
-                pre.cover_traffic,
-                pre.network_builder,
-                tickets_tx,
-                ticket_factory,
-                pre.session_tx,
-            )
-            .await?;
-        processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
-
-        let hopr = Hopr {
-            chain_id: NodeOnchainIdentity {
-                node_address: pre.chain_id.public().to_address(),
-                safe_address: pre.cfg.safe_module.safe_address,
-                module_address: pre.cfg.safe_module.module_address,
-            },
-            cfg: pre.cfg,
-            state: pre.state.clone(),
-            ticket_event_subscribers: pre.ticket_event_subscribers,
-            transport_id: pre.transport_id,
-            transport_api: pre.transport_api,
-            chain_api: pre.chain_api,
-            processes,
-            ticket_manager,
-        };
-
-        hopr.state
-            .store(HoprState::Running, std::sync::atomic::Ordering::Relaxed);
-
-        tracing::info!(
-            id = %hopr.transport_id.public().to_peerid_str(),
-            version = constants::APP_VERSION,
-            "FULL NODE STARTED AND RUNNING"
-        );
-
-        #[cfg(all(feature = "telemetry", not(test)))]
-        METRIC_HOPR_NODE_INFO.set(
-            &[
-                &hopr.transport_id.public().to_peerid_str(),
-                &hopr.chain_id.node_address.to_string(),
-                &hopr.chain_id.safe_address.to_string(),
-                &hopr.chain_id.module_address.to_string(),
-            ],
-            1.0,
-        );
-
-        Ok(hopr)
     }
 }

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -51,7 +51,7 @@ lazy_static::lazy_static! {
 type Factory<T> = Box<dyn FnOnce(&BuildCtx) -> T + Send>;
 
 /// Context available to factory closures during the build step.
-pub(crate) struct BuildCtx {
+pub struct BuildCtx {
     /// Node's on-chain keypair.
     pub chain_key: ChainKeypair,
     /// Node's off-chain (packet) keypair.

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -46,8 +46,6 @@ lazy_static::lazy_static! {
 }
 
 /// Intermediate state produced by the shared initialization sequence.
-///
-/// Holds all resources needed by the divergent `build_edge` / `build_full` finalization steps.
 struct PreHopr<Chain, Graph, Net, NB, Ct> {
     chain_id: ChainKeypair,
     transport_id: OffchainKeypair,
@@ -62,9 +60,44 @@ struct PreHopr<Chain, Graph, Net, NB, Ct> {
     processes: AbortableList<HoprLibProcess>,
     session_tx: futures::channel::mpsc::Sender<IncomingSession>,
     session_rx: futures::channel::mpsc::Receiver<IncomingSession>,
-    // Moved out for transport.run()
     cover_traffic: Ct,
     network_builder: NB,
+}
+
+/// Attaches a session server to the incoming session receiver and inserts
+/// the spawned process into the process list.
+#[cfg(feature = "session-server")]
+fn attach_session_server<Srv>(
+    session_rx: futures::channel::mpsc::Receiver<IncomingSession>,
+    server: Srv,
+    processes: &mut AbortableList<HoprLibProcess>,
+) where
+    Srv: hopr_api::node::HoprSessionServer<Session = IncomingSession>,
+    Srv::Error: std::fmt::Display,
+{
+    tracing::debug!("attaching session server");
+    processes.insert(
+        HoprLibProcess::SessionServer,
+        hopr_async_runtime::spawn_as_abortable!(
+            session_rx
+                .for_each_concurrent(None, move |session| {
+                    let server = server.clone();
+                    async move {
+                        let session_id = *session.session.id();
+                        match server.process(session).await {
+                            Ok(()) => tracing::debug!(?session_id, "session processed successfully"),
+                            Err(error) => {
+                                tracing::error!(?session_id, %error, "session processing failed")
+                            }
+                        }
+                    }
+                })
+                .inspect(|_| tracing::warn!(
+                    task = %HoprLibProcess::SessionServer,
+                    "long-running background task finished"
+                ))
+        ),
+    );
 }
 
 /// Abstract builder for the [`Hopr`] node object.
@@ -83,7 +116,7 @@ struct PreHopr<Chain, Graph, Net, NB, Ct> {
 /// - `Ct` — cover traffic / probing ([`ProbingTrafficGeneration`] + [`CoverTrafficGeneration`])
 ///
 /// Ticket management, ticket factory, and session server are **not** builder generics —
-/// they are parameters to the build methods or handled by the caller after building.
+/// they are parameters to the build methods.
 pub struct HoprBuilder<Chain = (), Graph = (), NB = (), Ct = ()> {
     chain: Option<Chain>,
     graph: Option<Graph>,
@@ -94,7 +127,6 @@ pub struct HoprBuilder<Chain = (), Graph = (), NB = (), Ct = ()> {
     cfg: HoprLibConfig,
 }
 
-// Manual Default — no trait bounds on generics
 impl<Chain, Graph, NB, Ct> Default for HoprBuilder<Chain, Graph, NB, Ct> {
     fn default() -> Self {
         Self {
@@ -108,8 +140,6 @@ impl<Chain, Graph, NB, Ct> Default for HoprBuilder<Chain, Graph, NB, Ct> {
         }
     }
 }
-
-// === Configuration methods (no trait bounds needed) ===
 
 impl<Chain, Graph, NB, Ct> HoprBuilder<Chain, Graph, NB, Ct> {
     /// Sets the chain API implementation.
@@ -155,20 +185,6 @@ impl<Chain, Graph, NB, Ct> HoprBuilder<Chain, Graph, NB, Ct> {
     }
 }
 
-/// Result of a successful build, containing the node and a receiver for incoming sessions.
-///
-/// The caller is responsible for attaching a session server to the `session_rx`
-/// if the node should process incoming sessions.
-pub struct BuiltNode<Chain, Graph, Net, TMgr> {
-    /// The built HOPR node.
-    pub node: Hopr<Chain, Graph, Net, TMgr>,
-    /// Receiver for incoming sessions from the transport layer.
-    ///
-    /// Attach a [`HoprSessionServer`](hopr_api::node::HoprSessionServer) to this
-    /// receiver to process incoming sessions, or drop it to discard them.
-    pub session_rx: futures::channel::mpsc::Receiver<IncomingSession>,
-}
-
 // === Build methods ===
 
 impl<Chain, Graph, NB, Ct> HoprBuilder<Chain, Graph, NB, Ct>
@@ -188,19 +204,21 @@ where
     /// Edge nodes use a standalone ticket factory for outgoing tickets but do **not**
     /// process incoming winning tickets — the incoming ticket sink is drained.
     ///
-    /// The caller must sync the `ticket_factory` with on-chain state before calling
-    /// this method (e.g. via `sync_from_outgoing_channels`).
+    /// When the `session-server` feature is enabled, a session server must be provided
+    /// to handle incoming sessions. Without the feature, incoming sessions are dropped.
     pub async fn build_edge<TFact>(
         self,
         ticket_factory: TFact,
-    ) -> Result<BuiltNode<Chain, Graph, <NB as NetworkBuilder>::Network, ()>, HoprLibError>
+        #[cfg(feature = "session-server")] session_server: impl hopr_api::node::HoprSessionServer<
+            Session = IncomingSession,
+            Error: std::fmt::Display,
+        >,
+    ) -> Result<Hopr<Chain, Graph, <NB as NetworkBuilder>::Network, ()>, HoprLibError>
     where
         TFact: TicketFactory + Clone + Send + Sync + 'static,
     {
         let pre = self.pre_build().await?;
-        let session_rx = pre.session_rx;
 
-        // Edge nodes drain incoming tickets — no ticket processing.
         tracing::info!("starting transport for edge node");
         let (_, transport_processes) = pre
             .transport_api
@@ -216,7 +234,10 @@ where
         let mut processes = pre.processes;
         processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
 
-        let node = Hopr {
+        #[cfg(feature = "session-server")]
+        attach_session_server(pre.session_rx, session_server, &mut processes);
+
+        let hopr = Hopr {
             chain_id: NodeOnchainIdentity {
                 node_address: pre.chain_id.public().to_address(),
                 safe_address: pre.cfg.safe_module.safe_address,
@@ -232,15 +253,15 @@ where
             ticket_manager: (),
         };
 
-        node.state
+        hopr.state
             .store(HoprState::Running, std::sync::atomic::Ordering::Relaxed);
         tracing::info!(
-            id = %node.transport_id.public().to_peerid_str(),
+            id = %hopr.transport_id.public().to_peerid_str(),
             version = constants::APP_VERSION,
             "EDGE NODE STARTED AND RUNNING"
         );
 
-        Ok(BuiltNode { node, session_rx })
+        Ok(hopr)
     }
 
     /// Builds a full (relay) [`Hopr`] node.
@@ -248,26 +269,26 @@ where
     /// Full nodes process incoming winning tickets via the `ticket_manager` and use a
     /// coupled ticket factory that accounts for unrealized balance.
     ///
-    /// The caller must:
-    /// 1. Create the ticket manager and factory together (e.g. via `HoprTicketManager::new_with_factory`)
-    /// 2. Sync both with on-chain state before calling this method
-    /// 3. Manage periodic outgoing index persistence externally
+    /// When the `session-server` feature is enabled, a session server must be provided
+    /// to handle incoming sessions. Without the feature, incoming sessions are dropped.
     pub async fn build_full<TMgr, TFact>(
         self,
         ticket_manager: TMgr,
         ticket_factory: TFact,
-    ) -> Result<BuiltNode<Chain, Graph, <NB as NetworkBuilder>::Network, TMgr>, HoprLibError>
+        #[cfg(feature = "session-server")] session_server: impl hopr_api::node::HoprSessionServer<
+            Session = IncomingSession,
+            Error: std::fmt::Display,
+        >,
+    ) -> Result<Hopr<Chain, Graph, <NB as NetworkBuilder>::Network, TMgr>, HoprLibError>
     where
         TMgr: TicketManagement + Clone + Send + Sync + 'static,
         TFact: TicketFactory + Clone + Send + Sync + 'static,
     {
         let pre = self.pre_build().await?;
-        let session_rx = pre.session_rx;
 
         let mut processes = pre.processes;
 
         // === Ticket event processing ===
-        // Incoming winning tickets are forwarded to the ticket manager.
         tracing::info!("starting ticket events processor");
         let (tickets_tx, tickets_rx) = channel(8192);
         let (tickets_rx_stream, tickets_handle) = futures::stream::abortable(tickets_rx);
@@ -296,7 +317,6 @@ where
         );
 
         // === Channel closure → ticket neglect ===
-        // When an incoming channel is closed, neglect any remaining tickets.
         {
             let chain_for_neglect = pre.chain_api.clone();
             let tmgr_for_neglect = ticket_manager.clone();
@@ -336,10 +356,8 @@ where
                                     }
                                 }
                             }
-                            Some(ChannelDirection::Outgoing) => {
-                                // Outgoing ticket index cleanup happens automatically on new epoch
-                            }
-                            _ => {} // Event for a channel that is not ours
+                            Some(ChannelDirection::Outgoing) => {}
+                            _ => {}
                         }
                     }
                 })
@@ -367,7 +385,10 @@ where
             .await?;
         processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
 
-        let node = Hopr {
+        #[cfg(feature = "session-server")]
+        attach_session_server(pre.session_rx, session_server, &mut processes);
+
+        let hopr = Hopr {
             chain_id: NodeOnchainIdentity {
                 node_address: pre.chain_id.public().to_address(),
                 safe_address: pre.cfg.safe_module.safe_address,
@@ -383,11 +404,11 @@ where
             ticket_manager,
         };
 
-        node.state
+        hopr.state
             .store(HoprState::Running, std::sync::atomic::Ordering::Relaxed);
 
         tracing::info!(
-            id = %node.transport_id.public().to_peerid_str(),
+            id = %hopr.transport_id.public().to_peerid_str(),
             version = constants::APP_VERSION,
             "FULL NODE STARTED AND RUNNING"
         );
@@ -395,15 +416,15 @@ where
         #[cfg(all(feature = "telemetry", not(test)))]
         METRIC_HOPR_NODE_INFO.set(
             &[
-                &node.transport_id.public().to_peerid_str(),
-                &node.chain_id.node_address.to_string(),
-                &node.chain_id.safe_address.to_string(),
-                &node.chain_id.module_address.to_string(),
+                &hopr.transport_id.public().to_peerid_str(),
+                &hopr.chain_id.node_address.to_string(),
+                &hopr.chain_id.safe_address.to_string(),
+                &hopr.chain_id.module_address.to_string(),
             ],
             1.0,
         );
 
-        Ok(BuiltNode { node, session_rx })
+        Ok(hopr)
     }
 
     /// Shared initialization sequence for both edge and full node builds.
@@ -430,7 +451,6 @@ where
             .take()
             .ok_or(HoprLibError::BuilderError("missing network builder"))?;
 
-        // Create transport
         let transport_api = HoprTransport::new(
             (&chain_id, &transport_id),
             chain_api.clone(),
@@ -440,7 +460,6 @@ where
         )
         .map_err(HoprLibError::TransportError)?;
 
-        // Telemetry
         #[cfg(all(feature = "telemetry", not(test)))]
         {
             use hopr_api::types::primitive::traits::AsUnixTimestamp;
@@ -457,12 +476,10 @@ where
             );
         }
 
-        // Ticket event broadcast
         let (mut new_tickets_tx, new_tickets_rx) = async_broadcast::broadcast(2048);
         new_tickets_tx.set_await_active(false);
         new_tickets_tx.set_overflow(true);
 
-        // === Fund check ===
         let me_onchain = chain_id.public().to_address();
 
         #[cfg(feature = "testing")]
@@ -496,7 +513,6 @@ where
             ));
         }
 
-        // === Ticket price / win prob validation ===
         let network_min_ticket_price = chain_api.minimum_ticket_price().await.map_err(HoprLibError::chain)?;
         let configured_ticket_price = self.cfg.protocol.packet.codec.outgoing_ticket_price;
         if configured_ticket_price.is_some_and(|c| c < network_min_ticket_price) {
@@ -527,7 +543,6 @@ where
             "Node information"
         );
 
-        // === Safe registration ===
         let safe_addr = self.cfg.safe_module.safe_address;
         if me_onchain == safe_addr {
             return Err(HoprLibError::GeneralError(
@@ -557,7 +572,6 @@ where
             }
         }
 
-        // === Announce ===
         let multiaddresses_to_announce = if self.cfg.publish {
             transport_api.announceable_multiaddresses()
         } else {
@@ -595,7 +609,6 @@ where
             }
         }
 
-        // === Key binding ===
         let this_node_account = node_ready
             .await
             .map_err(HoprLibError::other)?
@@ -607,7 +620,6 @@ where
 
         tracing::info!(%this_node_account, "node account is ready");
 
-        // === Session channel ===
         let incoming_session_capacity = std::env::var("HOPR_INTERNAL_SESSION_INCOMING_CAPACITY")
             .ok()
             .and_then(|s| s.trim().parse::<usize>().ok())
@@ -618,8 +630,6 @@ where
         let (session_tx, session_rx) = channel::<IncomingSession>(incoming_session_capacity);
 
         // === Chain → Graph event wiring ===
-        // Subscribe to chain events and update the graph accordingly.
-        // This runs as a background task for the lifetime of the node.
         let processes = {
             let chain_events = chain_api
                 .subscribe_with_state_sync([StateSyncOptions::PublicAccounts, StateSyncOptions::OpenedChannels])

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -200,7 +200,10 @@ impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
     #[cfg(feature = "session-server")]
     pub fn with_session_server(
         self,
-        server: impl hopr_api::node::HoprSessionServer<Session = IncomingSession, Error: std::fmt::Display>,
+        server: impl hopr_api::node::HoprSessionServer<Session = IncomingSession, Error: std::fmt::Display>
+        + Clone
+        + Send
+        + 'static,
     ) -> HoprBuilderWithSession<Chain, Graph, Net, Ct> {
         let incoming_session_capacity = std::env::var("HOPR_INTERNAL_SESSION_INCOMING_CAPACITY")
             .ok()

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -53,6 +53,20 @@ lazy_static::lazy_static! {
 /// Type-erased factory closure producing `T` from a [`BuildCtx`] reference.
 type Factory<T> = Box<dyn FnOnce(&BuildCtx) -> T + Send>;
 
+/// Trait for processing incoming HOPR sessions on exit nodes.
+///
+/// Implementors define how each incoming session is handled (e.g. IP forwarding,
+/// echo, etc.). Used by [`HoprBuilderConfigured::with_session_server`].
+#[cfg(feature = "session-server")]
+#[async_trait::async_trait]
+pub trait HoprSessionServer: Clone + Send + 'static {
+    /// Error type for session processing.
+    type Error: std::fmt::Display + Send + Sync + 'static;
+
+    /// Fully process a single incoming HOPR session.
+    async fn process(&self, session: IncomingSession) -> Result<(), Self::Error>;
+}
+
 /// Context available to factory closures during the build step.
 pub struct BuildCtx {
     /// Node's on-chain keypair.
@@ -216,10 +230,7 @@ impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
     /// Eagerly spawns the server task. Sessions are not emitted until
     /// transport starts during build, so spawning the consumer early is safe.
     #[cfg(feature = "session-server")]
-    pub fn with_session_server(
-        mut self,
-        server: impl hopr_api::node::HoprSessionServer<Session = IncomingSession, Error: std::fmt::Display>,
-    ) -> Self {
+    pub fn with_session_server(mut self, server: impl HoprSessionServer) -> Self {
         let incoming_session_capacity = std::env::var("HOPR_INTERNAL_SESSION_INCOMING_CAPACITY")
             .ok()
             .and_then(|s| s.trim().parse::<usize>().ok())

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -45,27 +45,10 @@ lazy_static::lazy_static! {
     ).unwrap();
 }
 
-/// Intermediate state produced by the shared initialization sequence.
-struct PreHopr<Chain, Graph, Net, NB, Ct> {
-    chain_id: ChainKeypair,
-    transport_id: OffchainKeypair,
-    cfg: HoprLibConfig,
-    state: Arc<AtomicHoprState>,
-    transport_api: HoprTransport<Chain, Graph, Net>,
-    chain_api: Chain,
-    ticket_event_subscribers: (
-        async_broadcast::Sender<TicketEvent>,
-        async_broadcast::InactiveReceiver<TicketEvent>,
-    ),
-    processes: AbortableList<HoprLibProcess>,
-    session_tx: futures::channel::mpsc::Sender<IncomingSession>,
-    session_rx: futures::channel::mpsc::Receiver<IncomingSession>,
-    cover_traffic: Ct,
-    network_builder: NB,
-}
+// ---------------------------------------------------------------------------
+// Session server attachment helper
+// ---------------------------------------------------------------------------
 
-/// Attaches a session server to the incoming session receiver and inserts
-/// the spawned process into the process list.
 #[cfg(feature = "session-server")]
 fn attach_session_server<Srv>(
     session_rx: futures::channel::mpsc::Receiver<IncomingSession>,
@@ -100,24 +83,12 @@ fn attach_session_server<Srv>(
     );
 }
 
-/// Abstract builder for the [`Hopr`] node object.
-///
-/// Collects components common to all node types (edge and relay/full) and provides
-/// two distinct build paths:
-///
-/// - [`build_edge`](HoprBuilder::build_edge) — standalone ticket factory, no ticket management
-/// - [`build_full`](HoprBuilder::build_full) — coupled ticket factory + ticket manager
-///
-/// # Type Parameters
-///
-/// - `Chain` — blockchain API ([`HoprChainApi`])
-/// - `Graph` — network graph ([`HoprGraphApi`])
-/// - `NB` — network builder factory ([`NetworkBuilder`])
-/// - `Ct` — cover traffic / probing ([`ProbingTrafficGeneration`] + [`CoverTrafficGeneration`])
-///
-/// Ticket management, ticket factory, and session server are **not** builder generics —
-/// they are parameters to the build methods.
-pub struct HoprBuilder<Chain = (), Graph = (), NB = (), Ct = ()> {
+// ---------------------------------------------------------------------------
+// Builder core — shared across feature variants
+// ---------------------------------------------------------------------------
+
+/// Internal core holding builder fields common to all feature configurations.
+struct HoprBuilderCore<Chain, Graph, NB, Ct> {
     chain: Option<Chain>,
     graph: Option<Graph>,
     network_builder: Option<NB>,
@@ -127,7 +98,7 @@ pub struct HoprBuilder<Chain = (), Graph = (), NB = (), Ct = ()> {
     cfg: HoprLibConfig,
 }
 
-impl<Chain, Graph, NB, Ct> Default for HoprBuilder<Chain, Graph, NB, Ct> {
+impl<Chain, Graph, NB, Ct> Default for HoprBuilderCore<Chain, Graph, NB, Ct> {
     fn default() -> Self {
         Self {
             chain: None,
@@ -141,53 +112,26 @@ impl<Chain, Graph, NB, Ct> Default for HoprBuilder<Chain, Graph, NB, Ct> {
     }
 }
 
-impl<Chain, Graph, NB, Ct> HoprBuilder<Chain, Graph, NB, Ct> {
-    /// Sets the chain API implementation.
-    pub fn with_chain_api(mut self, chain: Chain) -> Self {
-        self.chain = Some(chain);
-        self
-    }
-
-    /// Sets the network graph.
-    pub fn with_graph(mut self, graph: Graph) -> Self {
-        self.graph = Some(graph);
-        self
-    }
-
-    /// Sets the network builder (factory for P2P network).
-    pub fn with_network_builder(mut self, builder: NB) -> Self {
-        self.network_builder = Some(builder);
-        self
-    }
-
-    /// Sets the cover traffic and probing provider.
-    pub fn with_cover_traffic(mut self, ct: Ct) -> Self {
-        self.cover_traffic = Some(ct);
-        self
-    }
-
-    /// Sets the node's on-chain and off-chain identity.
-    pub fn with_identity(mut self, chain_key: &ChainKeypair, offchain_key: &OffchainKeypair) -> Self {
-        self.identity = Some((chain_key.clone(), offchain_key.clone()));
-        self
-    }
-
-    /// Sets the node Safe and module addresses.
-    pub fn with_safe_module(mut self, safe: &Address, module: &Address) -> Self {
-        self.safe_and_module = Some((*safe, *module));
-        self
-    }
-
-    /// Sets the [`HoprLibConfig`].
-    pub fn with_config(mut self, cfg: HoprLibConfig) -> Self {
-        self.cfg = cfg;
-        self
-    }
+/// Intermediate state produced by the shared initialization sequence.
+struct PreHopr<Chain, Graph, Net, NB, Ct> {
+    chain_id: ChainKeypair,
+    transport_id: OffchainKeypair,
+    cfg: HoprLibConfig,
+    state: Arc<AtomicHoprState>,
+    transport_api: HoprTransport<Chain, Graph, Net>,
+    chain_api: Chain,
+    ticket_event_subscribers: (
+        async_broadcast::Sender<TicketEvent>,
+        async_broadcast::InactiveReceiver<TicketEvent>,
+    ),
+    processes: AbortableList<HoprLibProcess>,
+    session_tx: futures::channel::mpsc::Sender<IncomingSession>,
+    session_rx: futures::channel::mpsc::Receiver<IncomingSession>,
+    cover_traffic: Ct,
+    network_builder: NB,
 }
 
-// === Build methods ===
-
-impl<Chain, Graph, NB, Ct> HoprBuilder<Chain, Graph, NB, Ct>
+impl<Chain, Graph, NB, Ct> HoprBuilderCore<Chain, Graph, NB, Ct>
 where
     Chain: HoprChainApi + Clone + Send + Sync + 'static,
     Graph: HoprGraphApi<HoprNodeId = hopr_api::OffchainPublicKey> + Clone + Send + Sync + 'static,
@@ -199,235 +143,6 @@ where
         hopr_api::network::NetworkView + NetworkStreamControl + Send + Sync + Clone + 'static,
     Ct: ProbingTrafficGeneration + CoverTrafficGeneration + Send + Sync + 'static,
 {
-    /// Builds an edge (entry/exit) [`Hopr`] node.
-    ///
-    /// Edge nodes use a standalone ticket factory for outgoing tickets but do **not**
-    /// process incoming winning tickets — the incoming ticket sink is drained.
-    ///
-    /// When the `session-server` feature is enabled, a session server must be provided
-    /// to handle incoming sessions. Without the feature, incoming sessions are dropped.
-    pub async fn build_edge<TFact>(
-        self,
-        ticket_factory: TFact,
-        #[cfg(feature = "session-server")] session_server: impl hopr_api::node::HoprSessionServer<
-            Session = IncomingSession,
-            Error: std::fmt::Display,
-        >,
-    ) -> Result<Hopr<Chain, Graph, <NB as NetworkBuilder>::Network, ()>, HoprLibError>
-    where
-        TFact: TicketFactory + Clone + Send + Sync + 'static,
-    {
-        let pre = self.pre_build().await?;
-
-        tracing::info!("starting transport for edge node");
-        let (_, transport_processes) = pre
-            .transport_api
-            .run(
-                pre.cover_traffic,
-                pre.network_builder,
-                futures::sink::drain(),
-                ticket_factory,
-                pre.session_tx,
-            )
-            .await?;
-
-        let mut processes = pre.processes;
-        processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
-
-        #[cfg(feature = "session-server")]
-        attach_session_server(pre.session_rx, session_server, &mut processes);
-
-        let hopr = Hopr {
-            chain_id: NodeOnchainIdentity {
-                node_address: pre.chain_id.public().to_address(),
-                safe_address: pre.cfg.safe_module.safe_address,
-                module_address: pre.cfg.safe_module.module_address,
-            },
-            cfg: pre.cfg,
-            state: pre.state.clone(),
-            ticket_event_subscribers: pre.ticket_event_subscribers,
-            transport_id: pre.transport_id,
-            transport_api: pre.transport_api,
-            chain_api: pre.chain_api,
-            processes,
-            ticket_manager: (),
-        };
-
-        hopr.state
-            .store(HoprState::Running, std::sync::atomic::Ordering::Relaxed);
-        tracing::info!(
-            id = %hopr.transport_id.public().to_peerid_str(),
-            version = constants::APP_VERSION,
-            "EDGE NODE STARTED AND RUNNING"
-        );
-
-        Ok(hopr)
-    }
-
-    /// Builds a full (relay) [`Hopr`] node.
-    ///
-    /// Full nodes process incoming winning tickets via the `ticket_manager` and use a
-    /// coupled ticket factory that accounts for unrealized balance.
-    ///
-    /// When the `session-server` feature is enabled, a session server must be provided
-    /// to handle incoming sessions. Without the feature, incoming sessions are dropped.
-    pub async fn build_full<TMgr, TFact>(
-        self,
-        ticket_manager: TMgr,
-        ticket_factory: TFact,
-        #[cfg(feature = "session-server")] session_server: impl hopr_api::node::HoprSessionServer<
-            Session = IncomingSession,
-            Error: std::fmt::Display,
-        >,
-    ) -> Result<Hopr<Chain, Graph, <NB as NetworkBuilder>::Network, TMgr>, HoprLibError>
-    where
-        TMgr: TicketManagement + Clone + Send + Sync + 'static,
-        TFact: TicketFactory + Clone + Send + Sync + 'static,
-    {
-        let pre = self.pre_build().await?;
-
-        let mut processes = pre.processes;
-
-        // === Ticket event processing ===
-        tracing::info!("starting ticket events processor");
-        let (tickets_tx, tickets_rx) = channel(8192);
-        let (tickets_rx_stream, tickets_handle) = futures::stream::abortable(tickets_rx);
-        processes.insert(HoprLibProcess::TicketEvents, tickets_handle);
-        let new_ticket_tx = pre.ticket_event_subscribers.0.clone();
-        let tmgr_clone = ticket_manager.clone();
-        spawn(
-            tickets_rx_stream
-                .for_each(move |event| {
-                    if let TicketEvent::WinningTicket(ticket) = &event
-                        && let Err(error) = tmgr_clone.insert_incoming_ticket(**ticket)
-                    {
-                        tracing::error!(%error, "failed to insert incoming ticket");
-                    }
-                    if let Err(error) = new_ticket_tx.try_broadcast(event) {
-                        tracing::error!(%error, "failed to broadcast ticket event");
-                    }
-                    futures::future::ready(())
-                })
-                .inspect(|_| {
-                    tracing::warn!(
-                        task = %HoprLibProcess::TicketEvents,
-                        "long-running background task finished"
-                    )
-                }),
-        );
-
-        // === Channel closure → ticket neglect ===
-        {
-            let chain_for_neglect = pre.chain_api.clone();
-            let tmgr_for_neglect = ticket_manager.clone();
-            let events = pre.chain_api.subscribe().map_err(HoprLibError::chain)?;
-            let (neglect_handle, neglect_reg) = hopr_async_runtime::AbortHandle::new_pair();
-            spawn(
-                futures::stream::Abortable::new(
-                    events.filter_map(move |event| {
-                        futures::future::ready(match event {
-                            ChainEvent::ChannelClosed(ch) => Some(ch),
-                            _ => None,
-                        })
-                    }),
-                    neglect_reg,
-                )
-                .for_each(move |closed_channel| {
-                    let chain = chain_for_neglect.clone();
-                    let tmgr = tmgr_for_neglect.clone();
-                    async move {
-                        use hopr_api::types::internal::prelude::ChannelDirection;
-                        match closed_channel.direction(chain.me()) {
-                            Some(ChannelDirection::Incoming) => {
-                                match tmgr.neglect_tickets(closed_channel.get_id(), None) {
-                                    Ok(neglected) if !neglected.is_empty() => {
-                                        tracing::warn!(
-                                            num_neglected = neglected.len(),
-                                            %closed_channel,
-                                            "tickets on incoming closed channel were neglected"
-                                        );
-                                    }
-                                    Ok(_) => {}
-                                    Err(error) => {
-                                        tracing::error!(
-                                            %error, %closed_channel,
-                                            "failed to neglect tickets on closed channel"
-                                        );
-                                    }
-                                }
-                            }
-                            Some(ChannelDirection::Outgoing) => {}
-                            _ => {}
-                        }
-                    }
-                })
-                .inspect(|_| {
-                    tracing::warn!(
-                        task = %HoprLibProcess::ChannelEvents,
-                        "channel closure ticket neglect task finished"
-                    )
-                }),
-            );
-            processes.insert(HoprLibProcess::OutIndexSync, neglect_handle);
-        }
-
-        // === Start transport ===
-        tracing::info!("starting transport for full node");
-        let (_, transport_processes) = pre
-            .transport_api
-            .run(
-                pre.cover_traffic,
-                pre.network_builder,
-                tickets_tx,
-                ticket_factory,
-                pre.session_tx,
-            )
-            .await?;
-        processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
-
-        #[cfg(feature = "session-server")]
-        attach_session_server(pre.session_rx, session_server, &mut processes);
-
-        let hopr = Hopr {
-            chain_id: NodeOnchainIdentity {
-                node_address: pre.chain_id.public().to_address(),
-                safe_address: pre.cfg.safe_module.safe_address,
-                module_address: pre.cfg.safe_module.module_address,
-            },
-            cfg: pre.cfg,
-            state: pre.state.clone(),
-            ticket_event_subscribers: pre.ticket_event_subscribers,
-            transport_id: pre.transport_id,
-            transport_api: pre.transport_api,
-            chain_api: pre.chain_api,
-            processes,
-            ticket_manager,
-        };
-
-        hopr.state
-            .store(HoprState::Running, std::sync::atomic::Ordering::Relaxed);
-
-        tracing::info!(
-            id = %hopr.transport_id.public().to_peerid_str(),
-            version = constants::APP_VERSION,
-            "FULL NODE STARTED AND RUNNING"
-        );
-
-        #[cfg(all(feature = "telemetry", not(test)))]
-        METRIC_HOPR_NODE_INFO.set(
-            &[
-                &hopr.transport_id.public().to_peerid_str(),
-                &hopr.chain_id.node_address.to_string(),
-                &hopr.chain_id.safe_address.to_string(),
-                &hopr.chain_id.module_address.to_string(),
-            ],
-            1.0,
-        );
-
-        Ok(hopr)
-    }
-
-    /// Shared initialization sequence for both edge and full node builds.
     async fn pre_build(
         mut self,
     ) -> Result<PreHopr<Chain, Graph, <NB as NetworkBuilder>::Network, NB, Ct>, HoprLibError> {
@@ -776,5 +491,564 @@ where
             cover_traffic,
             network_builder,
         })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HoprBuilder — with session-server feature
+// ---------------------------------------------------------------------------
+
+#[cfg(feature = "session-server")]
+pub struct HoprBuilder<Chain = (), Graph = (), NB = (), Ct = (), Srv = ()> {
+    core: HoprBuilderCore<Chain, Graph, NB, Ct>,
+    session_server: Option<Srv>,
+}
+
+#[cfg(feature = "session-server")]
+impl<Chain, Graph, NB, Ct, Srv> Default for HoprBuilder<Chain, Graph, NB, Ct, Srv> {
+    fn default() -> Self {
+        Self {
+            core: Default::default(),
+            session_server: None,
+        }
+    }
+}
+
+#[cfg(feature = "session-server")]
+impl<Chain, Graph, NB, Ct, Srv> HoprBuilder<Chain, Graph, NB, Ct, Srv> {
+    pub fn with_chain_api(mut self, chain: Chain) -> Self {
+        self.core.chain = Some(chain);
+        self
+    }
+
+    pub fn with_graph(mut self, graph: Graph) -> Self {
+        self.core.graph = Some(graph);
+        self
+    }
+
+    pub fn with_network_builder(mut self, builder: NB) -> Self {
+        self.core.network_builder = Some(builder);
+        self
+    }
+
+    pub fn with_cover_traffic(mut self, ct: Ct) -> Self {
+        self.core.cover_traffic = Some(ct);
+        self
+    }
+
+    pub fn with_identity(mut self, chain_key: &ChainKeypair, offchain_key: &OffchainKeypair) -> Self {
+        self.core.identity = Some((chain_key.clone(), offchain_key.clone()));
+        self
+    }
+
+    pub fn with_safe_module(mut self, safe: &Address, module: &Address) -> Self {
+        self.core.safe_and_module = Some((*safe, *module));
+        self
+    }
+
+    pub fn with_config(mut self, cfg: HoprLibConfig) -> Self {
+        self.core.cfg = cfg;
+        self
+    }
+
+    /// Sets the session server for handling incoming sessions.
+    pub fn with_session_server(mut self, srv: Srv) -> Self {
+        self.session_server = Some(srv);
+        self
+    }
+}
+
+#[cfg(feature = "session-server")]
+impl<Chain, Graph, NB, Ct, Srv> HoprBuilder<Chain, Graph, NB, Ct, Srv>
+where
+    Chain: HoprChainApi + Clone + Send + Sync + 'static,
+    Graph: HoprGraphApi<HoprNodeId = hopr_api::OffchainPublicKey> + Clone + Send + Sync + 'static,
+    <Graph as hopr_api::graph::NetworkGraphTraverse>::Observed:
+        hopr_api::graph::traits::EdgeObservableRead + Send + 'static,
+    <Graph as hopr_api::graph::NetworkGraphWrite>::Observed: hopr_api::graph::traits::EdgeObservableWrite + Send,
+    NB: NetworkBuilder + Send + Sync + 'static,
+    <NB as NetworkBuilder>::Network:
+        hopr_api::network::NetworkView + NetworkStreamControl + Send + Sync + Clone + 'static,
+    Ct: ProbingTrafficGeneration + CoverTrafficGeneration + Send + Sync + 'static,
+    Srv: hopr_api::node::HoprSessionServer<Session = IncomingSession>,
+    <Srv as hopr_api::node::HoprSessionServer>::Error: std::fmt::Display,
+{
+    /// Builds an edge (entry/exit) [`Hopr`] node.
+    pub async fn build_edge<TFact>(
+        self,
+        ticket_factory: TFact,
+    ) -> Result<Hopr<Chain, Graph, <NB as NetworkBuilder>::Network, ()>, HoprLibError>
+    where
+        TFact: TicketFactory + Clone + Send + Sync + 'static,
+    {
+        let pre = self.core.pre_build().await?;
+
+        tracing::info!("starting transport for edge node");
+        let (_, transport_processes) = pre
+            .transport_api
+            .run(
+                pre.cover_traffic,
+                pre.network_builder,
+                futures::sink::drain(),
+                ticket_factory,
+                pre.session_tx,
+            )
+            .await?;
+
+        let mut processes = pre.processes;
+        processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
+
+        if let Some(server) = self.session_server {
+            attach_session_server(pre.session_rx, server, &mut processes);
+        }
+
+        let hopr = Hopr {
+            chain_id: NodeOnchainIdentity {
+                node_address: pre.chain_id.public().to_address(),
+                safe_address: pre.cfg.safe_module.safe_address,
+                module_address: pre.cfg.safe_module.module_address,
+            },
+            cfg: pre.cfg,
+            state: pre.state.clone(),
+            ticket_event_subscribers: pre.ticket_event_subscribers,
+            transport_id: pre.transport_id,
+            transport_api: pre.transport_api,
+            chain_api: pre.chain_api,
+            processes,
+            ticket_manager: (),
+        };
+
+        hopr.state
+            .store(HoprState::Running, std::sync::atomic::Ordering::Relaxed);
+        tracing::info!(
+            id = %hopr.transport_id.public().to_peerid_str(),
+            version = constants::APP_VERSION,
+            "EDGE NODE STARTED AND RUNNING"
+        );
+
+        Ok(hopr)
+    }
+
+    /// Builds a full (relay) [`Hopr`] node.
+    pub async fn build_full<TMgr, TFact>(
+        self,
+        ticket_manager: TMgr,
+        ticket_factory: TFact,
+    ) -> Result<Hopr<Chain, Graph, <NB as NetworkBuilder>::Network, TMgr>, HoprLibError>
+    where
+        TMgr: TicketManagement + Clone + Send + Sync + 'static,
+        TFact: TicketFactory + Clone + Send + Sync + 'static,
+    {
+        let pre = self.core.pre_build().await?;
+        let mut processes = pre.processes;
+
+        // Ticket event processing
+        tracing::info!("starting ticket events processor");
+        let (tickets_tx, tickets_rx) = channel(8192);
+        let (tickets_rx_stream, tickets_handle) = futures::stream::abortable(tickets_rx);
+        processes.insert(HoprLibProcess::TicketEvents, tickets_handle);
+        let new_ticket_tx = pre.ticket_event_subscribers.0.clone();
+        let tmgr_clone = ticket_manager.clone();
+        spawn(
+            tickets_rx_stream
+                .for_each(move |event| {
+                    if let TicketEvent::WinningTicket(ticket) = &event
+                        && let Err(error) = tmgr_clone.insert_incoming_ticket(**ticket)
+                    {
+                        tracing::error!(%error, "failed to insert incoming ticket");
+                    }
+                    if let Err(error) = new_ticket_tx.try_broadcast(event) {
+                        tracing::error!(%error, "failed to broadcast ticket event");
+                    }
+                    futures::future::ready(())
+                })
+                .inspect(|_| {
+                    tracing::warn!(
+                        task = %HoprLibProcess::TicketEvents,
+                        "long-running background task finished"
+                    )
+                }),
+        );
+
+        // Channel closure → ticket neglect
+        {
+            let chain_for_neglect = pre.chain_api.clone();
+            let tmgr_for_neglect = ticket_manager.clone();
+            let events = pre.chain_api.subscribe().map_err(HoprLibError::chain)?;
+            let (neglect_handle, neglect_reg) = hopr_async_runtime::AbortHandle::new_pair();
+            spawn(
+                futures::stream::Abortable::new(
+                    events.filter_map(move |event| {
+                        futures::future::ready(match event {
+                            ChainEvent::ChannelClosed(ch) => Some(ch),
+                            _ => None,
+                        })
+                    }),
+                    neglect_reg,
+                )
+                .for_each(move |closed_channel| {
+                    let chain = chain_for_neglect.clone();
+                    let tmgr = tmgr_for_neglect.clone();
+                    async move {
+                        use hopr_api::types::internal::prelude::ChannelDirection;
+                        match closed_channel.direction(chain.me()) {
+                            Some(ChannelDirection::Incoming) => {
+                                match tmgr.neglect_tickets(closed_channel.get_id(), None) {
+                                    Ok(neglected) if !neglected.is_empty() => {
+                                        tracing::warn!(
+                                            num_neglected = neglected.len(),
+                                            %closed_channel,
+                                            "tickets on incoming closed channel were neglected"
+                                        );
+                                    }
+                                    Ok(_) => {}
+                                    Err(error) => {
+                                        tracing::error!(
+                                            %error, %closed_channel,
+                                            "failed to neglect tickets on closed channel"
+                                        );
+                                    }
+                                }
+                            }
+                            Some(ChannelDirection::Outgoing) => {}
+                            _ => {}
+                        }
+                    }
+                })
+                .inspect(|_| {
+                    tracing::warn!(
+                        task = %HoprLibProcess::ChannelEvents,
+                        "channel closure ticket neglect task finished"
+                    )
+                }),
+            );
+            processes.insert(HoprLibProcess::OutIndexSync, neglect_handle);
+        }
+
+        // Start transport
+        tracing::info!("starting transport for full node");
+        let (_, transport_processes) = pre
+            .transport_api
+            .run(
+                pre.cover_traffic,
+                pre.network_builder,
+                tickets_tx,
+                ticket_factory,
+                pre.session_tx,
+            )
+            .await?;
+        processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
+
+        if let Some(server) = self.session_server {
+            attach_session_server(pre.session_rx, server, &mut processes);
+        }
+
+        let hopr = Hopr {
+            chain_id: NodeOnchainIdentity {
+                node_address: pre.chain_id.public().to_address(),
+                safe_address: pre.cfg.safe_module.safe_address,
+                module_address: pre.cfg.safe_module.module_address,
+            },
+            cfg: pre.cfg,
+            state: pre.state.clone(),
+            ticket_event_subscribers: pre.ticket_event_subscribers,
+            transport_id: pre.transport_id,
+            transport_api: pre.transport_api,
+            chain_api: pre.chain_api,
+            processes,
+            ticket_manager,
+        };
+
+        hopr.state
+            .store(HoprState::Running, std::sync::atomic::Ordering::Relaxed);
+
+        tracing::info!(
+            id = %hopr.transport_id.public().to_peerid_str(),
+            version = constants::APP_VERSION,
+            "FULL NODE STARTED AND RUNNING"
+        );
+
+        #[cfg(all(feature = "telemetry", not(test)))]
+        METRIC_HOPR_NODE_INFO.set(
+            &[
+                &hopr.transport_id.public().to_peerid_str(),
+                &hopr.chain_id.node_address.to_string(),
+                &hopr.chain_id.safe_address.to_string(),
+                &hopr.chain_id.module_address.to_string(),
+            ],
+            1.0,
+        );
+
+        Ok(hopr)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HoprBuilder — without session-server feature
+// ---------------------------------------------------------------------------
+
+#[cfg(not(feature = "session-server"))]
+pub struct HoprBuilder<Chain = (), Graph = (), NB = (), Ct = ()> {
+    core: HoprBuilderCore<Chain, Graph, NB, Ct>,
+}
+
+#[cfg(not(feature = "session-server"))]
+impl<Chain, Graph, NB, Ct> Default for HoprBuilder<Chain, Graph, NB, Ct> {
+    fn default() -> Self {
+        Self {
+            core: Default::default(),
+        }
+    }
+}
+
+#[cfg(not(feature = "session-server"))]
+impl<Chain, Graph, NB, Ct> HoprBuilder<Chain, Graph, NB, Ct> {
+    pub fn with_chain_api(mut self, chain: Chain) -> Self {
+        self.core.chain = Some(chain);
+        self
+    }
+
+    pub fn with_graph(mut self, graph: Graph) -> Self {
+        self.core.graph = Some(graph);
+        self
+    }
+
+    pub fn with_network_builder(mut self, builder: NB) -> Self {
+        self.core.network_builder = Some(builder);
+        self
+    }
+
+    pub fn with_cover_traffic(mut self, ct: Ct) -> Self {
+        self.core.cover_traffic = Some(ct);
+        self
+    }
+
+    pub fn with_identity(mut self, chain_key: &ChainKeypair, offchain_key: &OffchainKeypair) -> Self {
+        self.core.identity = Some((chain_key.clone(), offchain_key.clone()));
+        self
+    }
+
+    pub fn with_safe_module(mut self, safe: &Address, module: &Address) -> Self {
+        self.core.safe_and_module = Some((*safe, *module));
+        self
+    }
+
+    pub fn with_config(mut self, cfg: HoprLibConfig) -> Self {
+        self.core.cfg = cfg;
+        self
+    }
+}
+
+#[cfg(not(feature = "session-server"))]
+impl<Chain, Graph, NB, Ct> HoprBuilder<Chain, Graph, NB, Ct>
+where
+    Chain: HoprChainApi + Clone + Send + Sync + 'static,
+    Graph: HoprGraphApi<HoprNodeId = hopr_api::OffchainPublicKey> + Clone + Send + Sync + 'static,
+    <Graph as hopr_api::graph::NetworkGraphTraverse>::Observed:
+        hopr_api::graph::traits::EdgeObservableRead + Send + 'static,
+    <Graph as hopr_api::graph::NetworkGraphWrite>::Observed: hopr_api::graph::traits::EdgeObservableWrite + Send,
+    NB: NetworkBuilder + Send + Sync + 'static,
+    <NB as NetworkBuilder>::Network:
+        hopr_api::network::NetworkView + NetworkStreamControl + Send + Sync + Clone + 'static,
+    Ct: ProbingTrafficGeneration + CoverTrafficGeneration + Send + Sync + 'static,
+{
+    /// Builds an edge (entry/exit) [`Hopr`] node.
+    pub async fn build_edge<TFact>(
+        self,
+        ticket_factory: TFact,
+    ) -> Result<Hopr<Chain, Graph, <NB as NetworkBuilder>::Network, ()>, HoprLibError>
+    where
+        TFact: TicketFactory + Clone + Send + Sync + 'static,
+    {
+        let pre = self.core.pre_build().await?;
+
+        tracing::info!("starting transport for edge node");
+        let (_, transport_processes) = pre
+            .transport_api
+            .run(
+                pre.cover_traffic,
+                pre.network_builder,
+                futures::sink::drain(),
+                ticket_factory,
+                pre.session_tx,
+            )
+            .await?;
+
+        let mut processes = pre.processes;
+        processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
+
+        let hopr = Hopr {
+            chain_id: NodeOnchainIdentity {
+                node_address: pre.chain_id.public().to_address(),
+                safe_address: pre.cfg.safe_module.safe_address,
+                module_address: pre.cfg.safe_module.module_address,
+            },
+            cfg: pre.cfg,
+            state: pre.state.clone(),
+            ticket_event_subscribers: pre.ticket_event_subscribers,
+            transport_id: pre.transport_id,
+            transport_api: pre.transport_api,
+            chain_api: pre.chain_api,
+            processes,
+            ticket_manager: (),
+        };
+
+        hopr.state
+            .store(HoprState::Running, std::sync::atomic::Ordering::Relaxed);
+        tracing::info!(
+            id = %hopr.transport_id.public().to_peerid_str(),
+            version = constants::APP_VERSION,
+            "EDGE NODE STARTED AND RUNNING"
+        );
+
+        Ok(hopr)
+    }
+
+    /// Builds a full (relay) [`Hopr`] node.
+    pub async fn build_full<TMgr, TFact>(
+        self,
+        ticket_manager: TMgr,
+        ticket_factory: TFact,
+    ) -> Result<Hopr<Chain, Graph, <NB as NetworkBuilder>::Network, TMgr>, HoprLibError>
+    where
+        TMgr: TicketManagement + Clone + Send + Sync + 'static,
+        TFact: TicketFactory + Clone + Send + Sync + 'static,
+    {
+        let pre = self.core.pre_build().await?;
+        let mut processes = pre.processes;
+
+        // Ticket event processing
+        tracing::info!("starting ticket events processor");
+        let (tickets_tx, tickets_rx) = channel(8192);
+        let (tickets_rx_stream, tickets_handle) = futures::stream::abortable(tickets_rx);
+        processes.insert(HoprLibProcess::TicketEvents, tickets_handle);
+        let new_ticket_tx = pre.ticket_event_subscribers.0.clone();
+        let tmgr_clone = ticket_manager.clone();
+        spawn(
+            tickets_rx_stream
+                .for_each(move |event| {
+                    if let TicketEvent::WinningTicket(ticket) = &event
+                        && let Err(error) = tmgr_clone.insert_incoming_ticket(**ticket)
+                    {
+                        tracing::error!(%error, "failed to insert incoming ticket");
+                    }
+                    if let Err(error) = new_ticket_tx.try_broadcast(event) {
+                        tracing::error!(%error, "failed to broadcast ticket event");
+                    }
+                    futures::future::ready(())
+                })
+                .inspect(|_| {
+                    tracing::warn!(
+                        task = %HoprLibProcess::TicketEvents,
+                        "long-running background task finished"
+                    )
+                }),
+        );
+
+        // Channel closure → ticket neglect
+        {
+            let chain_for_neglect = pre.chain_api.clone();
+            let tmgr_for_neglect = ticket_manager.clone();
+            let events = pre.chain_api.subscribe().map_err(HoprLibError::chain)?;
+            let (neglect_handle, neglect_reg) = hopr_async_runtime::AbortHandle::new_pair();
+            spawn(
+                futures::stream::Abortable::new(
+                    events.filter_map(move |event| {
+                        futures::future::ready(match event {
+                            ChainEvent::ChannelClosed(ch) => Some(ch),
+                            _ => None,
+                        })
+                    }),
+                    neglect_reg,
+                )
+                .for_each(move |closed_channel| {
+                    let chain = chain_for_neglect.clone();
+                    let tmgr = tmgr_for_neglect.clone();
+                    async move {
+                        use hopr_api::types::internal::prelude::ChannelDirection;
+                        match closed_channel.direction(chain.me()) {
+                            Some(ChannelDirection::Incoming) => {
+                                match tmgr.neglect_tickets(closed_channel.get_id(), None) {
+                                    Ok(neglected) if !neglected.is_empty() => {
+                                        tracing::warn!(
+                                            num_neglected = neglected.len(),
+                                            %closed_channel,
+                                            "tickets on incoming closed channel were neglected"
+                                        );
+                                    }
+                                    Ok(_) => {}
+                                    Err(error) => {
+                                        tracing::error!(
+                                            %error, %closed_channel,
+                                            "failed to neglect tickets on closed channel"
+                                        );
+                                    }
+                                }
+                            }
+                            Some(ChannelDirection::Outgoing) => {}
+                            _ => {}
+                        }
+                    }
+                })
+                .inspect(|_| {
+                    tracing::warn!(
+                        task = %HoprLibProcess::ChannelEvents,
+                        "channel closure ticket neglect task finished"
+                    )
+                }),
+            );
+            processes.insert(HoprLibProcess::OutIndexSync, neglect_handle);
+        }
+
+        tracing::info!("starting transport for full node");
+        let (_, transport_processes) = pre
+            .transport_api
+            .run(
+                pre.cover_traffic,
+                pre.network_builder,
+                tickets_tx,
+                ticket_factory,
+                pre.session_tx,
+            )
+            .await?;
+        processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
+
+        let hopr = Hopr {
+            chain_id: NodeOnchainIdentity {
+                node_address: pre.chain_id.public().to_address(),
+                safe_address: pre.cfg.safe_module.safe_address,
+                module_address: pre.cfg.safe_module.module_address,
+            },
+            cfg: pre.cfg,
+            state: pre.state.clone(),
+            ticket_event_subscribers: pre.ticket_event_subscribers,
+            transport_id: pre.transport_id,
+            transport_api: pre.transport_api,
+            chain_api: pre.chain_api,
+            processes,
+            ticket_manager,
+        };
+
+        hopr.state
+            .store(HoprState::Running, std::sync::atomic::Ordering::Relaxed);
+
+        tracing::info!(
+            id = %hopr.transport_id.public().to_peerid_str(),
+            version = constants::APP_VERSION,
+            "FULL NODE STARTED AND RUNNING"
+        );
+
+        #[cfg(all(feature = "telemetry", not(test)))]
+        METRIC_HOPR_NODE_INFO.set(
+            &[
+                &hopr.transport_id.public().to_peerid_str(),
+                &hopr.chain_id.node_address.to_string(),
+                &hopr.chain_id.safe_address.to_string(),
+                &hopr.chain_id.module_address.to_string(),
+            ],
+            1.0,
+        );
+
+        Ok(hopr)
     }
 }

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -9,7 +9,7 @@ use hopr_api::{
     ct::{CoverTrafficGeneration, ProbingTrafficGeneration},
     graph::{EdgeCapacityUpdate, HoprGraphApi},
     network::{NetworkBuilder, NetworkStreamControl},
-    node::{AtomicHoprState, HoprSessionServer, HoprState, NodeOnchainIdentity, TicketEvent},
+    node::{AtomicHoprState, HoprState, NodeOnchainIdentity, TicketEvent},
     tickets::{TicketFactory, TicketManagement},
     types::{
         chain::chain_events::ChainEvent,
@@ -61,6 +61,7 @@ struct PreBuiltNode<Chain, Graph, Net, NB, Ct> {
     ),
     processes: AbortableList<HoprLibProcess>,
     session_tx: futures::channel::mpsc::Sender<IncomingSession>,
+    session_rx: futures::channel::mpsc::Receiver<IncomingSession>,
     // Moved out for transport.run()
     cover_traffic: Ct,
     network_builder: NB,
@@ -79,32 +80,28 @@ struct PreBuiltNode<Chain, Graph, Net, NB, Ct> {
 /// - `Chain` — blockchain API ([`HoprChainApi`])
 /// - `Graph` — network graph ([`HoprGraphApi`])
 /// - `NB` — network builder factory ([`NetworkBuilder`])
-/// - `Srv` — session server handler ([`HoprSessionServer`])
 /// - `Ct` — cover traffic / probing ([`ProbingTrafficGeneration`] + [`CoverTrafficGeneration`])
 ///
-/// Ticket management and ticket factory are **not** builder generics — they are
-/// parameters to the build methods, because edge and relay nodes construct them
-/// differently (standalone factory vs coupled factory+manager).
-pub struct HoprBuilder<Chain = (), Graph = (), NB = (), Srv = (), Ct = ()> {
+/// Ticket management, ticket factory, and session server are **not** builder generics —
+/// they are parameters to the build methods or handled by the caller after building.
+pub struct HoprBuilder<Chain = (), Graph = (), NB = (), Ct = ()> {
     chain: Option<Chain>,
     graph: Option<Graph>,
     network_builder: Option<NB>,
     cover_traffic: Option<Ct>,
-    session_server: Option<Srv>,
     identity: Option<(ChainKeypair, OffchainKeypair)>,
     safe_and_module: Option<(Address, Address)>,
     cfg: HoprLibConfig,
 }
 
 // Manual Default — no trait bounds on generics
-impl<Chain, Graph, NB, Srv, Ct> Default for HoprBuilder<Chain, Graph, NB, Srv, Ct> {
+impl<Chain, Graph, NB, Ct> Default for HoprBuilder<Chain, Graph, NB, Ct> {
     fn default() -> Self {
         Self {
             chain: None,
             graph: None,
             network_builder: None,
             cover_traffic: None,
-            session_server: None,
             identity: None,
             safe_and_module: None,
             cfg: Default::default(),
@@ -114,7 +111,7 @@ impl<Chain, Graph, NB, Srv, Ct> Default for HoprBuilder<Chain, Graph, NB, Srv, C
 
 // === Configuration methods (no trait bounds needed) ===
 
-impl<Chain, Graph, NB, Srv, Ct> HoprBuilder<Chain, Graph, NB, Srv, Ct> {
+impl<Chain, Graph, NB, Ct> HoprBuilder<Chain, Graph, NB, Ct> {
     /// Sets the chain API implementation.
     pub fn with_chain_api(mut self, chain: Chain) -> Self {
         self.chain = Some(chain);
@@ -139,12 +136,6 @@ impl<Chain, Graph, NB, Srv, Ct> HoprBuilder<Chain, Graph, NB, Srv, Ct> {
         self
     }
 
-    /// Sets the session server handler.
-    pub fn with_session_server(mut self, srv: Srv) -> Self {
-        self.session_server = Some(srv);
-        self
-    }
-
     /// Sets the node's on-chain and off-chain identity.
     pub fn with_identity(mut self, chain_key: &ChainKeypair, offchain_key: &OffchainKeypair) -> Self {
         self.identity = Some((chain_key.clone(), offchain_key.clone()));
@@ -164,9 +155,23 @@ impl<Chain, Graph, NB, Srv, Ct> HoprBuilder<Chain, Graph, NB, Srv, Ct> {
     }
 }
 
+/// Result of a successful build, containing the node and a receiver for incoming sessions.
+///
+/// The caller is responsible for attaching a session server to the `session_rx`
+/// if the node should process incoming sessions.
+pub struct BuiltNode<Chain, Graph, Net, TMgr> {
+    /// The built HOPR node.
+    pub node: Hopr<Chain, Graph, Net, TMgr>,
+    /// Receiver for incoming sessions from the transport layer.
+    ///
+    /// Attach a [`HoprSessionServer`](hopr_api::node::HoprSessionServer) to this
+    /// receiver to process incoming sessions, or drop it to discard them.
+    pub session_rx: futures::channel::mpsc::Receiver<IncomingSession>,
+}
+
 // === Build methods ===
 
-impl<Chain, Graph, NB, Srv, Ct> HoprBuilder<Chain, Graph, NB, Srv, Ct>
+impl<Chain, Graph, NB, Ct> HoprBuilder<Chain, Graph, NB, Ct>
 where
     Chain: HoprChainApi + Clone + Send + Sync + 'static,
     Graph: HoprGraphApi<HoprNodeId = hopr_api::OffchainPublicKey> + Clone + Send + Sync + 'static,
@@ -176,7 +181,6 @@ where
     NB: NetworkBuilder + Send + Sync + 'static,
     <NB as NetworkBuilder>::Network:
         hopr_api::network::NetworkView + NetworkStreamControl + Send + Sync + Clone + 'static,
-    Srv: HoprSessionServer<Session = IncomingSession> + Send + Clone + 'static,
     Ct: ProbingTrafficGeneration + CoverTrafficGeneration + Send + Sync + 'static,
 {
     /// Builds an edge (entry/exit) [`Hopr`] node.
@@ -189,11 +193,12 @@ where
     pub async fn build_edge<TFact>(
         self,
         ticket_factory: TFact,
-    ) -> Result<Hopr<Chain, Graph, <NB as NetworkBuilder>::Network, ()>, HoprLibError>
+    ) -> Result<BuiltNode<Chain, Graph, <NB as NetworkBuilder>::Network, ()>, HoprLibError>
     where
         TFact: TicketFactory + Clone + Send + Sync + 'static,
     {
         let pre = self.pre_build().await?;
+        let session_rx = pre.session_rx;
 
         // Edge nodes drain incoming tickets — no ticket processing.
         tracing::info!("starting transport for edge node");
@@ -211,7 +216,7 @@ where
         let mut processes = pre.processes;
         processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
 
-        let hopr = Hopr {
+        let node = Hopr {
             chain_id: NodeOnchainIdentity {
                 node_address: pre.chain_id.public().to_address(),
                 safe_address: pre.cfg.safe_module.safe_address,
@@ -227,15 +232,15 @@ where
             ticket_manager: (),
         };
 
-        hopr.state
+        node.state
             .store(HoprState::Running, std::sync::atomic::Ordering::Relaxed);
         tracing::info!(
-            id = %hopr.transport_id.public().to_peerid_str(),
+            id = %node.transport_id.public().to_peerid_str(),
             version = constants::APP_VERSION,
             "EDGE NODE STARTED AND RUNNING"
         );
 
-        Ok(hopr)
+        Ok(BuiltNode { node, session_rx })
     }
 
     /// Builds a full (relay) [`Hopr`] node.
@@ -251,12 +256,13 @@ where
         self,
         ticket_manager: TMgr,
         ticket_factory: TFact,
-    ) -> Result<Hopr<Chain, Graph, <NB as NetworkBuilder>::Network, TMgr>, HoprLibError>
+    ) -> Result<BuiltNode<Chain, Graph, <NB as NetworkBuilder>::Network, TMgr>, HoprLibError>
     where
         TMgr: TicketManagement + Clone + Send + Sync + 'static,
         TFact: TicketFactory + Clone + Send + Sync + 'static,
     {
         let pre = self.pre_build().await?;
+        let session_rx = pre.session_rx;
 
         let mut processes = pre.processes;
 
@@ -361,7 +367,7 @@ where
             .await?;
         processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
 
-        let hopr = Hopr {
+        let node = Hopr {
             chain_id: NodeOnchainIdentity {
                 node_address: pre.chain_id.public().to_address(),
                 safe_address: pre.cfg.safe_module.safe_address,
@@ -377,11 +383,11 @@ where
             ticket_manager,
         };
 
-        hopr.state
+        node.state
             .store(HoprState::Running, std::sync::atomic::Ordering::Relaxed);
 
         tracing::info!(
-            id = %hopr.transport_id.public().to_peerid_str(),
+            id = %node.transport_id.public().to_peerid_str(),
             version = constants::APP_VERSION,
             "FULL NODE STARTED AND RUNNING"
         );
@@ -389,22 +395,18 @@ where
         #[cfg(all(feature = "telemetry", not(test)))]
         METRIC_HOPR_NODE_INFO.set(
             &[
-                &hopr.transport_id.public().to_peerid_str(),
-                &hopr.chain_id.node_address.to_string(),
-                &hopr.chain_id.safe_address.to_string(),
-                &hopr.chain_id.module_address.to_string(),
+                &node.transport_id.public().to_peerid_str(),
+                &node.chain_id.node_address.to_string(),
+                &node.chain_id.safe_address.to_string(),
+                &node.chain_id.module_address.to_string(),
             ],
             1.0,
         );
 
-        Ok(hopr)
+        Ok(BuiltNode { node, session_rx })
     }
 
     /// Shared initialization sequence for both edge and full node builds.
-    ///
-    /// Performs: config validation, transport creation, fund waiting, ticket parameter
-    /// validation, Safe registration, node announcement, key binding, session
-    /// infrastructure, and chain→graph event wiring.
     async fn pre_build(
         mut self,
     ) -> Result<PreBuiltNode<Chain, Graph, <NB as NetworkBuilder>::Network, NB, Ct>, HoprLibError> {
@@ -605,51 +607,20 @@ where
 
         tracing::info!(%this_node_account, "node account is ready");
 
-        // === Session infrastructure ===
-        tracing::info!("initializing session infrastructure");
+        // === Session channel ===
         let incoming_session_capacity = std::env::var("HOPR_INTERNAL_SESSION_INCOMING_CAPACITY")
             .ok()
             .and_then(|s| s.trim().parse::<usize>().ok())
             .filter(|&c| c > 0)
             .unwrap_or(256);
 
-        #[allow(unused_mut)]
-        let mut processes = AbortableList::<HoprLibProcess>::default();
-
-        let (session_tx, _session_rx) = channel::<IncomingSession>(incoming_session_capacity);
-
-        if let Some(serve_handler) = self.session_server.take() {
-            tracing::debug!(capacity = incoming_session_capacity, "creating session server");
-            processes.insert(
-                HoprLibProcess::SessionServer,
-                hopr_async_runtime::spawn_as_abortable!(
-                    _session_rx
-                        .for_each_concurrent(None, move |session| {
-                            let serve_handler = serve_handler.clone();
-                            async move {
-                                let session_id = *session.session.id();
-                                match serve_handler.process(session).await {
-                                    Ok(_) => {
-                                        tracing::debug!(?session_id, "session processed successfully")
-                                    }
-                                    Err(error) => {
-                                        tracing::error!(?session_id, %error, "session processing failed")
-                                    }
-                                }
-                            }
-                        })
-                        .inspect(|_| tracing::warn!(
-                            task = %HoprLibProcess::SessionServer,
-                            "long-running background task finished"
-                        ))
-                ),
-            );
-        }
+        let processes = AbortableList::<HoprLibProcess>::default();
+        let (session_tx, session_rx) = channel::<IncomingSession>(incoming_session_capacity);
 
         // === Chain → Graph event wiring ===
         // Subscribe to chain events and update the graph accordingly.
         // This runs as a background task for the lifetime of the node.
-        {
+        let mut processes = {
             let chain_events = chain_api
                 .subscribe_with_state_sync([StateSyncOptions::PublicAccounts, StateSyncOptions::OpenedChannels])
                 .map_err(HoprLibError::chain)?;
@@ -773,11 +744,13 @@ where
                     "long-running background task finished"
                 )
             });
+            let mut processes = processes;
             processes.insert(
                 HoprLibProcess::ChannelEvents,
                 hopr_async_runtime::spawn_as_abortable!(proc),
             );
-        }
+            processes
+        };
 
         Ok(PreBuiltNode {
             chain_id,
@@ -789,6 +762,7 @@ where
             ticket_event_subscribers: (new_tickets_tx, new_tickets_rx.deactivate()),
             processes,
             session_tx,
+            session_rx,
             cover_traffic,
             network_builder,
         })

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -9,7 +9,7 @@ use hopr_api::{
     ct::{CoverTrafficGeneration, ProbingTrafficGeneration},
     graph::{EdgeCapacityUpdate, HoprGraphApi},
     network::{NetworkBuilder, NetworkStreamControl},
-    node::{AtomicHoprState, HoprState, NodeOnchainIdentity, TicketEvent},
+    node::{AtomicHoprState, HoprSessionServer, HoprState, NodeOnchainIdentity, TicketEvent},
     tickets::{TicketFactory, TicketManagement},
     types::{
         chain::chain_events::ChainEvent,
@@ -24,7 +24,7 @@ use validator::Validate;
 
 use crate::{
     Hopr, HoprLibError, HoprLibProcess, IncomingSession, MIN_NATIVE_BALANCE, NODE_READY_TIMEOUT,
-    SUGGESTED_NATIVE_BALANCE, config::HoprLibConfig, constants, traits::HoprSessionServer,
+    SUGGESTED_NATIVE_BALANCE, config::HoprLibConfig, constants,
 };
 
 #[cfg(all(feature = "telemetry", not(test)))]
@@ -176,7 +176,7 @@ where
     NB: NetworkBuilder + Send + Sync + 'static,
     <NB as NetworkBuilder>::Network:
         hopr_api::network::NetworkView + NetworkStreamControl + Send + Sync + Clone + 'static,
-    Srv: HoprSessionServer + Clone + Send + 'static,
+    Srv: HoprSessionServer<Session = IncomingSession> + Send + Clone + 'static,
     Ct: ProbingTrafficGeneration + CoverTrafficGeneration + Send + Sync + 'static,
 {
     /// Builds an edge (entry/exit) [`Hopr`] node.

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -46,10 +46,6 @@ lazy_static::lazy_static! {
     ).unwrap();
 }
 
-// ---------------------------------------------------------------------------
-// BuildCtx — passed to factory closures
-// ---------------------------------------------------------------------------
-
 /// Type-erased factory closure producing `T` from a [`BuildCtx`] reference.
 type Factory<T> = Box<dyn FnOnce(&BuildCtx) -> T + Send>;
 
@@ -105,23 +101,21 @@ impl HoprBuilderWithIdentity {
             graph_factory: None,
             network_factory: None,
             ct_factory: None,
-            #[cfg(feature = "session-server")]
-            session: None,
         }
     }
 }
 
+// ---------------------------------------------------------------------------
+// HoprBuilderConfigured — stores factories, no session yet
+// ---------------------------------------------------------------------------
+
 /// Configured builder accepting factory closures for components.
 ///
-/// All `with_*` factory methods accept `FnOnce(&BuildCtx) -> T` closures
-/// that are invoked during `build_edge()`/`build_full()`.
+/// When the `session-server` feature is enabled, [`with_session_server`](HoprBuilderConfigured::with_session_server)
+/// must be called before building — it returns a [`HoprBuilderWithSession`] which
+/// has the `build_edge` / `build_full` methods.
 ///
-/// # Type Parameters
-///
-/// - `Chain` — blockchain API produced by the chain factory
-/// - `Graph` — network graph produced by the graph factory
-/// - `Net` — network produced by the network factory
-/// - `Ct` — cover traffic produced by the cover traffic factory
+/// When the feature is disabled, `build_edge` / `build_full` are available directly.
 pub struct HoprBuilderConfigured<Chain = (), Graph = (), Net = (), Ct = ()> {
     ctx: BuildCtx,
     safe_and_module: Option<(Address, Address)>,
@@ -129,11 +123,6 @@ pub struct HoprBuilderConfigured<Chain = (), Graph = (), Net = (), Ct = ()> {
     graph_factory: Option<Factory<Graph>>,
     network_factory: Option<Factory<(Net, BoxedProcessFn)>>,
     ct_factory: Option<Factory<Ct>>,
-    #[cfg(feature = "session-server")]
-    session: Option<(
-        futures::channel::mpsc::Sender<IncomingSession>,
-        hopr_async_runtime::AbortHandle,
-    )>,
 }
 
 impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
@@ -155,8 +144,6 @@ impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
             graph_factory: self.graph_factory,
             network_factory: self.network_factory,
             ct_factory: self.ct_factory,
-            #[cfg(feature = "session-server")]
-            session: self.session,
         }
     }
 
@@ -172,8 +159,6 @@ impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
             graph_factory: Some(Box::new(f)),
             network_factory: self.network_factory,
             ct_factory: self.ct_factory,
-            #[cfg(feature = "session-server")]
-            session: self.session,
         }
     }
 
@@ -189,8 +174,6 @@ impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
             graph_factory: self.graph_factory,
             network_factory: Some(Box::new(f)),
             ct_factory: self.ct_factory,
-            #[cfg(feature = "session-server")]
-            session: self.session,
         }
     }
 
@@ -206,20 +189,18 @@ impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
             graph_factory: self.graph_factory,
             network_factory: self.network_factory,
             ct_factory: Some(Box::new(f)),
-            #[cfg(feature = "session-server")]
-            session: self.session,
         }
     }
 
     /// Attaches a session server for handling incoming sessions.
     ///
-    /// Eagerly spawns the server task. Sessions are not emitted until
-    /// transport starts during build, so spawning the consumer early is safe.
+    /// Eagerly spawns the server task and returns a [`HoprBuilderWithSession`]
+    /// that has the `build_edge` / `build_full` methods.
     #[cfg(feature = "session-server")]
     pub fn with_session_server(
-        mut self,
+        self,
         server: impl hopr_api::node::HoprSessionServer<Session = IncomingSession, Error: std::fmt::Display>,
-    ) -> Self {
+    ) -> HoprBuilderWithSession<Chain, Graph, Net, Ct> {
         let incoming_session_capacity = std::env::var("HOPR_INTERNAL_SESSION_INCOMING_CAPACITY")
             .ok()
             .and_then(|s| s.trim().parse::<usize>().ok())
@@ -249,9 +230,26 @@ impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
                 ))
         );
 
-        self.session = Some((session_tx, handle));
-        self
+        HoprBuilderWithSession {
+            inner: self,
+            session_tx,
+            session_handle: handle,
+        }
     }
+}
+
+// ---------------------------------------------------------------------------
+// HoprBuilderWithSession — session server attached, ready to build
+// ---------------------------------------------------------------------------
+
+/// Builder with a session server attached. Has `build_edge` / `build_full`.
+///
+/// Only exists when the `session-server` feature is enabled.
+#[cfg(feature = "session-server")]
+pub struct HoprBuilderWithSession<Chain = (), Graph = (), Net = (), Ct = ()> {
+    inner: HoprBuilderConfigured<Chain, Graph, Net, Ct>,
+    session_tx: futures::channel::mpsc::Sender<IncomingSession>,
+    session_handle: hopr_async_runtime::AbortHandle,
 }
 
 // ---------------------------------------------------------------------------
@@ -277,9 +275,620 @@ struct PreHopr<Chain, Graph, Net, Ct> {
 }
 
 // ---------------------------------------------------------------------------
-// Build methods
+// Shared pre_build logic
 // ---------------------------------------------------------------------------
 
+async fn pre_build_inner<Chain, Graph, Net, Ct>(
+    configured: HoprBuilderConfigured<Chain, Graph, Net, Ct>,
+    session_tx: futures::channel::mpsc::Sender<IncomingSession>,
+    mut processes: AbortableList<HoprLibProcess>,
+) -> Result<PreHopr<Chain, Graph, Net, Ct>, HoprLibError>
+where
+    Chain: HoprChainApi + Clone + Send + Sync + 'static,
+    Graph: HoprGraphApi<HoprNodeId = hopr_api::OffchainPublicKey> + Clone + Send + Sync + 'static,
+    <Graph as hopr_api::graph::NetworkGraphTraverse>::Observed:
+        hopr_api::graph::traits::EdgeObservableRead + Send + 'static,
+    <Graph as hopr_api::graph::NetworkGraphWrite>::Observed: hopr_api::graph::traits::EdgeObservableWrite + Send,
+    Net: NetworkView + NetworkStreamControl + Send + Sync + Clone + 'static,
+    Ct: ProbingTrafficGeneration + CoverTrafficGeneration + Send + Sync + 'static,
+{
+    let ctx = configured.ctx;
+    ctx.cfg.validate()?;
+
+    let chain_api = (configured
+        .chain_factory
+        .ok_or(HoprLibError::BuilderError("missing chain factory"))?)(&ctx);
+    let graph = (configured
+        .graph_factory
+        .ok_or(HoprLibError::BuilderError("missing graph factory"))?)(&ctx);
+    let (network, network_process) = (configured
+        .network_factory
+        .ok_or(HoprLibError::BuilderError("missing network factory"))?)(&ctx);
+    let cover_traffic = (configured
+        .ct_factory
+        .ok_or(HoprLibError::BuilderError("missing cover traffic factory"))?)(&ctx);
+
+    let (chain_id, transport_id) = (ctx.chain_key.clone(), ctx.packet_key.clone());
+
+    let transport_api = HoprTransport::new(
+        (&chain_id, &transport_id),
+        chain_api.clone(),
+        graph.clone(),
+        vec![(&ctx.cfg.host).try_into().map_err(HoprLibError::TransportError)?],
+        ctx.cfg.protocol.clone(),
+    )
+    .map_err(HoprLibError::TransportError)?;
+
+    #[cfg(all(feature = "telemetry", not(test)))]
+    {
+        use hopr_api::types::primitive::traits::AsUnixTimestamp;
+        METRIC_PROCESS_START_TIME.set(hopr_platform::time::current_time().as_unix_timestamp().as_secs_f64());
+        METRIC_HOPR_LIB_VERSION.set(
+            &[const_format::formatcp!("{}", constants::APP_VERSION)],
+            const_format::formatcp!(
+                "{}.{}",
+                env!("CARGO_PKG_VERSION_MAJOR"),
+                env!("CARGO_PKG_VERSION_MINOR")
+            )
+            .parse()
+            .unwrap_or(0.0),
+        );
+    }
+
+    let (mut new_tickets_tx, new_tickets_rx) = async_broadcast::broadcast(2048);
+    new_tickets_tx.set_await_active(false);
+    new_tickets_tx.set_overflow(true);
+
+    let me_onchain = chain_id.public().to_address();
+
+    #[cfg(feature = "testing")]
+    tracing::warn!("!! FOR TESTING ONLY !! Node is running with some safety checks disabled!");
+
+    tracing::info!(
+        address = %me_onchain,
+        minimum_balance = %*SUGGESTED_NATIVE_BALANCE,
+        "node is not started, please fund this node",
+    );
+
+    crate::helpers::wait_for_funds(
+        *MIN_NATIVE_BALANCE,
+        *SUGGESTED_NATIVE_BALANCE,
+        Duration::from_secs(200),
+        me_onchain,
+        &chain_api,
+    )
+    .await?;
+
+    tracing::info!("starting HOPR node...");
+    let balance: hopr_api::types::primitive::prelude::XDaiBalance =
+        chain_api.balance(me_onchain).await.map_err(HoprLibError::chain)?;
+    let minimum_balance = *constants::MIN_NATIVE_BALANCE;
+
+    tracing::info!(address = %me_onchain, %balance, %minimum_balance, "node information");
+
+    if balance.le(&minimum_balance) {
+        return Err(HoprLibError::GeneralError(
+            "cannot start the node without a sufficiently funded wallet".into(),
+        ));
+    }
+
+    let network_min_ticket_price = chain_api.minimum_ticket_price().await.map_err(HoprLibError::chain)?;
+    let configured_ticket_price = ctx.cfg.protocol.packet.codec.outgoing_ticket_price;
+    if configured_ticket_price.is_some_and(|c| c < network_min_ticket_price) {
+        return Err(HoprLibError::GeneralError(format!(
+            "configured outgoing ticket price < network minimum: {configured_ticket_price:?} < \
+             {network_min_ticket_price}"
+        )));
+    }
+
+    let network_min_win_prob = chain_api
+        .minimum_incoming_ticket_win_prob()
+        .await
+        .map_err(HoprLibError::chain)?;
+    let configured_win_prob = ctx.cfg.protocol.packet.codec.outgoing_win_prob;
+    if !std::env::var("HOPR_TEST_DISABLE_CHECKS").is_ok_and(|v| v.to_lowercase() == "true")
+        && configured_win_prob.is_some_and(|c| c.approx_cmp(&network_min_win_prob).is_lt())
+    {
+        return Err(HoprLibError::GeneralError(format!(
+            "configured outgoing win probability < network minimum: {configured_win_prob:?} < {network_min_win_prob}"
+        )));
+    }
+
+    tracing::info!(
+        peer_id = %transport_id.public().to_peerid_str(),
+        address = %me_onchain,
+        version = constants::APP_VERSION,
+        "Node information"
+    );
+
+    let safe_addr = ctx.cfg.safe_module.safe_address;
+    if me_onchain == safe_addr {
+        return Err(HoprLibError::GeneralError(
+            "cannot use self as staking safe address".into(),
+        ));
+    }
+
+    tracing::info!(%safe_addr, "registering safe with this node");
+    match chain_api.register_safe(&safe_addr).await {
+        Ok(awaiter) => {
+            awaiter.await.map_err(|error| {
+                tracing::error!(%safe_addr, %error, "safe registration failed");
+                HoprLibError::chain(error)
+            })?;
+            tracing::info!(%safe_addr, "safe successfully registered with this node");
+        }
+        Err(SafeRegistrationError::AlreadyRegistered(registered_safe)) if registered_safe == safe_addr => {
+            tracing::info!(%safe_addr, "this safe is already registered with this node");
+        }
+        Err(SafeRegistrationError::AlreadyRegistered(registered_safe)) if registered_safe != safe_addr => {
+            tracing::error!(%safe_addr, %registered_safe, "node registered with different safe");
+            return Err(HoprLibError::GeneralError("node registered with different safe".into()));
+        }
+        Err(error) => {
+            tracing::error!(%safe_addr, %error, "safe registration failed");
+            return Err(HoprLibError::chain(error));
+        }
+    }
+
+    let multiaddresses_to_announce = if ctx.cfg.publish {
+        transport_api.announceable_multiaddresses()
+    } else {
+        Vec::with_capacity(0)
+    };
+
+    multiaddresses_to_announce
+        .iter()
+        .filter(|a| !is_public_address(a))
+        .for_each(|multi_addr| tracing::warn!(?multi_addr, "announcing private multiaddress"));
+
+    let chain_api_clone = chain_api.clone();
+    let me_offchain = *transport_id.public();
+    let node_ready = spawn(async move {
+        chain_api_clone
+            .await_key_binding(&me_offchain, NODE_READY_TIMEOUT)
+            .await
+    });
+
+    tracing::info!(?multiaddresses_to_announce, "announcing node on chain");
+    match chain_api.announce(&multiaddresses_to_announce, &transport_id).await {
+        Ok(awaiter) => {
+            awaiter.await.map_err(|error| {
+                tracing::error!(?multiaddresses_to_announce, %error, "node announcement failed");
+                HoprLibError::chain(error)
+            })?;
+            tracing::info!(?multiaddresses_to_announce, "node announced successfully");
+        }
+        Err(AnnouncementError::AlreadyAnnounced) => {
+            tracing::info!("node already announced on chain");
+        }
+        Err(error) => {
+            tracing::error!(%error, "failed to transmit node announcement");
+            return Err(HoprLibError::chain(error));
+        }
+    }
+
+    let this_node_account = node_ready
+        .await
+        .map_err(HoprLibError::other)?
+        .map_err(HoprLibError::chain)?;
+    if this_node_account.chain_addr != me_onchain || this_node_account.safe_address.is_none_or(|a| a != safe_addr) {
+        tracing::error!(%this_node_account, "account key-binding mismatch");
+        return Err(HoprLibError::GeneralError("account key-binding mismatch".into()));
+    }
+
+    tracing::info!(%this_node_account, "node account is ready");
+
+    // Network → graph event wiring (subscribe before transport starts)
+    {
+        let network_events = network.subscribe_network_events();
+        let graph_updater = graph.clone();
+        spawn(async move {
+            network_events
+                .for_each(|event| {
+                    let graph_updater = graph_updater.clone();
+                    async move {
+                        let (peer_id, connected) = match event {
+                            hopr_api::network::NetworkEvent::PeerConnected(p) => (p, true),
+                            hopr_api::network::NetworkEvent::PeerDisconnected(p) => (p, false),
+                        };
+                        if let Ok(opk) = hopr_api::OffchainPublicKey::from_peerid(&peer_id) {
+                            graph_updater.record_edge(hopr_api::graph::MeasurableEdge::<
+                                hopr_transport::NeighborTelemetry,
+                                hopr_transport::PathTelemetry,
+                            >::ConnectionStatus {
+                                peer: opk,
+                                connected,
+                            });
+                        } else {
+                            tracing::error!(%peer_id, "failed to convert peer ID to public key for graph update");
+                        }
+                    }
+                })
+                .await;
+        });
+    }
+
+    // Chain → graph event wiring
+    {
+        let chain_events = chain_api
+            .subscribe_with_state_sync([StateSyncOptions::PublicAccounts, StateSyncOptions::OpenedChannels])
+            .map_err(HoprLibError::chain)?;
+
+        let graph_updater = graph.clone();
+        let chain_reader = chain_api.clone();
+
+        let ticket_price = Arc::new(parking_lot::RwLock::new(
+            chain_reader.minimum_ticket_price().await.unwrap_or_default(),
+        ));
+        let win_probability = Arc::new(parking_lot::RwLock::new(
+            chain_reader
+                .minimum_incoming_ticket_win_prob()
+                .await
+                .unwrap_or_default(),
+        ));
+
+        let proc = async move {
+            chain_events
+                .for_each(|chain_event| {
+                    let chain_reader = chain_reader.clone();
+                    let graph_updater = graph_updater.clone();
+                    let ticket_price = ticket_price.clone();
+                    let win_probability = win_probability.clone();
+
+                    async move {
+                        match chain_event {
+                            ChainEvent::Announcement(account) => {
+                                tracing::debug!(
+                                    account = %account.public_key,
+                                    "recording graph node for announced account"
+                                );
+                                graph_updater.record_node(account.public_key);
+                            }
+                            ChainEvent::ChannelOpened(channel)
+                            | ChainEvent::ChannelClosed(channel)
+                            | ChainEvent::ChannelBalanceIncreased(channel, _)
+                            | ChainEvent::ChannelBalanceDecreased(channel, _) => {
+                                let keys = hopr_async_runtime::prelude::spawn_blocking(move || {
+                                    chain_reader
+                                        .chain_key_to_packet_key(&channel.source)
+                                        .and_then(|src| {
+                                            Ok(src.zip(chain_reader.chain_key_to_packet_key(&channel.destination)?))
+                                        })
+                                        .map_err(anyhow::Error::from)
+                                })
+                                .await
+                                .map_err(anyhow::Error::from)
+                                .and_then(identity);
+
+                                match keys {
+                                    Ok(Some((from, to))) => {
+                                        let capacity = if matches!(
+                                            channel.status,
+                                            hopr_api::types::internal::prelude::ChannelStatus::Closed
+                                        ) {
+                                            None
+                                        } else if let Ok(ticket_value) =
+                                            ticket_price.read().div_f64(win_probability.read().as_f64())
+                                        {
+                                            Some(
+                                                channel
+                                                    .balance
+                                                    .amount()
+                                                    .checked_div(ticket_value.amount())
+                                                    .map(|v| v.low_u128())
+                                                    .unwrap_or(u128::MAX),
+                                            )
+                                        } else {
+                                            None
+                                        };
+
+                                        tracing::debug!(
+                                            %channel, ?capacity,
+                                            "recording graph edge for channel capacity"
+                                        );
+                                        graph_updater.record_edge(hopr_api::graph::MeasurableEdge::<
+                                            hopr_transport::NeighborTelemetry,
+                                            hopr_transport::PathTelemetry,
+                                        >::Capacity(
+                                            Box::new(EdgeCapacityUpdate {
+                                                capacity,
+                                                src: from,
+                                                dest: to,
+                                            }),
+                                        ));
+                                    }
+                                    Ok(None) => {
+                                        tracing::error!(
+                                            %channel,
+                                            "could not find packet keys for channel endpoints"
+                                        );
+                                    }
+                                    Err(error) => {
+                                        tracing::error!(
+                                            %error, %channel,
+                                            "failed to convert chain keys to packet keys"
+                                        );
+                                    }
+                                }
+                            }
+                            ChainEvent::ChannelClosureInitiated(_) => {}
+                            ChainEvent::WinningProbabilityIncreased(prob)
+                            | ChainEvent::WinningProbabilityDecreased(prob) => {
+                                tracing::debug!(%prob, "recording winning probability change");
+                                *win_probability.write() = prob;
+                            }
+                            ChainEvent::TicketPriceChanged(price) => {
+                                tracing::debug!(%price, "recording ticket price change");
+                                *ticket_price.write() = price;
+                            }
+                            _ => {}
+                        }
+                    }
+                })
+                .await;
+        }
+        .inspect(|_| {
+            tracing::warn!(
+                task = "chain-to-graph event wiring",
+                "long-running background task finished"
+            )
+        });
+        processes.insert(
+            HoprLibProcess::ChannelEvents,
+            hopr_async_runtime::spawn_as_abortable!(proc),
+        );
+    }
+
+    Ok(PreHopr {
+        chain_id,
+        transport_id,
+        cfg: ctx.cfg,
+        state: Arc::new(AtomicHoprState::new(HoprState::Uninitialized)),
+        transport_api,
+        chain_api,
+        ticket_event_subscribers: (new_tickets_tx, new_tickets_rx.deactivate()),
+        processes,
+        session_tx,
+        cover_traffic,
+        network,
+        network_process,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Build methods — shared via macro to avoid duplicating edge/full logic
+// ---------------------------------------------------------------------------
+
+macro_rules! impl_build_methods {
+    () => {
+        /// Builds an edge (entry/exit) [`Hopr`] node.
+        pub async fn build_edge<TFact>(
+            self,
+            ticket_factory: TFact,
+        ) -> Result<Hopr<Chain, Graph, Net, ()>, HoprLibError>
+        where
+            TFact: TicketFactory + Clone + Send + Sync + 'static,
+        {
+            let (configured, session_tx, processes) = self.into_parts();
+            let pre = pre_build_inner(configured, session_tx, processes).await?;
+
+            tracing::info!("starting transport for edge node");
+            let (_, transport_processes) = pre
+                .transport_api
+                .run(
+                    pre.cover_traffic,
+                    pre.network,
+                    pre.network_process,
+                    futures::sink::drain(),
+                    ticket_factory,
+                    pre.session_tx,
+                )
+                .await?;
+
+            let mut processes = pre.processes;
+            processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
+
+            let hopr = Hopr {
+                chain_id: NodeOnchainIdentity {
+                    node_address: pre.chain_id.public().to_address(),
+                    safe_address: pre.cfg.safe_module.safe_address,
+                    module_address: pre.cfg.safe_module.module_address,
+                },
+                cfg: pre.cfg,
+                state: pre.state.clone(),
+                ticket_event_subscribers: pre.ticket_event_subscribers,
+                transport_id: pre.transport_id,
+                transport_api: pre.transport_api,
+                chain_api: pre.chain_api,
+                processes,
+                ticket_manager: (),
+            };
+
+            hopr.state.store(HoprState::Running, std::sync::atomic::Ordering::Relaxed);
+            tracing::info!(
+                id = %hopr.transport_id.public().to_peerid_str(),
+                version = constants::APP_VERSION,
+                "EDGE NODE STARTED AND RUNNING"
+            );
+
+            Ok(hopr)
+        }
+
+        /// Builds a full (relay) [`Hopr`] node.
+        pub async fn build_full<TMgr, TFact>(
+            self,
+            ticket_manager: TMgr,
+            ticket_factory: TFact,
+        ) -> Result<Hopr<Chain, Graph, Net, TMgr>, HoprLibError>
+        where
+            TMgr: TicketManagement + Clone + Send + Sync + 'static,
+            TFact: TicketFactory + Clone + Send + Sync + 'static,
+        {
+            let (configured, session_tx, processes) = self.into_parts();
+            let pre = pre_build_inner(configured, session_tx, processes).await?;
+            let mut processes = pre.processes;
+
+            tracing::info!("starting ticket events processor");
+            let (tickets_tx, tickets_rx) = channel(8192);
+            let (tickets_rx_stream, tickets_handle) = futures::stream::abortable(tickets_rx);
+            processes.insert(HoprLibProcess::TicketEvents, tickets_handle);
+            let new_ticket_tx = pre.ticket_event_subscribers.0.clone();
+            let tmgr_clone = ticket_manager.clone();
+            spawn(
+                tickets_rx_stream
+                    .for_each(move |event| {
+                        if let TicketEvent::WinningTicket(ticket) = &event
+                            && let Err(error) = tmgr_clone.insert_incoming_ticket(**ticket)
+                        {
+                            tracing::error!(%error, "failed to insert incoming ticket");
+                        }
+                        if let Err(error) = new_ticket_tx.try_broadcast(event) {
+                            tracing::error!(%error, "failed to broadcast ticket event");
+                        }
+                        futures::future::ready(())
+                    })
+                    .inspect(|_| {
+                        tracing::warn!(task = %HoprLibProcess::TicketEvents, "long-running background task finished")
+                    }),
+            );
+
+            {
+                let chain_for_neglect = pre.chain_api.clone();
+                let tmgr_for_neglect = ticket_manager.clone();
+                let events = pre.chain_api.subscribe().map_err(HoprLibError::chain)?;
+                let (neglect_handle, neglect_reg) = hopr_async_runtime::AbortHandle::new_pair();
+                spawn(
+                    futures::stream::Abortable::new(
+                        events.filter_map(move |event| {
+                            futures::future::ready(match event {
+                                ChainEvent::ChannelClosed(ch) => Some(ch),
+                                _ => None,
+                            })
+                        }),
+                        neglect_reg,
+                    )
+                    .for_each(move |closed_channel| {
+                        let chain = chain_for_neglect.clone();
+                        let tmgr = tmgr_for_neglect.clone();
+                        async move {
+                            use hopr_api::types::internal::prelude::ChannelDirection;
+                            match closed_channel.direction(chain.me()) {
+                                Some(ChannelDirection::Incoming) => {
+                                    match tmgr.neglect_tickets(closed_channel.get_id(), None) {
+                                        Ok(neglected) if !neglected.is_empty() => {
+                                            tracing::warn!(
+                                                num_neglected = neglected.len(),
+                                                %closed_channel,
+                                                "tickets on incoming closed channel were neglected"
+                                            );
+                                        }
+                                        Ok(_) => {}
+                                        Err(error) => {
+                                            tracing::error!(
+                                                %error, %closed_channel,
+                                                "failed to neglect tickets on closed channel"
+                                            );
+                                        }
+                                    }
+                                }
+                                Some(ChannelDirection::Outgoing) => {}
+                                _ => {}
+                            }
+                        }
+                    })
+                    .inspect(|_| {
+                        tracing::warn!(
+                            task = %HoprLibProcess::ChannelEvents,
+                            "channel closure ticket neglect task finished"
+                        )
+                    }),
+                );
+                processes.insert(HoprLibProcess::OutIndexSync, neglect_handle);
+            }
+
+            tracing::info!("starting transport for full node");
+            let (_, transport_processes) = pre
+                .transport_api
+                .run(
+                    pre.cover_traffic,
+                    pre.network,
+                    pre.network_process,
+                    tickets_tx,
+                    ticket_factory,
+                    pre.session_tx,
+                )
+                .await?;
+            processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
+
+            let hopr = Hopr {
+                chain_id: NodeOnchainIdentity {
+                    node_address: pre.chain_id.public().to_address(),
+                    safe_address: pre.cfg.safe_module.safe_address,
+                    module_address: pre.cfg.safe_module.module_address,
+                },
+                cfg: pre.cfg,
+                state: pre.state.clone(),
+                ticket_event_subscribers: pre.ticket_event_subscribers,
+                transport_id: pre.transport_id,
+                transport_api: pre.transport_api,
+                chain_api: pre.chain_api,
+                processes,
+                ticket_manager,
+            };
+
+            hopr.state.store(HoprState::Running, std::sync::atomic::Ordering::Relaxed);
+
+            tracing::info!(
+                id = %hopr.transport_id.public().to_peerid_str(),
+                version = constants::APP_VERSION,
+                "FULL NODE STARTED AND RUNNING"
+            );
+
+            #[cfg(all(feature = "telemetry", not(test)))]
+            METRIC_HOPR_NODE_INFO.set(
+                &[
+                    &hopr.transport_id.public().to_peerid_str(),
+                    &hopr.chain_id.node_address.to_string(),
+                    &hopr.chain_id.safe_address.to_string(),
+                    &hopr.chain_id.module_address.to_string(),
+                ],
+                1.0,
+            );
+
+            Ok(hopr)
+        }
+    };
+}
+
+// When session-server is ON: build methods only on HoprBuilderWithSession
+#[cfg(feature = "session-server")]
+impl<Chain, Graph, Net, Ct> HoprBuilderWithSession<Chain, Graph, Net, Ct>
+where
+    Chain: HoprChainApi + Clone + Send + Sync + 'static,
+    Graph: HoprGraphApi<HoprNodeId = hopr_api::OffchainPublicKey> + Clone + Send + Sync + 'static,
+    <Graph as hopr_api::graph::NetworkGraphTraverse>::Observed:
+        hopr_api::graph::traits::EdgeObservableRead + Send + 'static,
+    <Graph as hopr_api::graph::NetworkGraphWrite>::Observed: hopr_api::graph::traits::EdgeObservableWrite + Send,
+    Net: NetworkView + NetworkStreamControl + Send + Sync + Clone + 'static,
+    Ct: ProbingTrafficGeneration + CoverTrafficGeneration + Send + Sync + 'static,
+{
+    impl_build_methods!();
+
+    fn into_parts(
+        self,
+    ) -> (
+        HoprBuilderConfigured<Chain, Graph, Net, Ct>,
+        futures::channel::mpsc::Sender<IncomingSession>,
+        AbortableList<HoprLibProcess>,
+    ) {
+        let mut processes = AbortableList::<HoprLibProcess>::default();
+        processes.insert(HoprLibProcess::SessionServer, self.session_handle);
+        (self.inner, self.session_tx, processes)
+    }
+}
+
+// When session-server is OFF: build methods directly on HoprBuilderConfigured
+#[cfg(not(feature = "session-server"))]
 impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct>
 where
     Chain: HoprChainApi + Clone + Send + Sync + 'static,
@@ -290,589 +899,17 @@ where
     Net: NetworkView + NetworkStreamControl + Send + Sync + Clone + 'static,
     Ct: ProbingTrafficGeneration + CoverTrafficGeneration + Send + Sync + 'static,
 {
-    /// Builds an edge (entry/exit) [`Hopr`] node.
-    pub async fn build_edge<TFact>(self, ticket_factory: TFact) -> Result<Hopr<Chain, Graph, Net, ()>, HoprLibError>
-    where
-        TFact: TicketFactory + Clone + Send + Sync + 'static,
-    {
-        let pre = self.pre_build().await?;
+    impl_build_methods!();
 
-        tracing::info!("starting transport for edge node");
-        let (_, transport_processes) = pre
-            .transport_api
-            .run(
-                pre.cover_traffic,
-                pre.network,
-                pre.network_process,
-                futures::sink::drain(),
-                ticket_factory,
-                pre.session_tx,
-            )
-            .await?;
-
-        let mut processes = pre.processes;
-        processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
-
-        let hopr = Hopr {
-            chain_id: NodeOnchainIdentity {
-                node_address: pre.chain_id.public().to_address(),
-                safe_address: pre.cfg.safe_module.safe_address,
-                module_address: pre.cfg.safe_module.module_address,
-            },
-            cfg: pre.cfg,
-            state: pre.state.clone(),
-            ticket_event_subscribers: pre.ticket_event_subscribers,
-            transport_id: pre.transport_id,
-            transport_api: pre.transport_api,
-            chain_api: pre.chain_api,
-            processes,
-            ticket_manager: (),
-        };
-
-        hopr.state
-            .store(HoprState::Running, std::sync::atomic::Ordering::Relaxed);
-        tracing::info!(
-            id = %hopr.transport_id.public().to_peerid_str(),
-            version = constants::APP_VERSION,
-            "EDGE NODE STARTED AND RUNNING"
-        );
-
-        Ok(hopr)
-    }
-
-    /// Builds a full (relay) [`Hopr`] node.
-    pub async fn build_full<TMgr, TFact>(
+    fn into_parts(
         self,
-        ticket_manager: TMgr,
-        ticket_factory: TFact,
-    ) -> Result<Hopr<Chain, Graph, Net, TMgr>, HoprLibError>
-    where
-        TMgr: TicketManagement + Clone + Send + Sync + 'static,
-        TFact: TicketFactory + Clone + Send + Sync + 'static,
-    {
-        let pre = self.pre_build().await?;
-        let mut processes = pre.processes;
-
-        // Ticket event processing
-        tracing::info!("starting ticket events processor");
-        let (tickets_tx, tickets_rx) = channel(8192);
-        let (tickets_rx_stream, tickets_handle) = futures::stream::abortable(tickets_rx);
-        processes.insert(HoprLibProcess::TicketEvents, tickets_handle);
-        let new_ticket_tx = pre.ticket_event_subscribers.0.clone();
-        let tmgr_clone = ticket_manager.clone();
-        spawn(
-            tickets_rx_stream
-                .for_each(move |event| {
-                    if let TicketEvent::WinningTicket(ticket) = &event
-                        && let Err(error) = tmgr_clone.insert_incoming_ticket(**ticket)
-                    {
-                        tracing::error!(%error, "failed to insert incoming ticket");
-                    }
-                    if let Err(error) = new_ticket_tx.try_broadcast(event) {
-                        tracing::error!(%error, "failed to broadcast ticket event");
-                    }
-                    futures::future::ready(())
-                })
-                .inspect(|_| {
-                    tracing::warn!(
-                        task = %HoprLibProcess::TicketEvents,
-                        "long-running background task finished"
-                    )
-                }),
-        );
-
-        // Channel closure → ticket neglect
-        {
-            let chain_for_neglect = pre.chain_api.clone();
-            let tmgr_for_neglect = ticket_manager.clone();
-            let events = pre.chain_api.subscribe().map_err(HoprLibError::chain)?;
-            let (neglect_handle, neglect_reg) = hopr_async_runtime::AbortHandle::new_pair();
-            spawn(
-                futures::stream::Abortable::new(
-                    events.filter_map(move |event| {
-                        futures::future::ready(match event {
-                            ChainEvent::ChannelClosed(ch) => Some(ch),
-                            _ => None,
-                        })
-                    }),
-                    neglect_reg,
-                )
-                .for_each(move |closed_channel| {
-                    let chain = chain_for_neglect.clone();
-                    let tmgr = tmgr_for_neglect.clone();
-                    async move {
-                        use hopr_api::types::internal::prelude::ChannelDirection;
-                        match closed_channel.direction(chain.me()) {
-                            Some(ChannelDirection::Incoming) => {
-                                match tmgr.neglect_tickets(closed_channel.get_id(), None) {
-                                    Ok(neglected) if !neglected.is_empty() => {
-                                        tracing::warn!(
-                                            num_neglected = neglected.len(),
-                                            %closed_channel,
-                                            "tickets on incoming closed channel were neglected"
-                                        );
-                                    }
-                                    Ok(_) => {}
-                                    Err(error) => {
-                                        tracing::error!(
-                                            %error, %closed_channel,
-                                            "failed to neglect tickets on closed channel"
-                                        );
-                                    }
-                                }
-                            }
-                            Some(ChannelDirection::Outgoing) => {}
-                            _ => {}
-                        }
-                    }
-                })
-                .inspect(|_| {
-                    tracing::warn!(
-                        task = %HoprLibProcess::ChannelEvents,
-                        "channel closure ticket neglect task finished"
-                    )
-                }),
-            );
-            processes.insert(HoprLibProcess::OutIndexSync, neglect_handle);
-        }
-
-        // Start transport
-        tracing::info!("starting transport for full node");
-        let (_, transport_processes) = pre
-            .transport_api
-            .run(
-                pre.cover_traffic,
-                pre.network,
-                pre.network_process,
-                tickets_tx,
-                ticket_factory,
-                pre.session_tx,
-            )
-            .await?;
-        processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
-
-        let hopr = Hopr {
-            chain_id: NodeOnchainIdentity {
-                node_address: pre.chain_id.public().to_address(),
-                safe_address: pre.cfg.safe_module.safe_address,
-                module_address: pre.cfg.safe_module.module_address,
-            },
-            cfg: pre.cfg,
-            state: pre.state.clone(),
-            ticket_event_subscribers: pre.ticket_event_subscribers,
-            transport_id: pre.transport_id,
-            transport_api: pre.transport_api,
-            chain_api: pre.chain_api,
-            processes,
-            ticket_manager,
-        };
-
-        hopr.state
-            .store(HoprState::Running, std::sync::atomic::Ordering::Relaxed);
-
-        tracing::info!(
-            id = %hopr.transport_id.public().to_peerid_str(),
-            version = constants::APP_VERSION,
-            "FULL NODE STARTED AND RUNNING"
-        );
-
-        #[cfg(all(feature = "telemetry", not(test)))]
-        METRIC_HOPR_NODE_INFO.set(
-            &[
-                &hopr.transport_id.public().to_peerid_str(),
-                &hopr.chain_id.node_address.to_string(),
-                &hopr.chain_id.safe_address.to_string(),
-                &hopr.chain_id.module_address.to_string(),
-            ],
-            1.0,
-        );
-
-        Ok(hopr)
-    }
-
-    /// Shared initialization: invoke factories, wire events, do on-chain setup.
-    async fn pre_build(self) -> Result<PreHopr<Chain, Graph, Net, Ct>, HoprLibError> {
-        let ctx = self.ctx;
-        ctx.cfg.validate()?;
-
-        // Invoke factories
-        let chain_api = (self
-            .chain_factory
-            .ok_or(HoprLibError::BuilderError("missing chain factory"))?)(&ctx);
-        let graph = (self
-            .graph_factory
-            .ok_or(HoprLibError::BuilderError("missing graph factory"))?)(&ctx);
-        let (network, network_process) =
-            (self
-                .network_factory
-                .ok_or(HoprLibError::BuilderError("missing network factory"))?)(&ctx);
-        let cover_traffic = (self
-            .ct_factory
-            .ok_or(HoprLibError::BuilderError("missing cover traffic factory"))?)(&ctx);
-
-        let (chain_id, transport_id) = (ctx.chain_key.clone(), ctx.packet_key.clone());
-
-        let transport_api = HoprTransport::new(
-            (&chain_id, &transport_id),
-            chain_api.clone(),
-            graph.clone(),
-            vec![(&ctx.cfg.host).try_into().map_err(HoprLibError::TransportError)?],
-            ctx.cfg.protocol.clone(),
-        )
-        .map_err(HoprLibError::TransportError)?;
-
-        #[cfg(all(feature = "telemetry", not(test)))]
-        {
-            use hopr_api::types::primitive::traits::AsUnixTimestamp;
-            METRIC_PROCESS_START_TIME.set(hopr_platform::time::current_time().as_unix_timestamp().as_secs_f64());
-            METRIC_HOPR_LIB_VERSION.set(
-                &[const_format::formatcp!("{}", constants::APP_VERSION)],
-                const_format::formatcp!(
-                    "{}.{}",
-                    env!("CARGO_PKG_VERSION_MAJOR"),
-                    env!("CARGO_PKG_VERSION_MINOR")
-                )
-                .parse()
-                .unwrap_or(0.0),
-            );
-        }
-
-        let (mut new_tickets_tx, new_tickets_rx) = async_broadcast::broadcast(2048);
-        new_tickets_tx.set_await_active(false);
-        new_tickets_tx.set_overflow(true);
-
-        let me_onchain = chain_id.public().to_address();
-
-        #[cfg(feature = "testing")]
-        tracing::warn!("!! FOR TESTING ONLY !! Node is running with some safety checks disabled!");
-
-        tracing::info!(
-            address = %me_onchain,
-            minimum_balance = %*SUGGESTED_NATIVE_BALANCE,
-            "node is not started, please fund this node",
-        );
-
-        crate::helpers::wait_for_funds(
-            *MIN_NATIVE_BALANCE,
-            *SUGGESTED_NATIVE_BALANCE,
-            Duration::from_secs(200),
-            me_onchain,
-            &chain_api,
-        )
-        .await?;
-
-        tracing::info!("starting HOPR node...");
-        let balance: hopr_api::types::primitive::prelude::XDaiBalance =
-            chain_api.balance(me_onchain).await.map_err(HoprLibError::chain)?;
-        let minimum_balance = *constants::MIN_NATIVE_BALANCE;
-
-        tracing::info!(address = %me_onchain, %balance, %minimum_balance, "node information");
-
-        if balance.le(&minimum_balance) {
-            return Err(HoprLibError::GeneralError(
-                "cannot start the node without a sufficiently funded wallet".into(),
-            ));
-        }
-
-        let network_min_ticket_price = chain_api.minimum_ticket_price().await.map_err(HoprLibError::chain)?;
-        let configured_ticket_price = ctx.cfg.protocol.packet.codec.outgoing_ticket_price;
-        if configured_ticket_price.is_some_and(|c| c < network_min_ticket_price) {
-            return Err(HoprLibError::GeneralError(format!(
-                "configured outgoing ticket price < network minimum: {configured_ticket_price:?} < \
-                 {network_min_ticket_price}"
-            )));
-        }
-
-        let network_min_win_prob = chain_api
-            .minimum_incoming_ticket_win_prob()
-            .await
-            .map_err(HoprLibError::chain)?;
-        let configured_win_prob = ctx.cfg.protocol.packet.codec.outgoing_win_prob;
-        if !std::env::var("HOPR_TEST_DISABLE_CHECKS").is_ok_and(|v| v.to_lowercase() == "true")
-            && configured_win_prob.is_some_and(|c| c.approx_cmp(&network_min_win_prob).is_lt())
-        {
-            return Err(HoprLibError::GeneralError(format!(
-                "configured outgoing win probability < network minimum: {configured_win_prob:?} < \
-                 {network_min_win_prob}"
-            )));
-        }
-
-        tracing::info!(
-            peer_id = %transport_id.public().to_peerid_str(),
-            address = %me_onchain,
-            version = constants::APP_VERSION,
-            "Node information"
-        );
-
-        let safe_addr = ctx.cfg.safe_module.safe_address;
-        if me_onchain == safe_addr {
-            return Err(HoprLibError::GeneralError(
-                "cannot use self as staking safe address".into(),
-            ));
-        }
-
-        tracing::info!(%safe_addr, "registering safe with this node");
-        match chain_api.register_safe(&safe_addr).await {
-            Ok(awaiter) => {
-                awaiter.await.map_err(|error| {
-                    tracing::error!(%safe_addr, %error, "safe registration failed");
-                    HoprLibError::chain(error)
-                })?;
-                tracing::info!(%safe_addr, "safe successfully registered with this node");
-            }
-            Err(SafeRegistrationError::AlreadyRegistered(registered_safe)) if registered_safe == safe_addr => {
-                tracing::info!(%safe_addr, "this safe is already registered with this node");
-            }
-            Err(SafeRegistrationError::AlreadyRegistered(registered_safe)) if registered_safe != safe_addr => {
-                tracing::error!(%safe_addr, %registered_safe, "node registered with different safe");
-                return Err(HoprLibError::GeneralError("node registered with different safe".into()));
-            }
-            Err(error) => {
-                tracing::error!(%safe_addr, %error, "safe registration failed");
-                return Err(HoprLibError::chain(error));
-            }
-        }
-
-        let multiaddresses_to_announce = if ctx.cfg.publish {
-            transport_api.announceable_multiaddresses()
-        } else {
-            Vec::with_capacity(0)
-        };
-
-        multiaddresses_to_announce
-            .iter()
-            .filter(|a| !is_public_address(a))
-            .for_each(|multi_addr| tracing::warn!(?multi_addr, "announcing private multiaddress"));
-
-        let chain_api_clone = chain_api.clone();
-        let me_offchain = *transport_id.public();
-        let node_ready = spawn(async move {
-            chain_api_clone
-                .await_key_binding(&me_offchain, NODE_READY_TIMEOUT)
-                .await
-        });
-
-        tracing::info!(?multiaddresses_to_announce, "announcing node on chain");
-        match chain_api.announce(&multiaddresses_to_announce, &transport_id).await {
-            Ok(awaiter) => {
-                awaiter.await.map_err(|error| {
-                    tracing::error!(?multiaddresses_to_announce, %error, "node announcement failed");
-                    HoprLibError::chain(error)
-                })?;
-                tracing::info!(?multiaddresses_to_announce, "node announced successfully");
-            }
-            Err(AnnouncementError::AlreadyAnnounced) => {
-                tracing::info!("node already announced on chain");
-            }
-            Err(error) => {
-                tracing::error!(%error, "failed to transmit node announcement");
-                return Err(HoprLibError::chain(error));
-            }
-        }
-
-        let this_node_account = node_ready
-            .await
-            .map_err(HoprLibError::other)?
-            .map_err(HoprLibError::chain)?;
-        if this_node_account.chain_addr != me_onchain || this_node_account.safe_address.is_none_or(|a| a != safe_addr) {
-            tracing::error!(%this_node_account, "account key-binding mismatch");
-            return Err(HoprLibError::GeneralError("account key-binding mismatch".into()));
-        }
-
-        tracing::info!(%this_node_account, "node account is ready");
-
-        // Session channel
-        let mut processes = AbortableList::<HoprLibProcess>::default();
-
-        #[cfg(feature = "session-server")]
-        let session_tx = if let Some((tx, handle)) = self.session {
-            processes.insert(HoprLibProcess::SessionServer, handle);
-            tx
-        } else {
-            let (tx, _rx) = channel::<IncomingSession>(1);
-            tx
-        };
-
-        #[cfg(not(feature = "session-server"))]
-        let session_tx = {
-            let (tx, _rx) = channel::<IncomingSession>(1);
-            tx
-        };
-
-        // Network → graph event wiring (subscribe before transport starts)
-        {
-            let network_events = network.subscribe_network_events();
-            let graph_updater = graph.clone();
-            spawn(async move {
-                network_events
-                    .for_each(|event| {
-                        let graph_updater = graph_updater.clone();
-                        async move {
-                            let (peer_id, connected) = match event {
-                                hopr_api::network::NetworkEvent::PeerConnected(p) => (p, true),
-                                hopr_api::network::NetworkEvent::PeerDisconnected(p) => (p, false),
-                            };
-                            if let Ok(opk) = hopr_api::OffchainPublicKey::from_peerid(&peer_id) {
-                                graph_updater.record_edge(hopr_api::graph::MeasurableEdge::<
-                                    hopr_transport::NeighborTelemetry,
-                                    hopr_transport::PathTelemetry,
-                                >::ConnectionStatus {
-                                    peer: opk,
-                                    connected,
-                                });
-                            } else {
-                                tracing::error!(%peer_id, "failed to convert peer ID to public key for graph update");
-                            }
-                        }
-                    })
-                    .await;
-            });
-        }
-
-        // Chain → graph event wiring
-        {
-            let chain_events = chain_api
-                .subscribe_with_state_sync([StateSyncOptions::PublicAccounts, StateSyncOptions::OpenedChannels])
-                .map_err(HoprLibError::chain)?;
-
-            let graph_updater = graph.clone();
-            let chain_reader = chain_api.clone();
-
-            let ticket_price = Arc::new(parking_lot::RwLock::new(
-                chain_reader.minimum_ticket_price().await.unwrap_or_default(),
-            ));
-            let win_probability = Arc::new(parking_lot::RwLock::new(
-                chain_reader
-                    .minimum_incoming_ticket_win_prob()
-                    .await
-                    .unwrap_or_default(),
-            ));
-
-            let proc = async move {
-                chain_events
-                    .for_each(|chain_event| {
-                        let chain_reader = chain_reader.clone();
-                        let graph_updater = graph_updater.clone();
-                        let ticket_price = ticket_price.clone();
-                        let win_probability = win_probability.clone();
-
-                        async move {
-                            match chain_event {
-                                ChainEvent::Announcement(account) => {
-                                    tracing::debug!(
-                                        account = %account.public_key,
-                                        "recording graph node for announced account"
-                                    );
-                                    graph_updater.record_node(account.public_key);
-                                }
-                                ChainEvent::ChannelOpened(channel)
-                                | ChainEvent::ChannelClosed(channel)
-                                | ChainEvent::ChannelBalanceIncreased(channel, _)
-                                | ChainEvent::ChannelBalanceDecreased(channel, _) => {
-                                    let keys = hopr_async_runtime::prelude::spawn_blocking(move || {
-                                        chain_reader
-                                            .chain_key_to_packet_key(&channel.source)
-                                            .and_then(|src| {
-                                                Ok(src.zip(chain_reader.chain_key_to_packet_key(&channel.destination)?))
-                                            })
-                                            .map_err(anyhow::Error::from)
-                                    })
-                                    .await
-                                    .map_err(anyhow::Error::from)
-                                    .and_then(identity);
-
-                                    match keys {
-                                        Ok(Some((from, to))) => {
-                                            let capacity = if matches!(
-                                                channel.status,
-                                                hopr_api::types::internal::prelude::ChannelStatus::Closed
-                                            ) {
-                                                None
-                                            } else if let Ok(ticket_value) =
-                                                ticket_price.read().div_f64(win_probability.read().as_f64())
-                                            {
-                                                Some(
-                                                    channel
-                                                        .balance
-                                                        .amount()
-                                                        .checked_div(ticket_value.amount())
-                                                        .map(|v| v.low_u128())
-                                                        .unwrap_or(u128::MAX),
-                                                )
-                                            } else {
-                                                None
-                                            };
-
-                                            tracing::debug!(
-                                                %channel, ?capacity,
-                                                "recording graph edge for channel capacity"
-                                            );
-                                            graph_updater.record_edge(hopr_api::graph::MeasurableEdge::<
-                                                hopr_transport::NeighborTelemetry,
-                                                hopr_transport::PathTelemetry,
-                                            >::Capacity(
-                                                Box::new(EdgeCapacityUpdate {
-                                                    capacity,
-                                                    src: from,
-                                                    dest: to,
-                                                }),
-                                            ));
-                                        }
-                                        Ok(None) => {
-                                            tracing::error!(
-                                                %channel,
-                                                "could not find packet keys for channel endpoints"
-                                            );
-                                        }
-                                        Err(error) => {
-                                            tracing::error!(
-                                                %error, %channel,
-                                                "failed to convert chain keys to packet keys"
-                                            );
-                                        }
-                                    }
-                                }
-                                ChainEvent::ChannelClosureInitiated(_) => {}
-                                ChainEvent::WinningProbabilityIncreased(prob)
-                                | ChainEvent::WinningProbabilityDecreased(prob) => {
-                                    tracing::debug!(%prob, "recording winning probability change");
-                                    *win_probability.write() = prob;
-                                }
-                                ChainEvent::TicketPriceChanged(price) => {
-                                    tracing::debug!(%price, "recording ticket price change");
-                                    *ticket_price.write() = price;
-                                }
-                                _ => {}
-                            }
-                        }
-                    })
-                    .await;
-            }
-            .inspect(|_| {
-                tracing::warn!(
-                    task = "chain-to-graph event wiring",
-                    "long-running background task finished"
-                )
-            });
-            processes.insert(
-                HoprLibProcess::ChannelEvents,
-                hopr_async_runtime::spawn_as_abortable!(proc),
-            );
-        }
-
-        Ok(PreHopr {
-            chain_id,
-            transport_id,
-            cfg: ctx.cfg,
-            state: Arc::new(AtomicHoprState::new(HoprState::Uninitialized)),
-            transport_api,
-            chain_api,
-            ticket_event_subscribers: (new_tickets_tx, new_tickets_rx.deactivate()),
-            processes,
-            session_tx,
-            cover_traffic,
-            network,
-            network_process,
-        })
+    ) -> (
+        HoprBuilderConfigured<Chain, Graph, Net, Ct>,
+        futures::channel::mpsc::Sender<IncomingSession>,
+        AbortableList<HoprLibProcess>,
+    ) {
+        let (tx, _rx) = channel::<IncomingSession>(1);
+        let processes = AbortableList::<HoprLibProcess>::default();
+        (self, tx, processes)
     }
 }

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -53,20 +53,6 @@ lazy_static::lazy_static! {
 /// Type-erased factory closure producing `T` from a [`BuildCtx`] reference.
 type Factory<T> = Box<dyn FnOnce(&BuildCtx) -> T + Send>;
 
-/// Trait for processing incoming HOPR sessions on exit nodes.
-///
-/// Implementors define how each incoming session is handled (e.g. IP forwarding,
-/// echo, etc.). Used by [`HoprBuilderConfigured::with_session_server`].
-#[cfg(feature = "session-server")]
-#[async_trait::async_trait]
-pub trait HoprSessionServer: Clone + Send + 'static {
-    /// Error type for session processing.
-    type Error: std::fmt::Display + Send + Sync + 'static;
-
-    /// Fully process a single incoming HOPR session.
-    async fn process(&self, session: IncomingSession) -> Result<(), Self::Error>;
-}
-
 /// Context available to factory closures during the build step.
 pub struct BuildCtx {
     /// Node's on-chain keypair.
@@ -230,7 +216,10 @@ impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
     /// Eagerly spawns the server task. Sessions are not emitted until
     /// transport starts during build, so spawning the consumer early is safe.
     #[cfg(feature = "session-server")]
-    pub fn with_session_server(mut self, server: impl HoprSessionServer) -> Self {
+    pub fn with_session_server(
+        mut self,
+        server: impl hopr_api::node::HoprSessionServer<Session = IncomingSession, Error: std::fmt::Display>,
+    ) -> Self {
         let incoming_session_capacity = std::env::var("HOPR_INTERNAL_SESSION_INCOMING_CAPACITY")
             .ok()
             .and_then(|s| s.trim().parse::<usize>().ok())

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -9,7 +9,7 @@ use hopr_api::{
     chain::{AnnouncementError, HoprChainApi, SafeRegistrationError, StateSyncOptions},
     ct::{CoverTrafficGeneration, ProbingTrafficGeneration},
     graph::{EdgeCapacityUpdate, HoprGraphApi},
-    network::{NetworkBuilder, NetworkStreamControl},
+    network::{BoxedProcessFn, NetworkStreamControl, NetworkView},
     node::{AtomicHoprState, HoprState, NodeOnchainIdentity, TicketEvent},
     tickets::{TicketFactory, TicketManagement},
     types::{
@@ -46,49 +46,89 @@ lazy_static::lazy_static! {
     ).unwrap();
 }
 
-/// Intermediate state produced by the shared initialization sequence.
-struct PreHopr<Chain, Graph, Net, NB, Ct> {
-    chain_id: ChainKeypair,
-    transport_id: OffchainKeypair,
-    cfg: HoprLibConfig,
-    state: Arc<AtomicHoprState>,
-    transport_api: HoprTransport<Chain, Graph, Net>,
-    chain_api: Chain,
-    ticket_event_subscribers: (
-        async_broadcast::Sender<TicketEvent>,
-        async_broadcast::InactiveReceiver<TicketEvent>,
-    ),
-    processes: AbortableList<HoprLibProcess>,
-    session_tx: futures::channel::mpsc::Sender<IncomingSession>,
-    cover_traffic: Ct,
-    network_builder: NB,
+// ---------------------------------------------------------------------------
+// BuildCtx — passed to factory closures
+// ---------------------------------------------------------------------------
+
+/// Type-erased factory closure producing `T` from a [`BuildCtx`] reference.
+type Factory<T> = Box<dyn FnOnce(&BuildCtx) -> T + Send>;
+
+/// Context available to factory closures during the build step.
+pub struct BuildCtx {
+    /// Node's on-chain keypair.
+    pub chain_key: ChainKeypair,
+    /// Node's off-chain (packet) keypair.
+    pub packet_key: OffchainKeypair,
+    /// Node configuration.
+    pub cfg: HoprLibConfig,
 }
 
-/// Abstract builder for the [`Hopr`] node object.
+// ---------------------------------------------------------------------------
+// Type-state builder phases
+// ---------------------------------------------------------------------------
+
+/// Initial builder — forces `with_identity` first.
+#[derive(Default)]
+pub struct HoprBuilder;
+
+impl HoprBuilder {
+    pub fn new() -> Self {
+        Self
+    }
+
+    /// Sets the node's on-chain and off-chain identity.
+    pub fn with_identity(self, chain_key: &ChainKeypair, offchain_key: &OffchainKeypair) -> HoprBuilderWithIdentity {
+        HoprBuilderWithIdentity {
+            chain_key: chain_key.clone(),
+            packet_key: offchain_key.clone(),
+        }
+    }
+}
+
+/// Builder with identity set — forces `with_config` next.
+pub struct HoprBuilderWithIdentity {
+    chain_key: ChainKeypair,
+    packet_key: OffchainKeypair,
+}
+
+impl HoprBuilderWithIdentity {
+    /// Sets the node configuration and produces the configured builder.
+    pub fn with_config(self, cfg: HoprLibConfig) -> HoprBuilderConfigured {
+        HoprBuilderConfigured {
+            ctx: BuildCtx {
+                chain_key: self.chain_key,
+                packet_key: self.packet_key,
+                cfg,
+            },
+            safe_and_module: None,
+            chain_factory: None,
+            graph_factory: None,
+            network_factory: None,
+            ct_factory: None,
+            #[cfg(feature = "session-server")]
+            session: None,
+        }
+    }
+}
+
+/// Configured builder accepting factory closures for components.
 ///
-/// Provides two distinct build paths:
-///
-/// - [`build_edge`](HoprBuilder::build_edge) — standalone ticket factory, no ticket management
-/// - [`build_full`](HoprBuilder::build_full) — coupled ticket factory + ticket manager
+/// All `with_*` factory methods accept `FnOnce(&BuildCtx) -> T` closures
+/// that are invoked during `build_edge()`/`build_full()`.
 ///
 /// # Type Parameters
 ///
-/// - `Chain` — blockchain API ([`HoprChainApi`])
-/// - `Graph` — network graph ([`HoprGraphApi`])
-/// - `NB` — network builder factory ([`NetworkBuilder`])
-/// - `Ct` — cover traffic / probing ([`ProbingTrafficGeneration`] + [`CoverTrafficGeneration`])
-pub struct HoprBuilder<Chain = (), Graph = (), NB = (), Ct = ()> {
-    chain: Option<Chain>,
-    graph: Option<Graph>,
-    network_builder: Option<NB>,
-    cover_traffic: Option<Ct>,
-    identity: Option<(ChainKeypair, OffchainKeypair)>,
+/// - `Chain` — blockchain API produced by the chain factory
+/// - `Graph` — network graph produced by the graph factory
+/// - `Net` — network produced by the network factory
+/// - `Ct` — cover traffic produced by the cover traffic factory
+pub struct HoprBuilderConfigured<Chain = (), Graph = (), Net = (), Ct = ()> {
+    ctx: BuildCtx,
     safe_and_module: Option<(Address, Address)>,
-    cfg: HoprLibConfig,
-    /// Pre-spawned session server: `(session_tx, abort_handle)`.
-    /// Created by [`with_session_server`](HoprBuilder::with_session_server).
-    /// Sessions are not emitted until transport starts during build, so
-    /// spawning the consumer early is safe.
+    chain_factory: Option<Factory<Chain>>,
+    graph_factory: Option<Factory<Graph>>,
+    network_factory: Option<Factory<(Net, BoxedProcessFn)>>,
+    ct_factory: Option<Factory<Ct>>,
     #[cfg(feature = "session-server")]
     session: Option<(
         futures::channel::mpsc::Sender<IncomingSession>,
@@ -96,71 +136,85 @@ pub struct HoprBuilder<Chain = (), Graph = (), NB = (), Ct = ()> {
     )>,
 }
 
-impl<Chain, Graph, NB, Ct> Default for HoprBuilder<Chain, Graph, NB, Ct> {
-    fn default() -> Self {
-        Self {
-            chain: None,
-            graph: None,
-            network_builder: None,
-            cover_traffic: None,
-            identity: None,
-            safe_and_module: None,
-            cfg: Default::default(),
-            #[cfg(feature = "session-server")]
-            session: None,
-        }
-    }
-}
-
-impl<Chain, Graph, NB, Ct> HoprBuilder<Chain, Graph, NB, Ct> {
-    /// Sets the chain API implementation.
-    pub fn with_chain_api(mut self, chain: Chain) -> Self {
-        self.chain = Some(chain);
-        self
-    }
-
-    /// Sets the network graph.
-    pub fn with_graph(mut self, graph: Graph) -> Self {
-        self.graph = Some(graph);
-        self
-    }
-
-    /// Sets the network builder (factory for P2P network).
-    pub fn with_network_builder(mut self, builder: NB) -> Self {
-        self.network_builder = Some(builder);
-        self
-    }
-
-    /// Sets the cover traffic and probing provider.
-    pub fn with_cover_traffic(mut self, ct: Ct) -> Self {
-        self.cover_traffic = Some(ct);
-        self
-    }
-
-    /// Sets the node's on-chain and off-chain identity.
-    pub fn with_identity(mut self, chain_key: &ChainKeypair, offchain_key: &OffchainKeypair) -> Self {
-        self.identity = Some((chain_key.clone(), offchain_key.clone()));
-        self
-    }
-
+impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
     /// Sets the node Safe and module addresses.
     pub fn with_safe_module(mut self, safe: &Address, module: &Address) -> Self {
         self.safe_and_module = Some((*safe, *module));
         self
     }
 
-    /// Sets the [`HoprLibConfig`].
-    pub fn with_config(mut self, cfg: HoprLibConfig) -> Self {
-        self.cfg = cfg;
-        self
+    /// Sets the chain API factory.
+    pub fn with_chain_api<NewChain>(
+        self,
+        f: impl FnOnce(&BuildCtx) -> NewChain + Send + 'static,
+    ) -> HoprBuilderConfigured<NewChain, Graph, Net, Ct> {
+        HoprBuilderConfigured {
+            ctx: self.ctx,
+            safe_and_module: self.safe_and_module,
+            chain_factory: Some(Box::new(f)),
+            graph_factory: self.graph_factory,
+            network_factory: self.network_factory,
+            ct_factory: self.ct_factory,
+            #[cfg(feature = "session-server")]
+            session: self.session,
+        }
+    }
+
+    /// Sets the graph factory.
+    pub fn with_graph<NewGraph>(
+        self,
+        f: impl FnOnce(&BuildCtx) -> NewGraph + Send + 'static,
+    ) -> HoprBuilderConfigured<Chain, NewGraph, Net, Ct> {
+        HoprBuilderConfigured {
+            ctx: self.ctx,
+            safe_and_module: self.safe_and_module,
+            chain_factory: self.chain_factory,
+            graph_factory: Some(Box::new(f)),
+            network_factory: self.network_factory,
+            ct_factory: self.ct_factory,
+            #[cfg(feature = "session-server")]
+            session: self.session,
+        }
+    }
+
+    /// Sets the network factory. Must return `(Net, BoxedProcessFn)`.
+    pub fn with_network<NewNet>(
+        self,
+        f: impl FnOnce(&BuildCtx) -> (NewNet, BoxedProcessFn) + Send + 'static,
+    ) -> HoprBuilderConfigured<Chain, Graph, NewNet, Ct> {
+        HoprBuilderConfigured {
+            ctx: self.ctx,
+            safe_and_module: self.safe_and_module,
+            chain_factory: self.chain_factory,
+            graph_factory: self.graph_factory,
+            network_factory: Some(Box::new(f)),
+            ct_factory: self.ct_factory,
+            #[cfg(feature = "session-server")]
+            session: self.session,
+        }
+    }
+
+    /// Sets the cover traffic factory.
+    pub fn with_cover_traffic<NewCt>(
+        self,
+        f: impl FnOnce(&BuildCtx) -> NewCt + Send + 'static,
+    ) -> HoprBuilderConfigured<Chain, Graph, Net, NewCt> {
+        HoprBuilderConfigured {
+            ctx: self.ctx,
+            safe_and_module: self.safe_and_module,
+            chain_factory: self.chain_factory,
+            graph_factory: self.graph_factory,
+            network_factory: self.network_factory,
+            ct_factory: Some(Box::new(f)),
+            #[cfg(feature = "session-server")]
+            session: self.session,
+        }
     }
 
     /// Attaches a session server for handling incoming sessions.
     ///
-    /// Eagerly spawns the server task and creates the incoming session channel.
-    /// The spawned task blocks on the receiver until transport starts emitting
-    /// sessions during [`build_edge`](HoprBuilder::build_edge) or
-    /// [`build_full`](HoprBuilder::build_full).
+    /// Eagerly spawns the server task. Sessions are not emitted until
+    /// transport starts during build, so spawning the consumer early is safe.
     #[cfg(feature = "session-server")]
     pub fn with_session_server(
         mut self,
@@ -200,25 +254,44 @@ impl<Chain, Graph, NB, Ct> HoprBuilder<Chain, Graph, NB, Ct> {
     }
 }
 
-// === Build methods ===
+// ---------------------------------------------------------------------------
+// Intermediate pre-build state
+// ---------------------------------------------------------------------------
 
-impl<Chain, Graph, NB, Ct> HoprBuilder<Chain, Graph, NB, Ct>
+struct PreHopr<Chain, Graph, Net, Ct> {
+    chain_id: ChainKeypair,
+    transport_id: OffchainKeypair,
+    cfg: HoprLibConfig,
+    state: Arc<AtomicHoprState>,
+    transport_api: HoprTransport<Chain, Graph, Net>,
+    chain_api: Chain,
+    ticket_event_subscribers: (
+        async_broadcast::Sender<TicketEvent>,
+        async_broadcast::InactiveReceiver<TicketEvent>,
+    ),
+    processes: AbortableList<HoprLibProcess>,
+    session_tx: futures::channel::mpsc::Sender<IncomingSession>,
+    cover_traffic: Ct,
+    network: Net,
+    network_process: BoxedProcessFn,
+}
+
+// ---------------------------------------------------------------------------
+// Build methods
+// ---------------------------------------------------------------------------
+
+impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct>
 where
     Chain: HoprChainApi + Clone + Send + Sync + 'static,
     Graph: HoprGraphApi<HoprNodeId = hopr_api::OffchainPublicKey> + Clone + Send + Sync + 'static,
     <Graph as hopr_api::graph::NetworkGraphTraverse>::Observed:
         hopr_api::graph::traits::EdgeObservableRead + Send + 'static,
     <Graph as hopr_api::graph::NetworkGraphWrite>::Observed: hopr_api::graph::traits::EdgeObservableWrite + Send,
-    NB: NetworkBuilder + Send + Sync + 'static,
-    <NB as NetworkBuilder>::Network:
-        hopr_api::network::NetworkView + NetworkStreamControl + Send + Sync + Clone + 'static,
+    Net: NetworkView + NetworkStreamControl + Send + Sync + Clone + 'static,
     Ct: ProbingTrafficGeneration + CoverTrafficGeneration + Send + Sync + 'static,
 {
     /// Builds an edge (entry/exit) [`Hopr`] node.
-    pub async fn build_edge<TFact>(
-        self,
-        ticket_factory: TFact,
-    ) -> Result<Hopr<Chain, Graph, <NB as NetworkBuilder>::Network, ()>, HoprLibError>
+    pub async fn build_edge<TFact>(self, ticket_factory: TFact) -> Result<Hopr<Chain, Graph, Net, ()>, HoprLibError>
     where
         TFact: TicketFactory + Clone + Send + Sync + 'static,
     {
@@ -229,7 +302,8 @@ where
             .transport_api
             .run(
                 pre.cover_traffic,
-                pre.network_builder,
+                pre.network,
+                pre.network_process,
                 futures::sink::drain(),
                 ticket_factory,
                 pre.session_tx,
@@ -271,7 +345,7 @@ where
         self,
         ticket_manager: TMgr,
         ticket_factory: TFact,
-    ) -> Result<Hopr<Chain, Graph, <NB as NetworkBuilder>::Network, TMgr>, HoprLibError>
+    ) -> Result<Hopr<Chain, Graph, Net, TMgr>, HoprLibError>
     where
         TMgr: TicketManagement + Clone + Send + Sync + 'static,
         TFact: TicketFactory + Clone + Send + Sync + 'static,
@@ -368,7 +442,8 @@ where
             .transport_api
             .run(
                 pre.cover_traffic,
-                pre.network_builder,
+                pre.network,
+                pre.network_process,
                 tickets_tx,
                 ticket_factory,
                 pre.session_tx,
@@ -415,32 +490,34 @@ where
         Ok(hopr)
     }
 
-    /// Shared initialization sequence for both build paths.
-    async fn pre_build(self) -> Result<PreHopr<Chain, Graph, <NB as NetworkBuilder>::Network, NB, Ct>, HoprLibError> {
-        let mut chain = self.chain;
-        let mut graph = self.graph;
-        let mut network_builder = self.network_builder;
-        let mut cover_traffic = self.cover_traffic;
-        let cfg = self.cfg;
+    /// Shared initialization: invoke factories, wire events, do on-chain setup.
+    async fn pre_build(self) -> Result<PreHopr<Chain, Graph, Net, Ct>, HoprLibError> {
+        let ctx = self.ctx;
+        ctx.cfg.validate()?;
 
-        cfg.validate()?;
+        // Invoke factories
+        let chain_api = (self
+            .chain_factory
+            .ok_or(HoprLibError::BuilderError("missing chain factory"))?)(&ctx);
+        let graph = (self
+            .graph_factory
+            .ok_or(HoprLibError::BuilderError("missing graph factory"))?)(&ctx);
+        let (network, network_process) =
+            (self
+                .network_factory
+                .ok_or(HoprLibError::BuilderError("missing network factory"))?)(&ctx);
+        let cover_traffic = (self
+            .ct_factory
+            .ok_or(HoprLibError::BuilderError("missing cover traffic factory"))?)(&ctx);
 
-        let chain_api = chain.take().ok_or(HoprLibError::BuilderError("missing chain API"))?;
-        let graph = graph.take().ok_or(HoprLibError::BuilderError("missing graph"))?;
-        let (chain_id, transport_id) = self.identity.ok_or(HoprLibError::BuilderError("missing identity"))?;
-        let cover_traffic = cover_traffic
-            .take()
-            .ok_or(HoprLibError::BuilderError("missing cover traffic"))?;
-        let network_builder = network_builder
-            .take()
-            .ok_or(HoprLibError::BuilderError("missing network builder"))?;
+        let (chain_id, transport_id) = (ctx.chain_key.clone(), ctx.packet_key.clone());
 
         let transport_api = HoprTransport::new(
             (&chain_id, &transport_id),
             chain_api.clone(),
             graph.clone(),
-            vec![(&cfg.host).try_into().map_err(HoprLibError::TransportError)?],
-            cfg.protocol.clone(),
+            vec![(&ctx.cfg.host).try_into().map_err(HoprLibError::TransportError)?],
+            ctx.cfg.protocol.clone(),
         )
         .map_err(HoprLibError::TransportError)?;
 
@@ -498,7 +575,7 @@ where
         }
 
         let network_min_ticket_price = chain_api.minimum_ticket_price().await.map_err(HoprLibError::chain)?;
-        let configured_ticket_price = cfg.protocol.packet.codec.outgoing_ticket_price;
+        let configured_ticket_price = ctx.cfg.protocol.packet.codec.outgoing_ticket_price;
         if configured_ticket_price.is_some_and(|c| c < network_min_ticket_price) {
             return Err(HoprLibError::GeneralError(format!(
                 "configured outgoing ticket price < network minimum: {configured_ticket_price:?} < \
@@ -510,7 +587,7 @@ where
             .minimum_incoming_ticket_win_prob()
             .await
             .map_err(HoprLibError::chain)?;
-        let configured_win_prob = cfg.protocol.packet.codec.outgoing_win_prob;
+        let configured_win_prob = ctx.cfg.protocol.packet.codec.outgoing_win_prob;
         if !std::env::var("HOPR_TEST_DISABLE_CHECKS").is_ok_and(|v| v.to_lowercase() == "true")
             && configured_win_prob.is_some_and(|c| c.approx_cmp(&network_min_win_prob).is_lt())
         {
@@ -527,7 +604,7 @@ where
             "Node information"
         );
 
-        let safe_addr = cfg.safe_module.safe_address;
+        let safe_addr = ctx.cfg.safe_module.safe_address;
         if me_onchain == safe_addr {
             return Err(HoprLibError::GeneralError(
                 "cannot use self as staking safe address".into(),
@@ -556,7 +633,7 @@ where
             }
         }
 
-        let multiaddresses_to_announce = if cfg.publish {
+        let multiaddresses_to_announce = if ctx.cfg.publish {
             transport_api.announceable_multiaddresses()
         } else {
             Vec::with_capacity(0)
@@ -604,8 +681,7 @@ where
 
         tracing::info!(%this_node_account, "node account is ready");
 
-        // Session channel — use pre-spawned session server channel if available,
-        // otherwise create a dummy channel (sessions will be dropped).
+        // Session channel
         let mut processes = AbortableList::<HoprLibProcess>::default();
 
         #[cfg(feature = "session-server")]
@@ -623,7 +699,37 @@ where
             tx
         };
 
-        // Chain → Graph event wiring
+        // Network → graph event wiring (subscribe before transport starts)
+        {
+            let network_events = network.subscribe_network_events();
+            let graph_updater = graph.clone();
+            spawn(async move {
+                network_events
+                    .for_each(|event| {
+                        let graph_updater = graph_updater.clone();
+                        async move {
+                            let (peer_id, connected) = match event {
+                                hopr_api::network::NetworkEvent::PeerConnected(p) => (p, true),
+                                hopr_api::network::NetworkEvent::PeerDisconnected(p) => (p, false),
+                            };
+                            if let Ok(opk) = hopr_api::OffchainPublicKey::from_peerid(&peer_id) {
+                                graph_updater.record_edge(hopr_api::graph::MeasurableEdge::<
+                                    hopr_transport::NeighborTelemetry,
+                                    hopr_transport::PathTelemetry,
+                                >::ConnectionStatus {
+                                    peer: opk,
+                                    connected,
+                                });
+                            } else {
+                                tracing::error!(%peer_id, "failed to convert peer ID to public key for graph update");
+                            }
+                        }
+                    })
+                    .await;
+            });
+        }
+
+        // Chain → graph event wiring
         {
             let chain_events = chain_api
                 .subscribe_with_state_sync([StateSyncOptions::PublicAccounts, StateSyncOptions::OpenedChannels])
@@ -757,7 +863,7 @@ where
         Ok(PreHopr {
             chain_id,
             transport_id,
-            cfg,
+            cfg: ctx.cfg,
             state: Arc::new(AtomicHoprState::new(HoprState::Uninitialized)),
             transport_api,
             chain_api,
@@ -765,7 +871,8 @@ where
             processes,
             session_tx,
             cover_traffic,
-            network_builder,
+            network,
+            network_process,
         })
     }
 }

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -51,7 +51,7 @@ lazy_static::lazy_static! {
 type Factory<T> = Box<dyn FnOnce(&BuildCtx) -> T + Send>;
 
 /// Context available to factory closures during the build step.
-pub struct BuildCtx {
+pub(crate) struct BuildCtx {
     /// Node's on-chain keypair.
     pub chain_key: ChainKeypair,
     /// Node's off-chain (packet) keypair.

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -23,8 +23,6 @@ pub mod config;
 pub mod constants;
 /// Lists all errors thrown from this library.
 pub mod errors;
-/// Public traits for interactions with this library.
-pub mod traits;
 /// Public domain types for peer discovery.
 pub mod types;
 /// Utility module with helper types and functionality over hopr-lib behavior.

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -307,6 +307,7 @@ where
         self.transport_api.graph()
     }
 
+    #[cfg(feature = "session-client")]
     fn error_if_not_in_state(&self, state: HoprState, error: String) -> errors::Result<()> {
         if HoprNodeOperations::status(self) == state {
             Ok(())

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -86,7 +86,7 @@ use hopr_api::{
 };
 pub use hopr_api::{
     graph::EdgeLinkObservable,
-    network::{NetworkBuilder, NetworkStreamControl},
+    network::NetworkStreamControl,
     node::{
         EitherErr, HoprNodeOperations, HoprState, IncentiveChannelOperations, IncentiveRedeemOperations,
         TransportOperations,

--- a/hopr/hopr-lib/src/traits.rs
+++ b/hopr/hopr-lib/src/traits.rs
@@ -1,2 +1,0 @@
-// Session server trait is defined in hopr-api (node::HoprSessionServer).
-// Import it directly from hopr_api::node where needed.

--- a/hopr/hopr-lib/src/traits.rs
+++ b/hopr/hopr-lib/src/traits.rs
@@ -1,2 +1,2 @@
-/// Re-export the session server trait from hopr-api.
-pub use hopr_api::node::HoprSessionServer;
+// Session server trait is defined in hopr-api (node::HoprSessionServer).
+// Import it directly from hopr_api::node where needed.

--- a/hopr/hopr-lib/src/traits.rs
+++ b/hopr/hopr-lib/src/traits.rs
@@ -1,23 +1,2 @@
-/// Session-related traits.
-pub mod session {
-    use crate::{errors::Result, exports::transport::IncomingSession};
-
-    /// Interface representing the HOPR server behavior for each incoming session instance
-    /// supplied as an argument.
-    #[async_trait::async_trait]
-    pub trait HoprSessionServer {
-        /// Fully process a single HOPR session
-        async fn process(&self, session: IncomingSession) -> Result<()>;
-    }
-}
-
-pub use session::HoprSessionServer;
-
-/// Noop implementation for nodes that do not run a session server.
-#[async_trait::async_trait]
-impl HoprSessionServer for () {
-    async fn process(&self, _session: crate::exports::transport::IncomingSession) -> crate::errors::Result<()> {
-        tracing::warn!("incoming session received but no session server configured, dropping");
-        Ok(())
-    }
-}
+/// Re-export the session server trait from hopr-api.
+pub use hopr_api::node::HoprSessionServer;

--- a/hopr/reference/Cargo.toml
+++ b/hopr/reference/Cargo.toml
@@ -67,7 +67,6 @@ validator = { workspace = true, optional = true }
 
 hopr-lib = { workspace = true, features = ["utils_parallel"] }
 hopr-metrics = { workspace = true, optional = true }
-hopr-transport = { workspace = true }
 # impls
 hopr-chain-connector = { workspace = true }
 hopr-ct-full-network = { workspace = true }

--- a/hopr/reference/src/exit.rs
+++ b/hopr/reference/src/exit.rs
@@ -57,9 +57,8 @@ impl HoprServerIpForwardingReactor {
 pub const SERVICE_ID_LOOPBACK: ServiceId = 0;
 
 #[async_trait::async_trait]
-impl hopr_lib::api::node::HoprSessionServer for HoprServerIpForwardingReactor {
+impl hopr_lib::builder::HoprSessionServer for HoprServerIpForwardingReactor {
     type Error = hopr_lib::errors::HoprLibError;
-    type Session = hopr_lib::exports::transport::IncomingSession;
 
     #[tracing::instrument(level = "debug", skip(self, session))]
     async fn process(

--- a/hopr/reference/src/exit.rs
+++ b/hopr/reference/src/exit.rs
@@ -57,7 +57,7 @@ impl HoprServerIpForwardingReactor {
 pub const SERVICE_ID_LOOPBACK: ServiceId = 0;
 
 #[async_trait::async_trait]
-impl hopr_lib::traits::HoprSessionServer for HoprServerIpForwardingReactor {
+impl hopr_lib::api::node::HoprSessionServer for HoprServerIpForwardingReactor {
     type Error = hopr_lib::errors::HoprLibError;
     type Session = hopr_lib::exports::transport::IncomingSession;
 

--- a/hopr/reference/src/exit.rs
+++ b/hopr/reference/src/exit.rs
@@ -57,8 +57,9 @@ impl HoprServerIpForwardingReactor {
 pub const SERVICE_ID_LOOPBACK: ServiceId = 0;
 
 #[async_trait::async_trait]
-impl hopr_lib::builder::HoprSessionServer for HoprServerIpForwardingReactor {
+impl hopr_lib::api::node::HoprSessionServer for HoprServerIpForwardingReactor {
     type Error = hopr_lib::errors::HoprLibError;
+    type Session = hopr_lib::exports::transport::IncomingSession;
 
     #[tracing::instrument(level = "debug", skip(self, session))]
     async fn process(

--- a/hopr/reference/src/exit.rs
+++ b/hopr/reference/src/exit.rs
@@ -57,12 +57,15 @@ impl HoprServerIpForwardingReactor {
 pub const SERVICE_ID_LOOPBACK: ServiceId = 0;
 
 #[async_trait::async_trait]
-impl hopr_lib::traits::session::HoprSessionServer for HoprServerIpForwardingReactor {
+impl hopr_lib::traits::HoprSessionServer for HoprServerIpForwardingReactor {
+    type Error = hopr_lib::errors::HoprLibError;
+    type Session = hopr_lib::exports::transport::IncomingSession;
+
     #[tracing::instrument(level = "debug", skip(self, session))]
     async fn process(
         &self,
         mut session: hopr_lib::exports::transport::IncomingSession,
-    ) -> hopr_lib::errors::Result<()> {
+    ) -> Result<(), hopr_lib::errors::HoprLibError> {
         let session_id = *session.session.id();
         match session.target {
             hopr_lib::SessionTarget::UdpStream(udp_target) => {

--- a/hopr/reference/src/lib.rs
+++ b/hopr/reference/src/lib.rs
@@ -135,7 +135,7 @@ where
     // Sync ticket manager and factory with on-chain state
     {
         use futures::StreamExt;
-        use hopr_lib::api::chain::{ChannelSelector, HoprChainApi};
+        use hopr_lib::api::chain::ChannelSelector;
 
         let me = chain_connector.me();
         let incoming_channels: Vec<_> = chain_connector

--- a/hopr/reference/src/lib.rs
+++ b/hopr/reference/src/lib.rs
@@ -175,9 +175,19 @@ where
         .with_chain_api(move |_ctx| chain_connector)
         .with_graph(move |_ctx| graph)
         .with_network(move |ctx| {
+            let multiaddresses = vec![
+                (&ctx.cfg.host)
+                    .try_into()
+                    .expect("host config must be a valid multiaddress"),
+            ];
             let nb = HoprLibp2pNetworkBuilder::new(peer_discovery_rx);
-            futures::executor::block_on(nb.build(&ctx.packet_key, vec![], "/hopr/mix/1.1.0", false))
-                .expect("network must be constructible")
+            futures::executor::block_on(nb.build(
+                &ctx.packet_key,
+                multiaddresses,
+                "/hopr/mix/1.1.0",
+                ctx.cfg.protocol.transport.prefer_local_addresses,
+            ))
+            .expect("network must be constructible")
         })
         .with_cover_traffic(move |ctx| {
             hopr_ct_full_network::FullNetworkDiscovery::new(*ctx.packet_key.public(), prober_cfg, graph_for_ct)

--- a/hopr/reference/src/lib.rs
+++ b/hopr/reference/src/lib.rs
@@ -161,18 +161,9 @@ where
         });
     }
 
-    // Build the network eagerly (before the builder) so the factory closure can be sync
-    let nb = HoprLibp2pNetworkBuilder::new(peer_discovery_rx);
-    let (network, network_process) = nb
-        .build(packet_key, vec![], "/hopr/mix/1.1.0", false)
-        .await
-        .map_err(|e| anyhow::anyhow!("failed to build network: {e}"))?;
-
-    // Graph and cover traffic are also created eagerly
-    let graph: SharedChannelGraph = Arc::new(ChannelGraph::new(*packet_key.public()));
     let prober_cfg = probe_cfg.unwrap_or_default();
-    let cover_traffic =
-        hopr_ct_full_network::FullNetworkDiscovery::new(*packet_key.public(), prober_cfg, graph.clone());
+    let graph: SharedChannelGraph = Arc::new(ChannelGraph::new(*packet_key.public()));
+    let graph_for_ct = graph.clone();
 
     let safe_address = config.safe_module.safe_address;
     let module_address = config.safe_module.module_address;
@@ -183,8 +174,14 @@ where
         .with_safe_module(&safe_address, &module_address)
         .with_chain_api(move |_ctx| chain_connector)
         .with_graph(move |_ctx| graph)
-        .with_network(move |_ctx| (network, network_process))
-        .with_cover_traffic(move |_ctx| cover_traffic);
+        .with_network(move |ctx| {
+            let nb = HoprLibp2pNetworkBuilder::new(peer_discovery_rx);
+            futures::executor::block_on(nb.build(&ctx.packet_key, vec![], "/hopr/mix/1.1.0", false))
+                .expect("network must be constructible")
+        })
+        .with_cover_traffic(move |ctx| {
+            hopr_ct_full_network::FullNetworkDiscovery::new(*ctx.packet_key.public(), prober_cfg, graph_for_ct)
+        });
 
     #[cfg(feature = "session-server")]
     let builder = builder.with_session_server(server);

--- a/hopr/reference/src/lib.rs
+++ b/hopr/reference/src/lib.rs
@@ -41,11 +41,7 @@ pub type SharedTicketManager = Arc<HoprTicketManager<RedbStore, RedbTicketQueue>
 pub type ReferenceHopr =
     Hopr<Arc<HoprBlockchainSafeConnector<BlokliClient>>, SharedChannelGraph, HoprNetwork, SharedTicketManager>;
 
-/// Builds a reference HOPR node using canonical implementations:
-/// - Blokli blockchain connector
-/// - Petgraph-based channel graph
-/// - libp2p-based P2P network
-/// - Redb-backed ticket management
+/// Builds a reference HOPR node using canonical implementations.
 #[cfg(feature = "runtime-tokio")]
 pub async fn build_reference(
     identity: (&ChainKeypair, &OffchainKeypair),
@@ -104,7 +100,7 @@ pub async fn build_reference(
 #[cfg(feature = "runtime-tokio")]
 pub async fn build_with_chain<
     Chain,
-    #[cfg(feature = "session-server")] Srv: hopr_lib::api::node::HoprSessionServer<Session = hopr_lib::IncomingSession> + Send + Clone + 'static,
+    #[cfg(feature = "session-server")] Srv: hopr_lib::api::node::HoprSessionServer<Session = hopr_lib::IncomingSession, Error: std::fmt::Display>,
 >(
     chain_key: &ChainKeypair,
     packet_key: &OffchainKeypair,
@@ -204,7 +200,6 @@ where
     let ticket_manager = Arc::new(ticket_manager);
     let ticket_factory = Arc::new(ticket_factory);
 
-    // Use the abstract builder — session server is wired separately
     let builder = hopr_lib::builder::HoprBuilder::default()
         .with_chain_api(chain_connector)
         .with_graph(graph)
@@ -214,28 +209,14 @@ where
         .with_safe_module(&config.safe_module.safe_address, &config.safe_module.module_address)
         .with_config(config);
 
-    let built = builder.build_full(ticket_manager, ticket_factory).await?;
+    let node = builder
+        .build_full(
+            ticket_manager,
+            ticket_factory,
+            #[cfg(feature = "session-server")]
+            server,
+        )
+        .await?;
 
-    // Wire session server to the incoming session receiver
-    #[cfg(feature = "session-server")]
-    {
-        use futures::StreamExt;
-        let session_rx = built.session_rx;
-        tokio::spawn(async move {
-            session_rx
-                .for_each_concurrent(None, move |session| {
-                    let server = server.clone();
-                    async move {
-                        let session_id = *session.session.id();
-                        match server.process(session).await {
-                            Ok(()) => tracing::debug!(?session_id, "session processed successfully"),
-                            Err(error) => tracing::error!(?session_id, %error, "session processing failed"),
-                        }
-                    }
-                })
-                .await;
-        });
-    }
-
-    Ok(Arc::new(built.node))
+    Ok(Arc::new(node))
 }

--- a/hopr/reference/src/lib.rs
+++ b/hopr/reference/src/lib.rs
@@ -132,6 +132,31 @@ where
     let ticket_manager = Arc::new(ticket_manager);
     let ticket_factory = Arc::new(ticket_factory);
 
+    // Sync ticket manager and factory with on-chain state
+    {
+        use futures::StreamExt;
+        use hopr_lib::api::chain::{ChannelSelector, HoprChainApi};
+
+        let me = chain_connector.me();
+        let incoming_channels: Vec<_> = chain_connector
+            .stream_channels(ChannelSelector::default().with_destination(*me))
+            .map_err(|e| anyhow::anyhow!("failed to stream incoming channels: {e}"))?
+            .collect()
+            .await;
+        ticket_manager
+            .sync_from_incoming_channels(&incoming_channels)
+            .map_err(|e| anyhow::anyhow!("failed to sync ticket manager: {e}"))?;
+
+        let outgoing_channels: Vec<_> = chain_connector
+            .stream_channels(ChannelSelector::default().with_source(*me))
+            .map_err(|e| anyhow::anyhow!("failed to stream outgoing channels: {e}"))?
+            .collect()
+            .await;
+        ticket_factory
+            .sync_from_outgoing_channels(&outgoing_channels)
+            .map_err(|e| anyhow::anyhow!("failed to sync ticket factory: {e}"))?;
+    }
+
     // Chain→peer-discovery wiring
     let (peer_discovery_tx, peer_discovery_rx) = futures::channel::mpsc::channel(2048);
     {

--- a/hopr/reference/src/lib.rs
+++ b/hopr/reference/src/lib.rs
@@ -124,9 +124,12 @@ where
         );
     }
 
-    let graph: SharedChannelGraph = Arc::new(ChannelGraph::new(*packet_key.public()));
+    let backend = RedbStore::new_temp().map_err(hopr_ticket_manager::TicketManagerError::store)?;
+    let (ticket_manager, ticket_factory) = HoprTicketManager::new_with_factory(backend);
+    let ticket_manager = Arc::new(ticket_manager);
+    let ticket_factory = Arc::new(ticket_factory);
 
-    // Wire chain announcement events → network peer discovery
+    // Chain→peer-discovery wiring
     let (peer_discovery_tx, peer_discovery_rx) = futures::channel::mpsc::channel(2048);
     {
         use futures::{SinkExt, StreamExt};
@@ -158,55 +161,30 @@ where
         });
     }
 
-    let network_builder = HoprLibp2pNetworkBuilder::new(peer_discovery_rx);
+    // Build the network eagerly (before the builder) so the factory closure can be sync
+    let nb = HoprLibp2pNetworkBuilder::new(peer_discovery_rx);
+    let (network, network_process) = nb
+        .build(packet_key, vec![], "/hopr/mix/1.1.0", false)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to build network: {e}"))?;
 
-    // Wire network events → graph updates
-    {
-        use futures::StreamExt;
-        use hopr_lib::api::graph::NetworkGraphUpdate;
-        let network_events = network_builder.subscribe_network_events();
-        let graph_updater = graph.clone();
-        tokio::spawn(async move {
-            network_events
-                .for_each(|event| {
-                    let graph_updater = graph_updater.clone();
-                    async move {
-                        let (peer_id, connected) = match event {
-                            hopr_lib::api::network::NetworkEvent::PeerConnected(p) => (p, true),
-                            hopr_lib::api::network::NetworkEvent::PeerDisconnected(p) => (p, false),
-                        };
-                        if let Ok(opk) = hopr_lib::api::OffchainPublicKey::from_peerid(&peer_id) {
-                            graph_updater.record_edge(hopr_lib::api::graph::MeasurableEdge::<
-                                hopr_transport::NeighborTelemetry,
-                                hopr_transport::PathTelemetry,
-                            >::ConnectionStatus {
-                                peer: opk,
-                                connected,
-                            });
-                        }
-                    }
-                })
-                .await;
-        });
-    }
-
+    // Graph and cover traffic are also created eagerly
+    let graph: SharedChannelGraph = Arc::new(ChannelGraph::new(*packet_key.public()));
     let prober_cfg = probe_cfg.unwrap_or_default();
     let cover_traffic =
         hopr_ct_full_network::FullNetworkDiscovery::new(*packet_key.public(), prober_cfg, graph.clone());
 
-    let backend = RedbStore::new_temp().map_err(hopr_ticket_manager::TicketManagerError::store)?;
-    let (ticket_manager, ticket_factory) = HoprTicketManager::new_with_factory(backend);
-    let ticket_manager = Arc::new(ticket_manager);
-    let ticket_factory = Arc::new(ticket_factory);
+    let safe_address = config.safe_module.safe_address;
+    let module_address = config.safe_module.module_address;
 
-    let builder = hopr_lib::builder::HoprBuilder::default()
-        .with_chain_api(chain_connector)
-        .with_graph(graph)
-        .with_network_builder(network_builder)
-        .with_cover_traffic(cover_traffic)
+    let builder = hopr_lib::builder::HoprBuilder::new()
         .with_identity(chain_key, packet_key)
-        .with_safe_module(&config.safe_module.safe_address, &config.safe_module.module_address)
-        .with_config(config);
+        .with_config(config)
+        .with_safe_module(&safe_address, &module_address)
+        .with_chain_api(move |_ctx| chain_connector)
+        .with_graph(move |_ctx| graph)
+        .with_network(move |_ctx| (network, network_process))
+        .with_cover_traffic(move |_ctx| cover_traffic);
 
     #[cfg(feature = "session-server")]
     let builder = builder.with_session_server(server);

--- a/hopr/reference/src/lib.rs
+++ b/hopr/reference/src/lib.rs
@@ -20,8 +20,6 @@ use hopr_chain_connector::{
 pub use hopr_lib;
 #[cfg(feature = "runtime-tokio")]
 use hopr_lib::builder::{ChainKeypair, Keypair, OffchainKeypair};
-#[cfg(feature = "session-server")]
-use hopr_lib::traits::HoprSessionServer;
 #[cfg(feature = "runtime-tokio")]
 use hopr_lib::{Hopr, config::HoprLibConfig};
 #[cfg(feature = "runtime-tokio")]
@@ -106,7 +104,7 @@ pub async fn build_reference(
 #[cfg(feature = "runtime-tokio")]
 pub async fn build_with_chain<
     Chain,
-    #[cfg(feature = "session-server")] Srv: HoprSessionServer<Session = hopr_lib::IncomingSession> + Send + Clone + 'static,
+    #[cfg(feature = "session-server")] Srv: hopr_lib::api::node::HoprSessionServer<Session = hopr_lib::IncomingSession> + Send + Clone + 'static,
 >(
     chain_key: &ChainKeypair,
     packet_key: &OffchainKeypair,
@@ -206,8 +204,8 @@ where
     let ticket_manager = Arc::new(ticket_manager);
     let ticket_factory = Arc::new(ticket_factory);
 
-    // Use the abstract builder with build_full for relay node
-    let mut builder = hopr_lib::builder::HoprBuilder::default()
+    // Use the abstract builder — session server is wired separately
+    let builder = hopr_lib::builder::HoprBuilder::default()
         .with_chain_api(chain_connector)
         .with_graph(graph)
         .with_network_builder(network_builder)
@@ -216,17 +214,28 @@ where
         .with_safe_module(&config.safe_module.safe_address, &config.safe_module.module_address)
         .with_config(config);
 
+    let built = builder.build_full(ticket_manager, ticket_factory).await?;
+
+    // Wire session server to the incoming session receiver
     #[cfg(feature = "session-server")]
     {
-        builder = builder.with_session_server(server);
+        use futures::StreamExt;
+        let session_rx = built.session_rx;
+        tokio::spawn(async move {
+            session_rx
+                .for_each_concurrent(None, move |session| {
+                    let server = server.clone();
+                    async move {
+                        let session_id = *session.session.id();
+                        match server.process(session).await {
+                            Ok(()) => tracing::debug!(?session_id, "session processed successfully"),
+                            Err(error) => tracing::error!(?session_id, %error, "session processing failed"),
+                        }
+                    }
+                })
+                .await;
+        });
     }
 
-    #[cfg(not(feature = "session-server"))]
-    {
-        builder = builder.with_session_server(());
-    }
-
-    let node = builder.build_full(ticket_manager, ticket_factory).await?;
-
-    Ok(Arc::new(node))
+    Ok(Arc::new(built.node))
 }

--- a/hopr/reference/src/lib.rs
+++ b/hopr/reference/src/lib.rs
@@ -100,7 +100,10 @@ pub async fn build_reference(
 #[cfg(feature = "runtime-tokio")]
 pub async fn build_with_chain<
     Chain,
-    #[cfg(feature = "session-server")] Srv: hopr_lib::api::node::HoprSessionServer<Session = hopr_lib::IncomingSession, Error: std::fmt::Display>,
+    #[cfg(feature = "session-server")] Srv: hopr_lib::api::node::HoprSessionServer<Session = hopr_lib::IncomingSession, Error: std::fmt::Display>
+        + Clone
+        + Send
+        + 'static,
 >(
     chain_key: &ChainKeypair,
     packet_key: &OffchainKeypair,

--- a/hopr/reference/src/lib.rs
+++ b/hopr/reference/src/lib.rs
@@ -98,10 +98,7 @@ pub async fn build_reference(
 /// Builds a HOPR node with a custom chain connector using canonical implementations
 /// for all other components.
 #[cfg(feature = "runtime-tokio")]
-pub async fn build_with_chain<
-    Chain,
-    #[cfg(feature = "session-server")] Srv: hopr_lib::api::node::HoprSessionServer<Session = hopr_lib::IncomingSession, Error: std::fmt::Display>,
->(
+pub async fn build_with_chain<Chain, #[cfg(feature = "session-server")] Srv: hopr_lib::builder::HoprSessionServer>(
     chain_key: &ChainKeypair,
     packet_key: &OffchainKeypair,
     config: HoprLibConfig,

--- a/hopr/reference/src/lib.rs
+++ b/hopr/reference/src/lib.rs
@@ -98,7 +98,10 @@ pub async fn build_reference(
 /// Builds a HOPR node with a custom chain connector using canonical implementations
 /// for all other components.
 #[cfg(feature = "runtime-tokio")]
-pub async fn build_with_chain<Chain, #[cfg(feature = "session-server")] Srv: hopr_lib::builder::HoprSessionServer>(
+pub async fn build_with_chain<
+    Chain,
+    #[cfg(feature = "session-server")] Srv: hopr_lib::api::node::HoprSessionServer<Session = hopr_lib::IncomingSession, Error: std::fmt::Display>,
+>(
     chain_key: &ChainKeypair,
     packet_key: &OffchainKeypair,
     config: HoprLibConfig,

--- a/hopr/reference/src/lib.rs
+++ b/hopr/reference/src/lib.rs
@@ -124,7 +124,6 @@ where
         );
     }
 
-    // Create concrete components
     let graph: SharedChannelGraph = Arc::new(ChannelGraph::new(*packet_key.public()));
 
     // Wire chain announcement events → network peer discovery
@@ -161,7 +160,7 @@ where
 
     let network_builder = HoprLibp2pNetworkBuilder::new(peer_discovery_rx);
 
-    // Wire network events (peer connected/disconnected) → graph updates
+    // Wire network events → graph updates
     {
         use futures::StreamExt;
         use hopr_lib::api::graph::NetworkGraphUpdate;
@@ -209,14 +208,10 @@ where
         .with_safe_module(&config.safe_module.safe_address, &config.safe_module.module_address)
         .with_config(config);
 
-    let node = builder
-        .build_full(
-            ticket_manager,
-            ticket_factory,
-            #[cfg(feature = "session-server")]
-            server,
-        )
-        .await?;
+    #[cfg(feature = "session-server")]
+    let builder = builder.with_session_server(server);
+
+    let node = builder.build_full(ticket_manager, ticket_factory).await?;
 
     Ok(Arc::new(node))
 }

--- a/hopr/reference/src/lib.rs
+++ b/hopr/reference/src/lib.rs
@@ -106,7 +106,7 @@ pub async fn build_reference(
 #[cfg(feature = "runtime-tokio")]
 pub async fn build_with_chain<
     Chain,
-    #[cfg(feature = "session-server")] Srv: HoprSessionServer + Clone + Send + 'static,
+    #[cfg(feature = "session-server")] Srv: HoprSessionServer<Session = hopr_lib::IncomingSession> + Send + Clone + 'static,
 >(
     chain_key: &ChainKeypair,
     packet_key: &OffchainKeypair,

--- a/hopr/reference/src/testing/dummies.rs
+++ b/hopr/reference/src/testing/dummies.rs
@@ -1,5 +1,5 @@
 use futures::AsyncReadExt;
-use hopr_lib::{IncomingSession, builder::HoprSessionServer, errors::HoprLibError};
+use hopr_lib::{IncomingSession, api::node::HoprSessionServer, errors::HoprLibError};
 use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
 
 #[derive(Debug, Clone, Default)]
@@ -14,6 +14,7 @@ impl EchoServer {
 #[async_trait::async_trait]
 impl HoprSessionServer for EchoServer {
     type Error = HoprLibError;
+    type Session = IncomingSession;
 
     async fn process(&self, session: IncomingSession) -> Result<(), HoprLibError> {
         tokio::spawn(async move {

--- a/hopr/reference/src/testing/dummies.rs
+++ b/hopr/reference/src/testing/dummies.rs
@@ -1,5 +1,5 @@
 use futures::AsyncReadExt;
-use hopr_lib::{IncomingSession, errors::HoprLibError, traits::session::HoprSessionServer};
+use hopr_lib::{IncomingSession, errors::HoprLibError, traits::HoprSessionServer};
 use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
 
 #[derive(Debug, Clone, Default)]
@@ -13,7 +13,10 @@ impl EchoServer {
 
 #[async_trait::async_trait]
 impl HoprSessionServer for EchoServer {
-    async fn process(&self, session: IncomingSession) -> std::result::Result<(), HoprLibError> {
+    type Error = HoprLibError;
+    type Session = IncomingSession;
+
+    async fn process(&self, session: IncomingSession) -> Result<(), HoprLibError> {
         tokio::spawn(async move {
             let (r, w) = session.session.split();
 

--- a/hopr/reference/src/testing/dummies.rs
+++ b/hopr/reference/src/testing/dummies.rs
@@ -1,5 +1,5 @@
 use futures::AsyncReadExt;
-use hopr_lib::{IncomingSession, errors::HoprLibError, traits::HoprSessionServer};
+use hopr_lib::{IncomingSession, api::node::HoprSessionServer, errors::HoprLibError};
 use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
 
 #[derive(Debug, Clone, Default)]

--- a/hopr/reference/src/testing/dummies.rs
+++ b/hopr/reference/src/testing/dummies.rs
@@ -1,5 +1,5 @@
 use futures::AsyncReadExt;
-use hopr_lib::{IncomingSession, api::node::HoprSessionServer, errors::HoprLibError};
+use hopr_lib::{IncomingSession, builder::HoprSessionServer, errors::HoprLibError};
 use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
 
 #[derive(Debug, Clone, Default)]
@@ -14,7 +14,6 @@ impl EchoServer {
 #[async_trait::async_trait]
 impl HoprSessionServer for EchoServer {
     type Error = HoprLibError;
-    type Session = IncomingSession;
 
     async fn process(&self, session: IncomingSession) -> Result<(), HoprLibError> {
         tokio::spawn(async move {

--- a/impls/transport/p2p/src/lib.rs
+++ b/impls/transport/p2p/src/lib.rs
@@ -63,6 +63,7 @@ pub struct HoprNetwork {
     store: Arc<crate::peer_store::NetworkPeerStore>,
     control: libp2p_stream::Control,
     protocol: libp2p::StreamProtocol,
+    event_rx: async_broadcast::InactiveReceiver<hopr_api::network::NetworkEvent>,
 }
 
 impl std::fmt::Debug for HoprNetwork {
@@ -109,6 +110,12 @@ impl NetworkView for HoprNetwork {
             2..4 => Health::Yellow,
             _ => Health::Green,
         }
+    }
+
+    fn subscribe_network_events(
+        &self,
+    ) -> impl futures::Stream<Item = hopr_api::network::NetworkEvent> + Send + 'static {
+        self.event_rx.clone().activate()
     }
 }
 

--- a/impls/transport/p2p/src/swarm.rs
+++ b/impls/transport/p2p/src/swarm.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use dashmap::DashSet;
 use futures::{FutureExt, Stream, StreamExt, stream::BoxStream};
-use hopr_api::{Multiaddr, OffchainKeypair, network::NetworkBuilder};
+use hopr_api::{Multiaddr, OffchainKeypair, network::BoxedProcessFn};
 use hopr_network_types::prelude::is_public_address;
 use libp2p::{
     autonat,
@@ -167,17 +167,12 @@ pub struct InactiveConfiguredNetwork {
     swarm: libp2p::Swarm<HoprNetworkBehavior>,
 }
 
-/// Builder of the network view and an actual background process running the libp2p core
-/// event processing loop.
+/// Factory for constructing the libp2p network and its background process.
 ///
-/// This object is primarily constructed to allow delayed starting of the background process,
-/// as well as setup all the interconnections with the underlying network views to allow complex
-/// functionality and signalling.
+/// Accepts a peer discovery stream and produces a [`HoprNetwork`] + background
+/// process function. The network supports event subscription via
+/// [`NetworkView::subscribe_network_events`](hopr_api::network::NetworkView::subscribe_network_events).
 pub struct HoprLibp2pNetworkBuilder {
-    subscribtions: (
-        async_broadcast::Sender<hopr_api::network::NetworkEvent>,
-        async_broadcast::InactiveReceiver<hopr_api::network::NetworkEvent>,
-    ),
     bootstrap: std::pin::Pin<Box<dyn Stream<Item = PeerDiscovery> + Send + Sync>>,
 }
 
@@ -186,18 +181,9 @@ impl HoprLibp2pNetworkBuilder {
     where
         T: Stream<Item = PeerDiscovery> + Send + Sync + 'static,
     {
-        let (tx, rx) = async_broadcast::broadcast(1000);
         Self {
-            subscribtions: (tx, rx.deactivate()),
             bootstrap: Box::pin(bootstrap),
         }
-    }
-
-    pub fn subscribe_network_events(
-        &self,
-    ) -> impl futures::Stream<Item = hopr_api::network::NetworkEvent> + Send + Sync + 'static {
-        let rx = self.subscribtions.1.clone();
-        rx.activate()
     }
 }
 
@@ -207,17 +193,18 @@ impl std::fmt::Debug for HoprLibp2pNetworkBuilder {
     }
 }
 
-#[async_trait::async_trait]
-impl NetworkBuilder for HoprLibp2pNetworkBuilder {
-    type Network = HoprNetwork;
-
-    async fn build(
+impl HoprLibp2pNetworkBuilder {
+    /// Build the network and return it along with its background process.
+    ///
+    /// The returned [`HoprNetwork`] supports event subscription — subscribe
+    /// before starting the process to avoid missing events.
+    pub async fn build(
         self,
         identity: &OffchainKeypair,
         my_multiaddresses: Vec<Multiaddr>,
         protocol: &'static str,
         allow_private_addresses: bool,
-    ) -> std::result::Result<(Self::Network, hopr_api::network::BoxedProcessFn), impl std::error::Error> {
+    ) -> std::result::Result<(HoprNetwork, BoxedProcessFn), impl std::error::Error> {
         #[cfg(all(feature = "telemetry", not(test)))]
         {
             METRIC_NETWORK_HEALTH.set(0.0);
@@ -237,14 +224,15 @@ impl NetworkBuilder for HoprLibp2pNetworkBuilder {
         let store = crate::peer_store::NetworkPeerStore::new(me, my_multiaddresses.into_iter().collect());
         let tracker: Arc<DashSet<libp2p::PeerId>> = Default::default();
 
+        let (notifier, event_rx) = async_broadcast::broadcast(1000);
+
         let network = HoprNetwork {
             tracker: tracker.clone(),
             store: Arc::new(store.clone()),
             control: swarm.behaviour().streams.new_control(),
             protocol: libp2p::StreamProtocol::new(protocol),
+            event_rx: event_rx.deactivate(),
         };
-
-        let notifier = self.subscribtions.0.clone();
 
         #[cfg(all(feature = "telemetry", not(test)))]
         let network_inner = network.clone();

--- a/impls/transport/p2p/tests/p2p_transport_test.rs
+++ b/impls/transport/p2p/tests/p2p_transport_test.rs
@@ -11,10 +11,7 @@ use futures::{
     SinkExt, StreamExt,
     channel::mpsc::{Receiver, Sender},
 };
-use hopr_api::{
-    network::NetworkBuilder,
-    types::crypto::{keypairs::Keypair, prelude::OffchainKeypair},
-};
+use hopr_api::types::crypto::{keypairs::Keypair, prelude::OffchainKeypair};
 use hopr_platform::time::native::current_time;
 use hopr_transport_p2p::{HoprLibp2pNetworkBuilder, HoprNetwork, PeerDiscovery};
 use hopr_transport_probe::ping::PingQueryReplier;

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -52,7 +52,7 @@ use hopr_api::{
     chain::{ChainKeyOperations, ChainReadAccountOperations, ChainReadChannelOperations, ChainValues},
     ct::{CoverTrafficGeneration, ProbingTrafficGeneration},
     graph::{NetworkGraphUpdate, NetworkGraphView, traits::EdgeObservableRead},
-    network::{NetworkBuilder, NetworkStreamControl},
+    network::{BoxedProcessFn, NetworkStreamControl},
     types::primitive::prelude::*,
 };
 use hopr_async_runtime::{AbortableList, prelude::spawn, spawn_as_abortable};
@@ -341,10 +341,11 @@ where
     /// `HoprTransportProcess::BloomFilterSave`, `HoprTransportProcess::Swarm` and session-related
     /// processes and return join handles to the calling function. These processes are not started immediately but
     /// are waiting for a trigger from this piece of code.
-    pub async fn run<T, TFact, Ct, NetBuilder>(
+    pub async fn run<T, TFact, Ct>(
         &self,
         cover_traffic: Ct,
-        network_builder: NetBuilder,
+        network: Net,
+        network_process: BoxedProcessFn,
         ticket_events: T,
         ticket_factory: TFact,
         on_incoming_session: Sender<IncomingSession>,
@@ -359,7 +360,6 @@ where
         T: futures::Sink<hopr_api::node::TicketEvent> + Clone + Send + Unpin + 'static,
         T::Error: std::error::Error + Clone + Send,
         Ct: ProbingTrafficGeneration + CoverTrafficGeneration + Send + Sync + 'static,
-        NetBuilder: NetworkBuilder<Network = Net> + Send + Sync + 'static,
         TFact: TicketFactory + Clone + Send + Sync + 'static,
     {
         let mut processes = AbortableList::<HoprTransportProcess>::default();
@@ -369,19 +369,8 @@ where
 
         // -- transport medium
 
-        // NOTE: Private address filtering is implemented at multiple levels for defense-in-depth:
-        // 1. Discovery events are filtered before they reach the transport component
-        // 2. SwarmEvent::NewExternalAddrOfPeer events are filtered using is_public_address()
-        let allow_private_addresses = self.cfg.transport.prefer_local_addresses;
-        let (transport_network, transport_layer_process) = network_builder
-            .build(
-                &self.packet_key,
-                self.my_multiaddresses.clone(),
-                hopr_transport_protocol::CURRENT_HOPR_MSG_PROTOCOL,
-                allow_private_addresses,
-            )
-            .await
-            .map_err(|e| HoprTransportError::Api(e.to_string()))?;
+        let transport_network = network;
+        let transport_layer_process = network_process;
 
         let msg_codec = hopr_transport_protocol::HoprBinaryCodec {};
         let (wire_msg_tx, wire_msg_rx) =
@@ -935,6 +924,15 @@ where
 
     fn health(&self) -> Health {
         self.network.get().map(|n| n.health()).unwrap_or(Health::Red)
+    }
+
+    fn subscribe_network_events(
+        &self,
+    ) -> impl futures::Stream<Item = hopr_api::network::NetworkEvent> + Send + 'static {
+        match self.network.get() {
+            Some(n) => futures::future::Either::Left(n.subscribe_network_events()),
+            None => futures::future::Either::Right(futures::stream::empty()),
+        }
     }
 }
 

--- a/transport/api/tests/stubs/mod.rs
+++ b/transport/api/tests/stubs/mod.rs
@@ -230,6 +230,12 @@ impl NetworkView for StubNet {
     fn health(&self) -> Health {
         Health::Red
     }
+
+    fn subscribe_network_events(
+        &self,
+    ) -> impl futures::Stream<Item = hopr_api::network::NetworkEvent> + Send + 'static {
+        futures::stream::empty()
+    }
 }
 
 #[async_trait]


### PR DESCRIPTION
## Summary

- Move `HoprSessionServer` trait from `hopr-lib/src/traits.rs` to `hopr-api` behind `node-session-server` feature
- Trait uses associated types (`Session`, `Error`) to keep transport-level types out of hopr-api
- Remove `Srv` from `HoprBuilder` generics (5→4 type params) — session server is no longer a builder concern
- `build_edge()`/`build_full()` return `BuiltNode { node, session_rx }` — caller wires session server externally
- Bump hopr-api to latest which includes: HoprSessionServer trait, removed `impl TicketManagement for ()`, `auto_impl` on HasTicketManagement
- Update all consumers to import `HoprSessionServer` directly from `hopr_lib::api::node`