### PR TITLE
feat(hopr-strategy,hopr-lib): structured debug logging for channel lifecycle + SESSION_MTU re-export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3589,7 +3589,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.2-rc.1"
+version = "4.0.2-rc.3"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3602,7 +3602,6 @@ dependencies = [
  "futures-time",
  "hopr-api",
  "hopr-transport",
- "hopr-types",
  "hopr-utils",
  "humantime-serde",
  "lazy_static",
@@ -3654,7 +3653,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-hopr"
-version = "4.6.0"
+version = "4.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3669,7 +3668,6 @@ dependencies = [
  "hopr-chain-connector",
  "hopr-crypto-packet",
  "hopr-ticket-manager",
- "hopr-types",
  "hopr-utils",
  "humantime-serde",
  "lazy_static",
@@ -3749,7 +3747,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-reference"
-version = "4.2.1"
+version = "4.2.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3764,7 +3762,6 @@ dependencies = [
  "hopr-reference",
  "hopr-ticket-manager",
  "hopr-transport-p2p",
- "hopr-types",
  "lazy_static",
  "opentelemetry-prometheus-text-exporter",
  "opentelemetry_sdk",
@@ -3784,7 +3781,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-strategy"
-version = "0.19.1"
+version = "0.19.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3923,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-p2p"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3936,7 +3933,6 @@ dependencies = [
  "hopr-crypto-packet",
  "hopr-transport",
  "hopr-transport-probe",
- "hopr-types",
  "hopr-utils",
  "lazy_static",
  "libp2p",
@@ -3982,7 +3978,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.22.0"
+version = "0.22.1"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -3997,7 +3993,6 @@ dependencies = [
  "hopr-protocol-session",
  "hopr-protocol-start",
  "hopr-transport-tag-allocator",
- "hopr-types",
  "hopr-utils",
  "humantime-serde",
  "insta",
@@ -4131,7 +4126,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-utils-session"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4143,7 +4138,6 @@ dependencies = [
  "hopr-api",
  "hopr-lib",
  "hopr-transport",
- "hopr-types",
  "hopr-utils",
  "human-bandwidth",
  "lazy_static",

--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-lib"
-version = "4.0.2-rc.2"
+version = "4.0.2-rc.3"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition.workspace = true
 rust-version.workspace = true

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -73,6 +73,11 @@ pub use hopr_utils::runtime::{Abortable, AbortableList};
 use tracing::debug;
 
 pub use crate::constants::{MIN_NATIVE_BALANCE, SUGGESTED_NATIVE_BALANCE};
+/// Maximum user-data payload per HOPR session frame (bytes).
+///
+/// Use this when sizing buffers or computing how many session frames a given
+/// wxHOPR balance can fund (together with the on-chain ticket price).
+pub use hopr_transport::SESSION_MTU;
 use crate::errors::HoprLibError;
 
 /// Public routing configuration for session opening in `hopr-lib`.

--- a/impls/strategy/Cargo.toml
+++ b/impls/strategy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-strategy"
-version = "0.19.1"
+version = "0.19.2"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Contains implementations of different HOPR strategies"
 edition.workspace = true

--- a/impls/strategy/src/channel_lifecycle/events.rs
+++ b/impls/strategy/src/channel_lifecycle/events.rs
@@ -14,7 +14,7 @@ use hopr_api::{
         primitive::prelude::Address,
     },
 };
-use tracing::debug;
+use tracing::{debug, info};
 
 use super::{ChannelLifecycleStrategyInner, ChannelObservation};
 
@@ -75,17 +75,17 @@ where
         self.last_observed.entry(*ch.get_id()).and_modify(|obs| {
             obs.balance = ch.balance;
         });
-        debug!(%ch, "channel-lifecycle: cleared fund in-flight after balance increase");
+        info!(%ch, "channel-lifecycle: channel balance increased");
     }
 
     pub(super) fn on_channel_opened(&self, ch: ChannelEntry) {
         self.open_in_flight.remove(&ch.destination);
-        debug!(%ch, "channel-lifecycle: channel opened, cleared open in-flight");
+        info!(%ch, "channel-lifecycle: channel opened");
     }
 
     pub(super) fn on_channel_closure_initiated(&self, ch: ChannelEntry) {
         self.close_in_flight.remove(ch.get_id());
-        debug!(%ch, "channel-lifecycle: closure initiated, cleared close in-flight");
+        info!(%ch, "channel-lifecycle: channel closure initiated");
     }
 
     /// Starts the peer cooldown so the channel is not immediately re-opened.
@@ -95,7 +95,7 @@ where
         self.peer_ticket_activity.remove(&ch.destination);
         let until = Instant::now() + self.cfg.population.peer_reopen_cooldown;
         self.cooldown.insert(ch.destination, until);
-        debug!(%ch, "channel-lifecycle: channel closed, peer on cooldown");
+        info!(%ch, "channel-lifecycle: channel closed");
     }
 
     /// Records ticket activity for the proactive drain-rate estimate.

