### PR TITLE
fix(transport-hopr): remove post-validation non-adjacent duplicate filter from path planner

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,7 +838,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -849,7 +849,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2682,7 +2682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3437,9 +3437,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "253cae294dced141adf9e102a09bd4bcbac36efaf13451d1fad93661b59c5a16"
+checksum = "e33fb0c32d216e93e58a050edea339bc8ed5bd8fe844bf893b849fc402824412"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -3865,7 +3865,6 @@ dependencies = [
  "hopr-transport-probe",
  "hopr-transport-session",
  "hopr-transport-tag-allocator",
- "hopr-types",
  "hopr-utils",
  "humantime-serde",
  "insta",
@@ -4293,7 +4292,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5600,7 +5599,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6393,7 +6392,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6430,7 +6429,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6941,7 +6940,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7568,7 +7567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7768,7 +7767,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8579,7 +8578,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -838,7 +838,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -849,7 +849,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2682,7 +2682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4030,9 +4030,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f06ce2e57452d2b33e65e6fe9f320422fee2b87970e6ef07803005827e28dfb"
+checksum = "75e82a6426de74cdef7bbef15f651ce546ab39fc77ef1dc4002247b6bbf034fc"
 dependencies = [
  "aes",
  "anyhow",
@@ -4293,7 +4293,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5600,7 +5600,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6393,7 +6393,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6430,7 +6430,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -6941,7 +6941,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7568,7 +7568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7768,7 +7768,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8579,7 +8579,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,7 +159,7 @@ mimalloc = { version = "0.1.50", default-features = false, features = [
   "secure",
 ] }
 
-hopr-api = "1.9.0"
+hopr-api = "1.10.0"
 hopr-types = { version = "1.8.2", features = ["use-bindings"] }
 hopr-utils = { path = "utils", default-features = false }
 hopr-crypto-packet = { path = "crypto/packet", default-features = false, features = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,7 +160,7 @@ mimalloc = { version = "0.1.50", default-features = false, features = [
 ] }
 
 hopr-api = "1.9.0"
-hopr-types = { version = "1.8.0", features = ["use-bindings"] }
+hopr-types = { version = "1.8.2", features = ["use-bindings"] }
 hopr-utils = { path = "utils", default-features = false }
 hopr-crypto-packet = { path = "crypto/packet", default-features = false, features = [
   "ed25519",

--- a/impls/ct/full-network/src/discovery.rs
+++ b/impls/ct/full-network/src/discovery.rs
@@ -31,14 +31,18 @@ impl<U> FullNetworkDiscovery<U> {
     }
 }
 
-/// Strip the trailing loopback closure from a loopback path.
+/// Strip leading and/or trailing `me` markers from a loopback path.
 ///
 /// `simple_loopback_to_self` returns `[intermediates..., me]` — the leading source
-/// is already excluded by the graph crate; only the closing `me` needs to be removed
-/// so the caller can pass the remaining intermediates to `IntermediatePath`.
+/// is already excluded by the graph crate. This helper also strips a leading `me`
+/// defensively in case the graph-crate contract changes, so the result is always
+/// a plain intermediate list suitable for `IntermediatePath`.
 fn strip_loopback_trailer(mut path: Vec<OffchainPublicKey>, me: &OffchainPublicKey) -> Vec<OffchainPublicKey> {
     if path.last() == Some(me) {
         path.pop();
+    }
+    if path.first() == Some(me) {
+        path.remove(0);
     }
     path
 }

--- a/impls/ct/full-network/src/discovery.rs
+++ b/impls/ct/full-network/src/discovery.rs
@@ -31,17 +31,14 @@ impl<U> FullNetworkDiscovery<U> {
     }
 }
 
-/// Strip the leading source and trailing destination from a loopback path.
+/// Strip the trailing loopback closure from a loopback path.
 ///
-/// `simple_loopback_to_self` returns `[me, intermediates..., me]`.  The caller
-/// adds `me` as the destination and the planner prepends `me` as source, so
-/// only the interior intermediate nodes are needed.
-fn strip_loopback_endpoints(mut path: Vec<OffchainPublicKey>, me: &OffchainPublicKey) -> Vec<OffchainPublicKey> {
+/// `simple_loopback_to_self` returns `[intermediates..., me]` — the leading source
+/// is already excluded by the graph crate; only the closing `me` needs to be removed
+/// so the caller can pass the remaining intermediates to `IntermediatePath`.
+fn strip_loopback_trailer(mut path: Vec<OffchainPublicKey>, me: &OffchainPublicKey) -> Vec<OffchainPublicKey> {
     if path.last() == Some(me) {
         path.pop();
-    }
-    if path.first() == Some(me) {
-        path.remove(0);
     }
     path
 }
@@ -97,7 +94,7 @@ where
 
                 loopback_path_stream(self.cfg, self.graph.clone())
                     .filter_map(move |(path, _)| {
-                        let intermediates = strip_loopback_endpoints(path, &me);
+                        let intermediates = strip_loopback_trailer(path, &me);
                         futures::future::ready(loopback_routing(me_node, intermediates))
                     })
                     .boxed()
@@ -125,7 +122,7 @@ where
 
         let me_node: NodeId = me.into();
         let intermediates = loopback_path_stream(cfg, self.graph.clone()).filter_map(move |(path, path_id)| {
-            let intermediates = strip_loopback_endpoints(path, &me);
+            let intermediates = strip_loopback_trailer(path, &me);
             let routing = loopback_routing(me_node, intermediates).map(|r| ProbeRouting::Looping((r, path_id)));
             futures::future::ready(routing)
         });
@@ -622,18 +619,20 @@ mod tests {
 
     #[tokio::test]
     async fn loopback_routing_should_reject_full_path_with_me() -> anyhow::Result<()> {
-        // Verify that passing the full path [me, a, b, me] to loopback_routing
-        // exceeds BoundedVec capacity and returns None.
+        // Verify that loopback_routing rejects paths that are too long for BoundedVec.
+        // simple_loopback_to_self now returns [a, b, me] (no leading me); after
+        // strip_loopback_trailer this becomes [a, b], which is the correct input.
         let me = random_key();
         let a = random_key();
         let b = random_key();
         let me_node = NodeId::Offchain(me);
 
-        // Full path as returned by simple_loopback_to_self: [me, a, b, me]
-        let full_path = vec![me, a, b, me];
+        // Path with too many elements: [a, b, c, me] — 4 elements exceeds BoundedVec<3>.
+        let c = random_key();
+        let oversized_path = vec![a, b, c, me];
         assert!(
-            loopback_routing(me_node, full_path).is_none(),
-            "full path [me, a, b, me] should exceed BoundedVec<3> and return None"
+            loopback_routing(me_node, oversized_path).is_none(),
+            "path [a, b, c, me] should exceed BoundedVec<3> and return None"
         );
 
         // Stripped path (intermediates only): [a, b]

--- a/impls/ct/full-network/src/discovery.rs
+++ b/impls/ct/full-network/src/discovery.rs
@@ -37,7 +37,7 @@ impl<U> FullNetworkDiscovery<U> {
 /// is already excluded by the graph crate. This helper also strips a leading `me`
 /// defensively in case the graph-crate contract changes, so the result is always
 /// a plain intermediate list suitable for `IntermediatePath`.
-fn strip_loopback_trailer(mut path: Vec<OffchainPublicKey>, me: &OffchainPublicKey) -> Vec<OffchainPublicKey> {
+fn strip_loopback_endpoints(mut path: Vec<OffchainPublicKey>, me: &OffchainPublicKey) -> Vec<OffchainPublicKey> {
     if path.last() == Some(me) {
         path.pop();
     }
@@ -98,7 +98,7 @@ where
 
                 loopback_path_stream(self.cfg, self.graph.clone())
                     .filter_map(move |(path, _)| {
-                        let intermediates = strip_loopback_trailer(path, &me);
+                        let intermediates = strip_loopback_endpoints(path, &me);
                         futures::future::ready(loopback_routing(me_node, intermediates))
                     })
                     .boxed()
@@ -126,7 +126,7 @@ where
 
         let me_node: NodeId = me.into();
         let intermediates = loopback_path_stream(cfg, self.graph.clone()).filter_map(move |(path, path_id)| {
-            let intermediates = strip_loopback_trailer(path, &me);
+            let intermediates = strip_loopback_endpoints(path, &me);
             let routing = loopback_routing(me_node, intermediates).map(|r| ProbeRouting::Looping((r, path_id)));
             futures::future::ready(routing)
         });
@@ -625,7 +625,7 @@ mod tests {
     async fn loopback_routing_should_reject_full_path_with_me() -> anyhow::Result<()> {
         // Verify that loopback_routing rejects paths that are too long for BoundedVec.
         // simple_loopback_to_self now returns [a, b, me] (no leading me); after
-        // strip_loopback_trailer this becomes [a, b], which is the correct input.
+        // strip_loopback_endpoints this becomes [a, b], which is the correct input.
         let me = random_key();
         let a = random_key();
         let b = random_key();

--- a/impls/graph/src/petgraph/algorithm.rs
+++ b/impls/graph/src/petgraph/algorithm.rs
@@ -575,6 +575,66 @@ mod test {
     }
 
     #[test]
+    fn complete_graph_should_yield_all_and_only_simple_paths() {
+        use petgraph::graph::NodeIndex;
+
+        // Build K5: complete directed graph on 5 nodes (every ordered pair gets an edge).
+        let edges: Vec<(u32, u32)> = (0u32..5)
+            .flat_map(|a| (0u32..5).filter(move |&b| b != a).map(move |b| (a, b)))
+            .collect();
+        let graph = DiGraph::<i32, ()>::from_edges(edges);
+
+        let src: NodeIndex = 0.into();
+        let dst: NodeIndex = 4.into();
+        let targets = HashSet::from_iter([dst]);
+
+        // ── Without exclusions ─────────────────────────────────────────────
+        let all_paths: Vec<(Vec<NodeIndex>, i32)> = all_simple_paths_multi::<_, _, RandomState, _, _>(
+            &graph, src, &targets, None, 0, None, 0, None, |c, _, _| c,
+        )
+        .collect();
+
+        // Intermediate pool = {1, 2, 3} (3 nodes).
+        // Simple paths = P(3,0) + P(3,1) + P(3,2) + P(3,3) = 1 + 3 + 6 + 6 = 16.
+        assert_eq!(all_paths.len(), 16, "expected 16 simple paths in K5 from 0 to 4");
+
+        for (path, _) in &all_paths {
+            assert_eq!(path.first(), Some(&src), "path must start at src: {path:?}");
+            assert_eq!(path.last(), Some(&dst), "path must end at dst: {path:?}");
+            // Uniqueness: collect into a set and compare lengths.
+            let unique: HashSet<&NodeIndex, RandomState> = path.iter().collect();
+            assert_eq!(unique.len(), path.len(), "duplicate node in path: {path:?}");
+        }
+
+        // ── With excluded_nodes = {2} ──────────────────────────────────────
+        let excluded: HashSet<NodeIndex, RandomState> = HashSet::from_iter([NodeIndex::from(2u32)]);
+        let restricted: Vec<(Vec<NodeIndex>, i32)> = all_simple_paths_multi::<_, _, RandomState, _, _>(
+            &graph, src, &targets, Some(&excluded), 0, None, 0, None, |c, _, _| c,
+        )
+        .collect();
+
+        // Intermediate pool shrinks to {1, 3} (2 nodes).
+        // P(2,0) + P(2,1) + P(2,2) = 1 + 2 + 2 = 5.
+        assert_eq!(restricted.len(), 5, "expected 5 paths when node 2 is excluded");
+
+        for (path, _) in &restricted {
+            assert!(!path.contains(&NodeIndex::from(2u32)), "excluded node 2 in path: {path:?}");
+            let unique: HashSet<&NodeIndex, RandomState> = path.iter().collect();
+            assert_eq!(unique.len(), path.len(), "duplicate node in path: {path:?}");
+        }
+
+        // Restricted paths are a strict subset: every restricted path also appears in all_paths.
+        let all_set: Vec<Vec<usize>> = all_paths
+            .iter()
+            .map(|(p, _)| p.iter().map(|n| n.index()).collect())
+            .collect();
+        for (path, _) in &restricted {
+            let as_usize: Vec<usize> = path.iter().map(|n| n.index()).collect();
+            assert!(all_set.contains(&as_usize), "restricted path not in all-paths: {path:?}");
+        }
+    }
+
+    #[test]
     fn excluded_from_should_be_ignored() {
         // Excluding the source itself must not prevent paths from starting.
         let graph = DiGraph::<i32, ()>::from_edges([(0, 1), (1, 2)]);

--- a/impls/graph/src/petgraph/algorithm.rs
+++ b/impls/graph/src/petgraph/algorithm.rs
@@ -601,7 +601,11 @@ mod test {
         for (path, _) in &all_paths {
             assert_eq!(path.first(), Some(&src), "path must start at src: {path:?}");
             assert_eq!(path.last(), Some(&dst), "path must end at dst: {path:?}");
-            // Uniqueness: collect into a set and compare lengths.
+            // src and dst must not appear anywhere in the interior of the path.
+            let interior = &path[1..path.len() - 1];
+            assert!(!interior.contains(&src), "src repeated inside path: {path:?}");
+            assert!(!interior.contains(&dst), "dst repeated inside path: {path:?}");
+            // No node anywhere in the path (including src and dst) appears more than once.
             let unique: HashSet<&NodeIndex, RandomState> = path.iter().collect();
             assert_eq!(unique.len(), path.len(), "duplicate node in path: {path:?}");
         }

--- a/impls/graph/src/petgraph/algorithm.rs
+++ b/impls/graph/src/petgraph/algorithm.rs
@@ -132,11 +132,9 @@ where
             if let Some(edge) = edges.next() {
                 let child = edge.target();
 
-                // Skip nodes already on the current path or caller-excluded.
-                // Excluded nodes are checked separately so they never appear in
-                // `visited` and never pollute the yielded path.
-                // `from` is already in `visited`, so excluding it via `excluded_nodes`
-                // is always a no-op (the source can't be re-entered).
+                // Excluded nodes checked separately — not inserted into `visited` — so they
+                // never appear in the yielded path. Excluding `from` is a no-op since it's
+                // already in `visited` at position 0.
                 if visited.contains(&child) || excluded_nodes.is_some_and(|excl| excl.contains(&child)) {
                     continue;
                 }
@@ -651,6 +649,14 @@ mod test {
             Some(&excluded),
             0,
             None,
+            0,
+            None,
+            |c, _, _| c,
+        ));
+        assert_eq!(paths, vec![vec![0, 1, 2]]);
+    }
+}
+       None,
             0,
             None,
             |c, _, _| c,

--- a/impls/graph/src/petgraph/algorithm.rs
+++ b/impls/graph/src/petgraph/algorithm.rs
@@ -36,6 +36,10 @@ use petgraph::{
 /// * `graph`: an input graph.
 /// * `from`: an initial node of desired paths.
 /// * `to`: a `HashSet` of target nodes. A path is yielded as soon as it reaches any node in this set.
+/// * `excluded_nodes`: an optional set of nodes to exclude from all returned paths. Excluded nodes are
+///   pre-seeded into the visited set so the DFS never enters a branch containing them. Passing `Some(&empty)`
+///   or `None` is equivalent to the default behavior (no exclusions). If `from` is in the excluded set, it
+///   is ignored — the source is always reachable.
 /// * `min_intermediate_nodes`: the minimum number of nodes in the desired paths.
 /// * `max_intermediate_nodes`: the maximum number of nodes in the desired paths (optional).
 /// * `initial_cost`: the starting cost value before any edges are traversed.
@@ -74,7 +78,7 @@ use petgraph::{
 /// // Find paths from "a" to either "c" or "d", accumulating edge costs.
 /// let targets = HashSet::from_iter([c, d]);
 /// let mut paths = all_simple_paths_multi::<Vec<_>, _, RandomState, _, _>(
-///     &graph, a, &targets, 0, None, 0i32, None, |cost, weight, _| cost + weight,
+///     &graph, a, &targets, None, 0, None, 0i32, None, |cost, weight, _| cost + weight,
 /// )
 ///     .collect::<Vec<_>>();
 ///
@@ -91,6 +95,7 @@ pub fn all_simple_paths_multi<'a, TargetColl, G, S, F, C>(
     graph: G,
     from: G::NodeId,
     to: &'a HashSet<G::NodeId, S>,
+    excluded_nodes: Option<&'a HashSet<G::NodeId, S>>,
     min_intermediate_nodes: usize,
     max_intermediate_nodes: Option<usize>,
     initial_cost: C,
@@ -127,7 +132,12 @@ where
             if let Some(edge) = edges.next() {
                 let child = edge.target();
 
-                if visited.contains(&child) {
+                // Skip nodes already on the current path or caller-excluded.
+                // Excluded nodes are checked separately so they never appear in
+                // `visited` and never pollute the yielded path.
+                // `from` is already in `visited`, so excluding it via `excluded_nodes`
+                // is always a no-op (the source can't be re-entered).
+                if visited.contains(&child) || excluded_nodes.is_some_and(|excl| excl.contains(&child)) {
                     continue;
                 }
 
@@ -197,6 +207,7 @@ mod test {
             &graph,
             0.into(),
             &targets,
+            None,
             0,
             None,
             0,
@@ -214,6 +225,7 @@ mod test {
             &graph,
             0.into(),
             &targets,
+            None,
             0,
             None,
             0,
@@ -231,6 +243,7 @@ mod test {
             &graph,
             0.into(),
             &targets,
+            None,
             0,
             Some(2),
             0,
@@ -253,6 +266,7 @@ mod test {
             &graph,
             0.into(),
             &targets,
+            None,
             0,
             Some(1),
             0,
@@ -270,6 +284,7 @@ mod test {
             &graph,
             0.into(),
             &targets,
+            None,
             0,
             Some(2),
             0,
@@ -287,6 +302,7 @@ mod test {
             &graph,
             0.into(),
             &targets,
+            None,
             0,
             None,
             0,
@@ -304,6 +320,7 @@ mod test {
             &graph,
             0.into(),
             &targets,
+            None,
             0,
             None,
             0,
@@ -321,6 +338,7 @@ mod test {
             &graph,
             0.into(),
             &targets,
+            None,
             0,
             None,
             0,
@@ -349,6 +367,7 @@ mod test {
             &graph,
             1.into(),
             &targets,
+            None,
             0,
             None,
             0,
@@ -366,6 +385,7 @@ mod test {
             &graph,
             0.into(),
             &targets,
+            None,
             2,
             None,
             0,
@@ -389,12 +409,19 @@ mod test {
         ]);
 
         let targets = HashSet::from_iter([n[3], n[4]]);
-        let results: Vec<(Vec<_>, f64)> =
-            all_simple_paths_multi::<_, _, RandomState, _, _>(&graph, n[0], &targets, 0, None, 1.0, None, |c, w, _| {
-                c * w
-            })
-            .map(|(v, cost): (Vec<_>, f64)| (v.into_iter().map(|i| i.index()).collect(), cost))
-            .collect();
+        let results: Vec<(Vec<_>, f64)> = all_simple_paths_multi::<_, _, RandomState, _, _>(
+            &graph,
+            n[0],
+            &targets,
+            None,
+            0,
+            None,
+            1.0,
+            None,
+            |c, w, _| c * w,
+        )
+        .map(|(v, cost): (Vec<_>, f64)| (v.into_iter().map(|i| i.index()).collect(), cost))
+        .collect();
 
         // Path 0->1->2->3: cost = 1.0 * 0.9 * 0.8 * 0.7 = 0.504
         // Path 0->1->4:     cost = 1.0 * 0.9 * 0.6 = 0.54
@@ -428,6 +455,7 @@ mod test {
             &graph,
             n[0],
             &targets,
+            None,
             0,
             None,
             1.0,
@@ -462,6 +490,7 @@ mod test {
             &graph,
             n[0],
             &targets,
+            None,
             0,
             None,
             1.0,
@@ -490,6 +519,7 @@ mod test {
             &graph,
             n[0],
             &targets,
+            None,
             0,
             None,
             1.0,
@@ -500,5 +530,67 @@ mod test {
         .collect();
 
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn excluded_nodes_should_prune_branches_containing_them() {
+        // 0 → 1 → 2 → 3
+        //      ↘ 4 → 3
+        // Excluding node 2 forces the DFS to take only the 0→1→4→3 branch.
+        let graph = DiGraph::<i32, ()>::from_edges([(0, 1), (1, 2), (2, 3), (1, 4), (4, 3)]);
+        let targets = HashSet::from_iter([3.into()]);
+        let excluded: HashSet<petgraph::graph::NodeIndex, RandomState> = HashSet::from_iter([2.into()]);
+        let paths = sorted_paths(all_simple_paths_multi::<_, _, RandomState, _, _>(
+            &graph,
+            0.into(),
+            &targets,
+            Some(&excluded),
+            0,
+            None,
+            0,
+            None,
+            |c, _, _| c,
+        ));
+        assert_eq!(paths, vec![vec![0, 1, 4, 3]]);
+    }
+
+    #[test]
+    fn excluded_target_yields_no_paths() {
+        // If the only target is excluded, no paths should be returned.
+        let graph = DiGraph::<i32, ()>::from_edges([(0, 1), (1, 2)]);
+        let targets = HashSet::from_iter([2.into()]);
+        let excluded: HashSet<petgraph::graph::NodeIndex, RandomState> = HashSet::from_iter([2.into()]);
+        let paths = sorted_paths(all_simple_paths_multi::<_, _, RandomState, _, _>(
+            &graph,
+            0.into(),
+            &targets,
+            Some(&excluded),
+            0,
+            None,
+            0,
+            None,
+            |c, _, _| c,
+        ));
+        assert!(paths.is_empty());
+    }
+
+    #[test]
+    fn excluded_from_should_be_ignored() {
+        // Excluding the source itself must not prevent paths from starting.
+        let graph = DiGraph::<i32, ()>::from_edges([(0, 1), (1, 2)]);
+        let targets = HashSet::from_iter([2.into()]);
+        let excluded: HashSet<petgraph::graph::NodeIndex, RandomState> = HashSet::from_iter([0.into()]);
+        let paths = sorted_paths(all_simple_paths_multi::<_, _, RandomState, _, _>(
+            &graph,
+            0.into(),
+            &targets,
+            Some(&excluded),
+            0,
+            None,
+            0,
+            None,
+            |c, _, _| c,
+        ));
+        assert_eq!(paths, vec![vec![0, 1, 2]]);
     }
 }

--- a/impls/graph/src/petgraph/algorithm.rs
+++ b/impls/graph/src/petgraph/algorithm.rs
@@ -656,11 +656,3 @@ mod test {
         assert_eq!(paths, vec![vec![0, 1, 2]]);
     }
 }
-       None,
-            0,
-            None,
-            |c, _, _| c,
-        ));
-        assert_eq!(paths, vec![vec![0, 1, 2]]);
-    }
-}

--- a/impls/graph/src/petgraph/traverse.rs
+++ b/impls/graph/src/petgraph/traverse.rs
@@ -41,6 +41,7 @@ where
         &inner.graph,
         source,
         destinations,
+        None,
         intermediates,
         Some(intermediates),
         initial_value,

--- a/impls/graph/src/petgraph/traverse.rs
+++ b/impls/graph/src/petgraph/traverse.rs
@@ -187,9 +187,12 @@ impl hopr_api::graph::NetworkGraphTraverse for ChannelGraph {
                     // find_paths already strips the leading `me` (source), so `a` is
                     // [intermediates…, connected_neighbor]. Append `me` to close the loopback;
                     // this is the only sanctioned position where `me` appears as a "destination".
+                    //
+                    // b is filled by find_paths BEFORE skip(1), so b[0] = me_idx and
+                    // b[1..=path_node_count] = path nodes. Closing me goes at b[path_node_count + 1].
                     let path_node_count = a.len();
-                    if path_node_count < b.len() {
-                        b[path_node_count] = me_idx.index() as u64;
+                    if path_node_count + 1 < b.len() {
+                        b[path_node_count + 1] = me_idx.index() as u64;
                     }
                     a.push(self.me);
                     (a, b)

--- a/impls/graph/src/petgraph/traverse.rs
+++ b/impls/graph/src/petgraph/traverse.rs
@@ -57,13 +57,16 @@ where
             path_id[i] = node_idx.index() as u64;
         }
 
-        // Convert node indices to public keys
+        // Convert node indices to public keys; strip `source` (first element).
+        // path_id retains all indices including source for stable caching.
         let nodes = node_indices
             .into_iter()
+            .skip(1)
             .filter_map(|v| inner.indices.get_by_right(&v).copied())
             .collect::<Vec<_>>();
-        // Path includes source + intermediates + destination = length + 1 nodes
-        (nodes.len() == length + 1).then_some((nodes, path_id, final_cost))
+        // After stripping source: intermediates + destination = length nodes.
+        // `simple_paths` additionally pops the destination; the others return as-is.
+        (nodes.len() == length).then_some((nodes, path_id, final_cost))
     });
 
     if let Some(take_count) = take_count {
@@ -98,6 +101,8 @@ impl hopr_api::graph::NetworkGraphTraverse for ChannelGraph {
         };
         let end = HashSet::from_iter([*end]);
 
+        // find_paths returns [intermediates…, destination]; pop destination since caller
+        // supplies it as an explicit input argument and it must not repeat in the path body.
         find_paths(
             &inner,
             *start,
@@ -108,6 +113,12 @@ impl hopr_api::graph::NetworkGraphTraverse for ChannelGraph {
             value_fn.min_value(),
             value_fn.into_value_fn(),
         )
+        .into_iter()
+        .map(|(mut nodes, path_id, cost)| {
+            nodes.pop(); // strip destination — caller already knows it
+            (nodes, path_id, cost)
+        })
+        .collect()
     }
 
     fn simple_paths_from<C: ValueFn<Weight = Self::Observed>>(
@@ -172,7 +183,9 @@ impl hopr_api::graph::NetworkGraphTraverse for ChannelGraph {
                 )
                 .into_iter()
                 .map(|(mut a, mut b, _c)| {
-                    // Append me's node index to close the loopback in the PathId
+                    // find_paths already strips the leading `me` (source), so `a` is
+                    // [intermediates…, connected_neighbor]. Append `me` to close the loopback;
+                    // this is the only sanctioned position where `me` appears as a "destination".
                     let path_node_count = a.len();
                     if path_node_count < b.len() {
                         b[path_node_count] = me_idx.index() as u64;
@@ -648,12 +661,17 @@ mod tests {
         );
         assert_eq!(routes_3.len(), 5, "should find exactly 5 three-edge paths");
 
-        // Verify all returned paths have positive cost
+        // Verify all returned paths have positive cost.
+        // simple_paths strips both src and dest, so a 3-edge path has 2 intermediates.
         for (path, _path_id, cost) in &routes_3 {
             assert!(*cost > 0.0, "path {path:?} should have positive cost, got {cost}");
-            assert_eq!(path.len(), 4, "3-edge path should contain 4 nodes");
-            assert_eq!(path.first(), Some(&me), "path should start at me");
-            assert_eq!(path.last(), Some(&f), "path should end at f");
+            assert_eq!(
+                path.len(),
+                2,
+                "3-edge path should contain 2 intermediates (src and dest stripped)"
+            );
+            assert!(!path.contains(&me), "path must not contain src");
+            assert!(!path.contains(&f), "path must not contain dest");
         }
 
         // --- 1-edge path: no direct me→f edge ---
@@ -1179,15 +1197,12 @@ mod tests {
         assert_eq!(routes.len(), 1, "should find exactly one 2-edge loopback");
 
         let (path, _path_id) = &routes[0];
-        assert_eq!(
-            path.len(),
-            4,
-            "loopback path should have 4 nodes (2 internal edges + appended me)"
-        );
-        assert_eq!(path.first(), Some(&me), "path should start with me");
-        assert_eq!(path.last(), Some(&me), "path should end with me (appended)");
-        assert_eq!(path[1], a, "first intermediate should be a");
-        assert_eq!(path[2], b, "destination (connected neighbor) should be b");
+        // simple_loopback_to_self strips the leading `me` and keeps the closing `me`.
+        // For a 2-edge internal path (me → a → b), the result is [a, b, me].
+        assert_eq!(path.len(), 3, "loopback path: 2 internal nodes + closing me");
+        assert_eq!(path.last(), Some(&me), "path should end with me (closing loopback)");
+        assert_eq!(path[0], a, "first intermediate should be a");
+        assert_eq!(path[1], b, "destination (connected neighbor) should be b");
 
         Ok(())
     }
@@ -1218,10 +1233,11 @@ mod tests {
         assert_eq!(routes.len(), 1, "should find exactly one 3-edge loopback");
 
         let (path, _path_id) = &routes[0];
-        assert_eq!(path.len(), 5, "3-edge internal path + appended me = 5 nodes");
-        assert_eq!(path.first(), Some(&me), "starts with me");
+        // simple_loopback_to_self strips leading `me`, keeps closing `me`.
+        // For a 3-edge internal path (me → a → b → c), result is [a, b, c, me].
+        assert_eq!(path.len(), 4, "3-edge internal path + closing me = 4 nodes");
         assert_eq!(path.last(), Some(&me), "ends with me");
-        assert_eq!(&path[1..4], &[a, b, c], "interior nodes");
+        assert_eq!(&path[0..3], &[a, b, c], "interior nodes");
 
         Ok(())
     }
@@ -1255,13 +1271,13 @@ mod tests {
         assert_eq!(routes.len(), 2, "diamond should yield two 2-edge loopback paths");
 
         for (path, _path_id) in &routes {
-            assert_eq!(path.first(), Some(&me), "every path starts with me");
+            // Leading `me` is stripped; path is [intermediate, c, me].
             assert_eq!(path.last(), Some(&me), "every path ends with me");
             assert_eq!(path[path.len() - 2], c, "penultimate node is c (connected neighbor)");
         }
 
-        // Verify distinct intermediates (a and b)
-        let intermediates: HashSet<_> = routes.iter().map(|(p, _)| p[1]).collect();
+        // Verify distinct first intermediates (a and b)
+        let intermediates: HashSet<_> = routes.iter().map(|(p, _)| p[0]).collect();
         assert!(intermediates.contains(&a), "should include path through a");
         assert!(intermediates.contains(&b), "should include path through b");
 
@@ -1296,9 +1312,8 @@ mod tests {
             "should find loopback paths to both connected neighbors"
         );
 
-        // Both paths start and end with me
+        // Leading `me` is stripped; path is [intermediate, connected_neighbor, me].
         for (path, _) in &routes {
-            assert_eq!(path.first(), Some(&me));
             assert_eq!(path.last(), Some(&me));
         }
 

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -163,7 +163,7 @@ name = "protocol_stress_throughput"
 path = "tests/protocol/stress_throughput.rs"
 
 [package.metadata.cargo-machete]
-ignored = ["humantime-serde"]
+ignored = ["humantime-serde", "hopr-types"]
 
 [package.metadata.cargo-shear]
-ignored = ["humantime-serde", "hopr-transport-probe"]
+ignored = ["humantime-serde", "hopr-transport-probe", "hopr-types"]

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -67,19 +67,17 @@ validator = { workspace = true }
 
 hopr-api = { workspace = true, features = [
   "types-random",
+  "types-internal",
   "tickets",
   "node",
   "network",
   "chain",
   "graph",
 ] }
-hopr-types = { workspace = true, features = [
-  "crypto",
-  "random",
-  "internal",
-  "primitive",
-  "serde",
-] }
+# Retained only to activate hopr-types/telemetry via the `telemetry` feature above.
+# Once hopr-api >= 1.10.0 is published (which adds types-telemetry), replace
+# hopr-types/telemetry in the feature above with hopr-api/types-telemetry and remove this dep.
+hopr-types = { workspace = true }
 
 hopr-utils = { workspace = true, features = [
   "network-types",

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -16,7 +16,7 @@ all-benchmarks = []
 capture = ["dep:pcap-file"]
 telemetry = [
   "serde",
-  "hopr-types/telemetry",
+  "hopr-api/types-telemetry",
   "hopr-protocol-hopr/telemetry",
   "hopr-transport-session/telemetry",
   "hopr-utils/network-types-telemetry",
@@ -74,10 +74,6 @@ hopr-api = { workspace = true, features = [
   "chain",
   "graph",
 ] }
-# Retained only to activate hopr-types/telemetry via the `telemetry` feature above.
-# Once hopr-api >= 1.10.0 is published (which adds types-telemetry), replace
-# hopr-types/telemetry in the feature above with hopr-api/types-telemetry and remove this dep.
-hopr-types = { workspace = true }
 
 hopr-utils = { workspace = true, features = [
   "network-types",
@@ -163,7 +159,7 @@ name = "protocol_stress_throughput"
 path = "tests/protocol/stress_throughput.rs"
 
 [package.metadata.cargo-machete]
-ignored = ["humantime-serde", "hopr-types"]
+ignored = ["humantime-serde"]
 
 [package.metadata.cargo-shear]
-ignored = ["humantime-serde", "hopr-transport-probe", "hopr-types"]
+ignored = ["humantime-serde", "hopr-transport-probe"]

--- a/transport/hopr/src/path/errors.rs
+++ b/transport/hopr/src/path/errors.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use hopr_types::internal::errors::PathError;
+use hopr_api::types::internal::errors::PathError;
 
 pub type Result<T> = std::result::Result<T, PathPlannerError>;
 

--- a/transport/hopr/src/path/planner.rs
+++ b/transport/hopr/src/path/planner.rs
@@ -565,12 +565,7 @@ mod tests {
     }
 
     fn mark_edge_last(graph: &ChannelGraph, src: &OffchainPublicKey, dst: &OffchainPublicKey) {
-        graph.upsert_edge(src, dst, |obs| {
-            obs.record(EdgeWeightType::Connected(true));
-            obs.record(EdgeWeightType::Immediate(Ok(std::time::Duration::from_millis(50))));
-            obs.record(EdgeWeightType::Intermediate(Ok(std::time::Duration::from_millis(50))));
-            obs.record(EdgeWeightType::Capacity(Some(1000)));
-        });
+        mark_edge_full(graph, src, dst);
     }
 
     fn small_config() -> PathPlannerConfig {
@@ -834,6 +829,14 @@ mod tests {
         let cfg = small_config();
         let selector = HoprGraphPathSelector::new(me, graph, cfg.max_cached_paths, cfg.edge_penalty, cfg.min_ack_rate);
         let chain_api = TestChainApi::new(me, me_addr(), vec![]);
+        let surb_store = hopr_protocol_hopr::MemorySurbStore::default();
+
+        let planner = PathPlanner::new(me, surb_store, chain_api, selector, small_config());
+        // Just ensure it compiles and produces a future.
+        let _future = planner.run_background_refresh();
+    }
+}
+nApi::new(me, me_addr(), vec![]);
         let surb_store = hopr_protocol_hopr::MemorySurbStore::default();
 
         let planner = PathPlanner::new(me, surb_store, chain_api, selector, small_config());

--- a/transport/hopr/src/path/planner.rs
+++ b/transport/hopr/src/path/planner.rs
@@ -836,11 +836,3 @@ mod tests {
         let _future = planner.run_background_refresh();
     }
 }
-nApi::new(me, me_addr(), vec![]);
-        let surb_store = hopr_protocol_hopr::MemorySurbStore::default();
-
-        let planner = PathPlanner::new(me, surb_store, chain_api, selector, small_config());
-        // Just ensure it compiles and produces a future.
-        let _future = planner.run_background_refresh();
-    }
-}

--- a/transport/hopr/src/path/planner.rs
+++ b/transport/hopr/src/path/planner.rs
@@ -5,11 +5,14 @@ use hopr_api::chain::{ChainKeyOperations, ChainPathResolver, ChainReadChannelOpe
 use hopr_crypto_packet::prelude::*;
 use hopr_protocol_hopr::{FoundSurb, SurbStore};
 #[cfg(all(feature = "telemetry", not(test)))]
-use hopr_types::internal::path::Path;
-use hopr_types::{
-    crypto::{crypto_traits::Randomizable, types::OffchainPublicKey},
-    internal::{errors::PathError, prelude::*},
-    primitive::traits::ToHex,
+use hopr_api::types::internal::path::Path;
+use hopr_api::{
+    OffchainPublicKey,
+    types::{
+        crypto::crypto_traits::Randomizable,
+        internal::{errors::PathError, prelude::*},
+        primitive::traits::ToHex,
+    },
 };
 use tracing::trace;
 use validator::{Validate, ValidationError};
@@ -21,7 +24,7 @@ use super::{
 
 #[cfg(all(feature = "telemetry", not(test)))]
 lazy_static::lazy_static! {
-    static ref METRIC_PATH_LENGTH: hopr_types::telemetry::SimpleHistogram = hopr_types::telemetry::SimpleHistogram::new(
+    static ref METRIC_PATH_LENGTH: hopr_api::types::telemetry::SimpleHistogram = hopr_api::types::telemetry::SimpleHistogram::new(
         "hopr_path_length",
         "Distribution of number of hops of sent messages",
         vec![0.0, 1.0, 2.0, 3.0, 4.0]
@@ -222,7 +225,7 @@ where
 
         #[cfg(all(feature = "telemetry", not(test)))]
         {
-            hopr_types::telemetry::SimpleHistogram::observe(&METRIC_PATH_LENGTH, (path.num_hops() - 1) as f64);
+            hopr_api::types::telemetry::SimpleHistogram::observe(&METRIC_PATH_LENGTH, (path.num_hops() - 1) as f64);
         }
 
         trace!(%path, "validated resolved path");
@@ -403,7 +406,7 @@ mod tests {
         },
     };
     use hopr_network_graph::ChannelGraph;
-    use hopr_types::{
+    use hopr_api::types::{
         crypto::prelude::{Keypair, OffchainKeypair},
         internal::channels::{ChannelEntry, ChannelStatus, generate_channel_id},
         primitive::prelude::*,
@@ -684,7 +687,7 @@ mod tests {
         let surb_store = hopr_protocol_hopr::MemorySurbStore::default();
         let planner = PathPlanner::new(me, surb_store, chain_api, selector, small_config());
 
-        use hopr_types::primitive::prelude::BoundedVec;
+        use hopr_api::types::primitive::prelude::BoundedVec;
         let intermediate_path = BoundedVec::try_from(vec![NodeId::Offchain(a)]).expect("valid");
 
         let routing = DestinationRouting::Forward {
@@ -716,7 +719,7 @@ mod tests {
 
         let planner = PathPlanner::new(me, surb_store, chain_api, selector, small_config());
 
-        use hopr_types::internal::routing::SurbMatcher;
+        use hopr_api::types::internal::routing::SurbMatcher;
         let matcher = SurbMatcher::Pseudonym(HoprPseudonym::random());
         let routing = DestinationRouting::Return(matcher);
 

--- a/transport/hopr/src/path/planner.rs
+++ b/transport/hopr/src/path/planner.rs
@@ -196,16 +196,8 @@ where
                         for pwc in candidates {
                             let node_ids: Vec<NodeId> = pwc.path.into_iter().map(NodeId::Offchain).collect::<Vec<_>>();
                             match ValidatedPath::new(source, node_ids, &chain_resolver).await {
-                                Ok(vp) => {
-                                    // Post-resolution: catch non-adjacent chain-address duplicates
-                                    // (ValidatedPath::new only checks consecutive collisions).
-                                    if vp.chain_path().iter().enumerate().any(|(i, a)| vp.chain_path()[..i].contains(a)) {
-                                        tracing::debug!(path = %vp, "skipping path candidate with repeated chain addresses");
-                                        continue;
-                                    }
-                                    valid_paths.push((vp, pwc.cost))
-                                }
-                                Err(e) => tracing::warn!(error = %e, "path candidate failed validation"),
+                                Ok(vp) => valid_paths.push((vp, pwc.cost)),
+                                Err(e) => tracing::debug!(error = %e, "path candidate failed validation"),
                             }
                         }
 
@@ -376,14 +368,8 @@ where
                         for pwc in candidates {
                             let node_ids: Vec<NodeId> = pwc.path.into_iter().map(NodeId::Offchain).collect::<Vec<_>>();
                             match ValidatedPath::new(src, node_ids, &chain_resolver).await {
-                                Ok(vp) => {
-                                    if vp.chain_path().iter().enumerate().any(|(i, a)| vp.chain_path()[..i].contains(a)) {
-                                        tracing::debug!(path = %vp, "background refresh: skipping candidate with repeated chain addresses");
-                                        continue;
-                                    }
-                                    valid_paths.push((vp, pwc.cost))
-                                }
-                                Err(e) => tracing::warn!(error = %e, "background refresh: path candidate failed validation"),
+                                Ok(vp) => valid_paths.push((vp, pwc.cost)),
+                                Err(e) => tracing::debug!(error = %e, "background refresh: path candidate failed validation"),
                             }
                         }
 

--- a/transport/hopr/src/path/selector.rs
+++ b/transport/hopr/src/path/selector.rs
@@ -292,17 +292,8 @@ mod tests {
         });
     }
 
-    /// Mark an edge as ready only as the last hop (forward or return).
-    ///
-    /// Forward last edge requires capacity; return last edge requires connectivity + score.
-    /// This helper sets all of them so it works for either direction.
     fn mark_edge_last(graph: &ChannelGraph, src: &OffchainPublicKey, dst: &OffchainPublicKey) {
-        graph.upsert_edge(src, dst, |obs| {
-            obs.record(EdgeWeightType::Connected(true));
-            obs.record(EdgeWeightType::Immediate(Ok(Duration::from_millis(50))));
-            obs.record(EdgeWeightType::Intermediate(Ok(Duration::from_millis(50))));
-            obs.record(EdgeWeightType::Capacity(Some(1000)));
-        });
+        mark_edge_full(graph, src, dst);
     }
 
     // Helper: build a bidirectional 2-hop graph: me ↔ hop ↔ dest.
@@ -721,6 +712,22 @@ mod tests {
         graph.add_node(hop);
         graph.add_node(dest);
         graph.add_edge(&me, &hop).context("adding edge me -> hop")?;
+        graph.add_edge(&hop, &dest).context("adding edge hop -> dest")?;
+        // No mark_edge_full/mark_edge_last → observations are empty → cost = 0
+
+        let selector = test_selector(me, graph, MAX_PATHS);
+
+        let err = selector
+            .select_path(me, dest, 1)
+            .expect_err("zero-cost paths should be filtered out");
+        anyhow::ensure!(
+            matches!(err, PathPlannerError::Path(PathError::PathNotFound(..))),
+            "expected PathNotFound, got: {err}"
+        );
+        Ok(())
+    }
+}
+op")?;
         graph.add_edge(&hop, &dest).context("adding edge hop -> dest")?;
         // No mark_edge_full/mark_edge_last → observations are empty → cost = 0
 

--- a/transport/hopr/src/path/selector.rs
+++ b/transport/hopr/src/path/selector.rs
@@ -12,8 +12,8 @@ use super::{
 ///
 /// `length` is the number of edges to traverse (= intermediate hops + 1).
 /// `take` caps the number of candidate paths returned.
-/// The source node is stripped from every returned path; callers receive
-/// `([intermediates..., dest], cost)`.
+/// The graph crate returns only the intermediate nodes (both `src` and `dest` stripped);
+/// this function re-appends `dest` so callers receive `([intermediates..., dest], cost)`.
 fn compute_paths<G, C>(
     graph: &G,
     src: &OffchainPublicKey,
@@ -33,11 +33,11 @@ where
         .filter_map(|(path, _, cost)| {
             tracing::trace!(?path, ?cost, "evaluating candidate path");
             if cost > 0.0 {
-                // Drop the first element (src) — callers expect [intermediates..., dest].
-                Some(PathWithCost {
-                    path: path.into_iter().skip(1).collect::<Vec<_>>(),
-                    cost,
-                })
+                // The graph crate returns only intermediates (src and dest already stripped).
+                // Re-append dest so callers receive [intermediates..., dest].
+                let mut path = path;
+                path.push(*dest);
+                Some(PathWithCost { path, cost })
             } else {
                 None
             }
@@ -122,15 +122,13 @@ where
                     return None;
                 }
 
-                // Strip source to get intermediate hops only.
-                // Guard: if dest already appears as an intermediate, appending it
-                // again creates a [dest, ..., dest] path that ValidatedPath::new
-                // would reject as a non-adjacent duplicate — skip early.
-                let candidate: Vec<_> = path.into_iter().skip(1).collect();
-                if candidate.contains(dest) {
+                // The graph crate already strips `src`; `path` is [intermediates…, terminator].
+                // Guard: if dest already appears as an intermediate or terminator, appending it
+                // would produce a non-adjacent duplicate that ValidatedPath::new rejects — skip early.
+                if path.contains(dest) {
                     return None;
                 }
-                let mut candidate = candidate;
+                let mut candidate = path;
                 candidate.push(*dest);
 
                 // Skip paths already found by Phase 1 (compare path component only).

--- a/transport/hopr/src/path/selector.rs
+++ b/transport/hopr/src/path/selector.rs
@@ -124,8 +124,8 @@ where
 
                 // Strip source to get intermediate hops only.
                 // Guard: if dest already appears as an intermediate, appending it
-                // again creates a [dest, dest] loop that ValidatedPath::new would
-                // reject — skip early instead of generating noise.
+                // again creates a [dest, ..., dest] path that ValidatedPath::new
+                // would reject as a non-adjacent duplicate — skip early.
                 let candidate: Vec<_> = path.into_iter().skip(1).collect();
                 if candidate.contains(dest) {
                     return None;

--- a/transport/hopr/src/path/selector.rs
+++ b/transport/hopr/src/path/selector.rs
@@ -1,7 +1,7 @@
 use hopr_api::graph::{
     NetworkGraphTraverse, NetworkGraphView, ValueFn, function::EdgeValueFn, traits::EdgeObservableRead,
 };
-use hopr_types::{crypto::types::OffchainPublicKey, internal::errors::PathError};
+use hopr_api::{OffchainPublicKey, types::internal::errors::PathError};
 
 use super::{
     errors::{PathPlannerError, Result},
@@ -253,7 +253,7 @@ mod tests {
         traits::{EdgeObservableWrite, EdgeWeightType},
     };
     use hopr_network_graph::ChannelGraph;
-    use hopr_types::{
+    use hopr_api::types::{
         crypto::prelude::{Keypair, OffchainKeypair},
         internal::routing::RoutingOptions,
     };

--- a/transport/hopr/src/path/selector.rs
+++ b/transport/hopr/src/path/selector.rs
@@ -727,19 +727,3 @@ mod tests {
         Ok(())
     }
 }
-op")?;
-        graph.add_edge(&hop, &dest).context("adding edge hop -> dest")?;
-        // No mark_edge_full/mark_edge_last → observations are empty → cost = 0
-
-        let selector = test_selector(me, graph, MAX_PATHS);
-
-        let err = selector
-            .select_path(me, dest, 1)
-            .expect_err("zero-cost paths should be filtered out");
-        anyhow::ensure!(
-            matches!(err, PathPlannerError::Path(PathError::PathNotFound(..))),
-            "expected PathNotFound, got: {err}"
-        );
-        Ok(())
-    }
-}

--- a/transport/hopr/src/path/traits.rs
+++ b/transport/hopr/src/path/traits.rs
@@ -1,4 +1,4 @@
-use hopr_types::crypto::types::OffchainPublicKey;
+use hopr_api::OffchainPublicKey;
 
 use super::errors::Result;
 

--- a/transport/hopr/src/protocol/pipeline/mod.rs
+++ b/transport/hopr/src/protocol/pipeline/mod.rs
@@ -37,12 +37,12 @@ const PACKET_ENCODING_TIMEOUT: std::time::Duration = std::time::Duration::from_m
 
 #[cfg(all(feature = "telemetry", not(test)))]
 lazy_static::lazy_static! {
-    static ref METRIC_PACKET_COUNT:  hopr_types::telemetry::MultiCounter =  hopr_types::telemetry::MultiCounter::new(
+    static ref METRIC_PACKET_COUNT:  hopr_api::types::telemetry::MultiCounter =  hopr_api::types::telemetry::MultiCounter::new(
         "hopr_packets_count",
         "Number of processed packets of different types (sent, received, forwarded)",
         &["type"]
     ).unwrap();
-    static ref METRIC_PACKET_REJECTED_COUNT: hopr_types::telemetry::MultiCounter = hopr_types::telemetry::MultiCounter::new(
+    static ref METRIC_PACKET_REJECTED_COUNT: hopr_api::types::telemetry::MultiCounter = hopr_api::types::telemetry::MultiCounter::new(
         "hopr_packet_rejected_count",
         "Number of incoming packets rejected due various reasons",
         &["reason"]
@@ -51,11 +51,11 @@ lazy_static::lazy_static! {
     // A sustained non-zero rate here indicates the Rayon pool is saturated—correlate with
     // `hopr_rayon_tasks_cancelled_total` and hopr_rayon_queue_wait_seconds to diagnose whether
     // the bottleneck is queue depth, individual task duration, or both.
-    static ref METRIC_PACKET_DECODE_TIMEOUTS: hopr_types::telemetry::SimpleCounter = hopr_types::telemetry::SimpleCounter::new(
+    static ref METRIC_PACKET_DECODE_TIMEOUTS: hopr_api::types::telemetry::SimpleCounter = hopr_api::types::telemetry::SimpleCounter::new(
         "hopr_packet_decode_timeouts_total",
         "Number of incoming packets dropped due to decode timeout (sustained rate indicates Rayon pool saturation)"
     ).unwrap();
-    static ref METRIC_VALIDATION_ERRORS: hopr_types::telemetry::MultiCounter =  hopr_types::telemetry::MultiCounter::new(
+    static ref METRIC_VALIDATION_ERRORS: hopr_api::types::telemetry::MultiCounter =  hopr_api::types::telemetry::MultiCounter::new(
         "hopr_packet_ticket_validation_errors",
         "Number of different ticket validation errors encountered during packet processing",
         &["type"]

--- a/transport/hopr/src/protocol/stream.rs
+++ b/transport/hopr/src/protocol/stream.rs
@@ -17,8 +17,8 @@ use tokio_util::{
 
 #[cfg(all(feature = "telemetry", not(test)))]
 lazy_static::lazy_static! {
-    static ref METRIC_PER_PEER_SEND_TIMEOUT: hopr_types::telemetry::SimpleCounter =
-        hopr_types::telemetry::SimpleCounter::new(
+    static ref METRIC_PER_PEER_SEND_TIMEOUT: hopr_api::types::telemetry::SimpleCounter =
+        hopr_api::types::telemetry::SimpleCounter::new(
             "hopr_egress_per_peer_send_timed_out",
             "Number of packets dropped due to per-peer egress send timeout",
         )


### PR DESCRIPTION
## Summary

Removes the post-validation non-adjacent duplicate path filter from `PathPlanner` — the check now lives in `ValidatedPath::new` in `hopr-types` v1.8.2, making the local workaround redundant. Downgraded the `warn!` log for rejected path candidates to `debug!`.

Tightens the graph traversal contract so returned paths exclude `src` everywhere and exclude `dest` when the caller supplied it. `HoprGraphPathSelector` re-appends `dest` before handing paths to the planner, preserving the existing `PathWithCost` contract unchanged. `simple_loopback_to_self` returns `[intermediates…, me]` (leading `me` stripped, closing `me` still appended). The `strip_loopback_endpoints` helper in `discovery.rs` is kept two-sided to guard against future contract drift.

Adds an optional `excluded_nodes` parameter to `all_simple_paths_multi` that pre-seeds the DFS visited set, enabling callers to prune entire subtrees without touching the algorithm's per-path uniqueness invariant.

Migrates every `hopr_types::*` import in `transport/hopr` to `hopr_api::types::*`. Bumps workspace `hopr-types` to `1.8.2` and `hopr-api` to `1.10.0`. `transport/hopr` no longer declares `hopr-types` as a direct dependency.

Depends on: https://github.com/hoprnet/hopr-types/pull/53