### PR TITLE
chore: use blokli-client from main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,8 +1559,8 @@ dependencies = [
 
 [[package]]
 name = "blokli-client"
-version = "0.23.1"
-source = "git+https://github.com/hoprnet/blokli?rev=9bee1183c63ba005c709ada1a275a759d2413d8b#9bee1183c63ba005c709ada1a275a759d2413d8b"
+version = "0.25.0"
+source = "git+https://github.com/hoprnet/blokli?branch=main#d42dba4fbb33d560ef2bab9420039ce2ecb7b383"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1573,7 +1573,7 @@ dependencies = [
  "futures",
  "futures-time",
  "hex",
- "hopr-types 1.5.4 (git+https://github.com/hoprnet/hopr-types?branch=main)",
+ "hopr-types",
  "http",
  "indexmap 2.14.0",
  "launchdarkly-sdk-transport",
@@ -2805,7 +2805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4293,7 +4293,7 @@ dependencies = [
  "chrono",
  "futures",
  "futures-concurrency",
- "hopr-types 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hopr-types",
  "libp2p-identity",
  "multiaddr",
  "serde",
@@ -4333,7 +4333,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4372,7 +4372,7 @@ dependencies = [
  "anyhow",
  "hex",
  "hopr-platform",
- "hopr-types 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hopr-types",
  "insta",
  "scrypt",
  "serde",
@@ -4396,7 +4396,7 @@ dependencies = [
  "hex-literal",
  "hopr-crypto-sphinx",
  "hopr-parallelize",
- "hopr-types 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hopr-types",
  "lazy_static",
  "mimalloc",
  "parameterized",
@@ -4419,7 +4419,7 @@ dependencies = [
  "elliptic-curve",
  "generic-array 1.3.5",
  "hex",
- "hopr-types 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hopr-types",
  "k256",
  "parameterized",
  "postcard",
@@ -4548,7 +4548,7 @@ dependencies = [
  "hickory-resolver",
  "hopr-async-runtime",
  "hopr-metrics",
- "hopr-types 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hopr-types",
  "lazy_static",
  "libp2p-identity",
  "multiaddr",
@@ -4595,7 +4595,7 @@ version = "1.0.1"
 dependencies = [
  "anyhow",
  "hopr-crypto-packet",
- "hopr-types 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hopr-types",
  "serde",
  "serde_bytes",
  "strum 0.28.0",
@@ -4660,7 +4660,7 @@ dependencies = [
  "hopr-metrics",
  "hopr-network-types",
  "hopr-protocol-app",
- "hopr-types 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hopr-types",
  "indexmap 2.14.0",
  "insta",
  "lazy_static",
@@ -4871,7 +4871,7 @@ dependencies = [
  "futures-timer",
  "hopr-metrics",
  "hopr-transport-mixer",
- "hopr-types 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hopr-types",
  "humantime-serde",
  "insta",
  "lazy_static",
@@ -4927,7 +4927,7 @@ dependencies = [
  "hopr-network-graph",
  "hopr-protocol-hopr",
  "hopr-statistics",
- "hopr-types 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hopr-types",
  "lazy_static",
  "moka",
  "smart-default",
@@ -5038,7 +5038,7 @@ dependencies = [
  "hopr-protocol-session",
  "hopr-protocol-start",
  "hopr-transport-tag-allocator",
- "hopr-types 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hopr-types",
  "humantime-serde",
  "insta",
  "lazy_static",
@@ -5113,51 +5113,6 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_with",
- "sha2",
- "sha3",
- "smart-default",
- "strum 0.28.0",
- "subtle",
- "thiserror 2.0.18",
- "tracing",
- "typenum",
- "zeroize",
-]
-
-[[package]]
-name = "hopr-types"
-version = "1.5.4"
-source = "git+https://github.com/hoprnet/hopr-types?branch=main#b6e633fb6759e4cdc188ac267a978715db1814c7"
-dependencies = [
- "aes",
- "aquamarine",
- "async-trait",
- "bigdecimal",
- "blake3",
- "chacha20 0.9.1",
- "chrono",
- "cipher",
- "ctr",
- "curve25519-dalek",
- "digest 0.10.7",
- "ed25519-dalek",
- "float-cmp",
- "generic-array 1.3.5",
- "hex",
- "hex-literal",
- "k256",
- "lazy_static",
- "libp2p-identity",
- "multiaddr",
- "num_enum",
- "poly1305",
- "primitive-types 0.14.0",
- "rand 0.10.1",
- "rayon",
- "regex",
- "secp256k1 0.31.1",
- "serde",
- "serde_bytes",
  "sha2",
  "sha3",
  "smart-default",
@@ -5317,7 +5272,7 @@ dependencies = [
  "hopr-chain-connector",
  "hopr-lib",
  "hopr-reference",
- "hopr-types 1.5.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hopr-types",
  "hoprd",
  "hoprd-api",
  "hoprd-api-client",
@@ -5887,7 +5842,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8422,7 +8377,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9357,7 +9312,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10436,7 +10391,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ backon = { version = "1.6.0", default-features = false }
 base64 = "0.22.1"
 bimap = "0.6.3"
 bitvec = "1.0.1"
-blokli-client = { git = "https://github.com/hoprnet/blokli", rev = "9bee1183c63ba005c709ada1a275a759d2413d8b" } # Pinned: later revs (c4eb515+) have a broken `testing` feature (BlokliTestClient missing `subscribe_track_transaction`); revert to `branch = "main"` once fixed upstream.
+blokli-client = { git = "https://github.com/hoprnet/blokli", branch = "main" }
 bloomfilter = { version = "3.0.1" }
 bytesize = { version = "2.3.1", features = ["serde"] }
 bytes = "1.11.1"

--- a/impls/connector/Cargo.toml
+++ b/impls/connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-chain-connector"
-version = "0.19.0"
+version = "0.19.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["HOPR Association <tech@hoprnet.org>"]

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_reannounce_when_existing_account_has_same_multiaddresses.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_reannounce_when_existing_account_has_same_multiaddresses.snap
@@ -32,8 +32,11 @@ deployed_safes:
   "0202020202020202020202020202020202020202":
     address: "0202020202020202020202020202020202020202"
     chain_key: 668430def9eacd2b5064acf85d73fb0b351a1c8c
+    owners:
+      - 668430def9eacd2b5064acf85d73fb0b351a1c8c
     module_address: 463977c851087dca6e69d488fbd69dbad3ffc7fe
     registered_nodes: []
+    threshold: "1"
 safe_redeem_stats: {}
 tx_counts: {}
 channels: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_register_any_safe_when_node_already_registered.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_register_any_safe_when_node_already_registered.snap
@@ -13,14 +13,20 @@ deployed_safes:
   "0202020202020202020202020202020202020202":
     address: "0202020202020202020202020202020202020202"
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
+    owners:
+      - bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: "1111111111111111111111111111111111111111"
     registered_nodes:
       - 668430def9eacd2b5064acf85d73fb0b351a1c8c
+    threshold: "1"
   "0101010101010101010101010101010101010101":
     address: "0101010101010101010101010101010101010101"
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
+    owners:
+      - bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: "1111111111111111111111111111111111111111"
     registered_nodes: []
+    threshold: "1"
 safe_redeem_stats: {}
 tx_counts: {}
 channels: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_reannounce_when_existing_account_has_no_multiaddresses.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_reannounce_when_existing_account_has_no_multiaddresses.snap
@@ -32,8 +32,11 @@ deployed_safes:
   "0202020202020202020202020202020202020202":
     address: "0202020202020202020202020202020202020202"
     chain_key: 668430def9eacd2b5064acf85d73fb0b351a1c8c
+    owners:
+      - 668430def9eacd2b5064acf85d73fb0b351a1c8c
     module_address: 463977c851087dca6e69d488fbd69dbad3ffc7fe
     registered_nodes: []
+    threshold: "1"
 safe_redeem_stats: {}
 tx_counts:
   668430def9eacd2b5064acf85d73fb0b351a1c8c: 1

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_register_safe.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_register_safe.snap
@@ -13,9 +13,12 @@ deployed_safes:
   "0101010101010101010101010101010101010101":
     address: "0101010101010101010101010101010101010101"
     chain_key: 668430def9eacd2b5064acf85d73fb0b351a1c8c
+    owners:
+      - 668430def9eacd2b5064acf85d73fb0b351a1c8c
     module_address: "1111111111111111111111111111111111111111"
     registered_nodes:
       - 668430def9eacd2b5064acf85d73fb0b351a1c8c
+    threshold: "1"
 safe_redeem_stats: {}
 tx_counts:
   668430def9eacd2b5064acf85d73fb0b351a1c8c: 1

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_register_safe_that_has_nodes_registered_already.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_register_safe_that_has_nodes_registered_already.snap
@@ -13,10 +13,13 @@ deployed_safes:
   "0202020202020202020202020202020202020202":
     address: "0202020202020202020202020202020202020202"
     chain_key: 668430def9eacd2b5064acf85d73fb0b351a1c8c
+    owners:
+      - 668430def9eacd2b5064acf85d73fb0b351a1c8c
     module_address: "1111111111111111111111111111111111111111"
     registered_nodes:
       - bea83ba0fcee21da44a30c893f466e6bf0c29bbb
       - 668430def9eacd2b5064acf85d73fb0b351a1c8c
+    threshold: "1"
 safe_redeem_stats: {}
 tx_counts:
   668430def9eacd2b5064acf85d73fb0b351a1c8c: 1

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_close_incoming_channel.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_close_incoming_channel.snap
@@ -52,13 +52,19 @@ deployed_safes:
   "0101010101010101010101010101010101010101":
     address: "0101010101010101010101010101010101010101"
     chain_key: 668430def9eacd2b5064acf85d73fb0b351a1c8c
+    owners:
+      - 668430def9eacd2b5064acf85d73fb0b351a1c8c
     module_address: 463977c851087dca6e69d488fbd69dbad3ffc7fe
     registered_nodes: []
+    threshold: "1"
   "0202020202020202020202020202020202020202":
     address: "0202020202020202020202020202020202020202"
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
+    owners:
+      - bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+    threshold: "1"
 safe_redeem_stats: {}
 tx_counts:
   668430def9eacd2b5064acf85d73fb0b351a1c8c: 1

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_finalize_channel_closure.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_finalize_channel_closure.snap
@@ -52,13 +52,19 @@ deployed_safes:
   "0101010101010101010101010101010101010101":
     address: "0101010101010101010101010101010101010101"
     chain_key: 668430def9eacd2b5064acf85d73fb0b351a1c8c
+    owners:
+      - 668430def9eacd2b5064acf85d73fb0b351a1c8c
     module_address: 463977c851087dca6e69d488fbd69dbad3ffc7fe
     registered_nodes: []
+    threshold: "1"
   "0202020202020202020202020202020202020202":
     address: "0202020202020202020202020202020202020202"
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
+    owners:
+      - bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+    threshold: "1"
 safe_redeem_stats: {}
 tx_counts:
   668430def9eacd2b5064acf85d73fb0b351a1c8c: 1

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_fund_channel.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_fund_channel.snap
@@ -52,13 +52,19 @@ deployed_safes:
   "0101010101010101010101010101010101010101":
     address: "0101010101010101010101010101010101010101"
     chain_key: 668430def9eacd2b5064acf85d73fb0b351a1c8c
+    owners:
+      - 668430def9eacd2b5064acf85d73fb0b351a1c8c
     module_address: 463977c851087dca6e69d488fbd69dbad3ffc7fe
     registered_nodes: []
+    threshold: "1"
   "0202020202020202020202020202020202020202":
     address: "0202020202020202020202020202020202020202"
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
+    owners:
+      - bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+    threshold: "1"
 safe_redeem_stats: {}
 tx_counts:
   668430def9eacd2b5064acf85d73fb0b351a1c8c: 1

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_initiate_channel_closure.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_initiate_channel_closure.snap
@@ -52,13 +52,19 @@ deployed_safes:
   "0101010101010101010101010101010101010101":
     address: "0101010101010101010101010101010101010101"
     chain_key: 668430def9eacd2b5064acf85d73fb0b351a1c8c
+    owners:
+      - 668430def9eacd2b5064acf85d73fb0b351a1c8c
     module_address: 463977c851087dca6e69d488fbd69dbad3ffc7fe
     registered_nodes: []
+    threshold: "1"
   "0202020202020202020202020202020202020202":
     address: "0202020202020202020202020202020202020202"
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
+    owners:
+      - bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+    threshold: "1"
 safe_redeem_stats: {}
 tx_counts:
   668430def9eacd2b5064acf85d73fb0b351a1c8c: 1

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_open_channel.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_open_channel.snap
@@ -52,13 +52,19 @@ deployed_safes:
   "0101010101010101010101010101010101010101":
     address: "0101010101010101010101010101010101010101"
     chain_key: 668430def9eacd2b5064acf85d73fb0b351a1c8c
+    owners:
+      - 668430def9eacd2b5064acf85d73fb0b351a1c8c
     module_address: 463977c851087dca6e69d488fbd69dbad3ffc7fe
     registered_nodes: []
+    threshold: "1"
   "0202020202020202020202020202020202020202":
     address: "0202020202020202020202020202020202020202"
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
+    owners:
+      - bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+    threshold: "1"
 safe_redeem_stats: {}
 tx_counts:
   668430def9eacd2b5064acf85d73fb0b351a1c8c: 1

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__safe__tests__connector_should_query_existing_safe.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__safe__tests__connector_should_query_existing_safe.snap
@@ -13,8 +13,11 @@ deployed_safes:
   "0101010101010101010101010101010101010101":
     address: "0101010101010101010101010101010101010101"
     chain_key: 668430def9eacd2b5064acf85d73fb0b351a1c8c
+    owners:
+      - 668430def9eacd2b5064acf85d73fb0b351a1c8c
     module_address: "1111111111111111111111111111111111111111"
     registered_nodes: []
+    threshold: "1"
 safe_redeem_stats: {}
 tx_counts: {}
 channels: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_on_closed_channel.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_on_closed_channel.snap
@@ -52,13 +52,19 @@ deployed_safes:
   "0101010101010101010101010101010101010101":
     address: "0101010101010101010101010101010101010101"
     chain_key: 668430def9eacd2b5064acf85d73fb0b351a1c8c
+    owners:
+      - 668430def9eacd2b5064acf85d73fb0b351a1c8c
     module_address: 463977c851087dca6e69d488fbd69dbad3ffc7fe
     registered_nodes: []
+    threshold: "1"
   "0202020202020202020202020202020202020202":
     address: "0202020202020202020202020202020202020202"
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
+    owners:
+      - bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+    threshold: "1"
 safe_redeem_stats: {}
 tx_counts:
   668430def9eacd2b5064acf85d73fb0b351a1c8c: 1

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_on_non_existing_channel.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_on_non_existing_channel.snap
@@ -52,13 +52,19 @@ deployed_safes:
   "0101010101010101010101010101010101010101":
     address: "0101010101010101010101010101010101010101"
     chain_key: 668430def9eacd2b5064acf85d73fb0b351a1c8c
+    owners:
+      - 668430def9eacd2b5064acf85d73fb0b351a1c8c
     module_address: 463977c851087dca6e69d488fbd69dbad3ffc7fe
     registered_nodes: []
+    threshold: "1"
   "0202020202020202020202020202020202020202":
     address: "0202020202020202020202020202020202020202"
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
+    owners:
+      - bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+    threshold: "1"
 safe_redeem_stats: {}
 tx_counts: {}
 channels:

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_amount_higher_than_channel_stake.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_amount_higher_than_channel_stake.snap
@@ -52,13 +52,19 @@ deployed_safes:
   "0101010101010101010101010101010101010101":
     address: "0101010101010101010101010101010101010101"
     chain_key: 668430def9eacd2b5064acf85d73fb0b351a1c8c
+    owners:
+      - 668430def9eacd2b5064acf85d73fb0b351a1c8c
     module_address: 463977c851087dca6e69d488fbd69dbad3ffc7fe
     registered_nodes: []
+    threshold: "1"
   "0202020202020202020202020202020202020202":
     address: "0202020202020202020202020202020202020202"
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
+    owners:
+      - bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+    threshold: "1"
 safe_redeem_stats: {}
 tx_counts: {}
 channels:

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_old_index.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_old_index.snap
@@ -52,13 +52,19 @@ deployed_safes:
   "0101010101010101010101010101010101010101":
     address: "0101010101010101010101010101010101010101"
     chain_key: 668430def9eacd2b5064acf85d73fb0b351a1c8c
+    owners:
+      - 668430def9eacd2b5064acf85d73fb0b351a1c8c
     module_address: 463977c851087dca6e69d488fbd69dbad3ffc7fe
     registered_nodes: []
+    threshold: "1"
   "0202020202020202020202020202020202020202":
     address: "0202020202020202020202020202020202020202"
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
+    owners:
+      - bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+    threshold: "1"
 safe_redeem_stats: {}
 tx_counts: {}
 channels:

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_previous_epoch.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_previous_epoch.snap
@@ -52,13 +52,19 @@ deployed_safes:
   "0101010101010101010101010101010101010101":
     address: "0101010101010101010101010101010101010101"
     chain_key: 668430def9eacd2b5064acf85d73fb0b351a1c8c
+    owners:
+      - 668430def9eacd2b5064acf85d73fb0b351a1c8c
     module_address: 463977c851087dca6e69d488fbd69dbad3ffc7fe
     registered_nodes: []
+    threshold: "1"
   "0202020202020202020202020202020202020202":
     address: "0202020202020202020202020202020202020202"
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
+    owners:
+      - bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+    threshold: "1"
 safe_redeem_stats: {}
 tx_counts: {}
 channels:

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_redeem_ticket.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_redeem_ticket.snap
@@ -52,13 +52,19 @@ deployed_safes:
   "0101010101010101010101010101010101010101":
     address: "0101010101010101010101010101010101010101"
     chain_key: 668430def9eacd2b5064acf85d73fb0b351a1c8c
+    owners:
+      - 668430def9eacd2b5064acf85d73fb0b351a1c8c
     module_address: 463977c851087dca6e69d488fbd69dbad3ffc7fe
     registered_nodes: []
+    threshold: "1"
   "0202020202020202020202020202020202020202":
     address: "0202020202020202020202020202020202020202"
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
+    owners:
+      - bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+    threshold: "1"
 safe_redeem_stats:
   "0101010101010101010101010101010101010101":
     __typename: RedeemedStats

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_redeem_ticket_and_increase_redeemed_stats.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_redeem_ticket_and_increase_redeemed_stats.snap
@@ -52,13 +52,19 @@ deployed_safes:
   "0101010101010101010101010101010101010101":
     address: "0101010101010101010101010101010101010101"
     chain_key: 668430def9eacd2b5064acf85d73fb0b351a1c8c
+    owners:
+      - 668430def9eacd2b5064acf85d73fb0b351a1c8c
     module_address: 463977c851087dca6e69d488fbd69dbad3ffc7fe
     registered_nodes: []
+    threshold: "1"
   "0202020202020202020202020202020202020202":
     address: "0202020202020202020202020202020202020202"
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
+    owners:
+      - bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+    threshold: "1"
 safe_redeem_stats:
   "0101010101010101010101010101010101010101":
     __typename: RedeemedStats

--- a/impls/connector/src/testing/mod.rs
+++ b/impls/connector/src/testing/mod.rs
@@ -98,10 +98,12 @@ impl BlokliTestStateBuilder {
                             blokli_client::api::types::Safe {
                                 address: safe_addr,
                                 chain_key: hex::encode(account.chain_addr),
+                                owners: [hex::encode(account.chain_addr)].to_vec(),
                                 module_address: hex::encode(
                                     &Hash::create(&[account.chain_addr.as_ref()]).as_ref()[0..Address::SIZE],
                                 ),
                                 registered_nodes: vec![],
+                                threshold: Some("1".to_string()),
                             },
                         );
                     }
@@ -158,8 +160,10 @@ impl BlokliTestStateBuilder {
                 blokli_client::api::types::Safe {
                     address: hex::encode(safe.address),
                     chain_key: hex::encode(safe.owner),
+                    owners: [hex::encode(safe.owner)].to_vec(),
                     module_address: hex::encode(safe.module),
                     registered_nodes: safe.registered_nodes.into_iter().map(hex::encode).collect(),
+                    threshold: Some("1".to_string()),
                 },
             )
         }));

--- a/impls/strategy/src/snapshots/hopr_strategy__auto_funding__tests__auto_funding_strategy.snap
+++ b/impls/strategy/src/snapshots/hopr_strategy__auto_funding__tests__auto_funding_strategy.snap
@@ -94,23 +94,35 @@ deployed_safes:
   93534e8ca82510a346dd329115ce7aefd4d35583:
     address: 93534e8ca82510a346dd329115ce7aefd4d35583
     chain_key: 18f8ae833c85c51fbeba29cef9fbfb53b3bad950
+    owners:
+      - 18f8ae833c85c51fbeba29cef9fbfb53b3bad950
     module_address: c2ac223dbf64edf995c70c5a3d5599c3fb6d6291
     registered_nodes: []
+    threshold: "1"
   259bed99d230648d7c8a116af59abdd15c9f4f1e:
     address: 259bed99d230648d7c8a116af59abdd15c9f4f1e
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
+    owners:
+      - bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
     registered_nodes: []
+    threshold: "1"
   0f944bc36fdcf97fff6807174eeb839ecd6035bd:
     address: 0f944bc36fdcf97fff6807174eeb839ecd6035bd
     chain_key: b6021e0860dd9d96c9ff0a73e2e5ba3a466ba234
+    owners:
+      - b6021e0860dd9d96c9ff0a73e2e5ba3a466ba234
     module_address: 1613d5898cae268775bb85aa0b7e6e7fbc9dcd47
     registered_nodes: []
+    threshold: "1"
   f982b19d6920ee93a267aec482349ab4a6c8a150:
     address: f982b19d6920ee93a267aec482349ab4a6c8a150
     chain_key: 68499f50ff68d523385dc60686069935d17d762a
+    owners:
+      - 68499f50ff68d523385dc60686069935d17d762a
     module_address: c6cf223b5fa5a0002e5f975453407134b848c312
     registered_nodes: []
+    threshold: "1"
 safe_redeem_stats: {}
 tx_counts:
   bea83ba0fcee21da44a30c893f466e6bf0c29bbb: 1


### PR DESCRIPTION
Uses the latest `blokli-client` version from main again, instead of the pinned revision.
Adapts the `hopr-connector` tests accordingly.