### PR TITLE
refactor(path): unify edge scoring defaults through PathPlannerConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2439,7 +2439,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2805,7 +2805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4932,6 +4932,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "validator",
 ]
 
 [[package]]
@@ -5884,7 +5885,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8419,7 +8420,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8461,9 +8462,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -9354,7 +9355,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10433,7 +10434,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4514,7 +4514,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-network-graph"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assertables",
@@ -4912,7 +4912,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-path"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "bimap",

--- a/hopr/reference/src/lib.rs
+++ b/hopr/reference/src/lib.rs
@@ -187,7 +187,12 @@ where
     }
 
     let prober_cfg = probe_cfg.unwrap_or_default();
-    let graph: SharedChannelGraph = Arc::new(ChannelGraph::new(*packet_key.public()));
+    let path_cfg = config.protocol.path_planner;
+    let graph: SharedChannelGraph = Arc::new(ChannelGraph::with_edge_params(
+        *packet_key.public(),
+        path_cfg.edge_penalty,
+        path_cfg.min_ack_rate,
+    ));
     let graph_for_ct = graph.clone();
 
     let safe_address = config.safe_module.safe_address;

--- a/impls/graph/Cargo.toml
+++ b/impls/graph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-network-graph"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Implementation of the HOPR network graph."
 edition.workspace = true

--- a/impls/graph/benches/traverse.rs
+++ b/impls/graph/benches/traverse.rs
@@ -10,9 +10,11 @@ use hopr_api::{
     },
     types::crypto::prelude::Keypair,
 };
-use hopr_network_graph::{ChannelGraph, DEFAULT_EDGE_PENALTY};
+use hopr_network_graph::ChannelGraph;
+
+const BENCH_EDGE_PENALTY: f64 = 0.5;
 /// Intentionally 0.0 for benchmarks (no ack filtering).
-const DEFAULT_MIN_ACK_RATE: f64 = 0.0;
+const BENCH_MIN_ACK_RATE: f64 = 0.0;
 
 // ── Graph construction helpers ───────────────────────────────────────────────
 
@@ -128,8 +130,8 @@ fn bench_simple_paths(c: &mut Criterion) {
                         Some(10),
                         EdgeValueFn::forward(
                             std::num::NonZeroUsize::new(2).expect("is greater than 1"),
-                            DEFAULT_EDGE_PENALTY,
-                            DEFAULT_MIN_ACK_RATE,
+                            BENCH_EDGE_PENALTY,
+                            BENCH_MIN_ACK_RATE,
                         ),
                     ))
                 });
@@ -144,8 +146,8 @@ fn bench_simple_paths(c: &mut Criterion) {
                         Some(10),
                         EdgeValueFn::forward(
                             std::num::NonZeroUsize::new(3).expect("is greater than 1"),
-                            DEFAULT_EDGE_PENALTY,
-                            DEFAULT_MIN_ACK_RATE,
+                            BENCH_EDGE_PENALTY,
+                            BENCH_MIN_ACK_RATE,
                         ),
                     ))
                 });
@@ -160,8 +162,8 @@ fn bench_simple_paths(c: &mut Criterion) {
                         Some(10),
                         EdgeValueFn::forward(
                             std::num::NonZeroUsize::new(4).expect("is greater than 1"),
-                            DEFAULT_EDGE_PENALTY,
-                            DEFAULT_MIN_ACK_RATE,
+                            BENCH_EDGE_PENALTY,
+                            BENCH_MIN_ACK_RATE,
                         ),
                     ))
                 });

--- a/impls/graph/src/lib.rs
+++ b/impls/graph/src/lib.rs
@@ -32,12 +32,6 @@ use hopr_api::OffchainPublicKey;
 pub use petgraph::*;
 pub use weight::Observations;
 
-/// Default penalty multiplier for edges lacking probe-based quality observations.
-pub const DEFAULT_EDGE_PENALTY: f64 = 0.5;
-
-/// Default minimum acceptable message acknowledgment rate for path selection.
-pub const DEFAULT_MIN_ACK_RATE: f64 = 0.1;
-
 /// A thread-safe, shareable handle to a [`ChannelGraph`].
 ///
 /// This is a convenience alias. Since [`ChannelGraph`] uses interior mutability,

