### PR TITLE
refactor(hopr-lib): minimize re-exports, use api::types paths, fair stream merge

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,9 +1179,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.41"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f9ee0f6e02ffd7ad5816e9464499fba7b3effd01123b515c41d1697c43dad1"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -1570,7 +1570,7 @@ dependencies = [
 [[package]]
 name = "blokli-client"
 version = "0.25.0"
-source = "git+https://github.com/hoprnet/blokli?branch=main#8353acaf6dd96bbe0a35d24c88eadbdc022de2c5"
+source = "git+https://github.com/hoprnet/blokli?branch=main#97f38aa19c014ea670def67c6b5f627e7e7274a4"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1753,9 +1753,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1966,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "compression-codecs"
-version = "0.4.37"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
 dependencies = [
  "brotli",
  "compression-core",
@@ -1980,9 +1980,9 @@ dependencies = [
 
 [[package]]
 name = "compression-core"
-version = "0.4.31"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75984efb6ed102a0d42db99afb6c1948f0380d1d91808d5529916e6c08b49d8d"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -2159,9 +2159,9 @@ dependencies = [
 
 [[package]]
 name = "crc-catalog"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -2473,15 +2473,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8142a83c17aa9461d637e649271eae18bf2edd00e91f2e105df36c3c16355bdb"
+checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -2489,9 +2489,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
+checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
  "syn 2.0.117",
@@ -3224,9 +3224,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-time"
-version = "3.0.1"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f4f4272ec2be25287f1e184066c249b1f6b6d4d982d7c2f56f424096ae64e2"
+checksum = "24076708e74fbd55fb36079acbba19988175140026cc67a878b91b0c3751220b"
 dependencies = [
  "async-channel 1.9.0",
  "async-io",
@@ -3279,9 +3279,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "1.3.5"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf57c49a95fd1fe24b90b3033bee6dc7e8f1288d51494cb44e627c295e38542"
+checksum = "e38154b42567e31b925d3859382888aa6f86e446d1f018c89ef337fc1726bcf2"
 dependencies = [
  "rustversion",
  "serde_core",
@@ -3989,9 +3989,9 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0"
+checksum = "6f23569e55f2ffaf958617353b9734a7d52a7c19c439eeaa5e3efc217fd2270e"
 
 [[package]]
 name = "gix-transport"
@@ -4041,9 +4041,9 @@ dependencies = [
 
 [[package]]
 name = "gix-utils"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befcdbdfb1238d2854591f760a48711bed85e72d80a10e8f2f93f656746ef7c5"
+checksum = "4e477b4f07a6e8da4ba791c53c858102959703c60d70f199932010d5b94adb2c"
 dependencies = [
  "bstr",
  "fastrand",
@@ -4562,7 +4562,7 @@ dependencies = [
  "bimap",
  "curve25519-dalek",
  "elliptic-curve",
- "generic-array 1.3.5",
+ "generic-array 1.4.0",
  "hex",
  "hopr-types",
  "k256",
@@ -4615,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.1-rc.1"
+version = "4.0.2-rc.1"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4625,6 +4625,7 @@ dependencies = [
  "cfg_eval",
  "const_format",
  "futures",
+ "futures-concurrency",
  "futures-time",
  "hopr-api",
  "hopr-async-runtime",
@@ -5238,7 +5239,7 @@ dependencies = [
  "digest 0.10.7",
  "ed25519-dalek",
  "float-cmp",
- "generic-array 1.3.5",
+ "generic-array 1.4.0",
  "hex",
  "hex-literal",
  "hopr-bindings",
@@ -5510,9 +5511,9 @@ dependencies = [
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
 dependencies = [
  "typenum",
 ]
@@ -6200,9 +6201,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -8314,9 +8315,9 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regress"
-version = "0.10.5"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2057b2325e68a893284d1538021ab90279adac1139957ca2a74426c6f118fb48"
+checksum = "158a764437582235e3501f683b93a0a6f8d825d04a789dbe5ed30b8799b8908a"
 dependencies = [
  "hashbrown 0.16.1",
  "memchr",
@@ -8658,9 +8659,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -10106,9 +10107,9 @@ checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "typify"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b715573a376585888b742ead9be5f4826105e622169180662e2c81bed4a149c3"
+checksum = "bc0b89f47309feaeb23c4509c15c9a04234f7deccef6f96c3bfe95319819a304"
 dependencies = [
  "typify-impl",
  "typify-macro",
@@ -10116,9 +10117,9 @@ dependencies = [
 
 [[package]]
 name = "typify-impl"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2fd0d27608a466d063d23b97cf2d26c25d838f01b4f7d5ff406a7446f16b6e3"
+checksum = "fa7b026f540b148b81043c720889dbb942b08659aa8a43f624ac4f04dbfc1861"
 dependencies = [
  "heck 0.5.0",
  "log",
@@ -10136,9 +10137,9 @@ dependencies = [
 
 [[package]]
 name = "typify-macro"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd04bb1207cd4e250941cc1641f4c4815f7eaa2145f45c09dd49cb0a3691710a"
+checksum = "39ed96c57f06ae0839416b986921a98f18b220da63bbb243a8570a00c8492183"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4615,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.2-rc.1"
+version = "4.0.1-rc.1"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4634,7 +4634,6 @@ dependencies = [
  "hopr-network-types",
  "hopr-parallelize",
  "hopr-platform",
- "hopr-ticket-manager",
  "hopr-transport",
  "humantime-serde",
  "lazy_static",

--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-lib"
-version = "4.0.1-rc.1"
+version = "4.0.2-rc.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition.workspace = true
 rust-version.workspace = true
@@ -61,6 +61,7 @@ cfg_eval = { workspace = true, optional = true }
 cfg-if = { workspace = true }
 const_format = { workspace = true }
 futures = { workspace = true }
+futures-concurrency = { workspace = true }
 futures-time = { workspace = true }
 humantime-serde = { workspace = true, optional = true }
 lazy_static = { workspace = true }

--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -84,7 +84,6 @@ hopr-network-types = { workspace = true }
 hopr-platform = { workspace = true }
 hopr-parallelize = { workspace = true, features = ["rayon"] }
 hopr-transport = { workspace = true }
-hopr-ticket-manager = { workspace = true }
 
 [dev-dependencies]
 hopr-async-runtime = { workspace = true, features = ["runtime-tokio"] }

--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-lib"
-version = "4.0.2-rc.1"
+version = "4.0.1-rc.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition.workspace = true
 rust-version.workspace = true

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -2,7 +2,7 @@
 //!
 //! The builder guides construction through a series of mandatory phases:
 //!
-//! 1. **Identity** — `HoprBuilder::default` → `HoprBuilder::with_identity`
+//! 1. **Identity** — `HoprBuilder` → `HoprBuilder::with_identity`
 //! 2. **Configuration** — `HoprBuilderWithIdentity::with_config`
 //! 3. **Component factories** — chain API, graph, network, and cover-traffic
 //! 4. **Session server** (when the `session-server` feature is enabled) — `HoprBuilderConfigured::with_session_server`
@@ -17,7 +17,7 @@
 //! let offchain_key = OffchainKeypair::random();
 //! let config = HoprLibConfig::default();
 //!
-//! let builder = HoprBuilder::default()
+//! let builder = HoprBuilder
 //!     .with_identity(&chain_key, &offchain_key)
 //!     .with_config(config)
 //!     .with_chain_api(|_ctx| { /* ... */ todo!() })

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -48,12 +48,12 @@ use hopr_api::{
 };
 use hopr_async_runtime::{AbortableList, prelude::spawn};
 use hopr_network_types::addr::is_public_address;
-use hopr_transport::HoprTransport;
+use hopr_transport::{HoprTransport, IncomingSession};
 use validator::Validate;
 
 use crate::{
-    Hopr, HoprLibError, HoprLibProcess, IncomingSession, MIN_NATIVE_BALANCE, NODE_READY_TIMEOUT,
-    SUGGESTED_NATIVE_BALANCE, config::HoprLibConfig, constants,
+    Hopr, HoprLibError, HoprLibProcess, MIN_NATIVE_BALANCE, NODE_READY_TIMEOUT, SUGGESTED_NATIVE_BALANCE,
+    config::HoprLibConfig, constants,
 };
 
 #[cfg(all(feature = "telemetry", not(test)))]

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -46,10 +46,9 @@ use hopr_api::{
         primitive::prelude::{Address, UnitaryFloatOps},
     },
 };
-use hopr_async_runtime::AbortableList;
+use hopr_async_runtime::{AbortableList, prelude::spawn};
 use hopr_network_types::addr::is_public_address;
 use hopr_transport::HoprTransport;
-use tokio::spawn;
 use validator::Validate;
 
 use crate::{

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -406,7 +406,7 @@ where
     tracing::info!(address = %me_onchain, %balance, %minimum_balance, "node information");
 
     if balance.le(&minimum_balance) {
-        return Err(HoprLibError::GeneralError(
+        return Err(HoprLibError::InsufficientFunds(
             "cannot start the node without a sufficiently funded wallet".into(),
         ));
     }

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -2,7 +2,7 @@
 //!
 //! The builder guides construction through a series of mandatory phases:
 //!
-//! 1. **Identity** — `HoprBuilder::new` → `HoprBuilder::with_identity`
+//! 1. **Identity** — `HoprBuilder::default` → `HoprBuilder::with_identity`
 //! 2. **Configuration** — `HoprBuilderWithIdentity::with_config`
 //! 3. **Component factories** — chain API, graph, network, and cover-traffic
 //! 4. **Session server** (when the `session-server` feature is enabled) — `HoprBuilderConfigured::with_session_server`
@@ -17,7 +17,7 @@
 //! let offchain_key = OffchainKeypair::random();
 //! let config = HoprLibConfig::default();
 //!
-//! let builder = HoprBuilder::new()
+//! let builder = HoprBuilder::default()
 //!     .with_identity(&chain_key, &offchain_key)
 //!     .with_config(config)
 //!     .with_chain_api(|_ctx| { /* ... */ todo!() })
@@ -98,10 +98,6 @@ pub struct BuildCtx {
 pub struct HoprBuilder;
 
 impl HoprBuilder {
-    pub fn new() -> Self {
-        Self
-    }
-
     /// Sets the node's on-chain and off-chain identity.
     pub fn with_identity(self, chain_key: &ChainKeypair, offchain_key: &OffchainKeypair) -> HoprBuilderWithIdentity {
         HoprBuilderWithIdentity {

--- a/hopr/hopr-lib/src/errors.rs
+++ b/hopr/hopr-lib/src/errors.rs
@@ -1,50 +1,72 @@
 use hopr_api::node::HoprState;
+pub use hopr_network_types::errors::NetworkTypeError;
 pub use hopr_transport::errors::{HoprTransportError, ProbeError, ProtocolError};
 use thiserror::Error;
 
-/// Enumeration of status errors thrown from this library.
-#[derive(Error, Debug)]
-pub enum HoprStatusError {
-    #[error("HOPR status general error: '{0}'")]
-    General(String),
-
-    #[error("HOPR status error: '{0}'")]
-    NotThereYet(HoprState, String),
-}
-
 /// Enumeration of errors thrown from this library.
+///
+/// Consumers should prefer matching on specific variants over catching
+/// [`GeneralError`](Self::GeneralError). Transport and network sub-variant types
+/// ([`HoprTransportError`], [`ProbeError`], [`ProtocolError`], [`NetworkTypeError`])
+/// are re-exported from this module for convenient pattern matching.
 #[derive(Error, Debug)]
 pub enum HoprLibError {
-    #[error("HOPR lib Error: '{0}'")]
+    /// A general-purpose error with a descriptive message.
+    ///
+    /// Prefer matching on specific variants when possible.
+    #[error("HOPR lib error: '{0}'")]
     GeneralError(String),
 
+    /// The [`Hopr`](crate::Hopr) object could not be built due to a missing component.
     #[error("hopr object could not be built: {0}")]
     BuilderError(&'static str),
 
+    /// The node configuration failed validation.
     #[error("configuration validation failed: {0}")]
     ConfigurationError(#[from] validator::ValidationErrors),
 
+    /// An error originating from the blockchain/chain connector layer.
+    ///
+    /// The inner error is type-erased because the chain connector is injected
+    /// via trait objects. Use the `Display` output for diagnostics.
     #[error("chain error: {0}")]
     ChainError(#[source] anyhow::Error),
 
-    #[error(transparent)]
-    StatusError(#[from] HoprStatusError),
+    /// The node is not in the required operational state.
+    ///
+    /// Contains the current [`HoprState`] and a message describing what was expected.
+    /// REST API consumers typically map this to HTTP 412 Precondition Failed.
+    #[error("node not ready ({0}): {1}")]
+    NotReady(HoprState, String),
 
+    /// An operation timed out.
+    #[error("{context} timed out")]
+    Timeout {
+        /// Description of what timed out and how long it waited.
+        context: String,
+    },
+
+    /// The node's wallet has insufficient native token balance.
+    #[error("insufficient funds: {0}")]
+    InsufficientFunds(String),
+
+    /// An error from the transport layer (messaging, sessions, probing).
+    ///
+    /// Sub-variant types [`ProtocolError`] and [`ProbeError`] are re-exported
+    /// from this module for convenient pattern matching.
     #[error(transparent)]
     TransportError(#[from] HoprTransportError),
 
+    /// A network-layer type error (address parsing, sealed targets, IO).
+    ///
+    /// The [`NetworkTypeError`] type is re-exported from this module.
     #[error(transparent)]
-    TypeError(#[from] hopr_api::types::primitive::errors::GeneralError),
+    NetworkTypeError(#[from] NetworkTypeError),
 
-    #[error(transparent)]
-    NetworkTypeError(#[from] hopr_network_types::errors::NetworkTypeError),
-
-    #[error("rayon thread pool queue full: {0}")]
-    SpawnError(#[from] hopr_parallelize::cpu::SpawnError),
-
-    #[error("ticket manager error: {0}")]
-    TicketManager(#[from] hopr_ticket_manager::TicketManagerError),
-
+    /// An unclassified internal error.
+    ///
+    /// Used for subsystems where a typed error variant does not exist.
+    /// Use the `Display` output for diagnostics.
     #[error("unspecified error: {0}")]
     Other(#[source] anyhow::Error),
 }

--- a/hopr/hopr-lib/src/helpers.rs
+++ b/hopr/hopr-lib/src/helpers.rs
@@ -43,7 +43,7 @@ pub(crate) async fn wait_for_funds<R: ChainValues>(
         current_delay = current_delay.mul_f64(multiplier);
     }
 
-    Err(HoprLibError::GeneralError(format!(
+    Err(HoprLibError::InsufficientFunds(format!(
         "failed to fund the node within {} seconds",
         max_delay.as_secs()
     )))

--- a/hopr/hopr-lib/src/helpers.rs
+++ b/hopr/hopr-lib/src/helpers.rs
@@ -10,7 +10,7 @@ use crate::errors::HoprLibError;
 /// Waits until the given address is funded.
 ///
 /// This is done by querying the RPC provider for balance with backoff until `max_delay` argument.
-pub async fn wait_for_funds<R: ChainValues>(
+pub(crate) async fn wait_for_funds<R: ChainValues>(
     min_balance: XDaiBalance,
     suggested_balance: XDaiBalance,
     max_delay: Duration,

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -64,13 +64,9 @@ use hopr_api::{
 use hopr_async_runtime::prelude::spawn;
 pub use hopr_async_runtime::{Abortable, AbortableList};
 pub use hopr_crypto_keypair::key_pair::{HoprKeys, IdentityRetrievalModes};
-#[cfg(feature = "runtime-tokio")]
-pub use hopr_transport::transfer_session;
-// Transport-native types (not available via hopr_lib::api)
-pub use hopr_transport::{
-    ApplicationData, ApplicationDataIn, ApplicationDataOut, HoprSession, HoprSessionConfigurator, HoprTransport,
-    HoprTransportProcess, IncomingSession, OffchainPublicKey, SESSION_MTU, SURB_SIZE, ServiceId, SessionCapabilities,
-    SessionCapability, SessionClientConfig, SessionId, SessionTarget, SurbBalancerConfig, Tag, peer_id_to_public_key,
+use hopr_transport::{
+    ApplicationDataIn, ApplicationDataOut, HoprSession, HoprSessionConfigurator, HoprTransport, HoprTransportProcess,
+    OffchainPublicKey, SessionCapabilities, SessionCapability, SessionTarget, SurbBalancerConfig,
 };
 use tracing::debug;
 

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -65,9 +65,10 @@ use hopr_api::{
 use hopr_async_runtime::prelude::spawn;
 pub use hopr_async_runtime::{Abortable, AbortableList};
 pub use hopr_crypto_keypair::key_pair::{HoprKeys, IdentityRetrievalModes};
+use hopr_transport::{ApplicationDataIn, ApplicationDataOut, HoprTransport, HoprTransportProcess, OffchainPublicKey};
+#[cfg(feature = "session-client")]
 use hopr_transport::{
-    ApplicationDataIn, ApplicationDataOut, HoprSession, HoprSessionConfigurator, HoprTransport, HoprTransportProcess,
-    OffchainPublicKey, SessionCapabilities, SessionCapability, SessionTarget, SurbBalancerConfig,
+    HoprSession, HoprSessionConfigurator, SessionCapabilities, SessionCapability, SessionTarget, SurbBalancerConfig,
 };
 use tracing::debug;
 

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -31,7 +31,7 @@ pub use hopr_api as api;
 /// Exports of libraries necessary for API and interface operations.
 ///
 /// Use `hopr_lib::api::types::*` for all type access.
-/// This module retains only network-specific types not available in `hopr_lib::api`.
+/// This module retains transport and network-specific types not available in `hopr_lib::api`.
 #[doc(hidden)]
 pub mod exports {
     pub mod network {
@@ -393,19 +393,14 @@ where
                     })
                     .await?
                     .ok_or(
-                        HoprLibError::Timeout {
-                            context: format!("on-chain event for {ctx}"),
-                        }
-                        .into_right(),
+                        HoprLibError::GeneralError(format!("on-chain event stream for {ctx} ended unexpectedly"))
+                            .into_right(),
                     );
                 debug!(%ctx, ?res, "on-chain event waiting done");
                 res
             })
             .map_err(move |_| {
-                HoprLibError::Timeout {
-                    context: format!("spawn for {context}"),
-                }
-                .into_right()
+                HoprLibError::GeneralError(format!("failed to spawn on-chain event wait for {context}")).into_right()
             })
             .and_then(futures::future::ready)
             .boxed(),

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -72,10 +72,8 @@ use hopr_transport::{
 };
 use tracing::debug;
 
-pub use crate::{
-    constants::{MIN_NATIVE_BALANCE, SUGGESTED_NATIVE_BALANCE},
-    errors::{HoprLibError, HoprStatusError},
-};
+pub use crate::constants::{MIN_NATIVE_BALANCE, SUGGESTED_NATIVE_BALANCE};
+use crate::errors::HoprLibError;
 
 /// Public routing configuration for session opening in `hopr-lib`.
 ///
@@ -279,7 +277,7 @@ where
         if HoprNodeOperations::status(self) == state {
             Ok(())
         } else {
-            Err(HoprLibError::StatusError(HoprStatusError::NotThereYet(state, error)))
+            Err(HoprLibError::NotReady(state, error))
         }
     }
 }
@@ -387,15 +385,28 @@ where
                 let res = event_stream
                     .next()
                     .timeout(futures_time::time::Duration::from(timeout))
-                    .map_err(|_| HoprLibError::GeneralError(format!("{ctx} timed out after {timeout:?}")).into_right())
+                    .map_err(|_| {
+                        HoprLibError::Timeout {
+                            context: format!("{ctx} (after {timeout:?})"),
+                        }
+                        .into_right()
+                    })
                     .await?
                     .ok_or(
-                        HoprLibError::GeneralError(format!("failed to yield an on-chain event for {ctx}")).into_right(),
+                        HoprLibError::Timeout {
+                            context: format!("on-chain event for {ctx}"),
+                        }
+                        .into_right(),
                     );
                 debug!(%ctx, ?res, "on-chain event waiting done");
                 res
             })
-            .map_err(move |_| HoprLibError::GeneralError(format!("failed to spawn future for {context}")).into_right())
+            .map_err(move |_| {
+                HoprLibError::Timeout {
+                    context: format!("spawn for {context}"),
+                }
+                .into_right()
+            })
             .and_then(futures::future::ready)
             .boxed(),
             handle,

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -23,48 +23,22 @@ pub mod config;
 pub mod constants;
 /// Lists all errors thrown from this library.
 pub mod errors;
-// Re-export peer discovery types from hopr-api.
-pub use hopr_api::node::{AnnouncedPeer, AnnouncementOrigin};
 /// Utility module with helper types and functionality over hopr-lib behavior.
 pub mod utils;
 
 pub use hopr_api as api;
 
 /// Exports of libraries necessary for API and interface operations.
+///
+/// Use `hopr_lib::api::types::*` for all type access.
+/// This module retains only network-specific types not available in `hopr_lib::api`.
 #[doc(hidden)]
 pub mod exports {
-    pub mod types {
-        pub use hopr_api::types::{chain, internal, primitive};
-    }
-
-    pub mod crypto {
-        pub use hopr_api::types::crypto as types;
-        pub use hopr_crypto_keypair as keypair;
-    }
-
     pub mod network {
         pub use hopr_network_types as types;
     }
 
     pub use hopr_transport as transport;
-}
-
-/// Export of relevant types for easier integration.
-#[doc(hidden)]
-pub mod prelude {
-    #[cfg(feature = "runtime-tokio")]
-    pub use super::exports::network::types::{
-        prelude::ForeignDataMode,
-        udp::{ConnectedUdpStream, UdpStreamParallelism},
-    };
-    pub use super::exports::{
-        crypto::{
-            keypair::key_pair::HoprKeys,
-            types::prelude::{ChainKeypair, Hash, OffchainKeypair},
-        },
-        transport::{OffchainPublicKey, socket::HoprSocket},
-        types::primitive::prelude::Address,
-    };
 }
 
 use std::{
@@ -74,34 +48,30 @@ use std::{
 
 use futures::{FutureExt, Stream, StreamExt, TryFutureExt, pin_mut};
 use futures_time::future::FutureExt as FuturesTimeFutureExt;
-#[cfg(feature = "session-client")]
-pub use hopr_api::node::HoprSessionClientOperations;
 use hopr_api::{
+    PeerId,
     chain::*,
     graph::HoprGraphApi,
-    network::NetworkView as _,
+    network::{Health, NetworkStreamControl, NetworkView},
     node::{
         AtomicHoprState, ComponentStatus, ComponentStatusReporter, EitherErrExt, EventWaitResult, HasChainApi,
-        HasGraphView, HasNetworkView, HasTicketManagement, HasTransportApi, NodeOnchainIdentity,
+        HasGraphView, HasNetworkView, HasTicketManagement, HasTransportApi, HoprNodeOperations, HoprState,
+        NodeOnchainIdentity,
     },
-};
-pub use hopr_api::{
-    graph::EdgeLinkObservable,
-    network::NetworkStreamControl,
-    node::{
-        EitherErr, HoprNodeOperations, HoprState, IncentiveChannelOperations, IncentiveRedeemOperations,
-        TransportOperations,
-    },
-    tickets::{ChannelStats, RedemptionResult, TicketManagement, TicketManagementExt},
-    types::{crypto::prelude::*, internal::prelude::*, primitive::prelude::*},
+    tickets::TicketManagement,
+    types::{crypto::prelude::OffchainKeypair, internal::routing::DestinationRouting},
 };
 use hopr_async_runtime::prelude::spawn;
 pub use hopr_async_runtime::{Abortable, AbortableList};
 pub use hopr_crypto_keypair::key_pair::{HoprKeys, IdentityRetrievalModes};
-pub use hopr_network_types::prelude::*;
 #[cfg(feature = "runtime-tokio")]
 pub use hopr_transport::transfer_session;
-pub use hopr_transport::*;
+// Transport-native types (not available via hopr_lib::api)
+pub use hopr_transport::{
+    ApplicationData, ApplicationDataIn, ApplicationDataOut, HoprSession, HoprSessionConfigurator, HoprTransport,
+    HoprTransportProcess, IncomingSession, OffchainPublicKey, SESSION_MTU, SURB_SIZE, ServiceId, SessionCapabilities,
+    SessionCapability, SessionClientConfig, SessionId, SessionTarget, SurbBalancerConfig, Tag, peer_id_to_public_key,
+};
 use tracing::debug;
 
 pub use crate::{
@@ -252,7 +222,7 @@ pub fn prepare_tokio_runtime(
 }
 
 /// Type alias used to send and receive transport data via a running HOPR node.
-pub type HoprTransportIO = socket::HoprSocket<
+pub type HoprTransportIO = hopr_transport::socket::HoprSocket<
     futures::channel::mpsc::Receiver<ApplicationDataIn>,
     futures::channel::mpsc::Sender<(DestinationRouting, ApplicationDataOut)>,
 >;
@@ -337,7 +307,7 @@ where
 
     async fn connect_to(
         &self,
-        destination: Address,
+        destination: hopr_api::types::primitive::prelude::Address,
         target: Self::Target,
         cfg: Self::Config,
     ) -> Result<(Self::Session, Self::SessionConfigurator), Self::Error> {
@@ -532,6 +502,7 @@ where
         filter: Option<&[hopr_api::node::ActionableEventDiscriminant]>,
     ) -> Result<futures::stream::BoxStream<'static, hopr_api::node::ActionableEvent>, String> {
         use futures::StreamExt as _;
+        use futures_concurrency::stream::Merge as _;
         use hopr_api::node::{ActionableEvent, ActionableEventDiscriminant};
 
         let wants = |d: ActionableEventDiscriminant| filter.is_none_or(|f| f.contains(&d));
@@ -571,8 +542,8 @@ where
             return Ok(futures::stream::empty().boxed());
         }
 
-        // `select_all` round-robins across active sources, preventing starvation.
-        Ok(futures::stream::select_all(streams).boxed())
+        // `Merge` provides fair polling distribution across active sources.
+        Ok(streams.merge().boxed())
     }
 }
 

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -47,6 +47,7 @@ use std::{
 };
 
 use futures::{FutureExt, Stream, StreamExt, TryFutureExt, pin_mut};
+use futures_concurrency::stream::Merge as _;
 use futures_time::future::FutureExt as FuturesTimeFutureExt;
 use hopr_api::{
     PeerId,
@@ -54,9 +55,9 @@ use hopr_api::{
     graph::HoprGraphApi,
     network::{Health, NetworkStreamControl, NetworkView},
     node::{
-        AtomicHoprState, ComponentStatus, ComponentStatusReporter, EitherErrExt, EventWaitResult, HasChainApi,
-        HasGraphView, HasNetworkView, HasTicketManagement, HasTransportApi, HoprNodeOperations, HoprState,
-        NodeOnchainIdentity,
+        ActionableEvent, ActionableEventDiscriminant, AtomicHoprState, ComponentStatus, ComponentStatusReporter,
+        EitherErrExt, EventWaitResult, HasChainApi, HasGraphView, HasNetworkView, HasTicketManagement, HasTransportApi,
+        HoprNodeOperations, HoprState, NodeOnchainIdentity,
     },
     tickets::TicketManagement,
     types::{crypto::prelude::OffchainKeypair, internal::routing::DestinationRouting},
@@ -71,7 +72,6 @@ use hopr_transport::{
 use tracing::debug;
 
 pub use crate::{
-    config::SafeModule,
     constants::{MIN_NATIVE_BALANCE, SUGGESTED_NATIVE_BALANCE},
     errors::{HoprLibError, HoprStatusError},
 };
@@ -495,12 +495,8 @@ where
 {
     fn subscribe_to_actionable_events(
         &self,
-        filter: Option<&[hopr_api::node::ActionableEventDiscriminant]>,
-    ) -> Result<futures::stream::BoxStream<'static, hopr_api::node::ActionableEvent>, String> {
-        use futures::StreamExt as _;
-        use futures_concurrency::stream::Merge as _;
-        use hopr_api::node::{ActionableEvent, ActionableEventDiscriminant};
-
+        filter: Option<&[ActionableEventDiscriminant]>,
+    ) -> Result<futures::stream::BoxStream<'static, ActionableEvent>, String> {
         let wants = |d: ActionableEventDiscriminant| filter.is_none_or(|f| f.contains(&d));
 
         let mut streams = Vec::<futures::stream::BoxStream<'static, ActionableEvent>>::new();

--- a/hopr/reference/src/exit.rs
+++ b/hopr/reference/src/exit.rs
@@ -1,14 +1,15 @@
 use std::{net::SocketAddr, num::NonZeroUsize};
 
 use hopr_lib::{
-    ServiceId,
     api::types::crypto::prelude::OffchainKeypair,
     errors::HoprLibError,
-    exports::network::types::{
-        prelude::ForeignDataMode,
-        udp::{ConnectedUdpStream, UdpStreamParallelism},
+    exports::{
+        network::types::{
+            prelude::ForeignDataMode,
+            udp::{ConnectedUdpStream, UdpStreamParallelism},
+        },
+        transport::{ServiceId, SessionTarget, transfer_session},
     },
-    transfer_session,
 };
 
 use crate::config::SessionIpForwardingConfig;
@@ -72,7 +73,7 @@ impl hopr_lib::api::node::HoprSessionServer for HoprServerIpForwardingReactor {
     ) -> Result<(), hopr_lib::errors::HoprLibError> {
         let session_id = *session.session.id();
         match session.target {
-            hopr_lib::SessionTarget::UdpStream(udp_target) => {
+            SessionTarget::UdpStream(udp_target) => {
                 let kp = self.keypair.clone();
                 let udp_target = hopr_lib::utils::hopr_parallelize::cpu::spawn_blocking(
                     move || udp_target.unseal(&kp),
@@ -163,7 +164,7 @@ impl hopr_lib::api::node::HoprSessionServer for HoprServerIpForwardingReactor {
 
                 Ok(())
             }
-            hopr_lib::SessionTarget::TcpStream(tcp_target) => {
+            SessionTarget::TcpStream(tcp_target) => {
                 let kp = self.keypair.clone();
                 let tcp_target = hopr_lib::utils::hopr_parallelize::cpu::spawn_blocking(
                     move || tcp_target.unseal(&kp),
@@ -240,7 +241,7 @@ impl hopr_lib::api::node::HoprSessionServer for HoprServerIpForwardingReactor {
 
                 Ok(())
             }
-            hopr_lib::SessionTarget::ExitNode(SERVICE_ID_LOOPBACK) => {
+            SessionTarget::ExitNode(SERVICE_ID_LOOPBACK) => {
                 tracing::debug!(?session_id, "bridging the session to the loopback service");
                 let (mut reader, mut writer) = tokio::io::split(session.session);
 
@@ -259,7 +260,7 @@ impl hopr_lib::api::node::HoprSessionServer for HoprServerIpForwardingReactor {
 
                 Ok(())
             }
-            hopr_lib::SessionTarget::ExitNode(_) => Err(HoprLibError::GeneralError(
+            SessionTarget::ExitNode(_) => Err(HoprLibError::GeneralError(
                 "server does not support internal session processing".into(),
             )),
         }

--- a/hopr/reference/src/exit.rs
+++ b/hopr/reference/src/exit.rs
@@ -1,9 +1,13 @@
 use std::{net::SocketAddr, num::NonZeroUsize};
 
 use hopr_lib::{
-    OffchainKeypair, ServiceId,
+    ServiceId,
+    api::types::crypto::prelude::OffchainKeypair,
     errors::HoprLibError,
-    prelude::{ConnectedUdpStream, ForeignDataMode, UdpStreamParallelism},
+    exports::network::types::{
+        prelude::ForeignDataMode,
+        udp::{ConnectedUdpStream, UdpStreamParallelism},
+    },
     transfer_session,
 };
 

--- a/hopr/reference/src/lib.rs
+++ b/hopr/reference/src/lib.rs
@@ -200,7 +200,7 @@ where
     let safe_address = config.safe_module.safe_address;
     let module_address = config.safe_module.module_address;
 
-    let builder = hopr_lib::builder::HoprBuilder::default()
+    let builder = hopr_lib::builder::HoprBuilder
         .with_identity(chain_key, packet_key)
         .with_config(config)
         .with_safe_module(&safe_address, &module_address)

--- a/hopr/reference/src/lib.rs
+++ b/hopr/reference/src/lib.rs
@@ -200,7 +200,7 @@ where
     let safe_address = config.safe_module.safe_address;
     let module_address = config.safe_module.module_address;
 
-    let builder = hopr_lib::builder::HoprBuilder::new()
+    let builder = hopr_lib::builder::HoprBuilder::default()
         .with_identity(chain_key, packet_key)
         .with_config(config)
         .with_safe_module(&safe_address, &module_address)

--- a/hopr/reference/src/lib.rs
+++ b/hopr/reference/src/lib.rs
@@ -97,8 +97,10 @@ pub async fn build_reference(
 #[cfg(feature = "runtime-tokio")]
 pub async fn build_with_chain<
     Chain,
-    #[cfg(feature = "session-server")] Srv: hopr_lib::api::node::HoprSessionServer<Session = hopr_lib::IncomingSession, Error: std::fmt::Display>
-        + Clone
+    #[cfg(feature = "session-server")] Srv: hopr_lib::api::node::HoprSessionServer<
+            Session = hopr_lib::exports::transport::IncomingSession,
+            Error: std::fmt::Display,
+        > + Clone
         + Send
         + 'static,
 >(

--- a/hopr/reference/src/testing/dummies.rs
+++ b/hopr/reference/src/testing/dummies.rs
@@ -1,5 +1,5 @@
 use futures::AsyncReadExt;
-use hopr_lib::{IncomingSession, api::node::HoprSessionServer, errors::HoprLibError};
+use hopr_lib::{api::node::HoprSessionServer, errors::HoprLibError, exports::transport::IncomingSession};
 use tokio_util::compat::{FuturesAsyncReadCompatExt, FuturesAsyncWriteCompatExt};
 
 #[derive(Debug, Clone, Default)]

--- a/hopr/reference/src/testing/fixtures.rs
+++ b/hopr/reference/src/testing/fixtures.rs
@@ -11,11 +11,23 @@ use hopr_chain_connector::{
     testing::{BlokliTestClient, BlokliTestStateBuilder, FullStateEmulator},
 };
 use hopr_lib::{
-    Address, ChainKeypair, HopRouting, HoprBalance, HoprNodeOperations, HoprSessionClientConfig,
-    HoprSessionClientOperations, HoprState, IpOrHost, Keypair, OffchainKeypair, SealedHost, WinningProbability,
-    XDaiBalance,
-    api::{network::NetworkView, node::HasNetworkView},
-    exports::transport::{HoprSession, SessionTarget},
+    HopRouting, HoprSessionClientConfig,
+    api::{
+        network::NetworkView,
+        node::{HasNetworkView, HoprNodeOperations, HoprSessionClientOperations, HoprState},
+        types::{
+            crypto::{
+                keypairs::Keypair,
+                prelude::{ChainKeypair, OffchainKeypair},
+            },
+            internal::prelude::{ChannelEntry, ChannelStatus, WinningProbability},
+            primitive::prelude::{Address, HoprBalance, XDaiBalance},
+        },
+    },
+    exports::{
+        network::types::prelude::{IpOrHost, SealedHost},
+        transport::{HoprSession, SessionTarget},
+    },
 };
 use rand::seq::{IteratorRandom, SliceRandom};
 use rstest::fixture;
@@ -110,7 +122,7 @@ impl ClusterGuard {
     ) -> anyhow::Result<()> {
         let deadline = tokio::time::Instant::now() + timeout;
         loop {
-            let channels: Vec<hopr_lib::ChannelEntry> = {
+            let channels: Vec<ChannelEntry> = {
                 use hopr_lib::api::{chain::ChainReadChannelOperations, node::HasChainApi};
                 match observer
                     .inner()
@@ -122,10 +134,7 @@ impl ClusterGuard {
                 }
             };
 
-            let open_count = channels
-                .iter()
-                .filter(|c| c.status == hopr_lib::ChannelStatus::Open)
-                .count();
+            let open_count = channels.iter().filter(|c| c.status == ChannelStatus::Open).count();
 
             if open_count >= expected_channels {
                 tracing::info!(open_count, expected_channels, "channel graph converged");

--- a/hopr/reference/src/testing/hopr.rs
+++ b/hopr/reference/src/testing/hopr.rs
@@ -233,7 +233,7 @@ impl ChannelGuard {
                         }
                         _ => {}
                     }
-                    Ok::<_, hopr_lib::HoprLibError>(false)
+                    Ok::<_, hopr_lib::errors::HoprLibError>(false)
                 },
                 Duration::from_secs(30),
             )
@@ -270,7 +270,7 @@ impl Drop for ChannelGuard {
                                     }
                                     _ => {}
                                 }
-                                Ok::<_, hopr_lib::HoprLibError>(false)
+                                Ok::<_, hopr_lib::errors::HoprLibError>(false)
                             },
                             Duration::from_secs(30),
                         )

--- a/hopr/reference/src/testing/hopr.rs
+++ b/hopr/reference/src/testing/hopr.rs
@@ -3,11 +3,16 @@ use std::{fmt::Formatter, sync::Arc, time::Duration};
 use anyhow::Context;
 use futures::future::join_all;
 use hopr_lib::{
-    Address, ChannelEntry, ChannelStatus, Hash, HoprBalance, HoprNodeOperations, HoprState, IncentiveChannelOperations,
-    PeerId,
-    api::node::HasChainApi,
+    api::{
+        PeerId,
+        node::{HasChainApi, HoprNodeOperations, HoprState, IncentiveChannelOperations},
+        types::{
+            crypto::prelude::Hash,
+            internal::prelude::{ChannelEntry, ChannelStatus},
+            primitive::prelude::{Address, HoprBalance},
+        },
+    },
     config::{HoprLibConfig, SessionGlobalConfig},
-    prelude,
 };
 
 use crate::testing::{TestingConnector, TestingHopr};
@@ -120,7 +125,7 @@ impl TestedHopr {
         self.instance.config()
     }
 
-    pub async fn channel_from_hash(&self, channel_hash: &prelude::Hash) -> Option<ChannelEntry> {
+    pub async fn channel_from_hash(&self, channel_hash: &Hash) -> Option<ChannelEntry> {
         IncentiveChannelOperations::channel_by_id(&*self.instance, channel_hash).unwrap_or(None)
     }
 

--- a/hopr/reference/tests/api_general.rs
+++ b/hopr/reference/tests/api_general.rs
@@ -1,8 +1,5 @@
 use anyhow::Context;
-use hopr_lib::{
-    PeerId,
-    api::{chain::ChainKeyOperations, node::HasChainApi},
-};
+use hopr_lib::api::{PeerId, chain::ChainKeyOperations, node::HasChainApi};
 use hopr_reference::testing::fixtures::{ClusterGuard, TEST_GLOBAL_TIMEOUT, size_2_cluster_fixture as cluster};
 use rstest::*;
 use serial_test::serial;

--- a/hopr/reference/tests/chain_operations-size2.rs
+++ b/hopr/reference/tests/chain_operations-size2.rs
@@ -1,5 +1,11 @@
 use anyhow::Context;
-use hopr_lib::{HoprBalance, IncentiveChannelOperations, WinningProbability, WxHOPR, XDai, XDaiBalance};
+use hopr_lib::api::{
+    node::IncentiveChannelOperations,
+    types::{
+        internal::prelude::WinningProbability,
+        primitive::prelude::{HoprBalance, WxHOPR, XDai, XDaiBalance},
+    },
+};
 use hopr_reference::testing::fixtures::{
     ClusterGuard, DEFAULT_SAFE_ALLOWANCE, INITIAL_NODE_NATIVE, INITIAL_NODE_TOKEN, INITIAL_SAFE_NATIVE,
     INITIAL_SAFE_TOKEN, MINIMUM_INCOMING_WIN_PROB, TEST_GLOBAL_TIMEOUT, size_2_cluster_fixture as cluster,
@@ -63,7 +69,7 @@ async fn ticket_price_is_set_to_non_zero_value_on_start(cluster: &ClusterGuard) 
         .await
         .context("failed to get ticket price")?;
 
-    assert!(ticket_price > hopr_lib::HoprBalance::zero());
+    assert!(ticket_price > HoprBalance::zero());
 
     Ok(())
 }

--- a/hopr/reference/tests/chain_operations-size3.rs
+++ b/hopr/reference/tests/chain_operations-size3.rs
@@ -2,8 +2,12 @@ use std::ops::Mul;
 
 use anyhow::Context;
 use hopr_chain_connector::blokli_client::BlokliQueryClient;
-use hopr_lib::{
-    Address, BytesRepresentable, ChannelId, ChannelStatus, HoprBalance, api::node::IncentiveChannelOperations,
+use hopr_lib::api::{
+    node::IncentiveChannelOperations,
+    types::{
+        internal::prelude::{ChannelId, ChannelStatus},
+        primitive::prelude::{Address, BytesRepresentable, HoprBalance, XDai, XDaiBalance},
+    },
 };
 use hopr_reference::testing::{
     fixtures::{ClusterGuard, TEST_GLOBAL_TIMEOUT, chain_propagation_delay, size_3_cluster_fixture as cluster},
@@ -154,7 +158,7 @@ async fn test_withdraw_native(cluster: &ClusterGuard) -> anyhow::Result<()> {
 
     // We use a standalone fixed address to prevent side effects from other tests.
     let target_addr: Address = [0xad_u8; Address::SIZE].into();
-    let withdrawn_amount = "0.005 xDai".parse::<hopr_lib::XDaiBalance>()?;
+    let withdrawn_amount = "0.005 xDai".parse::<XDaiBalance>()?;
 
     let balance = cluster
         .chain_client
@@ -166,7 +170,7 @@ async fn test_withdraw_native(cluster: &ClusterGuard) -> anyhow::Result<()> {
 
     let initial_balance_src = src
         .inner()
-        .get_balance::<hopr_lib::XDai>()
+        .get_balance::<XDai>()
         .await
         .context("should get node xdai balance")?;
 
@@ -178,7 +182,7 @@ async fn test_withdraw_native(cluster: &ClusterGuard) -> anyhow::Result<()> {
 
     let final_balance_src = src
         .inner()
-        .get_balance::<hopr_lib::XDai>()
+        .get_balance::<XDai>()
         .await
         .context("should get node xdai balance")?;
 

--- a/hopr/reference/tests/session_integration_tests.rs
+++ b/hopr/reference/tests/session_integration_tests.rs
@@ -1,11 +1,18 @@
 use futures::StreamExt;
 use hopr_api::types::crypto_random::Randomizable;
 use hopr_lib::{
-    Address, ApplicationDataIn, ApplicationDataOut, ChainKeypair, ConnectedUdpStream, HoprPseudonym, Keypair,
-    UdpStreamParallelism,
+    ApplicationDataIn, ApplicationDataOut,
+    api::types::{
+        crypto::{keypairs::Keypair, prelude::ChainKeypair},
+        internal::{
+            prelude::HoprPseudonym,
+            routing::{DestinationRouting, RoutingOptions},
+        },
+        primitive::prelude::Address,
+    },
     exports::{
+        network::types::udp::{ConnectedUdpStream, UdpStreamParallelism},
         transport::session::{Capabilities, Capability, HoprSession, HoprSessionConfig, SessionId, transfer_session},
-        types::internal::routing::{DestinationRouting, RoutingOptions},
     },
 };
 use rstest::*;

--- a/hopr/reference/tests/session_integration_tests.rs
+++ b/hopr/reference/tests/session_integration_tests.rs
@@ -1,7 +1,6 @@
 use futures::StreamExt;
 use hopr_api::types::crypto_random::Randomizable;
 use hopr_lib::{
-    ApplicationDataIn, ApplicationDataOut,
     api::types::{
         crypto::{keypairs::Keypair, prelude::ChainKeypair},
         internal::{
@@ -12,7 +11,10 @@ use hopr_lib::{
     },
     exports::{
         network::types::udp::{ConnectedUdpStream, UdpStreamParallelism},
-        transport::session::{Capabilities, Capability, HoprSession, HoprSessionConfig, SessionId, transfer_session},
+        transport::{
+            ApplicationDataIn, ApplicationDataOut,
+            session::{Capabilities, Capability, HoprSession, HoprSessionConfig, SessionId, transfer_session},
+        },
     },
 };
 use rstest::*;

--- a/hopr/reference/tests/transport_p2p-size3.rs
+++ b/hopr/reference/tests/transport_p2p-size3.rs
@@ -1,16 +1,14 @@
 use std::time::Duration;
 
 use anyhow::Context;
-use hopr_lib::{
-    Address,
-    api::{
-        graph::{
-            NetworkGraphConnectivity,
-            traits::{EdgeLinkObservable, EdgeObservableRead},
-        },
-        network::NetworkView,
-        node::{HasNetworkView, HasTransportApi, IncentiveChannelOperations},
+use hopr_lib::api::{
+    graph::{
+        NetworkGraphConnectivity,
+        traits::{EdgeLinkObservable, EdgeObservableRead},
     },
+    network::NetworkView,
+    node::{HasNetworkView, HasTransportApi, IncentiveChannelOperations},
+    types::primitive::prelude::Address,
 };
 use hopr_reference::testing::fixtures::{ClusterGuard, TEST_GLOBAL_TIMEOUT, size_3_cluster_fixture as cluster};
 use rstest::*;

--- a/hopr/reference/tests/transport_session-size3.rs
+++ b/hopr/reference/tests/transport_session-size3.rs
@@ -2,9 +2,13 @@ use std::{str::FromStr, time::Duration};
 
 use anyhow::Context;
 use hopr_lib::{
-    HopRouting, HoprSessionClientConfig, HoprSessionClientOperations, SessionCapabilities, SessionTarget,
+    HopRouting, HoprSessionClientConfig, SessionCapabilities, SessionTarget,
+    api::node::HoprSessionClientOperations,
     errors::HoprTransportError,
-    exports::transport::session::{IpOrHost, SealedHost},
+    exports::{
+        network::types::prelude::{IpOrHost, SealedHost},
+        transport::{SessionManagerError, TransportSessionError},
+    },
 };
 use hopr_reference::testing::fixtures::{ClusterGuard, TEST_GLOBAL_TIMEOUT, size_3_cluster_fixture as cluster};
 use rstest::*;
@@ -47,9 +51,7 @@ async fn test_keep_alive_session(cluster: &ClusterGuard) -> anyhow::Result<()> {
     sleep(Duration::from_secs(3)).await; // sleep longer than the session timeout
 
     match configurator.ping().await {
-        Err(HoprTransportError::Session(hopr_lib::TransportSessionError::Manager(
-            hopr_lib::SessionManagerError::NonExistingSession,
-        ))) => {}
+        Err(HoprTransportError::Session(TransportSessionError::Manager(SessionManagerError::NonExistingSession))) => {}
         Err(e) => panic!(
             "expected SessionNotFound error when keeping alive session, but got different error: {:?}",
             e

--- a/hopr/reference/tests/transport_session-size3.rs
+++ b/hopr/reference/tests/transport_session-size3.rs
@@ -2,12 +2,12 @@ use std::{str::FromStr, time::Duration};
 
 use anyhow::Context;
 use hopr_lib::{
-    HopRouting, HoprSessionClientConfig, SessionCapabilities, SessionTarget,
+    HopRouting, HoprSessionClientConfig,
     api::node::HoprSessionClientOperations,
     errors::HoprTransportError,
     exports::{
         network::types::prelude::{IpOrHost, SealedHost},
-        transport::{SessionManagerError, TransportSessionError},
+        transport::{SessionCapabilities, SessionManagerError, SessionTarget, TransportSessionError},
     },
 };
 use hopr_reference::testing::fixtures::{ClusterGuard, TEST_GLOBAL_TIMEOUT, size_3_cluster_fixture as cluster};

--- a/hopr/reference/tests/transport_session.rs
+++ b/hopr/reference/tests/transport_session.rs
@@ -2,7 +2,7 @@
 use futures::future::try_join_all;
 use hopr_chain_connector::blokli_client::BlokliQueryClient;
 #[cfg(feature = "session-client")]
-use hopr_lib::HoprBalance;
+use hopr_lib::api::types::primitive::prelude::HoprBalance;
 use hopr_reference::testing::{
     fixtures::{
         MINIMUM_INCOMING_WIN_PROB, TEST_GLOBAL_TIMEOUT, TestNodeConfig, chain_propagation_delay, cluster_fixture,

--- a/hopr/reference/tests/transport_tickets.rs
+++ b/hopr/reference/tests/transport_tickets.rs
@@ -9,8 +9,8 @@ use hopr_api::{
 };
 use hopr_reference::{
     hopr_lib::{
-        HoprLibError,
         api::types::primitive::prelude::{HoprBalance, UnitaryFloatOps},
+        errors::HoprLibError,
     },
     testing::{
         fixtures::{ClusterGuard, MINIMUM_INCOMING_WIN_PROB, TEST_GLOBAL_TIMEOUT, TestNodeConfig, cluster_fixture},

--- a/hopr/reference/tests/transport_tickets.rs
+++ b/hopr/reference/tests/transport_tickets.rs
@@ -8,7 +8,10 @@ use hopr_api::{
     node::{HasChainApi, HasTicketManagement, IncentiveChannelOperations, IncentiveRedeemOperations},
 };
 use hopr_reference::{
-    hopr_lib::{HoprBalance, HoprLibError, UnitaryFloatOps},
+    hopr_lib::{
+        HoprLibError,
+        api::types::primitive::prelude::{HoprBalance, UnitaryFloatOps},
+    },
     testing::{
         fixtures::{ClusterGuard, MINIMUM_INCOMING_WIN_PROB, TEST_GLOBAL_TIMEOUT, TestNodeConfig, cluster_fixture},
         hopr::ChannelGuard,

--- a/hoprd/hoprd/src/config.rs
+++ b/hoprd/hoprd/src/config.rs
@@ -1,10 +1,9 @@
 use std::time::Duration;
 
 use hopr_lib::{
-    SafeModule,
     api::types::{internal::prelude::WinningProbability, primitive::prelude::HoprBalance},
     config::{
-        HoprLibConfig, HoprPacketPipelineConfig, HoprProtocolConfig, HostConfig, HostType, ProbeConfig,
+        HoprLibConfig, HoprPacketPipelineConfig, HoprProtocolConfig, HostConfig, HostType, ProbeConfig, SafeModule,
         SessionGlobalConfig, TagAllocatorConfig, TransportConfig,
     },
     exports::transport::config::HoprCodecConfig,

--- a/hoprd/hoprd/src/config.rs
+++ b/hoprd/hoprd/src/config.rs
@@ -1,10 +1,11 @@
 use std::time::Duration;
 
 use hopr_lib::{
-    HoprBalance, HoprProtocolConfig, SafeModule, TagAllocatorConfig, WinningProbability,
+    SafeModule,
+    api::types::{internal::prelude::WinningProbability, primitive::prelude::HoprBalance},
     config::{
-        HoprLibConfig, HoprPacketPipelineConfig, HostConfig, HostType, ProbeConfig, SessionGlobalConfig,
-        TransportConfig,
+        HoprLibConfig, HoprPacketPipelineConfig, HoprProtocolConfig, HostConfig, HostType, ProbeConfig,
+        SessionGlobalConfig, TagAllocatorConfig, TransportConfig,
     },
     exports::transport::config::HoprCodecConfig,
 };
@@ -338,7 +339,7 @@ mod tests {
 
     use anyhow::Context;
     use clap::{Args, Command, FromArgMatches};
-    use hopr_lib::Address;
+    use hopr_lib::api::types::primitive::prelude::Address;
     use tempfile::NamedTempFile;
 
     use super::*;

--- a/hoprd/hoprd/src/main.rs
+++ b/hoprd/hoprd/src/main.rs
@@ -3,7 +3,11 @@ use std::{num::NonZeroUsize, process::ExitCode, str::FromStr, sync::Arc};
 use async_signal::{Signal, Signals};
 use futures::{FutureExt, StreamExt, future::abortable};
 use hopr_chain_connector::{HoprBlockchainSafeConnector, blokli_client::BlokliClient};
-use hopr_lib::{AbortableList, HoprKeys, IdentityRetrievalModes, Keypair, ToHex, config::HoprLibConfig};
+use hopr_lib::{
+    AbortableList, HoprKeys, IdentityRetrievalModes,
+    api::types::{crypto::keypairs::Keypair, primitive::prelude::ToHex},
+    config::HoprLibConfig,
+};
 use hopr_network_graph::SharedChannelGraph;
 use hopr_transport_p2p::HoprNetwork;
 use hoprd::{cli::CliArgs, config::HoprdConfig, errors::HoprdError};

--- a/hoprd/rest-api-client/src/codegen/mod.rs
+++ b/hoprd/rest-api-client/src/codegen/mod.rs
@@ -2506,6 +2506,7 @@ at least the size of 2 Session packet payloads.*/
     /// </details>
     #[derive(::serde::Deserialize, ::serde::Serialize, Clone, Debug)]
     pub struct TicketProbabilityResponse {
+        ///Winning probability of a ticket.
         pub probability: f64,
     }
     ///Request body for the withdrawal endpoint.

--- a/hoprd/rest-api/src/account.rs
+++ b/hoprd/rest-api/src/account.rs
@@ -5,7 +5,10 @@ use axum::{
     http::status::StatusCode,
     response::IntoResponse,
 };
-use hopr_lib::{Address, HoprBalance, IncentiveChannelOperations, WxHOPR, XDai, XDaiBalance, api::node::HasChainApi};
+use hopr_lib::api::{
+    node::{HasChainApi, IncentiveChannelOperations},
+    types::primitive::prelude::{Address, HoprBalance, WxHOPR, XDai, XDaiBalance},
+};
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
 

--- a/hoprd/rest-api/src/channels.rs
+++ b/hoprd/rest-api/src/channels.rs
@@ -7,13 +7,16 @@ use axum::{
 };
 use futures::{StreamExt, TryFutureExt};
 use hopr_lib::{
-    Address, AsUnixTimestamp, ChannelEntry, ChannelStatus, HoprBalance, IncentiveChannelOperations,
     api::{
         chain::{ChainReadChannelOperations, ChannelSelector},
-        node::HasChainApi,
+        node::{HasChainApi, IncentiveChannelOperations},
+        types::{
+            crypto::prelude::Hash,
+            internal::prelude::{ChannelEntry, ChannelStatus},
+            primitive::prelude::{Address, AsUnixTimestamp, HoprBalance},
+        },
     },
     errors::{HoprLibError, HoprStatusError},
-    prelude::Hash,
 };
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
@@ -326,7 +329,7 @@ pub(super) async fn open_channel<
             }),
         )
             .into_response(),
-        Err(hopr_lib::EitherErr::Right(HoprLibError::StatusError(HoprStatusError::NotThereYet(..)))) => {
+        Err(hopr_lib::api::node::EitherErr::Right(HoprLibError::StatusError(HoprStatusError::NotThereYet(..)))) => {
             (StatusCode::PRECONDITION_FAILED, ApiErrorStatus::NotReady).into_response()
         }
         Err(e) => (
@@ -511,7 +514,7 @@ pub(super) async fn close_channel<
             }),
         )
             .into_response(),
-        Err(hopr_lib::EitherErr::Right(HoprLibError::StatusError(HoprStatusError::NotThereYet(..)))) => {
+        Err(hopr_lib::api::node::EitherErr::Right(HoprLibError::StatusError(HoprStatusError::NotThereYet(..)))) => {
             (StatusCode::PRECONDITION_FAILED, ApiErrorStatus::NotReady).into_response()
         }
         Err(e) => (
@@ -607,7 +610,7 @@ pub(super) async fn fund_channel<
             }),
         )
             .into_response(),
-        Err(hopr_lib::EitherErr::Right(HoprLibError::StatusError(HoprStatusError::NotThereYet(..)))) => {
+        Err(hopr_lib::api::node::EitherErr::Right(HoprLibError::StatusError(HoprStatusError::NotThereYet(..)))) => {
             (StatusCode::PRECONDITION_FAILED, ApiErrorStatus::NotReady).into_response()
         }
         Err(e) => (

--- a/hoprd/rest-api/src/channels.rs
+++ b/hoprd/rest-api/src/channels.rs
@@ -16,7 +16,7 @@ use hopr_lib::{
             primitive::prelude::{Address, AsUnixTimestamp, HoprBalance},
         },
     },
-    errors::{HoprLibError, HoprStatusError},
+    errors::HoprLibError,
 };
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
@@ -329,7 +329,7 @@ pub(super) async fn open_channel<
             }),
         )
             .into_response(),
-        Err(hopr_lib::api::node::EitherErr::Right(HoprLibError::StatusError(HoprStatusError::NotThereYet(..)))) => {
+        Err(hopr_lib::api::node::EitherErr::Right(HoprLibError::NotReady(..))) => {
             (StatusCode::PRECONDITION_FAILED, ApiErrorStatus::NotReady).into_response()
         }
         Err(e) => (
@@ -514,7 +514,7 @@ pub(super) async fn close_channel<
             }),
         )
             .into_response(),
-        Err(hopr_lib::api::node::EitherErr::Right(HoprLibError::StatusError(HoprStatusError::NotThereYet(..)))) => {
+        Err(hopr_lib::api::node::EitherErr::Right(HoprLibError::NotReady(..))) => {
             (StatusCode::PRECONDITION_FAILED, ApiErrorStatus::NotReady).into_response()
         }
         Err(e) => (
@@ -610,7 +610,7 @@ pub(super) async fn fund_channel<
             }),
         )
             .into_response(),
-        Err(hopr_lib::api::node::EitherErr::Right(HoprLibError::StatusError(HoprStatusError::NotThereYet(..)))) => {
+        Err(hopr_lib::api::node::EitherErr::Right(HoprLibError::NotReady(..))) => {
             (StatusCode::PRECONDITION_FAILED, ApiErrorStatus::NotReady).into_response()
         }
         Err(e) => (

--- a/hoprd/rest-api/src/lib.rs
+++ b/hoprd/rest-api/src/lib.rs
@@ -63,7 +63,7 @@ pub trait HoprNode:
     + hopr_lib::api::node::HasGraphView
     + hopr_lib::api::node::HasTransportApi
     + hopr_lib::api::node::HasTicketManagement
-    + hopr_lib::HoprSessionClientOperations
+    + hopr_lib::api::node::HoprSessionClientOperations
     + Send
     + Sync
     + 'static
@@ -77,7 +77,7 @@ impl<T> HoprNode for T where
         + hopr_lib::api::node::HasGraphView
         + hopr_lib::api::node::HasTransportApi
         + hopr_lib::api::node::HasTicketManagement
-        + hopr_lib::HoprSessionClientOperations
+        + hopr_lib::api::node::HoprSessionClientOperations
         + Send
         + Sync
         + 'static

--- a/hoprd/rest-api/src/middleware/prometheus.rs
+++ b/hoprd/rest-api/src/middleware/prometheus.rs
@@ -1,6 +1,6 @@
 use axum::{extract::Request, middleware::Next, response::Response};
 #[cfg(all(feature = "telemetry", not(test)))]
-use hopr_lib::AsUnixTimestamp;
+use hopr_lib::api::types::primitive::prelude::AsUnixTimestamp;
 
 #[cfg(all(feature = "telemetry", not(test)))]
 lazy_static::lazy_static! {

--- a/hoprd/rest-api/src/network.rs
+++ b/hoprd/rest-api/src/network.rs
@@ -347,7 +347,7 @@ pub(super) async fn graph<
         unique_keys.insert(*dst);
     }
 
-    let mut key_to_addr: HashMap<hopr_lib::OffchainPublicKey, String> = HashMap::new();
+    let mut key_to_addr: HashMap<hopr_lib::exports::transport::OffchainPublicKey, String> = HashMap::new();
     for key in &unique_keys {
         let label = match hopr.chain_api().packet_key_to_chain_key(key) {
             Ok(Some(addr)) => addr.to_string(),
@@ -356,7 +356,9 @@ pub(super) async fn graph<
         key_to_addr.insert(*key, label);
     }
 
-    let label = |key: &hopr_lib::OffchainPublicKey| key_to_addr.get(key).cloned().unwrap_or_else(|| key.to_string());
+    let label = |key: &hopr_lib::exports::transport::OffchainPublicKey| {
+        key_to_addr.get(key).cloned().unwrap_or_else(|| key.to_string())
+    };
 
     // Render DOT (Graphviz) format inline using trait methods on the observations.
     let mut dot = String::from("digraph hopr {\n");

--- a/hoprd/rest-api/src/network.rs
+++ b/hoprd/rest-api/src/network.rs
@@ -5,16 +5,15 @@ use axum::{
     http::status::StatusCode,
     response::IntoResponse,
 };
-use hopr_lib::{
-    Address, HoprBalance, IncentiveChannelOperations, Multiaddr,
-    api::{
-        chain::ChainKeyOperations,
-        graph::{
-            EdgeLinkObservable, NetworkGraphConnectivity, NetworkGraphView,
-            traits::{EdgeNetworkObservableRead, EdgeObservableRead, EdgeProtocolObservable},
-        },
-        node::{HasChainApi, HasGraphView},
+use hopr_lib::api::{
+    Multiaddr,
+    chain::ChainKeyOperations,
+    graph::{
+        EdgeLinkObservable, NetworkGraphConnectivity, NetworkGraphView,
+        traits::{EdgeNetworkObservableRead, EdgeObservableRead, EdgeProtocolObservable},
     },
+    node::{HasChainApi, HasGraphView, IncentiveChannelOperations},
+    types::primitive::prelude::{Address, HoprBalance},
 };
 use serde_with::{DisplayFromStr, serde_as};
 
@@ -218,11 +217,11 @@ pub(crate) enum AnnouncementOriginResponse {
     Dht,
 }
 
-impl From<hopr_lib::AnnouncementOrigin> for AnnouncementOriginResponse {
-    fn from(origin: hopr_lib::AnnouncementOrigin) -> Self {
+impl From<hopr_lib::api::node::AnnouncementOrigin> for AnnouncementOriginResponse {
+    fn from(origin: hopr_lib::api::node::AnnouncementOrigin) -> Self {
         match origin {
-            hopr_lib::AnnouncementOrigin::Chain => Self::Chain,
-            hopr_lib::AnnouncementOrigin::DHT => Self::Dht,
+            hopr_lib::api::node::AnnouncementOrigin::Chain => Self::Chain,
+            hopr_lib::api::node::AnnouncementOrigin::DHT => Self::Dht,
         }
     }
 }
@@ -447,7 +446,7 @@ mod tests {
     #[test]
     fn chain_origin_should_convert_from_domain_type() {
         assert_eq!(
-            AnnouncementOriginResponse::from(hopr_lib::AnnouncementOrigin::Chain),
+            AnnouncementOriginResponse::from(hopr_lib::api::node::AnnouncementOrigin::Chain),
             AnnouncementOriginResponse::Chain
         );
     }
@@ -455,7 +454,7 @@ mod tests {
     #[test]
     fn dht_origin_should_convert_from_domain_type() {
         assert_eq!(
-            AnnouncementOriginResponse::from(hopr_lib::AnnouncementOrigin::DHT),
+            AnnouncementOriginResponse::from(hopr_lib::api::node::AnnouncementOrigin::DHT),
             AnnouncementOriginResponse::Dht
         );
     }

--- a/hoprd/rest-api/src/node.rs
+++ b/hoprd/rest-api/src/node.rs
@@ -8,12 +8,11 @@ use axum::{
     http::status::StatusCode,
     response::IntoResponse,
 };
-use hopr_lib::{
-    Address, IncentiveChannelOperations, Multiaddr,
-    api::{
-        network::{Health, NetworkView},
-        node::{ComponentStatus, HasChainApi, HasNetworkView},
-    },
+use hopr_lib::api::{
+    Multiaddr,
+    network::{Health, NetworkView},
+    node::{ComponentStatus, HasChainApi, HasNetworkView, IncentiveChannelOperations},
+    types::primitive::prelude::Address,
 };
 use serde::Serialize;
 use serde_with::{DisplayFromStr, serde_as};

--- a/hoprd/rest-api/src/peers.rs
+++ b/hoprd/rest-api/src/peers.rs
@@ -6,15 +6,21 @@ use axum::{
     response::IntoResponse,
 };
 use hopr_lib::{
-    Address, ChannelEntry, ChannelStatus, HoprBalance, IncentiveChannelOperations, Multiaddr,
     api::{
+        Multiaddr,
         chain::{AccountSelector, ChainKeyOperations, ChainReadAccountOperations},
         graph::{EdgeLinkObservable, NetworkGraphConnectivity, NetworkGraphView, traits::EdgeObservableRead},
         network::NetworkView,
-        node::{HasChainApi, HasGraphView, HasNetworkView, HasTransportApi, TransportOperations},
+        node::{
+            HasChainApi, HasGraphView, HasNetworkView, HasTransportApi, IncentiveChannelOperations, TransportOperations,
+        },
+        types::{
+            crypto::prelude::Hash,
+            internal::prelude::{ChannelEntry, ChannelStatus},
+            primitive::prelude::{Address, HoprBalance},
+        },
     },
     errors::{HoprLibError, HoprTransportError},
-    prelude::Hash,
 };
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, DurationMilliSeconds, serde_as};
@@ -330,13 +336,13 @@ where
         Err(HoprTransportError::Protocol(hopr_lib::errors::ProtocolError::Timeout)) => {
             Ok((StatusCode::REQUEST_TIMEOUT, ApiErrorStatus::Timeout).into_response())
         }
-        Err(HoprTransportError::Probe(hopr_lib::ProbeError::TrafficError(_))) => {
+        Err(HoprTransportError::Probe(hopr_lib::errors::ProbeError::TrafficError(_))) => {
             Ok((StatusCode::REQUEST_TIMEOUT, ApiErrorStatus::Timeout).into_response())
         }
-        Err(HoprTransportError::Probe(hopr_lib::ProbeError::PingerError(e))) => {
+        Err(HoprTransportError::Probe(hopr_lib::errors::ProbeError::PingerError(e))) => {
             Ok((StatusCode::UNPROCESSABLE_ENTITY, ApiErrorStatus::PingError(e)).into_response())
         }
-        Err(HoprTransportError::Probe(hopr_lib::ProbeError::NonExistingPeer)) => {
+        Err(HoprTransportError::Probe(hopr_lib::errors::ProbeError::NonExistingPeer)) => {
             Ok((StatusCode::NOT_FOUND, ApiErrorStatus::PeerNotFound).into_response())
         }
         Err(e) => Ok((

--- a/hoprd/rest-api/src/session.rs
+++ b/hoprd/rest-api/src/session.rs
@@ -7,8 +7,8 @@ use axum::{
 };
 use base64::Engine;
 use hopr_lib::{
-    Address, HopRouting, HoprSessionClientConfig, SESSION_MTU, SURB_SIZE, ServiceId, SessionCapabilities, SessionId,
-    SessionTarget, SurbBalancerConfig, errors::HoprLibError,
+    HopRouting, HoprSessionClientConfig, SESSION_MTU, SURB_SIZE, ServiceId, SessionCapabilities, SessionId,
+    SessionTarget, SurbBalancerConfig, api::types::primitive::prelude::Address, errors::HoprLibError,
 };
 use hopr_utils_session::{ListenerId, build_binding_host, create_tcp_client_binding, create_udp_client_binding};
 use serde::{Deserialize, Serialize};
@@ -125,7 +125,7 @@ pub enum RoutingOptions {
 }
 
 impl TryFrom<RoutingOptions> for hopr_lib::HopRouting {
-    type Error = hopr_lib::GeneralError;
+    type Error = hopr_lib::api::types::primitive::errors::GeneralError;
 
     /// Converts API routing options into protocol-level hop routing.
     fn try_from(value: RoutingOptions) -> Result<Self, Self::Error> {
@@ -225,7 +225,14 @@ impl SessionClientRequest {
     pub(crate) async fn into_protocol_session_config(
         self,
         target_protocol: IpProtocol,
-    ) -> Result<(hopr_lib::Address, SessionTarget, HoprSessionClientConfig), ApiErrorStatus> {
+    ) -> Result<
+        (
+            hopr_lib::api::types::primitive::prelude::Address,
+            SessionTarget,
+            HoprSessionClientConfig,
+        ),
+        ApiErrorStatus,
+    > {
         let target_spec: hopr_utils_session::SessionTargetSpec = self.target.clone().into();
         Ok((
             self.destination,
@@ -735,11 +742,11 @@ pub enum IpProtocol {
     UDP,
 }
 
-impl From<IpProtocol> for hopr_lib::IpProtocol {
-    fn from(protocol: IpProtocol) -> hopr_lib::IpProtocol {
+impl From<IpProtocol> for hopr_lib::exports::network::types::prelude::IpProtocol {
+    fn from(protocol: IpProtocol) -> hopr_lib::exports::network::types::prelude::IpProtocol {
         match protocol {
-            IpProtocol::TCP => hopr_lib::IpProtocol::TCP,
-            IpProtocol::UDP => hopr_lib::IpProtocol::UDP,
+            IpProtocol::TCP => hopr_lib::exports::network::types::prelude::IpProtocol::TCP,
+            IpProtocol::UDP => hopr_lib::exports::network::types::prelude::IpProtocol::UDP,
         }
     }
 }
@@ -796,7 +803,7 @@ pub(crate) async fn close_client<H: Send + Sync + 'static>(
         let open_listeners = &state.open_listeners.0;
 
         let mut to_remove = Vec::new();
-        let protocol: hopr_lib::IpProtocol = protocol.into();
+        let protocol: hopr_lib::exports::network::types::prelude::IpProtocol = protocol.into();
 
         // Find all listeners with protocol, listening IP and optionally port number (if > 0)
         open_listeners

--- a/hoprd/rest-api/src/session.rs
+++ b/hoprd/rest-api/src/session.rs
@@ -7,8 +7,12 @@ use axum::{
 };
 use base64::Engine;
 use hopr_lib::{
-    HopRouting, HoprSessionClientConfig, SESSION_MTU, SURB_SIZE, ServiceId, SessionCapabilities, SessionId,
-    SessionTarget, SurbBalancerConfig, api::types::primitive::prelude::Address, errors::HoprLibError,
+    HopRouting, HoprSessionClientConfig,
+    api::types::primitive::prelude::Address,
+    errors::HoprLibError,
+    exports::transport::{
+        SESSION_MTU, SURB_SIZE, ServiceId, SessionCapabilities, SessionId, SessionTarget, SurbBalancerConfig,
+    },
 };
 use hopr_utils_session::{ListenerId, build_binding_host, create_tcp_client_binding, create_udp_client_binding};
 use serde::{Deserialize, Serialize};
@@ -103,16 +107,19 @@ pub enum SessionCapability {
     NoRateControl,
 }
 
-impl From<SessionCapability> for hopr_lib::SessionCapabilities {
-    fn from(cap: SessionCapability) -> hopr_lib::SessionCapabilities {
+impl From<SessionCapability> for hopr_lib::exports::transport::SessionCapabilities {
+    fn from(cap: SessionCapability) -> hopr_lib::exports::transport::SessionCapabilities {
         match cap {
-            SessionCapability::Segmentation => hopr_lib::SessionCapability::Segmentation.into(),
+            SessionCapability::Segmentation => hopr_lib::exports::transport::SessionCapability::Segmentation.into(),
             SessionCapability::Retransmission => {
-                hopr_lib::SessionCapability::RetransmissionNack | hopr_lib::SessionCapability::RetransmissionAck
+                hopr_lib::exports::transport::SessionCapability::RetransmissionNack
+                    | hopr_lib::exports::transport::SessionCapability::RetransmissionAck
             }
-            SessionCapability::RetransmissionAckOnly => hopr_lib::SessionCapability::RetransmissionAck.into(),
-            SessionCapability::NoDelay => hopr_lib::SessionCapability::NoDelay.into(),
-            SessionCapability::NoRateControl => hopr_lib::SessionCapability::NoRateControl.into(),
+            SessionCapability::RetransmissionAckOnly => {
+                hopr_lib::exports::transport::SessionCapability::RetransmissionAck.into()
+            }
+            SessionCapability::NoDelay => hopr_lib::exports::transport::SessionCapability::NoDelay.into(),
+            SessionCapability::NoRateControl => hopr_lib::exports::transport::SessionCapability::NoRateControl.into(),
         }
     }
 }
@@ -249,9 +256,9 @@ impl SessionClientRequest {
                     })
                     .unwrap_or_else(|| match target_protocol {
                         IpProtocol::TCP => {
-                            hopr_lib::SessionCapability::RetransmissionAck
-                                | hopr_lib::SessionCapability::RetransmissionNack
-                                | hopr_lib::SessionCapability::Segmentation
+                            hopr_lib::exports::transport::SessionCapability::RetransmissionAck
+                                | hopr_lib::exports::transport::SessionCapability::RetransmissionNack
+                                | hopr_lib::exports::transport::SessionCapability::Segmentation
                         }
                         // Only Segmentation capability for UDP per default
                         _ => SessionCapability::Segmentation.into(),

--- a/hoprd/rest-api/src/testing.rs
+++ b/hoprd/rest-api/src/testing.rs
@@ -18,9 +18,9 @@ use async_trait::async_trait;
 use bimap::BiMap;
 use futures::stream::{self, BoxStream};
 use hopr_lib::{
-    Address, ChainKeypair, HoprBalance, Keypair, Multiaddr, OffchainKeypair, OffchainPublicKey, PeerId,
-    WinningProbability,
+    OffchainPublicKey,
     api::{
+        Multiaddr, PeerId,
         chain::{self, *},
         network::{Health, NetworkEvent, NetworkView},
         node::{
@@ -28,7 +28,14 @@ use hopr_lib::{
             HoprState, NodeOnchainIdentity, TicketEvent,
         },
         tickets::{ChannelStats, RedemptionResult, TicketManagement},
-        types::primitive::prelude::{Balance, Currency, KeyIdMapping, KeyIdent},
+        types::{
+            crypto::{
+                keypairs::Keypair,
+                prelude::{ChainKeypair, OffchainKeypair},
+            },
+            internal::prelude::WinningProbability,
+            primitive::prelude::{Address, Balance, Currency, HoprBalance, KeyIdMapping, KeyIdent},
+        },
     },
     errors::HoprLibError,
 };

--- a/hoprd/rest-api/src/testing.rs
+++ b/hoprd/rest-api/src/testing.rs
@@ -18,7 +18,6 @@ use async_trait::async_trait;
 use bimap::BiMap;
 use futures::stream::{self, BoxStream};
 use hopr_lib::{
-    OffchainPublicKey,
     api::{
         Multiaddr, PeerId,
         chain::{self, *},
@@ -31,7 +30,7 @@ use hopr_lib::{
         types::{
             crypto::{
                 keypairs::Keypair,
-                prelude::{ChainKeypair, OffchainKeypair},
+                prelude::{ChainKeypair, OffchainKeypair, OffchainPublicKey},
             },
             internal::prelude::WinningProbability,
             primitive::prelude::{Address, Balance, Currency, HoprBalance, KeyIdMapping, KeyIdent},

--- a/hoprd/rest-api/src/tickets.rs
+++ b/hoprd/rest-api/src/tickets.rs
@@ -5,13 +5,14 @@ use axum::{
     http::status::StatusCode,
     response::IntoResponse,
 };
-use hopr_lib::{
-    Address, ChannelStatus, HoprBalance, IncentiveChannelOperations, IncentiveRedeemOperations,
-    api::{
-        node::{HasChainApi, HasTicketManagement},
-        tickets::ChannelStats,
+use hopr_lib::api::{
+    node::{HasChainApi, HasTicketManagement, IncentiveChannelOperations, IncentiveRedeemOperations},
+    tickets::ChannelStats,
+    types::{
+        crypto::prelude::Hash,
+        internal::prelude::ChannelStatus,
+        primitive::prelude::{Address, HoprBalance},
     },
-    prelude::Hash,
 };
 use serde::Deserialize;
 use serde_with::{DisplayFromStr, serde_as};

--- a/impls/strategy/src/auto_funding.rs
+++ b/impls/strategy/src/auto_funding.rs
@@ -18,14 +18,15 @@ use std::{
 use async_trait::async_trait;
 use dashmap::DashSet;
 use futures::StreamExt;
-use hopr_lib::{
-    ChannelDirection, ChannelEntry, ChannelId, ChannelStatus, ChannelStatusDiscriminants, HoprBalance,
-    api::{
-        chain::{
-            ChainReadChannelOperations, ChainReadSafeOperations, ChainValues, ChainWriteChannelOperations,
-            ChannelSelector, SafeSelector,
-        },
-        node::{ActionableEventDiscriminant, ActionableEventSource, HasChainApi},
+use hopr_lib::api::{
+    chain::{
+        ChainReadChannelOperations, ChainReadSafeOperations, ChainValues, ChainWriteChannelOperations, ChannelSelector,
+        SafeSelector,
+    },
+    node::{ActionableEventDiscriminant, ActionableEventSource, HasChainApi},
+    types::{
+        internal::prelude::{ChannelDirection, ChannelEntry, ChannelId, ChannelStatus, ChannelStatusDiscriminants},
+        primitive::prelude::HoprBalance,
     },
 };
 use serde::{Deserialize, Serialize};
@@ -398,15 +399,16 @@ mod tests {
     use futures_time::future::FutureExt;
     use hex_literal::hex;
     use hopr_chain_connector::{create_trustful_hopr_blokli_connector, testing::BlokliTestStateBuilder};
-    use hopr_lib::{
-        Address, BytesRepresentable, ChainKeypair, ChannelDirection, ChannelEntry, ChannelStatus, HoprBalance, Keypair,
-        XDaiBalance,
-        api::{
-            chain::{ChainEvent, ChainEvents, HoprChainApi},
-            node::{
-                ActionableEvent, ComponentStatus, ComponentStatusReporter, EventWaitResult, HasChainApi,
-                NodeOnchainIdentity,
-            },
+    use hopr_lib::api::{
+        chain::{ChainEvent, ChainEvents, HoprChainApi},
+        node::{
+            ActionableEvent, ComponentStatus, ComponentStatusReporter, EventWaitResult, HasChainApi,
+            NodeOnchainIdentity,
+        },
+        types::{
+            crypto::{keypairs::Keypair, prelude::ChainKeypair},
+            internal::prelude::{ChannelDirection, ChannelEntry, ChannelStatus},
+            primitive::prelude::{Address, BytesRepresentable, HoprBalance, XDaiBalance},
         },
     };
 

--- a/impls/strategy/src/auto_redeeming.rs
+++ b/impls/strategy/src/auto_redeeming.rs
@@ -13,15 +13,16 @@ use std::{
 use async_trait::async_trait;
 use futures::{StreamExt, TryStreamExt};
 use hopr_async_runtime::{prelude::AbortHandle, spawn_as_abortable};
-use hopr_lib::{
-    ChannelChange, ChannelDirection, ChannelEntry, ChannelId, ChannelStatus, HoprBalance, VerifiedTicket,
-    api::{
-        chain::{ChainEvent, ChainReadChannelOperations, ChainWriteTicketOperations, ChannelSelector},
-        node::{
-            ActionableEvent, ActionableEventDiscriminant, ActionableEventSource, HasChainApi, HasTicketManagement,
-            TicketEvent,
-        },
-        tickets::TicketManagement,
+use hopr_lib::api::{
+    chain::{ChainEvent, ChainReadChannelOperations, ChainWriteTicketOperations, ChannelSelector},
+    node::{
+        ActionableEvent, ActionableEventDiscriminant, ActionableEventSource, HasChainApi, HasTicketManagement,
+        TicketEvent,
+    },
+    tickets::TicketManagement,
+    types::{
+        internal::prelude::{ChannelChange, ChannelDirection, ChannelEntry, ChannelId, ChannelStatus, VerifiedTicket},
+        primitive::prelude::HoprBalance,
     },
 };
 use moka::notification::RemovalCause;
@@ -408,15 +409,19 @@ mod tests {
         types::crypto_random::Randomizable,
     };
     use hopr_chain_connector::{HoprBlockchainSafeConnector, create_trustful_hopr_blokli_connector, testing::*};
-    use hopr_lib::{
-        Address, BytesRepresentable, ChainKeypair, HalfKey, Hash, HoprBalance, Keypair, RedeemableTicket, Response,
-        TicketBuilder, UnitaryFloatOps, WinningProbability, XDaiBalance,
-        api::{
-            chain::{ChainEvent, ChainEvents, ChainWriteTicketOperations, HoprChainApi},
-            node::{
-                ActionableEvent, ComponentStatus, ComponentStatusReporter, EventWaitResult, HasChainApi,
-                HasTicketManagement, NodeOnchainIdentity, TicketEvent,
+    use hopr_lib::api::{
+        chain::{ChainEvent, ChainEvents, ChainWriteTicketOperations, HoprChainApi},
+        node::{
+            ActionableEvent, ComponentStatus, ComponentStatusReporter, EventWaitResult, HasChainApi,
+            HasTicketManagement, NodeOnchainIdentity, TicketEvent,
+        },
+        types::{
+            crypto::{
+                keypairs::Keypair,
+                prelude::{ChainKeypair, HalfKey, Hash, Response},
             },
+            internal::prelude::{RedeemableTicket, TicketBuilder, WinningProbability},
+            primitive::prelude::{Address, BytesRepresentable, HoprBalance, UnitaryFloatOps, XDaiBalance},
         },
     };
 

--- a/impls/strategy/src/channel_finalizer.rs
+++ b/impls/strategy/src/channel_finalizer.rs
@@ -7,12 +7,10 @@ use std::{
 
 use async_trait::async_trait;
 use futures::StreamExt;
-use hopr_lib::{
-    ChannelStatusDiscriminants, Utc,
-    api::{
-        chain::{ChainReadChannelOperations, ChainWriteChannelOperations, ChannelSelector},
-        node::HasChainApi,
-    },
+use hopr_lib::api::{
+    chain::{ChainReadChannelOperations, ChainWriteChannelOperations, ChannelSelector},
+    node::HasChainApi,
+    types::{internal::prelude::ChannelStatusDiscriminants, primitive::prelude::Utc},
 };
 use serde::{Deserialize, Serialize};
 use tracing::{debug, error, info};
@@ -168,11 +166,13 @@ mod tests {
     use futures_time::future::FutureExt;
     use hex_literal::hex;
     use hopr_chain_connector::{create_trustful_hopr_blokli_connector, testing::BlokliTestStateBuilder};
-    use hopr_lib::{
-        Address, BytesRepresentable, ChainKeypair, ChannelEntry, ChannelStatus, HoprBalance, Keypair, XDaiBalance,
-        api::{
-            chain::{ChainEvent, ChainEvents, HoprChainApi},
-            node::{ComponentStatus, ComponentStatusReporter, EventWaitResult, HasChainApi, NodeOnchainIdentity},
+    use hopr_lib::api::{
+        chain::{ChainEvent, ChainEvents, HoprChainApi},
+        node::{ComponentStatus, ComponentStatusReporter, EventWaitResult, HasChainApi, NodeOnchainIdentity},
+        types::{
+            crypto::{keypairs::Keypair, prelude::ChainKeypair},
+            internal::prelude::{ChannelEntry, ChannelStatus},
+            primitive::prelude::{Address, BytesRepresentable, HoprBalance, XDaiBalance},
         },
     };
     use lazy_static::lazy_static;

--- a/impls/strategy/src/errors.rs
+++ b/impls/strategy/src/errors.rs
@@ -13,8 +13,8 @@ pub enum StrategyError {
     #[error("non-specific strategy error: {0}")]
     Other(anyhow::Error),
 
-    #[error(transparent)]
-    HoprLib(#[from] hopr_lib::errors::HoprLibError),
+    #[error("HOPR error: {0}")]
+    HoprError(String),
 
     #[error("lower-level error: {0}")]
     GeneralError(#[from] GeneralError),

--- a/impls/strategy/src/errors.rs
+++ b/impls/strategy/src/errors.rs
@@ -14,7 +14,7 @@ pub enum StrategyError {
     Other(anyhow::Error),
 
     #[error("HOPR error: {0}")]
-    HoprError(String),
+    HoprError(anyhow::Error),
 
     #[error("lower-level error: {0}")]
     GeneralError(#[from] GeneralError),

--- a/impls/strategy/src/errors.rs
+++ b/impls/strategy/src/errors.rs
@@ -1,4 +1,4 @@
-use hopr_lib::GeneralError;
+use hopr_lib::api::types::primitive::errors::GeneralError;
 use thiserror::Error;
 
 /// Enumerates all errors in this crate.

--- a/localcluster/src/client_helper.rs
+++ b/localcluster/src/client_helper.rs
@@ -2,7 +2,7 @@ use std::process::Child;
 
 use anyhow::{Context, Result};
 use futures::future::try_join_all;
-use hopr_lib::HoprBalance;
+use hopr_lib::api::types::primitive::prelude::HoprBalance;
 use hoprd_api_client;
 use reqwest::header::{AUTHORIZATION, HeaderMap, HeaderValue};
 

--- a/localcluster/src/identity.rs
+++ b/localcluster/src/identity.rs
@@ -9,11 +9,12 @@ use hopr_chain_connector::{
     reexports::chain::exports::alloy::hex,
 };
 use hopr_lib::{
-    HoprKeys, SafeModule,
+    HoprKeys,
     api::types::{
         crypto::{crypto_traits::Randomizable, keypairs::Keypair, prelude::ChainKeypair},
         primitive::prelude::XDaiBalance,
     },
+    config::SafeModule,
 };
 use hopr_reference::config::SessionIpForwardingConfig;
 use hoprd::config::{Db, HoprdConfig, Identity, UserHoprLibConfig, UserHoprNetworkConfig};

--- a/localcluster/src/identity.rs
+++ b/localcluster/src/identity.rs
@@ -8,7 +8,13 @@ use hopr_chain_connector::{
     create_trustful_safeless_hopr_blokli_connector,
     reexports::chain::exports::alloy::hex,
 };
-use hopr_lib::{ChainKeypair, HoprKeys, Keypair, SafeModule, XDaiBalance, crypto_traits::Randomizable};
+use hopr_lib::{
+    HoprKeys, SafeModule,
+    api::types::{
+        crypto::{crypto_traits::Randomizable, keypairs::Keypair, prelude::ChainKeypair},
+        primitive::prelude::XDaiBalance,
+    },
+};
 use hopr_reference::config::SessionIpForwardingConfig;
 use hoprd::config::{Db, HoprdConfig, Identity, UserHoprLibConfig, UserHoprNetworkConfig};
 use hoprd_api::config::{Api, Auth};

--- a/utils/session/src/lib.rs
+++ b/utils/session/src/lib.rs
@@ -27,9 +27,15 @@ use hopr_api::{
 };
 use hopr_async_runtime::Abortable;
 use hopr_lib::{
-    Address, Hopr, HoprSession, HoprSessionClientConfig, HoprSessionClientOperations, HoprSessionConfigurator,
-    NetworkView, OffchainPublicKey, RoutingOptions, SURB_SIZE, ServiceId, SessionId, SessionTarget,
-    errors::HoprLibError, transfer_session,
+    Hopr, HoprSession, HoprSessionClientConfig, HoprSessionConfigurator, OffchainPublicKey, SURB_SIZE, ServiceId,
+    SessionId, SessionTarget,
+    api::{
+        network::NetworkView,
+        node::HoprSessionClientOperations,
+        types::{internal::routing::RoutingOptions, primitive::prelude::Address},
+    },
+    errors::HoprLibError,
+    transfer_session,
 };
 use hopr_network_types::{
     prelude::{ConnectedUdpStream, IpOrHost, IpProtocol, SealedHost, UdpStreamParallelism},
@@ -779,8 +785,14 @@ mod tests {
     use futures_time::future::FutureExt as TimeFutureExt;
     use hopr_api::types::crypto::crypto_traits::Randomizable;
     use hopr_lib::{
-        Address, ApplicationData, ApplicationDataIn, ApplicationDataOut, HoprPseudonym, HoprSession, SessionId,
-        exports::types::internal::routing::{DestinationRouting, RoutingOptions},
+        ApplicationData, ApplicationDataIn, ApplicationDataOut, HoprSession, SessionId,
+        api::types::{
+            internal::{
+                prelude::HoprPseudonym,
+                routing::{DestinationRouting, RoutingOptions},
+            },
+            primitive::prelude::Address,
+        },
     };
     use hopr_transport::session::HoprSessionConfig;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};

--- a/utils/session/src/lib.rs
+++ b/utils/session/src/lib.rs
@@ -27,15 +27,17 @@ use hopr_api::{
 };
 use hopr_async_runtime::Abortable;
 use hopr_lib::{
-    Hopr, HoprSession, HoprSessionClientConfig, HoprSessionConfigurator, OffchainPublicKey, SURB_SIZE, ServiceId,
-    SessionId, SessionTarget,
+    Hopr, HoprSessionClientConfig,
     api::{
         network::NetworkView,
         node::HoprSessionClientOperations,
         types::{internal::routing::RoutingOptions, primitive::prelude::Address},
     },
     errors::HoprLibError,
-    transfer_session,
+    exports::transport::{
+        HoprSession, HoprSessionConfigurator, OffchainPublicKey, SURB_SIZE, ServiceId, SessionId, SessionTarget,
+        transfer_session,
+    },
 };
 use hopr_network_types::{
     prelude::{ConnectedUdpStream, IpOrHost, IpProtocol, SealedHost, UdpStreamParallelism},
@@ -785,7 +787,6 @@ mod tests {
     use futures_time::future::FutureExt as TimeFutureExt;
     use hopr_api::types::crypto::crypto_traits::Randomizable;
     use hopr_lib::{
-        ApplicationData, ApplicationDataIn, ApplicationDataOut, HoprSession, SessionId,
         api::types::{
             internal::{
                 prelude::HoprPseudonym,
@@ -793,6 +794,7 @@ mod tests {
             },
             primitive::prelude::Address,
         },
+        exports::transport::{ApplicationData, ApplicationDataIn, ApplicationDataOut, HoprSession, SessionId},
     };
     use hopr_transport::session::HoprSessionConfig;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};


### PR DESCRIPTION
## Summary

- Replaces `futures::stream::select_all` with `futures_concurrency::Merge` in `ActionableEventSource` for fair stream distribution
- Removes the massive flat re-export surface (`pub use hopr_transport::*`, `pub use hopr_network_types::prelude::*`, `pub use hopr_api::types::{crypto, internal, primitive}::prelude::*`) from hopr-lib root — all hopr-api types are now exclusively accessible via `hopr_lib::api::*`
- Moves all `pub use hopr_transport::{...}` items into `hopr_lib::exports::transport`, removing them from the root namespace
- Gates session-client `use hopr_transport` imports behind `#[cfg(feature = "session-client")]`
- Narrows `wait_for_funds` visibility to `pub(crate)`
- Removes `pub use crate::config::SafeModule` from hopr-lib root
- Replaces `StrategyError::HoprLib(#[from] HoprLibError)` with `HoprError(anyhow::Error)` in hopr-strategy (preserves backtraces)
- Removes `HoprBuilder::new()` (unit struct — superseded by struct literal); callers use `HoprBuilder` directly
- Updates all consumers (hoprd, hoprd-rest-api, hopr-strategy, hopr-reference, hopr-utils-session, localcluster) to use `hopr_lib::api::*` and `hopr_lib::exports::transport::*` paths
- Refactors `HoprLibError` (closes hoprnet/hoprnet#7990):
  - Removes root re-exports of `HoprLibError` — errors are exclusively under `hopr_lib::errors::*`, config under `hopr_lib::config::*`
  - Flattens `HoprStatusError` into `HoprLibError` — replaces two-level `StatusError(HoprStatusError::NotThereYet(..))` with direct `NotReady(HoprState, String)` variant
  - Removes 3 dead `From` impls (`TypeError`, `SpawnError`, `TicketManager`) — none were triggered anywhere in the workspace
  - Drops `hopr-ticket-manager` as a direct dependency of hopr-lib
  - Adds `Timeout { context }` and `InsufficientFunds(String)` variants, replacing overloaded `GeneralError` uses in the library's own code
  - Publicly exposes `NetworkTypeError` sub-variants from `errors::*` for consumer pattern matching, parallel to the existing transport error re-exports
  - Adds doc comments to every `HoprLibError` variant