### PR TITLE
feat(hopr-lib): add free-standing collect_hopr_metrics() function and cleanup hopr-reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4621,7 +4621,6 @@ dependencies = [
  "async-broadcast",
  "async-trait",
  "backon",
- "cfg-if",
  "cfg_eval",
  "const_format",
  "futures",

--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -58,7 +58,6 @@ async-trait = { workspace = true }
 async-broadcast = { workspace = true }
 backon = { workspace = true, features = ["futures-timer-sleep"] }
 cfg_eval = { workspace = true, optional = true }
-cfg-if = { workspace = true }
 const_format = { workspace = true }
 futures = { workspace = true }
 futures-concurrency = { workspace = true }

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -619,6 +619,7 @@ where
     }
 }
 
+#[cfg(feature = "telemetry")]
 impl<Chain, Graph, Net, TMgr> Hopr<Chain, Graph, Net, TMgr> {
     /// Prometheus formatted metrics collected by the hopr-lib components.
     ///
@@ -638,19 +639,10 @@ impl<Chain, Graph, Net, TMgr> HoprNodeOperations for Hopr<Chain, Graph, Net, TMg
 
 /// Prometheus-formatted metrics collected by the hopr-lib components.
 ///
-/// Returns an error when the crate is compiled without the `telemetry` feature
-/// or when running inside unit tests (metrics are disabled in test builds even
-/// if `telemetry` is enabled).
+/// Only available when compiled with the `telemetry` feature.
+#[cfg(feature = "telemetry")]
 pub fn collect_hopr_metrics() -> errors::Result<String> {
-    cfg_if::cfg_if! {
-        if #[cfg(all(feature = "telemetry", not(test)))] {
-            hopr_metrics::gather_all_metrics().map_err(HoprLibError::other)
-        } else {
-            Err(HoprLibError::GeneralError(
-                "metrics unavailable: enable the `telemetry` feature and run outside unit tests".into(),
-            ))
-        }
-    }
+    hopr_metrics::gather_all_metrics().map_err(HoprLibError::other)
 }
 
 #[cfg(test)]

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -638,6 +638,15 @@ impl<Chain, Graph, Net, TMgr> HoprNodeOperations for Hopr<Chain, Graph, Net, TMg
     }
 }
 
+/// Prometheus-formatted metrics collected by the hopr-lib components.
+///
+/// This is a free-standing convenience wrapper around
+/// [`Hopr::collect_hopr_metrics`] that avoids the caller having to supply
+/// the four generic type parameters.
+pub fn collect_hopr_metrics() -> errors::Result<String> {
+    Hopr::<(), (), (), ()>::collect_hopr_metrics()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -640,11 +640,15 @@ impl<Chain, Graph, Net, TMgr> HoprNodeOperations for Hopr<Chain, Graph, Net, TMg
 
 /// Prometheus-formatted metrics collected by the hopr-lib components.
 ///
-/// This is a free-standing convenience wrapper around
-/// [`Hopr::collect_hopr_metrics`] that avoids the caller having to supply
-/// the four generic type parameters.
+/// Returns an error when the crate is compiled without the `telemetry` feature.
 pub fn collect_hopr_metrics() -> errors::Result<String> {
-    Hopr::<(), (), (), ()>::collect_hopr_metrics()
+    cfg_if::cfg_if! {
+        if #[cfg(all(feature = "telemetry", not(test)))] {
+            hopr_metrics::gather_all_metrics().map_err(HoprLibError::other)
+        } else {
+            Err(HoprLibError::GeneralError("BUILT WITHOUT METRICS SUPPORT".into()))
+        }
+    }
 }
 
 #[cfg(test)]

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -637,7 +637,6 @@ where
     }
 }
 
-
 impl<Chain, Graph, Net, TMgr> HoprNodeOperations for Hopr<Chain, Graph, Net, TMgr> {
     fn status(&self) -> HoprState {
         self.state.load(Ordering::Relaxed)

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -619,17 +619,6 @@ where
     }
 }
 
-#[cfg(feature = "telemetry")]
-impl<Chain, Graph, Net, TMgr> Hopr<Chain, Graph, Net, TMgr> {
-    /// Prometheus formatted metrics collected by the hopr-lib components.
-    ///
-    /// Delegates to the crate-level [`collect_hopr_metrics`] free-standing function.
-    /// Prefer calling [`collect_hopr_metrics`] directly to avoid specifying the
-    /// generic type parameters.
-    pub fn collect_hopr_metrics() -> errors::Result<String> {
-        collect_hopr_metrics()
-    }
-}
 
 impl<Chain, Graph, Net, TMgr> HoprNodeOperations for Hopr<Chain, Graph, Net, TMgr> {
     fn status(&self) -> HoprState {

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -621,14 +621,12 @@ where
 
 impl<Chain, Graph, Net, TMgr> Hopr<Chain, Graph, Net, TMgr> {
     /// Prometheus formatted metrics collected by the hopr-lib components.
+    ///
+    /// Delegates to the crate-level [`collect_hopr_metrics`] free-standing function.
+    /// Prefer calling [`collect_hopr_metrics`] directly to avoid specifying the
+    /// generic type parameters.
     pub fn collect_hopr_metrics() -> errors::Result<String> {
-        cfg_if::cfg_if! {
-            if #[cfg(all(feature = "telemetry", not(test)))] {
-                hopr_metrics::gather_all_metrics().map_err(HoprLibError::other)
-            } else {
-                Err(HoprLibError::GeneralError("BUILT WITHOUT METRICS SUPPORT".into()))
-            }
-        }
+        collect_hopr_metrics()
     }
 }
 
@@ -640,13 +638,17 @@ impl<Chain, Graph, Net, TMgr> HoprNodeOperations for Hopr<Chain, Graph, Net, TMg
 
 /// Prometheus-formatted metrics collected by the hopr-lib components.
 ///
-/// Returns an error when the crate is compiled without the `telemetry` feature.
+/// Returns an error when the crate is compiled without the `telemetry` feature
+/// or when running inside unit tests (metrics are disabled in test builds even
+/// if `telemetry` is enabled).
 pub fn collect_hopr_metrics() -> errors::Result<String> {
     cfg_if::cfg_if! {
         if #[cfg(all(feature = "telemetry", not(test)))] {
             hopr_metrics::gather_all_metrics().map_err(HoprLibError::other)
         } else {
-            Err(HoprLibError::GeneralError("BUILT WITHOUT METRICS SUPPORT".into()))
+            Err(HoprLibError::GeneralError(
+                "metrics unavailable: enable the `telemetry` feature and run outside unit tests".into(),
+            ))
         }
     }
 }

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -115,6 +115,13 @@ impl From<HopRouting> for hopr_api::types::internal::routing::RoutingOptions {
     }
 }
 
