### PR TITLE
chore(deps): pin blokli-client

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -7,6 +7,7 @@ ignore = [
   "RUSTSEC-2026-0049", # `rustls-webpki` - needs alloy removal
   "RUSTSEC-2026-0097", # workspace already pins `rand` 0.10.1, but Cargo.lock still contains transitive `rand` 0.9.3; remove this ignore once upstream deps stop pulling 0.9.3
   "RUSTSEC-2026-0098", # `rustls-webpki` 0.101.7 pulled transitively by blokli-client -> eventsource-client 0.16.2 -> hyper-rustls 0.24.2; our own `rustls-webpki` bumped to >=0.103.12 in Cargo.lock. Drop once blokli-client upgrades eventsource-client (see https://github.com/hoprnet/blokli/issues/107)
+  "RUSTSEC-2026-0119", # `hickory-proto` 0.25.2 pulled by libp2p-dns 0.44.0 -> libp2p 0.56.0; cannot upgrade without a major libp2p bump. The 0.26.x instance is fixed (hickory-proto 0.26.1).
 ]
 informational_warnings = ["unmaintained"]
 severity_threshold = "low"

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -7,7 +7,8 @@ ignore = [
   "RUSTSEC-2026-0049", # `rustls-webpki` - needs alloy removal
   "RUSTSEC-2026-0097", # workspace already pins `rand` 0.10.1, but Cargo.lock still contains transitive `rand` 0.9.3; remove this ignore once upstream deps stop pulling 0.9.3
   "RUSTSEC-2026-0098", # `rustls-webpki` 0.101.7 pulled transitively by blokli-client -> eventsource-client 0.16.2 -> hyper-rustls 0.24.2; our own `rustls-webpki` bumped to >=0.103.12 in Cargo.lock. Drop once blokli-client upgrades eventsource-client (see https://github.com/hoprnet/blokli/issues/107)
-  "RUSTSEC-2026-0119", # `hickory-proto` 0.25.2 pulled by libp2p-dns 0.44.0 -> libp2p 0.56.0; cannot upgrade without a major libp2p bump. The 0.26.x instance is fixed (hickory-proto 0.26.1).
+  "RUSTSEC-2026-0118", # `hickory-proto` 0.25.2 pulled by libp2p-dns 0.44.0 -> libp2p 0.56.0; no fix for 0.25.x; cannot remove without a major libp2p bump
+  "RUSTSEC-2026-0119", # same root cause as 0118 (different advisory DB version); hickory-proto 0.26.x is fixed via hickory-proto 0.26.1
 ]
 informational_warnings = ["unmaintained"]
 severity_threshold = "low"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -99,8 +99,7 @@ jobs:
           command: |
             nix develop -c env -u VIRTUAL_ENV UV_CACHE_DIR=.ci/no-git-dependencies/.uv-cache \
               uv run --project .ci/no-git-dependencies \
