### PR TITLE
fix: reduce benchmark time + configure timeouts

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -789,9 +789,12 @@
               program = toString (
                 pkgs.writeShellScript "bench-run" ''
                   set -euo pipefail
-                  nix build -L .#bench-build
                   shopt -s nullglob
                   bins=(result/bin/*)
+                  if [ ''${#bins[@]} -eq 0 ]; then
+                    nix build -L .#bench-build
+                    bins=(result/bin/*)
+                  fi
                   if [ ''${#bins[@]} -eq 0 ]; then
                     echo "No benchmark binaries found under result/bin" >&2
                     exit 1

--- a/impls/graph/benches/traverse_bench.rs
+++ b/impls/graph/benches/traverse_bench.rs
@@ -109,66 +109,71 @@ fn build_graph(node_count: usize, density: usize) -> (ChannelGraph, Vec<Offchain
 fn bench_simple_paths(c: &mut Criterion) {
     let mut group = c.benchmark_group("NetworkGraphTraverse/simple_paths");
 
-    for size in [10_usize, 100, 1_000] {
-        for density in [10_usize, 100, 1_000] {
-            let (graph, keys) = build_graph(size, density);
-            let me = &keys[0];
-            let epn = (size - 1).min(density); // effective edges per node
+    for (size, density) in [
+        (10, 10),
+        (100, 10),
+        (100, 100),
+        (1_000, 10),
+        (1_000, 100),
+        (1_000, 1_000),
+    ] {
+        let (graph, keys) = build_graph(size, density);
+        let me = &keys[0];
+        let epn = (size - 1).min(density); // effective edges per node
 
-            let dst_2edge = &keys[(epn + 1).min(size - 1)];
-            let dst_3edge = &keys[(2 * epn + 1).min(size - 1)];
-            let dst_4edge = &keys[(3 * epn + 1).min(size - 1)];
+        let dst_2edge = &keys[(epn + 1).min(size - 1)];
+        let dst_3edge = &keys[(2 * epn + 1).min(size - 1)];
+        let dst_4edge = &keys[(3 * epn + 1).min(size - 1)];
 
-            let param = format!("{size}nodes/{density}x");
+        let param = format!("{size}nodes/{density}x");
 
-            group.bench_with_input(BenchmarkId::new("2-edge", &param), &size, |b, _| {
-                b.iter(|| {
-                    black_box(graph.simple_paths(
-                        me,
-                        black_box(dst_2edge),
-                        2,
-                        Some(10),
-                        EdgeValueFn::forward(
-                            std::num::NonZeroUsize::new(2).expect("is greater than 1"),
-                            BENCH_EDGE_PENALTY,
-                            BENCH_MIN_ACK_RATE,
-                        ),
-                    ))
-                });
+        group.bench_with_input(BenchmarkId::new("2-edge", &param), &size, |b, _| {
+            b.iter(|| {
+                black_box(graph.simple_paths(
+                    me,
+                    black_box(dst_2edge),
+                    2,
+                    Some(10),
+                    EdgeValueFn::forward(
+                        std::num::NonZeroUsize::new(2).expect("is greater than 1"),
+                        BENCH_EDGE_PENALTY,
+                        BENCH_MIN_ACK_RATE,
+                    ),
+                ))
             });
+        });
 
-            group.bench_with_input(BenchmarkId::new("3-edge", &param), &size, |b, _| {
-                b.iter(|| {
-                    black_box(graph.simple_paths(
-                        me,
-                        black_box(dst_3edge),
-                        3,
-                        Some(10),
-                        EdgeValueFn::forward(
-                            std::num::NonZeroUsize::new(3).expect("is greater than 1"),
-                            BENCH_EDGE_PENALTY,
-                            BENCH_MIN_ACK_RATE,
-                        ),
-                    ))
-                });
+        group.bench_with_input(BenchmarkId::new("3-edge", &param), &size, |b, _| {
+            b.iter(|| {
+                black_box(graph.simple_paths(
+                    me,
+                    black_box(dst_3edge),
+                    3,
+                    Some(10),
+                    EdgeValueFn::forward(
+                        std::num::NonZeroUsize::new(3).expect("is greater than 1"),
+                        BENCH_EDGE_PENALTY,
+                        BENCH_MIN_ACK_RATE,
+                    ),
+                ))
             });
+        });
 
-            group.bench_with_input(BenchmarkId::new("4-edge", &param), &size, |b, _| {
-                b.iter(|| {
-                    black_box(graph.simple_paths(
-                        me,
-                        black_box(dst_4edge),
-                        4,
-                        Some(10),
-                        EdgeValueFn::forward(
-                            std::num::NonZeroUsize::new(4).expect("is greater than 1"),
-                            BENCH_EDGE_PENALTY,
-                            BENCH_MIN_ACK_RATE,
-                        ),
-                    ))
-                });
+        group.bench_with_input(BenchmarkId::new("4-edge", &param), &size, |b, _| {
+            b.iter(|| {
+                black_box(graph.simple_paths(
+                    me,
+                    black_box(dst_4edge),
+                    4,
+                    Some(10),
+                    EdgeValueFn::forward(
+                        std::num::NonZeroUsize::new(4).expect("is greater than 1"),
+                        BENCH_EDGE_PENALTY,
+                        BENCH_MIN_ACK_RATE,
+                    ),
+                ))
             });
-        }
+        });
     }
 
     group.finish();
@@ -191,23 +196,28 @@ fn bench_simple_paths(c: &mut Criterion) {
 fn bench_simple_loopback(c: &mut Criterion) {
     let mut group = c.benchmark_group("NetworkGraphTraverse/simple_loopback_to_self");
 
-    for size in [10_usize, 100, 1_000] {
-        for density in [10_usize, 100, 1_000] {
-            let (graph, _keys) = build_graph(size, density);
-            let param = format!("{size}nodes/{density}x");
+    for (size, density) in [
+        (10, 10),
+        (100, 10),
+        (100, 100),
+        (1_000, 10),
+        (1_000, 100),
+        (1_000, 1_000),
+    ] {
+        let (graph, _keys) = build_graph(size, density);
+        let param = format!("{size}nodes/{density}x");
 
-            group.bench_with_input(BenchmarkId::new("2-edge", &param), &size, |b, _| {
-                b.iter(|| black_box(graph.simple_loopback_to_self(2, Some(10))));
-            });
+        group.bench_with_input(BenchmarkId::new("2-edge", &param), &size, |b, _| {
+            b.iter(|| black_box(graph.simple_loopback_to_self(2, Some(10))));
+        });
 
-            group.bench_with_input(BenchmarkId::new("3-edge", &param), &size, |b, _| {
-                b.iter(|| black_box(graph.simple_loopback_to_self(3, Some(10))));
-            });
+        group.bench_with_input(BenchmarkId::new("3-edge", &param), &size, |b, _| {
+            b.iter(|| black_box(graph.simple_loopback_to_self(3, Some(10))));
+        });
 
-            group.bench_with_input(BenchmarkId::new("4-edge", &param), &size, |b, _| {
-                b.iter(|| black_box(graph.simple_loopback_to_self(4, Some(10))));
-            });
-        }
+        group.bench_with_input(BenchmarkId::new("4-edge", &param), &size, |b, _| {
+            b.iter(|| black_box(graph.simple_loopback_to_self(4, Some(10))));
+        });
     }
 
     group.finish();

--- a/protocols/session/benches/socket_bench.rs
+++ b/protocols/session/benches/socket_bench.rs
@@ -58,7 +58,7 @@ pub fn stateless_socket_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("stateless_socket_benchmark");
     const KB: usize = 1024;
 
-    group.sample_size(100000);
+    group.sample_size(50000);
 
     for size in [/* 16 * KB, 64 * KB, */ 128 * KB, 1024 * KB].iter() {
         let mut alice_data = vec![0u8; *size];

--- a/transport/mixer/benches/mixer_throughput_bench.rs
+++ b/transport/mixer/benches/mixer_throughput_bench.rs
@@ -21,16 +21,12 @@ pub fn mixer_throughput(
     c: &mut Criterion,
     cfg: MixerConfig,
     description: &str,
+    sizes: &[usize],
     f: impl Fn(&'static str, usize, MixerConfig) -> BoxFuture<'static, ()>,
 ) {
     let mut group = c.benchmark_group("mixer_throughput");
     group.sample_size(SAMPLE_SIZE);
-    for bytes in [
-        10 * 1024 * 2 * RANDOM_GIBBERISH.len(),
-        40 * 1024 * 2 * RANDOM_GIBBERISH.len(),
-    ]
-    .iter()
-    {
+    for bytes in sizes {
         group.throughput(Throughput::Bytes(*bytes as u64));
         group.bench_with_input(
             BenchmarkId::from_parameter(format!(
@@ -93,6 +89,10 @@ pub fn mixer_channel_throughput_minimal_mixing(c: &mut Criterion) {
         c,
         minimal_delay_mixer_cfg(),
         "mixer_channel",
+        &[
+            10 * 1024 * 2 * RANDOM_GIBBERISH.len(),
+            40 * 1024 * 2 * RANDOM_GIBBERISH.len(),
+        ],
         send_continuous_channel_load,
     );
 }
@@ -102,6 +102,7 @@ pub fn mixer_channel_throughput_through_sink_minimal_mixing(c: &mut Criterion) {
         c,
         minimal_delay_mixer_cfg(),
         "mixer_channel_sink_pipe",
+        &[40 * 1024 * 2 * RANDOM_GIBBERISH.len()],
         send_continuous_channel_load_through_sink_pipe,
     );
 }
@@ -136,6 +137,7 @@ pub fn mixer_stream_throughput_minimal_mixing(c: &mut Criterion) {
         c,
         minimal_delay_mixer_cfg(),
         "mixer_stream",
+        &[40 * 1024 * 2 * RANDOM_GIBBERISH.len()],
         send_continuous_stream_load,
     );
 }

--- a/transport/session/benches/session_bench.rs
+++ b/transport/session/benches/session_bench.rs
@@ -94,7 +94,7 @@ pub fn session_raw_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("session_raw_benchmark");
     const KB: usize = 1024;
 
-    group.sample_size(100000);
+    group.sample_size(50000);
     group.measurement_time(std::time::Duration::from_secs(30));
 
     for size in [16 * KB, 64 * KB, 128 * KB, 1024 * KB].iter() {
@@ -123,7 +123,7 @@ pub fn session_segmentation_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("session_segmentation_benchmark");
     const KB: usize = 1024;
 
-    group.sample_size(100000);
+    group.sample_size(50000);
     group.measurement_time(std::time::Duration::from_secs(30));
 
     for size in [16 * KB, 64 * KB, 128 * KB, 1024 * KB].iter() {


### PR DESCRIPTION
- reduced sample size in some tests to reduce bench time
- small cache reading optimization during bench run
- also removing some cases based on measurements performed in local-env
 simple_paths — clear saturation pattern:
  10nodes/10x ≈ 10nodes/100x ≈ 10nodes/1000x   (~3µs)   ← identical graph, 100x/1000x redundant
  100nodes/10x   3.9µs
  100nodes/100x  18µs  ← jump, meaningful
  100nodes/1000x 18µs  ← SAME as 100x, redundant
  1000nodes/10x  3.9µs
  1000nodes/100x 18µs
  1000nodes/1000x 156µs ← NOT saturated, meaningful

  simple_loopback — more interesting, worst case is NOT max density:
  100nodes/4-edge/10x   135µs
  100nodes/4-edge/100x   18µs  ← FASTER (take_count=10 kicks in sooner at higher density)
  1000nodes/4-edge/10x  135µs
  1000nodes/4-edge/100x 126ms  ← WORST case (sparse large graph, few paths)
  1000nodes/4-edge/1000x  1.4ms ← saturated, fast again

  Redundant in both functions: (10nodes,100x), (10nodes,1000x), (100nodes,1000x) — same graph, same time.

  Mixer — already fast, but:
  channel:      10MB=2.3 GiB/s,  40MB=3.8 GiB/s  ← both interesting, not saturated
  channel_sink: 10MB=2.3 GiB/s,  40MB=2.1 GiB/s  ← saturated at 10MB already
  stream:       10MB=1.6 GiB/s,  40MB=1.5 GiB/s  ← saturated at 10MB already