### PR TITLE
fix: get safes by node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4428,9 +4428,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.8.1"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b63138c13e08d2bbc8bd73bd97628a8aaccf17848ce29a62026150a0e24e22"
+checksum = "1ed6b52e38053a83ad25a0a0eb53e09a1dc8bcb9b69b11d9d693a59e662d69de"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -4478,7 +4478,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4889,7 +4889,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-strategy"
-version = "0.18.0"
+version = "0.18.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5408,7 +5408,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd-localcluster"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,7 +219,7 @@ mimalloc = { version = "0.1.50", default-features = false, features = [
   "secure",
 ] }
 
-hopr-api = { version = "1.8.1" }
+hopr-api = { version = "1.8.2" }
 hopr-types = { version = "1.5.4", features = ["use-bindings"] }
 hopr-async-runtime = { path = "common/async-runtime" }
 hopr-crypto-keypair = { path = "crypto/keypair", default-features = false }

--- a/flake.lock
+++ b/flake.lock
@@ -293,11 +293,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776914043,
-        "narHash": "sha256-qug5r56yW1qOsjSI99l3Jm15JNT9CvS2otkXNRNtrPI=",
+        "lastModified": 1777519017,
+        "narHash": "sha256-TXilQ8MwFFtZs7HSogSI/LJzAS63nicE8iF63iB93WM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2d35c4358d7de3a0e606a6e8b27925d981c01cc3",
+        "rev": "09b556f18dacc39e97a46e0a1cba47af7b3af1d8",
         "type": "github"
       },
       "original": {

--- a/impls/connector/Cargo.toml
+++ b/impls/connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-chain-connector"
-version = "0.19.1"
+version = "0.19.2"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["HOPR Association <tech@hoprnet.org>"]

--- a/impls/connector/src/connector/safe.rs
+++ b/impls/connector/src/connector/safe.rs
@@ -147,11 +147,13 @@ mod tests {
     async fn connector_should_query_existing_safe() -> anyhow::Result<()> {
         let me = ChainKeypair::from_secret(&PRIVATE_KEY_1)?.public().to_address();
         let safe_addr = [1u8; Address::SIZE].into();
+        let node_addr = [2u8; Address::SIZE].into();
+
         let safe = DeployedSafe {
             address: safe_addr,
             owner: me,
             module: MODULE_ADDR.into(),
-            registered_nodes: vec![],
+            registered_nodes: vec![node_addr],
         };
         let blokli_client = BlokliTestStateBuilder::default()
             .with_balances([(me, XDaiBalance::new_base(10))])
@@ -162,7 +164,14 @@ mod tests {
         let connector = create_connector(blokli_client)?;
 
         assert_eq!(Some(safe.clone()), connector.safe_info(SafeSelector::Owner(me)).await?);
-        assert_eq!(Some(safe), connector.safe_info(SafeSelector::Address(safe_addr)).await?);
+        assert_eq!(
+            Some(safe.clone()),
+            connector.safe_info(SafeSelector::Address(safe_addr)).await?
+        );
+        assert_eq!(
+            Some(safe),
+            connector.safe_info(SafeSelector::NodeAddress(node_addr)).await?
+        );
 
         insta::assert_yaml_snapshot!(*connector.client.snapshot());
 

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__safe__tests__connector_should_query_existing_safe.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__safe__tests__connector_should_query_existing_safe.snap
@@ -16,7 +16,8 @@ deployed_safes:
     owners:
       - 668430def9eacd2b5064acf85d73fb0b351a1c8c
     module_address: "1111111111111111111111111111111111111111"
-    registered_nodes: []
+    registered_nodes:
+      - "0202020202020202020202020202020202020202"
     threshold: "1"
 safe_redeem_stats: {}
 tx_counts: {}

--- a/impls/connector/src/reader.rs
+++ b/impls/connector/src/reader.rs
@@ -136,6 +136,9 @@ where
         let selector = match selector {
             SafeSelector::Owner(owner_address) => blokli_client::api::SafeSelector::ChainKey(owner_address.into()),
             SafeSelector::Address(safe_address) => blokli_client::api::SafeSelector::SafeAddress(safe_address.into()),
+            SafeSelector::NodeAddress(node_address) => {
+                blokli_client::api::SafeSelector::RegisteredNode(node_address.into())
+            }
         };
 
         if let Some(safe) = self.0.query_safe(selector).await? {

--- a/impls/connector/src/reader.rs
+++ b/impls/connector/src/reader.rs
@@ -134,6 +134,9 @@ where
 
     async fn safe_info(&self, selector: SafeSelector) -> Result<Option<DeployedSafe>, Self::Error> {
         let selector = match selector {
+            // This assumes that the deployer of a safe (chain_key) is always the owner of the safe. Assumption holds
+            // always for edge-clients, but may not hold for other nodes. Assumption could be lifted if needed by
+            // introducing a new selector variant that would explicitly query for safes by owner/chain_key.
             SafeSelector::Owner(owner_address) => blokli_client::api::SafeSelector::ChainKey(owner_address.into()),
             SafeSelector::Address(safe_address) => blokli_client::api::SafeSelector::SafeAddress(safe_address.into()),
             SafeSelector::NodeAddress(node_address) => {

--- a/impls/strategy/Cargo.toml
+++ b/impls/strategy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-strategy"
-version = "0.18.0"
+version = "0.18.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Contains implementations of different HOPR strategies"
 edition.workspace = true

--- a/impls/strategy/src/auto_funding.rs
+++ b/impls/strategy/src/auto_funding.rs
@@ -395,12 +395,16 @@ where
 mod tests {
     use std::str::FromStr;
 
+    use anyhow::Context;
     use futures::StreamExt;
     use futures_time::future::FutureExt;
     use hex_literal::hex;
     use hopr_chain_connector::{create_trustful_hopr_blokli_connector, testing::BlokliTestStateBuilder};
     use hopr_lib::api::{
-        chain::{ChainEvent, ChainEvents, HoprChainApi},
+        chain::{
+            AccountSelector, ChainEvent, ChainEvents, ChainReadAccountOperations, ChainWriteAccountOperations,
+            HoprChainApi,
+        },
         node::{
             ActionableEvent, ComponentStatus, ComponentStatusReporter, EventWaitResult, HasChainApi,
             NodeOnchainIdentity,
@@ -481,6 +485,22 @@ mod tests {
                 .map(ActionableEvent::Chain)
                 .boxed())
         }
+    }
+
+    async fn register_test_safe<C>(chain_connector: &C, node_address: Address) -> anyhow::Result<()>
+    where
+        C: HoprChainApi + ChainReadAccountOperations + ChainWriteAccountOperations,
+    {
+        let account = chain_connector
+            .stream_accounts(AccountSelector::default().with_chain_key(node_address))?
+            .next()
+            .await
+            .context("missing test account for node")?;
+        let safe_address = account.safe_address.context("missing test safe address for node")?;
+
+        chain_connector.register_safe(&safe_address).await?.await?;
+
+        Ok(())
     }
 
     #[test_log::test(tokio::test)]
@@ -630,6 +650,7 @@ mod tests {
             create_trustful_hopr_blokli_connector(&BOB_KP, Default::default(), blokli_sim, [1; Address::SIZE].into())
                 .await?;
         chain_connector.connect().await?;
+        register_test_safe(&chain_connector, *BOB).await?;
         let chain_connector = Arc::new(chain_connector);
         let events = chain_connector.subscribe()?;
 
@@ -687,6 +708,7 @@ mod tests {
             create_trustful_hopr_blokli_connector(&BOB_KP, Default::default(), blokli_sim, [1; Address::SIZE].into())
                 .await?;
         chain_connector.connect().await?;
+        register_test_safe(&chain_connector, *BOB).await?;
         let chain_connector = Arc::new(chain_connector);
         let events = chain_connector.subscribe()?;
 
@@ -764,6 +786,7 @@ mod tests {
             create_trustful_hopr_blokli_connector(&BOB_KP, Default::default(), blokli_sim, [1; Address::SIZE].into())
                 .await?;
         chain_connector.connect().await?;
+        register_test_safe(&chain_connector, *BOB).await?;
         let chain_connector = Arc::new(chain_connector);
         let events = chain_connector.subscribe()?;
 
@@ -833,6 +856,7 @@ mod tests {
             create_trustful_hopr_blokli_connector(&BOB_KP, Default::default(), blokli_sim, [1; Address::SIZE].into())
                 .await?;
         chain_connector.connect().await?;
+        register_test_safe(&chain_connector, *BOB).await?;
         let chain_connector = Arc::new(chain_connector);
         let _events = chain_connector.subscribe()?;
 
@@ -896,6 +920,7 @@ mod tests {
             create_trustful_hopr_blokli_connector(&BOB_KP, Default::default(), blokli_sim, [1; Address::SIZE].into())
                 .await?;
         chain_connector.connect().await?;
+        register_test_safe(&chain_connector, *BOB).await?;
         let chain_connector = Arc::new(chain_connector);
         let _events = chain_connector.subscribe()?;
 
@@ -959,6 +984,7 @@ mod tests {
             create_trustful_hopr_blokli_connector(&BOB_KP, Default::default(), blokli_sim, [1; Address::SIZE].into())
                 .await?;
         chain_connector.connect().await?;
+        register_test_safe(&chain_connector, *BOB).await?;
         let chain_connector = Arc::new(chain_connector);
         let _events = chain_connector.subscribe()?;
 

--- a/impls/strategy/src/auto_funding.rs
+++ b/impls/strategy/src/auto_funding.rs
@@ -201,7 +201,7 @@ where
         let chain = self.node.chain_api().clone();
 
         let safe = chain
-            .safe_info(SafeSelector::Owner(me))
+            .safe_info(SafeSelector::NodeAddress(me))
             .await
             .map_err(|e| StrategyError::Other(e.into()))?;
 

--- a/localcluster/Cargo.toml
+++ b/localcluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd-localcluster"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition.workspace = true
 rust-version.workspace = true

--- a/localcluster/src/identity.rs
+++ b/localcluster/src/identity.rs
@@ -146,7 +146,10 @@ pub async fn generate(config: &GenerationConfig) -> anyhow::Result<()> {
         }
 
         eprint!("\x1b[2K\rNode {id}: Checking Safe deployment...");
-        let safe = if let Some(safe) = node_connector.safe_info(SafeSelector::Owner(node_address)).await? {
+        let safe = if let Some(safe) = node_connector
+            .safe_info(SafeSelector::NodeAddress(node_address))
+            .await?
+        {
             safe
         } else {
             // Send 1000 wxHOPR tokens to the new node address from Anvil 0 account
@@ -171,7 +174,10 @@ pub async fn generate(config: &GenerationConfig) -> anyhow::Result<()> {
             let node_connector_clone = node_connector.clone();
             let jh = tokio::task::spawn(async move {
                 node_connector_clone
-                    .await_safe_deployment(SafeSelector::Owner(node_address), std::time::Duration::from_secs(10))
+                    .await_safe_deployment(
+                        SafeSelector::NodeAddress(node_address),
+                        std::time::Duration::from_secs(10),
+                    )
                     .await
             });
             node_connector.deploy_safe(initial_token_balance).await?.await?;


### PR DESCRIPTION
Get the safe by node address instead of by owner.

Until now, the safe was retrieved by safe owner (`owner` in the vocabulary of `hopr-lib`, `chain-key` meaning deployer in the vocabulary of `blokli`). 
This assumes that the deployer of a safe is always the owner of the safe, which is not necessarily the case. Applies nicely to edge-clients, but isn't generally true for all nodes. Getting the safe by node address makes the retrieval more resilient. 