### PR TITLE
fix(hopr-transport): eliminate CPU hotspot in path planner background refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3835,7 +3835,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.29.0"
+version = "0.29.1"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3892,7 +3892,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-mixer"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "bytesize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3835,7 +3835,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.29.1"
+version = "0.29.2"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3836,7 +3836,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.29.3"
+version = "0.29.4"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3835,7 +3835,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.28.2"
+version = "0.29.0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3476,11 +3476,12 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "ahash",
  "anyhow",
  "async-broadcast",
+ "async-lock",
  "async-trait",
  "atomic_enum",
  "blokli-client",
@@ -3561,7 +3562,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-ct-immediate"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "futures",
@@ -3835,7 +3836,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.29.2"
+version = "0.29.3"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3943,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-probe"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/impls/connector/Cargo.toml
+++ b/impls/connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-chain-connector"
-version = "0.20.0"
+version = "0.20.1"
 edition.workspace = true
 rust-version.workspace = true
 authors = ["HOPR Association <tech@hoprnet.org>"]
@@ -26,7 +26,8 @@ futures = { workspace = true }
 futures-time = { workspace = true }
 futures-concurrency = { workspace = true }
 hex = { workspace = true, optional = true }
-moka = { workspace = true, features = ["future", "sync"] }
+async-lock = { workspace = true }
+moka = { workspace = true, features = ["sync"] }
 parking_lot = { workspace = true }
 petgraph = { workspace = true, features = ["rayon", "graphmap"] }
 postcard = { workspace = true }

--- a/impls/connector/src/connector/mod.rs
+++ b/impls/connector/src/connector/mod.rs
@@ -13,7 +13,7 @@ use petgraph::prelude::DiGraphMap;
 
 use crate::{
     backend::Backend,
-    connector::{keys::HoprKeyMapper, sequencer::TransactionSequencer, values::CHAIN_INFO_CACHE_KEY},
+    connector::{keys::HoprKeyMapper, sequencer::TransactionSequencer},
     errors::ConnectorError,
     utils::{
         ParsedChainInfo, model_to_account_entry, model_to_graph_entry, model_to_ticket_params,
@@ -122,8 +122,8 @@ pub struct HoprBlockchainConnector<C, B, P, R> {
     channel_by_id: moka::sync::Cache<ChannelId, Option<ChannelEntry>, ahash::RandomState>,
     // Fast retrieval of channel entries by parties
     channel_by_parties: moka::sync::Cache<ChannelParties, Option<ChannelEntry>, ahash::RandomState>,
-    // Contains chain info (no TTL - kept fresh by subscription handler)
-    values: moka::future::Cache<u32, ParsedChainInfo>,
+    // Contains chain info (no TTL - kept fresh by subscription handler; reset only on reconnect)
+    values: std::sync::Arc<async_lock::OnceCell<parking_lot::RwLock<ParsedChainInfo>>>,
     // Ticket values (winning probability, price), kept fresh by subscription handler
     // Set only when connected
     ticket_values: std::sync::Arc<parking_lot::RwLock<Option<(WinningProbability, HoprBalance)>>>,
@@ -192,7 +192,7 @@ where
                 .time_to_idle(DEFAULT_CACHE_TIMEOUT)
                 .build_with_hasher(ahash::RandomState::default()),
             // No TTL: kept fresh by the Blokli subscription handler
-            values: moka::future::CacheBuilder::new(1).build(),
+            values: std::sync::Arc::new(async_lock::OnceCell::new()),
             ticket_values: Default::default(),
         }
     }
@@ -235,7 +235,7 @@ where
         let graph = self.graph.clone();
         let event_tx = self.events.0.clone();
         let me = self.chain_key.public().to_address();
-        let values_cache = self.values.clone();
+        let values_cell = self.values.clone();
 
         let chain_to_packet = self.chain_to_packet.clone();
         let packet_to_chain = self.packet_to_chain.clone();
@@ -360,47 +360,30 @@ where
                     }
                 })
                 .and_then(|(new_ticket_price, new_win_prob)| {
-                    let values_cache = values_cache.clone();
+                    let values_cell = values_cell.clone();
                     async move {
                         let mut events = Vec::<SubscribedEventType>::new();
-                        values_cache
-                            .entry(CHAIN_INFO_CACHE_KEY)
-                            .and_compute_with(|cached_entry| {
-                                futures::future::ready(match cached_entry {
-                                    Some(chain_info) => {
-                                        let mut chain_info = chain_info.into_value();
-                                        if chain_info.ticket_price != new_ticket_price {
-                                            events.push(SubscribedEventType::TicketPrice((
-                                                new_ticket_price,
-                                                Some(chain_info.ticket_price),
-                                            )));
-                                            chain_info.ticket_price = new_ticket_price;
-                                        }
-                                        if !chain_info.ticket_win_prob.approx_eq(&new_win_prob) {
-                                            events.push(SubscribedEventType::WinningProbability((
-                                                new_win_prob,
-                                                Some(chain_info.ticket_win_prob),
-                                            )));
-                                            chain_info.ticket_win_prob = new_win_prob;
-                                        }
-
-                                        if !events.is_empty() {
-                                            moka::ops::compute::Op::Put(chain_info)
-                                        } else {
-                                            moka::ops::compute::Op::Nop
-                                        }
-                                    }
-                                    None => {
-                                        tracing::warn!(
-                                            "chain info not present in the cache before ticket params update"
-                                        );
-                                        events.push(SubscribedEventType::TicketPrice((new_ticket_price, None)));
-                                        events.push(SubscribedEventType::WinningProbability((new_win_prob, None)));
-                                        moka::ops::compute::Op::Nop
-                                    }
-                                })
-                            })
-                            .await;
+                        if let Some(lock) = values_cell.get() {
+                            let mut chain_info = lock.write();
+                            if chain_info.ticket_price != new_ticket_price {
+                                events.push(SubscribedEventType::TicketPrice((
+                                    new_ticket_price,
+                                    Some(chain_info.ticket_price),
+                                )));
+                                chain_info.ticket_price = new_ticket_price;
+                            }
+                            if !chain_info.ticket_win_prob.approx_eq(&new_win_prob) {
+                                events.push(SubscribedEventType::WinningProbability((
+                                    new_win_prob,
+                                    Some(chain_info.ticket_win_prob),
+                                )));
+                                chain_info.ticket_win_prob = new_win_prob;
+                            }
+                        } else {
+                            tracing::warn!("chain info not present before ticket params update");
+                            events.push(SubscribedEventType::TicketPrice((new_ticket_price, None)));
+                            events.push(SubscribedEventType::WinningProbability((new_win_prob, None)));
+                        }
                         Ok(futures::stream::iter(events).map(Ok::<_, ConnectorError>))
                     }
                 })
@@ -677,7 +660,7 @@ impl<B, C, P, R> HoprBlockchainConnector<C, R, B, P> {
         self.channel_by_id.invalidate_all();
         self.packet_to_chain.invalidate_all();
         self.chain_to_packet.invalidate_all();
-        self.values.invalidate_all();
+        // `values` is a OnceCell — no TTL, never evicted; chain info stays valid across reconnects.
     }
 }
 

