### PR TITLE
feat: utils session helper to create explicit-path sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4124,7 +4124,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-utils-session"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/utils-session/Cargo.toml
+++ b/utils-session/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-utils-session"
-version = "1.1.3"
+version = "1.2.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition.workspace = true
 rust-version.workspace = true
@@ -20,6 +20,7 @@ runtime-tokio = [
   "hopr-utils/network-types-runtime-tokio",
   "hopr-transport/runtime-tokio",
 ]
+explicit-path = ["hopr-lib/explicit-path"]
 telemetry = [
   "hopr-types/telemetry",
   "hopr-transport/telemetry",

--- a/utils-session/src/lib.rs
+++ b/utils-session/src/lib.rs
@@ -24,8 +24,9 @@ use hopr_api::{
         traits::{EdgeObservableRead, EdgeObservableWrite},
     },
     network::NetworkStreamControl,
-    types::internal::routing::RoutingOptions,
 };
+#[cfg(not(feature = "explicit-path"))]
+use hopr_lib::HopRouting;
 #[cfg(feature = "explicit-path")]
 use hopr_lib::HoprSessionClientExplicitPathConfig;
 use hopr_lib::{
@@ -67,6 +68,15 @@ lazy_static::lazy_static! {
         &["type"]
     ).unwrap();
 }