--- a/impls/graph/src/petgraph/graph.rs
+++ b/impls/graph/src/petgraph/graph.rs
@@ -5,7 +5,7 @@ use hopr_api::OffchainPublicKey;
 use parking_lot::RwLock;
 use petgraph::graph::{DiGraph, NodeIndex};
 
-use crate::{DEFAULT_EDGE_PENALTY, DEFAULT_MIN_ACK_RATE, Observations, errors::ChannelGraphError};
+use crate::{Observations, errors::ChannelGraphError};
 
 /// Internal mutable state of a [`ChannelGraph`], protected by a lock.
 #[derive(Debug, Clone, Default)]
@@ -34,12 +34,16 @@ pub struct ChannelGraph {
 }
 
 impl ChannelGraph {
-    /// Creates a new channel graph with the given self identity and default edge scoring parameters.
+    /// Creates a new channel graph with the given self identity and default edge scoring
+    /// parameters (edge_penalty = 0.5, min_ack_rate = 0.1).
     ///
     /// The `me` key represents the local node which is automatically added
     /// to the graph as the first node.
+    ///
+    /// Production code should prefer [`with_edge_params`](Self::with_edge_params) to
+    /// receive values from [`PathPlannerConfig`](hopr_transport_path::PathPlannerConfig).
     pub fn new(me: OffchainPublicKey) -> Self {
-        Self::with_edge_params(me, DEFAULT_EDGE_PENALTY, DEFAULT_MIN_ACK_RATE)
+        Self::with_edge_params(me, 0.5, 0.1)
     }
 
     /// Creates a new channel graph with custom edge scoring parameters.

--- a/impls/graph/src/petgraph/graph.rs
+++ b/impls/graph/src/petgraph/graph.rs
@@ -41,7 +41,7 @@ impl ChannelGraph {
     /// to the graph as the first node.
     ///
     /// Production code should prefer [`with_edge_params`](Self::with_edge_params) to
-    /// receive values from [`PathPlannerConfig`](hopr_transport_path::PathPlannerConfig).
+    /// receive values from `PathPlannerConfig`.
     pub fn new(me: OffchainPublicKey) -> Self {
         Self::with_edge_params(me, 0.5, 0.1)
     }

--- a/impls/graph/src/petgraph/graph.rs
+++ b/impls/graph/src/petgraph/graph.rs
@@ -5,7 +5,7 @@ use hopr_api::OffchainPublicKey;
 use parking_lot::RwLock;
 use petgraph::graph::{DiGraph, NodeIndex};
 
-use crate::{Observations, errors::ChannelGraphError};
+use crate::{DEFAULT_EDGE_PENALTY, DEFAULT_MIN_ACK_RATE, Observations, errors::ChannelGraphError};
 
 /// Internal mutable state of a [`ChannelGraph`], protected by a lock.
 #[derive(Debug, Clone, Default)]
@@ -28,15 +28,26 @@ pub(crate) struct InnerGraph {
 #[derive(Debug, Clone)]
 pub struct ChannelGraph {
     pub(crate) me: OffchainPublicKey,
+    pub(crate) edge_penalty: f64,
+    pub(crate) min_ack_rate: f64,
     pub(crate) inner: Arc<RwLock<InnerGraph>>,
 }
 
 impl ChannelGraph {
-    /// Creates a new channel graph with the given self identity.
+    /// Creates a new channel graph with the given self identity and default edge scoring parameters.
     ///
     /// The `me` key represents the local node which is automatically added
     /// to the graph as the first node.
     pub fn new(me: OffchainPublicKey) -> Self {
+        Self::with_edge_params(me, DEFAULT_EDGE_PENALTY, DEFAULT_MIN_ACK_RATE)
+    }
+
+    /// Creates a new channel graph with custom edge scoring parameters.
+    ///
+    /// * `me` – offchain public key of the local node (added as the first graph node).
+    /// * `edge_penalty` – penalty multiplier for edges lacking probe-based quality observations.
+    /// * `min_ack_rate` – minimum acceptable message acknowledgment rate for path selection.
+    pub fn with_edge_params(me: OffchainPublicKey, edge_penalty: f64, min_ack_rate: f64) -> Self {
         let mut graph = DiGraph::new();
         let mut indices = BiHashMap::new();
 
@@ -45,6 +56,8 @@ impl ChannelGraph {
 
         Self {
             me,
+            edge_penalty,
+            min_ack_rate,
             inner: Arc::new(RwLock::new(InnerGraph { graph, indices })),
         }
     }

--- a/impls/graph/src/petgraph/traverse.rs
+++ b/impls/graph/src/petgraph/traverse.rs
@@ -10,9 +10,7 @@ use hopr_api::{
 };
 use petgraph::graph::NodeIndex;
 
-use crate::{
-    ChannelGraph, DEFAULT_EDGE_PENALTY, DEFAULT_MIN_ACK_RATE, algorithm::all_simple_paths_multi, graph::InnerGraph,
-};
+use crate::{ChannelGraph, algorithm::all_simple_paths_multi, graph::InnerGraph};
 
 /// A shared cost function that computes a cumulative cost from edge observations.
 pub(crate) type SharedValueFn<C> = Arc<dyn Fn(C, &crate::Observations, usize) -> C + Send + Sync>;
@@ -160,7 +158,7 @@ impl hopr_api::graph::NetworkGraphTraverse for ChannelGraph {
                     })
                     .collect::<HashSet<_>>();
 
-                let value_fn = EdgeValueFn::forward_without_self_loopback(DEFAULT_EDGE_PENALTY, DEFAULT_MIN_ACK_RATE);
+                let value_fn = EdgeValueFn::forward_without_self_loopback(self.edge_penalty, self.min_ack_rate);
 
                 return find_paths(
                     &inner,

--- a/transport/api/src/config.rs
+++ b/transport/api/src/config.rs
@@ -47,6 +47,7 @@ pub struct HoprProtocolConfig {
     #[cfg_attr(feature = "serde", serde(default))]
     pub session: SessionGlobalConfig,
     /// Path planner configuration
+    #[validate(nested)]
     #[cfg_attr(feature = "serde", serde(skip))]
     pub path_planner: hopr_transport_path::PathPlannerConfig,
     /// Interval at which per-peer protocol conformance counters are flushed

--- a/transport/api/src/lib.rs
+++ b/transport/api/src/lib.rs
@@ -266,7 +266,13 @@ where
     ) -> errors::Result<Self> {
         let me_offchain = *identity.1.public();
         let planner_config = cfg.path_planner;
-        let selector = HoprGraphPathSelector::new(me_offchain, graph.clone(), planner_config.max_cached_paths);
+        let selector = HoprGraphPathSelector::new(
+            me_offchain,
+            graph.clone(),
+            planner_config.max_cached_paths,
+            planner_config.edge_penalty,
+            planner_config.min_ack_rate,
+        );
 
         let tag_allocators = hopr_transport_tag_allocator::create_allocators_from_config(&cfg.session.tag_allocator)?;
 

--- a/transport/path/Cargo.toml
+++ b/transport/path/Cargo.toml
@@ -22,6 +22,7 @@ moka = { workspace = true }
 smart-default = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+validator = { workspace = true }
 
 hopr-api = { workspace = true, features = ["chain", "graph"] }
 hopr-statistics = { workspace = true, features = ["weighted"] }

--- a/transport/path/Cargo.toml
+++ b/transport/path/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-path"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Graph-based path planning and selection for the HOPR transport layer"
 edition = "2024"

--- a/transport/path/src/planner.rs
+++ b/transport/path/src/planner.rs
@@ -44,6 +44,14 @@ pub struct PathPlannerConfig {
     /// All returned candidates are validated and cached.
     #[default = 8]
     pub max_cached_paths: usize,
+    /// Penalty multiplier for edges lacking probe-based quality observations.
+    /// Applied during path cost evaluation to down-weight unprobed edges.
+    #[default = 0.5]
+    pub edge_penalty: f64,
+    /// Minimum acceptable message acknowledgment rate for path selection.
+    /// Edges with an ack rate below this threshold are excluded from candidate paths.
+    #[default = 0.1]
+    pub min_ack_rate: f64,
 }
 
 /// Cache key for the path planner: `(source, destination, hops)`.
@@ -558,6 +566,7 @@ mod tests {
             cache_ttl: std::time::Duration::from_secs(60),
             refresh_period: std::time::Duration::from_secs(60),
             max_cached_paths: 2,
+            ..PathPlannerConfig::default()
         }
     }
 
@@ -570,7 +579,8 @@ mod tests {
 
         // Build empty graph (no edges) — selector would fail if called.
         let graph = ChannelGraph::new(me);
-        let selector = HoprGraphPathSelector::new(me, graph, small_config().max_cached_paths);
+        let cfg = small_config();
+        let selector = HoprGraphPathSelector::new(me, graph, cfg.max_cached_paths, cfg.edge_penalty, cfg.min_ack_rate);
 
         let chain_api = TestChainApi::new(me, me_addr(), vec![(dest, dest_addr())]);
         let surb_store = hopr_protocol_hopr::MemorySurbStore::default();
@@ -616,7 +626,8 @@ mod tests {
         mark_edge_full(&graph, &me, &a);
         mark_edge_last(&graph, &a, &dest);
 
-        let selector = HoprGraphPathSelector::new(me, graph, small_config().max_cached_paths);
+        let cfg = small_config();
+        let selector = HoprGraphPathSelector::new(me, graph, cfg.max_cached_paths, cfg.edge_penalty, cfg.min_ack_rate);
 
         let chain_api = TestChainApi::new(me, me_addr(), vec![(a, a_addr()), (dest, dest_addr())])
             .with_open_channel(me_addr(), a_addr())
@@ -655,7 +666,8 @@ mod tests {
 
         // Empty graph — selector would fail; explicit path should not use it.
         let graph = ChannelGraph::new(me);
-        let selector = HoprGraphPathSelector::new(me, graph, small_config().max_cached_paths);
+        let cfg = small_config();
+        let selector = HoprGraphPathSelector::new(me, graph, cfg.max_cached_paths, cfg.edge_penalty, cfg.min_ack_rate);
 
         let chain_api = TestChainApi::new(me, me_addr(), vec![(a, a_addr()), (dest, dest_addr())])
             .with_open_channel(me_addr(), a_addr())
@@ -689,7 +701,8 @@ mod tests {
     async fn return_routing_without_surb_should_return_error() {
         let me = pubkey(&SECRET_ME);
         let graph = ChannelGraph::new(me);
-        let selector = HoprGraphPathSelector::new(me, graph, small_config().max_cached_paths);
+        let cfg = small_config();
+        let selector = HoprGraphPathSelector::new(me, graph, cfg.max_cached_paths, cfg.edge_penalty, cfg.min_ack_rate);
         let chain_api = TestChainApi::new(me, me_addr(), vec![]);
         let surb_store = hopr_protocol_hopr::MemorySurbStore::default();
 
@@ -723,7 +736,8 @@ mod tests {
         mark_edge_full(&graph, &me, &a);
         mark_edge_last(&graph, &a, &dest);
 
-        let selector = HoprGraphPathSelector::new(me, graph, small_config().max_cached_paths);
+        let cfg = small_config();
+        let selector = HoprGraphPathSelector::new(me, graph, cfg.max_cached_paths, cfg.edge_penalty, cfg.min_ack_rate);
         let chain_api = TestChainApi::new(me, me_addr(), vec![(a, a_addr()), (dest, dest_addr())])
             .with_open_channel(me_addr(), a_addr())
             .with_open_channel(a_addr(), dest_addr());
@@ -768,7 +782,8 @@ mod tests {
         mark_edge_full(&graph, &me, &a);
         mark_edge_last(&graph, &a, &dest);
 
-        let selector = HoprGraphPathSelector::new(me, graph, small_config().max_cached_paths);
+        let cfg = small_config();
+        let selector = HoprGraphPathSelector::new(me, graph, cfg.max_cached_paths, cfg.edge_penalty, cfg.min_ack_rate);
         let chain_api = TestChainApi::new(me, me_addr(), vec![(a, a_addr()), (dest, dest_addr())])
             .with_open_channel(me_addr(), a_addr())
             .with_open_channel(a_addr(), dest_addr());
@@ -803,7 +818,8 @@ mod tests {
     async fn background_refresh_should_produce_a_future() {
         let me = pubkey(&SECRET_ME);
         let graph = ChannelGraph::new(me);
-        let selector = HoprGraphPathSelector::new(me, graph, small_config().max_cached_paths);
+        let cfg = small_config();
+        let selector = HoprGraphPathSelector::new(me, graph, cfg.max_cached_paths, cfg.edge_penalty, cfg.min_ack_rate);
         let chain_api = TestChainApi::new(me, me_addr(), vec![]);
         let surb_store = hopr_protocol_hopr::MemorySurbStore::default();
 

--- a/transport/path/src/planner.rs
+++ b/transport/path/src/planner.rs
@@ -12,6 +12,7 @@ use hopr_types::{
     primitive::traits::ToHex,
 };
 use tracing::trace;
+use validator::{Validate, ValidationError};
 
 use crate::{
     errors::{PathPlannerError, Result},
@@ -28,7 +29,7 @@ lazy_static::lazy_static! {
 }
 
 /// Configuration for [`PathPlanner`]'s internal path cache.
-#[derive(Debug, Clone, Copy, PartialEq, smart_default::SmartDefault)]
+#[derive(Debug, Clone, Copy, PartialEq, smart_default::SmartDefault, Validate)]
 pub struct PathPlannerConfig {
     /// Maximum number of `(source, destination, options)` entries in the path cache.
     #[default = 10_000]
@@ -46,12 +47,24 @@ pub struct PathPlannerConfig {
     pub max_cached_paths: usize,
     /// Penalty multiplier for edges lacking probe-based quality observations.
     /// Applied during path cost evaluation to down-weight unprobed edges.
+    /// Must be finite and in `0.0..=1.0`.
     #[default = 0.5]
+    #[validate(custom(function = "validate_unit_interval"))]
     pub edge_penalty: f64,
     /// Minimum acceptable message acknowledgment rate for path selection.
     /// Edges with an ack rate below this threshold are excluded from candidate paths.
+    /// Must be finite and in `0.0..=1.0`.
     #[default = 0.1]
+    #[validate(custom(function = "validate_unit_interval"))]
     pub min_ack_rate: f64,
+}
+
+fn validate_unit_interval(value: f64) -> std::result::Result<(), ValidationError> {
+    if value.is_finite() && (0.0..=1.0).contains(&value) {
+        Ok(())
+    } else {
+        Err(ValidationError::new("value must be finite and in 0.0..=1.0"))
+    }
 }
 
 /// Cache key for the path planner: `(source, destination, hops)`.

--- a/transport/path/src/selector.rs
+++ b/transport/path/src/selector.rs
@@ -3,11 +3,6 @@ use hopr_api::graph::{
 };
 use hopr_types::{crypto::types::OffchainPublicKey, internal::errors::PathError};
 
-// Duplicated from hopr_network_graph::{DEFAULT_EDGE_PENALTY, DEFAULT_MIN_ACK_RATE}
-// — transport/path cannot depend on impls/graph to avoid circular deps.
-const DEFAULT_EDGE_PENALTY: f64 = 0.5;
-const DEFAULT_MIN_ACK_RATE: f64 = 0.1;
-
 use crate::{
     errors::{PathPlannerError, Result},
     traits::{PathSelector, PathWithCost},
@@ -50,62 +45,6 @@ where
         .collect::<Vec<_>>()
 }
 
-/// Extended forward path search: find shorter paths using [`EdgeValueFn::forward_without_self_loopback`]
-/// and append `dest` to each one.
-///
-/// This handles the case where the last edge (relay -> dest) has no graph edge
-/// (e.g. no payment channel) but the path planner can still assume the last hop
-/// is reachable. Paths already found by Phase 1 are excluded via `existing`.
-///
-/// The cost from the shorter traversal is preserved as-is — the missing last
-/// edge contributes a neutral `1.0` multiplier (no quality data available).
-fn compute_extended_forward_paths<G>(
-    graph: &G,
-    src: &OffchainPublicKey,
-    dest: &OffchainPublicKey,
-    shorter_length: std::num::NonZeroUsize,
-    take: usize,
-    existing: &[PathWithCost],
-) -> Vec<PathWithCost>
-where
-    G: NetworkGraphTraverse<NodeId = OffchainPublicKey> + NetworkGraphView<NodeId = OffchainPublicKey>,
-    <G as NetworkGraphTraverse>::Observed: EdgeObservableRead + Send + 'static,
-{
-    let raw = graph.simple_paths_from(
-        src,
-        shorter_length.get(),
-        Some(take),
-        EdgeValueFn::forward_without_self_loopback(DEFAULT_EDGE_PENALTY, DEFAULT_MIN_ACK_RATE),
-    );
-
-    raw.into_iter()
-        .filter_map(|(path, _, cost)| {
-            if cost <= 0.0 {
-                return None;
-            }
-
-            // Strip source and append dest.
-            let mut candidate: Vec<_> = path.into_iter().skip(1).collect();
-
-            // Ensure dest is not already in the path (would create a repeated node).
-            if candidate.contains(dest) {
-                return None;
-            }
-
-            candidate.push(*dest);
-
-            // Skip paths already found by Phase 1 (compare path component only).
-            if existing.iter().any(|pwc| pwc.path == candidate) {
-                return None;
-            }
-
-            tracing::trace!(?candidate, ?cost, "extended forward path candidate");
-            Some(PathWithCost { path: candidate, cost })
-        })
-        .take(take)
-        .collect()
-}
-
 /// A lightweight graph-backed path selector.
 ///
 /// Returns all candidate paths for a `(src, dest, hops)` query directly from
@@ -122,6 +61,8 @@ pub struct HoprGraphPathSelector<G> {
     me: OffchainPublicKey,
     graph: G,
     max_paths: usize,
+    edge_penalty: f64,
+    min_ack_rate: f64,
 }
 
 impl<G> HoprGraphPathSelector<G>
@@ -139,8 +80,68 @@ where
     /// * `me` – the planner's own offchain public key, used to determine path direction.
     /// * `graph` – the network graph to query.
     /// * `max_paths` – maximum number of candidate paths to return per query.
-    pub fn new(me: OffchainPublicKey, graph: G, max_paths: usize) -> Self {
-        Self { me, graph, max_paths }
+    /// * `edge_penalty` – penalty multiplier for edges lacking probe-based quality observations.
+    /// * `min_ack_rate` – minimum acceptable message acknowledgment rate for path selection.
+    pub fn new(me: OffchainPublicKey, graph: G, max_paths: usize, edge_penalty: f64, min_ack_rate: f64) -> Self {
+        Self {
+            me,
+            graph,
+            max_paths,
+            edge_penalty,
+            min_ack_rate,
+        }
+    }
+
+    /// Extended forward path search: find shorter paths using
+    /// [`EdgeValueFn::forward_without_self_loopback`] and append `dest` to each one.
+    ///
+    /// This handles the case where the last edge (relay -> dest) has no graph edge
+    /// (e.g. no payment channel) but the path planner can still assume the last hop
+    /// is reachable. Paths already found by Phase 1 are excluded via `existing`.
+    ///
+    /// The cost from the shorter traversal is preserved as-is — the missing last
+    /// edge contributes a neutral `1.0` multiplier (no quality data available).
+    fn compute_extended_forward_paths(
+        &self,
+        src: &OffchainPublicKey,
+        dest: &OffchainPublicKey,
+        shorter_length: std::num::NonZeroUsize,
+        take: usize,
+        existing: &[PathWithCost],
+    ) -> Vec<PathWithCost> {
+        let raw = self.graph.simple_paths_from(
+            src,
+            shorter_length.get(),
+            Some(take),
+            EdgeValueFn::forward_without_self_loopback(self.edge_penalty, self.min_ack_rate),
+        );
+
+        raw.into_iter()
+            .filter_map(|(path, _, cost)| {
+                if cost <= 0.0 {
+                    return None;
+                }
+
+                // Strip source and append dest.
+                let mut candidate: Vec<_> = path.into_iter().skip(1).collect();
+
+                // Ensure dest is not already in the path (would create a repeated node).
+                if candidate.contains(dest) {
+                    return None;
+                }
+
+                candidate.push(*dest);
+
+                // Skip paths already found by Phase 1 (compare path component only).
+                if existing.iter().any(|pwc| pwc.path == candidate) {
+                    return None;
+                }
+
+                tracing::trace!(?candidate, ?cost, "extended forward path candidate");
+                Some(PathWithCost { path: candidate, cost })
+            })
+            .take(take)
+            .collect()
     }
 }
 
@@ -181,7 +182,7 @@ where
                 &dest,
                 length,
                 self.max_paths,
-                EdgeValueFn::forward(length, DEFAULT_EDGE_PENALTY, DEFAULT_MIN_ACK_RATE),
+                EdgeValueFn::forward(length, self.edge_penalty, self.min_ack_rate),
             );
             tracing::debug!(
                 direction,
@@ -196,7 +197,7 @@ where
                 && let Some(shorter) = std::num::NonZeroUsize::new(length.get() - 1)
             {
                 let remaining = self.max_paths - found.len();
-                let extended = compute_extended_forward_paths(&self.graph, &src, &dest, shorter, remaining, &found);
+                let extended = self.compute_extended_forward_paths(&src, &dest, shorter, remaining, &found);
                 tracing::debug!(
                     direction,
                     phase = 2,
@@ -214,7 +215,7 @@ where
                 &dest,
                 length,
                 self.max_paths,
-                EdgeValueFn::returning(length, DEFAULT_EDGE_PENALTY, DEFAULT_MIN_ACK_RATE),
+                EdgeValueFn::returning(length, self.edge_penalty, self.min_ack_rate),
             );
             tracing::debug!(direction, count = found.len(), "[return] candidates");
             found
@@ -259,7 +260,16 @@ mod tests {
     };
 
     use super::*;
-    use crate::traits::PathSelector;
+    use crate::{PathPlannerConfig, traits::PathSelector};
+
+    fn test_selector(
+        me: OffchainPublicKey,
+        graph: ChannelGraph,
+        max_paths: usize,
+    ) -> HoprGraphPathSelector<ChannelGraph> {
+        let cfg = PathPlannerConfig::default();
+        HoprGraphPathSelector::new(me, graph, max_paths, cfg.edge_penalty, cfg.min_ack_rate)
+    }
 
     const SECRET_0: [u8; 32] = hex!("60741b83b99e36aa0c1331578156e16b8e21166d01834abb6c64b103f885734d");
     const SECRET_1: [u8; 32] = hex!("71bf1f42ebbfcd89c3e197a3fd7cda79b92499e509b6fefa0fe44d02821d146a");
@@ -323,7 +333,7 @@ mod tests {
         let unreachable = pubkey(&SECRET_1);
         let graph = ChannelGraph::new(me);
         // No edges at all — neither direction has a path.
-        let selector = HoprGraphPathSelector::new(me, graph, MAX_PATHS);
+        let selector = test_selector(me, graph, MAX_PATHS);
 
         let fwd = selector.select_path(me, unreachable, 1);
         assert!(fwd.is_err(), "forward: should error when destination is unreachable");
@@ -345,7 +355,7 @@ mod tests {
     #[tokio::test]
     async fn path_should_exclude_source() -> anyhow::Result<()> {
         let (me, _hop, dest, graph) = two_hop_graph();
-        let selector = HoprGraphPathSelector::new(me, graph, MAX_PATHS);
+        let selector = test_selector(me, graph, MAX_PATHS);
 
         let fwd = selector.select_path(me, dest, 1).context("forward path")?;
         assert!(!fwd.is_empty());
@@ -390,7 +400,7 @@ mod tests {
         mark_edge_full(&graph, &b, &a);
         mark_edge_last(&graph, &a, &me);
 
-        let selector = HoprGraphPathSelector::new(me, graph, MAX_PATHS);
+        let selector = test_selector(me, graph, MAX_PATHS);
 
         let fwd = selector.select_path(me, dest, 2).context("forward 2-hop path")?;
         assert!(!fwd.is_empty());
@@ -413,7 +423,7 @@ mod tests {
     async fn one_hop_path_should_include_relay_and_destination() -> anyhow::Result<()> {
         // Bidirectional: me ↔ relay ↔ dest
         let (me, relay, dest, graph) = two_hop_graph();
-        let selector = HoprGraphPathSelector::new(me, graph, MAX_PATHS);
+        let selector = test_selector(me, graph, MAX_PATHS);
 
         let fwd = selector.select_path(me, dest, 1).context("forward 1-hop path")?;
         assert!(!fwd.is_empty());
@@ -465,7 +475,7 @@ mod tests {
         mark_edge_last(&graph, &a, &me);
         mark_edge_last(&graph, &b, &me);
 
-        let selector = HoprGraphPathSelector::new(me, graph, MAX_PATHS);
+        let selector = test_selector(me, graph, MAX_PATHS);
 
         let fwd = selector.select_path(me, dest, 1).context("forward path")?;
         assert_eq!(fwd.len(), 2, "forward: both paths via a and b should be returned");
@@ -493,7 +503,7 @@ mod tests {
         graph.add_edge(&dest, &me).unwrap();
         // No observations → cost function will return non-positive cost → pruned.
 
-        let selector = HoprGraphPathSelector::new(me, graph, MAX_PATHS);
+        let selector = test_selector(me, graph, MAX_PATHS);
         assert!(
             selector.select_path(me, dest, 1).is_err(),
             "forward: edge with no observations should produce no valid path"
@@ -517,7 +527,7 @@ mod tests {
         mark_edge_full(&graph, &me, &dest);
         mark_edge_full(&graph, &dest, &me);
 
-        let selector = HoprGraphPathSelector::new(me, graph, MAX_PATHS);
+        let selector = test_selector(me, graph, MAX_PATHS);
         assert!(
             selector.select_path(me, dest, 2).is_err(),
             "forward: no 2-hop path should exist for a direct edge"
@@ -549,7 +559,7 @@ mod tests {
         mark_edge_full(&graph, &dest, &relay);
         mark_edge_last(&graph, &relay, &me);
 
-        let selector = HoprGraphPathSelector::new(me, graph, MAX_PATHS);
+        let selector = test_selector(me, graph, MAX_PATHS);
 
         // Forward path should work via virtual last hop
         let fwd = selector
@@ -604,7 +614,7 @@ mod tests {
         mark_edge_full(&graph, &b, &a);
         mark_edge_last(&graph, &a, &me);
 
-        let selector = HoprGraphPathSelector::new(me, graph, MAX_PATHS);
+        let selector = test_selector(me, graph, MAX_PATHS);
 
         let fwd = selector
             .select_path(me, dest, RoutingOptions::MAX_INTERMEDIATE_HOPS)
@@ -642,7 +652,7 @@ mod tests {
         graph.add_edge(&hop, &dest).context("adding edge hop -> dest")?;
         // No mark_edge_full/mark_edge_last → observations are empty → cost = 0
 
-        let selector = HoprGraphPathSelector::new(me, graph, MAX_PATHS);
+        let selector = test_selector(me, graph, MAX_PATHS);
 
         let err = selector
             .select_path(me, dest, 1)
@@ -668,7 +678,7 @@ mod tests {
         graph.add_edge(&me, &dest).context("adding edge me -> dest")?;
         mark_edge_full(&graph, &me, &dest);
 
-        let selector = HoprGraphPathSelector::new(me, graph, MAX_PATHS);
+        let selector = test_selector(me, graph, MAX_PATHS);
 
         // Ask for 2-hop path. Phase 1 won't find any (no 2-hop path exists).
         // Phase 2 finds me → dest as a shorter_length=1 path, but candidate=[dest]


### PR DESCRIPTION
## Summary

- Consolidates `DEFAULT_EDGE_PENALTY` and `DEFAULT_MIN_ACK_RATE` into configurable fields on `PathPlannerConfig` — the sole source of truth, flowing through `HoprProtocolConfig` → `HoprLibConfig` → the public API
- Removes the `pub const` duplicates from both `impls/graph/src/lib.rs` and `transport/path/src/selector.rs`
- Adds `Validate` derive on `PathPlannerConfig` with unit-interval checks (finite, 0.0..=1.0)
- Adds `edge_penalty` and `min_ack_rate` fields to `ChannelGraph` with a `with_edge_params` constructor
- Wires `PathPlannerConfig` into `ChannelGraph` construction in `hopr-reference`
- Upgrades `rustls-webpki` 0.103.12 → 0.103.13 (RUSTSEC-2026-0104)

Closes #7981