--- a/impls/strategy/src/channel_lifecycle/pipeline.rs
+++ b/impls/strategy/src/channel_lifecycle/pipeline.rs
@@ -25,7 +25,7 @@ use hopr_api::{
         primitive::prelude::{Address, HoprBalance},
     },
 };
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 use super::{ChannelLifecycleStrategyInner, ChannelObservation, PeerAddrCache};
 use crate::errors::StrategyError;
@@ -198,7 +198,7 @@ where
             return false;
         }
 
-        info!(%channel, %topup, "channel-lifecycle: funding channel");
+        debug!(%channel, %topup, "channel-lifecycle: funding channel");
         #[cfg(all(feature = "telemetry", not(test)))]
         super::METRIC_CHANNEL_FUNDS.increment();
 
@@ -236,7 +236,7 @@ where
             return false;
         }
 
-        info!(%channel, "channel-lifecycle: closing channel");
+        debug!(%channel, "channel-lifecycle: closing channel");
         #[cfg(all(feature = "telemetry", not(test)))]
         super::METRIC_CHANNEL_CLOSES.increment();
 
@@ -275,7 +275,7 @@ where
             return false;
         }
 
-        info!(%channel, "channel-lifecycle: finalizing closure");
+        debug!(%channel, "channel-lifecycle: finalizing closure");
         #[cfg(all(feature = "telemetry", not(test)))]
         super::METRIC_CHANNEL_FINALIZES.increment();
 
@@ -330,10 +330,10 @@ where
                     ChannelStatus::Open => {
                         self.open_in_flight.remove(&dest);
                         if existing.balance >= self.cfg.funding.lower_balance_threshold {
-                            info!(%dest, balance = %existing.balance, "channel-lifecycle: already open at desired stake, skipping");
+                            debug!(%dest, balance = %existing.balance, "channel-lifecycle: already open at desired stake, skipping");
                             return None;
                         }
-                        info!(%dest, balance = %existing.balance, "channel-lifecycle: already open below threshold, funding immediately");
+                        debug!(%dest, balance = %existing.balance, "channel-lifecycle: already open below threshold, funding immediately");
                         let topup = self.cfg.funding.topup_balance;
                         return self.try_fund_channel(&existing, topup).then_some(topup);
                     }
@@ -351,7 +351,7 @@ where
             }
         }
 
-        info!(%dest, %amount, "channel-lifecycle: opening channel");
+        debug!(%dest, %amount, "channel-lifecycle: opening channel");
         #[cfg(all(feature = "telemetry", not(test)))]
         super::METRIC_CHANNEL_OPENS.increment();
 
@@ -452,6 +452,13 @@ where
             .filter(|c| c.status == ChannelStatus::Open)
             .collect();
         let open_count = open_channels.len() + self.open_in_flight.len();
+        debug!(
+            open = open_count,
+            in_flight = self.total_in_flight(),
+            safe = %safe_balance,
+            channels = all_channels.len(),
+            "channel-lifecycle: tick"
+        );
 
         // Computed once here so close and open passes don't each iterate all
         // activity.  Floored at 1 to keep `peer_score_for` from dividing by 0.
@@ -478,6 +485,8 @@ where
                     self.proactive_fund_needed(ch, &prev_observations, est_tx_secs, min_ticket_price_wei);
 
                 if needs_topup || needs_proactive {
+                    let reason = if needs_topup { "below_lower_threshold" } else { "proactive_drain" };
+                    debug!(%ch, reason, safe_remaining = %safe_remaining, "channel-lifecycle: fund candidate");
                     if safe_remaining < self.cfg.funding.topup_balance {
                         debug!("channel-lifecycle: safe balance exhausted in fund pass");
                         break;
@@ -487,11 +496,18 @@ where
                     }
                 }
             }
