### PR TITLE
refactor(deps): drop hopr-lib as a dependency where it could be replaced by hopr-api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3784,7 +3784,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-strategy"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3796,8 +3796,6 @@ dependencies = [
  "hex-literal",
  "hopr-api",
  "hopr-chain-connector",
- "hopr-lib",
- "hopr-types",
  "hopr-utils",
  "humantime-serde",
  "insta",

--- a/impls/graph/src/petgraph/algorithm.rs
+++ b/impls/graph/src/petgraph/algorithm.rs
@@ -36,10 +36,10 @@ use petgraph::{
 /// * `graph`: an input graph.
 /// * `from`: an initial node of desired paths.
 /// * `to`: a `HashSet` of target nodes. A path is yielded as soon as it reaches any node in this set.
-/// * `excluded_nodes`: an optional set of nodes to exclude from all returned paths. Excluded nodes are
-///   pre-seeded into the visited set so the DFS never enters a branch containing them. Passing `Some(&empty)`
-///   or `None` is equivalent to the default behavior (no exclusions). If `from` is in the excluded set, it
-///   is ignored — the source is always reachable.
+/// * `excluded_nodes`: an optional set of nodes to exclude from all returned paths. Excluded nodes are pre-seeded into
+///   the visited set so the DFS never enters a branch containing them. Passing `Some(&empty)` or `None` is equivalent
+///   to the default behavior (no exclusions). If `from` is in the excluded set, it is ignored — the source is always
+///   reachable.
 /// * `min_intermediate_nodes`: the minimum number of nodes in the desired paths.
 /// * `max_intermediate_nodes`: the maximum number of nodes in the desired paths (optional).
 /// * `initial_cost`: the starting cost value before any edges are traversed.
@@ -588,7 +588,15 @@ mod test {
 
         // ── Without exclusions ─────────────────────────────────────────────
         let all_paths: Vec<(Vec<NodeIndex>, i32)> = all_simple_paths_multi::<_, _, RandomState, _, _>(
-            &graph, src, &targets, None, 0, None, 0, None, |c, _, _| c,
+            &graph,
+            src,
+            &targets,
+            None,
+            0,
+            None,
+            0,
+            None,
+            |c, _, _| c,
         )
         .collect();
 
@@ -611,7 +619,15 @@ mod test {
         // ── With excluded_nodes = {2} ──────────────────────────────────────
         let excluded: HashSet<NodeIndex, RandomState> = HashSet::from_iter([NodeIndex::from(2u32)]);
         let restricted: Vec<(Vec<NodeIndex>, i32)> = all_simple_paths_multi::<_, _, RandomState, _, _>(
-            &graph, src, &targets, Some(&excluded), 0, None, 0, None, |c, _, _| c,
+            &graph,
+            src,
+            &targets,
+            Some(&excluded),
+            0,
+            None,
+            0,
+            None,
+            |c, _, _| c,
         )
         .collect();
 
@@ -620,7 +636,10 @@ mod test {
         assert_eq!(restricted.len(), 5, "expected 5 paths when node 2 is excluded");
 
         for (path, _) in &restricted {
-            assert!(!path.contains(&NodeIndex::from(2u32)), "excluded node 2 in path: {path:?}");
+            assert!(
+                !path.contains(&NodeIndex::from(2u32)),
+                "excluded node 2 in path: {path:?}"
+            );
             let unique: HashSet<&NodeIndex, RandomState> = path.iter().collect();
             assert_eq!(unique.len(), path.len(), "duplicate node in path: {path:?}");
         }
@@ -632,7 +651,10 @@ mod test {
             .collect();
         for (path, _) in &restricted {
             let as_usize: Vec<usize> = path.iter().map(|n| n.index()).collect();
-            assert!(all_set.contains(&as_usize), "restricted path not in all-paths: {path:?}");
+            assert!(
+                all_set.contains(&as_usize),
+                "restricted path not in all-paths: {path:?}"
+            );
         }
     }
 

--- a/impls/strategy/Cargo.toml
+++ b/impls/strategy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-strategy"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Contains implementations of different HOPR strategies"
 edition.workspace = true
@@ -15,8 +15,8 @@ crate-type = ["rlib"]
 
 [features]
 default = []
-runtime-tokio = ["hopr-lib/runtime-tokio", "hopr-utils/runtime-tokio"]
-telemetry = ["hopr-types/telemetry"]
+runtime-tokio = ["hopr-utils/runtime-tokio"]
+telemetry = ["hopr-api/types-telemetry"]
 ## Strategy features — each enables one strategy implementation.
 strategy-auto-funding = []
 strategy-auto-redeeming = []
@@ -39,8 +39,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 validator = { workspace = true }
 
-hopr-lib = { workspace = true }
-hopr-types = { workspace = true }
+hopr-api = { workspace = true, features = ["node", "serde"] }
 hopr-utils = { workspace = true }
 moka = { workspace = true, features = ["sync"] }
 parking_lot = { workspace = true }
@@ -48,7 +47,6 @@ parking_lot = { workspace = true }
 [dev-dependencies]
 chrono = { workspace = true }
 hex-literal = { workspace = true }
-hopr-lib = { workspace = true, features = ["runtime-tokio"] }
 hopr-utils = { workspace = true, features = ["runtime-tokio"] }
 hopr-chain-connector = { workspace = true, features = [
   "testing",

--- a/impls/strategy/src/auto_funding.rs
+++ b/impls/strategy/src/auto_funding.rs
@@ -18,7 +18,7 @@ use std::{
 use async_trait::async_trait;
 use dashmap::DashSet;
 use futures::StreamExt;
-use hopr_lib::api::{
+use hopr_api::{
     chain::{
         ChainReadChannelOperations, ChainReadSafeOperations, ChainValues, ChainWriteChannelOperations, ChannelSelector,
         SafeSelector,
@@ -38,10 +38,10 @@ use crate::{errors::StrategyError, strategy::Strategy as StrategyTrait};
 
 #[cfg(all(feature = "telemetry", not(test)))]
 lazy_static::lazy_static! {
-    static ref METRIC_COUNT_AUTO_FUNDINGS: hopr_types::telemetry::SimpleCounter =
-        hopr_types::telemetry::SimpleCounter::new("hopr_strategy_auto_funding_funding_count", "Count of initiated automatic fundings").unwrap();
-    static ref METRIC_COUNT_AUTO_FUNDING_FAILURES: hopr_types::telemetry::SimpleCounter =
-        hopr_types::telemetry::SimpleCounter::new("hopr_strategy_auto_funding_failure_count", "Count of failed automatic funding attempts").unwrap();
+    static ref METRIC_COUNT_AUTO_FUNDINGS: hopr_api::types::telemetry::SimpleCounter =
+        hopr_api::types::telemetry::SimpleCounter::new("hopr_strategy_auto_funding_funding_count", "Count of initiated automatic fundings").unwrap();
+    static ref METRIC_COUNT_AUTO_FUNDING_FAILURES: hopr_api::types::telemetry::SimpleCounter =
+        hopr_api::types::telemetry::SimpleCounter::new("hopr_strategy_auto_funding_failure_count", "Count of failed automatic funding attempts").unwrap();
 }
 
 fn validate_funding_amount(amount: &HoprBalance) -> std::result::Result<(), ValidationError> {
@@ -287,7 +287,7 @@ where
         + 'static,
 {
     async fn run(&mut self) -> crate::errors::Result<()> {
-        use hopr_lib::api::{chain::ChainEvent, node::ActionableEvent};
+        use hopr_api::{chain::ChainEvent, node::ActionableEvent};
 
         enum Event {
             Tick,
@@ -399,8 +399,7 @@ mod tests {
     use futures::StreamExt;
     use futures_time::future::FutureExt;
     use hex_literal::hex;
-    use hopr_chain_connector::{create_trustful_hopr_blokli_connector, testing::BlokliTestStateBuilder};
-    use hopr_lib::api::{
+    use hopr_api::{
         chain::{
             AccountSelector, ChainEvent, ChainEvents, ChainReadAccountOperations, ChainWriteAccountOperations,
             HoprChainApi,
@@ -415,6 +414,7 @@ mod tests {
             primitive::prelude::{Address, BytesRepresentable, HoprBalance, XDaiBalance},
         },
     };
+    use hopr_chain_connector::{create_trustful_hopr_blokli_connector, testing::BlokliTestStateBuilder};
 
     use super::*;
 

--- a/impls/strategy/src/auto_redeeming.rs
+++ b/impls/strategy/src/auto_redeeming.rs
@@ -12,7 +12,7 @@ use std::{
 
 use async_trait::async_trait;
 use futures::{StreamExt, TryStreamExt};
-use hopr_lib::api::{
+use hopr_api::{
     chain::{ChainEvent, ChainReadChannelOperations, ChainWriteTicketOperations, ChannelSelector},
     node::{
         ActionableEvent, ActionableEventDiscriminant, ActionableEventSource, HasChainApi, HasTicketManagement,
@@ -42,8 +42,8 @@ const REDEMPTION_TIMEOUT: Duration = Duration::from_secs(300);
 
 #[cfg(all(feature = "telemetry", not(test)))]
 lazy_static::lazy_static! {
-    static ref METRIC_COUNT_AUTO_REDEEMS:  hopr_types::telemetry::SimpleCounter =
-         hopr_types::telemetry::SimpleCounter::new("hopr_strategy_auto_redeem_redeem_count", "Count of initiated automatic redemptions").unwrap();
+    static ref METRIC_COUNT_AUTO_REDEEMS:  hopr_api::types::telemetry::SimpleCounter =
+         hopr_api::types::telemetry::SimpleCounter::new("hopr_strategy_auto_redeem_redeem_count", "Count of initiated automatic redemptions").unwrap();
 }
 
 fn min_redeem_hopr() -> HoprBalance {
@@ -405,25 +405,23 @@ mod tests {
     use futures_time::future::FutureExt as TimeExt;
     use hex_literal::hex;
     use hopr_api::{
-        tickets::{ChannelStats, RedemptionResult},
-        types::crypto_random::Randomizable,
-    };
-    use hopr_chain_connector::{HoprBlockchainSafeConnector, create_trustful_hopr_blokli_connector, testing::*};
-    use hopr_lib::api::{
         chain::{ChainEvent, ChainEvents, ChainWriteTicketOperations, HoprChainApi},
         node::{
             ActionableEvent, ComponentStatus, ComponentStatusReporter, EventWaitResult, HasChainApi,
             HasTicketManagement, NodeOnchainIdentity, TicketEvent,
         },
+        tickets::{ChannelStats, RedemptionResult},
         types::{
             crypto::{
                 keypairs::Keypair,
                 prelude::{ChainKeypair, HalfKey, Hash, Response},
             },
+            crypto_random::Randomizable,
             internal::prelude::{RedeemableTicket, TicketBuilder, WinningProbability},
             primitive::prelude::{Address, BytesRepresentable, HoprBalance, UnitaryFloatOps, XDaiBalance},
         },
     };
+    use hopr_chain_connector::{HoprBlockchainSafeConnector, create_trustful_hopr_blokli_connector, testing::*};
 
     use super::*;
 

--- a/impls/strategy/src/channel_finalizer.rs
+++ b/impls/strategy/src/channel_finalizer.rs
@@ -7,7 +7,7 @@ use std::{
 
 use async_trait::async_trait;
 use futures::StreamExt;
-use hopr_lib::api::{
+use hopr_api::{
     chain::{ChainReadChannelOperations, ChainWriteChannelOperations, ChannelSelector},
     node::HasChainApi,
     types::{internal::prelude::ChannelStatusDiscriminants, primitive::prelude::Utc},
@@ -20,7 +20,7 @@ use crate::{errors, strategy::Strategy as StrategyTrait};
 
 #[cfg(all(feature = "telemetry", not(test)))]
 lazy_static::lazy_static! {
-    static ref METRIC_COUNT_CLOSURE_FINALIZATIONS: hopr_types::telemetry::SimpleCounter = hopr_types::telemetry::SimpleCounter::new(
+    static ref METRIC_COUNT_CLOSURE_FINALIZATIONS: hopr_api::types::telemetry::SimpleCounter = hopr_api::types::telemetry::SimpleCounter::new(
         "hopr_strategy_closure_auto_finalization_count",
         "Count of channels where closure finalizing was initiated automatically"
     )
@@ -165,8 +165,7 @@ mod tests {
     use futures::StreamExt;
     use futures_time::future::FutureExt;
     use hex_literal::hex;
-    use hopr_chain_connector::{create_trustful_hopr_blokli_connector, testing::BlokliTestStateBuilder};
-    use hopr_lib::api::{
+    use hopr_api::{
         chain::{ChainEvent, ChainEvents, HoprChainApi},
         node::{ComponentStatus, ComponentStatusReporter, EventWaitResult, HasChainApi, NodeOnchainIdentity},
         types::{
@@ -175,6 +174,7 @@ mod tests {
             primitive::prelude::{Address, BytesRepresentable, HoprBalance, XDaiBalance},
         },
     };
+    use hopr_chain_connector::{create_trustful_hopr_blokli_connector, testing::BlokliTestStateBuilder};
     use lazy_static::lazy_static;
 
     use super::*;

--- a/impls/strategy/src/channel_lifecycle/config.rs
+++ b/impls/strategy/src/channel_lifecycle/config.rs
@@ -1,6 +1,6 @@
 use std::{collections::HashSet, time::Duration};
 
-use hopr_lib::api::types::primitive::prelude::{Address, HoprBalance};
+use hopr_api::types::primitive::prelude::{Address, HoprBalance};
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
 use validator::Validate;

--- a/impls/strategy/src/channel_lifecycle/events.rs
+++ b/impls/strategy/src/channel_lifecycle/events.rs
@@ -3,7 +3,7 @@
 
 use std::time::Instant;
 
-use hopr_lib::api::{
+use hopr_api::{
     chain::{
         ChainReadAccountOperations, ChainReadChannelOperations, ChainReadSafeOperations, ChainValues,
         ChainWriteChannelOperations,

--- a/impls/strategy/src/channel_lifecycle/mod.rs
+++ b/impls/strategy/src/channel_lifecycle/mod.rs
@@ -66,7 +66,7 @@ mod strategy;
 use std::{collections::HashMap, sync::Arc, time::Instant};
 
 use dashmap::{DashMap, DashSet};
-use hopr_lib::api::{
+use hopr_api::{
     PeerId,
     types::{
         crypto::prelude::OffchainPublicKey,
@@ -79,23 +79,23 @@ pub use strategy::ChannelLifecycleStrategy;
 
 #[cfg(all(feature = "telemetry", not(test)))]
 lazy_static::lazy_static! {
-    static ref METRIC_CHANNEL_OPENS: hopr_types::telemetry::SimpleCounter =
-        hopr_types::telemetry::SimpleCounter::new(
+    static ref METRIC_CHANNEL_OPENS: hopr_api::types::telemetry::SimpleCounter =
+        hopr_api::types::telemetry::SimpleCounter::new(
             "hopr_strategy_channel_lifecycle_opens",
             "Count of initiated channel opens",
         ).unwrap();
-    static ref METRIC_CHANNEL_FUNDS: hopr_types::telemetry::SimpleCounter =
-        hopr_types::telemetry::SimpleCounter::new(
+    static ref METRIC_CHANNEL_FUNDS: hopr_api::types::telemetry::SimpleCounter =
+        hopr_api::types::telemetry::SimpleCounter::new(
             "hopr_strategy_channel_lifecycle_fundings",
             "Count of initiated channel fundings",
         ).unwrap();
-    static ref METRIC_CHANNEL_CLOSES: hopr_types::telemetry::SimpleCounter =
-        hopr_types::telemetry::SimpleCounter::new(
+    static ref METRIC_CHANNEL_CLOSES: hopr_api::types::telemetry::SimpleCounter =
+        hopr_api::types::telemetry::SimpleCounter::new(
             "hopr_strategy_channel_lifecycle_closes",
             "Count of initiated channel closures",
         ).unwrap();
-    static ref METRIC_CHANNEL_FINALIZES: hopr_types::telemetry::SimpleCounter =
-        hopr_types::telemetry::SimpleCounter::new(
+    static ref METRIC_CHANNEL_FINALIZES: hopr_api::types::telemetry::SimpleCounter =
+        hopr_api::types::telemetry::SimpleCounter::new(
             "hopr_strategy_channel_lifecycle_finalizations",
             "Count of initiated channel closure finalizations",
         ).unwrap();

--- a/impls/strategy/src/channel_lifecycle/pipeline.rs
+++ b/impls/strategy/src/channel_lifecycle/pipeline.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use futures::StreamExt as _;
-use hopr_lib::api::{
+use hopr_api::{
     PeerId,
     chain::{
         AccountSelector, ChainReadAccountOperations, ChainReadChannelOperations, ChainReadSafeOperations, ChainValues,
@@ -696,8 +696,7 @@ mod tests {
     use dashmap::DashMap;
     use futures::StreamExt as _;
     use hex_literal::hex;
-    use hopr_chain_connector::{create_trustful_hopr_blokli_connector, testing::BlokliTestStateBuilder};
-    use hopr_lib::api::{
+    use hopr_api::{
         PeerId,
         chain::{
             AccountSelector, ChainEvent, ChainEvents, ChainReadAccountOperations, ChainReadChannelOperations,
@@ -716,6 +715,7 @@ mod tests {
             primitive::prelude::{Address, BytesRepresentable, HoprBalance, XDaiBalance},
         },
     };
+    use hopr_chain_connector::{create_trustful_hopr_blokli_connector, testing::BlokliTestStateBuilder};
 
     // `super` here is `pipeline`; `super::super` is `channel_lifecycle`.
     // Private items (ChannelLifecycleStrategyInner) are accessible from descendant modules.
@@ -788,12 +788,12 @@ mod tests {
 
     struct StubNetworkView;
 
-    impl hopr_lib::api::network::NetworkView for StubNetworkView {
-        fn listening_as(&self) -> HashSet<hopr_lib::api::Multiaddr> {
+    impl hopr_api::network::NetworkView for StubNetworkView {
+        fn listening_as(&self) -> HashSet<hopr_api::Multiaddr> {
             HashSet::new()
         }
 
-        fn multiaddress_of(&self, _peer: &PeerId) -> Option<HashSet<hopr_lib::api::Multiaddr>> {
+        fn multiaddress_of(&self, _peer: &PeerId) -> Option<HashSet<hopr_api::Multiaddr>> {
             None
         }
 
@@ -809,13 +809,13 @@ mod tests {
             false
         }
 
-        fn health(&self) -> hopr_lib::api::network::Health {
-            hopr_lib::api::network::Health::Red
+        fn health(&self) -> hopr_api::network::Health {
+            hopr_api::network::Health::Red
         }
 
         fn subscribe_network_events(
             &self,
-        ) -> impl futures::Stream<Item = hopr_lib::api::network::NetworkEvent> + Send + 'static {
+        ) -> impl futures::Stream<Item = hopr_api::network::NetworkEvent> + Send + 'static {
             futures::stream::pending()
         }
     }
@@ -838,7 +838,7 @@ mod tests {
 
     struct StubGraph;
 
-    impl hopr_lib::api::graph::NetworkGraphView for StubGraph {
+    impl hopr_api::graph::NetworkGraphView for StubGraph {
         type NodeId = OffchainPublicKey;
         type Observed = StubEdge;
 
@@ -861,15 +861,15 @@ mod tests {
         fn identity(&self) -> &OffchainPublicKey {
             static KEY: std::sync::OnceLock<OffchainPublicKey> = std::sync::OnceLock::new();
             KEY.get_or_init(|| {
-                use hopr_lib::api::types::crypto::keypairs::Keypair as _;
-                *hopr_lib::api::types::crypto::prelude::OffchainKeypair::from_secret(&[1u8; 32])
+                use hopr_api::types::crypto::keypairs::Keypair as _;
+                *hopr_api::types::crypto::prelude::OffchainKeypair::from_secret(&[1u8; 32])
                     .expect("test key")
                     .public()
             })
         }
     }
 
-    impl hopr_lib::api::graph::NetworkGraphConnectivity for StubGraph {
+    impl hopr_api::graph::NetworkGraphConnectivity for StubGraph {
         type NodeId = OffchainPublicKey;
         type Observed = StubEdge;
 
@@ -882,11 +882,11 @@ mod tests {
         }
     }
 
-    impl hopr_lib::api::graph::NetworkGraphTraverse for StubGraph {
+    impl hopr_api::graph::NetworkGraphTraverse for StubGraph {
         type NodeId = OffchainPublicKey;
         type Observed = StubEdge;
 
-        fn simple_paths<V: hopr_lib::api::graph::ValueFn<Weight = StubEdge>>(
+        fn simple_paths<V: hopr_api::graph::ValueFn<Weight = StubEdge>>(
             &self,
             _source: &OffchainPublicKey,
             _destination: &OffchainPublicKey,
@@ -897,7 +897,7 @@ mod tests {
             Vec::new()
         }
 
-        fn simple_paths_from<V: hopr_lib::api::graph::ValueFn<Weight = StubEdge>>(
+        fn simple_paths_from<V: hopr_api::graph::ValueFn<Weight = StubEdge>>(
             &self,
             _source: &OffchainPublicKey,
             _length: usize,
@@ -918,7 +918,7 @@ mod tests {
 
     struct StubEdge;
 
-    impl hopr_lib::api::graph::EdgeObservableRead for StubEdge {
+    impl hopr_api::graph::EdgeObservableRead for StubEdge {
         type ImmediateMeasurement = StubMeasurement;
         type IntermediateMeasurement = StubMeasurement;
 
@@ -939,14 +939,14 @@ mod tests {
         }
     }
 
-    impl hopr_lib::api::graph::traits::EdgeObservableWrite for StubEdge {
-        fn record(&mut self, _measurement: hopr_lib::api::graph::traits::EdgeWeightType) {}
+    impl hopr_api::graph::traits::EdgeObservableWrite for StubEdge {
+        fn record(&mut self, _measurement: hopr_api::graph::traits::EdgeWeightType) {}
     }
 
     struct StubMeasurement;
 
-    impl hopr_lib::api::graph::EdgeLinkObservable for StubMeasurement {
-        fn record(&mut self, _: hopr_lib::api::graph::traits::EdgeTransportMeasurement) {}
+    impl hopr_api::graph::EdgeLinkObservable for StubMeasurement {
+        fn record(&mut self, _: hopr_api::graph::traits::EdgeTransportMeasurement) {}
 
         fn average_latency(&self) -> Option<Duration> {
             None
@@ -961,19 +961,19 @@ mod tests {
         }
     }
 
-    impl hopr_lib::api::graph::traits::EdgeNetworkObservableRead for StubMeasurement {
+    impl hopr_api::graph::traits::EdgeNetworkObservableRead for StubMeasurement {
         fn is_connected(&self) -> bool {
             false
         }
     }
 
-    impl hopr_lib::api::graph::EdgeImmediateProtocolObservable for StubMeasurement {
+    impl hopr_api::graph::EdgeImmediateProtocolObservable for StubMeasurement {
         fn ack_rate(&self) -> Option<f64> {
             None
         }
     }
 
-    impl hopr_lib::api::graph::traits::EdgeProtocolObservable for StubMeasurement {
+    impl hopr_api::graph::traits::EdgeProtocolObservable for StubMeasurement {
         fn capacity(&self) -> Option<u128> {
             None
         }
@@ -1540,7 +1540,11 @@ mod tests {
         let result = inner.try_open_channel(*ALICE, HoprBalance::from(10_u32));
 
         // Should return Some(topup_balance) (fund tx submitted) and clear open_in_flight.
-        assert_eq!(result, Some(topup_balance), "try_open_channel should return Some(topup_balance) when delegating to fund");
+        assert_eq!(
+            result,
+            Some(topup_balance),
+            "try_open_channel should return Some(topup_balance) when delegating to fund"
+        );
         assert!(inner.open_in_flight.is_empty(), "open_in_flight must be cleared");
 
         // Wait for the fund tx to confirm.
@@ -1597,7 +1601,11 @@ mod tests {
         let inner = fresh_inner_with_chain(cfg, Arc::clone(&connector));
 
         let result = inner.try_open_channel(*ALICE, initial_balance);
-        assert_eq!(result, Some(initial_balance), "try_open_channel should return Some(initial_balance) for a fresh channel");
+        assert_eq!(
+            result,
+            Some(initial_balance),
+            "try_open_channel should return Some(initial_balance) for a fresh channel"
+        );
 
         // Wait for the open tx to confirm.
         tokio::time::sleep(Duration::from_secs(1)).await;

--- a/impls/strategy/src/channel_lifecycle/strategy.rs
+++ b/impls/strategy/src/channel_lifecycle/strategy.rs
@@ -9,7 +9,7 @@ use std::{
 use async_trait::async_trait;
 use dashmap::{DashMap, DashSet};
 use futures::StreamExt as _;
-use hopr_lib::api::{
+use hopr_api::{
     chain::{
         ChainEvent, ChainReadAccountOperations, ChainReadChannelOperations, ChainReadSafeOperations, ChainValues,
         ChainWriteChannelOperations,

--- a/impls/strategy/src/errors.rs
+++ b/impls/strategy/src/errors.rs
@@ -1,4 +1,4 @@
-use hopr_lib::api::types::primitive::errors::GeneralError;
+use hopr_api::types::primitive::errors::GeneralError;
 use thiserror::Error;
 
 /// Enumerates all errors in this crate.

--- a/transport/hopr/src/path/planner.rs
+++ b/transport/hopr/src/path/planner.rs
@@ -1,19 +1,19 @@
 use std::{sync::Arc, time::Duration};
 
 use futures::{StreamExt as _, TryStreamExt, stream::FuturesUnordered};
-use hopr_api::chain::{ChainKeyOperations, ChainPathResolver, ChainReadChannelOperations};
-use hopr_crypto_packet::prelude::*;
-use hopr_protocol_hopr::{FoundSurb, SurbStore};
 #[cfg(all(feature = "telemetry", not(test)))]
 use hopr_api::types::internal::path::Path;
 use hopr_api::{
     OffchainPublicKey,
+    chain::{ChainKeyOperations, ChainPathResolver, ChainReadChannelOperations},
     types::{
         crypto::crypto_traits::Randomizable,
         internal::{errors::PathError, prelude::*},
         primitive::traits::ToHex,
     },
 };
+use hopr_crypto_packet::prelude::*;
+use hopr_protocol_hopr::{FoundSurb, SurbStore};
 use tracing::trace;
 use validator::{Validate, ValidationError};
 
@@ -372,7 +372,9 @@ where
                             let node_ids: Vec<NodeId> = pwc.path.into_iter().map(NodeId::Offchain).collect::<Vec<_>>();
                             match ValidatedPath::new(src, node_ids, &chain_resolver).await {
                                 Ok(vp) => valid_paths.push((vp, pwc.cost)),
-                                Err(e) => tracing::debug!(error = %e, "background refresh: path candidate failed validation"),
+                                Err(e) => {
+                                    tracing::debug!(error = %e, "background refresh: path candidate failed validation")
+                                }
                             }
                         }
 
@@ -404,13 +406,13 @@ mod tests {
             NetworkGraphWrite,
             traits::{EdgeObservableWrite, EdgeWeightType},
         },
+        types::{
+            crypto::prelude::{Keypair, OffchainKeypair},
+            internal::channels::{ChannelEntry, ChannelStatus, generate_channel_id},
+            primitive::prelude::*,
+        },
     };
     use hopr_network_graph::ChannelGraph;
-    use hopr_api::types::{
-        crypto::prelude::{Keypair, OffchainKeypair},
-        internal::channels::{ChannelEntry, ChannelStatus, generate_channel_id},
-        primitive::prelude::*,
-    };
 
     use super::*;
     use crate::path::selector::HoprGraphPathSelector;

--- a/transport/hopr/src/path/selector.rs
+++ b/transport/hopr/src/path/selector.rs
@@ -1,7 +1,8 @@
-use hopr_api::graph::{
-    NetworkGraphTraverse, NetworkGraphView, ValueFn, function::EdgeValueFn, traits::EdgeObservableRead,
+use hopr_api::{
+    OffchainPublicKey,
+    graph::{NetworkGraphTraverse, NetworkGraphView, ValueFn, function::EdgeValueFn, traits::EdgeObservableRead},
+    types::internal::errors::PathError,
 };
-use hopr_api::{OffchainPublicKey, types::internal::errors::PathError};
 
 use super::{
     errors::{PathPlannerError, Result},
@@ -248,15 +249,17 @@ mod tests {
 
     use anyhow::Context;
     use hex_literal::hex;
-    use hopr_api::graph::{
-        NetworkGraphWrite,
-        traits::{EdgeObservableWrite, EdgeWeightType},
+    use hopr_api::{
+        graph::{
+            NetworkGraphWrite,
+            traits::{EdgeObservableWrite, EdgeWeightType},
+        },
+        types::{
+            crypto::prelude::{Keypair, OffchainKeypair},
+            internal::routing::RoutingOptions,
+        },
     };
     use hopr_network_graph::ChannelGraph;
-    use hopr_api::types::{
-        crypto::prelude::{Keypair, OffchainKeypair},
-        internal::routing::RoutingOptions,
-    };
 
     use super::*;
     use crate::path::{PathPlannerConfig, traits::PathSelector};

--- a/transport/hopr/src/protocol/pipeline/mod.rs
+++ b/transport/hopr/src/protocol/pipeline/mod.rs
@@ -557,49 +557,48 @@ async fn start_relay_incoming_ack_pipeline<AckIn, T, TEvt>(
             let ticket_proc = ticket_proc.clone();
             let mut ticket_evt = ticket_events.clone();
             async move {
-                    tracing::trace!(num = acks.len(), "received acknowledgements");
-                    match hopr_utils::parallelize::cpu::spawn_fifo_blocking(
-                        move || ticket_proc.acknowledge_tickets(peer, acks),
-                        "ack_decode",
-                    )
-                    .await
-                    {
-                        Ok(Ok(resolutions)) if !resolutions.is_empty() => {
-                            let resolutions_iter = resolutions.into_iter().filter_map(|resolution| match resolution {
-                                ResolvedAcknowledgement::RelayingWin(redeemable_ticket) => {
-                                    tracing::trace!("received ack for a winning ticket");
-                                    Some(Ok(TicketEvent::WinningTicket(redeemable_ticket)))
-                                }
-                                ResolvedAcknowledgement::RelayingLoss(_) => {
-                                    // Losing tickets are not getting accounted for anywhere.
-                                    tracing::trace!("received ack for a losing ticket");
-                                    None
-                                }
-                            });
-
-                            // All acknowledgements that resulted in winning tickets go upstream
-                            if let Err(error) = ticket_evt.send_all(&mut futures::stream::iter(resolutions_iter)).await
-                            {
-                                tracing::error!(%error, "failed to notify ticket resolutions");
+                tracing::trace!(num = acks.len(), "received acknowledgements");
+                match hopr_utils::parallelize::cpu::spawn_fifo_blocking(
+                    move || ticket_proc.acknowledge_tickets(peer, acks),
+                    "ack_decode",
+                )
+                .await
+                {
+                    Ok(Ok(resolutions)) if !resolutions.is_empty() => {
+                        let resolutions_iter = resolutions.into_iter().filter_map(|resolution| match resolution {
+                            ResolvedAcknowledgement::RelayingWin(redeemable_ticket) => {
+                                tracing::trace!("received ack for a winning ticket");
+                                Some(Ok(TicketEvent::WinningTicket(redeemable_ticket)))
                             }
-                        }
-                        Ok(Ok(_)) => {
-                            tracing::debug!("acknowledgement batch could not acknowledge any ticket");
-                        }
-                        Ok(Err(TicketAcknowledgementError::UnexpectedAcknowledgement)) => {
-                            // Unexpected acknowledgements naturally happen
-                            // as acknowledgements of 0-hop packets
-                            tracing::trace!("received unexpected acknowledgement");
-                        }
-                        Ok(Err(error)) => {
-                            tracing::error!(%error, "failed to acknowledge ticket");
-                        }
-                        Err(error) => {
-                            tracing::error!(%error, "parallel processing of the incoming acknowledgements failed")
+                            ResolvedAcknowledgement::RelayingLoss(_) => {
+                                // Losing tickets are not getting accounted for anywhere.
+                                tracing::trace!("received ack for a losing ticket");
+                                None
+                            }
+                        });
+
+                        // All acknowledgements that resulted in winning tickets go upstream
+                        if let Err(error) = ticket_evt.send_all(&mut futures::stream::iter(resolutions_iter)).await {
+                            tracing::error!(%error, "failed to notify ticket resolutions");
                         }
                     }
+                    Ok(Ok(_)) => {
+                        tracing::debug!("acknowledgement batch could not acknowledge any ticket");
+                    }
+                    Ok(Err(TicketAcknowledgementError::UnexpectedAcknowledgement)) => {
+                        // Unexpected acknowledgements naturally happen
+                        // as acknowledgements of 0-hop packets
+                        tracing::trace!("received unexpected acknowledgement");
+                    }
+                    Ok(Err(error)) => {
+                        tracing::error!(%error, "failed to acknowledge ticket");
+                    }
+                    Err(error) => {
+                        tracing::error!(%error, "parallel processing of the incoming acknowledgements failed")
+                    }
                 }
-                .instrument(tracing::debug_span!("incoming_ack_batch", peer = peer.to_peerid_str()))
+            }
+            .instrument(tracing::debug_span!("incoming_ack_batch", peer = peer.to_peerid_str()))
         })
         .in_current_span()
         .await;

--- a/utils-session/src/lib.rs
+++ b/utils-session/src/lib.rs
@@ -323,6 +323,9 @@ where
     }
 
     fn routing_from_cfg(&self, cfg: &Self::Cfg) -> Result<(Routing, Routing), anyhow::Error> {
+        // `.into()` is a no-op when explicit-path is off (Routing = HopRouting) but
+        // required when explicit-path is on (Routing = RoutingOptions).
+        #[allow(clippy::useless_conversion)]
         Ok((cfg.forward_path.into(), cfg.return_path.into()))
     }
 

--- a/utils/src/runtime.rs
+++ b/utils/src/runtime.rs
@@ -125,11 +125,13 @@ pub mod diagnostics {
 
         #[cfg(not(feature = "runtime-tokio"))]
         eprintln!(
-            "high-frequency polling detected: task={name} location={location} total_polls={total_polls} elapsed_ms={} polls_per_sec={polls_per_sec}",
+            "high-frequency polling detected: task={name} location={location} total_polls={total_polls} elapsed_ms={} \
+             polls_per_sec={polls_per_sec}",
             elapsed.as_millis()
         );
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn warn_high_child_rate(
         name: &str,
         location: &str,
@@ -155,7 +157,9 @@ pub mod diagnostics {
 
         #[cfg(not(feature = "runtime-tokio"))]
         eprintln!(
-            "high-frequency concurrent child churn detected: task={name} location={location} started={started} completed={completed} dropped={dropped} in_flight={in_flight} elapsed_ms={} completed_per_sec={completed_per_sec}",
+            "high-frequency concurrent child churn detected: task={name} location={location} started={started} \
+             completed={completed} dropped={dropped} in_flight={in_flight} elapsed_ms={} \
+             completed_per_sec={completed_per_sec}",
             elapsed.as_millis()
         );
     }


### PR DESCRIPTION
## Summary

- Remove the `hopr-lib` dependency from `hopr-strategy` (`impls/strategy/Cargo.toml`)
- Replace all `hopr_lib::api::*` imports with `hopr_api::*` directly; add `features = ["node", "serde"]` to the hopr-api dep so the chain/node/graph/network/tickets modules are accessible
- After this change, only `utils-session` and `hopr-reference` depend on `hopr-lib` in the workspace

Two pre-existing clippy lints that block CI on `origin/master` are also fixed:
- `utils/src/runtime.rs`: `warn_high_child_rate` has 8 arguments — add `#[allow(clippy::too_many_arguments)]`
- `utils-session/src/lib.rs`: `routing_from_cfg` uses `.into()` that is a no-op when `explicit-path` is off but required when it's on — add `#[allow(clippy::useless_conversion)]`