+#[cfg(feature = "session-client")]
+impl std::fmt::Display for HopRouting {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}-hop routing", self.hop_count())
+    }
+}
+
 /// Session client configuration for `hopr-lib`.
 ///
 /// Unlike transport-level configuration, this API intentionally does not expose
@@ -252,6 +259,17 @@ pub struct Hopr<Chain, Graph, Net, TMgr> {
     pub(crate) ticket_manager: TMgr,
     #[allow(dead_code)] // Handles must stay alive to keep background tasks running
     pub(crate) processes: AbortableList<HoprLibProcess>,
+}
+
+impl<Chain, Graph, Net, TMgr> std::fmt::Debug for Hopr<Chain, Graph, Net, TMgr> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Hopr")
+            .field("identity", &self.chain_id)
+            .field("state", &self.state.load(std::sync::atomic::Ordering::Relaxed))
+            .field("config", &self.cfg)
+            .field("processes", &self.processes)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<Chain, Graph, Net, TMgr> Hopr<Chain, Graph, Net, TMgr>

--- a/hopr/reference/src/lib.rs
+++ b/hopr/reference/src/lib.rs
@@ -14,7 +14,6 @@ pub use hopr_lib;
 use hopr_ticket_manager::{HoprTicketManager, RedbStore, RedbTicketQueue};
 #[cfg(feature = "runtime-tokio")]
 use {
-    hopr_ticket_manager::{HoprTicketFactory, MemoryStore},
     hopr_chain_connector::{
         BlockchainConnectorConfig, HoprBlockchainSafeConnector,
         api::HoprChainApi,
@@ -22,7 +21,7 @@ use {
         create_trustful_hopr_blokli_connector,
     },
     hopr_lib::builder::{ChainKeypair, Keypair, OffchainKeypair},
-    hopr_lib::{Hopr, config::HoprLibConfig},
+    hopr_lib::{Hopr, api::types::primitive::prelude::Address, config::HoprLibConfig},
     hopr_network_graph::ChannelGraph,
     hopr_transport_p2p::HoprLibp2pNetworkBuilder,
     validator::Validate,
@@ -42,33 +41,35 @@ use crate::{config::SessionIpForwardingConfig, exit::HoprServerIpForwardingReact
 /// Shareable [`HoprTicketManager`] with [`RedbStore`] backend.
 pub type SharedTicketManager = Arc<HoprTicketManager<RedbStore, RedbTicketQueue>>;
 
-/// The full relay HOPR node type using canonical implementations.
+/// The canonical HOPR node type using the Blokli chain connector and canonical implementations.
+///
+/// Used for both full relay nodes (with session server) and edge/entry nodes
+/// (without session server) — both use the same [`SharedTicketManager`] so that
+/// outgoing ticket indices and any incoming tickets are correctly tracked.
 #[cfg(feature = "runtime-tokio")]
 pub type FullHopr =
     Hopr<Arc<HoprBlockchainSafeConnector<BlokliClient>>, SharedChannelGraph, HoprNetwork, SharedTicketManager>;
-
-/// Generic edge node type with `TMgr = ()`.
-///
-/// Edge nodes originate packets but do not relay or redeem incoming tickets,
-/// so the ticket manager type parameter is fixed to `()`.
-#[cfg(feature = "runtime-tokio")]
-pub type EdgeHopr<Chain, Graph, Net> = Hopr<Chain, Graph, Net, ()>;
 
 /// Re-export so downstream crates (e.g. `edgli`) do not need a direct
 /// `hopr-chain-connector` dependency.
 #[cfg(feature = "runtime-tokio")]
 pub use hopr_chain_connector;
 
-/// Builds a reference HOPR node using canonical implementations.
-#[cfg(feature = "runtime-tokio")]
-pub async fn build_reference(
-    identity: (&ChainKeypair, &OffchainKeypair),
-    config: HoprLibConfig,
-    blokli_url: String,
-    #[cfg(feature = "session-server")] server_config: SessionIpForwardingConfig,
-) -> anyhow::Result<Arc<FullHopr>> {
-    let (chain_key, packet_key) = identity;
+// ---------------------------------------------------------------------------
+// Private helpers
+// ---------------------------------------------------------------------------
 
+/// Creates and connects the default Blokli chain connector used by the
+/// convenience builder functions ([`build_edge`] and [`build_full_with_session_server`]).
+///
+/// Callers that need a non-default connector configuration should create the
+/// connector themselves and call [`build_with_chain`] directly.
+#[cfg(feature = "runtime-tokio")]
+async fn create_default_blokli_connector(
+    chain_key: &ChainKeypair,
+    blokli_url: String,
+    module_address: Address,
+) -> anyhow::Result<Arc<HoprBlockchainSafeConnector<BlokliClient>>> {
     let mut chain_connector = create_trustful_hopr_blokli_connector(
         chain_key,
         BlockchainConnectorConfig {
@@ -92,11 +93,62 @@ pub async fn build_reference(
                 ..Default::default()
             },
         ),
-        config.safe_module.module_address,
+        module_address,
     )
     .await?;
     chain_connector.connect().await?;
-    let chain_connector = Arc::new(chain_connector);
+    Ok(Arc::new(chain_connector))
+}
+
+// ---------------------------------------------------------------------------
+// Level-1 convenience builders (opinionated config, creates connector internally)
+// ---------------------------------------------------------------------------
+
+/// Builds an edge (entry/exit) [`FullHopr`] node using the default Blokli chain connector.
+///
+/// This is the opinionated convenience builder for edge nodes — it creates the
+/// chain connector from `blokli_url` using well-known defaults and delegates all
+/// subsystem wiring to [`build_with_chain`].
+///
+/// For a non-default connector configuration use [`build_with_chain`] directly.
+#[cfg(feature = "runtime-tokio")]
+pub async fn build_edge(
+    identity: (&ChainKeypair, &OffchainKeypair),
+    config: HoprLibConfig,
+    blokli_url: String,
+) -> anyhow::Result<Arc<FullHopr>> {
+    let (chain_key, packet_key) = identity;
+    let module_address = config.safe_module.module_address;
+    let chain_connector = create_default_blokli_connector(chain_key, blokli_url, module_address).await?;
+
+    build_with_chain(
+        chain_key,
+        packet_key,
+        config,
+        None,
+        chain_connector,
+    )
+    .await
+}
+
+/// Builds a full relay [`FullHopr`] node with a session server using the default
+/// Blokli chain connector.
+///
+/// This is the opinionated convenience builder for relay nodes that also serve
+/// incoming sessions. It creates the chain connector from `blokli_url` using
+/// well-known defaults and delegates all subsystem wiring to [`build_with_chain`].
+///
+/// For a non-default connector configuration use [`build_with_chain`] directly.
+#[cfg(feature = "runtime-tokio")]
+pub async fn build_full_with_session_server(
+    identity: (&ChainKeypair, &OffchainKeypair),
+    config: HoprLibConfig,
+    blokli_url: String,
+    #[cfg(feature = "session-server")] server_config: SessionIpForwardingConfig,
+) -> anyhow::Result<Arc<FullHopr>> {
+    let (chain_key, packet_key) = identity;
+    let module_address = config.safe_module.module_address;
+    let chain_connector = create_default_blokli_connector(chain_key, blokli_url, module_address).await?;
 
     #[cfg(feature = "session-server")]
     let session_server = HoprServerIpForwardingReactor::new(packet_key.clone(), server_config);
@@ -113,8 +165,17 @@ pub async fn build_reference(
     .await
 }
 
+// ---------------------------------------------------------------------------
+// Level-2 flexible builder (bring your own chain connector)
+// ---------------------------------------------------------------------------
+
 /// Builds a HOPR node with a custom chain connector using canonical implementations
 /// for all other components.
+///
+/// This is the shared internal entry point used by both [`build_edge`] and
+/// [`build_full_with_session_server`]. Call it directly when you need a
+/// non-default chain connector (e.g. custom [`BlockchainConnectorConfig`] or a
+/// test-only chain connector).
 #[cfg(feature = "runtime-tokio")]
 pub async fn build_with_chain<
     Chain,
@@ -253,137 +314,6 @@ where
     let builder = builder.with_session_server(server);
 
     let node = builder.build_full(ticket_manager, ticket_factory).await?;
-
-    Ok(Arc::new(node))
-}
-
-/// Builds a HOPR edge node with a custom chain connector using canonical
-/// implementations for all other components.
-///
-/// Compared to [`build_with_chain`], this function:
-/// - Uses a [`MemoryStore`]-backed [`HoprTicketFactory`] (no persistent storage,
-///   no ticket manager) — edge nodes originate packets but do not redeem tickets.
-/// - Does not sync ticket state with on-chain channel state.
-/// - Does not accept a session-server argument.
-/// - Calls `build_edge` rather than `build_full`, leaving `TMgr = ()`.
-///
-/// Cover traffic and all other wiring are identical to [`build_with_chain`].
-#[cfg(feature = "runtime-tokio")]
-pub async fn build_edge_with_chain<Chain>(
-    identity: (&ChainKeypair, &OffchainKeypair),
-    config: HoprLibConfig,
-    probe_cfg: Option<hopr_ct_full_network::ProberConfig>,
-    chain_connector: Chain,
-) -> anyhow::Result<Arc<Hopr<Chain, SharedChannelGraph, HoprNetwork, ()>>>
-where
-    Chain: HoprChainApi + Clone + Send + Sync + 'static,
-{
-    let (chain_key, packet_key) = identity;
-
-    if let Some(ref pcfg) = probe_cfg {
-        pcfg.validate()
-            .map_err(|e| anyhow::anyhow!("invalid ProberConfig: {e}"))?;
-        let probe_timeout = config.protocol.probe.timeout;
-        anyhow::ensure!(
-            pcfg.interval >= probe_timeout,
-            "ProberConfig interval ({:?}) must be >= ProbeConfig timeout ({:?})",
-            pcfg.interval,
-            probe_timeout,
-        );
-    }
-
-    let ticket_factory = Arc::new(HoprTicketFactory::new(MemoryStore::default()));
-
-    // Sync ticket factory with on-chain outgoing channel state so that after a
-    // restart the factory resumes from the correct ticket index per channel.
-    {
-        use futures::StreamExt;
-        use hopr_lib::api::chain::ChannelSelector;
-
-        let me = chain_connector.me();
-        let outgoing_channels: Vec<_> = chain_connector
-            .stream_channels(ChannelSelector::default().with_source(*me))
-            .map_err(|e| anyhow::anyhow!("failed to stream outgoing channels: {e}"))?
-            .collect()
-            .await;
-        ticket_factory
-            .sync_from_outgoing_channels(&outgoing_channels)
-            .map_err(|e| anyhow::anyhow!("failed to sync ticket factory: {e}"))?;
-    }
-
-    // Chain→peer-discovery wiring
-    let (peer_discovery_tx, peer_discovery_rx) = futures::channel::mpsc::channel(2048);
-    {
-        use futures::{SinkExt, StreamExt};
-        use hopr_lib::api::chain::StateSyncOptions;
-        let chain_events = chain_connector
-            .subscribe_with_state_sync([StateSyncOptions::PublicAccounts])
-            .map_err(|e| anyhow::anyhow!("failed to subscribe to chain events: {e}"))?;
-        let tx = peer_discovery_tx;
-        tokio::spawn(async move {
-            chain_events
-                .for_each(|event| {
-                    let mut tx = tx.clone();
-                    async move {
-                        if let hopr_lib::api::types::chain::chain_events::ChainEvent::Announcement(account) = event {
-                            let peer_id: hopr_lib::api::PeerId = account.public_key.into();
-                            if let Err(error) = tx
-                                .send(hopr_transport_p2p::PeerDiscovery::Announce(
-                                    peer_id,
-                                    account.get_multiaddrs().to_vec(),
-                                ))
-                                .await
-                            {
-                                tracing::error!(%peer_id, %error, "failed to send peer discovery event");
-                            }
-                        }
-                    }
-                })
-                .await;
-        });
-    }
-
-    let prober_cfg = probe_cfg.unwrap_or_default();
-    let path_cfg = config.protocol.path_planner;
-    let graph: SharedChannelGraph = Arc::new(ChannelGraph::with_edge_params(
-        *packet_key.public(),
-        path_cfg.edge_penalty,
-        path_cfg.min_ack_rate,
-    ));
-    let graph_for_ct = graph.clone();
-
-    let safe_address = config.safe_module.safe_address;
-    let module_address = config.safe_module.module_address;
-
-    let node = hopr_lib::builder::HoprBuilder
-        .with_identity(chain_key, packet_key)
-        .with_config(config)
-        .with_safe_module(&safe_address, &module_address)
-        .with_chain_api(move |_ctx| chain_connector)
-        .with_graph(move |_ctx| graph)
-        .with_network(move |ctx| {
-            Box::pin(async move {
-                let multiaddresses = vec![
-                    (&ctx.cfg.host)
-                        .try_into()
-                        .expect("host config must be a valid multiaddress"),
-                ];
-                let nb = HoprLibp2pNetworkBuilder::new(peer_discovery_rx);
-                nb.build(
-                    &ctx.packet_key,
-                    multiaddresses,
-                    "/hopr/mix/1.1.0",
-                    ctx.cfg.protocol.transport.prefer_local_addresses,
-                )
-                .await
-                .expect("network must be constructible")
-            })
-        })
-        .with_cover_traffic(move |ctx| {
-            hopr_ct_full_network::FullNetworkDiscovery::new(*ctx.packet_key.public(), prober_cfg, graph_for_ct)
-        })
-        .build_edge(ticket_factory)
-        .await?;
 
     Ok(Arc::new(node))
 }

--- a/hopr/reference/src/lib.rs
+++ b/hopr/reference/src/lib.rs
@@ -38,6 +38,25 @@ pub use hopr_transport_p2p::HoprNetwork;
 #[cfg(feature = "session-server")]
 use crate::{config::SessionIpForwardingConfig, exit::HoprServerIpForwardingReactor};
 
+/// No-op session server used by [`build_edge`] when the `session-server` feature is enabled.
+///
+/// Edge nodes do not serve incoming sessions, so the builder still needs a concrete type
+/// to satisfy the `build_with_chain` signature — this type simply drops every session.
+#[cfg(feature = "session-server")]
+#[derive(Debug, Clone, Default)]
+struct NoopSessionServer;
+
+#[cfg(feature = "session-server")]
+#[async_trait::async_trait]
+impl hopr_lib::api::node::HoprSessionServer for NoopSessionServer {
+    type Session = hopr_lib::exports::transport::IncomingSession;
+    type Error = std::convert::Infallible;
+
+    async fn process(&self, _session: Self::Session) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
 /// Shareable [`HoprTicketManager`] with [`RedbStore`] backend.
 pub type SharedTicketManager = Arc<HoprTicketManager<RedbStore, RedbTicketQueue>>;
 
@@ -123,6 +142,8 @@ pub async fn build_edge(
         config,
         None,
         chain_connector,
+        #[cfg(feature = "session-server")]
+        NoopSessionServer,
     )
     .await
 }

--- a/hopr/reference/src/lib.rs
+++ b/hopr/reference/src/lib.rs
@@ -42,10 +42,6 @@ use crate::{config::SessionIpForwardingConfig, exit::HoprServerIpForwardingReact
 pub type SharedTicketManager = Arc<HoprTicketManager<RedbStore, RedbTicketQueue>>;
 
 /// The canonical HOPR node type using the Blokli chain connector and canonical implementations.
-///
-/// Used for both full relay nodes (with session server) and edge/entry nodes
-/// (without session server) — both use the same [`SharedTicketManager`] so that
-/// outgoing ticket indices and any incoming tickets are correctly tracked.
 #[cfg(feature = "runtime-tokio")]
 pub type FullHopr =
     Hopr<Arc<HoprBlockchainSafeConnector<BlokliClient>>, SharedChannelGraph, HoprNetwork, SharedTicketManager>;

--- a/hopr/reference/src/lib.rs
+++ b/hopr/reference/src/lib.rs
@@ -11,7 +11,13 @@ use std::sync::Arc;
 
 #[cfg(feature = "runtime-tokio")]
 pub use hopr_lib;
+/// Re-export the canonical channel graph type for downstream crates.
+#[cfg(feature = "runtime-tokio")]
+pub use hopr_network_graph::SharedChannelGraph;
 use hopr_ticket_manager::{HoprTicketManager, RedbStore, RedbTicketQueue};
+/// Re-export the canonical network type for downstream crates.
+#[cfg(feature = "runtime-tokio")]
+pub use hopr_transport_p2p::HoprNetwork;
 #[cfg(feature = "runtime-tokio")]
 use {
     hopr_chain_connector::{
@@ -27,14 +33,6 @@ use {
     validator::Validate,
 };
 
-/// Re-export the canonical channel graph type for downstream crates.
-#[cfg(feature = "runtime-tokio")]
-pub use hopr_network_graph::SharedChannelGraph;
-
-/// Re-export the canonical network type for downstream crates.
-#[cfg(feature = "runtime-tokio")]
-pub use hopr_transport_p2p::HoprNetwork;
-
 #[cfg(feature = "session-server")]
 use crate::{config::SessionIpForwardingConfig, exit::HoprServerIpForwardingReactor};
 
@@ -49,8 +47,8 @@ struct NoopSessionServer;
 #[cfg(feature = "session-server")]
 #[async_trait::async_trait]
 impl hopr_lib::api::node::HoprSessionServer for NoopSessionServer {
-    type Session = hopr_lib::exports::transport::IncomingSession;
     type Error = std::convert::Infallible;
+    type Session = hopr_lib::exports::transport::IncomingSession;
 
     async fn process(&self, _session: Self::Session) -> Result<(), Self::Error> {
         Ok(())

--- a/hopr/reference/src/lib.rs
+++ b/hopr/reference/src/lib.rs
@@ -14,6 +14,7 @@ pub use hopr_lib;
 use hopr_ticket_manager::{HoprTicketManager, RedbStore, RedbTicketQueue};
 #[cfg(feature = "runtime-tokio")]
 use {
+    hopr_ticket_manager::{HoprTicketFactory, MemoryStore},
     hopr_chain_connector::{
         BlockchainConnectorConfig, HoprBlockchainSafeConnector,
         api::HoprChainApi,
@@ -37,6 +38,19 @@ pub type SharedTicketManager = Arc<HoprTicketManager<RedbStore, RedbTicketQueue>
 #[cfg(feature = "runtime-tokio")]
 pub type ReferenceHopr =
     Hopr<Arc<HoprBlockchainSafeConnector<BlokliClient>>, SharedChannelGraph, HoprNetwork, SharedTicketManager>;
+
+/// The HOPR edge node type using canonical implementations.
+///
+/// Edge nodes originate packets but do not relay or redeem incoming tickets,
+/// so the ticket manager type parameter is `()`.
+#[cfg(feature = "runtime-tokio")]
+pub type EdgeHopr =
+    Hopr<Arc<HoprBlockchainSafeConnector<BlokliClient>>, SharedChannelGraph, HoprNetwork, ()>;
+
+/// Re-export so downstream crates (e.g. `edgli`) do not need a direct
+/// `hopr-chain-connector` dependency.
+#[cfg(feature = "runtime-tokio")]
+pub use hopr_chain_connector;
 
 /// Builds a reference HOPR node using canonical implementations.
 #[cfg(feature = "runtime-tokio")]
@@ -232,6 +246,119 @@ where
     let builder = builder.with_session_server(server);
 
     let node = builder.build_full(ticket_manager, ticket_factory).await?;
+
+    Ok(Arc::new(node))
+}
+
+/// Builds a HOPR edge node with a custom chain connector using canonical
+/// implementations for all other components.
+///
+/// Compared to [`build_with_chain`], this function:
+/// - Uses a [`MemoryStore`]-backed [`HoprTicketFactory`] (no persistent storage,
+///   no ticket manager) — edge nodes originate packets but do not redeem tickets.
+/// - Does not sync ticket state with on-chain channel state.
+/// - Does not accept a session-server argument.
+/// - Calls `build_edge` rather than `build_full`, leaving `TMgr = ()`.
+///
+/// Cover traffic and all other wiring are identical to [`build_with_chain`].
+#[cfg(feature = "runtime-tokio")]
+pub async fn build_edge_with_chain<Chain>(
+    chain_key: &ChainKeypair,
+    packet_key: &OffchainKeypair,
+    config: HoprLibConfig,
+    probe_cfg: Option<hopr_ct_full_network::ProberConfig>,
+    chain_connector: Chain,
+) -> anyhow::Result<Arc<Hopr<Chain, SharedChannelGraph, HoprNetwork, ()>>>
+where
+    Chain: HoprChainApi + Clone + Send + Sync + 'static,
+{
+    if let Some(ref pcfg) = probe_cfg {
+        pcfg.validate()
+            .map_err(|e| anyhow::anyhow!("invalid ProberConfig: {e}"))?;
+        let probe_timeout = config.protocol.probe.timeout;
+        anyhow::ensure!(
+            pcfg.interval >= probe_timeout,
+            "ProberConfig interval ({:?}) must be >= ProbeConfig timeout ({:?})",
+            pcfg.interval,
+            probe_timeout,
+        );
+    }
+
+    let ticket_factory = Arc::new(HoprTicketFactory::new(MemoryStore::default()));
+
+    // Chain→peer-discovery wiring
+    let (peer_discovery_tx, peer_discovery_rx) = futures::channel::mpsc::channel(2048);
+    {
+        use futures::{SinkExt, StreamExt};
+        use hopr_lib::api::chain::StateSyncOptions;
+        let chain_events = chain_connector
+            .subscribe_with_state_sync([StateSyncOptions::PublicAccounts])
+            .map_err(|e| anyhow::anyhow!("failed to subscribe to chain events: {e}"))?;
+        let tx = peer_discovery_tx;
+        tokio::spawn(async move {
+            chain_events
+                .for_each(|event| {
+                    let mut tx = tx.clone();
+                    async move {
+                        if let hopr_lib::api::types::chain::chain_events::ChainEvent::Announcement(account) = event {
+                            let peer_id: hopr_lib::api::PeerId = account.public_key.into();
+                            if let Err(error) = tx
+                                .send(hopr_transport_p2p::PeerDiscovery::Announce(
+                                    peer_id,
+                                    account.get_multiaddrs().to_vec(),
+                                ))
+                                .await
+                            {
+                                tracing::error!(%peer_id, %error, "failed to send peer discovery event");
+                            }
+                        }
+                    }
+                })
+                .await;
+        });
+    }
+
+    let prober_cfg = probe_cfg.unwrap_or_default();
+    let path_cfg = config.protocol.path_planner;
+    let graph: SharedChannelGraph = Arc::new(ChannelGraph::with_edge_params(
+        *packet_key.public(),
+        path_cfg.edge_penalty,
+        path_cfg.min_ack_rate,
+    ));
+    let graph_for_ct = graph.clone();
+
+    let safe_address = config.safe_module.safe_address;
+    let module_address = config.safe_module.module_address;
+
+    let node = hopr_lib::builder::HoprBuilder
+        .with_identity(chain_key, packet_key)
+        .with_config(config)
+        .with_safe_module(&safe_address, &module_address)
+        .with_chain_api(move |_ctx| chain_connector)
+        .with_graph(move |_ctx| graph)
+        .with_network(move |ctx| {
+            Box::pin(async move {
+                let multiaddresses = vec![
+                    (&ctx.cfg.host)
+                        .try_into()
+                        .expect("host config must be a valid multiaddress"),
+                ];
+                let nb = HoprLibp2pNetworkBuilder::new(peer_discovery_rx);
+                nb.build(
+                    &ctx.packet_key,
+                    multiaddresses,
+                    "/hopr/mix/1.1.0",
+                    ctx.cfg.protocol.transport.prefer_local_addresses,
+                )
+                .await
+                .expect("network must be constructible")
+            })
+        })
+        .with_cover_traffic(move |ctx| {
+            hopr_ct_full_network::FullNetworkDiscovery::new(*ctx.packet_key.public(), prober_cfg, graph_for_ct)
+        })
+        .build_edge(ticket_factory)
+        .await?;
 
     Ok(Arc::new(node))
 }

--- a/hopr/reference/src/lib.rs
+++ b/hopr/reference/src/lib.rs
@@ -23,10 +23,18 @@ use {
     },
     hopr_lib::builder::{ChainKeypair, Keypair, OffchainKeypair},
     hopr_lib::{Hopr, config::HoprLibConfig},
-    hopr_network_graph::{ChannelGraph, SharedChannelGraph},
-    hopr_transport_p2p::{HoprLibp2pNetworkBuilder, HoprNetwork},
+    hopr_network_graph::ChannelGraph,
+    hopr_transport_p2p::HoprLibp2pNetworkBuilder,
     validator::Validate,
 };
+
+/// Re-export the canonical channel graph type for downstream crates.
+#[cfg(feature = "runtime-tokio")]
+pub use hopr_network_graph::SharedChannelGraph;
+
+/// Re-export the canonical network type for downstream crates.
+#[cfg(feature = "runtime-tokio")]
+pub use hopr_transport_p2p::HoprNetwork;
 
 #[cfg(feature = "session-server")]
 use crate::{config::SessionIpForwardingConfig, exit::HoprServerIpForwardingReactor};
@@ -34,18 +42,17 @@ use crate::{config::SessionIpForwardingConfig, exit::HoprServerIpForwardingReact
 /// Shareable [`HoprTicketManager`] with [`RedbStore`] backend.
 pub type SharedTicketManager = Arc<HoprTicketManager<RedbStore, RedbTicketQueue>>;
 
-/// The reference HOPR node type using canonical implementations.
+/// The full relay HOPR node type using canonical implementations.
 #[cfg(feature = "runtime-tokio")]
-pub type ReferenceHopr =
+pub type FullHopr =
     Hopr<Arc<HoprBlockchainSafeConnector<BlokliClient>>, SharedChannelGraph, HoprNetwork, SharedTicketManager>;
 
-/// The HOPR edge node type using canonical implementations.
+/// Generic edge node type with `TMgr = ()`.
 ///
 /// Edge nodes originate packets but do not relay or redeem incoming tickets,
-/// so the ticket manager type parameter is `()`.
+/// so the ticket manager type parameter is fixed to `()`.
 #[cfg(feature = "runtime-tokio")]
-pub type EdgeHopr =
-    Hopr<Arc<HoprBlockchainSafeConnector<BlokliClient>>, SharedChannelGraph, HoprNetwork, ()>;
+pub type EdgeHopr<Chain, Graph, Net> = Hopr<Chain, Graph, Net, ()>;
 
 /// Re-export so downstream crates (e.g. `edgli`) do not need a direct
 /// `hopr-chain-connector` dependency.
@@ -59,7 +66,7 @@ pub async fn build_reference(
     config: HoprLibConfig,
     blokli_url: String,
     #[cfg(feature = "session-server")] server_config: SessionIpForwardingConfig,
-) -> anyhow::Result<Arc<ReferenceHopr>> {
+) -> anyhow::Result<Arc<FullHopr>> {
     let (chain_key, packet_key) = identity;
 
     let mut chain_connector = create_trustful_hopr_blokli_connector(
@@ -263,8 +270,7 @@ where
 /// Cover traffic and all other wiring are identical to [`build_with_chain`].
 #[cfg(feature = "runtime-tokio")]
 pub async fn build_edge_with_chain<Chain>(
-    chain_key: &ChainKeypair,
-    packet_key: &OffchainKeypair,
+    identity: (&ChainKeypair, &OffchainKeypair),
     config: HoprLibConfig,
     probe_cfg: Option<hopr_ct_full_network::ProberConfig>,
     chain_connector: Chain,
@@ -272,6 +278,8 @@ pub async fn build_edge_with_chain<Chain>(
 where
     Chain: HoprChainApi + Clone + Send + Sync + 'static,
 {
+    let (chain_key, packet_key) = identity;
+
     if let Some(ref pcfg) = probe_cfg {
         pcfg.validate()
             .map_err(|e| anyhow::anyhow!("invalid ProberConfig: {e}"))?;
@@ -285,6 +293,23 @@ where
     }
 
     let ticket_factory = Arc::new(HoprTicketFactory::new(MemoryStore::default()));
+
+    // Sync ticket factory with on-chain outgoing channel state so that after a
+    // restart the factory resumes from the correct ticket index per channel.
+    {
+        use futures::StreamExt;
+        use hopr_lib::api::chain::ChannelSelector;
+
+        let me = chain_connector.me();
+        let outgoing_channels: Vec<_> = chain_connector
+            .stream_channels(ChannelSelector::default().with_source(*me))
+            .map_err(|e| anyhow::anyhow!("failed to stream outgoing channels: {e}"))?
+            .collect()
+            .await;
+        ticket_factory
+            .sync_from_outgoing_channels(&outgoing_channels)
+            .map_err(|e| anyhow::anyhow!("failed to sync ticket factory: {e}"))?;
+    }
 
     // Chain→peer-discovery wiring
     let (peer_discovery_tx, peer_discovery_rx) = futures::channel::mpsc::channel(2048);

--- a/hopr/reference/src/testing/hopr.rs
+++ b/hopr/reference/src/testing/hopr.rs
@@ -32,7 +32,6 @@ pub fn create_hopr_instance_config(host_port: u16, safe: NodeSafeConfig, winn_pr
         safe_module: hopr_lib::config::SafeModule {
             safe_address: safe.safe_address,
             module_address: safe.module_address,
-            ..Default::default()
         },
         protocol: hopr_lib::config::HoprProtocolConfig {
             transport: hopr_lib::config::TransportConfig {

--- a/hoprd/rest-api/src/session.rs
+++ b/hoprd/rest-api/src/session.rs
@@ -538,10 +538,8 @@ pub(crate) async fn list_clients<H: Send + Sync + 'static>(
         .map(|v| {
             let ListenerId(_, addr) = *v.key();
             let entry = v.value();
-            let forward_path = hopr_lib::HopRouting::try_from(entry.forward_path.count_hops())
-                .expect("stored routing options always have bounded hop count");
-            let return_path = hopr_lib::HopRouting::try_from(entry.return_path.count_hops())
-                .expect("stored routing options always have bounded hop count");
+            let forward_path = entry.forward_path;
+            let return_path = entry.return_path;
             SessionClientResponse {
                 protocol,
                 ip: addr.ip().to_string(),

--- a/logic/ticket-manager/Cargo.toml
+++ b/logic/ticket-manager/Cargo.toml
@@ -2,6 +2,7 @@
 name = "hopr-ticket-manager"
 description = "Manages outgoing ticket indices and incoming redeemable tickets"
 version = "0.4.0"
+license = "GPL-3.0-only"
 rust-version.workspace = true
 authors.workspace = true
 edition.workspace = true

--- a/utils/session/src/lib.rs
+++ b/utils/session/src/lib.rs
@@ -27,11 +27,11 @@ use hopr_api::{
 };
 use hopr_async_runtime::Abortable;
 use hopr_lib::{
-    Hopr, HoprSessionClientConfig,
+    Hopr, HopRouting, HoprSessionClientConfig,
     api::{
         network::NetworkView,
         node::HoprSessionClientOperations,
-        types::{internal::routing::RoutingOptions, primitive::prelude::Address},
+        types::primitive::prelude::Address,
     },
     errors::HoprLibError,
     exports::transport::{
@@ -147,9 +147,9 @@ pub struct StoredSessionEntry {
     /// Target of the Session.
     pub target: SessionTargetSpec,
     /// Forward path used for the Session.
-    pub forward_path: RoutingOptions,
+    pub forward_path: HopRouting,
     /// Return path used for the Session.
-    pub return_path: RoutingOptions,
+    pub return_path: HopRouting,
     /// The maximum number of client sessions that the listener can spawn.
     pub max_client_sessions: usize,
     /// The maximum number of SURB packets that can be sent upstream.
@@ -536,8 +536,8 @@ pub async fn create_tcp_client_binding(
         StoredSessionEntry {
             destination,
             target: target_spec,
-            forward_path: config.forward_path.into(),
-            return_path: config.return_path.into(),
+            forward_path: config.forward_path,
+            return_path: config.return_path,
             clients: active_sessions,
             max_client_sessions: max_clients,
             max_surb_upstream: config
@@ -638,8 +638,8 @@ pub async fn create_udp_client_binding(
         StoredSessionEntry {
             destination,
             target: target_spec,
-            forward_path: config.forward_path.into(),
-            return_path: config.return_path.into(),
+            forward_path: config.forward_path,
+            return_path: config.return_path,
             max_client_sessions: max_clients,
             max_surb_upstream: config
                 .surb_management
@@ -787,6 +787,7 @@ mod tests {
     use futures_time::future::FutureExt as TimeFutureExt;
     use hopr_api::types::crypto::crypto_traits::Randomizable;
     use hopr_lib::{
+        HopRouting,
         api::types::{
             internal::{
                 prelude::HoprPseudonym,
@@ -922,8 +923,8 @@ mod tests {
         StoredSessionEntry {
             destination: Address::default(),
             target: SessionTargetSpec::Plain("localhost:8080".into()),
-            forward_path: RoutingOptions::Hops(Default::default()),
-            return_path: RoutingOptions::Hops(Default::default()),
+            forward_path: HopRouting::default(),
+            return_path: HopRouting::default(),
             max_client_sessions: 5,
             max_surb_upstream: None,
             response_buffer: None,

--- a/utils/session/src/lib.rs
+++ b/utils/session/src/lib.rs
@@ -27,12 +27,8 @@ use hopr_api::{
 };
 use hopr_async_runtime::Abortable;
 use hopr_lib::{
-    Hopr, HopRouting, HoprSessionClientConfig,
-    api::{
-        network::NetworkView,
-        node::HoprSessionClientOperations,
-        types::primitive::prelude::Address,
-    },
+    HopRouting, Hopr, HoprSessionClientConfig,
+    api::{network::NetworkView, node::HoprSessionClientOperations, types::primitive::prelude::Address},
     errors::HoprLibError,
     exports::transport::{
         HoprSession, HoprSessionConfigurator, OffchainPublicKey, SURB_SIZE, ServiceId, SessionId, SessionTarget,


### PR DESCRIPTION
## Summary

- **`hopr-lib`**: Adds a free-standing `collect_hopr_metrics() -> Result<String>` function gated on `#[cfg(feature = "telemetry")]`. The symbol simply does not exist without the feature — no error path. The previous `Hopr::collect_hopr_metrics()` impl block is removed.

- **`hopr-lib`** (issue #7504): Adds missing trait implementations to public types:
  - `Debug for Hopr<Chain, Graph, Net, TMgr>` — manual impl printing identity, state, config, and process list; uses `finish_non_exhaustive()` to signal intentionally skipped opaque/generic fields
  - `Display for HopRouting` — delegates to `hop_count()`, e.g. `"3-hop routing"`

- **`hopr-reference`**: Unified edge and full node builder hierarchy:
  - `FullHopr` — concrete blokli-backed node type using `SharedTicketManager`; used for both relay nodes and edge/entry nodes
  - `EdgeHopr` type alias removed — both edge and full nodes now produce `FullHopr`

- **`hopr-ticket-manager`**: Added missing `license = "GPL-3.0-only"` to `Cargo.toml`. The field was absent from this crate while all other hoprnet crates carry it, causing downstream `cargo-deny` license checks to fail with an `unlicensed` error.

- **`hopr-utils-session`**: Narrowed `StoredSessionEntry.forward_path` and `return_path` fields from `RoutingOptions` to `HopRouting`. The `IntermediatePath` variant was never stored in session entries — only `Hops` via `From<HopRouting>` — so narrowing the type eliminates the `HopRouting → RoutingOptions → HopRouting` round-trip at both write and read boundaries.

- **`hoprd-api`**: Simplified `list_clients` to read `entry.forward_path` / `entry.return_path` directly as `HopRouting`; removed the `try_from(count_hops())` conversion that is now redundant.