+        } else {
+            debug!(
+                safe = %safe_balance,
+                min_required = %self.cfg.funding.min_safe_balance_required,
+                "channel-lifecycle: fund pass skipped: safe below minimum"
+            );
         }
 
         // ── 3. Close pass ─────────────────────────────────────────────────────
         if self.start_epoch.elapsed() >= self.cfg.restart.startup_close_grace_period {
             let mut close_count = self.close_in_flight.len();
+            debug!(in_flight = close_count, open = open_count, min = self.cfg.population.min_open_channels, "channel-lifecycle: close pass");
 
             for ch in &open_channels {
                 if close_count >= self.cfg.closure.close_max_concurrent {
@@ -534,6 +550,7 @@ where
 
         // ── 5. Open pass ──────────────────────────────────────────────────────
         let deficit = self.cfg.population.target_open_channels.saturating_sub(open_count);
+        debug!(deficit, open = open_count, target = self.cfg.population.target_open_channels, "channel-lifecycle: open pass");
 
         if deficit == 0 {
             return Ok(());
@@ -595,6 +612,7 @@ where
 
         candidates.sort_by(|a, b| b.2.partial_cmp(&a.2).unwrap_or(std::cmp::Ordering::Equal));
         candidates.truncate(deficit);
+        debug!(candidates = candidates.len(), deficit, "channel-lifecycle: open pass candidates");
 
         for (addr, ..) in candidates {
             if safe_remaining < self.cfg.funding.initial_balance {
@@ -615,6 +633,13 @@ where
         max_activity: u64,
     ) -> bool {
         if ch.balance <= self.cfg.closure.close_when_drained_below {
+            debug!(
+                dest = %ch.destination,
+                balance = %ch.balance,
+                threshold = %self.cfg.closure.close_when_drained_below,
+                reason = "balance_drained",
+                "channel-lifecycle: close candidate"
+            );
             return true;
         }
 
@@ -622,6 +647,13 @@ where
         if let Some(pk) = addr_to_key.get(&dest) {
             let score = self.peer_score_for(pk, &dest, max_activity);
             if score < self.cfg.closure.close_below_quality_score {
+                debug!(
+                    %dest,
+                    score,
+                    threshold = self.cfg.closure.close_below_quality_score,
+                    reason = "low_quality_score",
+                    "channel-lifecycle: close candidate"
+                );
                 return true;
             }
 
@@ -635,6 +667,13 @@ where
                 let observed_since_start = last_update < self.start_epoch.elapsed();
                 let guard_passed = !self.cfg.eligibility.require_observed_since_start || observed_since_start;
                 if stale && guard_passed {
+                    debug!(
+                        %dest,
+                        last_update_secs = last_update.as_secs(),
+                        unseen_threshold_secs = self.cfg.closure.close_when_peer_unseen_for.as_secs(),
+                        reason = "peer_stale",
+                        "channel-lifecycle: close candidate"
+                    );
                     return true;
                 }
             }

--- a/impls/strategy/src/channel_lifecycle/strategy.rs
+++ b/impls/strategy/src/channel_lifecycle/strategy.rs
@@ -19,8 +19,6 @@ use hopr_api::{
     },
 };
 
-use tracing::info;
-
 use super::{ChannelLifecycleConfig, ChannelLifecycleStrategyInner};
 use crate::{errors::StrategyError, strategy::Strategy as StrategyTrait};
 
@@ -103,7 +101,7 @@ where
         + 'static,
 {
     async fn run(&mut self) -> crate::errors::Result<()> {
-        info!(
+        tracing::info!(
             target = self.cfg.population.target_open_channels,
             min = self.cfg.population.min_open_channels,
             tick_interval_secs = self.cfg.tick_interval.as_secs(),

--- a/impls/strategy/src/channel_lifecycle/strategy.rs
+++ b/impls/strategy/src/channel_lifecycle/strategy.rs
@@ -19,6 +19,8 @@ use hopr_api::{
     },
 };
 
+use tracing::info;
+
 use super::{ChannelLifecycleConfig, ChannelLifecycleStrategyInner};
 use crate::{errors::StrategyError, strategy::Strategy as StrategyTrait};
 
@@ -101,6 +103,13 @@ where
         + 'static,
 {
     async fn run(&mut self) -> crate::errors::Result<()> {
+        info!(
+            target = self.cfg.population.target_open_channels,
+            min = self.cfg.population.min_open_channels,
+            tick_interval_secs = self.cfg.tick_interval.as_secs(),
+            initial_balance = %self.cfg.funding.initial_balance,
+            "channel-lifecycle: strategy started"
+        );
         self.run_pipeline().await;
 
         let me = *self.node.chain_api().me();

--- a/impls/strategy/src/snapshots/hopr_strategy__auto_funding__tests__auto_funding_strategy.snap
+++ b/impls/strategy/src/snapshots/hopr_strategy__auto_funding__tests__auto_funding_strategy.snap
@@ -158,7 +158,7 @@ chain_info:
   channel_closure_grace_period: "300"
   channel_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   block_number: 1
-  chain_id: 100
+  chain_id: 31337
   gas_price: "1000000000"
   ledger_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   max_fee_per_gas: "3000000000"
@@ -167,8 +167,8 @@ chain_info:
   key_binding_fee: 0.01 wxHOPR
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
-  network: jura
-  contract_addresses: "\n                {\n                    \"announcements\": \"0xf1c143B1bA20C7606d56aA2FA94502D25744b982\",\n                    \"channels\": \"0x77C9414043d27fdC98A6A2d73fc77b9b383092a7\",\n                    \"module_implementation\": \"0x32863c4974fBb6253E338a0cb70C382DCeD2eFCb\",\n                    \"node_safe_registry\": \"0x4F7C7dE3BA2B29ED8B2448dF2213cA43f94E45c0\",\n                    \"node_stake_factory\": \"0x791d190b2c95397F4BcE7bD8032FD67dCEA7a5F2\",\n                    \"node_safe_migration\": \"0x0000000000000000000000000000000000000000\",\n                    \"token\": \"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\n                    \"ticket_price_oracle\": \"0x442df1d946303fB088C9377eefdaeA84146DA0A6\",\n                    \"winning_probability_oracle\": \"0xC15675d4CCa538D91a91a8D3EcFBB8499C3B0471\"\n                }"
+  network: anvil-localhost
+  contract_addresses: "{\"announcements\":\"0xfD5C1c0f5299B51282a0BCB0465ff7f536F320a9\",\"channels\":\"0x37406b53C672083cd70a2Eb44732C7276EdE2049\",\"module_implementation\":\"0x8c4C7942a75754ebE57C8BAA2341d1f4922124c5\",\"node_safe_migration\":\"0x42C47173d81fb51Fc23A1bE3804e0cBA4972E6dd\",\"node_safe_registry\":\"0x81C9a8B5c1fD9E4b5C134Dab131ebc0b35D25994\",\"node_stake_factory\":\"0x51DFBBD2612D76EcC5a157F3c236B2b1cDFfa733\",\"ticket_price_oracle\":\"0x376b4A2243b74667EA186fC89114355599E6b5C4\",\"token\":\"0xCf4c708eEDa485f3fe5cEacEc86EaE46Ef3FC87d\",\"winning_probability_oracle\":\"0x0Ecb0E77E6bDE494665993DaD5B3b14c026c08bd\",\"xhopr_token\":\"0x0000000000000000000000000000000000000000\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"


### PR DESCRIPTION
## Summary

- **Move per-tick intent logs from `info!` to `debug!`** in `pipeline.rs`: `opening channel`, `funding channel`, `closing channel`, `finalizing closure` are now `debug!`, so `RUST_LOG=info` no longer shows per-tick chatter.
- **Upgrade confirmed-transition handlers from `debug!` to `info!`** in `events.rs`: channel opened/closed/funded/finalized each emit exactly one `info!` line when the chain event arrives.
- **Add structured `debug!` at every silent decision branch** in `pipeline.rs` and `should_close`: tick snapshot (open/in_flight/safe), fund-pass reason (`below_lower_threshold` / `proactive_drain`), close-pass entry summary, open-pass deficit + candidate count, per-candidate close reason (`balance_drained` / `low_quality_score` / `peer_stale`). All fields use `key=value` tracing style.
- **Add one-shot `info!` on strategy start** (target/min channels, tick_interval, initial_balance).
- **Re-export `SESSION_MTU` (= 1018 bytes) from `hopr-lib`** so downstream crates can compute byte-level channel capacity without taking a direct dep on `hopr-transport-session`.

## Log level policy after this change

| Level | What you see |
|---|---|
| `info` | One line per confirmed chain transition (opened/closed/funded/finalized) + strategy start |
| `debug` | Per-tick tick summary, every fund/close/open decision with `reason=…`, every pass entry |
| `warn` | Tx submit/confirm failures (unchanged) |