-              python .ci/no-git-dependencies/src/no_git_dependencies_check/main.py \
-              --allow blokli-client
+              python .ci/no-git-dependencies/src/no_git_dependencies_check/main.py
 
   checks:
     name: Check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2496,7 +2496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -4287,7 +4287,7 @@ dependencies = [
  "futures-channel",
  "futures-io",
  "futures-util",
- "hickory-proto 0.26.0",
+ "hickory-proto 0.26.1",
  "idna",
  "ipnet",
  "jni",
@@ -4327,9 +4327,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a916d0494600d99ecb15aadfab677ad97c4de559e8f1af0c129353a733ac1fcc"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
 dependencies = [
  "data-encoding",
  "idna",
@@ -4368,14 +4368,14 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10bd64d950b4d38ca21e25c8ae230712e4955fb8290cfcb29a5e5dc6017e544"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",
  "hickory-net",
- "hickory-proto 0.26.0",
+ "hickory-proto 0.26.1",
  "ipconfig",
  "ipnet",
  "jni",
@@ -4690,7 +4690,7 @@ dependencies = [
  "flume",
  "futures",
  "futures-time",
- "hickory-resolver 0.26.0",
+ "hickory-resolver 0.26.1",
  "hopr-async-runtime",
  "hopr-metrics",
  "hopr-types",
@@ -8961,7 +8961,7 @@ checksum = "f83ad47c2f14654528a89495f8d0dbc64173176f8512c7c72386cbe81009f661"
 dependencies = [
  "ahash",
  "annotate-snippets",
- "base64 0.22.1",
+ "base64 0.21.7",
  "encoding_rs_io",
  "getrandom 0.3.4",
  "nohash-hasher",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -834,7 +834,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -845,7 +845,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2873,7 +2873,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4277,9 +4277,9 @@ checksum = "e712f64ec3850b98572bffac52e2c6f282b29fe6c5fa6d42334b30be438d95c1"
 
 [[package]]
 name = "hickory-net"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c61c8db47fae51ba9f8f2a2748bd87542acfbe22f2ec9cf9c8ec72d1ee6e9a6"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -5601,7 +5601,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -6008,7 +6008,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7025,7 +7025,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8022,7 +8022,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8059,7 +8059,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8627,7 +8627,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9391,7 +9391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9591,7 +9591,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -10680,7 +10680,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,8 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "blokli-client"
-version = "0.25.0"
-source = "git+https://github.com/hoprnet/blokli?branch=main#97f38aa19c014ea670def67c6b5f627e7e7274a4"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0815759c61c8ccb53569f714beda0e292d12253126699160b21cb15f115b3fcd"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -1590,6 +1591,7 @@ dependencies = [
  "parking_lot",
  "rand 0.9.4",
  "reqwest 0.12.28",
+ "semver 1.0.28",
  "serde",
  "serde_json",
  "smart-default",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,7 +98,7 @@ halfbrown = "0.4.0"
 hashbrown = "0.17.0"
 hex = "0.4.3"
 hex-literal = "1.1.0"
-hickory-resolver = { version = "0.26.0", default-features = false, features = [
+hickory-resolver = { version = "0.26.1", default-features = false, features = [
   "system-config",
 ] }
 http = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ backon = { version = "1.6.0", default-features = false }
 base64 = "0.22.1"
 bimap = "0.6.3"
 bitvec = "1.0.1"
-blokli-client = { git = "https://github.com/hoprnet/blokli", branch = "main" }
+blokli-client = { version = "0.26.0" }
 bloomfilter = { version = "3.0.1" }
 bytesize = { version = "2.3.1", features = ["serde"] }
 bytes = "1.11.1"

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_announce_new_account_with_multiaddresses.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_announce_new_account_with_multiaddresses.snap
@@ -39,5 +39,8 @@ chain_info:
   expected_block_time: "5"
   finality: "3"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_announce_new_account_without_multiaddresses.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_announce_new_account_without_multiaddresses.snap
@@ -38,5 +38,8 @@ chain_info:
   expected_block_time: "5"
   finality: "3"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_re_register_safe.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_re_register_safe.snap
@@ -29,5 +29,8 @@ chain_info:
   network: rotsee
   contract_addresses: "{\"announcements\":\"0x5afe60f4f74159f8F68dadCE6202b938cDa80Dad\",\"channels\":\"0x5bD809bDBAa8D3d5f37743Ae86BFef766dEE56b6\",\"module_implementation\":\"0x1167FB204298799B0B9E98896D58958cAEd164B0\",\"node_safe_migration\":\"0xe95b481AA95e1d071a4B250Ea5F9dD498A19646b\",\"node_safe_registry\":\"0x0e4e1a2D851663462523bF38Ca56259aceCCBc76\",\"node_stake_factory\":\"0x878Ea9591726E70AA06f820c3bA5142A0C8ab58B\",\"ticket_price_oracle\":\"0x147899Ca57111d9081df125C2bcbd839981f04c2\",\"token\":\"0x9C312F8997F215ada9802DA9fb281206350EAd2b\",\"winning_probability_oracle\":\"0x74329f8153cBb33aABdEd79Ee84748fE8923c5E3\"}"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_reannounce_when_existing_account_has_same_multiaddresses.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_reannounce_when_existing_account_has_same_multiaddresses.snap
@@ -58,5 +58,8 @@ chain_info:
   expected_block_time: "5"
   finality: "3"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_register_any_safe_when_node_already_registered.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_register_any_safe_when_node_already_registered.snap
@@ -48,5 +48,8 @@ chain_info:
   expected_block_time: "5"
   finality: "3"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_register_safe_that_does_not_exist.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_register_safe_that_does_not_exist.snap
@@ -31,5 +31,8 @@ chain_info:
   expected_block_time: "5"
   finality: "3"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_reannounce_when_existing_account_has_no_multiaddresses.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_reannounce_when_existing_account_has_no_multiaddresses.snap
@@ -59,5 +59,8 @@ chain_info:
   expected_block_time: "5"
   finality: "3"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_register_safe.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_register_safe.snap
@@ -41,5 +41,8 @@ chain_info:
   expected_block_time: "5"
   finality: "3"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_register_safe_that_has_nodes_registered_already.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_register_safe_that_has_nodes_registered_already.snap
@@ -42,5 +42,8 @@ chain_info:
   expected_block_time: "5"
   finality: "3"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_withdraw.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_withdraw.snap
@@ -41,5 +41,8 @@ chain_info:
   expected_block_time: "5"
   finality: "3"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_close_incoming_channel.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_close_incoming_channel.snap
@@ -96,5 +96,8 @@ chain_info:
   expected_block_time: "5"
   finality: "3"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_finalize_channel_closure.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_finalize_channel_closure.snap
@@ -96,5 +96,8 @@ chain_info:
   expected_block_time: "5"
   finality: "3"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_fund_channel.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_fund_channel.snap
@@ -96,5 +96,8 @@ chain_info:
   expected_block_time: "5"
   finality: "3"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_initiate_channel_closure.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_initiate_channel_closure.snap
@@ -96,5 +96,8 @@ chain_info:
   expected_block_time: "5"
   finality: "3"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_open_channel.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_open_channel.snap
@@ -96,5 +96,8 @@ chain_info:
   expected_block_time: "5"
   finality: "3"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__safe__tests__connector_should_query_existing_safe.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__safe__tests__connector_should_query_existing_safe.snap
@@ -40,5 +40,8 @@ chain_info:
   expected_block_time: "5"
   finality: "3"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__sequencer__tests__sequencer_should_increase_nonce_after_rejected_tx.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__sequencer__tests__sequencer_should_increase_nonce_after_rejected_tx.snap
@@ -35,5 +35,8 @@ chain_info:
   network: rotsee
   contract_addresses: "{\"announcements\":\"0x5afe60f4f74159f8F68dadCE6202b938cDa80Dad\",\"channels\":\"0x5bD809bDBAa8D3d5f37743Ae86BFef766dEE56b6\",\"module_implementation\":\"0x1167FB204298799B0B9E98896D58958cAEd164B0\",\"node_safe_migration\":\"0xe95b481AA95e1d071a4B250Ea5F9dD498A19646b\",\"node_safe_registry\":\"0x0e4e1a2D851663462523bF38Ca56259aceCCBc76\",\"node_stake_factory\":\"0x878Ea9591726E70AA06f820c3bA5142A0C8ab58B\",\"ticket_price_oracle\":\"0x147899Ca57111d9081df125C2bcbd839981f04c2\",\"token\":\"0x9C312F8997F215ada9802DA9fb281206350EAd2b\",\"winning_probability_oracle\":\"0x74329f8153cBb33aABdEd79Ee84748fE8923c5E3\"}"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__sequencer__tests__sequencer_should_increase_nonce_after_successful_tx.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__sequencer__tests__sequencer_should_increase_nonce_after_successful_tx.snap
@@ -35,5 +35,8 @@ chain_info:
   network: rotsee
   contract_addresses: "{\"announcements\":\"0x5afe60f4f74159f8F68dadCE6202b938cDa80Dad\",\"channels\":\"0x5bD809bDBAa8D3d5f37743Ae86BFef766dEE56b6\",\"module_implementation\":\"0x1167FB204298799B0B9E98896D58958cAEd164B0\",\"node_safe_migration\":\"0xe95b481AA95e1d071a4B250Ea5F9dD498A19646b\",\"node_safe_registry\":\"0x0e4e1a2D851663462523bF38Ca56259aceCCBc76\",\"node_stake_factory\":\"0x878Ea9591726E70AA06f820c3bA5142A0C8ab58B\",\"ticket_price_oracle\":\"0x147899Ca57111d9081df125C2bcbd839981f04c2\",\"token\":\"0x9C312F8997F215ada9802DA9fb281206350EAd2b\",\"winning_probability_oracle\":\"0x74329f8153cBb33aABdEd79Ee84748fE8923c5E3\"}"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_on_closed_channel.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_on_closed_channel.snap
@@ -96,5 +96,8 @@ chain_info:
   expected_block_time: "5"
   finality: "3"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_on_non_existing_channel.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_on_non_existing_channel.snap
@@ -95,5 +95,8 @@ chain_info:
   expected_block_time: "5"
   finality: "3"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_amount_higher_than_channel_stake.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_amount_higher_than_channel_stake.snap
@@ -95,5 +95,8 @@ chain_info:
   expected_block_time: "5"
   finality: "3"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_old_index.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_old_index.snap
@@ -95,5 +95,8 @@ chain_info:
   expected_block_time: "5"
   finality: "3"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_previous_epoch.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_previous_epoch.snap
@@ -95,5 +95,8 @@ chain_info:
   expected_block_time: "5"
   finality: "3"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_redeem_ticket.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_redeem_ticket.snap
@@ -100,5 +100,8 @@ chain_info:
   expected_block_time: "5"
   finality: "3"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_redeem_ticket_and_increase_redeemed_stats.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_redeem_ticket_and_increase_redeemed_stats.snap
@@ -100,5 +100,8 @@ chain_info:
   expected_block_time: "5"
   finality: "3"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}

--- a/impls/strategy/src/snapshots/hopr_strategy__auto_funding__tests__auto_funding_strategy.snap
+++ b/impls/strategy/src/snapshots/hopr_strategy__auto_funding__tests__auto_funding_strategy.snap
@@ -172,5 +172,8 @@ chain_info:
   expected_block_time: "5"
   finality: "3"
 version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.26
 health: OK
 active_txs: {}


### PR DESCRIPTION
## Summary

Pin `blokli-client` from a git dependency to `v0.26.0` on crates.io to enable reproducible builds and proper version tracking.

**Changes:**
- `blokli-client`: `git+https://github.com/hoprnet/blokli?branch=main#97f38aa` → `v0.26.0` (crates.io)
- `hickory-resolver`: `0.26.0` → `0.26.1` to pull `hickory-proto 0.26.1` (fixes RUSTSEC-2026-0119)
- `hickory-net`: `0.26.0` → `0.26.1` (fixes RUSTSEC-2026-0120)
- Ignore RUSTSEC-2026-0118 and RUSTSEC-2026-0119 for `hickory-proto 0.25.2` pulled transitively by `libp2p-dns 0.44.0`; the 0.25.x branch has no fixed upgrade available and cannot be removed without a major libp2p bump
- Update all 25 `insta` snapshots to include the new `client_compatibility` field introduced in `blokli-client 0.26.0`