### PR TITLE
fix: reduce number of benches

### DIFF
--- a/.github/workflows/pr-label.yaml
+++ b/.github/workflows/pr-label.yaml
@@ -50,3 +50,25 @@ jobs:
     secrets:
       GCP_SA_GITHUB_RUNNER: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
       GH_RUNNER_TOKEN: ${{ secrets.GH_RUNNER_TOKEN }}
+
+  benchmarks:
+    name: Benchmarks
+    if: github.event.label.name == 'perf:benchmark' && github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+    uses: hoprnet/hopr-workflows/.github/workflows/benchmarks.yaml@13489274cf2d23929227fcd62bb8ac2341615b3e # workflow-benchmark-v2
+    with:
+      source_branch: ${{ github.event.pull_request.head.ref }}
+      runner: self-hosted-hoprnet-bigger
+      bencher_project: ${{ github.event.repository.name }}
+      should_build: true
+      should_run: true
+      build_command: "nix build -L .#bench-build"
+      run_command: "nix run .#bench-run"
+    secrets:
+      cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+      bencher_api_token: ${{ secrets.BENCHER_API_TOKEN }}
+      ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
+      ZULIP_EMAIL: ${{ secrets.ZULIP_EMAIL }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5024,6 +5024,7 @@ dependencies = [
  "lazy_static",
  "parking_lot",
  "rstest",
+ "rust-stream-ext-concurrent",
  "serde",
  "smart-default",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5024,7 +5024,6 @@ dependencies = [
  "lazy_static",
  "parking_lot",
  "rstest",
- "rust-stream-ext-concurrent",
  "serde",
  "smart-default",
  "thiserror 2.0.18",

--- a/crypto/packet/Cargo.toml
+++ b/crypto/packet/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["rlib"]
 
 [features]
 default = ["rayon"]
+run-all-benchmarks = []
 
 rayon = ["hopr-parallelize/rayon"]
 serde = [

--- a/crypto/packet/Cargo.toml
+++ b/crypto/packet/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["rlib"]
 
 [features]
 default = ["rayon"]
-run-all-benchmarks = []
+all-benchmarks = []
 
 rayon = ["hopr-parallelize/rayon"]
 serde = [

--- a/crypto/packet/benches/packet_bench.rs
+++ b/crypto/packet/benches/packet_bench.rs
@@ -27,7 +27,7 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 const SAMPLE_SIZE: usize = 100_000;
 
 /// Pairs of (hops, surb_count) to benchmark.
-#[cfg(feature = "run-all-benchmarks")]
+#[cfg(feature = "all-benchmarks")]
 const PACKET_BENCHMARK: &[(usize, usize)] = &[
     (0, 0), // 0-hop 0 SURBs = used for packet acknowledgements
     (1, 1), // 1-hop 1 SURB = common GnosisVPN use-case
@@ -37,7 +37,7 @@ const PACKET_BENCHMARK: &[(usize, usize)] = &[
     (3, 1), // 3-hop 1 SURB = common GnosisVPN use-case
     (3, 2), // 3-hop 2 SURBs = GnosisVPN use-case with asymmetric traffic (non-TCP)
 ];
-#[cfg(not(feature = "run-all-benchmarks"))]
+#[cfg(not(feature = "all-benchmarks"))]
 const PACKET_BENCHMARK: &[(usize, usize)] = &[
     (3, 2), // 3-hop 2 SURBs = worst case
 ];
@@ -123,7 +123,7 @@ pub fn packet_sending_bench(c: &mut Criterion) {
 
     // This benchmark does not depend on the number of SURBs, because they are created in the precomputation step
 
-    for &hops in if cfg!(feature = "run-all-benchmarks") {
+    for &hops in if cfg!(feature = "all-benchmarks") {
         &[0, 1, 2, 3][..]
     } else {
         &[3][..]

--- a/crypto/packet/benches/packet_bench.rs
+++ b/crypto/packet/benches/packet_bench.rs
@@ -27,7 +27,8 @@ static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 const SAMPLE_SIZE: usize = 100_000;
 
 /// Pairs of (hops, surb_count) to benchmark.
-const PACKET_BENCHMARK: [(usize, usize); 7] = [
+#[cfg(feature = "run-all-benchmarks")]
+const PACKET_BENCHMARK: &[(usize, usize)] = &[
     (0, 0), // 0-hop 0 SURBs = used for packet acknowledgements
     (1, 1), // 1-hop 1 SURB = common GnosisVPN use-case
     (1, 2), // 1-hop 2 SURBs = GnosisVPN use-case with asymmetric traffic (non-TCP)
@@ -35,6 +36,10 @@ const PACKET_BENCHMARK: [(usize, usize); 7] = [
     (2, 2), // 2-hop 2 SURBs = GnosisVPN use-case with asymmetric traffic (non-TCP)
     (3, 1), // 3-hop 1 SURB = common GnosisVPN use-case
     (3, 2), // 3-hop 2 SURBs = GnosisVPN use-case with asymmetric traffic (non-TCP)
+];
+#[cfg(not(feature = "run-all-benchmarks"))]
+const PACKET_BENCHMARK: &[(usize, usize)] = &[
+    (3, 2), // 3-hop 2 SURBs = worst case
 ];
 
 lazy_static::lazy_static! {
@@ -65,7 +70,7 @@ pub fn packet_sending_bench(c: &mut Criterion) {
     group.measurement_time(std::time::Duration::from_secs(30));
     group.throughput(Throughput::Elements(1));
 
-    for (hops, surb_count) in PACKET_BENCHMARK {
+    for &(hops, surb_count) in PACKET_BENCHMARK {
         group.bench_with_input(
             BenchmarkId::from_parameter(format!("{hops}_hop_{surb_count}_surbs")),
             &(hops, surb_count),
@@ -118,7 +123,11 @@ pub fn packet_sending_bench(c: &mut Criterion) {
 
     // This benchmark does not depend on the number of SURBs, because they are created in the precomputation step
 
-    for hops in [0, 1, 2, 3] {
+    for &hops in if cfg!(feature = "run-all-benchmarks") {
+        &[0, 1, 2, 3][..]
+    } else {
+        &[3][..]
+    } {
         group.bench_with_input(BenchmarkId::from_parameter(format!("{hops}_hop")), &hops, |b, &hops| {
             // The number of hops for ticket creation does not matter for benchmark purposes
             let tb = TicketBuilder::zero_hop().counterparty(destination_chain.public().to_address());
@@ -161,7 +170,7 @@ pub fn packet_precompute_bench(c: &mut Criterion) {
     group.throughput(Throughput::Elements(1));
     group.measurement_time(std::time::Duration::from_secs(30));
 
-    for (hops, surb_count) in PACKET_BENCHMARK {
+    for &(hops, surb_count) in PACKET_BENCHMARK {
         group.bench_with_input(
             BenchmarkId::from_parameter(format!("{hops}_hop_{surb_count}_surbs")),
             &(hops, surb_count),

--- a/crypto/packet/benches/por_bench.rs
+++ b/crypto/packet/benches/por_bench.rs
@@ -33,7 +33,11 @@ pub fn proof_of_relay_bench(c: &mut Criterion) {
     let mut group = c.benchmark_group("proof_of_relay_bench");
     group.sample_size(SAMPLE_SIZE);
 
-    for hop in [0, 1, 2, 3].iter() {
+    for hop in if cfg!(feature = "run-all-benchmarks") {
+        &[0, 1, 2, 3][..]
+    } else {
+        &[3][..]
+    } {
         group.throughput(Throughput::Elements(1));
         group.bench_with_input(
             BenchmarkId::from_parameter(format!("por_create_{hop}_hop")),

--- a/crypto/packet/benches/por_bench.rs
+++ b/crypto/packet/benches/por_bench.rs
@@ -33,7 +33,7 @@ pub fn proof_of_relay_bench(c: &mut Criterion) {
     let mut group = c.benchmark_group("proof_of_relay_bench");
     group.sample_size(SAMPLE_SIZE);
 
-    for hop in if cfg!(feature = "run-all-benchmarks") {
+    for hop in if cfg!(feature = "all-benchmarks") {
         &[0, 1, 2, 3][..]
     } else {
         &[3][..]

--- a/impls/connector/Cargo.toml
+++ b/impls/connector/Cargo.toml
@@ -38,6 +38,7 @@ tempfile = { workspace = true }
 
 hopr-api = { workspace = true, features = [
   "chain",
+  "node",
   "types-random",
   "serde",
   "types-with-bindings",

--- a/impls/graph/Cargo.toml
+++ b/impls/graph/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["rlib"]
 
 [features]
 default = ["petgraph"]
-run-all-benchmarks = []
+all-benchmarks = []
 petgraph = ["dep:petgraph", "dep:indexmap"]
 graph-api = ["petgraph"]
 

--- a/impls/graph/Cargo.toml
+++ b/impls/graph/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["rlib"]
 
 [features]
 default = ["petgraph"]
+run-all-benchmarks = []
 petgraph = ["dep:petgraph", "dep:indexmap"]
 graph-api = ["petgraph"]
 

--- a/impls/graph/benches/traverse_bench.rs
+++ b/impls/graph/benches/traverse_bench.rs
@@ -109,7 +109,7 @@ fn build_graph(node_count: usize, density: usize) -> (ChannelGraph, Vec<Offchain
 fn bench_simple_paths(c: &mut Criterion) {
     let mut group = c.benchmark_group("NetworkGraphTraverse/simple_paths");
 
-    for &(size, density) in if cfg!(feature = "run-all-benchmarks") {
+    for &(size, density) in if cfg!(feature = "all-benchmarks") {
         &[(10, 10), (100, 10), (100, 100), (1_000, 1_000)][..]
     } else {
         &[(1_000, 1_000)][..]
@@ -193,7 +193,7 @@ fn bench_simple_paths(c: &mut Criterion) {
 fn bench_simple_loopback(c: &mut Criterion) {
     let mut group = c.benchmark_group("NetworkGraphTraverse/simple_loopback_to_self");
 
-    for &(size, density) in if cfg!(feature = "run-all-benchmarks") {
+    for &(size, density) in if cfg!(feature = "all-benchmarks") {
         &[(10, 10), (100, 10), (100, 100), (1_000, 100), (1_000, 1_000)][..]
     } else {
         &[(1_000, 1_000)][..]

--- a/impls/graph/benches/traverse_bench.rs
+++ b/impls/graph/benches/traverse_bench.rs
@@ -109,12 +109,11 @@ fn build_graph(node_count: usize, density: usize) -> (ChannelGraph, Vec<Offchain
 fn bench_simple_paths(c: &mut Criterion) {
     let mut group = c.benchmark_group("NetworkGraphTraverse/simple_paths");
 
-    for (size, density) in [
-        (10, 10),
-        (100, 10),
-        (100, 100),
-        (1_000, 1_000),
-    ] {
+    for &(size, density) in if cfg!(feature = "run-all-benchmarks") {
+        &[(10, 10), (100, 10), (100, 100), (1_000, 1_000)][..]
+    } else {
+        &[(1_000, 1_000)][..]
+    } {
         let (graph, keys) = build_graph(size, density);
         let me = &keys[0];
         let epn = (size - 1).min(density); // effective edges per node
@@ -194,18 +193,20 @@ fn bench_simple_paths(c: &mut Criterion) {
 fn bench_simple_loopback(c: &mut Criterion) {
     let mut group = c.benchmark_group("NetworkGraphTraverse/simple_loopback_to_self");
 
-    for (size, density) in [
-        (10, 10),
-        (100, 10),
-        (100, 100),
-        (1_000, 100),
-        (1_000, 1_000),
-    ] {
+    for &(size, density) in if cfg!(feature = "run-all-benchmarks") {
+        &[(10, 10), (100, 10), (100, 100), (1_000, 100), (1_000, 1_000)][..]
+    } else {
+        &[(1_000, 1_000)][..]
+    } {
         let (graph, _keys) = build_graph(size, density);
         let param = format!("{size}nodes/{density}x");
         // At 1000nodes/1000x the graph is nearly complete — take_count=10 is hit at every depth,
         // so 3-edge and 4-edge produce identical results to 2-edge.
-        let depths: &[usize] = if size == 1_000 && density == 1_000 { &[2] } else { &[2, 3, 4] };
+        let depths: &[usize] = if size == 1_000 && density == 1_000 {
+            &[2]
+        } else {
+            &[2, 3, 4]
+        };
 
         for &depth in depths {
             group.bench_with_input(BenchmarkId::new(&format!("{depth}-edge"), &param), &size, |b, _| {

--- a/impls/graph/benches/traverse_bench.rs
+++ b/impls/graph/benches/traverse_bench.rs
@@ -113,8 +113,6 @@ fn bench_simple_paths(c: &mut Criterion) {
         (10, 10),
         (100, 10),
         (100, 100),
-        (1_000, 10),
-        (1_000, 100),
         (1_000, 1_000),
     ] {
         let (graph, keys) = build_graph(size, density);
@@ -200,24 +198,20 @@ fn bench_simple_loopback(c: &mut Criterion) {
         (10, 10),
         (100, 10),
         (100, 100),
-        (1_000, 10),
         (1_000, 100),
         (1_000, 1_000),
     ] {
         let (graph, _keys) = build_graph(size, density);
         let param = format!("{size}nodes/{density}x");
+        // At 1000nodes/1000x the graph is nearly complete — take_count=10 is hit at every depth,
+        // so 3-edge and 4-edge produce identical results to 2-edge.
+        let depths: &[usize] = if size == 1_000 && density == 1_000 { &[2] } else { &[2, 3, 4] };
 
-        group.bench_with_input(BenchmarkId::new("2-edge", &param), &size, |b, _| {
-            b.iter(|| black_box(graph.simple_loopback_to_self(2, Some(10))));
-        });
-
-        group.bench_with_input(BenchmarkId::new("3-edge", &param), &size, |b, _| {
-            b.iter(|| black_box(graph.simple_loopback_to_self(3, Some(10))));
-        });
-
-        group.bench_with_input(BenchmarkId::new("4-edge", &param), &size, |b, _| {
-            b.iter(|| black_box(graph.simple_loopback_to_self(4, Some(10))));
-        });
+        for &depth in depths {
+            group.bench_with_input(BenchmarkId::new(&format!("{depth}-edge"), &param), &size, |b, _| {
+                b.iter(|| black_box(graph.simple_loopback_to_self(depth, Some(10))));
+            });
+        }
     }
 
     group.finish();

--- a/impls/graph/benches/traverse_bench.rs
+++ b/impls/graph/benches/traverse_bench.rs
@@ -92,8 +92,7 @@ fn build_graph(node_count: usize, density: usize) -> (ChannelGraph, Vec<Offchain
 // ── Benchmark: NetworkGraphTraverse::simple_paths ────────────────────────────
 
 /// Benchmarks [`NetworkGraphTraverse::simple_paths`] for 2-edge, 3-edge, and
-/// 4-edge routes across all combinations of three node counts (10 / 100 / 1 000)
-/// and three edge densities (10× / 100× / 1 000×).
+/// 4-edge routes.
 ///
 /// The benchmark ID encodes both dimensions, e.g. `2-edge/100nodes/100x`.
 ///
@@ -106,6 +105,15 @@ fn build_graph(node_count: usize, density: usize) -> (ChannelGraph, Vec<Offchain
 ///
 /// `take_count` is capped at 10 to reflect realistic production usage and to
 /// keep the benchmark runtime bounded at high densities.
+///
+/// # Feature-gated coverage
+///
+/// Without `all-benchmarks`: runs only `(1_000 nodes, 1_000× density)` at
+/// all three depths (2-, 3-, 4-edge).
+///
+/// With `all-benchmarks`: runs the full matrix —
+/// `(10, 100, 1_000) nodes × (10, 10, 100, 1_000)× density` — at all three
+/// depths for every configuration.
 fn bench_simple_paths(c: &mut Criterion) {
     let mut group = c.benchmark_group("NetworkGraphTraverse/simple_paths");
 
@@ -179,8 +187,7 @@ fn bench_simple_paths(c: &mut Criterion) {
 // ── Benchmark: NetworkGraphTraverse::simple_loopback_to_self ─────────────────
 
 /// Benchmarks [`NetworkGraphTraverse::simple_loopback_to_self`] for 2-edge,
-/// 3-edge, and 4-edge loopback routes across all combinations of three node
-/// counts (10 / 100 / 1 000) and three edge densities (10× / 100× / 1 000×).
+/// 3-edge, and 4-edge loopback routes.
 ///
 /// The benchmark ID encodes both dimensions, e.g. `3-edge/1000nodes/100x`.
 ///
@@ -190,6 +197,16 @@ fn bench_simple_paths(c: &mut Criterion) {
 /// in addition to the path-enumeration depth.
 ///
 /// `take_count` is capped at 10.
+///
+/// # Feature-gated coverage
+///
+/// Without `all-benchmarks`: runs only `(1_000 nodes, 1_000× density)` at
+/// 2-edge depth (nearly-complete graph, single configuration).
+///
+/// With `all-benchmarks`: runs the full matrix —
+/// `(10, 100, 1_000) nodes × (10, 100, 1_000)× density` — and extends depth
+/// to `[2, 3, 4]`-edge for all but the `1_000/1_000` case (where all depths
+/// collapse to identical results due to `take_count` saturation).
 fn bench_simple_loopback(c: &mut Criterion) {
     let mut group = c.benchmark_group("NetworkGraphTraverse/simple_loopback_to_self");
 

--- a/protocols/hopr/Cargo.toml
+++ b/protocols/hopr/Cargo.toml
@@ -11,6 +11,7 @@ license = "GPL-3.0-only"
 
 [features]
 default = ["rayon"]
+run-all-benchmarks = []
 rayon = ["hopr-crypto-packet/rayon", "hopr-parallelize/rayon"]
 serde = [
   "dep:cfg_eval",

--- a/protocols/hopr/Cargo.toml
+++ b/protocols/hopr/Cargo.toml
@@ -11,7 +11,7 @@ license = "GPL-3.0-only"
 
 [features]
 default = ["rayon"]
-run-all-benchmarks = []
+all-benchmarks = []
 rayon = ["hopr-crypto-packet/rayon", "hopr-parallelize/rayon"]
 serde = [
   "dep:cfg_eval",

--- a/protocols/hopr/benches/codec_bench.rs
+++ b/protocols/hopr/benches/codec_bench.rs
@@ -60,7 +60,7 @@ pub fn create_decoder(receiver: &Node) -> TestDecoder {
 }
 
 /// Pairs of (hops, surb_count) to benchmark.
-#[cfg(feature = "run-all-benchmarks")]
+#[cfg(feature = "all-benchmarks")]
 const PACKET_BENCHMARK: &[(usize, usize)] = &[
     (0, 0), // 0-hop 0 SURBs = used for packet acknowledgements
     (1, 1), // 1-hop 1 SURB = common GnosisVPN use-case
@@ -70,7 +70,7 @@ const PACKET_BENCHMARK: &[(usize, usize)] = &[
     (3, 1), // 3-hop 1 SURB = common GnosisVPN use-case
     (3, 2), // 3-hop 2 SURBs = GnosisVPN use-case with asymmetric traffic (non-TCP)
 ];
-#[cfg(not(feature = "run-all-benchmarks"))]
+#[cfg(not(feature = "all-benchmarks"))]
 const PACKET_BENCHMARK: &[(usize, usize)] = &[
     (3, 2), // 3-hop 2 SURBs = worst case
 ];

--- a/protocols/hopr/benches/codec_bench.rs
+++ b/protocols/hopr/benches/codec_bench.rs
@@ -60,7 +60,8 @@ pub fn create_decoder(receiver: &Node) -> TestDecoder {
 }
 
 /// Pairs of (hops, surb_count) to benchmark.
-const PACKET_BENCHMARK: [(usize, usize); 7] = [
+#[cfg(feature = "run-all-benchmarks")]
+const PACKET_BENCHMARK: &[(usize, usize)] = &[
     (0, 0), // 0-hop 0 SURBs = used for packet acknowledgements
     (1, 1), // 1-hop 1 SURB = common GnosisVPN use-case
     (1, 2), // 1-hop 2 SURBs = GnosisVPN use-case with asymmetric traffic (non-TCP)
@@ -68,6 +69,10 @@ const PACKET_BENCHMARK: [(usize, usize); 7] = [
     (2, 2), // 2-hop 2 SURBs = GnosisVPN use-case with asymmetric traffic (non-TCP)
     (3, 1), // 3-hop 1 SURB = common GnosisVPN use-case
     (3, 2), // 3-hop 2 SURBs = GnosisVPN use-case with asymmetric traffic (non-TCP)
+];
+#[cfg(not(feature = "run-all-benchmarks"))]
+const PACKET_BENCHMARK: &[(usize, usize)] = &[
+    (3, 2), // 3-hop 2 SURBs = worst case
 ];
 
 fn hopr_encoder_bench(c: &mut Criterion) {
@@ -79,7 +84,7 @@ fn hopr_encoder_bench(c: &mut Criterion) {
     let mut group = c.benchmark_group("hopr_encoder");
     group.throughput(Throughput::Elements(1));
 
-    for (hops, rps) in PACKET_BENCHMARK {
+    for &(hops, rps) in PACKET_BENCHMARK {
         let path = runtime
             .block_on(async {
                 ValidatedPath::new(

--- a/protocols/hopr/benches/codec_bench.rs
+++ b/protocols/hopr/benches/codec_bench.rs
@@ -133,7 +133,7 @@ fn hopr_encoder_bench(c: &mut Criterion) {
     }
 
     let ack_recipient = *PEERS[1].1.public();
-    for num_acks in [1, 2, 5, 10] {
+    for num_acks in [10] {
         group.bench_with_input(
             BenchmarkId::from_parameter(format!("ack_batch_{num_acks}")),
             &num_acks,

--- a/protocols/session/Cargo.toml
+++ b/protocols/session/Cargo.toml
@@ -11,7 +11,7 @@ license = "GPL-3.0-only"
 
 [features]
 default = ["hashbrown"]
-run-all-benchmarks = []
+all-benchmarks = []
 serde = ["dep:serde", "dep:serde_bytes", "hopr-crypto-packet/serde"]
 telemetry = ["dep:auto_impl", "dep:hopr-metrics", "dep:lazy_static"]
 runtime-tokio = ["dep:tokio", "hopr-async-runtime/runtime-tokio"]

--- a/protocols/session/Cargo.toml
+++ b/protocols/session/Cargo.toml
@@ -11,6 +11,7 @@ license = "GPL-3.0-only"
 
 [features]
 default = ["hashbrown"]
+run-all-benchmarks = []
 serde = ["dep:serde", "dep:serde_bytes", "hopr-crypto-packet/serde"]
 telemetry = ["dep:auto_impl", "dep:hopr-metrics", "dep:lazy_static"]
 runtime-tokio = ["dep:tokio", "hopr-async-runtime/runtime-tokio"]

--- a/protocols/session/benches/socket_bench.rs
+++ b/protocols/session/benches/socket_bench.rs
@@ -60,7 +60,7 @@ pub fn stateless_socket_benchmark(c: &mut Criterion) {
 
     group.sample_size(50000);
 
-    for size in if cfg!(feature = "run-all-benchmarks") {
+    for size in if cfg!(feature = "all-benchmarks") {
         &[128 * KB, 1024 * KB][..]
     } else {
         &[1024 * KB][..]

--- a/protocols/session/benches/socket_bench.rs
+++ b/protocols/session/benches/socket_bench.rs
@@ -60,7 +60,11 @@ pub fn stateless_socket_benchmark(c: &mut Criterion) {
 
     group.sample_size(50000);
 
-    for size in [/* 16 * KB, 64 * KB, */ 128 * KB, 1024 * KB].iter() {
+    for size in if cfg!(feature = "run-all-benchmarks") {
+        &[128 * KB, 1024 * KB][..]
+    } else {
+        &[1024 * KB][..]
+    } {
         let mut alice_data = vec![0u8; *size];
 
         hopr_types::crypto_random::random_fill(&mut alice_data);

--- a/transport/mixer/Cargo.toml
+++ b/transport/mixer/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["rlib"]
 
 [features]
 default = []
-run-all-benchmarks = []
+all-benchmarks = []
 telemetry = ["dep:hopr-metrics", "dep:lazy_static"]
 serde = ["dep:serde", "dep:humantime-serde"]
 

--- a/transport/mixer/Cargo.toml
+++ b/transport/mixer/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["rlib"]
 
 [features]
 default = []
+run-all-benchmarks = []
 telemetry = ["dep:hopr-metrics", "dep:lazy_static"]
 serde = ["dep:serde", "dep:humantime-serde"]
 

--- a/transport/mixer/Cargo.toml
+++ b/transport/mixer/Cargo.toml
@@ -41,8 +41,6 @@ futures = { workspace = true }
 insta = { workspace = true, features = ["yaml"] }
 rstest = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
-rust-stream-ext-concurrent = { workspace = true }
-
 [package.metadata.cargo-machete]
 ignored = ["humantime-serde"]
 

--- a/transport/mixer/Cargo.toml
+++ b/transport/mixer/Cargo.toml
@@ -40,6 +40,7 @@ criterion = { workspace = true, features = ["async_futures", "async_tokio"] }
 futures = { workspace = true }
 insta = { workspace = true, features = ["yaml"] }
 rstest = { workspace = true }
+rust-stream-ext-concurrent = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
 [package.metadata.cargo-machete]
 ignored = ["humantime-serde"]

--- a/transport/mixer/benches/mixer_throughput_bench.rs
+++ b/transport/mixer/benches/mixer_throughput_bench.rs
@@ -85,14 +85,19 @@ fn send_continuous_channel_load_through_sink_pipe(
 }
 
 pub fn mixer_channel_throughput_minimal_mixing(c: &mut Criterion) {
+    let sizes: &[usize] = if cfg!(feature = "run-all-benchmarks") {
+        &[
+            10 * 1024 * 2 * RANDOM_GIBBERISH.len(),
+            40 * 1024 * 2 * RANDOM_GIBBERISH.len(),
+        ]
+    } else {
+        &[40 * 1024 * 2 * RANDOM_GIBBERISH.len()]
+    };
     mixer_throughput(
         c,
         minimal_delay_mixer_cfg(),
         "mixer_channel",
-        &[
-            10 * 1024 * 2 * RANDOM_GIBBERISH.len(),
-            40 * 1024 * 2 * RANDOM_GIBBERISH.len(),
-        ],
+        sizes,
         send_continuous_channel_load,
     );
 }

--- a/transport/mixer/benches/mixer_throughput_bench.rs
+++ b/transport/mixer/benches/mixer_throughput_bench.rs
@@ -60,32 +60,28 @@ fn send_continuous_channel_load(item: &str, iterations: usize, cfg: MixerConfig)
     })
 }
 
-pub fn mixer_channel_throughput_minimal_mixing(c: &mut Criterion) {
-    let sizes: &[usize] = if cfg!(feature = "all-benchmarks") {
-        &[
-            10 * 1024 * 2 * RANDOM_GIBBERISH.len(),
-            40 * 1024 * 2 * RANDOM_GIBBERISH.len(),
-        ]
-    } else {
-        &[40 * 1024 * 2 * RANDOM_GIBBERISH.len()]
-    };
-    mixer_throughput(
-        c,
-        minimal_delay_mixer_cfg(),
-        "mixer_channel",
-        sizes,
-        send_continuous_channel_load,
-    );
-}
+// Benchmark the throughput of the mixer channel when used in a pipe
+fn send_continuous_channel_load_through_sink_pipe(
+    item: &'static str,
+    iterations: usize,
+    cfg: MixerConfig,
+) -> BoxFuture<'static, ()> {
+    Box::pin(async move {
+        let (o_tx, o_rx) = futures::channel::mpsc::unbounded();
+        let (tx, mut rx) = channel(cfg);
 
-pub fn mixer_channel_throughput_through_sink_minimal_mixing(c: &mut Criterion) {
-    mixer_throughput(
-        c,
-        minimal_delay_mixer_cfg(),
-        "mixer_channel_sink_pipe",
-        &[40 * 1024 * 2 * RANDOM_GIBBERISH.len()],
-        send_continuous_channel_load_through_sink_pipe,
-    );
+        let pipe = tokio::task::spawn(o_rx.map(Ok).forward(tx));
+
+        for _ in 0..iterations {
+            o_tx.unbounded_send(item).expect("send must succeed");
+        }
+
+        for _ in 0..iterations {
+            rx.next().await.expect("receive must succeed");
+        }
+
+        pipe.abort();
+    })
 }
 
 fn send_continuous_stream_load(item: &str, iterations: usize, cfg: MixerConfig) -> BoxFuture<'_, ()> {
@@ -157,8 +153,6 @@ pub fn mixer_stream_throughput_minimal_mixing(c: &mut Criterion) {
 
 criterion_group!(
     benches,
-    mixer_channel_throughput_minimal_mixing,
-    mixer_channel_throughput_through_sink_minimal_mixing,
     mixer_sink_throughput_minimal_mixing,
     mixer_stream_throughput_minimal_mixing
 );

--- a/transport/mixer/benches/mixer_throughput_bench.rs
+++ b/transport/mixer/benches/mixer_throughput_bench.rs
@@ -60,32 +60,8 @@ fn send_continuous_channel_load(item: &str, iterations: usize, cfg: MixerConfig)
     })
 }
 
-// Benchmark the throughput of the mixer channel when used in a pipe
-fn send_continuous_channel_load_through_sink_pipe(
-    item: &'static str,
-    iterations: usize,
-    cfg: MixerConfig,
-) -> BoxFuture<'static, ()> {
-    Box::pin(async move {
-        let (o_tx, o_rx) = futures::channel::mpsc::unbounded();
-        let (tx, mut rx) = channel(cfg);
-
-        let pipe = tokio::task::spawn(o_rx.map(Ok).forward(tx));
-
-        for _ in 0..iterations {
-            o_tx.unbounded_send(item).expect("send must succeed");
-        }
-
-        for _ in 0..iterations {
-            rx.next().await.expect("receive must succeed");
-        }
-
-        pipe.abort();
-    })
-}
-
 pub fn mixer_channel_throughput_minimal_mixing(c: &mut Criterion) {
-    let sizes: &[usize] = if cfg!(feature = "run-all-benchmarks") {
+    let sizes: &[usize] = if cfg!(feature = "all-benchmarks") {
         &[
             10 * 1024 * 2 * RANDOM_GIBBERISH.len(),
             40 * 1024 * 2 * RANDOM_GIBBERISH.len(),

--- a/transport/protocol/Cargo.toml
+++ b/transport/protocol/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["rlib"]
 
 [features]
 default = []
+run-all-benchmarks = []
 telemetry = ["dep:hopr-metrics", "hopr-protocol-hopr/telemetry"]
 runtime-tokio = ["hopr-async-runtime/runtime-tokio"]
 serde = [

--- a/transport/protocol/Cargo.toml
+++ b/transport/protocol/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["rlib"]
 
 [features]
 default = []
-run-all-benchmarks = []
+all-benchmarks = []
 telemetry = ["dep:hopr-metrics", "hopr-protocol-hopr/telemetry"]
 runtime-tokio = ["hopr-async-runtime/runtime-tokio"]
 serde = [

--- a/transport/protocol/benches/pipeline_e2e_bench.rs
+++ b/transport/protocol/benches/pipeline_e2e_bench.rs
@@ -36,14 +36,14 @@ const SENDER_IDX: usize = 0;
 const PAYLOAD_SIZE: usize = HoprPacket::PAYLOAD_SIZE;
 const CHANNEL_CAPACITY: usize = 2048;
 
-#[cfg(feature = "run-all-benchmarks")]
+#[cfg(feature = "all-benchmarks")]
 const HOPS: &[usize] = &[0, 1, 2, 3];
-#[cfg(not(feature = "run-all-benchmarks"))]
+#[cfg(not(feature = "all-benchmarks"))]
 const HOPS: &[usize] = &[3];
 
-#[cfg(feature = "run-all-benchmarks")]
+#[cfg(feature = "all-benchmarks")]
 const PACKET_COUNTS: &[usize] = &[1_000, 2_500, 5_000];
-#[cfg(not(feature = "run-all-benchmarks"))]
+#[cfg(not(feature = "all-benchmarks"))]
 const PACKET_COUNTS: &[usize] = &[5_000];
 const WIN_PROB: f64 = 0.01;
 

--- a/transport/protocol/benches/pipeline_e2e_bench.rs
+++ b/transport/protocol/benches/pipeline_e2e_bench.rs
@@ -36,8 +36,15 @@ const SENDER_IDX: usize = 0;
 const PAYLOAD_SIZE: usize = HoprPacket::PAYLOAD_SIZE;
 const CHANNEL_CAPACITY: usize = 2048;
 
-const HOPS: [usize; 4] = [0, 1, 2, 3];
-const PACKET_COUNTS: [usize; 3] = [1_000, 2_500, 5_000];
+#[cfg(feature = "run-all-benchmarks")]
+const HOPS: &[usize] = &[0, 1, 2, 3];
+#[cfg(not(feature = "run-all-benchmarks"))]
+const HOPS: &[usize] = &[3];
+
+#[cfg(feature = "run-all-benchmarks")]
+const PACKET_COUNTS: &[usize] = &[1_000, 2_500, 5_000];
+#[cfg(not(feature = "run-all-benchmarks"))]
+const PACKET_COUNTS: &[usize] = &[5_000];
 const WIN_PROB: f64 = 0.01;
 
 /// Drains encoded packets from the mixer output and feeds pre-generated ack
@@ -150,7 +157,7 @@ fn pipeline_e2e_forward(c: &mut Criterion) {
     // Return:  PEERS[hops] → PEERS[hops-1..=0] (symmetric hop count).
     let paths: Vec<(ValidatedPath, ValidatedPath)> = runtime.block_on(async {
         let mut paths = Vec::with_capacity(HOPS.len());
-        for &hops in &HOPS {
+        for &hops in HOPS {
             let dest_idx = hops + 1; // index of the destination peer
 
             let forward = ValidatedPath::new(
@@ -193,7 +200,7 @@ fn pipeline_e2e_forward(c: &mut Criterion) {
     group.measurement_time(Duration::from_secs(MEASUREMENT_TIME_SECS));
 
     for (hop_idx, &hops) in HOPS.iter().enumerate() {
-        for &packet_count in &PACKET_COUNTS {
+        for &packet_count in PACKET_COUNTS {
             let total_bytes = (packet_count * PAYLOAD_SIZE) as u64;
             let id = format!("{hops}hop_{packet_count}pkt");
 

--- a/transport/protocol/benches/protocol_throughput_emulated_bench.rs
+++ b/transport/protocol/benches/protocol_throughput_emulated_bench.rs
@@ -37,7 +37,7 @@ pub fn protocol_throughput_sender(c: &mut Criterion) {
     let mut group = c.benchmark_group("protocol_throughput_pipeline");
     group.sample_size(SAMPLE_SIZE);
     group.measurement_time(std::time::Duration::from_secs(30));
-    for bytes in if cfg!(feature = "run-all-benchmarks") {
+    for bytes in if cfg!(feature = "all-benchmarks") {
         &[5 * 1024 * 2 * PAYLOAD_SIZE, 10 * 1024 * 2 * PAYLOAD_SIZE][..]
     } else {
         &[10 * 1024 * 2 * PAYLOAD_SIZE][..]

--- a/transport/protocol/benches/protocol_throughput_emulated_bench.rs
+++ b/transport/protocol/benches/protocol_throughput_emulated_bench.rs
@@ -37,7 +37,11 @@ pub fn protocol_throughput_sender(c: &mut Criterion) {
     let mut group = c.benchmark_group("protocol_throughput_pipeline");
     group.sample_size(SAMPLE_SIZE);
     group.measurement_time(std::time::Duration::from_secs(30));
-    for bytes in [5 * 1024 * 2 * PAYLOAD_SIZE, 10 * 1024 * 2 * PAYLOAD_SIZE].iter() {
+    for bytes in if cfg!(feature = "run-all-benchmarks") {
+        &[5 * 1024 * 2 * PAYLOAD_SIZE, 10 * 1024 * 2 * PAYLOAD_SIZE][..]
+    } else {
+        &[10 * 1024 * 2 * PAYLOAD_SIZE][..]
+    } {
         group.throughput(Throughput::Bytes(*bytes as u64));
         group.bench_with_input(
             BenchmarkId::from_parameter(format!(

--- a/transport/protocol/benches/protocol_throughput_emulated_bench.rs
+++ b/transport/protocol/benches/protocol_throughput_emulated_bench.rs
@@ -24,7 +24,7 @@ use hopr_protocol_hopr::{
     HoprCodecConfig, HoprDecoder, HoprEncoder, HoprUnacknowledgedTicketProcessor,
     HoprUnacknowledgedTicketProcessorConfig, MemorySurbStore, SurbStoreConfig,
 };
-use hopr_ticket_manager::{HoprTicketFactory, HoprTicketManager, RedbStore};
+use hopr_ticket_manager::{HoprTicketFactory, RedbStore};
 use libp2p::PeerId;
 
 const SAMPLE_SIZE: usize = 50;
@@ -84,11 +84,9 @@ pub fn protocol_throughput_sender(c: &mut Criterion) {
                         let (received_ack_tickets_tx, _received_ack_tickets_rx) =
                             futures::channel::mpsc::unbounded::<TicketEvent>();
 
-                        let (wire_msg_send_tx, wire_msg_send_rx) =
-                            futures::channel::mpsc::unbounded::<(PeerId, Bytes)>();
+                        let (wire_out_tx, wire_out_rx) = futures::channel::mpsc::unbounded::<(PeerId, Bytes)>();
 
-                        let (_wire_msg_recv_tx, wire_msg_recv_rx) =
-                            futures::channel::mpsc::unbounded::<(PeerId, Bytes)>();
+                        let (_wire_in_tx, wire_in_rx) = futures::channel::mpsc::unbounded::<(PeerId, Bytes)>();
 
                         let (api_send_tx, api_send_rx) = futures::channel::mpsc::unbounded::<(
                             ResolvedTransportRouting<HoprSurb>,
@@ -133,7 +131,7 @@ pub fn protocol_throughput_sender(c: &mut Criterion) {
 
                         let processes = hopr_transport_protocol::run_packet_pipeline(
                             PEERS[TESTED_PEER_ID].clone(),
-                            (wire_msg_send_tx, wire_msg_send_rx),
+                            (wire_out_tx, wire_in_rx),
                             (encoder, decoder),
                             ticket_proc,
                             received_ack_tickets_tx,
@@ -175,7 +173,7 @@ pub fn protocol_throughput_sender(c: &mut Criterion) {
                             })
                             .await;
 
-                        assert_eq!(wire_msg_recv_rx.take(count).count().await, count);
+                        assert_eq!(wire_out_rx.take(count).count().await, count);
 
                         processes.abort_all();
                     }

--- a/transport/session/Cargo.toml
+++ b/transport/session/Cargo.toml
@@ -14,6 +14,7 @@ crate-type = ["rlib"]
 
 [features]
 default = []
+run-all-benchmarks = []
 runtime-tokio = [
   "hopr-network-types/runtime-tokio",
   "hopr-protocol-session/runtime-tokio",

--- a/transport/session/Cargo.toml
+++ b/transport/session/Cargo.toml
@@ -14,7 +14,7 @@ crate-type = ["rlib"]
 
 [features]
 default = []
-run-all-benchmarks = []
+all-benchmarks = []
 runtime-tokio = [
   "hopr-network-types/runtime-tokio",
   "hopr-protocol-session/runtime-tokio",

--- a/transport/session/benches/session_bench.rs
+++ b/transport/session/benches/session_bench.rs
@@ -97,7 +97,7 @@ pub fn session_raw_benchmark(c: &mut Criterion) {
     group.sample_size(50000);
     group.measurement_time(std::time::Duration::from_secs(30));
 
-    for size in if cfg!(feature = "run-all-benchmarks") {
+    for size in if cfg!(feature = "all-benchmarks") {
         &[16 * KB, 64 * KB, 128 * KB, 1024 * KB][..]
     } else {
         &[1024 * KB][..]
@@ -130,7 +130,7 @@ pub fn session_segmentation_benchmark(c: &mut Criterion) {
     group.sample_size(50000);
     group.measurement_time(std::time::Duration::from_secs(30));
 
-    for size in if cfg!(feature = "run-all-benchmarks") {
+    for size in if cfg!(feature = "all-benchmarks") {
         &[16 * KB, 64 * KB, 128 * KB, 1024 * KB][..]
     } else {
         &[1024 * KB][..]

--- a/transport/session/benches/session_bench.rs
+++ b/transport/session/benches/session_bench.rs
@@ -97,7 +97,11 @@ pub fn session_raw_benchmark(c: &mut Criterion) {
     group.sample_size(50000);
     group.measurement_time(std::time::Duration::from_secs(30));
 
-    for size in [16 * KB, 64 * KB, 128 * KB, 1024 * KB].iter() {
+    for size in if cfg!(feature = "run-all-benchmarks") {
+        &[16 * KB, 64 * KB, 128 * KB, 1024 * KB][..]
+    } else {
+        &[1024 * KB][..]
+    } {
         let mut alice_data = vec![0u8; *size];
         rand::fill(&mut alice_data[..]);
 
@@ -126,7 +130,11 @@ pub fn session_segmentation_benchmark(c: &mut Criterion) {
     group.sample_size(50000);
     group.measurement_time(std::time::Duration::from_secs(30));
 
-    for size in [16 * KB, 64 * KB, 128 * KB, 1024 * KB].iter() {
+    for size in if cfg!(feature = "run-all-benchmarks") {
+        &[16 * KB, 64 * KB, 128 * KB, 1024 * KB][..]
+    } else {
+        &[1024 * KB][..]
+    } {
         let mut alice_data = vec![0u8; *size];
         rand::fill(&mut alice_data[..]);
 


### PR DESCRIPTION
Defaulting on running only one variant per bench by default, additionally we can run all benches with feature `run-all-benchmarks`.  Bellow there is analysis from local run explaining what has been deleted as it introduced 0 value. 


# Benchmark Analysis

## Coverage

119 benchmark instances defined across 12 bench files. Run produced output for 105 (3 groups never started, 1 cut mid-warmup).

---

## Benchmarks That Did NOT Run

| Group | Variants | Reason |
|-------|----------|--------|
| `session_raw_benchmark` | 8 | Not present in output |
| `session_segmentation_benchmark` | 8 | Not present in output |
| `protocol_throughput_pipeline` | 2 | Only compile warnings in output, no results |
| `pipeline_e2e_forward` 1–3hop | 9 of 12 | Run killed mid-warmup of `1hop_1000pkt` |

---

## Results by Group

### packet_sending_no_precomputation

| Variant | Time | Throughput |
|---------|------|------------|
| 0_hop_0_surbs | 96.7 µs | 10.3 Kelem/s |
| 1_hop_1_surbs | 272 µs | 3.67 Kelem/s |
| 1_hop_2_surbs | 298 µs | 3.36 Kelem/s |
| 2_hop_1_surbs | 393 µs | 2.54 Kelem/s |
| 2_hop_2_surbs | 424 µs | 2.36 Kelem/s |
| 3_hop_1_surbs | 531 µs | 1.88 Kelem/s |
| 3_hop_2_surbs | 546 µs | 1.83 Kelem/s |

Each hop adds ~130–170 µs. SURBs add ~25–30 µs per SURB. Clean linear scaling.

### packet_sending_precomputed

| Variant | Time | Throughput |
|---------|------|------------|
| 0_hop | 6.75 µs | 148 Kelem/s |
| 1_hop | 13.2 µs | 75.7 Kelem/s |
| 2_hop | 19.8 µs | 50.5 Kelem/s |
| 3_hop | 26.3 µs | 38.1 Kelem/s |

~6.6 µs per hop. 14× faster than no-precomputation at 0-hop (precompute dominates cost).

### packet_precompute

| Variant | Time | Throughput |
|---------|------|------------|
| 0_hop_0_surbs | 90.5 µs | 11.1 Kelem/s |
| 1_hop_1_surbs | 249 µs | 4.02 Kelem/s |
| 1_hop_2_surbs | 281 µs | 3.56 Kelem/s |
| 2_hop_1_surbs | 372 µs | 2.69 Kelem/s |
| 2_hop_2_surbs | 400 µs | 2.50 Kelem/s |
| 3_hop_1_surbs | 499 µs | 2.00 Kelem/s |
| 3_hop_2_surbs | 518 µs | 1.93 Kelem/s |

Near-identical to `packet_sending_no_precomputation` — precompute step dominates the full send cost.

### packet_forwarding / packet_receiving

| Variant | Time | Throughput |
|---------|------|------------|
| forwarding/any_hop | 120.9 µs | 8.27 Kelem/s |
| receiving/any_hop | 92.0 µs | 10.9 Kelem/s |

Receiving faster than forwarding (no ticket creation at destination).

### proof_of_relay_bench

| Variant | Time | Throughput |
|---------|------|------------|
| por_create_0_hop | 15.1 µs | 66.1 Kelem/s |
| por_create_1_hop | 45.2 µs | 22.1 Kelem/s |
| por_create_2_hop | 75.4 µs | 13.3 Kelem/s |
| por_create_3_hop | 106 µs | 9.42 Kelem/s |
| por_pre_verify | 26.0 µs | 38.4 Kelem/s |

~30 µs per additional hop. Pre-verify is ~60% the cost of 1-hop creation.

### validate_ticket_bench

| Variant | Time | Throughput |
|---------|------|------------|
| validate_unack_ticket | 30.3 µs | 33.0 Kelem/s |

### tag_bloom_filter

| Variant | Time | Throughput |
|---------|------|------------|
| check_existing | 48.5 ns | 20.6 Melem/s |
| check_non_existent | 11.7 ns | 85.7 Melem/s |

Non-existent check is 4× faster — early exit on first missing hash probe.

### hopr_encoder

| Variant | Throughput |
|---------|------------|
| 0hop_0surbs_1036b | 74.6 elem/s |
| 1hop_1surbs_641b | 66.1 elem/s |
| 1hop_2surbs_246b | 61.6 elem/s |
| 2hop_1surbs_641b | 66.5 elem/s |
| 2hop_2surbs_246b | 58.2 elem/s |
| 3hop_1surbs_641b | 61.4 elem/s |
| 3hop_2surbs_246b | 55.9 elem/s |
| ack_batch_10 | 71.2 elem/s |

All variants ~13–18 ms/op. Hop count contributes marginally — connector setup per iteration dominates. Wide CI (±10–25%) due to async overhead.

### hopr_decoder

| Variant | Time | Throughput |
|---------|------|------------|
| relay | 15.3 ms | 65.2 elem/s |
| ack_recipient | 14.2 ms | 70.2 elem/s |
| recipient | 14.6 ms | 68.4 elem/s |

All three decode paths cost ~14–15 ms, dominated by connector setup.

### stateless_socket_benchmark

| Variant | Throughput |
|---------|------------|
| alice_tx/128 KiB | 3.22 GiB/s |
| alice_tx/1 MiB | 4.10 GiB/s |
| bob_rx/128 KiB | 933 MiB/s |
| bob_rx/1 MiB | 1.19 GiB/s |

TX scales well with size (amortized framing). RX is 3–4× slower (decode + reassembly). 16 KiB and 64 KiB sizes were commented out in code.

### mixer_throughput

| Variant | Throughput |
|---------|------------|
| 10 MiB / channel | 3.83 GiB/s |
| 40 MiB / channel | 3.35 GiB/s |
| 40 MiB / channel_sink_pipe | 2.27 GiB/s |
| 40 MiB / stream | 1.65 GiB/s |

Direct channel fastest. Sink pipe adds ~30% overhead. Stream (concurrent delay) adds ~50% overhead vs channel.

### pipeline_e2e_forward (0-hop only — run cut)

| Variant | Throughput |
|---------|------------|
| 0hop_1000pkt | 38.7 MiB/s |
| 0hop_2500pkt | 34.8 MiB/s |
| 0hop_5000pkt | 31.3 MiB/s |

Throughput drops with larger batches — pipeline never reaches steady state. See issues section.

### NetworkGraphTraverse/simple_paths

| Size / Density | 2-edge | 3-edge | 4-edge |
|---------------|--------|--------|--------|
| 10nodes/10x | 3.13 µs | 4.22 µs | 5.07 µs |
| 100nodes/10x | 3.99 µs | 4.40 µs | 5.39 µs |
| 100nodes/100x | 17.8 µs | 18.3 µs | 19.6 µs |
| 1000nodes/1000x | 155 µs | 158 µs | 161 µs |

Depth adds ~1 µs per edge at low density, ~1.5 µs at high density.

### NetworkGraphTraverse/simple_loopback_to_self

| Size / Density | 2-edge | 3-edge | 4-edge |
|---------------|--------|--------|--------|
| 10nodes/10x | 2.47 µs | 3.51 µs | 3.85 µs |
| 100nodes/10x | 3.31 µs | 15.2 µs | 140 µs |
| 100nodes/100x | 16.7 µs | 17.8 µs | 18.1 µs |
| 1000nodes/100x | 29.9 µs | 1090 µs | 125000 µs |
| 1000nodes/1000x | 1358 µs | — | — |

4-edge at 100nodes/10x and 1000nodes/100x are expensive (path explosion). 1000x/1000x collapses to single depth (see removals).

### ticket_manager_bench

| Variant | Time |
|---------|------|
| ticket_insert_redb | 4.19 ms |
| unrealized_value_redb | 6.23 µs |
| create_multihop_ticket_redb | 43.8 ns |

`ticket_insert_redb` 3 orders of magnitude slower than `create_multihop_ticket_redb` — disk write dominates.

---

## Removed Variants (in this session)

### hopr_encoder / ack_batch — flat across all sizes

ack_batch_1/2/5/10 all measured ~70 elem/s with overlapping CIs. Cost dominated by `create_encoder()` called `BatchSize::PerIteration` (~14 ms fixed). Kept `ack_batch_10` only.

**Fix**: `[1, 2, 5, 10]` → `[10]` in `codec_bench.rs:136`.

### NetworkGraphTraverse/simple_paths — node count irrelevant at same density

At density 10×: 100nodes ≈ 1000nodes (path search sees only 10 neighbors regardless of total graph size). Same at 100× density.

Removed: `(1_000, 10)`, `(1_000, 100)` from `bench_simple_paths`.

Kept: `(10, 10)`, `(100, 10)`, `(100, 100)`, `(1_000, 1_000)`.

### NetworkGraphTraverse/simple_loopback — node count dupe + depth plateau

- `(1_000, 10)` → identical to `(100, 10)` results, removed.
- `(1_000, 1_000)` at depths 2/3/4 all measured 1.358 ms (take_count=10 hit immediately at every depth). Collapsed to depth-2 only.

**Fix**: restructured inner loop in `bench_simple_loopback` to use `depths: &[usize]` slice, selecting `&[2]` for the 1000x/1000x case.

### Net change: 119 → 105 benchmark instances

---

## Issues / Observations

### pipeline_e2e_forward — declining throughput, not steady-state

0-hop throughput drops 1000pkt→2500pkt→5000pkt (38.7→34.8→31.3 MiB/s). The pipeline processes packets in a batch then drains — with more packets, backpressure and buffering accumulate. No variant reaches true steady-state throughput. Needs a sustained-send design (continuous producer) rather than a fixed-batch approach to get a meaningful ceiling number.

### hopr_encoder/hopr_decoder — setup cost dominates, CIs too wide

`create_encoder()` called per iteration (`BatchSize::PerIteration`) costs ~13–14 ms. Actual encode is ~µs. This makes hop-count and SURB-count signal invisible in the noise. Either move setup to `iter_batched` setup closure (not per-iteration) or reuse encoder across samples.

### stateless_socket_benchmark — 16 KiB and 64 KiB commented out

`socket_bench.rs:63`: `[/* 16 * KB, 64 * KB, */ 128 * KB, 1024 * KB]`. Intentional or forgotten?

### session_raw_benchmark / session_segmentation_benchmark — never ran

16 variants total. Run was cut before reaching these benches. Schedule a dedicated run for session benches.
