### PR TITLE
fix: get safe by node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4365,7 +4365,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4413,7 +4413,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -5020,7 +5020,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-strategy"
-version = "0.17.2"
+version = "0.17.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5436,7 +5436,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd-localcluster"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4377,7 +4377,7 @@ dependencies = [
  "hopr-crypto-types 0.9.2",
  "hopr-internal-types",
  "hopr-network-types",
- "hopr-primitive-types 0.10.1",
+ "hopr-primitive-types 0.10.2",
  "multiaddr",
  "strum 0.28.0",
  "thiserror 2.0.18",
@@ -4433,7 +4433,7 @@ dependencies = [
  "hopr-crypto-random 0.4.1",
  "hopr-crypto-types 0.9.2",
  "hopr-internal-types",
- "hopr-primitive-types 0.10.1",
+ "hopr-primitive-types 0.10.2",
  "insta",
  "lazy_static",
  "moka",
@@ -4461,7 +4461,7 @@ dependencies = [
  "hopr-bindings",
  "hopr-crypto-types 0.9.2",
  "hopr-internal-types",
- "hopr-primitive-types 0.10.1",
+ "hopr-primitive-types 0.10.2",
  "insta",
  "lazy_static",
  "multiaddr",
@@ -4483,7 +4483,7 @@ dependencies = [
  "hopr-crypto-random 0.4.1",
  "hopr-crypto-types 0.9.2",
  "hopr-platform",
- "hopr-primitive-types 0.10.1",
+ "hopr-primitive-types 0.10.2",
  "scrypt",
  "serde",
  "serde_json",
@@ -4509,7 +4509,7 @@ dependencies = [
  "hopr-crypto-types 0.9.2",
  "hopr-internal-types",
  "hopr-parallelize",
- "hopr-primitive-types 0.10.1",
+ "hopr-primitive-types 0.10.2",
  "lazy_static",
  "mimalloc",
  "parameterized",
@@ -4552,7 +4552,7 @@ dependencies = [
  "hex",
  "hopr-crypto-random 0.4.1",
  "hopr-crypto-types 0.9.2",
- "hopr-primitive-types 0.10.1",
+ "hopr-primitive-types 0.10.2",
  "k256",
  "parameterized",
  "postcard",
@@ -4581,7 +4581,7 @@ dependencies = [
  "hex",
  "hex-literal",
  "hopr-crypto-random 0.4.1",
- "hopr-primitive-types 0.10.1",
+ "hopr-primitive-types 0.10.2",
  "k256",
  "lazy_static",
  "libp2p-identity",
@@ -4616,7 +4616,7 @@ dependencies = [
  "generic-array 1.3.5",
  "hex",
  "hopr-crypto-random 0.4.1 (git+https://github.com/hoprnet/hoprnet?branch=master)",
- "hopr-primitive-types 0.10.1 (git+https://github.com/hoprnet/hoprnet?branch=master)",
+ "hopr-primitive-types 0.10.1",
  "k256",
  "libp2p-identity",
  "poly1305",
@@ -4665,7 +4665,7 @@ dependencies = [
  "hopr-crypto-types 0.9.2",
  "hopr-db-migration",
  "hopr-internal-types",
- "hopr-primitive-types 0.10.1",
+ "hopr-primitive-types 0.10.2",
  "sea-orm",
  "sea-orm-cli",
  "sea-orm-migration",
@@ -4700,7 +4700,7 @@ dependencies = [
  "hopr-db-migration",
  "hopr-internal-types",
  "hopr-metrics",
- "hopr-primitive-types 0.10.1",
+ "hopr-primitive-types 0.10.2",
  "lazy_static",
  "moka",
  "sea-orm",
@@ -4716,7 +4716,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-internal-types"
-version = "0.17.1"
+version = "0.17.2"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4726,7 +4726,7 @@ dependencies = [
  "hopr-crypto-random 0.4.1",
  "hopr-crypto-types 0.9.2",
  "hopr-parallelize",
- "hopr-primitive-types 0.10.1",
+ "hopr-primitive-types 0.10.2",
  "lazy_static",
  "mockall",
  "multiaddr",
@@ -4772,7 +4772,7 @@ dependencies = [
  "hopr-network-types",
  "hopr-parallelize",
  "hopr-platform",
- "hopr-primitive-types 0.10.1",
+ "hopr-primitive-types 0.10.2",
  "hopr-transport",
  "insta",
  "lazy_static",
@@ -4817,7 +4817,7 @@ dependencies = [
  "hopr-crypto-types 0.9.2",
  "hopr-internal-types",
  "hopr-metrics",
- "hopr-primitive-types 0.10.1",
+ "hopr-primitive-types 0.10.2",
  "lazy_static",
  "libp2p-identity",
  "multiaddr",
@@ -4861,6 +4861,22 @@ dependencies = [
 [[package]]
 name = "hopr-primitive-types"
 version = "0.10.1"
+source = "git+https://github.com/hoprnet/hoprnet?branch=master#51237ad95168848edebf6f5a692694419a6cbd08"
+dependencies = [
+ "bigdecimal",
+ "chrono",
+ "float-cmp",
+ "hex",
+ "lazy_static",
+ "primitive-types 0.14.0",
+ "regex",
+ "sha3",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "hopr-primitive-types"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -4878,28 +4894,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "hopr-primitive-types"
-version = "0.10.1"
-source = "git+https://github.com/hoprnet/hoprnet?branch=master#51237ad95168848edebf6f5a692694419a6cbd08"
-dependencies = [
- "bigdecimal",
- "chrono",
- "float-cmp",
- "hex",
- "lazy_static",
- "primitive-types 0.14.0",
- "regex",
- "sha3",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "hopr-protocol-app"
 version = "1.0.0"
 dependencies = [
  "anyhow",
  "hopr-crypto-packet",
- "hopr-primitive-types 0.10.1",
+ "hopr-primitive-types 0.10.2",
  "serde",
  "serde_bytes",
  "strum 0.28.0",
@@ -4931,7 +4931,7 @@ dependencies = [
  "hopr-network-types",
  "hopr-parallelize",
  "hopr-platform",
- "hopr-primitive-types 0.10.1",
+ "hopr-primitive-types 0.10.2",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4970,7 +4970,7 @@ dependencies = [
  "hopr-crypto-random 0.4.1",
  "hopr-metrics",
  "hopr-network-types",
- "hopr-primitive-types 0.10.1",
+ "hopr-primitive-types 0.10.2",
  "hopr-protocol-app",
  "indexmap 2.13.0",
  "insta",
@@ -5070,7 +5070,7 @@ dependencies = [
  "hopr-internal-types",
  "hopr-metrics",
  "hopr-network-types",
- "hopr-primitive-types 0.10.1",
+ "hopr-primitive-types 0.10.2",
  "hopr-protocol-app",
  "hopr-protocol-hopr",
  "hopr-protocol-session",
@@ -5189,7 +5189,7 @@ dependencies = [
  "hopr-internal-types",
  "hopr-network-types",
  "hopr-platform",
- "hopr-primitive-types 0.10.1",
+ "hopr-primitive-types 0.10.2",
  "hopr-protocol-app",
  "humantime-serde",
  "lazy_static",
@@ -5231,7 +5231,7 @@ dependencies = [
  "hopr-internal-types",
  "hopr-metrics",
  "hopr-network-types",
- "hopr-primitive-types 0.10.1",
+ "hopr-primitive-types 0.10.2",
  "hopr-protocol-app",
  "hopr-protocol-hopr",
  "hopr-transport-identity",
@@ -5271,7 +5271,7 @@ dependencies = [
  "hopr-internal-types",
  "hopr-metrics",
  "hopr-network-types",
- "hopr-primitive-types 0.10.1",
+ "hopr-primitive-types 0.10.2",
  "hopr-protocol-app",
  "hopr-protocol-session",
  "hopr-protocol-start",
@@ -5443,7 +5443,7 @@ dependencies = [
  "futures",
  "hopr-chain-connector",
  "hopr-lib",
- "hopr-primitive-types 0.10.1",
+ "hopr-primitive-types 0.10.2",
  "hoprd",
  "hoprd-api",
  "hoprd-api-client",

--- a/chain/connector/Cargo.toml
+++ b/chain/connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-chain-connector"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2024"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Implementation of HOPR Chain APIs using Blokli client"

--- a/chain/connector/src/connector/safe.rs
+++ b/chain/connector/src/connector/safe.rs
@@ -138,11 +138,12 @@ mod tests {
     async fn connector_should_query_existing_safe() -> anyhow::Result<()> {
         let me = ChainKeypair::from_secret(&PRIVATE_KEY_1)?.public().to_address();
         let safe_addr = [1u8; Address::SIZE].into();
+        let node_addr = [2u8; Address::SIZE].into();
         let safe = DeployedSafe {
             address: safe_addr,
             owner: me,
             module: MODULE_ADDR.into(),
-            registered_nodes: vec![],
+            registered_nodes: vec![node_addr],
         };
         let blokli_client = BlokliTestStateBuilder::default()
             .with_balances([(me, XDaiBalance::new_base(10))])
@@ -152,9 +153,18 @@ mod tests {
 
         let connector = create_connector(blokli_client)?;
 
-        assert_eq!(Some(safe.clone()), connector.safe_info(SafeSelector::Owner(me)).await?);
-        assert_eq!(Some(safe), connector.safe_info(SafeSelector::Address(safe_addr)).await?);
-
+        assert_eq!(
+            Some(safe.clone()),
+            connector.safe_info(SafeSelector::NodeAddress(me)).await?
+        );
+        assert_eq!(
+            Some(safe.clone()),
+            connector.safe_info(SafeSelector::Address(safe_addr)).await?
+        );
+        assert_eq!(
+            Some(safe),
+            connector.safe_info(SafeSelector::NodeAddress(node_addr)).await?
+        );
         insta::assert_yaml_snapshot!(*connector.client.snapshot());
 
         Ok(())

--- a/chain/connector/src/connector/safe.rs
+++ b/chain/connector/src/connector/safe.rs
@@ -153,10 +153,7 @@ mod tests {
 
         let connector = create_connector(blokli_client)?;
 
-        assert_eq!(
-            Some(safe.clone()),
-            connector.safe_info(SafeSelector::NodeAddress(me)).await?
-        );
+        assert_eq!(Some(safe.clone()), connector.safe_info(SafeSelector::Owner(me)).await?);
         assert_eq!(
             Some(safe.clone()),
             connector.safe_info(SafeSelector::Address(safe_addr)).await?

--- a/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__safe__tests__connector_should_query_existing_safe.snap
+++ b/chain/connector/src/connector/snapshots/hopr_chain_connector__connector__safe__tests__connector_should_query_existing_safe.snap
@@ -14,7 +14,8 @@ deployed_safes:
     address: "0101010101010101010101010101010101010101"
     chain_key: 668430def9eacd2b5064acf85d73fb0b351a1c8c
     module_address: "1111111111111111111111111111111111111111"
-    registered_nodes: []
+    registered_nodes:
+      - "0202020202020202020202020202020202020202"
 tx_counts: {}
 channels: {}
 chain_info:

--- a/chain/connector/src/reader.rs
+++ b/chain/connector/src/reader.rs
@@ -118,8 +118,14 @@ where
 
     async fn safe_info(&self, selector: SafeSelector) -> Result<Option<DeployedSafe>, Self::Error> {
         let selector = match selector {
+            // This assumes that the deployer of a safe (chain_key) is always the owner of the safe. Assumption holds
+            // always for edge-clients, but may not hold for other nodes. Assumption could be lifted if needed by
+            // introducing a new selector variant that would explicitly query for safes by owner/chain_key.
             SafeSelector::Owner(owner_address) => blokli_client::api::SafeSelector::ChainKey(owner_address.into()),
             SafeSelector::Address(safe_address) => blokli_client::api::SafeSelector::SafeAddress(safe_address.into()),
+            SafeSelector::NodeAddress(node_address) => {
+                blokli_client::api::SafeSelector::RegisteredNode(node_address.into())
+            }
         };
 
         if let Some(safe) = self.0.query_safe(selector).await? {

--- a/common/internal-types/Cargo.toml
+++ b/common/internal-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-internal-types"
-version = "0.17.1"
+version = "0.17.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Contains HOPR-specific types required internally by the HOPR node"
 edition = "2024"

--- a/common/internal-types/src/channels.rs
+++ b/common/internal-types/src/channels.rs
@@ -59,7 +59,7 @@ impl PartialEq for ChannelStatus {
             (Self::Open, Self::Open) => true,
             (Self::Closed, Self::Closed) => true,
             (Self::PendingToClose(ct_1), Self::PendingToClose(ct_2)) => {
-                let diff = ct_1.max(ct_2).saturating_sub(*ct_1.min(ct_2));
+                let diff = hopr_primitive_types::traits::SaturatingSub::saturating_sub(ct_1, *ct_2);
                 diff.as_secs() == 0
             }
             _ => false,
@@ -178,7 +178,9 @@ impl ChannelEntry {
     pub fn remaining_closure_time(&self, current_time: SystemTime) -> Option<Duration> {
         match self.status {
             ChannelStatus::Open => None,
-            ChannelStatus::PendingToClose(closure_time) => Some(closure_time.saturating_sub(current_time)),
+            ChannelStatus::PendingToClose(closure_time) => Some(
+                hopr_primitive_types::traits::SaturatingSub::saturating_sub(&closure_time, current_time),
+            ),
             ChannelStatus::Closed => Some(Duration::ZERO),
         }
     }

--- a/common/primitive-types/Cargo.toml
+++ b/common/primitive-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-primitive-types"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2024"
 description = "Generic types used through the entire code base"

--- a/common/primitive-types/src/traits.rs
+++ b/common/primitive-types/src/traits.rs
@@ -114,7 +114,7 @@ pub trait AsUnixTimestamp {
 
 impl AsUnixTimestamp for std::time::SystemTime {
     fn as_unix_timestamp(&self) -> std::time::Duration {
-        self.saturating_sub(std::time::SystemTime::UNIX_EPOCH)
+        SaturatingSub::saturating_sub(self, std::time::SystemTime::UNIX_EPOCH)
     }
 }
 

--- a/flake.lock
+++ b/flake.lock
@@ -295,11 +295,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771297684,
-        "narHash": "sha256-wieWskQxZLPlNXX06JEB0bMoS/ZYQ89xBzF0RL9lyLs=",
+        "lastModified": 1777519017,
+        "narHash": "sha256-TXilQ8MwFFtZs7HSogSI/LJzAS63nicE8iF63iB93WM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "755d3669699a7c62aef35af187d75dc2728cfd85",
+        "rev": "09b556f18dacc39e97a46e0a1cba47af7b3af1d8",
         "type": "github"
       },
       "original": {

--- a/hopr/api/Cargo.toml
+++ b/hopr/api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-api"
-version = "0.10.1"
+version = "0.11.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2024"
 description = "Common HOPR-related high-level API traits used in the code base"

--- a/hopr/api/src/chain/safe.rs
+++ b/hopr/api/src/chain/safe.rs
@@ -26,6 +26,8 @@ pub enum SafeSelector {
     Owner(Address),
     /// Selects Safes with the given address.
     Address(Address),
+    /// Selects Safes linked to the given node address
+    NodeAddress(Address),
 }
 
 impl SafeSelector {
@@ -33,6 +35,7 @@ impl SafeSelector {
         match self {
             SafeSelector::Owner(owner) => &safe.owner == owner,
             SafeSelector::Address(address) => &safe.address == address,
+            SafeSelector::NodeAddress(node_address) => safe.registered_nodes.contains(node_address),
         }
     }
 }

--- a/localcluster/Cargo.toml
+++ b/localcluster/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hoprd-localcluster"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2024"
 license = "GPL-3.0-only"

--- a/localcluster/src/identity.rs
+++ b/localcluster/src/identity.rs
@@ -130,7 +130,10 @@ pub async fn generate(config: &GenerationConfig) -> anyhow::Result<()> {
         }
 
         eprint!("\x1b[2K\rNode {id}: Checking Safe deployment...");
-        let safe = if let Some(safe) = node_connector.safe_info(SafeSelector::Owner(node_address)).await? {
+        let safe = if let Some(safe) = node_connector
+            .safe_info(SafeSelector::NodeAddress(node_address))
+            .await?
+        {
             safe
         } else {
             // Send 1000 wxHOPR tokens to the new node address from Anvil 0 account
@@ -155,7 +158,10 @@ pub async fn generate(config: &GenerationConfig) -> anyhow::Result<()> {
             let node_connector_clone = node_connector.clone();
             let jh = tokio::task::spawn(async move {
                 node_connector_clone
-                    .await_safe_deployment(SafeSelector::Owner(node_address), std::time::Duration::from_secs(10))
+                    .await_safe_deployment(
+                        SafeSelector::NodeAddress(node_address),
+                        std::time::Duration::from_secs(10),
+                    )
                     .await
             });
             node_connector.deploy_safe(initial_token_balance).await?.await?;

--- a/logic/strategy/Cargo.toml
+++ b/logic/strategy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-strategy"
-version = "0.17.2"
+version = "0.17.3"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Contains implementations of different HOPR strategies"
 edition = "2024"

--- a/logic/strategy/src/auto_funding.rs
+++ b/logic/strategy/src/auto_funding.rs
@@ -306,10 +306,15 @@ impl<
 mod tests {
     use std::str::FromStr;
 
+    use anyhow::Context;
     use futures::StreamExt;
     use futures_time::future::FutureExt;
     use hex_literal::hex;
-    use hopr_chain_connector::{create_trustful_hopr_blokli_connector, testing::BlokliTestStateBuilder};
+    use hopr_chain_connector::{
+        api::{AccountSelector, ChainReadAccountOperations, ChainWriteAccountOperations, HoprChainApi},
+        create_trustful_hopr_blokli_connector,
+        testing::BlokliTestStateBuilder,
+    };
     use hopr_lib::{
         Address, BytesRepresentable, ChainKeypair, Keypair, XDaiBalance,
         api::chain::{ChainEvent, ChainEvents},
@@ -338,10 +343,12 @@ mod tests {
         C: HoprChainApi + ChainReadAccountOperations + ChainWriteAccountOperations,
     {
         let account = chain_connector
-            .stream_accounts(AccountSelector::default().with_chain_key(node_address))?
+            .stream_accounts(AccountSelector::default().with_chain_key(node_address))
+            .await?
             .next()
             .await
             .context("missing test account for node")?;
+
         let safe_address = account.safe_address.context("missing test safe address for node")?;
 
         chain_connector.register_safe(&safe_address).await?.await?;
@@ -384,8 +391,8 @@ mod tests {
         let mut chain_connector =
             create_trustful_hopr_blokli_connector(&BOB_KP, Default::default(), blokli_sim, [1; Address::SIZE].into())
                 .await?;
-        register_test_safe(&chain_connector, *BOB).await?;
         chain_connector.connect().await?;
+        register_test_safe(&chain_connector, *BOB).await?;
         let events = chain_connector.subscribe()?;
 
         let cfg = AutoFundingStrategyConfig {
@@ -489,8 +496,8 @@ mod tests {
         let mut chain_connector =
             create_trustful_hopr_blokli_connector(&BOB_KP, Default::default(), blokli_sim, [1; Address::SIZE].into())
                 .await?;
-        register_test_safe(&chain_connector, *BOB).await?;
         chain_connector.connect().await?;
+        register_test_safe(&chain_connector, *BOB).await?;
         let events = chain_connector.subscribe()?;
 
         let cfg = AutoFundingStrategyConfig {
@@ -537,8 +544,8 @@ mod tests {
         let mut chain_connector =
             create_trustful_hopr_blokli_connector(&BOB_KP, Default::default(), blokli_sim, [1; Address::SIZE].into())
                 .await?;
-        register_test_safe(&chain_connector, *BOB).await?;
         chain_connector.connect().await?;
+        register_test_safe(&chain_connector, *BOB).await?;
         let events = chain_connector.subscribe()?;
 
         let cfg = AutoFundingStrategyConfig {
@@ -592,8 +599,8 @@ mod tests {
         let mut chain_connector =
             create_trustful_hopr_blokli_connector(&BOB_KP, Default::default(), blokli_sim, [1; Address::SIZE].into())
                 .await?;
-        register_test_safe(&chain_connector, *BOB).await?;
         chain_connector.connect().await?;
+        register_test_safe(&chain_connector, *BOB).await?;
         let events = chain_connector.subscribe()?;
 
         let cfg = AutoFundingStrategyConfig {
@@ -657,8 +664,8 @@ mod tests {
         let mut chain_connector =
             create_trustful_hopr_blokli_connector(&BOB_KP, Default::default(), blokli_sim, [1; Address::SIZE].into())
                 .await?;
-        register_test_safe(&chain_connector, *BOB).await?;
         chain_connector.connect().await?;
+        register_test_safe(&chain_connector, *BOB).await?;
         let _events = chain_connector.subscribe()?;
 
         let cfg = AutoFundingStrategyConfig {
@@ -731,8 +738,8 @@ mod tests {
         let mut chain_connector =
             create_trustful_hopr_blokli_connector(&BOB_KP, Default::default(), blokli_sim, [1; Address::SIZE].into())
                 .await?;
-        register_test_safe(&chain_connector, *BOB).await?;
         chain_connector.connect().await?;
+        register_test_safe(&chain_connector, *BOB).await?;
         let _events = chain_connector.subscribe()?;
 
         let cfg = AutoFundingStrategyConfig {
@@ -806,8 +813,8 @@ mod tests {
         let mut chain_connector =
             create_trustful_hopr_blokli_connector(&BOB_KP, Default::default(), blokli_sim, [1; Address::SIZE].into())
                 .await?;
-        register_test_safe(&chain_connector, *BOB).await?;
         chain_connector.connect().await?;
+        register_test_safe(&chain_connector, *BOB).await?;
         let _events = chain_connector.subscribe()?;
 
         let cfg = AutoFundingStrategyConfig {

--- a/logic/strategy/src/auto_funding.rs
+++ b/logic/strategy/src/auto_funding.rs
@@ -183,7 +183,7 @@ impl<
         let me = *self.hopr_chain_actions.me();
         let safe = self
             .hopr_chain_actions
-            .safe_info(SafeSelector::Owner(me))
+            .safe_info(SafeSelector::NodeAddress(me))
             .await
             .map_err(|e| StrategyError::Other(e.into()))?;
 
@@ -333,6 +333,22 @@ mod tests {
         static ref DAVE: Address = hex!("68499f50ff68d523385dc60686069935d17d762a").into();
     }
 
+    async fn register_test_safe<C>(chain_connector: &C, node_address: Address) -> anyhow::Result<()>
+    where
+        C: HoprChainApi + ChainReadAccountOperations + ChainWriteAccountOperations,
+    {
+        let account = chain_connector
+            .stream_accounts(AccountSelector::default().with_chain_key(node_address))?
+            .next()
+            .await
+            .context("missing test account for node")?;
+        let safe_address = account.safe_address.context("missing test safe address for node")?;
+
+        chain_connector.register_safe(&safe_address).await?.await?;
+
+        Ok(())
+    }
+
     #[test_log::test(tokio::test)]
     async fn test_auto_funding_strategy() -> anyhow::Result<()> {
         let stake_limit = HoprBalance::from(7_u32);
@@ -368,6 +384,7 @@ mod tests {
         let mut chain_connector =
             create_trustful_hopr_blokli_connector(&BOB_KP, Default::default(), blokli_sim, [1; Address::SIZE].into())
                 .await?;
+        register_test_safe(&chain_connector, *BOB).await?;
         chain_connector.connect().await?;
         let events = chain_connector.subscribe()?;
 
@@ -472,6 +489,7 @@ mod tests {
         let mut chain_connector =
             create_trustful_hopr_blokli_connector(&BOB_KP, Default::default(), blokli_sim, [1; Address::SIZE].into())
                 .await?;
+        register_test_safe(&chain_connector, *BOB).await?;
         chain_connector.connect().await?;
         let events = chain_connector.subscribe()?;
 
@@ -519,6 +537,7 @@ mod tests {
         let mut chain_connector =
             create_trustful_hopr_blokli_connector(&BOB_KP, Default::default(), blokli_sim, [1; Address::SIZE].into())
                 .await?;
+        register_test_safe(&chain_connector, *BOB).await?;
         chain_connector.connect().await?;
         let events = chain_connector.subscribe()?;
 
@@ -573,6 +592,7 @@ mod tests {
         let mut chain_connector =
             create_trustful_hopr_blokli_connector(&BOB_KP, Default::default(), blokli_sim, [1; Address::SIZE].into())
                 .await?;
+        register_test_safe(&chain_connector, *BOB).await?;
         chain_connector.connect().await?;
         let events = chain_connector.subscribe()?;
 
@@ -637,6 +657,7 @@ mod tests {
         let mut chain_connector =
             create_trustful_hopr_blokli_connector(&BOB_KP, Default::default(), blokli_sim, [1; Address::SIZE].into())
                 .await?;
+        register_test_safe(&chain_connector, *BOB).await?;
         chain_connector.connect().await?;
         let _events = chain_connector.subscribe()?;
 
@@ -710,6 +731,7 @@ mod tests {
         let mut chain_connector =
             create_trustful_hopr_blokli_connector(&BOB_KP, Default::default(), blokli_sim, [1; Address::SIZE].into())
                 .await?;
+        register_test_safe(&chain_connector, *BOB).await?;
         chain_connector.connect().await?;
         let _events = chain_connector.subscribe()?;
 
@@ -784,6 +806,7 @@ mod tests {
         let mut chain_connector =
             create_trustful_hopr_blokli_connector(&BOB_KP, Default::default(), blokli_sim, [1; Address::SIZE].into())
                 .await?;
+        register_test_safe(&chain_connector, *BOB).await?;
         chain_connector.connect().await?;
         let _events = chain_connector.subscribe()?;
 

--- a/logic/strategy/src/snapshots/hopr_strategy__auto_funding__tests__auto_funding_strategy.snap
+++ b/logic/strategy/src/snapshots/hopr_strategy__auto_funding__tests__auto_funding_strategy.snap
@@ -36,7 +36,7 @@ native_balances:
     balance: 0 xDai
   bea83ba0fcee21da44a30c893f466e6bf0c29bbb:
     __typename: NativeBalance
-    balance: 0.999999999999999999 xDai
+    balance: 0.999999999999999998 xDai
   259bed99d230648d7c8a116af59abdd15c9f4f1e:
     __typename: NativeBalance
     balance: 0 xDai
@@ -100,7 +100,8 @@ deployed_safes:
     address: 259bed99d230648d7c8a116af59abdd15c9f4f1e
     chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
     module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
-    registered_nodes: []
+    registered_nodes:
+      - bea83ba0fcee21da44a30c893f466e6bf0c29bbb
   0f944bc36fdcf97fff6807174eeb839ecd6035bd:
     address: 0f944bc36fdcf97fff6807174eeb839ecd6035bd
     chain_key: b6021e0860dd9d96c9ff0a73e2e5ba3a466ba234
@@ -112,7 +113,7 @@ deployed_safes:
     module_address: c6cf223b5fa5a0002e5f975453407134b848c312
     registered_nodes: []
 tx_counts:
-  bea83ba0fcee21da44a30c893f466e6bf0c29bbb: 1
+  bea83ba0fcee21da44a30c893f466e6bf0c29bbb: 2
 channels:
   8a0da13eba62860787c9f93a665d2235d8e9632c491dc577ce9dd28d5be8a091:
     balance: 0.00000000000000001 wxHOPR

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.93"
+channel = "1.95"
 profile = "default"
 components = ["cargo", "clippy", "rust-src"]


### PR DESCRIPTION
Same fix as #8092, for the `edinburgh` release.