--- a/impls/connector/src/connector/values.rs
+++ b/impls/connector/src/connector/values.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use blokli_client::api::{BlokliQueryClient, RedeemedStatsSelector};
-use futures::TryFutureExt;
 use hopr_api::{
     chain::{ChainInfo, DomainSeparators, RedemptionStats},
     types::{internal::prelude::WinningProbability, primitive::prelude::*},
@@ -14,29 +13,25 @@ use crate::{
     utils::{ParsedChainInfo, model_to_chain_info, model_to_redeemed_stats},
 };
 
-pub(crate) const CHAIN_INFO_CACHE_KEY: u32 = 0;
-
 impl<B, C, P, R> HoprBlockchainConnector<C, R, B, P>
 where
     C: BlokliQueryClient + Send + Sync + 'static,
 {
     /// Queries chain info from cache, fetching from Blokli on cold start.
     ///
-    /// The cache has no TTL - it's kept fresh by the Blokli subscription handler
+    /// The cell has no TTL — it's kept fresh by the Blokli subscription handler
     /// which updates it whenever ticket parameters change. This prevents the
     /// cascading timeout issue where cache expiration during packet processing
     /// would trigger blocking Blokli queries.
     pub(crate) async fn query_cached_chain_info(&self) -> Result<ParsedChainInfo, ConnectorError> {
-        Ok(self
+        let lock = self
             .values
-            .try_get_with(
-                CHAIN_INFO_CACHE_KEY,
-                self.client
-                    .query_chain_info()
-                    .map_err(ConnectorError::from)
-                    .and_then(|model| futures::future::ready(model_to_chain_info(model))),
-            )
-            .await?)
+            .get_or_try_init(|| async {
+                let model = self.client.query_chain_info().await?;
+                model_to_chain_info(model).map(parking_lot::RwLock::new)
+            })
+            .await?;
+        Ok(lock.read().clone())
     }
 }
 

--- a/impls/ct/immediate/Cargo.toml
+++ b/impls/ct/immediate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-ct-immediate"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Basic implementation of the CT Telemetry functionality as specified in the HOPR RFCs describing the 0-hop probing."
 edition.workspace = true

--- a/impls/ct/immediate/src/lib.rs
+++ b/impls/ct/immediate/src/lib.rs
@@ -79,7 +79,7 @@ where
 {
     fn build(&self) -> BoxStream<'static, ProbeRouting> {
         // For each probe target a cached version of transport routing is stored
-        let cache_peer_routing: moka::future::Cache<OffchainPublicKey, ProbeRouting> = moka::future::Cache::builder()
+        let cache_peer_routing: moka::sync::Cache<OffchainPublicKey, ProbeRouting> = moka::sync::Cache::builder()
             .time_to_live(std::time::Duration::from_secs(600))
             .max_capacity(100_000)
             .build();
@@ -102,7 +102,7 @@ where
 
                 async move {
                     cache_peer_routing
-                        .try_get_with(peer, async move {
+                        .try_get_with(peer, || {
                             Ok::<ProbeRouting, anyhow::Error>(ProbeRouting::Neighbor(DestinationRouting::Forward {
                                 destination: Box::new(peer.into()),
                                 pseudonym: Some(HoprPseudonym::random()),
@@ -110,7 +110,6 @@ where
                                 return_options: Some(RoutingOptions::Hops(0.try_into().expect("0 is a valid u8"))),
                             }))
                         })
-                        .await
                         .ok()
                 }
             })

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport"
-version = "0.29.0"
+version = "0.29.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Implements the main HOPR transport interface for the core library"
 edition.workspace = true

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport"
-version = "0.29.4"
+version = "0.29.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Implements the main HOPR transport interface for the core library"
 edition.workspace = true

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport"
-version = "0.28.2"
+version = "0.29.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Implements the main HOPR transport interface for the core library"
 edition.workspace = true

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport"
-version = "0.29.1"
+version = "0.29.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Implements the main HOPR transport interface for the core library"
 edition.workspace = true

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport"
-version = "0.29.3"
+version = "0.29.4"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Implements the main HOPR transport interface for the core library"
 edition.workspace = true

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport"
-version = "0.29.2"
+version = "0.29.3"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Implements the main HOPR transport interface for the core library"
 edition.workspace = true

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -680,6 +680,7 @@ where
         let flush_graph = self.graph.clone();
         let flush_me = *self.packet_key.public();
         let flush_interval = self.cfg.counter_flush_interval;
+        tracing::info!(interval_ms = flush_interval.as_millis(), "counter flush task starting");
         processes.insert(
             HoprTransportProcess::CounterFlush,
             hopr_utils::spawn_as_abortable!(async move {

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -685,20 +685,51 @@ where
             hopr_utils::spawn_as_abortable!(async move {
                 use hopr_api::graph::traits::{EdgeObservableWrite, EdgeWeightType};
 
+                // One-shot yield: reschedules the task after every YIELD_EVERY upserts so
+                // graph readers (path selection, BFS, probe updates) can acquire the shared
+                // RwLock between writer acquisitions rather than being starved across the
+                // entire flush batch.
+                struct YieldNow(bool);
+                impl std::future::Future for YieldNow {
+                    type Output = ();
+
+                    fn poll(
+                        mut self: std::pin::Pin<&mut Self>,
+                        cx: &mut std::task::Context<'_>,
+                    ) -> std::task::Poll<()> {
+                        if self.0 {
+                            std::task::Poll::Ready(())
+                        } else {
+                            self.0 = true;
+                            cx.waker().wake_by_ref();
+                            std::task::Poll::Pending
+                        }
+                    }
+                }
+
+                const YIELD_EVERY: usize = 8;
+
                 futures_time::stream::interval(futures_time::time::Duration::from(flush_interval))
                     .for_each(|_| {
-                        for (peer, num_packets, num_acks) in flush_counters.drain() {
-                            tracing::trace!(
-                                %peer,
-                                num_packets,
-                                num_acks,
-                                "flushing protocol conformance counters"
-                            );
-                            flush_graph.upsert_edge(&flush_me, &peer, |obs| {
-                                obs.record(EdgeWeightType::ImmediateProtocolConformance { num_packets, num_acks });
-                            });
+                        let entries = flush_counters.drain();
+                        let fg = flush_graph.clone();
+                        async move {
+                            for (i, (peer, num_packets, num_acks)) in entries.into_iter().enumerate() {
+                                tracing::trace!(
+                                    %peer,
+                                    num_packets,
+                                    num_acks,
+                                    "flushing protocol conformance counters"
+                                );
+                                fg.upsert_edge(&flush_me, &peer, |obs| {
+                                    obs.record(EdgeWeightType::ImmediateProtocolConformance { num_packets, num_acks });
+                                });
+                                if (i + 1) % YIELD_EVERY == 0 {
+                                    YieldNow(false).await;
+                                }
+                            }
+                            YieldNow(false).await;
                         }
-                        futures::future::ready(())
                     })
                     .await;
             }),

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -512,12 +512,14 @@ where
 
         let mixing_channel_tx = hopr_transport_mixer::MixerSink::new(wire_msg_tx, build_mixer_cfg_from_env());
 
-        // -- path cache background refresh (only when tokio runtime is available)
+        // -- path cache background refresh (only when tokio runtime is available and configured)
         #[cfg(feature = "runtime-tokio")]
-        processes.insert(
-            HoprTransportProcess::PathRefresh,
-            hopr_utils::spawn_as_abortable!(self.path_planner.run_background_refresh()),
-        );
+        if let Some(period) = self.cfg.path_planner.background_refresh_period {
+            processes.insert(
+                HoprTransportProcess::PathRefresh,
+                hopr_utils::spawn_as_abortable!(self.path_planner.run_background_refresh(period)),
+            );
+        }
 
         processes.insert(
             HoprTransportProcess::Medium,

--- a/transport/hopr/src/path/mod.rs
+++ b/transport/hopr/src/path/mod.rs
@@ -5,9 +5,11 @@
 //!   network.
 //! - [`PathPlanner`]: Resolves `DestinationRouting` to `ResolvedTransportRouting`, delegating path discovery to any
 //!   [`PathSelector`][crate::path::traits::PathSelector] implementation and maintaining a `moka`-backed cache of
-//!   fully-validated `ValidatedPath` objects keyed by `(source, destination, options)`.
-//! - [`PathPlannerConfig`][crate::path::PathPlannerConfig]: Configuration for the planner's cache and background
-//!   refresh.
+//!   fully-validated `ValidatedPath` objects keyed by `(source, destination, options)`. Entries are evicted by
+//!   configurable TTL and TTI; an optional background refresh task can be spawned when
+//!   [`PathPlannerConfig::background_refresh_period`] is set.
+//! - [`PathPlannerConfig`][crate::path::PathPlannerConfig]: Configuration for the planner's cache (TTL, TTI, size cap)
+//!   and optional background refresh.
 
 pub mod errors;
 pub mod planner;

--- a/transport/hopr/src/path/mod.rs
+++ b/transport/hopr/src/path/mod.rs
@@ -7,7 +7,7 @@
 //!   [`PathSelector`][crate::path::traits::PathSelector] implementation and maintaining a `moka`-backed cache of
 //!   fully-validated `ValidatedPath` objects keyed by `(source, destination, options)`. Entries are evicted by
 //!   configurable TTL and TTI; an optional background refresh task can be spawned when
-//!   [`PathPlannerConfig::background_refresh_period`] is set.
+//!   [`crate::path::PathPlannerConfig::background_refresh_period`] is set.
 //! - [`PathPlannerConfig`][crate::path::PathPlannerConfig]: Configuration for the planner's cache (TTL, TTI, size cap)
 //!   and optional background refresh.
 

--- a/transport/hopr/src/path/planner.rs
+++ b/transport/hopr/src/path/planner.rs
@@ -28,19 +28,41 @@ lazy_static::lazy_static! {
     ).unwrap();
 }
 
+fn validate_planner_config(cfg: &PathPlannerConfig) -> std::result::Result<(), ValidationError> {
+    if let Some(period) = cfg.background_refresh_period {
+        if period >= cfg.cache_time_to_idle {
+            return Err(ValidationError::new(
+                "background_refresh_period must be strictly less than cache_time_to_idle",
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Configuration for [`PathPlanner`]'s internal path cache.
 #[derive(Debug, Clone, Copy, PartialEq, smart_default::SmartDefault, Validate)]
+#[validate(schema(function = "validate_planner_config"))]
 pub struct PathPlannerConfig {
     /// Maximum number of `(source, destination, options)` entries in the path cache.
     #[default = 10_000]
     pub max_cache_capacity: u64,
-    /// Time-to-live for a cached path list.  When an entry expires the next
-    /// [`PathPlanner::resolve_routing`] call transparently recomputes it (lazy refresh).
-    #[default(Duration::from_secs(60))]
-    pub cache_ttl: Duration,
-    /// Period between proactive background cache-refresh sweeps.
-    #[default(Duration::from_secs(30))]
-    pub refresh_period: Duration,
+    /// Absolute time-to-live for a cached entry, regardless of access frequency.
+    /// On expiry, the next [`PathPlanner::resolve_routing`] call transparently recomputes
+    /// the entry via the selector.
+    #[default(Duration::from_secs(15))]
+    pub cache_time_to_live: Duration,
+    /// Time-to-idle: evict an entry that has not been read for this long.
+    /// When background refresh is disabled, this is the primary eviction mechanism
+    /// for idle-traffic keys.
+    #[default(Duration::from_secs(5))]
+    pub cache_time_to_idle: Duration,
+    /// Optional period for the background cache-refresh task (via
+    /// [`BackgroundPathCacheRefreshable`]). `None` (default) disables the task entirely —
+    /// eviction is purely TTL + TTI driven. When `Some(period)`, the period must satisfy
+    /// `period < cache_time_to_idle`; callers are expected to only spawn the task when
+    /// this is `Some`.
+    #[default(None)]
+    pub background_refresh_period: Option<Duration>,
     /// Maximum number of candidate paths the selector may return per query.
     /// All returned candidates are validated and cached.
     #[default = 8]
@@ -85,8 +107,8 @@ type PlannerCacheValue = Arc<hopr_utils::statistics::WeightedCollection<Validate
 /// cache. On a cache hit a candidate is picked via weighted random selection (higher
 /// cost = higher quality = higher probability).
 ///
-/// A background sweep (`background_refresh`) can be spawned to
-/// proactively re-warm the cache for all previously-seen keys.
+/// An optional background refresh task (see [`BackgroundPathCacheRefreshable`]) can be
+/// spawned when [`PathPlannerConfig::background_refresh_period`] is configured.
 #[derive(Clone)]
 pub struct PathPlanner<Surb, R, S> {
     me: OffchainPublicKey,
@@ -94,7 +116,6 @@ pub struct PathPlanner<Surb, R, S> {
     resolver: Arc<R>,
     selector: Arc<S>,
     cache: moka::future::Cache<PlannerCacheKey, PlannerCacheValue>,
-    refresh_period: Duration,
 }
 
 impl<Surb, R, S> PathPlanner<Surb, R, S>
@@ -109,7 +130,8 @@ where
     pub fn new(me: OffchainPublicKey, surb_store: Surb, resolver: R, selector: S, config: PathPlannerConfig) -> Self {
         let cache = moka::future::Cache::builder()
             .max_capacity(config.max_cache_capacity)
-            .time_to_live(config.cache_ttl)
+            .time_to_live(config.cache_time_to_live)
+            .time_to_idle(config.cache_time_to_idle)
             .build();
 
         Self {
@@ -118,7 +140,6 @@ where
             resolver: Arc::new(resolver),
             selector: Arc::new(selector),
             cache,
-            refresh_period: config.refresh_period,
         }
     }
 
@@ -320,85 +341,83 @@ where
     R: ChainKeyOperations + ChainReadChannelOperations + Send + Sync + 'static,
     S: PathSelector + Send + Sync + 'static,
 {
-    /// Returns a future that runs the background path-cache refresh loop.
-    ///
-    /// The returned future iterates over all keys currently in the planner's cache
-    /// and recomputes their paths on a configurable schedule, so that steady-state
-    /// traffic is always served from cache.
-    fn run_background_refresh(&self) -> impl std::future::Future<Output = ()> + Send + 'static {
-        // Clone only the fields we need — avoids requiring R: Clone + S: Clone.
+    fn run_background_refresh(&self, period: Duration) -> impl std::future::Future<Output = ()> + Send + 'static {
+        // The returned future is `'static` — clone the three Arc fields once here,
+        // move them into the async block, then borrow inside the loop.
         let cache = self.cache.clone();
         let resolver = self.resolver.clone();
         let selector = self.selector.clone();
-        let refresh_period = self.refresh_period;
 
-        // run at a non-zero interval
-        futures_time::stream::interval(futures_time::time::Duration::from_millis(
-            refresh_period.as_millis() as u64 + 1u64,
-        ))
-        .for_each(move |_| {
-            let cache = cache.clone();
-            let resolver = resolver.clone();
-            let selector = selector.clone();
+        async move {
+            let mut ticker = futures_time::stream::interval(futures_time::time::Duration::from_millis(
+                period.as_millis() as u64 + 1u64,
+            ));
 
-            async move {
-                for (key, _) in cache.iter() {
-                    let (src, dest, hops_u32) = {
-                        let k = key.as_ref();
-                        (k.0, k.1, k.2)
-                    };
+            let chain_resolver = ChainPathResolver::from(&*resolver);
+            let selector_ref = &*selector;
+            let cache_ref = &cache;
 
+            while ticker.next().await.is_some() {
+                // Snapshot keys only; iter() yields (Arc<K>, V) — deref Arc<K> into the
+                // Copy PlannerCacheKey tuple and discard V immediately.
+                let keys: Vec<PlannerCacheKey> = cache_ref.iter().map(|(k, _v)| *k.as_ref()).collect();
+
+                for (src, dest, hops_u32) in keys {
                     if hops_u32 == 0 {
                         continue;
                     }
                     let hops_usize = hops_u32 as usize;
 
-                    let resolve_key = |node: NodeId| {
-                        let resolver = resolver.clone();
-
-                        async move {
-                            match node {
-                                NodeId::Offchain(k) => Some(k),
-                                NodeId::Chain(addr) => ChainPathResolver::from(&*resolver)
-                                    .resolve_transport_address(&addr)
-                                    .await
-                                    .ok()
-                                    .flatten(),
-                            }
-                        }
+                    let src_key = match src {
+                        NodeId::Offchain(k) => k,
+                        NodeId::Chain(addr) => match chain_resolver.resolve_transport_address(&addr).await {
+                            Ok(Some(k)) => k,
+                            _ => continue,
+                        },
+                    };
+                    let dest_key = match dest {
+                        NodeId::Offchain(k) => k,
+                        NodeId::Chain(addr) => match chain_resolver.resolve_transport_address(&addr).await {
+                            Ok(Some(k)) => k,
+                            _ => continue,
+                        },
                     };
 
-                    if let (Some(src_key), Some(dest_key)) = (resolve_key(src).await, resolve_key(dest).await)
-                        && let Ok(candidates) = selector.select_path(src_key, dest_key, hops_usize)
-                    {
-                        let chain_resolver = ChainPathResolver::from(&*resolver);
-                        let mut valid_paths: Vec<(ValidatedPath, f64)> = Vec::new();
-                        for pwc in candidates {
-                            let node_ids: Vec<NodeId> = pwc.path.into_iter().map(NodeId::Offchain).collect::<Vec<_>>();
-                            match ValidatedPath::new(src, node_ids, &chain_resolver).await {
-                                Ok(vp) => {
-                                    if vp.chain_path().iter().enumerate().any(|(i, a)| vp.chain_path()[..i].contains(a)) {
-                                        tracing::debug!(path = %vp, "background refresh: skipping candidate with repeated chain addresses");
-                                        continue;
-                                    }
-                                    valid_paths.push((vp, pwc.cost))
-                                }
-                                Err(e) => tracing::warn!(error = %e, "background refresh: path candidate failed validation"),
-                            }
-                        }
+                    let Ok(candidates) = selector_ref.select_path(src_key, dest_key, hops_usize) else {
+                        continue;
+                    };
 
-                        if !valid_paths.is_empty() {
-                            cache
-                                .insert(
-                                    (src, dest, hops_u32),
-                                    Arc::new(hopr_utils::statistics::WeightedCollection::new(valid_paths)),
-                                )
-                                .await;
+                    let mut valid_paths: Vec<(ValidatedPath, f64)> = Vec::with_capacity(candidates.len());
+                    for pwc in candidates {
+                        let node_ids: Vec<NodeId> = pwc.path.into_iter().map(NodeId::Offchain).collect();
+                        match ValidatedPath::new(src, node_ids, &chain_resolver).await {
+                            Ok(vp) => {
+                                if vp
+                                    .chain_path()
+                                    .iter()
+                                    .enumerate()
+                                    .any(|(i, a)| vp.chain_path()[..i].contains(a))
+                                {
+                                    tracing::debug!(path = %vp, "background refresh: skipping repeated chain addresses");
+                                    continue;
+                                }
+                                valid_paths.push((vp, pwc.cost));
+                            }
+                            Err(e) => tracing::warn!(error = %e, "background refresh: candidate failed validation"),
                         }
+                    }
+
+                    if !valid_paths.is_empty() {
+                        cache_ref
+                            .insert(
+                                (src, dest, hops_u32),
+                                Arc::new(hopr_utils::statistics::WeightedCollection::new(valid_paths)),
+                            )
+                            .await;
                     }
                 }
             }
-        })
+        }
     }
 }
 
@@ -590,8 +609,9 @@ mod tests {
     fn small_config() -> PathPlannerConfig {
         PathPlannerConfig {
             max_cache_capacity: 100,
-            cache_ttl: std::time::Duration::from_secs(60),
-            refresh_period: std::time::Duration::from_secs(60),
+            cache_time_to_live: std::time::Duration::from_secs(60),
+            cache_time_to_idle: std::time::Duration::from_secs(30),
+            background_refresh_period: None,
             max_cached_paths: 2,
             ..PathPlannerConfig::default()
         }
@@ -851,7 +871,38 @@ mod tests {
         let surb_store = hopr_protocol_hopr::MemorySurbStore::default();
 
         let planner = PathPlanner::new(me, surb_store, chain_api, selector, small_config());
-        // Just ensure it compiles and produces a future.
-        let _future = planner.run_background_refresh();
+        let _future = planner.run_background_refresh(std::time::Duration::from_secs(30));
+    }
+
+    #[test]
+    fn validate_rejects_refresh_period_geq_tti() {
+        use validator::Validate;
+
+        let bad = PathPlannerConfig {
+            background_refresh_period: Some(std::time::Duration::from_secs(5)),
+            cache_time_to_idle: std::time::Duration::from_secs(5),
+            ..PathPlannerConfig::default()
+        };
+        assert!(bad.validate().is_err(), "period == tti should fail validation");
+
+        let also_bad = PathPlannerConfig {
+            background_refresh_period: Some(std::time::Duration::from_secs(10)),
+            cache_time_to_idle: std::time::Duration::from_secs(5),
+            ..PathPlannerConfig::default()
+        };
+        assert!(also_bad.validate().is_err(), "period > tti should fail validation");
+
+        let ok = PathPlannerConfig {
+            background_refresh_period: Some(std::time::Duration::from_secs(4)),
+            cache_time_to_idle: std::time::Duration::from_secs(5),
+            ..PathPlannerConfig::default()
+        };
+        assert!(ok.validate().is_ok(), "period < tti should pass validation");
+    }
+
+    #[test]
+    fn validate_accepts_none_refresh_period() {
+        use validator::Validate;
+        assert!(PathPlannerConfig::default().validate().is_ok());
     }
 }

--- a/transport/hopr/src/path/planner.rs
+++ b/transport/hopr/src/path/planner.rs
@@ -115,7 +115,7 @@ pub struct PathPlanner<Surb, R, S> {
     pub surb_store: Surb,
     resolver: Arc<R>,
     selector: Arc<S>,
-    cache: moka::future::Cache<PlannerCacheKey, PlannerCacheValue>,
+    cache: moka::sync::Cache<PlannerCacheKey, PlannerCacheValue>,
 }
 
 impl<Surb, R, S> PathPlanner<Surb, R, S>
@@ -128,7 +128,7 @@ where
     ///
     /// `me` is this node's [`OffchainPublicKey`]; it is used as the source in path queries.
     pub fn new(me: OffchainPublicKey, surb_store: Surb, resolver: R, selector: S, config: PathPlannerConfig) -> Self {
-        let cache = moka::future::Cache::builder()
+        let cache = moka::sync::Cache::builder()
             .max_capacity(config.max_cache_capacity)
             .time_to_live(config.cache_time_to_live)
             .time_to_idle(config.cache_time_to_idle)
@@ -206,42 +206,42 @@ where
                 let resolver = self.resolver.clone();
                 let selector = self.selector.clone();
 
-                let paths = self
-                    .cache
-                    .try_get_with(cache_key, async move {
-                        trace!(hops = hops_usize, "path cache miss, querying selector");
-                        let candidates = selector.select_path(src_key, dest_key, hops_usize)?;
+                let paths = if let Some(cached) = self.cache.get(&cache_key) {
+                    cached
+                } else {
+                    trace!(hops = hops_usize, "path cache miss, querying selector");
+                    let candidates = selector.select_path(src_key, dest_key, hops_usize)?;
 
-                        let chain_resolver = ChainPathResolver::from(&*resolver);
-                        let mut valid_paths: Vec<(ValidatedPath, f64)> = Vec::new();
-                        for pwc in candidates {
-                            let node_ids: Vec<NodeId> = pwc.path.into_iter().map(NodeId::Offchain).collect::<Vec<_>>();
-                            match ValidatedPath::new(source, node_ids, &chain_resolver).await {
-                                Ok(vp) => {
-                                    // Post-resolution: catch non-adjacent chain-address duplicates
-                                    // (ValidatedPath::new only checks consecutive collisions).
-                                    if vp.chain_path().iter().enumerate().any(|(i, a)| vp.chain_path()[..i].contains(a)) {
-                                        tracing::debug!(path = %vp, "skipping path candidate with repeated chain addresses");
-                                        continue;
-                                    }
-                                    valid_paths.push((vp, pwc.cost))
+                    let chain_resolver = ChainPathResolver::from(&*resolver);
+                    let mut valid_paths: Vec<(ValidatedPath, f64)> = Vec::new();
+                    for pwc in candidates {
+                        let node_ids: Vec<NodeId> = pwc.path.into_iter().map(NodeId::Offchain).collect::<Vec<_>>();
+                        match ValidatedPath::new(source, node_ids, &chain_resolver).await {
+                            Ok(vp) => {
+                                // Post-resolution: catch non-adjacent chain-address duplicates
+                                // (ValidatedPath::new only checks consecutive collisions).
+                                if vp.chain_path().iter().enumerate().any(|(i, a)| vp.chain_path()[..i].contains(a)) {
+                                    tracing::debug!(path = %vp, "skipping path candidate with repeated chain addresses");
+                                    continue;
                                 }
-                                Err(e) => tracing::warn!(error = %e, "path candidate failed validation"),
+                                valid_paths.push((vp, pwc.cost))
                             }
+                            Err(e) => tracing::warn!(error = %e, "path candidate failed validation"),
                         }
+                    }
 
-                        if valid_paths.is_empty() {
-                            return Err(PathPlannerError::Path(PathError::PathNotFound(
-                                hops_usize,
-                                src_key.to_hex(),
-                                dest_key.to_hex(),
-                            )));
-                        }
+                    if valid_paths.is_empty() {
+                        return Err(PathPlannerError::Path(PathError::PathNotFound(
+                            hops_usize,
+                            src_key.to_hex(),
+                            dest_key.to_hex(),
+                        )));
+                    }
 
-                        Ok(Arc::new(hopr_utils::statistics::WeightedCollection::new(valid_paths)))
-                    })
-                    .await
-                    .map_err(PathPlannerError::CacheError)?;
+                    let paths = Arc::new(hopr_utils::statistics::WeightedCollection::new(valid_paths));
+                    self.cache.insert(cache_key, paths.clone());
+                    paths
+                };
 
                 paths.pick_one().ok_or_else(|| {
                     PathPlannerError::Path(PathError::PathNotFound(hops_usize, src_key.to_hex(), dest_key.to_hex()))
@@ -408,12 +408,10 @@ where
                     }
 
                     if !valid_paths.is_empty() {
-                        cache_ref
-                            .insert(
-                                (src, dest, hops_u32),
-                                Arc::new(hopr_utils::statistics::WeightedCollection::new(valid_paths)),
-                            )
-                            .await;
+                        cache_ref.insert(
+                            (src, dest, hops_u32),
+                            Arc::new(hopr_utils::statistics::WeightedCollection::new(valid_paths)),
+                        );
                     }
                 }
             }
@@ -794,7 +792,7 @@ mod tests {
         let cache_key: PlannerCacheKey = (NodeId::Offchain(me), NodeId::Offchain(dest), 1);
 
         assert!(
-            planner.cache.get(&cache_key).await.is_none(),
+            planner.cache.get(&cache_key).is_none(),
             "cache should be empty before first call"
         );
 
@@ -806,7 +804,7 @@ mod tests {
         };
         planner.resolve_routing(100, 0, routing).await.expect("should succeed");
 
-        let cached = planner.cache.get(&cache_key).await;
+        let cached = planner.cache.get(&cache_key);
         assert!(cached.is_some(), "cache should be populated after first call");
         let paths = cached.unwrap();
         assert!(!paths.is_empty(), "cached paths must be non-empty");

--- a/transport/hopr/src/path/traits.rs
+++ b/transport/hopr/src/path/traits.rs
@@ -43,14 +43,15 @@ pub trait PathSelector {
 
 /// A selector that can run a background path-cache refresh loop.
 ///
-/// Implementors pre-warm their internal caches on a periodic schedule,
-/// so that steady-state traffic is always served without a blocking query.
-///
-/// The returned future is `'static` because it is intended to be
-/// spawned as a long-lived background task.
+/// The returned future is `'static` because it is intended to be spawned as a
+/// long-lived background task. Callers should only spawn it when the deployment
+/// opts in via [`crate::path::PathPlannerConfig::background_refresh_period`].
 pub trait BackgroundPathCacheRefreshable: Send + Sync {
-    /// Returns a future that runs the periodic cache-refresh loop.
+    /// Returns a future that runs a periodic cache-refresh loop at the given `period`.
     ///
     /// The future never completes under normal operation.
-    fn run_background_refresh(&self) -> impl std::future::Future<Output = ()> + Send + 'static;
+    fn run_background_refresh(
+        &self,
+        period: std::time::Duration,
+    ) -> impl std::future::Future<Output = ()> + Send + 'static;
 }

--- a/transport/hopr/src/protocol/counters.rs
+++ b/transport/hopr/src/protocol/counters.rs
@@ -67,18 +67,21 @@ impl PeerProtocolCounterRegistry {
     }
 
     /// Swap all counters to 0, returning `(peer, msgs_sent, acks_received)` for non-zero entries.
+    ///
+    /// Entries with zero activity since the last call are evicted from the map so the map
+    /// stays bounded to peers that have been recently active.
     pub fn drain(&self) -> Vec<(OffchainPublicKey, u64, u64)> {
-        self.inner
-            .iter()
-            .filter_map(|entry| {
-                let (sent, received) = entry.value().take();
-                if sent > 0 || received > 0 {
-                    Some((*entry.key(), sent, received))
-                } else {
-                    None
-                }
-            })
-            .collect()
+        let mut result = Vec::new();
+        self.inner.retain(|key, counters| {
+            let (sent, received) = counters.take();
+            if sent > 0 || received > 0 {
+                result.push((*key, sent, received));
+                true
+            } else {
+                false
+            }
+        });
+        result
     }
 }
 
@@ -198,5 +201,30 @@ mod tests {
 
         let second_drain = registry.drain();
         assert!(second_drain.is_empty(), "counters should be zero after drain");
+    }
+
+    #[test]
+    fn drain_should_evict_zero_count_entries() {
+        let registry = PeerProtocolCounterRegistry::default();
+        let keys: Vec<_> = (0..100).map(|_| *OffchainKeypair::random().public()).collect();
+
+        // Insert 100 entries with no traffic recorded; drain must return empty and evict all.
+        for k in &keys {
+            registry.get_or_create(k);
+        }
+        let drained = registry.drain();
+        assert!(drained.is_empty());
+        assert_eq!(registry.inner.len(), 0, "zero-count entries must be evicted");
+
+        // Insert 100 entries, record traffic on half; drain must return only the active half.
+        for k in &keys {
+            registry.get_or_create(k);
+        }
+        for k in &keys[..50] {
+            registry.get_or_create(k).record_message_sent();
+        }
+        let drained = registry.drain();
+        assert_eq!(drained.len(), 50);
+        assert_eq!(registry.inner.len(), 50, "only the active subset must remain");
     }
 }

--- a/transport/hopr/src/protocol/counters.rs
+++ b/transport/hopr/src/protocol/counters.rs
@@ -59,6 +59,9 @@ pub struct PeerProtocolCounterRegistry {
 impl PeerProtocolCounterRegistry {
     /// Get or create counters for the given peer.
     pub fn get_or_create(&self, peer: &OffchainPublicKey) -> Arc<PeerProtocolCounters> {
+        if let Some(entry) = self.inner.get(peer) {
+            return entry.clone();
+        }
         self.inner
             .entry(*peer)
             .or_insert_with(|| Arc::new(PeerProtocolCounters::default()))
@@ -72,15 +75,28 @@ impl PeerProtocolCounterRegistry {
     /// stays bounded to peers that have been recently active.
     pub fn drain(&self) -> Vec<(OffchainPublicKey, u64, u64)> {
         let mut result = Vec::new();
-        self.inner.retain(|key, counters| {
-            let (sent, received) = counters.take();
+        let mut to_evict: Vec<OffchainPublicKey> = Vec::new();
+
+        // Phase 1: shared read lock per shard — atomic-swap counters, collect non-zero results.
+        // `PeerProtocolCounters::take()` uses internal atomics and is safe under a read lock.
+        for entry in self.inner.iter() {
+            let (sent, received) = entry.value().take();
             if sent > 0 || received > 0 {
-                result.push((*key, sent, received));
-                true
+                result.push((*entry.key(), sent, received));
             } else {
-                false
+                to_evict.push(*entry.key());
             }
-        });
+        }
+
+        // Phase 2: exclusive write lock per shard, but only for entries that were zero.
+        // Re-check before removing: a concurrent `get_or_create` + record may have
+        // incremented the counter between our `take()` and this removal.
+        for key in to_evict {
+            self.inner.remove_if(&key, |_, c| {
+                c.messages_sent.load(Ordering::Relaxed) == 0 && c.acks_received.load(Ordering::Relaxed) == 0
+            });
+        }
+
         result
     }
 }

--- a/transport/hopr/src/protocol/pipeline/mod.rs
+++ b/transport/hopr/src/protocol/pipeline/mod.rs
@@ -31,7 +31,7 @@ const DEFAULT_ACK_INPUT_CONCURRENCY: usize = 10;
 /// Default concurrency for the outgoing acknowledgement processing pipeline when not overridden
 /// via [`AcknowledgementPipelineConfig::ack_output_concurrency`].
 const DEFAULT_ACK_OUTPUT_CONCURRENCY: usize = 10;
-const QUEUE_SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(50);
+const QUEUE_SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(25);
 const PACKET_DECODING_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(150);
 const PACKET_ENCODING_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(150);
 

--- a/transport/hopr/src/protocol/stream.rs
+++ b/transport/hopr/src/protocol/stream.rs
@@ -32,7 +32,7 @@ const GLOBAL_STREAM_OPEN_TIMEOUT: std::time::Duration = std::time::Duration::fro
 
 /// Timeout for sending a single message into the per-peer mpsc buffer.
 /// If the buffer stays full for longer than this, the message is dropped.
-const DEFAULT_PER_PEER_SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(50);
+const DEFAULT_PER_PEER_SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(25);
 const MAX_CONCURRENT_PACKETS: usize = 30;
 
 /// Default pending-write-buffer byte threshold on the framed writer before a flush is

--- a/transport/mixer/Cargo.toml
+++ b/transport/mixer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-mixer"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition.workspace = true
 rust-version.workspace = true

--- a/transport/mixer/src/sink.rs
+++ b/transport/mixer/src/sink.rs
@@ -118,7 +118,12 @@ where
             let sleep_for = next_release.saturating_duration_since(now);
 
             if sleep_for.is_zero() {
-                continue;
+                // Reachable only because inner.poll_ready returned Pending earlier in
+                // this poll (we pushed the item back with release_at = now). The inner
+                // sink already registered its waker via that poll_ready call, and any
+                // items it had buffered were flushed by the poll_flush call above —
+                // delegate to the lower sink's wake-up signal and yield.
+                return Poll::Pending;
             }
 
             this.timer.reset(sleep_for);

--- a/transport/probe/Cargo.toml
+++ b/transport/probe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-probe"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition.workspace = true
 rust-version.workspace = true
@@ -22,7 +22,7 @@ async-trait = { workspace = true }
 futures = { workspace = true }
 futures-concurrency = { workspace = true }
 hex = { workspace = true }
-moka = { workspace = true, features = ["future"] }
+moka = { workspace = true, features = ["sync"] }
 rand = { workspace = true, features = ["std"] }
 serde = { workspace = true }
 humantime-serde = { workspace = true }

--- a/transport/probe/src/probe.rs
+++ b/transport/probe/src/probe.rs
@@ -43,8 +43,8 @@ pub enum ProbeDispatch {
 /// are yielded to the caller.
 #[derive(Clone)]
 pub struct ProbeClassifierState<G> {
-    active_neighbor_probes: moka::future::Cache<CacheNeighborKey, CacheNeighborValue>,
-    active_path_probes: moka::future::Cache<Tag, (PathTelemetry, Arc<AllocatedTag>)>,
+    active_neighbor_probes: moka::sync::Cache<CacheNeighborKey, CacheNeighborValue>,
+    active_path_probes: moka::sync::Cache<Tag, (PathTelemetry, Arc<AllocatedTag>)>,
     network_graph: G,
 }
 
@@ -68,7 +68,7 @@ where
     {
         let tag: Tag = in_data.data.application_tag;
 
-        if let Some((path_telemetry, _allocated_tag)) = self.active_path_probes.remove(&tag).await {
+        if let Some((path_telemetry, _allocated_tag)) = self.active_path_probes.remove(&tag) {
             tracing::debug!(%tag, "loopback probe successfully received");
             self.network_graph
                 .record_edge::<NeighborTelemetry, PathTelemetry>(hopr_api::graph::MeasurableEdge::Probe(Ok(
@@ -105,7 +105,6 @@ where
                         if let Some((peer, start, replier)) = self
                             .active_neighbor_probes
                             .remove(&(pseudonym, NeighborProbe::Ping(pong)))
-                            .await
                         {
                             let latency = current_time().as_unix_timestamp().saturating_sub(start);
 
@@ -209,80 +208,56 @@ impl Probe {
         let network_graph_internal_neighbor = network_graph.clone();
         let network_graph_internal_path = network_graph.clone();
         let timeout = self.cfg.timeout;
-        let active_neighbor_probes: moka::future::Cache<CacheNeighborKey, CacheNeighborValue> =
-            moka::future::Cache::builder()
+        let active_neighbor_probes: moka::sync::Cache<CacheNeighborKey, CacheNeighborValue> =
+            moka::sync::Cache::builder()
                 .time_to_live(timeout)
                 .max_capacity(100_000)
-                .async_eviction_listener(
-                    move |k: Arc<CacheNeighborKey>,
-                          v: CacheNeighborValue,
-                          cause|
-                          -> moka::notification::ListenerFuture {
-                        if matches!(cause, moka::notification::RemovalCause::Expired) {
-                            // If the eviction cause is expiration => record as a failed probe
-                            let store = network_graph_internal_neighbor.clone();
-                            let (peer, _start, notifier) = v;
+                .eviction_listener(move |k: Arc<CacheNeighborKey>, v: CacheNeighborValue, cause| {
+                    if matches!(cause, moka::notification::RemovalCause::Expired) {
+                        // If the eviction cause is expiration => record as a failed probe
+                        let store = network_graph_internal_neighbor.clone();
+                        let (peer, _start, notifier) = v;
 
-                            tracing::debug!(%peer, pseudonym = %k.0, probe = %k.1, reason = "timeout", "neighbor probe failed");
-                            if let Some(replier) = notifier {
-                                if matches!(peer.as_ref(), NodeId::Offchain(_)) {
-                                    replier.notify(Err(()));
-                                } else {
-                                    tracing::warn!(
-                                        reason = "non-offchain peer",
-                                        "cannot notify timeout for non-offchain peer"
-                                    );
-                                }
-                            };
-
-                            if let NodeId::Offchain(opk) = peer.as_ref() {
-                                let opk: OffchainPublicKey = *opk;
-                                store
-                                    .record_edge::<NeighborTelemetry, PathTelemetry>(
-                                        hopr_api::graph::MeasurableEdge::Probe(Err(
-                                            NetworkGraphError::ProbeNeighborTimeout(Box::new(opk)),
-                                        )),
-                                    );
-                                futures::FutureExt::boxed(futures::future::ready(()))
-
+                        tracing::debug!(%peer, pseudonym = %k.0, probe = %k.1, reason = "timeout", "neighbor probe failed");
+                        if let Some(replier) = notifier {
+                            if matches!(peer.as_ref(), NodeId::Offchain(_)) {
+                                replier.notify(Err(()));
                             } else {
-                                futures::FutureExt::boxed(futures::future::ready(()))
+                                tracing::warn!(
+                                    reason = "non-offchain peer",
+                                    "cannot notify timeout for non-offchain peer"
+                                );
                             }
-                        } else {
-                            // If the eviction cause is not expiration, nothing needs to be done
-                            futures::FutureExt::boxed(futures::future::ready(()))
+                        };
+
+                        if let NodeId::Offchain(opk) = peer.as_ref() {
+                            let opk: OffchainPublicKey = *opk;
+                            store.record_edge::<NeighborTelemetry, PathTelemetry>(
+                                hopr_api::graph::MeasurableEdge::Probe(Err(
+                                    NetworkGraphError::ProbeNeighborTimeout(Box::new(opk)),
+                                )),
+                            );
                         }
-                    },
-                )
+                    }
+                })
                 .build();
 
-        let active_path_probes: moka::future::Cache<Tag, (PathTelemetry, Arc<AllocatedTag>)> =
-            moka::future::Cache::builder()
+        let active_path_probes: moka::sync::Cache<Tag, (PathTelemetry, Arc<AllocatedTag>)> =
+            moka::sync::Cache::builder()
                 .time_to_live(timeout)
                 .max_capacity(100_000)
-                .async_eviction_listener(
-                    move |tag: Arc<Tag>,
-                          (path, _allocated_tag): (PathTelemetry, Arc<AllocatedTag>),
-                          cause|
-                          -> moka::notification::ListenerFuture {
-                        if matches!(cause, moka::notification::RemovalCause::Expired) {
-                            // If the eviction cause is expiration => record as a failed probe
-                            let store = network_graph_internal_path.clone();
+                .eviction_listener(move |tag: Arc<Tag>, (path, _allocated_tag): (PathTelemetry, Arc<AllocatedTag>), cause| {
+                    if matches!(cause, moka::notification::RemovalCause::Expired) {
+                        // If the eviction cause is expiration => record as a failed probe
+                        let store = network_graph_internal_path.clone();
 
-                            tracing::debug!(%tag, reason = "timeout", "loopback probe failed");
+                        tracing::debug!(%tag, reason = "timeout", "loopback probe failed");
 
-                            store.record_edge::<NeighborTelemetry, PathTelemetry>(
-                                hopr_api::graph::MeasurableEdge::Probe(Err(NetworkGraphError::ProbeLoopbackTimeout(
-                                    path,
-                                ))),
-                            );
-                            futures::FutureExt::boxed(futures::future::ready(()))
-                        } else {
-                            // If the eviction cause is not expiration, nothing needs to be done
-                            futures::FutureExt::boxed(futures::future::ready(()))
-                        }
-                    },
-                )
+                        store.record_edge::<NeighborTelemetry, PathTelemetry>(
+                            hopr_api::graph::MeasurableEdge::Probe(Err(NetworkGraphError::ProbeLoopbackTimeout(path))),
+                        );
+                    }
+                })
                 .build();
 
         let push_to_network = api_out.clone();
@@ -356,16 +331,14 @@ impl Probe {
                                         if let Err(_error) = push_to_network.send((routing, data)).await {
                                             tracing::error!("failed to send out a ping");
                                         } else {
-                                            active_neighbor_probes
-                                                .insert(
-                                                    (
-                                                        pseudonym
-                                                            .expect("the pseudonym must be present in Forward routing"),
-                                                        nonce,
-                                                    ),
-                                                    (destination, current_time().as_unix_timestamp(), notifier),
-                                                )
-                                                .await;
+                                            active_neighbor_probes.insert(
+                                                (
+                                                    pseudonym
+                                                        .expect("the pseudonym must be present in Forward routing"),
+                                                    nonce,
+                                                ),
+                                                (destination, current_time().as_unix_timestamp(), notifier),
+                                            );
                                         }
                                     } else {
                                         tracing::error!("failed to convert ping message into data");
@@ -414,8 +387,7 @@ impl Probe {
                                                 // the object is constructed above, so will always match
                                                 if let Message::Telemetry(telemetry) = message {
                                                     active_path_probes
-                                                        .insert(tag_value.into(), (telemetry, Arc::new(allocated_tag)))
-                                                        .await;
+                                                    .insert(tag_value.into(), (telemetry, Arc::new(allocated_tag)));
                                                 }
                                             }
                                         } else {

--- a/utils/src/network_types/mod.rs
+++ b/utils/src/network_types/mod.rs
@@ -2,7 +2,7 @@
 pub mod errors;
 
 /// Contains UDP socket-related helpers.
-#[cfg(all(feature = "network-types", feature = "runtime-tokio"))]
+#[cfg(feature = "network-types-runtime-tokio")]
 pub mod udp;
 
 /// Contains various networking-related types
@@ -21,7 +21,7 @@ pub mod timeout;
 pub mod prelude {
     pub use libp2p_identity::PeerId;
 
-    #[cfg(all(feature = "network-types", feature = "runtime-tokio"))]
+    #[cfg(feature = "network-types-runtime-tokio")]
     pub use super::udp::*;
     pub use super::{addr::*, types::*};
 }

--- a/utils/src/network_types/types.rs
+++ b/utils/src/network_types/types.rs
@@ -70,23 +70,16 @@ impl IpOrHost {
     /// If this enum is already an IP address and port, it will simply return it.
     ///
     /// Uses `tokio` resolver.
-    #[cfg(all(feature = "network-types", feature = "runtime-tokio"))]
+    #[cfg(feature = "network-types-runtime-tokio")]
     pub async fn resolve_tokio(self) -> std::io::Result<Vec<std::net::SocketAddr>> {
         match self {
             IpOrHost::Dns(name, port) => {
-                #[cfg(test)]
                 let resolver = hickory_resolver::Resolver::builder_with_config(
                     hickory_resolver::config::ResolverConfig::default(),
                     hickory_resolver::net::runtime::TokioRuntimeProvider::default(),
                 )
                 .build()
                 .map_err(std::io::Error::other)?;
-
-                #[cfg(not(test))]
-                let resolver = hickory_resolver::Resolver::builder_tokio()
-                    .map_err(std::io::Error::other)?
-                    .build()
-                    .map_err(std::io::Error::other)?;
 
                 let lookup = resolver.lookup_ip(&name).await.map_err(std::io::Error::other)?;
                 Ok(lookup.iter().map(|ip| std::net::SocketAddr::new(ip, port)).collect())
@@ -268,12 +261,12 @@ impl std::fmt::Display for SealedHost {
 #[cfg(test)]
 mod tests {
     use hopr_types::crypto::prelude::{Keypair, OffchainKeypair};
-    #[cfg(all(feature = "network-types", feature = "runtime-tokio"))]
+    #[cfg(feature = "network-types-runtime-tokio")]
     use {anyhow::anyhow, std::net::SocketAddr};
 
     use super::*;
 
-    #[cfg(all(feature = "network-types", feature = "runtime-tokio"))]
+    #[cfg(feature = "network-types-runtime-tokio")]
     #[tokio::test]
     async fn ip_or_host_must_resolve_dns_name() -> anyhow::Result<()> {
         match IpOrHost::Dns("localhost".to_string(), 1000)
@@ -288,7 +281,7 @@ mod tests {
         Ok(())
     }
 
-    #[cfg(all(feature = "network-types", feature = "runtime-tokio"))]
+    #[cfg(feature = "network-types-runtime-tokio")]
     #[tokio::test]
     async fn ip_or_host_must_resolve_ip_address() -> anyhow::Result<()> {
         let actual = IpOrHost::Ip("127.0.0.1:1000".parse()?).resolve_tokio().await?;

--- a/utils/src/runtime.rs
+++ b/utils/src/runtime.rs
@@ -125,7 +125,8 @@ pub mod diagnostics {
 
         #[cfg(not(feature = "runtime-tokio"))]
         eprintln!(
-            "high-frequency polling detected: task={name} location={location} total_polls={total_polls} elapsed_ms={} polls_per_sec={polls_per_sec}",
+            "high-frequency polling detected: task={name} location={location} total_polls={total_polls} elapsed_ms={} \
+             polls_per_sec={polls_per_sec}",
             elapsed.as_millis()
         );
     }
@@ -155,7 +156,9 @@ pub mod diagnostics {
 
         #[cfg(not(feature = "runtime-tokio"))]
         eprintln!(
-            "high-frequency concurrent child churn detected: task={name} location={location} started={started} completed={completed} dropped={dropped} in_flight={in_flight} elapsed_ms={} completed_per_sec={completed_per_sec}",
+            "high-frequency concurrent child churn detected: task={name} location={location} started={started} \
+             completed={completed} dropped={dropped} in_flight={in_flight} elapsed_ms={} \
+             completed_per_sec={completed_per_sec}",
             elapsed.as_millis()
         );
     }

--- a/utils/src/runtime.rs
+++ b/utils/src/runtime.rs
@@ -124,7 +124,7 @@ pub mod diagnostics {
         );
 
         #[cfg(not(feature = "runtime-tokio"))]
-        eprintln!(
+        tracing::warn!(
             "high-frequency polling detected: task={name} location={location} total_polls={total_polls} elapsed_ms={} \
              polls_per_sec={polls_per_sec}",
             elapsed.as_millis()
@@ -155,7 +155,7 @@ pub mod diagnostics {
         );
 
         #[cfg(not(feature = "runtime-tokio"))]
-        eprintln!(
+        tracing::warn!(
             "high-frequency concurrent child churn detected: task={name} location={location} started={started} \
              completed={completed} dropped={dropped} in_flight={in_flight} elapsed_ms={} \
              completed_per_sec={completed_per_sec}",


### PR DESCRIPTION
## Summary

Three perf fixes for the 100% idle-CPU issue in the Linux Docker node:

1. **Path planner background refresh opt-in** — `BackgroundPathCacheRefreshable::start_background_refresh` is now called only when `background_refresh_period` is configured; was always spawning a busy-polling task regardless of config.

2. **MixerSink busy-spin eliminated** — `poll_flush` previously `continue`d the outer loop when `sleep_for == 0` (reachable when `inner.poll_ready` returned `Pending` earlier in the same poll), pegging the executor core. Fix: return `Poll::Pending` to delegate wake-up to the inner sink's already-registered waker.

3. **Counter-flush task yields between graph upserts** — the 15 s flush task ran `drain() + N * upsert_edge()` inside a synchronous `for_each` closure, blocking the tokio worker across N consecutive `parking_lot::RwLock::write()` acquisitions on the shared `ChannelGraph`. Fix: async closure with a runtime-agnostic `YieldNow` every 8 upserts. Also replaces `iter().filter_map().collect()` in `PeerProtocolCounterRegistry::drain()` with `DashMap::retain` so zero-count entries are evicted in place, keeping the map bounded to recently-active peers.

Closes #8134

## Test plan

- `cargo nextest run --lib -p hopr-transport-mixer` — mixer sink tests pass
- `cargo nextest run --lib -p hopr-transport --features runtime-tokio` — 78/78 counter + path + codec tests pass including new `drain_should_evict_zero_count_entries`
- `cargo nextest run -p hopr-transport --test protocol_counters_graph_integration --features runtime-tokio -j 1` — 3/3 integration tests pass