### PR TITLE
feat(session): Add drop-driven session cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4744,7 +4744,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.0-rc.4"
+version = "4.0.0-rc.5"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -5255,7 +5255,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -5327,7 +5327,7 @@ dependencies = [
 
 [[package]]
 name = "hoprd"
-version = "4.0.0-rc.4"
+version = "4.0.0-rc.5"
 dependencies = [
  "anyhow",
  "async-signal",

--- a/transport/session/Cargo.toml
+++ b/transport/session/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-session"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition = "2024"
 description = "Session functionality providing session abstraction over the HOPR transport"

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -1921,6 +1921,85 @@ mod tests {
     }
 
     #[test_log::test(tokio::test)]
+    async fn session_manager_should_close_session_when_hopr_session_is_dropped() -> anyhow::Result<()> {
+        let pseudonym = HoprPseudonym::random();
+        let session_id = SessionId::new(16u64, pseudonym);
+        let routing = DestinationRouting::Return(pseudonym.into());
+
+        let mgr = SessionManager::new(Default::default());
+        let (msg_tx, _) = futures::channel::mpsc::unbounded::<(DestinationRouting, ApplicationDataOut)>();
+        let (new_session_tx, _) = futures::channel::mpsc::channel(1);
+        let abort_handles = mgr.start(msg_tx.clone(), new_session_tx)?;
+
+        let (session_tx, session_rx) = futures::channel::mpsc::unbounded::<ApplicationDataIn>();
+        // Register an active session in the manager first, then create the matching `HoprSession`.
+        // If `HoprSession::drop` does not notify the manager, this entry remains stale forever.
+        mgr.sessions
+            .insert(
+                session_id,
+                SessionSlot {
+                    session_tx: Arc::new(session_tx),
+                    routing_opts: routing.clone(),
+                    abort_handles: Default::default(),
+                    surb_mgmt: Default::default(),
+                    surb_estimator: Default::default(),
+                    #[cfg(feature = "telemetry")]
+                    telemetry: Arc::new(SessionTelemetry::new(session_id, Default::default())),
+                },
+            )
+            .await;
+
+        let (_, mut close_session_notifier) = mgr
+            .session_notifiers
+            .get()
+            .cloned()
+            .ok_or(anyhow!("session manager must be started"))?;
+        let closure_notifier = Box::new(move |session_id: SessionId, reason: ClosureReason| {
+            close_session_notifier
+                .try_send((session_id, reason))
+                .expect("session close notification must be delivered");
+        });
+
+        let session = HoprSession::new(
+            session_id,
+            routing,
+            Default::default(),
+            (msg_tx, session_rx),
+            Some(closure_notifier),
+            #[cfg(feature = "telemetry")]
+            Arc::new(SessionTelemetry::new(session_id, Default::default())),
+        )?;
+
+        // Sanity-check test setup: the manager must report one active session before drop.
+        assert_eq!(vec![session_id], mgr.active_sessions().await);
+
+        // Regression being guarded: dropping `HoprSession` must trigger session closure in manager.
+        // Otherwise stale entries keep consuming session slots and can prevent future sessions.
+        drop(session);
+
+        let close_result = timeout(Duration::from_secs(1), async {
+            loop {
+                if mgr.active_sessions().await.is_empty() {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await;
+        if close_result.is_err() {
+            return Err(anyhow!(
+                "dropping HoprSession did not remove the manager session entry in time (stale session leak)"
+            ));
+        }
+
+        futures::stream::iter(abort_handles)
+            .for_each(|ah| async move { ah.abort() })
+            .await;
+
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
     async fn session_manager_should_not_allow_establish_session_when_tag_range_is_used_up() -> anyhow::Result<()> {
         let alice_pseudonym = HoprPseudonym::random();
         let bob_peer: Address = (&ChainKeypair::random()).into();

--- a/transport/session/src/types.rs
+++ b/transport/session/src/types.rs
@@ -354,7 +354,10 @@ impl HoprSession {
     /// from the given `hopr` interface and passing it to the appropriate [`UnreliableSocket`] or [`ReliableSocket`]
     /// based on the given `capabilities`.
     ///
-    /// The `on_close` closure can be optionally called when the Session has been closed via `poll_close`.
+    /// The optional `on_close` closure is invoked at most once, on the first observed closure signal:
+    /// - `poll_close` completes -> [`ClosureReason::WriteClosed`]
+    /// - `poll_read` returns `0` (empty read / EOF) -> [`ClosureReason::EmptyRead`]
+    /// - the session is dropped before either of the above -> [`ClosureReason::WriteClosed`]
     #[tracing::instrument(skip_all, fields(id, routing, cfg, session_id = %id))]
     pub fn new<Tx, Rx>(
         id: SessionId,

--- a/transport/session/src/types.rs
+++ b/transport/session/src/types.rs
@@ -333,7 +333,7 @@ pub struct HoprSessionConfig {
 ///
 /// This is essentially a HOPR-specific wrapper for [`ReliableSocket`] and [`UnreliableSocket`]
 /// Session protocol sockets.
-#[pin_project::pin_project]
+#[pin_project::pin_project(PinnedDrop)]
 pub struct HoprSession {
     id: SessionId,
     #[pin]
@@ -492,6 +492,17 @@ impl std::fmt::Debug for HoprSession {
             .field("id", &self.id)
             .field("routing", &self.routing)
             .finish_non_exhaustive()
+    }
+}
+
+#[pin_project::pinned_drop]
+impl PinnedDrop for HoprSession {
+    fn drop(self: Pin<&mut Self>) {
+        let this = self.project();
+        if let Some(notifier) = this.on_close.take() {
+            tracing::trace!(session_id = %this.id, "notifying dropped session");
+            notifier(*this.id, ClosureReason::WriteClosed);
+        }
     }
 }
 


### PR DESCRIPTION
Fixing a session lifecycle gap where dropping a HoprSession could leave a stale entry in SessionManager if the caller did not close before.

