### PR TITLE
refactor: use per-session HoprSessionConfigurator in REST API

### DIFF
--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -514,25 +514,6 @@ where
 }
 
 impl<Chain, Graph, Net, TMgr> Hopr<Chain, Graph, Net, TMgr> {
-    /// Gets the SURB balancer configuration of a session by its ID.
-    pub async fn get_session_surb_balancer_config(&self, id: &SessionId) -> errors::Result<Option<SurbBalancerConfig>> {
-        Ok(self.transport_api.get_session_surb_balancer_config(id).await?)
-    }
-
-    /// Updates the SURB balancer configuration of a session by its ID.
-    pub async fn update_session_surb_balancer_config(
-        &self,
-        id: &SessionId,
-        config: SurbBalancerConfig,
-    ) -> errors::Result<()> {
-        Ok(self
-            .transport_api
-            .update_session_surb_balancer_config(id, config)
-            .await?)
-    }
-}
-
-impl<Chain, Graph, Net, TMgr> Hopr<Chain, Graph, Net, TMgr> {
     /// Prometheus formatted metrics collected by the hopr-lib components.
     pub fn collect_hopr_metrics() -> errors::Result<String> {
         cfg_if::cfg_if! {

--- a/hoprd/rest-api/src/session.rs
+++ b/hoprd/rest-api/src/session.rs
@@ -8,8 +8,7 @@ use axum::{
 use base64::Engine;
 use hopr_lib::{
     Address, HopRouting, HoprSessionClientConfig, SESSION_MTU, SURB_SIZE, ServiceId, SessionCapabilities, SessionId,
-    SessionManagerError, SessionTarget, SurbBalancerConfig, TransportSessionError,
-    errors::{HoprLibError, HoprTransportError},
+    SessionTarget, SurbBalancerConfig, errors::HoprLibError,
 };
 use hopr_utils_session::{ListenerId, build_binding_host, create_tcp_client_binding, create_udp_client_binding};
 use serde::{Deserialize, Serialize};

--- a/hoprd/rest-api/src/session.rs
+++ b/hoprd/rest-api/src/session.rs
@@ -654,15 +654,24 @@ pub(crate) async fn adjust_session(
         SessionId::from_str(&session_id).map_err(|_| (StatusCode::BAD_REQUEST, ApiErrorStatus::InvalidSessionId))?;
 
     if let Some(cfg) = Option::<SurbBalancerConfig>::from(args) {
-        match state.hopr.update_session_surb_balancer_config(&session_id, cfg).await {
-            Ok(_) => Ok::<_, (StatusCode, ApiErrorStatus)>((StatusCode::NO_CONTENT, "").into_response()),
-            Err(HoprLibError::TransportError(HoprTransportError::Session(TransportSessionError::Manager(
-                SessionManagerError::NonExistingSession,
-            )))) => Err((StatusCode::NOT_FOUND, ApiErrorStatus::SessionNotFound)),
-            Err(e) => Err((
-                StatusCode::NOT_ACCEPTABLE,
-                ApiErrorStatus::UnknownFailure(e.to_string()),
-            )),
+        // Find the configurator for this session across all listeners
+        let configurator = state.open_listeners.0.iter().find_map(|entry| {
+            entry
+                .value()
+                .get_clients()
+                .get(&session_id)
+                .map(|client| client.value().2.clone())
+        });
+
+        match configurator {
+            Some(configurator) => match configurator.update_surb_balancer_config(cfg).await {
+                Ok(_) => Ok::<_, (StatusCode, ApiErrorStatus)>((StatusCode::NO_CONTENT, "").into_response()),
+                Err(e) => Err((
+                    StatusCode::NOT_ACCEPTABLE,
+                    ApiErrorStatus::UnknownFailure(e.to_string()),
+                )),
+            },
+            None => Err((StatusCode::NOT_FOUND, ApiErrorStatus::SessionNotFound)),
         }
     } else {
         Err::<_, (StatusCode, ApiErrorStatus)>((StatusCode::BAD_REQUEST, ApiErrorStatus::InvalidInput))
@@ -696,15 +705,27 @@ pub(crate) async fn session_config(
     let session_id =
         SessionId::from_str(&session_id).map_err(|_| (StatusCode::BAD_REQUEST, ApiErrorStatus::InvalidSessionId))?;
 
-    match state.hopr.get_session_surb_balancer_config(&session_id).await {
-        Ok(Some(cfg)) => {
-            Ok::<_, (StatusCode, ApiErrorStatus)>((StatusCode::OK, Json(SessionConfig::from(cfg))).into_response())
-        }
-        Ok(None) => Err((StatusCode::NOT_FOUND, ApiErrorStatus::SessionNotFound)),
-        Err(e) => Err((
-            StatusCode::UNPROCESSABLE_ENTITY,
-            ApiErrorStatus::UnknownFailure(e.to_string()),
-        )),
+    // Find the configurator for this session across all listeners
+    let configurator = state.open_listeners.0.iter().find_map(|entry| {
+        entry
+            .value()
+            .get_clients()
+            .get(&session_id)
+            .map(|client| client.value().2.clone())
+    });
+
+    match configurator {
+        Some(configurator) => match configurator.get_surb_balancer_config().await {
+            Ok(Some(cfg)) => {
+                Ok::<_, (StatusCode, ApiErrorStatus)>((StatusCode::OK, Json(SessionConfig::from(cfg))).into_response())
+            }
+            Ok(None) => Err((StatusCode::NOT_FOUND, ApiErrorStatus::SessionNotFound)),
+            Err(e) => Err((
+                StatusCode::UNPROCESSABLE_ENTITY,
+                ApiErrorStatus::UnknownFailure(e.to_string()),
+            )),
+        },
+        None => Err((StatusCode::NOT_FOUND, ApiErrorStatus::SessionNotFound)),
     }
 }
 

--- a/hoprd/rest-api/src/session.rs
+++ b/hoprd/rest-api/src/session.rs
@@ -654,14 +654,7 @@ pub(crate) async fn adjust_session(
         SessionId::from_str(&session_id).map_err(|_| (StatusCode::BAD_REQUEST, ApiErrorStatus::InvalidSessionId))?;
 
     if let Some(cfg) = Option::<SurbBalancerConfig>::from(args) {
-        // Find the configurator for this session across all listeners
-        let configurator = state.open_listeners.0.iter().find_map(|entry| {
-            entry
-                .value()
-                .get_clients()
-                .get(&session_id)
-                .map(|client| client.value().2.clone())
-        });
+        let configurator = state.open_listeners.find_configurator(&session_id);
 
         match configurator {
             Some(configurator) => match configurator.update_surb_balancer_config(cfg).await {

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -840,24 +840,6 @@ where
     }
 }
 
-impl<Chain, Graph, Net> HoprTransport<Chain, Graph, Net> {
-    /// Gets the SURB balancer configuration of a session by its ID.
-    ///
-    /// Returns `Ok(None)` if the session does not use a SURB balancer.
-    pub async fn get_session_surb_balancer_config(&self, id: &SessionId) -> errors::Result<Option<SurbBalancerConfig>> {
-        Ok(self.smgr.get_surb_balancer_config(id).await?)
-    }
-
-    /// Updates the SURB balancer configuration of a session by its ID.
-    pub async fn update_session_surb_balancer_config(
-        &self,
-        id: &SessionId,
-        config: SurbBalancerConfig,
-    ) -> errors::Result<()> {
-        Ok(self.smgr.update_surb_balancer_config(id, config).await?)
-    }
-}
-
 fn build_mixer_cfg_from_env() -> MixerConfig {
     let mixer_cfg = MixerConfig {
         min_delay: std::time::Duration::from_millis(

--- a/utils/session/src/lib.rs
+++ b/utils/session/src/lib.rs
@@ -192,6 +192,19 @@ impl std::fmt::Display for ListenerId {
 #[derive(Default)]
 pub struct ListenerJoinHandles(pub DashMap<ListenerId, StoredSessionEntry>);
 
+impl ListenerJoinHandles {
+    /// Finds the [`HoprSessionConfigurator`] for the given session ID across all listeners.
+    pub fn find_configurator(&self, session_id: &SessionId) -> Option<HoprSessionConfigurator> {
+        self.0.iter().find_map(|entry| {
+            entry
+                .value()
+                .get_clients()
+                .get(session_id)
+                .map(|client| client.value().2.clone())
+        })
+    }
+}
+
 impl Abortable for ListenerJoinHandles {
     fn abort_task(&self) {
         self.0.alter_all(|_, v| {

--- a/utils/session/src/lib.rs
+++ b/utils/session/src/lib.rs
@@ -143,11 +143,11 @@ pub struct StoredSessionEntry {
     /// The abort handle for the Session processing.
     pub abort_handle: AbortHandle,
 
-    clients: Arc<DashMap<SessionId, (SocketAddr, AbortHandle)>>,
+    clients: Arc<DashMap<SessionId, (SocketAddr, AbortHandle, HoprSessionConfigurator)>>,
 }
 
 impl StoredSessionEntry {
-    pub fn get_clients(&self) -> &Arc<DashMap<SessionId, (SocketAddr, AbortHandle)>> {
+    pub fn get_clients(&self) -> &Arc<DashMap<SessionId, (SocketAddr, AbortHandle, HoprSessionConfigurator)>> {
         &self.clients
     }
 }
@@ -304,10 +304,8 @@ impl SessionPool {
         }
     }
 
-    pub fn pop(&mut self) -> Option<HoprSession> {
-        self.pool
-            .as_ref()
-            .and_then(|pool| pool.lock().pop_front().map(|(session, _)| session))
+    pub fn pop(&mut self) -> Option<(HoprSession, HoprSessionConfigurator)> {
+        self.pool.as_ref().and_then(|pool| pool.lock().pop_front())
     }
 }
 
@@ -398,7 +396,7 @@ where
                 let active_sessions = active_sessions_clone_2.clone();
 
                 // Try to pop from the pool only if a client was accepted
-                let maybe_pooled_session = accepted_client.is_ok().then(|| session_pool.pop()).flatten();
+                let maybe_pooled = accepted_client.is_ok().then(|| session_pool.pop()).flatten();
                 async move {
                     match accepted_client {
                         Ok((sock_addr, mut stream)) => {
@@ -416,15 +414,15 @@ where
                             }
 
                             // See if we still have some session pooled
-                            let session = match maybe_pooled_session {
-                                Some(s) => {
+                            let (session, configurator) = match maybe_pooled {
+                                Some((s, c)) => {
                                     debug!(session_id = %s.id(), "using pooled session");
-                                    s
+                                    (s, c)
                                 }
                                 None => {
                                     debug!("no more active sessions in the pool, creating a new one");
                                     match hopr.connect_to(destination, target, data).await {
-                                        Ok((s, _configurator)) => s,
+                                        Ok((s, c)) => (s, c),
                                         Err(error) => {
                                             error!(%error, "failed to establish session");
                                             return;
@@ -437,7 +435,7 @@ where
                             debug!(?sock_addr, %session_id, "new session for incoming TCP connection");
 
                             let (abort_handle, abort_reg) = AbortHandle::new_pair();
-                            active_sessions.insert(session_id, (sock_addr, abort_handle));
+                            active_sessions.insert(session_id, (sock_addr, abort_handle, configurator));
 
                             #[cfg(all(feature = "telemetry", not(test)))]
                             METRIC_ACTIVE_CLIENTS.increment(&["tcp"], 1.0);
@@ -467,7 +465,7 @@ where
 
         // Once the listener is done, abort all active sessions created by the listener
         active_sessions_clone.iter().for_each(|entry| {
-            let (sock_addr, handle) = entry.value();
+            let (sock_addr, handle, _) = entry.value();
             debug!(session_id = %entry.key(), ?sock_addr, "aborting opened TCP session after listener has been closed");
             handle.abort()
         });
@@ -545,7 +543,7 @@ where
         .map_err(|e| BindError::UnknownFailure(e.to_string()))?;
 
     // Create a single session for the UDP socket
-    let (session, _configurator) = hopr
+    let (session, configurator) = hopr
         .connect_to(destination, target, config.clone())
         .await
         .map_err(|e| BindError::UnknownFailure(e.to_string()))?;
@@ -569,7 +567,7 @@ where
 
     // TODO: add multiple client support to UDP sessions (#7370)
     let session_id = *session.id();
-    clients.insert(session_id, (bind_host, abort_handle.clone()));
+    clients.insert(session_id, (bind_host, abort_handle.clone(), configurator));
     hopr_async_runtime::prelude::spawn(async move {
         #[cfg(all(feature = "telemetry", not(test)))]
         METRIC_ACTIVE_CLIENTS.increment(&["udp"], 1.0);

--- a/utils/session/src/lib.rs
+++ b/utils/session/src/lib.rs
@@ -872,6 +872,46 @@ mod tests {
         Ok(())
     }
 
+    fn stub_stored_entry() -> StoredSessionEntry {
+        let (abort_handle, _) = AbortHandle::new_pair();
+        StoredSessionEntry {
+            destination: Address::default(),
+            target: SessionTargetSpec::Plain("localhost:8080".into()),
+            forward_path: RoutingOptions::Hops(Default::default()),
+            return_path: RoutingOptions::Hops(Default::default()),
+            max_client_sessions: 5,
+            max_surb_upstream: None,
+            response_buffer: None,
+            session_pool: None,
+            abort_handle,
+            clients: Arc::new(DashMap::new()),
+        }
+    }
+
+    #[test]
+    fn find_configurator_should_return_none_when_no_listeners() {
+        let handles = ListenerJoinHandles::default();
+        let session_id = SessionId::new(1234u64, HoprPseudonym::random());
+        assert!(handles.find_configurator(&session_id).is_none());
+    }
+
+    #[test]
+    fn find_configurator_should_return_none_when_session_not_tracked() {
+        let handles = ListenerJoinHandles::default();
+        let listener_id = ListenerId(IpProtocol::TCP, "127.0.0.1:9091".parse().unwrap());
+        handles.0.insert(listener_id, stub_stored_entry());
+
+        let session_id = SessionId::new(5678u64, HoprPseudonym::random());
+        assert!(handles.find_configurator(&session_id).is_none());
+    }
+
+    #[test]
+    fn stored_session_entry_clients_should_start_empty() {
+        let entry = stub_stored_entry();
+        assert!(entry.get_clients().is_empty());
+        assert_eq!(entry.max_client_sessions, 5);
+    }
+
     #[test]
     fn build_binding_address() {
         let default = "10.0.0.1:10000".parse().unwrap();


### PR DESCRIPTION
## Summary

- Store `HoprSessionConfigurator` alongside each session in the clients DashMap
- REST API session config endpoints (`adjust_session`, `session_config`) look up the per-session configurator instead of using old Hopr-level methods
- Remove `Hopr::get_session_surb_balancer_config` and `Hopr::update_session_surb_balancer_config` — no longer needed
- `SessionPool::pop()` now returns `(HoprSession, HoprSessionConfigurator)` instead of discarding the configurator
- Both TCP and UDP session creation store the configurator in the clients map