### PR TITLE
refactor(transport): replace mixer channel pair with MixerSink adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5009,7 +5009,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-mixer"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bytesize",

--- a/transport/mixer/Cargo.toml
+++ b/transport/mixer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-mixer"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition.workspace = true
 rust-version.workspace = true

--- a/transport/mixer/benches/mixer_throughput_bench.rs
+++ b/transport/mixer/benches/mixer_throughput_bench.rs
@@ -1,6 +1,6 @@
 use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
-use futures::{StreamExt, future::BoxFuture};
-use hopr_transport_mixer::{channel, config::MixerConfig};
+use futures::{SinkExt, StreamExt, future::BoxFuture};
+use hopr_transport_mixer::{MixerSink, channel, config::MixerConfig};
 use rust_stream_ext_concurrent::then_concurrent::StreamThenConcurrentExt;
 
 const SAMPLE_SIZE: usize = 10;
@@ -132,6 +132,38 @@ fn send_continuous_stream_load(item: &str, iterations: usize, cfg: MixerConfig) 
     })
 }
 
+fn send_continuous_sink_load(item: &'static str, iterations: usize, cfg: MixerConfig) -> BoxFuture<'static, ()> {
+    Box::pin(async move {
+        // Pre-allocate the inner mpsc large enough to absorb all flushed items at once,
+        // avoiding backpressure that would require concurrent draining.
+        let (tx, mut rx) = futures::channel::mpsc::channel(iterations);
+        let mut sink = MixerSink::new(tx, cfg);
+
+        for _ in 0..iterations {
+            sink.start_send_unpin(item).expect("start_send must succeed");
+        }
+
+        sink.flush().await.expect("flush must succeed");
+
+        for _ in 0..iterations {
+            rx.next().await.expect("receive must succeed");
+        }
+    })
+}
+
+pub fn mixer_sink_throughput_minimal_mixing(c: &mut Criterion) {
+    mixer_throughput(
+        c,
+        minimal_delay_mixer_cfg(),
+        "mixer_sink",
+        &[
+            10 * 1024 * 2 * RANDOM_GIBBERISH.len(),
+            40 * 1024 * 2 * RANDOM_GIBBERISH.len(),
+        ],
+        send_continuous_sink_load,
+    );
+}
+
 pub fn mixer_stream_throughput_minimal_mixing(c: &mut Criterion) {
     mixer_throughput(
         c,
@@ -146,6 +178,7 @@ criterion_group!(
     benches,
     mixer_channel_throughput_minimal_mixing,
     mixer_channel_throughput_through_sink_minimal_mixing,
+    mixer_sink_throughput_minimal_mixing,
     mixer_stream_throughput_minimal_mixing
 );
 criterion_main!(benches);

--- a/transport/mixer/src/lib.rs
+++ b/transport/mixer/src/lib.rs
@@ -1,6 +1,8 @@
 pub mod channel;
 pub mod config;
 pub mod data;
+pub mod sink;
 
 pub use channel::channel;
 pub use config::MixerConfig;
+pub use sink::MixerSink;

--- a/transport/mixer/src/sink.rs
+++ b/transport/mixer/src/sink.rs
@@ -1,0 +1,220 @@
+use std::{
+    cmp::Reverse,
+    collections::BinaryHeap,
+    pin::Pin,
+    task::{Context, Poll},
+    time::{Duration, Instant},
+};
+
+use futures::{FutureExt, Sink};
+use futures_timer::Delay;
+use tracing::trace;
+
+use crate::{config::MixerConfig, data::DelayedData};
+
+#[cfg(all(feature = "telemetry", not(test)))]
+use crate::channel::{METRIC_MIXER_AVERAGE_DELAY, METRIC_QUEUE_SIZE};
+
+/// A [`Sink`] adapter that applies random delays to items before forwarding them to an inner sink.
+///
+/// Items pushed via `start_send` are held in an internal heap until their randomly-assigned
+/// release time, then forwarded to the wrapped sink. `poll_flush` drains due items and parks
+/// on a timer for the next pending item, so the owning task wakes up automatically when items
+/// become ready — no separate forwarding task is required.
+///
+/// Cloning creates a fresh, empty sink that shares only the inner sink clone and configuration;
+/// each clone maintains an independent delay heap.
+pub struct MixerSink<S, T> {
+    inner: S,
+    heap: BinaryHeap<Reverse<DelayedData<T>>>,
+    timer: Delay,
+    cfg: MixerConfig,
+}
+
+impl<S, T> MixerSink<S, T> {
+    pub fn new(inner: S, cfg: MixerConfig) -> Self {
+        let mut heap = BinaryHeap::new();
+        heap.reserve(cfg.capacity);
+        Self {
+            inner,
+            heap,
+            timer: Delay::new(Duration::ZERO),
+            cfg,
+        }
+    }
+}
+
+impl<S: Clone, T> Clone for MixerSink<S, T> {
+    fn clone(&self) -> Self {
+        Self::new(self.inner.clone(), self.cfg)
+    }
+}
+
+impl<S, T> Sink<T> for MixerSink<S, T>
+where
+    S: Sink<T> + Unpin,
+    T: Unpin,
+{
+    type Error = S::Error;
+
+    fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: T) -> Result<(), Self::Error> {
+        let this = Pin::into_inner(self);
+        let random_delay = this.cfg.random_delay();
+
+        trace!(delay_ms = random_delay.as_millis(), "mixer: delaying item");
+
+        this.heap.push(Reverse(DelayedData::from((Instant::now() + random_delay, item))));
+
+        #[cfg(all(feature = "telemetry", not(test)))]
+        {
+            METRIC_QUEUE_SIZE.increment(1.0f64);
+
+            let weight = 1.0f64 / this.cfg.metric_delay_window as f64;
+            METRIC_MIXER_AVERAGE_DELAY.set(
+                (weight * random_delay.as_millis() as f64) + ((1.0f64 - weight) * METRIC_MIXER_AVERAGE_DELAY.get()),
+            );
+        }
+
+        Ok(())
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        let this = Pin::into_inner(self);
+
+        loop {
+            let now = Instant::now();
+
+            while this.heap.peek().is_some_and(|x| x.0.release_at <= now) {
+                let item = this.heap.pop().unwrap().0.item;
+
+                match Pin::new(&mut this.inner).poll_ready(cx) {
+                    Poll::Ready(Ok(())) => {}
+                    Poll::Ready(Err(e)) => return Poll::Ready(Err(e)),
+                    Poll::Pending => {
+                        this.heap.push(Reverse(DelayedData::from((now, item))));
+                        break;
+                    }
+                }
+
+                if let Err(e) = Pin::new(&mut this.inner).start_send(item) {
+                    return Poll::Ready(Err(e));
+                }
+
+                #[cfg(all(feature = "telemetry", not(test)))]
+                METRIC_QUEUE_SIZE.decrement(1.0f64);
+            }
+
+            futures::ready!(Pin::new(&mut this.inner).poll_flush(cx))?;
+
+            if this.heap.is_empty() {
+                return Poll::Ready(Ok(()));
+            }
+
+            let next_release = this.heap.peek().unwrap().0.release_at;
+            let sleep_for = next_release.saturating_duration_since(now);
+
+            if sleep_for.is_zero() {
+                continue;
+            }
+
+            this.timer.reset(sleep_for);
+            // Park until the timer fires; cx.waker() is registered inside poll_unpin.
+            futures::ready!(this.timer.poll_unpin(cx));
+        }
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        futures::ready!(self.as_mut().poll_flush(cx))?;
+        Pin::new(&mut Pin::into_inner(self).inner).poll_close(cx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use futures::{SinkExt, StreamExt, channel::mpsc};
+    use tokio::time::timeout;
+
+    use super::*;
+
+    const LEEWAY: Duration = Duration::from_millis(200);
+
+    #[tokio::test]
+    async fn items_are_forwarded_after_delay() {
+        let (tx, mut rx) = mpsc::channel::<u32>(100);
+        let cfg = MixerConfig {
+            min_delay: Duration::from_millis(50),
+            delay_range: Duration::from_millis(10),
+            capacity: 16,
+            metric_delay_window: 100,
+        };
+
+        let mut sink = MixerSink::new(tx, cfg);
+
+        sink.send(42u32).await.unwrap();
+
+        let item = timeout(Duration::from_millis(60) + LEEWAY, rx.next())
+            .await
+            .expect("should receive within leeway")
+            .unwrap();
+
+        assert_eq!(item, 42);
+    }
+
+    #[tokio::test]
+    async fn all_items_are_forwarded_with_zero_delay() {
+        let (tx, mut rx) = mpsc::channel::<u32>(100);
+        let cfg = MixerConfig {
+            min_delay: Duration::from_millis(0),
+            delay_range: Duration::from_millis(0),
+            capacity: 16,
+            metric_delay_window: 100,
+        };
+
+        let mut sink = MixerSink::new(tx, cfg);
+
+        for i in 0u32..5 {
+            sink.start_send_unpin(i).unwrap();
+        }
+        sink.flush().await.unwrap();
+
+        let mut received = Vec::new();
+        while let Ok(Some(item)) = timeout(Duration::from_millis(10), rx.next()).await {
+            received.push(item);
+        }
+
+        assert_eq!(received.len(), 5, "all items should be forwarded");
+    }
+
+    #[tokio::test]
+    async fn clone_starts_with_empty_heap() {
+        let (tx, mut rx) = mpsc::channel::<u32>(100);
+        let cfg = MixerConfig {
+            min_delay: Duration::from_millis(50),
+            delay_range: Duration::from_millis(10),
+            capacity: 16,
+            metric_delay_window: 100,
+        };
+
+        let mut sink = MixerSink::new(tx, cfg);
+        sink.start_send_unpin(1u32).unwrap();
+
+        let mut cloned = sink.clone();
+        cloned.flush().await.unwrap();
+
+        sink.flush().await.unwrap();
+
+        let item = timeout(Duration::from_millis(60) + LEEWAY, rx.next())
+            .await
+            .expect("original item should arrive")
+            .unwrap();
+        assert_eq!(item, 1);
+
+        assert!(timeout(Duration::from_millis(10), rx.next()).await.is_err());
+    }
+}


### PR DESCRIPTION
Removes the `mixing_channel_tx`/`rx` pair and dedicated forward task. Introduces `MixerSink<S, T>` which wraps any `Sink<T>` and applies random per-item delays directly in `poll_flush`, eliminating an intermediate channel hop on the outgoing path.

**Stack:**
- #8097 (bytes migration)
- #8098 (collapse dispatch)
- #8099 (parallel routing)
- **#8100** (this PR)
- #8101 (nonblocking egress)