+
+#[cfg(feature = "explicit-path")]
+use hopr_lib::HoprSessionClientExplicitPathConfig;
+
+#[cfg(feature = "explicit-path")]
+pub type Routing = RoutingOptions;
+
+#[cfg(not(feature = "explicit-path"))]
+pub type Routing = HopRouting;
 
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -148,9 +158,9 @@ pub struct StoredSessionEntry {
     /// Target of the Session.
     pub target: SessionTargetSpec,
     /// Forward routing options used for the Session.
-    pub forward_path: RoutingOptions,
+    pub forward_path: Routing,
     /// Return routing options used for the Session.
-    pub return_path: RoutingOptions,
+    pub return_path: Routing,
     /// The maximum number of client sessions that the listener can spawn.
     pub max_client_sessions: usize,
     /// The maximum number of SURB packets that can be sent upstream.
@@ -1287,8 +1297,8 @@ mod tests {
         StoredSessionEntry {
             destination: Address::default(),
             target: SessionTargetSpec::Plain("localhost:8080".into()),
-            forward_path: RoutingOptions::from(HopRouting::default()),
-            return_path: RoutingOptions::from(HopRouting::default()),
+            forward_path: Default::default(),
+            return_path: Default::default(),
             max_client_sessions: 5,
             max_surb_upstream: None,
             response_buffer: None,

--- a/utils-session/src/lib.rs
+++ b/utils-session/src/lib.rs
@@ -264,6 +264,9 @@ pub trait SessionFactory: Clone + Send + Sync + 'static {
         cfg: Self::Cfg,
     ) -> Result<(HoprSession, HoprSessionConfigurator), anyhow::Error>;
 
+    fn routing_from_cfg(&self, cfg: &Self::Cfg) -> Result<(Routing, Routing), anyhow::Error>;
+    fn listener_limits(&self, cfg: &Self::Cfg)
+    -> (Option<human_bandwidth::re::bandwidth::Bandwidth>, Option<ByteSize>);
     fn session_idle_timeout(&self) -> Option<std::time::Duration>;
 }
 
@@ -311,6 +314,22 @@ where
         cfg: Self::Cfg,
     ) -> Result<(HoprSession, HoprSessionConfigurator), anyhow::Error> {
         Ok(HoprSessionClientOperations::connect_to(self.hopr.as_ref(), dest, target, cfg).await?)
+    }
+
+    fn routing_from_cfg(&self, cfg: &Self::Cfg) -> Result<(Routing, Routing), anyhow::Error> {
+        Ok((cfg.forward_path.into(), cfg.return_path.into()))
+    }
+
+    fn listener_limits(
+        &self,
+        cfg: &Self::Cfg,
+    ) -> (Option<human_bandwidth::re::bandwidth::Bandwidth>, Option<ByteSize>) {
+        (
+            cfg.surb_management
+                .map(|v| Bandwidth::from_bps(v.max_surbs_per_sec * SURB_SIZE as u64)),
+            cfg.surb_management
+                .map(|v| ByteSize::b(v.target_surb_buffer_size * SURB_SIZE as u64)),
+        )
     }
 
     fn session_idle_timeout(&self) -> Option<std::time::Duration> {
@@ -366,6 +385,34 @@ where
         cfg: Self::Cfg,
     ) -> Result<(HoprSession, HoprSessionConfigurator), anyhow::Error> {
         Ok(self.hopr.connect_to_using_explicit_path(dest, target, cfg).await?)
+    }
+
+    fn routing_from_cfg(&self, cfg: &Self::Cfg) -> Result<(Routing, Routing), anyhow::Error> {
+        let forward_path = RoutingOptions::IntermediatePath(
+            cfg.forward_path
+                .clone()
+                .try_into()
+                .map_err(|e| anyhow!("invalid explicit forward path: {e}"))?,
+        );
+        let return_path = RoutingOptions::IntermediatePath(
+            cfg.return_path
+                .clone()
+                .try_into()
+                .map_err(|e| anyhow!("invalid explicit return path: {e}"))?,
+        );
+        Ok((forward_path, return_path))
+    }
+
+    fn listener_limits(
+        &self,
+        cfg: &Self::Cfg,
+    ) -> (Option<human_bandwidth::re::bandwidth::Bandwidth>, Option<ByteSize>) {
+        (
+            cfg.surb_management
+                .map(|v| Bandwidth::from_bps(v.max_surbs_per_sec * SURB_SIZE as u64)),
+            cfg.surb_management
+                .map(|v| ByteSize::b(v.target_surb_buffer_size * SURB_SIZE as u64)),
+        )
     }
 
     fn session_idle_timeout(&self) -> Option<std::time::Duration> {
@@ -464,14 +511,14 @@ impl Drop for SessionPool {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn create_tcp_client_binding<T: SessionFactory<Cfg = HoprSessionClientConfig>>(
+pub async fn create_tcp_client_binding<T: SessionFactory>(
     bind_host: std::net::SocketAddr,
     port_range: Option<String>,
     factory: T,
     open_listeners: Arc<ListenerJoinHandles>,
     destination: Address,
     target_spec: SessionTargetSpec,
-    config: HoprSessionClientConfig,
+    config: T::Cfg,
     use_session_pool: Option<usize>,
     max_client_sessions: Option<usize>,
 ) -> Result<(std::net::SocketAddr, Option<SessionId>, usize), BindError> {
@@ -491,6 +538,10 @@ pub async fn create_tcp_client_binding<T: SessionFactory<Cfg = HoprSessionClient
         .clone()
         .into_target(IpProtocol::TCP)
         .map_err(|e| BindError::UnknownFailure(e.to_string()))?;
+    let (forward_path, return_path) = factory
+        .routing_from_cfg(&config)
+        .map_err(|e| BindError::UnknownFailure(e.to_string()))?;
+    let (max_surb_upstream, response_buffer) = factory.listener_limits(&config);
 
     // Create a session pool if requested
     let session_pool_size = use_session_pool.unwrap_or(0);
@@ -614,16 +665,12 @@ pub async fn create_tcp_client_binding<T: SessionFactory<Cfg = HoprSessionClient
         StoredSessionEntry {
             destination,
             target: target_spec,
-            forward_path: config.forward_path.into(),
-            return_path: config.return_path.into(),
+            forward_path,
+            return_path,
             clients: active_sessions,
             max_client_sessions: max_clients,
-            max_surb_upstream: config
-                .surb_management
-                .map(|v| Bandwidth::from_bps(v.max_surbs_per_sec * SURB_SIZE as u64)),
-            response_buffer: config
-                .surb_management
-                .map(|v| ByteSize::b(v.target_surb_buffer_size * SURB_SIZE as u64)),
+            max_surb_upstream,
+            response_buffer,
             session_pool: Some(session_pool_size),
             abort_handle,
         },
@@ -640,14 +687,14 @@ pub enum BindError {
     UnknownFailure(String),
 }
 
-pub async fn create_udp_client_binding<T: SessionFactory<Cfg = HoprSessionClientConfig>>(
+pub async fn create_udp_client_binding<T: SessionFactory>(
     bind_host: std::net::SocketAddr,
     port_range: Option<String>,
     factory: T,
     open_listeners: Arc<ListenerJoinHandles>,
     destination: Address,
     target_spec: SessionTargetSpec,
-    config: HoprSessionClientConfig,
+    config: T::Cfg,
 ) -> Result<(std::net::SocketAddr, Option<SessionId>, usize), BindError> {
     // Bind the UDP socket first
     let (bound_host, udp_socket) = udp_bind_to(bind_host, port_range).await.map_err(|e| {
@@ -664,6 +711,10 @@ pub async fn create_udp_client_binding<T: SessionFactory<Cfg = HoprSessionClient
         .clone()
         .into_target(IpProtocol::UDP)
         .map_err(|e| BindError::UnknownFailure(e.to_string()))?;
+    let (forward_path, return_path) = factory
+        .routing_from_cfg(&config)
+        .map_err(|e| BindError::UnknownFailure(e.to_string()))?;
+    let (max_surb_upstream, response_buffer) = factory.listener_limits(&config);
 
     // Create a single session for the UDP socket
     let (session, configurator) = factory
@@ -716,270 +767,11 @@ pub async fn create_udp_client_binding<T: SessionFactory<Cfg = HoprSessionClient
         StoredSessionEntry {
             destination,
             target: target_spec,
-            forward_path: config.forward_path.into(),
-            return_path: config.return_path.into(),
-            max_client_sessions: max_clients,
-            max_surb_upstream: config
-                .surb_management
-                .map(|v| Bandwidth::from_bps(v.max_surbs_per_sec * SURB_SIZE as u64)),
-            response_buffer: config
-                .surb_management
-                .map(|v| ByteSize::b(v.target_surb_buffer_size * SURB_SIZE as u64)),
-            session_pool: None,
-            abort_handle,
-            clients,
-        },
-    );
-    Ok((bound_host, Some(session_id), max_clients))
-}
-
-#[cfg(feature = "explicit-path")]
-#[allow(clippy::too_many_arguments)]
-pub async fn create_tcp_client_binding_using_explicit_path<T>(
-    bind_host: std::net::SocketAddr,
-    port_range: Option<String>,
-    factory: T,
-    open_listeners: Arc<ListenerJoinHandles>,
-    destination: Address,
-    target_spec: SessionTargetSpec,
-    config: HoprSessionClientExplicitPathConfig,
-    use_session_pool: Option<usize>,
-    max_client_sessions: Option<usize>,
-) -> Result<(std::net::SocketAddr, Option<SessionId>, usize), BindError>
-where
-    T: SessionFactory<Cfg = HoprSessionClientExplicitPathConfig>,
-{
-    let forward_path = RoutingOptions::IntermediatePath(
-        config
-            .forward_path
-            .clone()
-            .try_into()
-            .map_err(|e| BindError::UnknownFailure(format!("invalid explicit forward path: {e}")))?,
-    );
-    let return_path = RoutingOptions::IntermediatePath(
-        config
-            .return_path
-            .clone()
-            .try_into()
-            .map_err(|e| BindError::UnknownFailure(format!("invalid explicit return path: {e}")))?,
-    );
-    let (bound_host, tcp_listener) = tcp_listen_on(bind_host, port_range).await.map_err(|e| {
-        if e.kind() == std::io::ErrorKind::AddrInUse {
-            BindError::ListenHostAlreadyUsed
-        } else {
-            BindError::UnknownFailure(format!("failed to start TCP listener on {bind_host}: {e}"))
-        }
-    })?;
-    info!(%bound_host, "TCP explicit-path session listener bound");
-
-    let target = target_spec
-        .clone()
-        .into_target(IpProtocol::TCP)
-        .map_err(|e| BindError::UnknownFailure(e.to_string()))?;
-
-    let session_pool_size = use_session_pool.unwrap_or(0);
-    let mut session_pool = SessionPool::new(
-        session_pool_size,
-        destination,
-        target.clone(),
-        config.clone(),
-        factory.clone(),
-    )
-    .await
-    .map_err(|e| BindError::UnknownFailure(e.to_string()))?;
-
-    let active_sessions = Arc::new(DashMap::new());
-    let mut max_clients = max_client_sessions.unwrap_or(5).max(1);
-    if max_clients < session_pool_size {
-        max_clients = session_pool_size;
-    }
-
-    let config_clone = config.clone();
-    let (abort_handle, abort_reg) = AbortHandle::new_pair();
-    let active_sessions_clone = active_sessions.clone();
-    hopr_utils::runtime::prelude::spawn(async move {
-        let active_sessions_clone_2 = active_sessions_clone.clone();
-        futures::stream::Abortable::new(tokio_stream::wrappers::TcpListenerStream::new(tcp_listener), abort_reg)
-            .and_then(|sock| async { Ok((sock.peer_addr()?, sock)) })
-            .for_each(move |accepted_client| {
-                let data = config_clone.clone();
-                let target = target.clone();
-                let factory = factory.clone();
-                let active_sessions = active_sessions_clone_2.clone();
-                let has_capacity = accepted_client.is_ok() && active_sessions.len() < max_clients;
-                let maybe_pooled = has_capacity.then(|| session_pool.pop()).flatten();
-                async move {
-                    match accepted_client {
-                        Ok((sock_addr, mut stream)) => {
-                            debug!(?sock_addr, "incoming TCP connection on explicit-path listener");
-                            if active_sessions.len() >= max_clients {
-                                error!(?bind_host, "no more client slots available at explicit-path listener");
-                                use tokio::io::AsyncWriteExt;
-                                if let Err(error) = stream.shutdown().await {
-                                    error!(%error, ?sock_addr, "failed to shutdown TCP connection");
-                                }
-                                return;
-                            }
-
-                            let (session, configurator) = match maybe_pooled {
-                                Some((s, c)) => {
-                                    debug!(session_id = %s.id(), "using pooled explicit-path session");
-                                    (s, c)
-                                }
-                                None => {
-                                    debug!("no pooled explicit-path sessions available, creating a new one");
-                                    match factory.create_session(destination, target, data).await {
-                                        Ok((s, c)) => (s, c),
-                                        Err(error) => {
-                                            error!(%error, "failed to establish explicit-path session");
-                                            return;
-                                        }
-                                    }
-                                }
-                            };
-
-                            let session_id = *session.id();
-                            let (abort_handle, abort_reg) = AbortHandle::new_pair();
-                            active_sessions.insert(
-                                session_id,
-                                ClientEntry {
-                                    sock_addr,
-                                    abort_handle,
-                                    configurator,
-                                },
-                            );
-
-                            #[cfg(all(feature = "telemetry", not(test)))]
-                            METRIC_ACTIVE_CLIENTS.increment(&["tcp"], 1.0);
-
-                            hopr_utils::runtime::prelude::spawn(
-                                bind_session_to_stream(session, stream, HOPR_TCP_BUFFER_SIZE, Some(abort_reg)).then(
-                                    move |_| async move {
-                                        active_sessions.remove(&session_id);
-                                        #[cfg(all(feature = "telemetry", not(test)))]
-                                        METRIC_ACTIVE_CLIENTS.decrement(&["tcp"], 1.0);
-                                    },
-                                ),
-                            );
-                        }
-                        Err(error) => error!(%error, "failed to accept connection"),
-                    }
-                }
-            })
-            .await;
-
-        active_sessions_clone.iter().for_each(|entry| {
-            let client = entry.value();
-            client.abort_handle.abort()
-        });
-    });
-
-    open_listeners.0.insert(
-        ListenerId(hopr_utils::network_types::types::IpProtocol::TCP, bound_host),
-        StoredSessionEntry {
-            destination,
-            target: target_spec,
-            forward_path,
-            return_path,
-            clients: active_sessions,
-            max_client_sessions: max_clients,
-            max_surb_upstream: config
-                .surb_management
-                .map(|v| Bandwidth::from_bps(v.max_surbs_per_sec * SURB_SIZE as u64)),
-            response_buffer: config
-                .surb_management
-                .map(|v| ByteSize::b(v.target_surb_buffer_size * SURB_SIZE as u64)),
-            session_pool: Some(session_pool_size),
-            abort_handle,
-        },
-    );
-    Ok((bound_host, None, max_clients))
-}
-
-#[cfg(feature = "explicit-path")]
-pub async fn create_udp_client_binding_using_explicit_path<T>(
-    bind_host: std::net::SocketAddr,
-    port_range: Option<String>,
-    factory: T,
-    open_listeners: Arc<ListenerJoinHandles>,
-    destination: Address,
-    target_spec: SessionTargetSpec,
-    config: HoprSessionClientExplicitPathConfig,
-) -> Result<(std::net::SocketAddr, Option<SessionId>, usize), BindError>
-where
-    T: SessionFactory<Cfg = HoprSessionClientExplicitPathConfig>,
-{
-    let forward_path = RoutingOptions::IntermediatePath(
-        config
-            .forward_path
-            .clone()
-            .try_into()
-            .map_err(|e| BindError::UnknownFailure(format!("invalid explicit forward path: {e}")))?,
-    );
-    let return_path = RoutingOptions::IntermediatePath(
-        config
-            .return_path
-            .clone()
-            .try_into()
-            .map_err(|e| BindError::UnknownFailure(format!("invalid explicit return path: {e}")))?,
-    );
-    let (bound_host, udp_socket) = udp_bind_to(bind_host, port_range).await.map_err(|e| {
-        if e.kind() == std::io::ErrorKind::AddrInUse {
-            BindError::ListenHostAlreadyUsed
-        } else {
-            BindError::UnknownFailure(format!("failed to start UDP listener on {bind_host}: {e}"))
-        }
-    })?;
-
-    info!(%bound_host, "UDP explicit-path session listener bound");
-
-    let target = target_spec
-        .clone()
-        .into_target(IpProtocol::UDP)
-        .map_err(|e| BindError::UnknownFailure(e.to_string()))?;
-
-    let (session, configurator) = factory
-        .create_session(destination, target, config.clone())
-        .await
-        .map_err(|e| BindError::UnknownFailure(e.to_string()))?;
-
-    let open_listeners_clone = open_listeners.clone();
-    let listener_id = ListenerId(hopr_utils::network_types::types::IpProtocol::UDP, bound_host);
-    let (abort_handle, abort_reg) = AbortHandle::new_pair();
-    let clients = Arc::new(DashMap::new());
-    let max_clients: usize = 1;
-    let session_id = *session.id();
-    clients.insert(
-        session_id,
-        ClientEntry {
-            sock_addr: bound_host,
-            abort_handle: abort_handle.clone(),
-            configurator,
-        },
-    );
-    hopr_utils::runtime::prelude::spawn(async move {
-        #[cfg(all(feature = "telemetry", not(test)))]
-        METRIC_ACTIVE_CLIENTS.increment(&["udp"], 1.0);
-        bind_session_to_stream(session, udp_socket, HOPR_UDP_BUFFER_SIZE, Some(abort_reg)).await;
-        #[cfg(all(feature = "telemetry", not(test)))]
-        METRIC_ACTIVE_CLIENTS.decrement(&["udp"], 1.0);
-        open_listeners_clone.0.remove(&listener_id);
-    });
-
-    open_listeners.0.insert(
-        listener_id,
-        StoredSessionEntry {
-            destination,
-            target: target_spec,
             forward_path,
             return_path,
             max_client_sessions: max_clients,
-            max_surb_upstream: config
-                .surb_management
-                .map(|v| Bandwidth::from_bps(v.max_surbs_per_sec * SURB_SIZE as u64)),
-            response_buffer: config
-                .surb_management
-                .map(|v| ByteSize::b(v.target_surb_buffer_size * SURB_SIZE as u64)),
+            max_surb_upstream,
+            response_buffer,
             session_pool: None,
             abort_handle,
             clients,

--- a/utils-session/src/lib.rs
+++ b/utils-session/src/lib.rs
@@ -250,35 +250,43 @@ impl Abortable for ListenerJoinHandles {
 }
 
 // ---------------------------------------------------------------------------
-// Session backend + generic SessionFactory adapters
+// Generic SessionFactory adapters
 // ---------------------------------------------------------------------------
 
-/// Trait abstracting HOPR session creation.
-///
-/// Production code uses `Hopr<...>` (via the blanket impl), while the REST API
-/// tests can provide a mock implementation.
 #[async_trait::async_trait]
-pub trait SessionBackend: Send + Sync + 'static {
+pub trait SessionFactory: Clone + Send + Sync + 'static {
+    type Cfg: Clone + Send + 'static;
+
     async fn create_session(
         &self,
         dest: Address,
         target: SessionTarget,
-        cfg: HoprSessionClientConfig,
-    ) -> Result<(HoprSession, HoprSessionConfigurator), anyhow::Error>;
-
-    #[cfg(feature = "explicit-path")]
-    async fn create_session_using_explicit_path(
-        &self,
-        dest: Address,
-        target: SessionTarget,
-        cfg: HoprSessionClientExplicitPathConfig,
+        cfg: Self::Cfg,
     ) -> Result<(HoprSession, HoprSessionConfigurator), anyhow::Error>;
 
     fn session_idle_timeout(&self) -> Option<std::time::Duration>;
 }
 
+pub struct HopSessionFactory<Chain, Graph, Net, TMgr> {
+    hopr: Arc<Hopr<Chain, Graph, Net, TMgr>>,
+}
+
+impl<Chain, Graph, Net, TMgr> HopSessionFactory<Chain, Graph, Net, TMgr> {
+    pub fn new(hopr: Arc<Hopr<Chain, Graph, Net, TMgr>>) -> Self {
+        Self { hopr }
+    }
+}
+
+impl<Chain, Graph, Net, TMgr> Clone for HopSessionFactory<Chain, Graph, Net, TMgr> {
+    fn clone(&self) -> Self {
+        Self {
+            hopr: self.hopr.clone(),
+        }
+    }
+}
+
 #[async_trait::async_trait]
-impl<Chain, Graph, Net, TMgr> SessionBackend for Hopr<Chain, Graph, Net, TMgr>
+impl<Chain, Graph, Net, TMgr> SessionFactory for HopSessionFactory<Chain, Graph, Net, TMgr>
 where
     Chain: HoprChainApi + Clone + Send + Sync + 'static,
     Graph: NetworkGraphView<NodeId = OffchainPublicKey>
@@ -294,102 +302,74 @@ where
     Net: NetworkView + NetworkStreamControl + Send + Sync + Clone + 'static,
     TMgr: Send + Sync + 'static,
 {
+    type Cfg = HoprSessionClientConfig;
+
     async fn create_session(
         &self,
         dest: Address,
         target: SessionTarget,
-        cfg: HoprSessionClientConfig,
+        cfg: Self::Cfg,
     ) -> Result<(HoprSession, HoprSessionConfigurator), anyhow::Error> {
-        Ok(HoprSessionClientOperations::connect_to(self, dest, target, cfg).await?)
-    }
-
-    #[cfg(feature = "explicit-path")]
-    async fn create_session_using_explicit_path(
-        &self,
-        dest: Address,
-        target: SessionTarget,
-        cfg: HoprSessionClientExplicitPathConfig,
-    ) -> Result<(HoprSession, HoprSessionConfigurator), anyhow::Error> {
-        Ok(self.connect_to_using_explicit_path(dest, target, cfg).await?)
+        Ok(HoprSessionClientOperations::connect_to(self.hopr.as_ref(), dest, target, cfg).await?)
     }
 
     fn session_idle_timeout(&self) -> Option<std::time::Duration> {
-        Some(self.config().protocol.session.idle_timeout)
-    }
-}
-
-#[async_trait::async_trait]
-pub trait SessionFactory: Clone + Send + Sync + 'static {
-    type Config: Clone + Send + 'static;
-
-    async fn create_session(
-        &self,
-        dest: Address,
-        target: SessionTarget,
-        cfg: Self::Config,
-    ) -> Result<(HoprSession, HoprSessionConfigurator), anyhow::Error>;
-
-    fn session_idle_timeout(&self) -> Option<std::time::Duration>;
-}
-
-#[derive(Clone)]
-pub struct HopSessionFactory {
-    backend: Arc<dyn SessionBackend>,
-}
-
-impl HopSessionFactory {
-    pub fn new(backend: Arc<dyn SessionBackend>) -> Self {
-        Self { backend }
-    }
-}
-
-#[async_trait::async_trait]
-impl SessionFactory for HopSessionFactory {
-    type Config = HoprSessionClientConfig;
-
-    async fn create_session(
-        &self,
-        dest: Address,
-        target: SessionTarget,
-        cfg: Self::Config,
-    ) -> Result<(HoprSession, HoprSessionConfigurator), anyhow::Error> {
-        self.backend.create_session(dest, target, cfg).await
-    }
-
-    fn session_idle_timeout(&self) -> Option<std::time::Duration> {
-        self.backend.session_idle_timeout()
+        Some(self.hopr.config().protocol.session.idle_timeout)
     }
 }
 
 #[cfg(feature = "explicit-path")]
-#[derive(Clone)]
-pub struct ExplicitPathSessionFactory {
-    backend: Arc<dyn SessionBackend>,
+pub struct ExplicitPathSessionFactory<Chain, Graph, Net, TMgr> {
+    hopr: Arc<Hopr<Chain, Graph, Net, TMgr>>,
 }
 
 #[cfg(feature = "explicit-path")]
-impl ExplicitPathSessionFactory {
-    pub fn new(backend: Arc<dyn SessionBackend>) -> Self {
-        Self { backend }
+impl<Chain, Graph, Net, TMgr> ExplicitPathSessionFactory<Chain, Graph, Net, TMgr> {
+    pub fn new(hopr: Arc<Hopr<Chain, Graph, Net, TMgr>>) -> Self {
+        Self { hopr }
+    }
+}
+
+#[cfg(feature = "explicit-path")]
+impl<Chain, Graph, Net, TMgr> Clone for ExplicitPathSessionFactory<Chain, Graph, Net, TMgr> {
+    fn clone(&self) -> Self {
+        Self {
+            hopr: self.hopr.clone(),
+        }
     }
 }
 
 #[cfg(feature = "explicit-path")]
 #[async_trait::async_trait]
-impl SessionFactory for ExplicitPathSessionFactory {
-    type Config = HoprSessionClientExplicitPathConfig;
+impl<Chain, Graph, Net, TMgr> SessionFactory for ExplicitPathSessionFactory<Chain, Graph, Net, TMgr>
+where
+    Chain: HoprChainApi + Clone + Send + Sync + 'static,
+    Graph: NetworkGraphView<NodeId = OffchainPublicKey>
+        + NetworkGraphUpdate
+        + NetworkGraphWrite<NodeId = OffchainPublicKey>
+        + NetworkGraphTraverse<NodeId = OffchainPublicKey>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+    <Graph as NetworkGraphTraverse>::Observed: EdgeObservableRead + Send + 'static,
+    <Graph as NetworkGraphWrite>::Observed: EdgeObservableWrite + Send,
+    Net: NetworkView + NetworkStreamControl + Send + Sync + Clone + 'static,
+    TMgr: Send + Sync + 'static,
+{
+    type Cfg = HoprSessionClientExplicitPathConfig;
 
     async fn create_session(
         &self,
         dest: Address,
         target: SessionTarget,
-        cfg: Self::Config,
+        cfg: Self::Cfg,
     ) -> Result<(HoprSession, HoprSessionConfigurator), anyhow::Error> {
-        self.backend.create_session_using_explicit_path(dest, target, cfg).await
+        Ok(self.hopr.connect_to_using_explicit_path(dest, target, cfg).await?)
     }
 
     fn session_idle_timeout(&self) -> Option<std::time::Duration> {
-        self.backend.session_idle_timeout()
+        Some(self.hopr.config().protocol.session.idle_timeout)
     }
 }
 
@@ -407,7 +387,7 @@ impl SessionPool {
         size: usize,
         dst: Address,
         target: SessionTarget,
-        cfg: T::Config,
+        cfg: T::Cfg,
         factory: T,
     ) -> Result<Self, anyhow::Error> {
         let pool = Arc::new(parking_lot::Mutex::new(VecDeque::with_capacity(size)));
@@ -484,10 +464,10 @@ impl Drop for SessionPool {
 }
 
 #[allow(clippy::too_many_arguments)]
-pub async fn create_tcp_client_binding(
+pub async fn create_tcp_client_binding<T: SessionFactory<Cfg = HoprSessionClientConfig>>(
     bind_host: std::net::SocketAddr,
     port_range: Option<String>,
-    factory: Arc<dyn SessionBackend>,
+    factory: T,
     open_listeners: Arc<ListenerJoinHandles>,
     destination: Address,
     target_spec: SessionTargetSpec,
@@ -519,7 +499,7 @@ pub async fn create_tcp_client_binding(
         destination,
         target.clone(),
         config.clone(),
-        HopSessionFactory::new(factory.clone()),
+        factory.clone(),
     )
     .await
     .map_err(|e| BindError::UnknownFailure(e.to_string()))?;
@@ -660,10 +640,10 @@ pub enum BindError {
     UnknownFailure(String),
 }
 
-pub async fn create_udp_client_binding(
+pub async fn create_udp_client_binding<T: SessionFactory<Cfg = HoprSessionClientConfig>>(
     bind_host: std::net::SocketAddr,
     port_range: Option<String>,
-    factory: Arc<dyn SessionBackend>,
+    factory: T,
     open_listeners: Arc<ListenerJoinHandles>,
     destination: Address,
     target_spec: SessionTargetSpec,
@@ -755,17 +735,20 @@ pub async fn create_udp_client_binding(
 
 #[cfg(feature = "explicit-path")]
 #[allow(clippy::too_many_arguments)]
-pub async fn create_tcp_client_binding_using_explicit_path(
+pub async fn create_tcp_client_binding_using_explicit_path<T>(
     bind_host: std::net::SocketAddr,
     port_range: Option<String>,
-    factory: Arc<dyn SessionBackend>,
+    factory: T,
     open_listeners: Arc<ListenerJoinHandles>,
     destination: Address,
     target_spec: SessionTargetSpec,
     config: HoprSessionClientExplicitPathConfig,
     use_session_pool: Option<usize>,
     max_client_sessions: Option<usize>,
-) -> Result<(std::net::SocketAddr, Option<SessionId>, usize), BindError> {
+) -> Result<(std::net::SocketAddr, Option<SessionId>, usize), BindError>
+where
+    T: SessionFactory<Cfg = HoprSessionClientExplicitPathConfig>,
+{
     let forward_path = RoutingOptions::IntermediatePath(
         config
             .forward_path
@@ -800,7 +783,7 @@ pub async fn create_tcp_client_binding_using_explicit_path(
         destination,
         target.clone(),
         config.clone(),
-        ExplicitPathSessionFactory::new(factory.clone()),
+        factory.clone(),
     )
     .await
     .map_err(|e| BindError::UnknownFailure(e.to_string()))?;
@@ -845,10 +828,7 @@ pub async fn create_tcp_client_binding_using_explicit_path(
                                 }
                                 None => {
                                     debug!("no pooled explicit-path sessions available, creating a new one");
-                                    match factory
-                                        .create_session_using_explicit_path(destination, target, data)
-                                        .await
-                                    {
+                                    match factory.create_session(destination, target, data).await {
                                         Ok((s, c)) => (s, c),
                                         Err(error) => {
                                             error!(%error, "failed to establish explicit-path session");
@@ -917,15 +897,18 @@ pub async fn create_tcp_client_binding_using_explicit_path(
 }
 
 #[cfg(feature = "explicit-path")]
-pub async fn create_udp_client_binding_using_explicit_path(
+pub async fn create_udp_client_binding_using_explicit_path<T>(
     bind_host: std::net::SocketAddr,
     port_range: Option<String>,
-    factory: Arc<dyn SessionBackend>,
+    factory: T,
     open_listeners: Arc<ListenerJoinHandles>,
     destination: Address,
     target_spec: SessionTargetSpec,
     config: HoprSessionClientExplicitPathConfig,
-) -> Result<(std::net::SocketAddr, Option<SessionId>, usize), BindError> {
+) -> Result<(std::net::SocketAddr, Option<SessionId>, usize), BindError>
+where
+    T: SessionFactory<Cfg = HoprSessionClientExplicitPathConfig>,
+{
     let forward_path = RoutingOptions::IntermediatePath(
         config
             .forward_path
@@ -956,7 +939,7 @@ pub async fn create_udp_client_binding_using_explicit_path(
         .map_err(|e| BindError::UnknownFailure(e.to_string()))?;
 
     let (session, configurator) = factory
-        .create_session_using_explicit_path(destination, target, config.clone())
+        .create_session(destination, target, config.clone())
         .await
         .map_err(|e| BindError::UnknownFailure(e.to_string()))?;
 

--- a/utils-session/src/lib.rs
+++ b/utils-session/src/lib.rs
@@ -257,6 +257,7 @@ impl Abortable for ListenerJoinHandles {
 pub trait SessionFactory: Clone + Send + Sync + 'static {
     type Cfg: Clone + Send + 'static;
 
+    /// Creates a new Session with the given destination, target and configuration.
     async fn create_session(
         &self,
         dest: Address,
@@ -264,9 +265,14 @@ pub trait SessionFactory: Clone + Send + Sync + 'static {
         cfg: Self::Cfg,
     ) -> Result<(HoprSession, HoprSessionConfigurator), anyhow::Error>;
 
+    /// Derives the forward and return routing options from the given configuration.
     fn routing_from_cfg(&self, cfg: &Self::Cfg) -> Result<(Routing, Routing), anyhow::Error>;
+
+    /// Derives the listener limits (max SURB upstream and response buffer) from the given configuration.
     fn listener_limits(&self, cfg: &Self::Cfg)
     -> (Option<human_bandwidth::re::bandwidth::Bandwidth>, Option<ByteSize>);
+
+    /// Returns the idle timeout duration for sessions created by this factory, if any.
     fn session_idle_timeout(&self) -> Option<std::time::Duration>;
 }
 

--- a/utils-session/src/lib.rs
+++ b/utils-session/src/lib.rs
@@ -24,11 +24,12 @@ use hopr_api::{
         traits::{EdgeObservableRead, EdgeObservableWrite},
     },
     network::NetworkStreamControl,
+    types::internal::routing::RoutingOptions,
 };
 #[cfg(feature = "explicit-path")]
 use hopr_lib::HoprSessionClientExplicitPathConfig;
 use hopr_lib::{
-    HopRouting, Hopr, HoprSessionClientConfig,
+    Hopr, HoprSessionClientConfig,
     api::{network::NetworkView, node::HoprSessionClientOperations, types::primitive::prelude::Address},
     errors::HoprLibError,
     exports::transport::{
@@ -146,10 +147,10 @@ pub struct StoredSessionEntry {
     pub destination: Address,
     /// Target of the Session.
     pub target: SessionTargetSpec,
-    /// Forward path used for the Session.
-    pub forward_path: HopRouting,
-    /// Return path used for the Session.
-    pub return_path: HopRouting,
+    /// Forward routing options used for the Session.
+    pub forward_path: RoutingOptions,
+    /// Return routing options used for the Session.
+    pub return_path: RoutingOptions,
     /// The maximum number of client sessions that the listener can spawn.
     pub max_client_sessions: usize,
     /// The maximum number of SURB packets that can be sent upstream.
@@ -489,12 +490,6 @@ impl Drop for ExplicitPathSessionPool {
     }
 }
 
-#[cfg(feature = "explicit-path")]
-fn explicit_path_to_hop_routing(path: Vec<hopr_api::types::internal::NodeId>) -> Result<HopRouting, BindError> {
-    HopRouting::try_from(path.len())
-        .map_err(|error| BindError::UnknownFailure(format!("invalid explicit path hop count: {error}")))
-}
-
 impl Drop for SessionPool {
     fn drop(&mut self) {
         if let Some(ah) = self.ah.take() {
@@ -654,8 +649,8 @@ pub async fn create_tcp_client_binding(
         StoredSessionEntry {
             destination,
             target: target_spec,
-            forward_path: config.forward_path,
-            return_path: config.return_path,
+            forward_path: config.forward_path.into(),
+            return_path: config.return_path.into(),
             clients: active_sessions,
             max_client_sessions: max_clients,
             max_surb_upstream: config
@@ -756,8 +751,8 @@ pub async fn create_udp_client_binding(
         StoredSessionEntry {
             destination,
             target: target_spec,
-            forward_path: config.forward_path,
-            return_path: config.return_path,
+            forward_path: config.forward_path.into(),
+            return_path: config.return_path.into(),
             max_client_sessions: max_clients,
             max_surb_upstream: config
                 .surb_management
@@ -786,8 +781,20 @@ pub async fn create_tcp_client_binding_using_explicit_path(
     use_session_pool: Option<usize>,
     max_client_sessions: Option<usize>,
 ) -> Result<(std::net::SocketAddr, Option<SessionId>, usize), BindError> {
-    let forward_path = explicit_path_to_hop_routing(config.forward_path.clone())?;
-    let return_path = explicit_path_to_hop_routing(config.return_path.clone())?;
+    let forward_path = RoutingOptions::IntermediatePath(
+        config
+            .forward_path
+            .clone()
+            .try_into()
+            .map_err(|e| BindError::UnknownFailure(format!("invalid explicit forward path: {e}")))?,
+    );
+    let return_path = RoutingOptions::IntermediatePath(
+        config
+            .return_path
+            .clone()
+            .try_into()
+            .map_err(|e| BindError::UnknownFailure(format!("invalid explicit return path: {e}")))?,
+    );
     let (bound_host, tcp_listener) = tcp_listen_on(bind_host, port_range).await.map_err(|e| {
         if e.kind() == std::io::ErrorKind::AddrInUse {
             BindError::ListenHostAlreadyUsed
@@ -933,8 +940,20 @@ pub async fn create_udp_client_binding_using_explicit_path(
     target_spec: SessionTargetSpec,
     config: HoprSessionClientExplicitPathConfig,
 ) -> Result<(std::net::SocketAddr, Option<SessionId>, usize), BindError> {
-    let forward_path = explicit_path_to_hop_routing(config.forward_path.clone())?;
-    let return_path = explicit_path_to_hop_routing(config.return_path.clone())?;
+    let forward_path = RoutingOptions::IntermediatePath(
+        config
+            .forward_path
+            .clone()
+            .try_into()
+            .map_err(|e| BindError::UnknownFailure(format!("invalid explicit forward path: {e}")))?,
+    );
+    let return_path = RoutingOptions::IntermediatePath(
+        config
+            .return_path
+            .clone()
+            .try_into()
+            .map_err(|e| BindError::UnknownFailure(format!("invalid explicit return path: {e}")))?,
+    );
     let (bound_host, udp_socket) = udp_bind_to(bind_host, port_range).await.map_err(|e| {
         if e.kind() == std::io::ErrorKind::AddrInUse {
             BindError::ListenHostAlreadyUsed
@@ -1268,8 +1287,8 @@ mod tests {
         StoredSessionEntry {
             destination: Address::default(),
             target: SessionTargetSpec::Plain("localhost:8080".into()),
-            forward_path: HopRouting::default(),
-            return_path: HopRouting::default(),
+            forward_path: RoutingOptions::from(HopRouting::default()),
+            return_path: RoutingOptions::from(HopRouting::default()),
             max_client_sessions: 5,
             max_surb_upstream: None,
             response_buffer: None,

--- a/utils-session/src/lib.rs
+++ b/utils-session/src/lib.rs
@@ -360,7 +360,7 @@ impl<Chain, Graph, Net, TMgr> Clone for ExplicitPathSessionFactory<Chain, Graph,
 
 #[cfg(feature = "explicit-path")]
 #[async_trait::async_trait]
-impl<Chain, Graph, Net, TMgr> SessionFactory for ExplicitPathSessionFactory<Chain, Graph, Net, TMgr>
+pub impl<Chain, Graph, Net, TMgr> SessionFactory for ExplicitPathSessionFactory<Chain, Graph, Net, TMgr>
 where
     Chain: HoprChainApi + Clone + Send + Sync + 'static,
     Graph: NetworkGraphView<NodeId = OffchainPublicKey>

--- a/utils-session/src/lib.rs
+++ b/utils-session/src/lib.rs
@@ -25,6 +25,8 @@ use hopr_api::{
     },
     network::NetworkStreamControl,
 };
+#[cfg(feature = "explicit-path")]
+use hopr_lib::HoprSessionClientExplicitPathConfig;
 use hopr_lib::{
     HopRouting, Hopr, HoprSessionClientConfig,
     api::{network::NetworkView, node::HoprSessionClientOperations, types::primitive::prelude::Address},
@@ -252,6 +254,14 @@ pub trait SessionFactory: Send + Sync + 'static {
         cfg: HoprSessionClientConfig,
     ) -> Result<(HoprSession, HoprSessionConfigurator), anyhow::Error>;
 
+    #[cfg(feature = "explicit-path")]
+    async fn create_session_using_explicit_path(
+        &self,
+        dest: Address,
+        target: SessionTarget,
+        cfg: HoprSessionClientExplicitPathConfig,
+    ) -> Result<(HoprSession, HoprSessionConfigurator), anyhow::Error>;
+
     fn session_idle_timeout(&self) -> Option<std::time::Duration>;
 }
 
@@ -279,6 +289,16 @@ where
         cfg: HoprSessionClientConfig,
     ) -> Result<(HoprSession, HoprSessionConfigurator), anyhow::Error> {
         Ok(HoprSessionClientOperations::connect_to(self, dest, target, cfg).await?)
+    }
+
+    #[cfg(feature = "explicit-path")]
+    async fn create_session_using_explicit_path(
+        &self,
+        dest: Address,
+        target: SessionTarget,
+        cfg: HoprSessionClientExplicitPathConfig,
+    ) -> Result<(HoprSession, HoprSessionConfigurator), anyhow::Error> {
+        Ok(self.connect_to_using_explicit_path(dest, target, cfg).await?)
     }
 
     fn session_idle_timeout(&self) -> Option<std::time::Duration> {
@@ -373,6 +393,106 @@ impl SessionPool {
     pub fn pop(&mut self) -> Option<(HoprSession, HoprSessionConfigurator)> {
         self.pool.as_ref().and_then(|pool| pool.lock().pop_front())
     }
+}
+
+#[cfg(feature = "explicit-path")]
+pub struct ExplicitPathSessionPool {
+    pool: Option<SessionPoolInner>,
+    ah: Option<AbortHandle>,
+}
+
+#[cfg(feature = "explicit-path")]
+impl ExplicitPathSessionPool {
+    pub const MAX_SESSION_POOL_SIZE: usize = 5;
+
+    pub async fn new(
+        size: usize,
+        dst: Address,
+        target: SessionTarget,
+        cfg: HoprSessionClientExplicitPathConfig,
+        factory: Arc<dyn SessionFactory>,
+    ) -> Result<Self, anyhow::Error> {
+        let pool = Arc::new(parking_lot::Mutex::new(VecDeque::with_capacity(size)));
+        let factory_clone = factory.clone();
+        let pool_clone = pool.clone();
+        futures::stream::iter(0..size.min(Self::MAX_SESSION_POOL_SIZE))
+            .map(Ok)
+            .try_for_each_concurrent(Self::MAX_SESSION_POOL_SIZE, move |i| {
+                let pool = pool_clone.clone();
+                let factory = factory_clone.clone();
+                let target = target.clone();
+                let cfg = cfg.clone();
+                async move {
+                    match factory
+                        .create_session_using_explicit_path(dst, target.clone(), cfg.clone())
+                        .await
+                    {
+                        Ok((session, configurator)) => {
+                            debug!(session_id = %session.id(), num_session = i, "created a new explicit-path session in pool");
+                            pool.lock().push_back((session, configurator));
+                            Ok(())
+                        }
+                        Err(error) => {
+                            error!(%error, num_session = i, "failed to establish explicit-path session for pool");
+                            Err(anyhow!("failed to establish explicit-path session #{i} in pool to {dst}: {error}"))
+                        }
+                    }
+                }
+            })
+            .await?;
+
+        if let Some(timeout) = factory.session_idle_timeout().filter(|_| !pool.lock().is_empty()) {
+            let pool_clone_1 = pool.clone();
+            let pool_clone_2 = pool.clone();
+            Ok(Self {
+                pool: Some(pool),
+                ah: Some(hopr_utils::spawn_as_abortable!(
+                    futures_time::stream::interval(futures_time::time::Duration::from(
+                        std::time::Duration::from_secs(1).max(timeout / 2)
+                    ))
+                    .take_while(move |_| futures::future::ready(!pool_clone_1.lock().is_empty()))
+                    .for_each(move |_| {
+                        let pool = pool_clone_2.clone();
+                        async move {
+                            let configurators: Vec<_> = pool.lock().iter().map(|(_, cfg)| cfg.clone()).collect();
+                            let mut dead_ids = Vec::new();
+                            for configurator in &configurators {
+                                if let Err(error) = configurator.ping().await {
+                                    let id = *configurator.id();
+                                    error!(%error, session_id = %id, "explicit-path session in pool is not alive, will remove");
+                                    dead_ids.push(id);
+                                }
+                            }
+                            if !dead_ids.is_empty() {
+                                pool.lock().retain(|(_, cfg)| !dead_ids.contains(cfg.id()));
+                            }
+                        }
+                    })
+                )),
+            })
+        } else {
+            Ok(Self { pool: None, ah: None })
+        }
+    }
+
+    pub fn pop(&mut self) -> Option<(HoprSession, HoprSessionConfigurator)> {
+        self.pool.as_ref().and_then(|pool| pool.lock().pop_front())
+    }
+}
+
+#[cfg(feature = "explicit-path")]
+impl Drop for ExplicitPathSessionPool {
+    fn drop(&mut self) {
+        if let Some(ah) = self.ah.take() {
+            ah.abort();
+        }
+    }
+}
+
+#[cfg(feature = "explicit-path")]
+fn explicit_path_to_hop_routing(path: Vec<hopr_api::types::internal::NodeId>) -> Result<HopRouting, BindError> {
+    HopRouting::try_from(path.len())
+        .map_err(|error| BindError::UnknownFailure(format!("invalid explicit path hop count: {error}")))
 }
 
 impl Drop for SessionPool {
@@ -638,6 +758,233 @@ pub async fn create_udp_client_binding(
             target: target_spec,
             forward_path: config.forward_path,
             return_path: config.return_path,
+            max_client_sessions: max_clients,
+            max_surb_upstream: config
+                .surb_management
+                .map(|v| Bandwidth::from_bps(v.max_surbs_per_sec * SURB_SIZE as u64)),
+            response_buffer: config
+                .surb_management
+                .map(|v| ByteSize::b(v.target_surb_buffer_size * SURB_SIZE as u64)),
+            session_pool: None,
+            abort_handle,
+            clients,
+        },
+    );
+    Ok((bound_host, Some(session_id), max_clients))
+}
+
+#[cfg(feature = "explicit-path")]
+#[allow(clippy::too_many_arguments)]
+pub async fn create_tcp_client_binding_using_explicit_path(
+    bind_host: std::net::SocketAddr,
+    port_range: Option<String>,
+    factory: Arc<dyn SessionFactory>,
+    open_listeners: Arc<ListenerJoinHandles>,
+    destination: Address,
+    target_spec: SessionTargetSpec,
+    config: HoprSessionClientExplicitPathConfig,
+    use_session_pool: Option<usize>,
+    max_client_sessions: Option<usize>,
+) -> Result<(std::net::SocketAddr, Option<SessionId>, usize), BindError> {
+    let forward_path = explicit_path_to_hop_routing(config.forward_path.clone())?;
+    let return_path = explicit_path_to_hop_routing(config.return_path.clone())?;
+    let (bound_host, tcp_listener) = tcp_listen_on(bind_host, port_range).await.map_err(|e| {
+        if e.kind() == std::io::ErrorKind::AddrInUse {
+            BindError::ListenHostAlreadyUsed
+        } else {
+            BindError::UnknownFailure(format!("failed to start TCP listener on {bind_host}: {e}"))
+        }
+    })?;
+    info!(%bound_host, "TCP explicit-path session listener bound");
+
+    let target = target_spec
+        .clone()
+        .into_target(IpProtocol::TCP)
+        .map_err(|e| BindError::UnknownFailure(e.to_string()))?;
+
+    let session_pool_size = use_session_pool.unwrap_or(0);
+    let mut session_pool = ExplicitPathSessionPool::new(
+        session_pool_size,
+        destination,
+        target.clone(),
+        config.clone(),
+        factory.clone(),
+    )
+    .await
+    .map_err(|e| BindError::UnknownFailure(e.to_string()))?;
+
+    let active_sessions = Arc::new(DashMap::new());
+    let mut max_clients = max_client_sessions.unwrap_or(5).max(1);
+    if max_clients < session_pool_size {
+        max_clients = session_pool_size;
+    }
+
+    let config_clone = config.clone();
+    let (abort_handle, abort_reg) = AbortHandle::new_pair();
+    let active_sessions_clone = active_sessions.clone();
+    hopr_utils::runtime::prelude::spawn(async move {
+        let active_sessions_clone_2 = active_sessions_clone.clone();
+        futures::stream::Abortable::new(tokio_stream::wrappers::TcpListenerStream::new(tcp_listener), abort_reg)
+            .and_then(|sock| async { Ok((sock.peer_addr()?, sock)) })
+            .for_each(move |accepted_client| {
+                let data = config_clone.clone();
+                let target = target.clone();
+                let factory = factory.clone();
+                let active_sessions = active_sessions_clone_2.clone();
+                let maybe_pooled = accepted_client.is_ok().then(|| session_pool.pop()).flatten();
+                async move {
+                    match accepted_client {
+                        Ok((sock_addr, mut stream)) => {
+                            debug!(?sock_addr, "incoming TCP connection on explicit-path listener");
+                            if active_sessions.len() >= max_clients {
+                                error!(?bind_host, "no more client slots available at explicit-path listener");
+                                use tokio::io::AsyncWriteExt;
+                                if let Err(error) = stream.shutdown().await {
+                                    error!(%error, ?sock_addr, "failed to shutdown TCP connection");
+                                }
+                                return;
+                            }
+
+                            let (session, configurator) = match maybe_pooled {
+                                Some((s, c)) => {
+                                    debug!(session_id = %s.id(), "using pooled explicit-path session");
+                                    (s, c)
+                                }
+                                None => {
+                                    debug!("no pooled explicit-path sessions available, creating a new one");
+                                    match factory
+                                        .create_session_using_explicit_path(destination, target, data)
+                                        .await
+                                    {
+                                        Ok((s, c)) => (s, c),
+                                        Err(error) => {
+                                            error!(%error, "failed to establish explicit-path session");
+                                            return;
+                                        }
+                                    }
+                                }
+                            };
+
+                            let session_id = *session.id();
+                            let (abort_handle, abort_reg) = AbortHandle::new_pair();
+                            active_sessions.insert(
+                                session_id,
+                                ClientEntry {
+                                    sock_addr,
+                                    abort_handle,
+                                    configurator,
+                                },
+                            );
+
+                            #[cfg(all(feature = "telemetry", not(test)))]
+                            METRIC_ACTIVE_CLIENTS.increment(&["tcp"], 1.0);
+
+                            hopr_utils::runtime::prelude::spawn(
+                                bind_session_to_stream(session, stream, HOPR_TCP_BUFFER_SIZE, Some(abort_reg)).then(
+                                    move |_| async move {
+                                        active_sessions.remove(&session_id);
+                                        #[cfg(all(feature = "telemetry", not(test)))]
+                                        METRIC_ACTIVE_CLIENTS.decrement(&["tcp"], 1.0);
+                                    },
+                                ),
+                            );
+                        }
+                        Err(error) => error!(%error, "failed to accept connection"),
+                    }
+                }
+            })
+            .await;
+
+        active_sessions_clone.iter().for_each(|entry| {
+            let client = entry.value();
+            client.abort_handle.abort()
+        });
+    });
+
+    open_listeners.0.insert(
+        ListenerId(hopr_utils::network_types::types::IpProtocol::TCP, bound_host),
+        StoredSessionEntry {
+            destination,
+            target: target_spec,
+            forward_path,
+            return_path,
+            clients: active_sessions,
+            max_client_sessions: max_clients,
+            max_surb_upstream: config
+                .surb_management
+                .map(|v| Bandwidth::from_bps(v.max_surbs_per_sec * SURB_SIZE as u64)),
+            response_buffer: config
+                .surb_management
+                .map(|v| ByteSize::b(v.target_surb_buffer_size * SURB_SIZE as u64)),
+            session_pool: Some(session_pool_size),
+            abort_handle,
+        },
+    );
+    Ok((bound_host, None, max_clients))
+}
+
+#[cfg(feature = "explicit-path")]
+pub async fn create_udp_client_binding_using_explicit_path(
+    bind_host: std::net::SocketAddr,
+    port_range: Option<String>,
+    factory: Arc<dyn SessionFactory>,
+    open_listeners: Arc<ListenerJoinHandles>,
+    destination: Address,
+    target_spec: SessionTargetSpec,
+    config: HoprSessionClientExplicitPathConfig,
+) -> Result<(std::net::SocketAddr, Option<SessionId>, usize), BindError> {
+    let forward_path = explicit_path_to_hop_routing(config.forward_path.clone())?;
+    let return_path = explicit_path_to_hop_routing(config.return_path.clone())?;
+    let (bound_host, udp_socket) = udp_bind_to(bind_host, port_range).await.map_err(|e| {
+        if e.kind() == std::io::ErrorKind::AddrInUse {
+            BindError::ListenHostAlreadyUsed
+        } else {
+            BindError::UnknownFailure(format!("failed to start UDP listener on {bind_host}: {e}"))
+        }
+    })?;
+
+    info!(%bound_host, "UDP explicit-path session listener bound");
+
+    let target = target_spec
+        .clone()
+        .into_target(IpProtocol::UDP)
+        .map_err(|e| BindError::UnknownFailure(e.to_string()))?;
+
+    let (session, configurator) = factory
+        .create_session_using_explicit_path(destination, target, config.clone())
+        .await
+        .map_err(|e| BindError::UnknownFailure(e.to_string()))?;
+
+    let open_listeners_clone = open_listeners.clone();
+    let listener_id = ListenerId(hopr_utils::network_types::types::IpProtocol::UDP, bound_host);
+    let (abort_handle, abort_reg) = AbortHandle::new_pair();
+    let clients = Arc::new(DashMap::new());
+    let max_clients: usize = 1;
+    let session_id = *session.id();
+    clients.insert(
+        session_id,
+        ClientEntry {
+            sock_addr: bound_host,
+            abort_handle: abort_handle.clone(),
+            configurator,
+        },
+    );
+    hopr_utils::runtime::prelude::spawn(async move {
+        #[cfg(all(feature = "telemetry", not(test)))]
+        METRIC_ACTIVE_CLIENTS.increment(&["udp"], 1.0);
+        bind_session_to_stream(session, udp_socket, HOPR_UDP_BUFFER_SIZE, Some(abort_reg)).await;
+        #[cfg(all(feature = "telemetry", not(test)))]
+        METRIC_ACTIVE_CLIENTS.decrement(&["udp"], 1.0);
+        open_listeners_clone.0.remove(&listener_id);
+    });
+
+    open_listeners.0.insert(
+        listener_id,
+        StoredSessionEntry {
+            destination,
+            target: target_spec,
+            forward_path,
+            return_path,
             max_client_sessions: max_clients,
             max_surb_upstream: config
                 .surb_management

--- a/utils-session/src/lib.rs
+++ b/utils-session/src/lib.rs
@@ -360,7 +360,7 @@ impl<Chain, Graph, Net, TMgr> Clone for ExplicitPathSessionFactory<Chain, Graph,
 
 #[cfg(feature = "explicit-path")]
 #[async_trait::async_trait]
-pub impl<Chain, Graph, Net, TMgr> SessionFactory for ExplicitPathSessionFactory<Chain, Graph, Net, TMgr>
+impl<Chain, Graph, Net, TMgr> SessionFactory for ExplicitPathSessionFactory<Chain, Graph, Net, TMgr>
 where
     Chain: HoprChainApi + Clone + Send + Sync + 'static,
     Graph: NetworkGraphView<NodeId = OffchainPublicKey>

--- a/utils-session/src/lib.rs
+++ b/utils-session/src/lib.rs
@@ -72,6 +72,8 @@ lazy_static::lazy_static! {
 }
 
 #[cfg(feature = "explicit-path")]
+/// Temporary compatibility alias while stored listener metadata is shared between
+/// hop-count and explicit-path session APIs.
 pub type Routing = RoutingOptions;
 
 #[cfg(not(feature = "explicit-path"))]
@@ -248,7 +250,7 @@ impl Abortable for ListenerJoinHandles {
 }
 
 // ---------------------------------------------------------------------------
-// SessionFactory trait — abstracts session creation for testability
+// Session backend + generic SessionFactory adapters
 // ---------------------------------------------------------------------------
 
 /// Trait abstracting HOPR session creation.
@@ -256,7 +258,7 @@ impl Abortable for ListenerJoinHandles {
 /// Production code uses `Hopr<...>` (via the blanket impl), while the REST API
 /// tests can provide a mock implementation.
 #[async_trait::async_trait]
-pub trait SessionFactory: Send + Sync + 'static {
+pub trait SessionBackend: Send + Sync + 'static {
     async fn create_session(
         &self,
         dest: Address,
@@ -276,7 +278,7 @@ pub trait SessionFactory: Send + Sync + 'static {
 }
 
 #[async_trait::async_trait]
-impl<Chain, Graph, Net, TMgr> SessionFactory for Hopr<Chain, Graph, Net, TMgr>
+impl<Chain, Graph, Net, TMgr> SessionBackend for Hopr<Chain, Graph, Net, TMgr>
 where
     Chain: HoprChainApi + Clone + Send + Sync + 'static,
     Graph: NetworkGraphView<NodeId = OffchainPublicKey>
@@ -316,6 +318,81 @@ where
     }
 }
 
+#[async_trait::async_trait]
+pub trait SessionFactory: Clone + Send + Sync + 'static {
+    type Config: Clone + Send + 'static;
+
+    async fn create_session(
+        &self,
+        dest: Address,
+        target: SessionTarget,
+        cfg: Self::Config,
+    ) -> Result<(HoprSession, HoprSessionConfigurator), anyhow::Error>;
+
+    fn session_idle_timeout(&self) -> Option<std::time::Duration>;
+}
+
+#[derive(Clone)]
+pub struct HopSessionFactory {
+    backend: Arc<dyn SessionBackend>,
+}
+
+impl HopSessionFactory {
+    pub fn new(backend: Arc<dyn SessionBackend>) -> Self {
+        Self { backend }
+    }
+}
+
+#[async_trait::async_trait]
+impl SessionFactory for HopSessionFactory {
+    type Config = HoprSessionClientConfig;
+
+    async fn create_session(
+        &self,
+        dest: Address,
+        target: SessionTarget,
+        cfg: Self::Config,
+    ) -> Result<(HoprSession, HoprSessionConfigurator), anyhow::Error> {
+        self.backend.create_session(dest, target, cfg).await
+    }
+
+    fn session_idle_timeout(&self) -> Option<std::time::Duration> {
+        self.backend.session_idle_timeout()
+    }
+}
+
+#[cfg(feature = "explicit-path")]
+#[derive(Clone)]
+pub struct ExplicitPathSessionFactory {
+    backend: Arc<dyn SessionBackend>,
+}
+
+#[cfg(feature = "explicit-path")]
+impl ExplicitPathSessionFactory {
+    pub fn new(backend: Arc<dyn SessionBackend>) -> Self {
+        Self { backend }
+    }
+}
+
+#[cfg(feature = "explicit-path")]
+#[async_trait::async_trait]
+impl SessionFactory for ExplicitPathSessionFactory {
+    type Config = HoprSessionClientExplicitPathConfig;
+
+    async fn create_session(
+        &self,
+        dest: Address,
+        target: SessionTarget,
+        cfg: Self::Config,
+    ) -> Result<(HoprSession, HoprSessionConfigurator), anyhow::Error> {
+        self.backend.create_session_using_explicit_path(dest, target, cfg).await
+    }
+
+    fn session_idle_timeout(&self) -> Option<std::time::Duration> {
+        self.backend.session_idle_timeout()
+    }
+}
+
 type SessionPoolInner = Arc<parking_lot::Mutex<VecDeque<(HoprSession, HoprSessionConfigurator)>>>;
 
 pub struct SessionPool {
@@ -326,12 +403,12 @@ pub struct SessionPool {
 impl SessionPool {
     pub const MAX_SESSION_POOL_SIZE: usize = 5;
 
-    pub async fn new(
+    pub async fn new<T: SessionFactory>(
         size: usize,
         dst: Address,
         target: SessionTarget,
-        cfg: HoprSessionClientConfig,
-        factory: Arc<dyn SessionFactory>,
+        cfg: T::Config,
+        factory: T,
     ) -> Result<Self, anyhow::Error> {
         let pool = Arc::new(parking_lot::Mutex::new(VecDeque::with_capacity(size)));
         let factory_clone = factory.clone();
@@ -359,98 +436,6 @@ impl SessionPool {
             })
             .await?;
 
-        // Spawn a task that periodically sends keep alive messages to the Session in the pool.
-        if let Some(timeout) = factory.session_idle_timeout().filter(|_| !pool.lock().is_empty()) {
-            let pool_clone_1 = pool.clone();
-            let pool_clone_2 = pool.clone();
-            Ok(Self {
-                pool: Some(pool),
-                ah: Some(hopr_utils::spawn_as_abortable!(
-                    futures_time::stream::interval(futures_time::time::Duration::from(
-                        std::time::Duration::from_secs(1).max(timeout / 2)
-                    ))
-                    .take_while(move |_| {
-                        // Continue the infinite interval stream until there are sessions in the pool
-                        futures::future::ready(!pool_clone_1.lock().is_empty())
-                    })
-                    .for_each(move |_| {
-                        let pool = pool_clone_2.clone();
-                        async move {
-                            // Collect configurators to ping (release lock before awaiting)
-                            let configurators: Vec<_> = pool.lock().iter().map(|(_, cfg)| cfg.clone()).collect();
-
-                            let mut dead_ids = Vec::new();
-                            for configurator in &configurators {
-                                if let Err(error) = configurator.ping().await {
-                                    let id = *configurator.id();
-                                    error!(%error, session_id = %id, "session in pool is not alive, will remove");
-                                    dead_ids.push(id);
-                                }
-                            }
-
-                            if !dead_ids.is_empty() {
-                                pool.lock().retain(|(_, cfg)| !dead_ids.contains(cfg.id()));
-                            }
-                        }
-                    })
-                )),
-            })
-        } else {
-            Ok(Self { pool: None, ah: None })
-        }
-    }
-
-    pub fn pop(&mut self) -> Option<(HoprSession, HoprSessionConfigurator)> {
-        self.pool.as_ref().and_then(|pool| pool.lock().pop_front())
-    }
-}
-
-#[cfg(feature = "explicit-path")]
-pub struct ExplicitPathSessionPool {
-    pool: Option<SessionPoolInner>,
-    ah: Option<AbortHandle>,
-}
-
-#[cfg(feature = "explicit-path")]
-impl ExplicitPathSessionPool {
-    pub const MAX_SESSION_POOL_SIZE: usize = 5;
-
-    pub async fn new(
-        size: usize,
-        dst: Address,
-        target: SessionTarget,
-        cfg: HoprSessionClientExplicitPathConfig,
-        factory: Arc<dyn SessionFactory>,
-    ) -> Result<Self, anyhow::Error> {
-        let pool = Arc::new(parking_lot::Mutex::new(VecDeque::with_capacity(size)));
-        let factory_clone = factory.clone();
-        let pool_clone = pool.clone();
-        futures::stream::iter(0..size.min(Self::MAX_SESSION_POOL_SIZE))
-            .map(Ok)
-            .try_for_each_concurrent(Self::MAX_SESSION_POOL_SIZE, move |i| {
-                let pool = pool_clone.clone();
-                let factory = factory_clone.clone();
-                let target = target.clone();
-                let cfg = cfg.clone();
-                async move {
-                    match factory
-                        .create_session_using_explicit_path(dst, target.clone(), cfg.clone())
-                        .await
-                    {
-                        Ok((session, configurator)) => {
-                            debug!(session_id = %session.id(), num_session = i, "created a new explicit-path session in pool");
-                            pool.lock().push_back((session, configurator));
-                            Ok(())
-                        }
-                        Err(error) => {
-                            error!(%error, num_session = i, "failed to establish explicit-path session for pool");
-                            Err(anyhow!("failed to establish explicit-path session #{i} in pool to {dst}: {error}"))
-                        }
-                    }
-                }
-            })
-            .await?;
-
         if let Some(timeout) = factory.session_idle_timeout().filter(|_| !pool.lock().is_empty()) {
             let pool_clone_1 = pool.clone();
             let pool_clone_2 = pool.clone();
@@ -469,7 +454,7 @@ impl ExplicitPathSessionPool {
                             for configurator in &configurators {
                                 if let Err(error) = configurator.ping().await {
                                     let id = *configurator.id();
-                                    error!(%error, session_id = %id, "explicit-path session in pool is not alive, will remove");
+                                    error!(%error, session_id = %id, "session in pool is not alive, will remove");
                                     dead_ids.push(id);
                                 }
                             }
@@ -490,15 +475,6 @@ impl ExplicitPathSessionPool {
     }
 }
 
-#[cfg(feature = "explicit-path")]
-impl Drop for ExplicitPathSessionPool {
-    fn drop(&mut self) {
-        if let Some(ah) = self.ah.take() {
-            ah.abort();
-        }
-    }
-}
-
 impl Drop for SessionPool {
     fn drop(&mut self) {
         if let Some(ah) = self.ah.take() {
@@ -511,7 +487,7 @@ impl Drop for SessionPool {
 pub async fn create_tcp_client_binding(
     bind_host: std::net::SocketAddr,
     port_range: Option<String>,
-    factory: Arc<dyn SessionFactory>,
+    factory: Arc<dyn SessionBackend>,
     open_listeners: Arc<ListenerJoinHandles>,
     destination: Address,
     target_spec: SessionTargetSpec,
@@ -543,7 +519,7 @@ pub async fn create_tcp_client_binding(
         destination,
         target.clone(),
         config.clone(),
-        factory.clone(),
+        HopSessionFactory::new(factory.clone()),
     )
     .await
     .map_err(|e| BindError::UnknownFailure(e.to_string()))?;
@@ -569,9 +545,9 @@ pub async fn create_tcp_client_binding(
                 let target = target.clone();
                 let factory = factory.clone();
                 let active_sessions = active_sessions_clone_2.clone();
+                let has_capacity = accepted_client.is_ok() && active_sessions.len() < max_clients;
+                let maybe_pooled = has_capacity.then(|| session_pool.pop()).flatten();
 
-                // Try to pop from the pool only if a client was accepted
-                let maybe_pooled = accepted_client.is_ok().then(|| session_pool.pop()).flatten();
                 async move {
                     match accepted_client {
                         Ok((sock_addr, mut stream)) => {
@@ -687,7 +663,7 @@ pub enum BindError {
 pub async fn create_udp_client_binding(
     bind_host: std::net::SocketAddr,
     port_range: Option<String>,
-    factory: Arc<dyn SessionFactory>,
+    factory: Arc<dyn SessionBackend>,
     open_listeners: Arc<ListenerJoinHandles>,
     destination: Address,
     target_spec: SessionTargetSpec,
@@ -782,7 +758,7 @@ pub async fn create_udp_client_binding(
 pub async fn create_tcp_client_binding_using_explicit_path(
     bind_host: std::net::SocketAddr,
     port_range: Option<String>,
-    factory: Arc<dyn SessionFactory>,
+    factory: Arc<dyn SessionBackend>,
     open_listeners: Arc<ListenerJoinHandles>,
     destination: Address,
     target_spec: SessionTargetSpec,
@@ -819,12 +795,12 @@ pub async fn create_tcp_client_binding_using_explicit_path(
         .map_err(|e| BindError::UnknownFailure(e.to_string()))?;
 
     let session_pool_size = use_session_pool.unwrap_or(0);
-    let mut session_pool = ExplicitPathSessionPool::new(
+    let mut session_pool = SessionPool::new(
         session_pool_size,
         destination,
         target.clone(),
         config.clone(),
-        factory.clone(),
+        ExplicitPathSessionFactory::new(factory.clone()),
     )
     .await
     .map_err(|e| BindError::UnknownFailure(e.to_string()))?;
@@ -847,7 +823,8 @@ pub async fn create_tcp_client_binding_using_explicit_path(
                 let target = target.clone();
                 let factory = factory.clone();
                 let active_sessions = active_sessions_clone_2.clone();
-                let maybe_pooled = accepted_client.is_ok().then(|| session_pool.pop()).flatten();
+                let has_capacity = accepted_client.is_ok() && active_sessions.len() < max_clients;
+                let maybe_pooled = has_capacity.then(|| session_pool.pop()).flatten();
                 async move {
                     match accepted_client {
                         Ok((sock_addr, mut stream)) => {
@@ -943,7 +920,7 @@ pub async fn create_tcp_client_binding_using_explicit_path(
 pub async fn create_udp_client_binding_using_explicit_path(
     bind_host: std::net::SocketAddr,
     port_range: Option<String>,
-    factory: Arc<dyn SessionFactory>,
+    factory: Arc<dyn SessionBackend>,
     open_listeners: Arc<ListenerJoinHandles>,
     destination: Address,
     target_spec: SessionTargetSpec,

--- a/utils-session/src/lib.rs
+++ b/utils-session/src/lib.rs
@@ -29,6 +29,8 @@ use hopr_api::{
 use hopr_lib::HopRouting;
 #[cfg(feature = "explicit-path")]
 use hopr_lib::HoprSessionClientExplicitPathConfig;
+#[cfg(feature = "explicit-path")]
+use hopr_lib::api::types::internal::routing::RoutingOptions;
 use hopr_lib::{
     Hopr, HoprSessionClientConfig,
     api::{network::NetworkView, node::HoprSessionClientOperations, types::primitive::prelude::Address},
@@ -68,9 +70,6 @@ lazy_static::lazy_static! {
         &["type"]
     ).unwrap();
 }
-
-#[cfg(feature = "explicit-path")]
-use hopr_lib::HoprSessionClientExplicitPathConfig;
 
 #[cfg(feature = "explicit-path")]
 pub type Routing = RoutingOptions;


### PR DESCRIPTION
The PR #8118 was missing the `utils-session` helpers to create udp/tcp sessions with explicit paths.

Added a check that avoid starving the session pool on client rejections.