### PR TITLE
feat(hopr): eliminate CPU hotspots and runtime issues discovered during testing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3835,7 +3835,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.28.1"
+version = "0.28.2"
 dependencies = [
  "ahash",
  "anyhow",

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -244,11 +244,19 @@ impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
         let (session_tx, session_rx) = channel::<IncomingSession>(incoming_session_capacity);
 
         tracing::debug!(capacity = incoming_session_capacity, "spawning session server");
-        let handle = hopr_utils::spawn_as_abortable!(
+        let session_diag = hopr_utils::runtime::diagnostics::ConcurrentDiagnostics::new(
+            "session_server_for_each_concurrent",
+            module_path!(),
+            file!(),
+            line!(),
+        );
+        let handle = hopr_utils::spawn_as_abortable_named!(
+            "hopr_lib_session_server",
             session_rx
                 .for_each_concurrent(None, move |session| {
                     let server = server.clone();
-                    async move {
+                    let session_diag = session_diag.clone();
+                    session_diag.wrap(async move {
                         let session_id = *session.session.id();
                         match server.process(session).await {
                             Ok(()) => tracing::debug!(?session_id, "session processed successfully"),
@@ -256,7 +264,7 @@ impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
                                 tracing::error!(?session_id, %error, "session processing failed")
                             }
                         }
-                    }
+                    })
                 })
                 .inspect(|_| tracing::warn!(
                     task = %HoprLibProcess::SessionServer,
@@ -774,7 +782,8 @@ macro_rules! impl_build_methods {
             let new_ticket_tx = pre.ticket_event_subscribers.0.clone();
             let tmgr_clone = ticket_manager.clone();
             spawn(
-                tickets_rx_stream
+                hopr_utils::runtime::diagnostics::instrument(
+                    tickets_rx_stream
                     .for_each(move |event| {
                         if let TicketEvent::WinningTicket(ticket) = &event
                             && let Err(error) = tmgr_clone.insert_incoming_ticket(**ticket)
@@ -789,6 +798,11 @@ macro_rules! impl_build_methods {
                     .inspect(|_| {
                         tracing::warn!(task = %HoprLibProcess::TicketEvents, "long-running background task finished")
                     }),
+                    "hopr_lib_ticket_events",
+                    module_path!(),
+                    file!(),
+                    line!(),
+                ),
             );
 
             {
@@ -796,51 +810,56 @@ macro_rules! impl_build_methods {
                 let tmgr_for_neglect = ticket_manager.clone();
                 let events = pre.chain_api.subscribe().map_err(HoprLibError::chain)?;
                 let (neglect_handle, neglect_reg) = hopr_utils::runtime::AbortHandle::new_pair();
-                spawn(
-                    futures::stream::Abortable::new(
-                        events.filter_map(move |event| {
-                            futures::future::ready(match event {
-                                ChainEvent::ChannelClosed(ch) => Some(ch),
-                                _ => None,
-                            })
-                        }),
-                        neglect_reg,
-                    )
-                    .for_each(move |closed_channel| {
-                        let chain = chain_for_neglect.clone();
-                        let tmgr = tmgr_for_neglect.clone();
-                        async move {
-                            match closed_channel.direction(chain.me()) {
-                                Some(ChannelDirection::Incoming) => {
-                                    match tmgr.neglect_tickets(closed_channel.get_id(), None) {
-                                        Ok(neglected) if !neglected.is_empty() => {
-                                            tracing::warn!(
-                                                num_neglected = neglected.len(),
-                                                %closed_channel,
-                                                "tickets on incoming closed channel were neglected"
-                                            );
-                                        }
-                                        Ok(_) => {}
-                                        Err(error) => {
-                                            tracing::error!(
-                                                %error, %closed_channel,
-                                                "failed to neglect tickets on closed channel"
-                                            );
-                                        }
+                let neglect_task = futures::stream::Abortable::new(
+                    events.filter_map(move |event| {
+                        futures::future::ready(match event {
+                            ChainEvent::ChannelClosed(ch) => Some(ch),
+                            _ => None,
+                        })
+                    }),
+                    neglect_reg,
+                )
+                .for_each(move |closed_channel| {
+                    let chain = chain_for_neglect.clone();
+                    let tmgr = tmgr_for_neglect.clone();
+                    async move {
+                        match closed_channel.direction(chain.me()) {
+                            Some(ChannelDirection::Incoming) => {
+                                match tmgr.neglect_tickets(closed_channel.get_id(), None) {
+                                    Ok(neglected) if !neglected.is_empty() => {
+                                        tracing::warn!(
+                                            num_neglected = neglected.len(),
+                                            %closed_channel,
+                                            "tickets on incoming closed channel were neglected"
+                                        );
+                                    }
+                                    Ok(_) => {}
+                                    Err(error) => {
+                                        tracing::error!(
+                                            %error, %closed_channel,
+                                            "failed to neglect tickets on closed channel"
+                                        );
                                     }
                                 }
-                                Some(ChannelDirection::Outgoing) => {}
-                                _ => {}
                             }
+                            Some(ChannelDirection::Outgoing) => {}
+                            _ => {}
                         }
-                    })
-                    .inspect(|_| {
-                        tracing::warn!(
-                            task = %HoprLibProcess::ChannelClosureNeglect,
-                            "channel closure ticket neglect task finished"
-                        )
-                    }),
-                );
+                    }
+                })
+                .inspect(|_| {
+                    tracing::warn!(
+                        task = %HoprLibProcess::ChannelClosureNeglect,
+                        "channel closure ticket neglect task finished"
+                    )
+                });
+                spawn(hopr_utils::runtime::diagnostics::instrument(
+                    neglect_task,
+                    "hopr_lib_channel_closure_neglect",
+                    module_path!(),
+                    file!(),
+                    line!(),
+                ));
                 processes.insert(HoprLibProcess::ChannelClosureNeglect, neglect_handle);
             }
 

--- a/impls/strategy/src/strategy.rs
+++ b/impls/strategy/src/strategy.rs
@@ -85,7 +85,14 @@ impl Strategy for MultiStrategy {
         let mut join_handles = Vec::new();
         let mut abort_handles: Vec<AbortHandle> = Vec::new();
         for mut s in strategies {
-            let (proc, abort_handle) = abortable(async move { s.run().await });
+            let proc = hopr_utils::runtime::diagnostics::instrument(
+                async move { s.run().await },
+                "multi_strategy_sub_task",
+                module_path!(),
+                file!(),
+                line!(),
+            );
+            let (proc, abort_handle) = abortable(proc);
             join_handles.push(spawn(proc));
             abort_handles.push(abort_handle);
         }

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport"
-version = "0.28.1"
+version = "0.28.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Implements the main HOPR transport interface for the core library"
 edition.workspace = true

--- a/transport/hopr/src/protocol/pipeline/mod.rs
+++ b/transport/hopr/src/protocol/pipeline/mod.rs
@@ -438,13 +438,6 @@ async fn start_outgoing_ack_pipeline<AckOut, E, WOut>(
     WOut: futures::Sink<(PeerId, Bytes)> + Clone + Unpin + Send + 'static,
     WOut::Error: std::error::Error,
 {
-    let ack_out_diag = hopr_utils::runtime::diagnostics::ConcurrentDiagnostics::new(
-        "packet_pipeline_ack_out_for_each_concurrent",
-        module_path!(),
-        file!(),
-        line!(),
-    );
-
     ack_outgoing
         .map(move |(destination, maybe_ack_key)| {
             let packet_key = packet_key.clone();
@@ -490,8 +483,7 @@ async fn start_outgoing_ack_pipeline<AckOut, E, WOut>(
             move |(destination, acks)| {
                 let encoder = encoder.clone();
                 let mut wire_outgoing = wire_outgoing.clone();
-                let ack_out_diag = ack_out_diag.clone();
-                ack_out_diag.wrap(async move {
+                async move {
                     // Make sure that the acknowledgements are sent in batches of at most MAX_ACKNOWLEDGEMENTS_BATCH_SIZE
                     // TODO: find better strategy to avoid reallocations
                     let c = acks.chunks(MAX_ACKNOWLEDGEMENTS_BATCH_SIZE).map(|c| c.to_vec()).collect::<Vec<_>>();
@@ -514,7 +506,7 @@ async fn start_outgoing_ack_pipeline<AckOut, E, WOut>(
                         tracing::error!(%error, "failed to flush acknowledgements batch to the transport layer");
                     }
                     tracing::trace!("acknowledgements out");
-                }.instrument(tracing::debug_span!("outgoing_ack_batch", peer = destination.to_peerid_str())))
+                }.instrument(tracing::debug_span!("outgoing_ack_batch", peer = destination.to_peerid_str()))
             }
         )
         .in_current_span()
@@ -560,20 +552,11 @@ async fn start_relay_incoming_ack_pipeline<AckIn, T, TEvt>(
     TEvt: futures::Sink<TicketEvent> + Clone + Unpin + Send + 'static,
     TEvt::Error: std::error::Error,
 {
-    let ack_in_diag = hopr_utils::runtime::diagnostics::ConcurrentDiagnostics::new(
-        "packet_pipeline_ack_in_for_each_concurrent",
-        module_path!(),
-        file!(),
-        line!(),
-    );
-
     ack_incoming
         .for_each_concurrent(concurrency, move |(peer, acks)| {
             let ticket_proc = ticket_proc.clone();
             let mut ticket_evt = ticket_events.clone();
-            let ack_in_diag = ack_in_diag.clone();
-            ack_in_diag.wrap(
-                async move {
+            async move {
                     tracing::trace!(num = acks.len(), "received acknowledgements");
                     match hopr_utils::parallelize::cpu::spawn_fifo_blocking(
                         move || ticket_proc.acknowledge_tickets(peer, acks),
@@ -616,8 +599,7 @@ async fn start_relay_incoming_ack_pipeline<AckIn, T, TEvt>(
                         }
                     }
                 }
-                .instrument(tracing::debug_span!("incoming_ack_batch", peer = peer.to_peerid_str())),
-            )
+                .instrument(tracing::debug_span!("incoming_ack_batch", peer = peer.to_peerid_str()))
         })
         .in_current_span()
         .await;
@@ -744,8 +726,7 @@ where
 
     processes.insert(
         PacketPipelineProcesses::MsgOut,
-        hopr_utils::spawn_as_abortable_named!(
-            "packet_pipeline_msg_out",
+        hopr_utils::spawn_as_abortable!(
             start_outgoing_packet_pipeline(
                 app_in,
                 encoder.clone(),
@@ -759,8 +740,7 @@ where
 
     processes.insert(
         PacketPipelineProcesses::MsgIn,
-        hopr_utils::spawn_as_abortable_named!(
-            "packet_pipeline_msg_in",
+        hopr_utils::spawn_as_abortable!(
             start_incoming_packet_pipeline(
                 (wire_out.clone(), wire_in),
                 decoder,
@@ -777,8 +757,7 @@ where
 
     processes.insert(
         PacketPipelineProcesses::AckOut,
-        hopr_utils::spawn_as_abortable_named!(
-            "packet_pipeline_ack_out",
+        hopr_utils::spawn_as_abortable!(
             start_outgoing_ack_pipeline(outgoing_ack_rx, encoder, cfg.ack_config, packet_key.clone(), wire_out,)
                 .in_current_span()
         ),
@@ -794,8 +773,7 @@ where
         NodeType::Relay => {
             processes.insert(
                 PacketPipelineProcesses::AckIn,
-                hopr_utils::spawn_as_abortable_named!(
-                    "packet_pipeline_ack_in",
+                hopr_utils::spawn_as_abortable!(
                     start_relay_incoming_ack_pipeline(
                         incoming_ack_rx,
                         ticket_events,
@@ -813,10 +791,7 @@ where
             let _ = (ticket_events, ticket_proc, ack_input_concurrency);
             processes.insert(
                 PacketPipelineProcesses::AckIn,
-                hopr_utils::spawn_as_abortable_named!(
-                    "packet_pipeline_ack_in_drain",
-                    start_exit_incoming_ack_pipeline(incoming_ack_rx).in_current_span()
-                ),
+                hopr_utils::spawn_as_abortable!(start_exit_incoming_ack_pipeline(incoming_ack_rx).in_current_span()),
             );
         }
         NodeType::Entry => {

--- a/transport/hopr/src/protocol/pipeline/mod.rs
+++ b/transport/hopr/src/protocol/pipeline/mod.rs
@@ -438,6 +438,13 @@ async fn start_outgoing_ack_pipeline<AckOut, E, WOut>(
     WOut: futures::Sink<(PeerId, Bytes)> + Clone + Unpin + Send + 'static,
     WOut::Error: std::error::Error,
 {
+    let ack_out_diag = hopr_utils::runtime::diagnostics::ConcurrentDiagnostics::new(
+        "packet_pipeline_ack_out_for_each_concurrent",
+        module_path!(),
+        file!(),
+        line!(),
+    );
+
     ack_outgoing
         .map(move |(destination, maybe_ack_key)| {
             let packet_key = packet_key.clone();
@@ -483,7 +490,8 @@ async fn start_outgoing_ack_pipeline<AckOut, E, WOut>(
             move |(destination, acks)| {
                 let encoder = encoder.clone();
                 let mut wire_outgoing = wire_outgoing.clone();
-                async move {
+                let ack_out_diag = ack_out_diag.clone();
+                ack_out_diag.wrap(async move {
                     // Make sure that the acknowledgements are sent in batches of at most MAX_ACKNOWLEDGEMENTS_BATCH_SIZE
                     // TODO: find better strategy to avoid reallocations
                     let c = acks.chunks(MAX_ACKNOWLEDGEMENTS_BATCH_SIZE).map(|c| c.to_vec()).collect::<Vec<_>>();
@@ -506,7 +514,7 @@ async fn start_outgoing_ack_pipeline<AckOut, E, WOut>(
                         tracing::error!(%error, "failed to flush acknowledgements batch to the transport layer");
                     }
                     tracing::trace!("acknowledgements out");
-                }.instrument(tracing::debug_span!("outgoing_ack_batch", peer = destination.to_peerid_str()))
+                }.instrument(tracing::debug_span!("outgoing_ack_batch", peer = destination.to_peerid_str())))
             }
         )
         .in_current_span()
@@ -552,53 +560,64 @@ async fn start_relay_incoming_ack_pipeline<AckIn, T, TEvt>(
     TEvt: futures::Sink<TicketEvent> + Clone + Unpin + Send + 'static,
     TEvt::Error: std::error::Error,
 {
+    let ack_in_diag = hopr_utils::runtime::diagnostics::ConcurrentDiagnostics::new(
+        "packet_pipeline_ack_in_for_each_concurrent",
+        module_path!(),
+        file!(),
+        line!(),
+    );
+
     ack_incoming
         .for_each_concurrent(concurrency, move |(peer, acks)| {
             let ticket_proc = ticket_proc.clone();
             let mut ticket_evt = ticket_events.clone();
-            async move {
-                tracing::trace!(num = acks.len(), "received acknowledgements");
-                match hopr_utils::parallelize::cpu::spawn_fifo_blocking(
-                    move || ticket_proc.acknowledge_tickets(peer, acks),
-                    "ack_decode",
-                )
-                .await
-                {
-                    Ok(Ok(resolutions)) if !resolutions.is_empty() => {
-                        let resolutions_iter = resolutions.into_iter().filter_map(|resolution| match resolution {
-                            ResolvedAcknowledgement::RelayingWin(redeemable_ticket) => {
-                                tracing::trace!("received ack for a winning ticket");
-                                Some(Ok(TicketEvent::WinningTicket(redeemable_ticket)))
-                            }
-                            ResolvedAcknowledgement::RelayingLoss(_) => {
-                                // Losing tickets are not getting accounted for anywhere.
-                                tracing::trace!("received ack for a losing ticket");
-                                None
-                            }
-                        });
+            let ack_in_diag = ack_in_diag.clone();
+            ack_in_diag.wrap(
+                async move {
+                    tracing::trace!(num = acks.len(), "received acknowledgements");
+                    match hopr_utils::parallelize::cpu::spawn_fifo_blocking(
+                        move || ticket_proc.acknowledge_tickets(peer, acks),
+                        "ack_decode",
+                    )
+                    .await
+                    {
+                        Ok(Ok(resolutions)) if !resolutions.is_empty() => {
+                            let resolutions_iter = resolutions.into_iter().filter_map(|resolution| match resolution {
+                                ResolvedAcknowledgement::RelayingWin(redeemable_ticket) => {
+                                    tracing::trace!("received ack for a winning ticket");
+                                    Some(Ok(TicketEvent::WinningTicket(redeemable_ticket)))
+                                }
+                                ResolvedAcknowledgement::RelayingLoss(_) => {
+                                    // Losing tickets are not getting accounted for anywhere.
+                                    tracing::trace!("received ack for a losing ticket");
+                                    None
+                                }
+                            });
 
-                        // All acknowledgements that resulted in winning tickets go upstream
-                        if let Err(error) = ticket_evt.send_all(&mut futures::stream::iter(resolutions_iter)).await {
-                            tracing::error!(%error, "failed to notify ticket resolutions");
+                            // All acknowledgements that resulted in winning tickets go upstream
+                            if let Err(error) = ticket_evt.send_all(&mut futures::stream::iter(resolutions_iter)).await
+                            {
+                                tracing::error!(%error, "failed to notify ticket resolutions");
+                            }
+                        }
+                        Ok(Ok(_)) => {
+                            tracing::debug!("acknowledgement batch could not acknowledge any ticket");
+                        }
+                        Ok(Err(TicketAcknowledgementError::UnexpectedAcknowledgement)) => {
+                            // Unexpected acknowledgements naturally happen
+                            // as acknowledgements of 0-hop packets
+                            tracing::trace!("received unexpected acknowledgement");
+                        }
+                        Ok(Err(error)) => {
+                            tracing::error!(%error, "failed to acknowledge ticket");
+                        }
+                        Err(error) => {
+                            tracing::error!(%error, "parallel processing of the incoming acknowledgements failed")
                         }
                     }
-                    Ok(Ok(_)) => {
-                        tracing::debug!("acknowledgement batch could not acknowledge any ticket");
-                    }
-                    Ok(Err(TicketAcknowledgementError::UnexpectedAcknowledgement)) => {
-                        // Unexpected acknowledgements naturally happen
-                        // as acknowledgements of 0-hop packets
-                        tracing::trace!("received unexpected acknowledgement");
-                    }
-                    Ok(Err(error)) => {
-                        tracing::error!(%error, "failed to acknowledge ticket");
-                    }
-                    Err(error) => {
-                        tracing::error!(%error, "parallel processing of the incoming acknowledgements failed")
-                    }
                 }
-            }
-            .instrument(tracing::debug_span!("incoming_ack_batch", peer = peer.to_peerid_str()))
+                .instrument(tracing::debug_span!("incoming_ack_batch", peer = peer.to_peerid_str())),
+            )
         })
         .in_current_span()
         .await;
@@ -725,7 +744,8 @@ where
 
     processes.insert(
         PacketPipelineProcesses::MsgOut,
-        hopr_utils::spawn_as_abortable!(
+        hopr_utils::spawn_as_abortable_named!(
+            "packet_pipeline_msg_out",
             start_outgoing_packet_pipeline(
                 app_in,
                 encoder.clone(),
@@ -739,7 +759,8 @@ where
 
     processes.insert(
         PacketPipelineProcesses::MsgIn,
-        hopr_utils::spawn_as_abortable!(
+        hopr_utils::spawn_as_abortable_named!(
+            "packet_pipeline_msg_in",
             start_incoming_packet_pipeline(
                 (wire_out.clone(), wire_in),
                 decoder,
@@ -756,7 +777,8 @@ where
 
     processes.insert(
         PacketPipelineProcesses::AckOut,
-        hopr_utils::spawn_as_abortable!(
+        hopr_utils::spawn_as_abortable_named!(
+            "packet_pipeline_ack_out",
             start_outgoing_ack_pipeline(outgoing_ack_rx, encoder, cfg.ack_config, packet_key.clone(), wire_out,)
                 .in_current_span()
         ),
@@ -772,7 +794,8 @@ where
         NodeType::Relay => {
             processes.insert(
                 PacketPipelineProcesses::AckIn,
-                hopr_utils::spawn_as_abortable!(
+                hopr_utils::spawn_as_abortable_named!(
+                    "packet_pipeline_ack_in",
                     start_relay_incoming_ack_pipeline(
                         incoming_ack_rx,
                         ticket_events,
@@ -790,7 +813,10 @@ where
             let _ = (ticket_events, ticket_proc, ack_input_concurrency);
             processes.insert(
                 PacketPipelineProcesses::AckIn,
-                hopr_utils::spawn_as_abortable!(start_exit_incoming_ack_pipeline(incoming_ack_rx).in_current_span()),
+                hopr_utils::spawn_as_abortable_named!(
+                    "packet_pipeline_ack_in_drain",
+                    start_exit_incoming_ack_pipeline(incoming_ack_rx).in_current_span()
+                ),
             );
         }
         NodeType::Entry => {

--- a/transport/hopr/src/protocol/stream.rs
+++ b/transport/hopr/src/protocol/stream.rs
@@ -484,6 +484,17 @@ mod tests {
                 .context("egress queue should accept test packet")?;
         }
 
+        // Wait for at least one stream open (first cache miss).
+        let open_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
+        while control.open_calls() < 1 && tokio::time::Instant::now() < open_deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+        assert!(
+            control.open_calls() >= 1,
+            "stream was never opened — egress task did not process any packet"
+        );
+
+        // Now give it another second to reopen pathologically; it must not.
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
         while control.open_calls() < 2 && tokio::time::Instant::now() < deadline {
             tokio::time::sleep(std::time::Duration::from_millis(25)).await;

--- a/transport/hopr/src/protocol/stream.rs
+++ b/transport/hopr/src/protocol/stream.rs
@@ -294,10 +294,78 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        pin::Pin,
+        sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        },
+        task::{Context as TaskContext, Poll},
+    };
+
     use anyhow::Context;
-    use futures::SinkExt;
+    use async_trait::async_trait;
+    use futures::{SinkExt, Stream};
+    use tokio_util::{bytes::BytesMut, codec::BytesCodec};
 
     use super::*;
+
+    #[derive(Clone, Default, Debug)]
+    struct CountingControl {
+        open_calls: Arc<AtomicUsize>,
+    }
+
+    impl CountingControl {
+        fn open_calls(&self) -> usize {
+            self.open_calls.load(Ordering::Relaxed)
+        }
+    }
+
+    #[derive(Default)]
+    struct FailingIo;
+
+    impl AsyncRead for FailingIo {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut TaskContext<'_>,
+            _buf: &mut [u8],
+        ) -> Poll<std::io::Result<usize>> {
+            Poll::Pending
+        }
+    }
+
+    impl AsyncWrite for FailingIo {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _cx: &mut TaskContext<'_>,
+            _buf: &[u8],
+        ) -> Poll<std::io::Result<usize>> {
+            Poll::Ready(Err(std::io::Error::new(
+                std::io::ErrorKind::BrokenPipe,
+                "intentional test failure",
+            )))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut TaskContext<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(self: Pin<&mut Self>, _cx: &mut TaskContext<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[async_trait]
+    impl hopr_api::network::traits::NetworkStreamControl for CountingControl {
+        fn accept(self) -> Result<impl Stream<Item = (PeerId, impl AsyncRead + AsyncWrite + Send)> + Send, impl std::error::Error> {
+            Ok::<_, std::io::Error>(futures::stream::empty::<(PeerId, FailingIo)>())
+        }
+
+        async fn open(self, _peer: PeerId) -> Result<impl AsyncRead + AsyncWrite + Send, impl std::error::Error> {
+            self.open_calls.fetch_add(1, Ordering::Relaxed);
+            Ok::<_, std::io::Error>(FailingIo)
+        }
+    }
 
     struct AsyncBinaryStreamChannel {
         read: async_channel_io::ChannelReader,
@@ -371,6 +439,38 @@ mod tests {
         assert_eq!(
             rx.next().await.context("Value must be present")??,
             tokio_util::bytes::BytesMut::from(expected.as_ref())
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn per_peer_stream_should_not_reopen_pathologically_on_send_failures() -> anyhow::Result<()> {
+        let control = CountingControl::default();
+        let (mut tx_out, _rx_in) = process_stream_protocol(BytesCodec::new(), control.clone()).await?;
+
+        let peer = PeerId::random();
+        let msg = BytesMut::from(&b"x"[..]);
+
+        // Failing writer closes each per-peer stream quickly. This triggers send errors,
+        // invalidation, and then lazy reopen for subsequent packets to the same peer.
+        for _ in 0..12 {
+            tx_out
+                .send((peer, msg.clone()))
+                .await
+                .context("egress queue should accept test packet")?;
+            tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+        }
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+        while control.open_calls() < 3 && tokio::time::Instant::now() < deadline {
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+
+        assert!(
+            control.open_calls() <= 1,
+            "pathological reopen churn detected for same peer under send failures (open_calls={})",
+            control.open_calls()
         );
 
         Ok(())

--- a/transport/hopr/src/protocol/stream.rs
+++ b/transport/hopr/src/protocol/stream.rs
@@ -48,10 +48,13 @@ const MAX_CONCURRENT_PACKETS: usize = 30;
 /// Override with `HOPR_TRANSPORT_FRAME_WRITER_BACKPRESSURE_BYTES`.
 const DEFAULT_FRAME_WRITER_BACKPRESSURE_BYTES: usize = 4096;
 
+type PeerStreamCache<T> = moka::sync::Cache<PeerId, Sender<T>>;
+type PeerOpenLockCache = moka::sync::Cache<PeerId, Arc<futures::lock::Mutex<()>>>;
+
 fn build_peer_stream_io<S, C>(
     peer: PeerId,
     stream: S,
-    cache: moka::future::Cache<PeerId, Sender<<C as Decoder>::Item>>,
+    cache: PeerStreamCache<<C as Decoder>::Item>,
     codec: C,
     ingress_from_peers: Sender<(PeerId, <C as Decoder>::Item)>,
     frame_writer_backpressure_bytes: usize,
@@ -113,7 +116,7 @@ where
                 // Make sure we invalidate the peer entry from the cache once the stream ends
                 let peer = peer;
                 async move {
-                    cache_internal.invalidate(&peer).await;
+                    cache_internal.invalidate(&peer);
                 }
             }),
     );
@@ -139,12 +142,16 @@ where
     let (tx_out, rx_out) = channel::<(PeerId, <C as Decoder>::Item)>(100_000);
     let (tx_in, rx_in) = channel::<(PeerId, <C as Decoder>::Item)>(100_000);
 
-    let cache_out = moka::future::Cache::builder()
+    let cache_out: PeerStreamCache<<C as Decoder>::Item> = moka::sync::Cache::builder()
         .max_capacity(2000)
         .eviction_listener(|key: Arc<PeerId>, _, cause| {
             tracing::trace!(peer = %key.as_ref(), ?cause, "evicting stream for peer");
         })
         .build();
+
+    // Serialize cache-miss stream opens per peer without holding a Moka initialization
+    // guard across async network I/O.
+    let open_locks: PeerOpenLockCache = moka::sync::Cache::builder().max_capacity(2000).build();
 
     let incoming = control
         .clone()
@@ -202,9 +209,7 @@ where
                     frame_writer_backpressure_bytes,
                 );
 
-                async move {
-                    cache.insert(peer, send).await;
-                }
+                async move { cache.insert(peer, send) }
             })
             .inspect(|_| {
                 tracing::info!(
@@ -220,14 +225,21 @@ where
             .inspect(|(peer, _)| tracing::trace!(%peer, "proceeding to deliver message to peer"))
             .for_each_concurrent(max_concurrent_packets, move |(peer, msg)| {
                 let cache = cache_out.clone();
+                let open_locks = open_locks.clone();
                 let open_ctx = open_ctx.clone();
 
                 async move {
                     tracing::trace!(%peer, "trying to deliver message to peer");
 
-                    let cache_clone = cache.clone();
-                    let cached: Result<Sender<<C as Decoder>::Item>, Arc<anyhow::Error>> = cache
-                        .try_get_with(peer, async move {
+                    let cached = if let Some(cached) = cache.get(&peer) {
+                        Ok(cached)
+                    } else {
+                        let open_lock = open_locks.get_with(peer, || Arc::new(futures::lock::Mutex::new(())));
+                        let _guard = open_lock.lock().await;
+
+                        if let Some(cached) = cache.get(&peer) {
+                            Ok(cached)
+                        } else {
                             tracing::trace!(%peer, "peer is not in cache, opening new stream");
 
                             // Only the cache-miss path needs the stream-open handles.
@@ -245,21 +257,32 @@ where
                                 .open(peer)
                                 .timeout(futures_time::time::Duration::from(global_stream_open_timeout))
                                 .await
-                                .map_err(|_| anyhow::anyhow!("timeout trying to open stream to {peer}"))?
-                                .map_err(|e| anyhow::anyhow!("could not open outgoing peer-to-peer stream: {e}"))?;
+                                .map_err(|_| anyhow::anyhow!("timeout trying to open stream to {peer}"))
+                                .and_then(|stream| {
+                                    stream.map_err(|e| {
+                                        anyhow::anyhow!("could not open outgoing peer-to-peer stream: {e}")
+                                    })
+                                });
 
-                            tracing::debug!(%peer, "opening outgoing peer-to-peer stream");
+                            match stream {
+                                Ok(stream) => {
+                                    tracing::debug!(%peer, "opening outgoing peer-to-peer stream");
 
-                            Ok(build_peer_stream_io(
-                                peer,
-                                stream,
-                                cache_clone,
-                                codec.clone(),
-                                tx_in.clone(),
-                                frame_writer_backpressure_bytes,
-                            ))
-                        })
-                        .await;
+                                    let send = build_peer_stream_io(
+                                        peer,
+                                        stream,
+                                        cache.clone(),
+                                        codec.clone(),
+                                        tx_in.clone(),
+                                        frame_writer_backpressure_bytes,
+                                    );
+                                    cache.insert(peer, send.clone());
+                                    Ok(send)
+                                }
+                                Err(error) => Err(error),
+                            }
+                        }
+                    };
 
                     match cached {
                         Ok(cached) => match cached.with_timeout(per_peer_send_timeout).send(msg).await {
@@ -268,11 +291,10 @@ where
                                 #[cfg(all(feature = "telemetry", not(test)))]
                                 METRIC_PER_PEER_SEND_TIMEOUT.increment();
                                 tracing::warn!(%peer, "per-peer egress send timed out, dropping packet");
-                                cache.invalidate(&peer).await;
                             }
                             Err(SinkTimeoutError::Inner(error)) => {
                                 tracing::error!(%peer, %error, "error sending message to peer");
-                                cache.invalidate(&peer).await;
+                                cache.invalidate(&peer);
                             }
                         },
                         Err(error) => {
@@ -322,48 +344,40 @@ mod tests {
     }
 
     #[derive(Default)]
-    struct FailingIo;
+    struct StalledWriteIo;
 
-    impl AsyncRead for FailingIo {
-        fn poll_read(
-            self: Pin<&mut Self>,
-            _cx: &mut TaskContext<'_>,
-            _buf: &mut [u8],
-        ) -> Poll<std::io::Result<usize>> {
+    impl AsyncRead for StalledWriteIo {
+        fn poll_read(self: Pin<&mut Self>, _cx: &mut TaskContext<'_>, _buf: &mut [u8]) -> Poll<std::io::Result<usize>> {
             Poll::Pending
         }
     }
 
-    impl AsyncWrite for FailingIo {
-        fn poll_write(
-            self: Pin<&mut Self>,
-            _cx: &mut TaskContext<'_>,
-            _buf: &[u8],
-        ) -> Poll<std::io::Result<usize>> {
-            Poll::Ready(Err(std::io::Error::new(
-                std::io::ErrorKind::BrokenPipe,
-                "intentional test failure",
-            )))
+    impl AsyncWrite for StalledWriteIo {
+        fn poll_write(self: Pin<&mut Self>, _cx: &mut TaskContext<'_>, _buf: &[u8]) -> Poll<std::io::Result<usize>> {
+            Poll::Pending
         }
 
         fn poll_flush(self: Pin<&mut Self>, _cx: &mut TaskContext<'_>) -> Poll<std::io::Result<()>> {
-            Poll::Ready(Ok(()))
+            Poll::Pending
         }
 
         fn poll_close(self: Pin<&mut Self>, _cx: &mut TaskContext<'_>) -> Poll<std::io::Result<()>> {
-            Poll::Ready(Ok(()))
+            Poll::Pending
         }
     }
 
     #[async_trait]
     impl hopr_api::network::traits::NetworkStreamControl for CountingControl {
-        fn accept(self) -> Result<impl Stream<Item = (PeerId, impl AsyncRead + AsyncWrite + Send)> + Send, impl std::error::Error> {
-            Ok::<_, std::io::Error>(futures::stream::empty::<(PeerId, FailingIo)>())
+        fn accept(
+            self,
+        ) -> Result<impl Stream<Item = (PeerId, impl AsyncRead + AsyncWrite + Send)> + Send, impl std::error::Error>
+        {
+            Ok::<_, std::io::Error>(futures::stream::empty::<(PeerId, StalledWriteIo)>())
         }
 
         async fn open(self, _peer: PeerId) -> Result<impl AsyncRead + AsyncWrite + Send, impl std::error::Error> {
             self.open_calls.fetch_add(1, Ordering::Relaxed);
-            Ok::<_, std::io::Error>(FailingIo)
+            Ok::<_, std::io::Error>(StalledWriteIo)
         }
     }
 
@@ -452,18 +466,18 @@ mod tests {
         let peer = PeerId::random();
         let msg = BytesMut::from(&b"x"[..]);
 
-        // Failing writer closes each per-peer stream quickly. This triggers send errors,
-        // invalidation, and then lazy reopen for subsequent packets to the same peer.
-        for _ in 0..12 {
+        // The stalled writer stops draining the per-peer stream channel. Once that
+        // channel fills, sends time out and packets are dropped, but short
+        // backpressure must not evict the cached stream sender and reopen the stream.
+        for _ in 0..1200 {
             tx_out
                 .send((peer, msg.clone()))
                 .await
                 .context("egress queue should accept test packet")?;
-            tokio::time::sleep(std::time::Duration::from_millis(30)).await;
         }
 
-        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
-        while control.open_calls() < 3 && tokio::time::Instant::now() < deadline {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(1);
+        while control.open_calls() < 2 && tokio::time::Instant::now() < deadline {
             tokio::time::sleep(std::time::Duration::from_millis(25)).await;
         }
 

--- a/transport/hopr/src/protocol/stream.rs
+++ b/transport/hopr/src/protocol/stream.rs
@@ -68,7 +68,8 @@ where
 {
     let (stream_rx, stream_tx) = stream.split();
     let (send, recv) = channel::<<C as Decoder>::Item>(1000);
-    let cache_internal = cache.clone();
+    let cache_for_write = cache.clone();
+    let cache_for_read = cache.clone();
 
     let mut frame_writer = FramedWrite::new(stream_tx.compat_write(), codec.clone());
 
@@ -86,6 +87,13 @@ where
             .forward(frame_writer)
             .inspect(move |res| {
                 tracing::debug!(%peer, ?res, component = "stream", "writing stream with peer finished");
+            })
+            .then(move |_| {
+                // Make sure we invalidate the peer entry from the cache once the stream ends
+                let peer = peer;
+                async move {
+                    cache_for_write.invalidate(&peer);
+                }
             }),
     );
 
@@ -116,7 +124,7 @@ where
                 // Make sure we invalidate the peer entry from the cache once the stream ends
                 let peer = peer;
                 async move {
-                    cache_internal.invalidate(&peer);
+                    cache_for_read.invalidate(&peer);
                 }
             }),
     );

--- a/transport/probe/src/probe.rs
+++ b/transport/probe/src/probe.rs
@@ -306,17 +306,24 @@ impl Probe {
         let tag_allocator = self.tag_allocator.clone();
         let classifier_neighbor_probes = active_neighbor_probes.clone();
         let classifier_path_probes = active_path_probes.clone();
+        let emit_diag = hopr_utils::runtime::diagnostics::ConcurrentDiagnostics::new(
+            "probe_emit_for_each_concurrent",
+            module_path!(),
+            file!(),
+            line!(),
+        );
         processes.insert(
             HoprProbeProcess::Emit,
-            hopr_utils::spawn_as_abortable!(async move {
+            hopr_utils::spawn_as_abortable_named!("probe_emit", async move {
                 direct_neighbors
                     .for_each_concurrent(max_parallel_probes, move |(peer, notifier)| {
                         let active_neighbor_probes = active_neighbor_probes.clone();
                         let active_path_probes = active_path_probes.clone();
                         let push_to_network = push_to_network.clone();
                         let tag_allocator = tag_allocator.clone();
+                        let emit_diag = emit_diag.clone();
 
-                        async move {
+                        emit_diag.wrap(async move {
                             match peer {
                                 ProbeRouting::Neighbor(DestinationRouting::Forward {
                                     destination,
@@ -419,7 +426,7 @@ impl Probe {
                                     }
                                 }
                             }
-                        }
+                        })
                     })
                     .inspect(|_| {
                         tracing::warn!(

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -511,11 +511,18 @@ where
             .map_err(|_| SessionManagerError::AlreadyStarted)?;
 
         let myself = self.clone();
-        let ah_closure_notifications = hopr_utils::spawn_as_abortable!(session_close_rx.for_each_concurrent(
-            None,
-            move |(session_id, closure_reason)| {
+        let closure_diag = hopr_utils::runtime::diagnostics::ConcurrentDiagnostics::new(
+            "session_close_for_each_concurrent",
+            module_path!(),
+            file!(),
+            line!(),
+        );
+        let ah_closure_notifications = hopr_utils::spawn_as_abortable_named!(
+            "session_close_notifications",
+            session_close_rx.for_each_concurrent(None, move |(session_id, closure_reason)| {
                 let myself = myself.clone();
-                async move {
+                let closure_diag = closure_diag.clone();
+                closure_diag.wrap(async move {
                     // These notifications come from the Sessions themselves once
                     // an empty read is encountered, which means the closure was done by the
                     // other party.
@@ -529,9 +536,9 @@ where
                             "could not find session id to close, maybe the session is already closed"
                         );
                     }
-                }
-            },
-        ));
+                })
+            },)
+        );
 
         // This is necessary to evict expired entries from the caches if
         // no session-related operations happen at all.

--- a/transport/session/src/utils.rs
+++ b/transport/session/src/utils.rs
@@ -171,7 +171,13 @@ where
 
     // This task will automatically terminate once the returned abort handle is used.
     debug!(%session_id, "spawning keep-alive stream");
-    hopr_utils::runtime::prelude::spawn(
+    let keep_alive_diag = hopr_utils::runtime::diagnostics::ConcurrentDiagnostics::new(
+        "session_keep_alive_try_for_each_concurrent",
+        module_path!(),
+        file!(),
+        line!(),
+    );
+    hopr_utils::runtime::prelude::spawn(hopr_utils::runtime::diagnostics::instrument(
         ka_stream
             .map(move |msg| {
                 ApplicationData::try_from(msg)
@@ -180,12 +186,13 @@ where
             .map_err(TransportSessionError::from)
             .try_for_each_concurrent(None, move |msg| {
                 let mut sender_clone = sender_clone.clone();
-                async move {
+                let keep_alive_diag = keep_alive_diag.clone();
+                keep_alive_diag.wrap(async move {
                     sender_clone
                         .send(msg)
                         .await
                         .map_err(TransportSessionError::packet_sending)
-                }
+                })
             })
             .then(move |res| {
                 match res {
@@ -200,7 +207,11 @@ where
                 futures::future::ready(())
             })
             .in_current_span(),
-    );
+        "session_keep_alive",
+        module_path!(),
+        file!(),
+        line!(),
+    ));
 
     (controller, abort_handle)
 }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["rlib"]
 default = []
 
 # runtime module (from hopr-async-runtime) — always compiled, feature gates optional deps only
-runtime-tokio = ["dep:tokio"]
+runtime-tokio = ["dep:tokio", "dep:tracing"]
 async-lock = ["dep:async-lock"]
 
 # network-types module (from hopr-network-types)

--- a/utils/src/network_types/mod.rs
+++ b/utils/src/network_types/mod.rs
@@ -2,7 +2,7 @@
 pub mod errors;
 
 /// Contains UDP socket-related helpers.
-#[cfg(all(feature = "network-types", feature = "runtime-tokio"))]
+#[cfg(feature = "network-types-runtime-tokio")]
 pub mod udp;
 
 /// Contains various networking-related types
@@ -21,7 +21,7 @@ pub mod timeout;
 pub mod prelude {
     pub use libp2p_identity::PeerId;
 
-    #[cfg(all(feature = "network-types", feature = "runtime-tokio"))]
+    #[cfg(feature = "network-types-runtime-tokio")]
     pub use super::udp::*;
     pub use super::{addr::*, types::*};
 }

--- a/utils/src/network_types/types.rs
+++ b/utils/src/network_types/types.rs
@@ -70,23 +70,16 @@ impl IpOrHost {
     /// If this enum is already an IP address and port, it will simply return it.
     ///
     /// Uses `tokio` resolver.
-    #[cfg(all(feature = "network-types", feature = "runtime-tokio"))]
+    #[cfg(feature = "network-types-runtime-tokio")]
     pub async fn resolve_tokio(self) -> std::io::Result<Vec<std::net::SocketAddr>> {
         match self {
             IpOrHost::Dns(name, port) => {
-                #[cfg(test)]
                 let resolver = hickory_resolver::Resolver::builder_with_config(
                     hickory_resolver::config::ResolverConfig::default(),
                     hickory_resolver::net::runtime::TokioRuntimeProvider::default(),
                 )
                 .build()
                 .map_err(std::io::Error::other)?;
-
-                #[cfg(not(test))]
-                let resolver = hickory_resolver::Resolver::builder_tokio()
-                    .map_err(std::io::Error::other)?
-                    .build()
-                    .map_err(std::io::Error::other)?;
 
                 let lookup = resolver.lookup_ip(&name).await.map_err(std::io::Error::other)?;
                 Ok(lookup.iter().map(|ip| std::net::SocketAddr::new(ip, port)).collect())

--- a/utils/src/runtime.rs
+++ b/utils/src/runtime.rs
@@ -1,7 +1,17 @@
 //! Executor API for HOPR which exposes the necessary async functions depending on the enabled
 //! runtime.
 
-use std::hash::Hash;
+use std::{
+    future::Future,
+    hash::Hash,
+    pin::Pin,
+    sync::{
+        Arc, OnceLock,
+        atomic::{AtomicBool, AtomicU64, Ordering},
+    },
+    task::{Context, Poll},
+    time::{Duration, Instant},
+};
 
 pub use futures::future::AbortHandle;
 
@@ -20,13 +30,350 @@ pub mod prelude {
     };
 }
 
+/// Passive diagnostics for attributing high-frequency async polling.
+///
+/// Diagnostics are disabled unless `HOPR_RUNTIME_POLL_DIAGNOSTICS=1` is set.
+/// When enabled, warnings are rate-limited by `HOPR_RUNTIME_POLL_WARN_EVERY`
+/// and start after `HOPR_RUNTIME_POLL_WARN_AFTER` polls or child futures.
+pub mod diagnostics {
+    use super::*;
+
+    const ENV_ENABLED: &str = "HOPR_RUNTIME_POLL_DIAGNOSTICS";
+    const ENV_WARN_AFTER: &str = "HOPR_RUNTIME_POLL_WARN_AFTER";
+    const ENV_WARN_EVERY: &str = "HOPR_RUNTIME_POLL_WARN_EVERY";
+    const DEFAULT_WARN_AFTER: u64 = 100_000;
+    const DEFAULT_WARN_EVERY: Duration = Duration::from_secs(5);
+
+    #[derive(Debug)]
+    struct DiagnosticsConfig {
+        enabled: bool,
+        warn_after: u64,
+        warn_every: Duration,
+    }
+
+    static CONFIG: OnceLock<DiagnosticsConfig> = OnceLock::new();
+
+    fn parse_bool(value: &str) -> bool {
+        matches!(value.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on")
+    }
+
+    fn parse_duration(value: &str) -> Option<Duration> {
+        let trimmed = value.trim();
+        if let Some(stripped) = trimmed.strip_suffix("ms") {
+            stripped.trim().parse::<u64>().ok().map(Duration::from_millis)
+        } else if let Some(stripped) = trimmed.strip_suffix('s') {
+            stripped.trim().parse::<u64>().ok().map(Duration::from_secs)
+        } else {
+            trimmed.parse::<u64>().ok().map(Duration::from_secs)
+        }
+    }
+
+    fn config() -> &'static DiagnosticsConfig {
+        CONFIG.get_or_init(|| DiagnosticsConfig {
+            enabled: std::env::var(ENV_ENABLED).is_ok_and(|v| parse_bool(&v)),
+            warn_after: std::env::var(ENV_WARN_AFTER)
+                .ok()
+                .and_then(|v| v.trim().parse::<u64>().ok())
+                .filter(|&v| v > 0)
+                .unwrap_or(DEFAULT_WARN_AFTER),
+            warn_every: std::env::var(ENV_WARN_EVERY)
+                .ok()
+                .and_then(|v| parse_duration(&v))
+                .filter(|&v| v > Duration::ZERO)
+                .unwrap_or(DEFAULT_WARN_EVERY),
+        })
+    }
+
+    /// Returns whether runtime poll diagnostics are enabled for this process.
+    pub fn enabled() -> bool {
+        config().enabled
+    }
+
+    fn location(module_path: &'static str, file: &'static str, line: u32) -> String {
+        format!("{module_path} at {file}:{line}")
+    }
+
+    fn should_warn(last_warn_nanos: &AtomicU64, elapsed: Duration, warn_every: Duration) -> bool {
+        let elapsed_nanos = elapsed.as_nanos().min(u64::MAX as u128) as u64;
+        let warn_every_nanos = warn_every.as_nanos().min(u64::MAX as u128) as u64;
+
+        loop {
+            let last = last_warn_nanos.load(Ordering::Relaxed);
+            if elapsed_nanos.saturating_sub(last) < warn_every_nanos {
+                return false;
+            }
+
+            if last_warn_nanos
+                .compare_exchange(last, elapsed_nanos, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                return true;
+            }
+        }
+    }
+
+    fn warn_high_poll_rate(name: &str, location: &str, total_polls: u64, elapsed: Duration, polls_per_sec: f64) {
+        #[cfg(feature = "runtime-tokio")]
+        tracing::warn!(
+            task = name,
+            location,
+            total_polls,
+            elapsed_ms = elapsed.as_millis() as u64,
+            polls_per_sec,
+            "high-frequency polling detected"
+        );
+
+        #[cfg(not(feature = "runtime-tokio"))]
+        eprintln!(
+            "high-frequency polling detected: task={name} location={location} total_polls={total_polls} elapsed_ms={} polls_per_sec={polls_per_sec}",
+            elapsed.as_millis()
+        );
+    }
+
+    fn warn_high_child_rate(
+        name: &str,
+        location: &str,
+        started: u64,
+        completed: u64,
+        dropped: u64,
+        in_flight: u64,
+        elapsed: Duration,
+        completed_per_sec: f64,
+    ) {
+        #[cfg(feature = "runtime-tokio")]
+        tracing::warn!(
+            task = name,
+            location,
+            started,
+            completed,
+            dropped,
+            in_flight,
+            elapsed_ms = elapsed.as_millis() as u64,
+            completed_per_sec,
+            "high-frequency concurrent child churn detected"
+        );
+
+        #[cfg(not(feature = "runtime-tokio"))]
+        eprintln!(
+            "high-frequency concurrent child churn detected: task={name} location={location} started={started} completed={completed} dropped={dropped} in_flight={in_flight} elapsed_ms={} completed_per_sec={completed_per_sec}",
+            elapsed.as_millis()
+        );
+    }
+
+    struct PollDiagnosticState {
+        name: String,
+        location: String,
+        started_at: Instant,
+        total_polls: AtomicU64,
+        last_warn_nanos: AtomicU64,
+    }
+
+    /// Future wrapper that counts polls and emits rate-limited warnings.
+    #[must_use = "futures do nothing unless polled or awaited"]
+    pub struct PollDiagnosticFuture<F> {
+        inner: F,
+        state: Option<Arc<PollDiagnosticState>>,
+    }
+
+    impl<F> PollDiagnosticFuture<F> {
+        fn new(inner: F, name: String, module_path: &'static str, file: &'static str, line: u32) -> Self {
+            let state = enabled().then(|| {
+                Arc::new(PollDiagnosticState {
+                    name,
+                    location: location(module_path, file, line),
+                    started_at: Instant::now(),
+                    total_polls: AtomicU64::new(0),
+                    last_warn_nanos: AtomicU64::new(0),
+                })
+            });
+
+            Self { inner, state }
+        }
+    }
+
+    impl<F: Future> Future for PollDiagnosticFuture<F> {
+        type Output = F::Output;
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            // SAFETY: `inner` is pinned in place as part of `self`; we never move it.
+            let this = unsafe { self.get_unchecked_mut() };
+
+            if let Some(state) = &this.state {
+                let total_polls = state.total_polls.fetch_add(1, Ordering::Relaxed) + 1;
+                let cfg = config();
+                if total_polls >= cfg.warn_after {
+                    let elapsed = state.started_at.elapsed();
+                    if should_warn(&state.last_warn_nanos, elapsed, cfg.warn_every) {
+                        let polls_per_sec = total_polls as f64 / elapsed.as_secs_f64().max(0.001);
+                        warn_high_poll_rate(&state.name, &state.location, total_polls, elapsed, polls_per_sec);
+                    }
+                }
+            }
+
+            // SAFETY: see above; projecting only the pinned `inner` field.
+            unsafe { Pin::new_unchecked(&mut this.inner) }.poll(cx)
+        }
+    }
+
+    /// Instruments a future using callsite metadata.
+    pub fn instrument<F>(
+        inner: F,
+        name: &'static str,
+        module_path: &'static str,
+        file: &'static str,
+        line: u32,
+    ) -> PollDiagnosticFuture<F> {
+        PollDiagnosticFuture::new(inner, name.to_owned(), module_path, file, line)
+    }
+
+    struct ConcurrentDiagnosticState {
+        name: String,
+        location: String,
+        started_at: Instant,
+        started: AtomicU64,
+        completed: AtomicU64,
+        dropped: AtomicU64,
+        in_flight: AtomicU64,
+        last_warn_nanos: AtomicU64,
+    }
+
+    /// Shared diagnostics for `for_each_concurrent`/`try_for_each_concurrent`
+    /// child futures.
+    #[derive(Clone)]
+    pub struct ConcurrentDiagnostics {
+        state: Option<Arc<ConcurrentDiagnosticState>>,
+    }
+
+    impl ConcurrentDiagnostics {
+        /// Creates a diagnostics handle for one concurrent stream operator.
+        pub fn new(name: &'static str, module_path: &'static str, file: &'static str, line: u32) -> Self {
+            let state = enabled().then(|| {
+                Arc::new(ConcurrentDiagnosticState {
+                    name: name.to_owned(),
+                    location: location(module_path, file, line),
+                    started_at: Instant::now(),
+                    started: AtomicU64::new(0),
+                    completed: AtomicU64::new(0),
+                    dropped: AtomicU64::new(0),
+                    in_flight: AtomicU64::new(0),
+                    last_warn_nanos: AtomicU64::new(0),
+                })
+            });
+
+            Self { state }
+        }
+
+        /// Wraps one child future produced by a concurrent stream operator.
+        pub fn wrap<F>(&self, inner: F) -> ConcurrentDiagnosticFuture<F> {
+            if let Some(state) = &self.state {
+                state.started.fetch_add(1, Ordering::Relaxed);
+                state.in_flight.fetch_add(1, Ordering::Relaxed);
+            }
+
+            ConcurrentDiagnosticFuture {
+                inner,
+                state: self.state.clone(),
+                finished: AtomicBool::new(false),
+            }
+        }
+    }
+
+    /// Child-future wrapper for concurrent stream diagnostics.
+    #[must_use = "futures do nothing unless polled or awaited"]
+    pub struct ConcurrentDiagnosticFuture<F> {
+        inner: F,
+        state: Option<Arc<ConcurrentDiagnosticState>>,
+        finished: AtomicBool,
+    }
+
+    impl<F> ConcurrentDiagnosticFuture<F> {
+        fn mark_finished(&self, completed: bool) {
+            if self.finished.swap(true, Ordering::Relaxed) {
+                return;
+            }
+
+            let Some(state) = &self.state else {
+                return;
+            };
+
+            state.in_flight.fetch_sub(1, Ordering::Relaxed);
+            if completed {
+                let completed = state.completed.fetch_add(1, Ordering::Relaxed) + 1;
+                let cfg = config();
+                if completed >= cfg.warn_after {
+                    let elapsed = state.started_at.elapsed();
+                    if should_warn(&state.last_warn_nanos, elapsed, cfg.warn_every) {
+                        let started = state.started.load(Ordering::Relaxed);
+                        let dropped = state.dropped.load(Ordering::Relaxed);
+                        let in_flight = state.in_flight.load(Ordering::Relaxed);
+                        let completed_per_sec = completed as f64 / elapsed.as_secs_f64().max(0.001);
+                        warn_high_child_rate(
+                            &state.name,
+                            &state.location,
+                            started,
+                            completed,
+                            dropped,
+                            in_flight,
+                            elapsed,
+                            completed_per_sec,
+                        );
+                    }
+                }
+            } else {
+                state.dropped.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    impl<F: Future> Future for ConcurrentDiagnosticFuture<F> {
+        type Output = F::Output;
+
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            // SAFETY: `inner` is pinned in place as part of `self`; we never move it.
+            let this = unsafe { self.get_unchecked_mut() };
+
+            // SAFETY: see above; projecting only the pinned `inner` field.
+            match unsafe { Pin::new_unchecked(&mut this.inner) }.poll(cx) {
+                Poll::Ready(output) => {
+                    this.mark_finished(true);
+                    Poll::Ready(output)
+                }
+                Poll::Pending => Poll::Pending,
+            }
+        }
+    }
+
+    impl<F> Drop for ConcurrentDiagnosticFuture<F> {
+        fn drop(&mut self) {
+            self.mark_finished(false);
+        }
+    }
+}
+
 #[macro_export]
 macro_rules! spawn_as_abortable {
-    ($($expr:expr),*) => {{
-        let (proc, abort_handle) = $crate::runtime::prelude::abortable($($expr),*);
+    ($expr:expr $(,)?) => {{
+        let proc = $crate::runtime::diagnostics::instrument(
+            $expr,
+            concat!(module_path!(), "::abortable_task"),
+            module_path!(),
+            file!(),
+            line!(),
+        );
+        let (proc, abort_handle) = $crate::runtime::prelude::abortable(proc);
         let _jh = $crate::runtime::prelude::spawn(proc);
         abort_handle
-    }}
+    }};
+}
+
+#[macro_export]
+macro_rules! spawn_as_abortable_named {
+    ($name:expr, $expr:expr $(,)?) => {{
+        let proc = $crate::runtime::diagnostics::instrument($expr, $name, module_path!(), file!(), line!());
+        let (proc, abort_handle) = $crate::runtime::prelude::abortable(proc);
+        let _jh = $crate::runtime::prelude::spawn(proc);
+        abort_handle
+    }};
 }
 
 /// Abstraction over tasks that can be aborted (such as join or abort handles).

--- a/utils/src/runtime.rs
+++ b/utils/src/runtime.rs
@@ -353,14 +353,7 @@ pub mod diagnostics {
 #[macro_export]
 macro_rules! spawn_as_abortable {
     ($expr:expr $(,)?) => {{
-        let proc = $crate::runtime::diagnostics::instrument(
-            $expr,
-            concat!(module_path!(), "::abortable_task"),
-            module_path!(),
-            file!(),
-            line!(),
-        );
-        let (proc, abort_handle) = $crate::runtime::prelude::abortable(proc);
+        let (proc, abort_handle) = $crate::runtime::prelude::abortable($expr);
         let _jh = $crate::runtime::prelude::spawn(proc);
         abort_handle
     }};


### PR DESCRIPTION
Refs https://github.com/hoprnet/hoprd/issues/36

## moka::sync migration and send-failure cache semantics

- Swap `moka::future::Cache` for `moka::sync::Cache` for the per-peer
    `Sender` cache and the new per-peer open-lock cache. `moka::sync` runs
    maintenance inline during `get`/`insert`/`invalidate` calls instead of via
    the background scheduler / timer wheel that was the perf hotspot.
- Stop invalidating the cache on `SinkTimeoutError::Timeout`. Short
    backpressure stalls now keep the cached `Sender` alive; only genuine write
    errors (`SinkTimeoutError::Inner`) tear it down.
- Eagerly invalidate from the write task on termination. When
    `recv.forward(frame_writer)` ends (BrokenPipe, peer disconnect, etc.) the
    cache entry is dropped immediately, mirroring the existing read-side
    cleanup.

## Additional CPU hotspot fixes (from merged PR #8132)

Three further perf fixes for the 100% idle-CPU issue in the Linux Docker node:

1. **Path planner background refresh opt-in** — `BackgroundPathCacheRefreshable::start_background_refresh` is now called only when `background_refresh_period` is configured; was always spawning a busy-polling task regardless of config.

2. **MixerSink busy-spin eliminated** — `poll_flush` previously `continue`d the outer loop when `sleep_for == 0` (reachable when `inner.poll_ready` returned `Pending` earlier in the same poll), pegging the executor core. Fix: return `Poll::Pending` to delegate wake-up to the inner sink's already-registered waker.

3. **Counter-flush task yields between graph upserts** — the 15 s flush task ran `drain() + N * upsert_edge()` inside a synchronous `for_each` closure, blocking the tokio worker across N consecutive `parking_lot::RwLock::write()` acquisitions on the shared `ChannelGraph`. Fix: async closure with a runtime-agnostic `YieldNow` every 8 upserts. Also replaces `iter().filter_map().collect()` in `PeerProtocolCounterRegistry::drain()` with `DashMap::retain` so zero-count entries are evicted in place, keeping the map bounded to recently-active peers.

## Pipeline instrumentation revert and test fix

- **Remove instrumentation overhead** — `spawn_as_abortable_named\!` and `ConcurrentDiagnostics` wrappers added for debugging incurred ~1.5% pipeline overhead even with `HOPR_RUNTIME_POLL_DIAGNOSTICS` unset (one extra indirection per poll). Reverted the 5 pipeline processes to plain `spawn_as_abortable\!`; the `spawn_as_abortable_named\!` macro and `diagnostics` module remain available in `hopr-utils` for explicit opt-in.
- **Fix vacuous test assertion** — `per_peer_stream_should_not_reopen_pathologically_on_send_failures` now asserts `open_calls() >= 1` (stream was opened at least once) before asserting `open_calls() <= 1`, preventing the test from passing vacuously if the egress task never ran.
- **Tighten hopr-utils cfg gates** — composite `network-types-runtime-tokio` feature flag used consistently for `udp` module and `IpOrHost::resolve_tokio`; fixes incorrect `all(network-types, runtime-tokio)` gates.