### PR TITLE
fix(transport): drain on_incoming_data_rx to prevent crashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.28.3"
+version = "0.28.4"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3896,7 +3896,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-mixer"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "bytesize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3589,7 +3589,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.2-rc.3"
+version = "4.0.3-rc.4"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3840,7 +3840,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.28.2"
+version = "0.28.3"
 dependencies = [
  "ahash",
  "anyhow",

--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-lib"
-version = "4.0.3-rc.4"
+version = "4.0.2-rc.4"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition.workspace = true
 rust-version.workspace = true

--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-lib"
-version = "4.0.2-rc.3"
+version = "4.0.3-rc.4"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition.workspace = true
 rust-version.workspace = true

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -749,8 +749,7 @@ macro_rules! impl_build_methods {
                 )
                 .await?;
 
-            // Drain unrelated packets so SessionsManagement(0) can forward without hitting
-            // SendError(disconnected).
+            // Drain unrelated packets to avoid missing blackhole
             spawn(drain_incoming_data(socket.reader()));
 
             let mut processes = pre.processes;
@@ -896,8 +895,7 @@ macro_rules! impl_build_methods {
                     pre.session_tx,
                 )
                 .await?;
-            // Drain unrelated packets so SessionsManagement(0) can forward without hitting
-            // SendError(disconnected).
+            // Drain unrelated packets to avoid missing blackhole
             spawn(drain_incoming_data(socket.reader()));
             processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
 

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -724,7 +724,7 @@ macro_rules! impl_build_methods {
             let pre = pre_build_inner(configured, session_tx, processes).await?;
 
             tracing::info!("starting transport for edge (entry) node");
-            let (_, transport_processes) = pre
+            let (socket, transport_processes) = pre
                 .transport_api
                 .run_entry(
                     pre.cover_traffic,
@@ -733,6 +733,29 @@ macro_rules! impl_build_methods {
                     ticket_factory,
                 )
                 .await?;
+
+            // Drain unrelated packets so SessionsManagement(0) can forward without hitting
+            // SendError(disconnected). Logs received/discarded counts every ~60 seconds.
+            hopr_utils::spawn_as_abortable!(async move {
+                let mut received: u64 = 0;
+                let mut discarded: u64 = 0;
+                let mut last_report = std::time::Instant::now();
+                let mut stream = socket.reader();
+                while let Some(_) = stream.next().await {
+                    received += 1;
+                    discarded += 1;
+                    if last_report.elapsed().as_secs() >= 60 {
+                        tracing::info!(
+                            received,
+                            discarded,
+                            "incoming-data drain: unrelated packets discarded in last ~1 min"
+                        );
+                        received = 0;
+                        discarded = 0;
+                        last_report = std::time::Instant::now();
+                    }
+                }
+            });
 
             let mut processes = pre.processes;
             processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
@@ -866,7 +889,7 @@ macro_rules! impl_build_methods {
             }
 
             tracing::info!("starting transport for full (relay) node");
-            let (_, transport_processes) = pre
+            let (socket, transport_processes) = pre
                 .transport_api
                 .run_relay(
                     pre.cover_traffic,
@@ -877,6 +900,28 @@ macro_rules! impl_build_methods {
                     pre.session_tx,
                 )
                 .await?;
+            // Drain unrelated packets so SessionsManagement(0) can forward without hitting
+            // SendError(disconnected). Logs received/discarded counts every ~60 seconds.
+            hopr_utils::spawn_as_abortable!(async move {
+                let mut received: u64 = 0;
+                let mut discarded: u64 = 0;
+                let mut last_report = std::time::Instant::now();
+                let mut stream = socket.reader();
+                while let Some(_) = stream.next().await {
+                    received += 1;
+                    discarded += 1;
+                    if last_report.elapsed().as_secs() >= 60 {
+                        tracing::info!(
+                            received,
+                            discarded,
+                            "incoming-data drain: unrelated packets discarded in last ~1 min"
+                        );
+                        received = 0;
+                        discarded = 0;
+                        last_report = std::time::Instant::now();
+                    }
+                }
+            });
             processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
 
             let hopr = Hopr {

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -751,7 +751,7 @@ macro_rules! impl_build_methods {
 
             // Drain unrelated packets so SessionsManagement(0) can forward without hitting
             // SendError(disconnected).
-            hopr_utils::spawn_as_abortable!(drain_incoming_data(socket.reader()));
+            spawn(drain_incoming_data(socket.reader()));
 
             let mut processes = pre.processes;
             processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
@@ -898,7 +898,7 @@ macro_rules! impl_build_methods {
                 .await?;
             // Drain unrelated packets so SessionsManagement(0) can forward without hitting
             // SendError(disconnected).
-            hopr_utils::spawn_as_abortable!(drain_incoming_data(socket.reader()));
+            spawn(drain_incoming_data(socket.reader()));
             processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
 
             let hopr = Hopr {

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -317,6 +317,21 @@ struct PreHopr<Chain, Graph, Net, Ct> {
 // Shared pre_build logic
 // ---------------------------------------------------------------------------
 
+/// Drains a HoprSocket reader, discarding all packets and logging throughput every ~60 seconds.
+/// Runs until the stream ends (sender side dropped).
+async fn drain_incoming_data<S: futures::Stream + Unpin>(mut reader: S) {
+    let mut received: u64 = 0;
+    let mut last_report = std::time::Instant::now();
+    while reader.next().await.is_some() {
+        received += 1;
+        if last_report.elapsed().as_secs() >= 60 {
+            tracing::info!(received, "incoming-data drain: unrelated packets discarded in last ~1 min");
+            received = 0;
+            last_report = std::time::Instant::now();
+        }
+    }
+}
+
 async fn pre_build_inner<Chain, Graph, Net, Ct>(
     configured: HoprBuilderConfigured<Chain, Graph, Net, Ct>,
     session_tx: futures::channel::mpsc::Sender<IncomingSession>,
@@ -735,27 +750,8 @@ macro_rules! impl_build_methods {
                 .await?;
 
             // Drain unrelated packets so SessionsManagement(0) can forward without hitting
-            // SendError(disconnected). Logs received/discarded counts every ~60 seconds.
-            hopr_utils::spawn_as_abortable!(async move {
-                let mut received: u64 = 0;
-                let mut discarded: u64 = 0;
-                let mut last_report = std::time::Instant::now();
-                let mut stream = socket.reader();
-                while let Some(_) = stream.next().await {
-                    received += 1;
-                    discarded += 1;
-                    if last_report.elapsed().as_secs() >= 60 {
-                        tracing::info!(
-                            received,
-                            discarded,
-                            "incoming-data drain: unrelated packets discarded in last ~1 min"
-                        );
-                        received = 0;
-                        discarded = 0;
-                        last_report = std::time::Instant::now();
-                    }
-                }
-            });
+            // SendError(disconnected).
+            hopr_utils::spawn_as_abortable!(drain_incoming_data(socket.reader()));
 
             let mut processes = pre.processes;
             processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
@@ -901,27 +897,8 @@ macro_rules! impl_build_methods {
                 )
                 .await?;
             // Drain unrelated packets so SessionsManagement(0) can forward without hitting
-            // SendError(disconnected). Logs received/discarded counts every ~60 seconds.
-            hopr_utils::spawn_as_abortable!(async move {
-                let mut received: u64 = 0;
-                let mut discarded: u64 = 0;
-                let mut last_report = std::time::Instant::now();
-                let mut stream = socket.reader();
-                while let Some(_) = stream.next().await {
-                    received += 1;
-                    discarded += 1;
-                    if last_report.elapsed().as_secs() >= 60 {
-                        tracing::info!(
-                            received,
-                            discarded,
-                            "incoming-data drain: unrelated packets discarded in last ~1 min"
-                        );
-                        received = 0;
-                        discarded = 0;
-                        last_report = std::time::Instant::now();
-                    }
-                }
-            });
+            // SendError(disconnected).
+            hopr_utils::spawn_as_abortable!(drain_incoming_data(socket.reader()));
             processes.flat_map_extend_from(transport_processes, HoprLibProcess::Transport);
 
             let hopr = Hopr {

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport"
-version = "0.28.2"
+version = "0.28.3"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Implements the main HOPR transport interface for the core library"
 edition.workspace = true

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport"
-version = "0.28.3"
+version = "0.28.4"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 description = "Implements the main HOPR transport interface for the core library"
 edition.workspace = true
@@ -157,6 +157,10 @@ path = "tests/protocol/pipeline_stage_isolation.rs"
 [[test]]
 name = "protocol_stress_throughput"
 path = "tests/protocol/stress_throughput.rs"
+
+[[test]]
+name = "mixer_shared_heap"
+path = "tests/mixer_shared_heap.rs"
 
 [package.metadata.cargo-machete]
 ignored = ["humantime-serde"]

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -800,7 +800,7 @@ where
                     .for_each(move |data| {
                         let mut tx = on_incoming_data_tx.clone();
                         async move {
-                            if let Err(_) = tx.send(data).await {
+                            if tx.send(data).await.is_err() {
                                 tracing::error!(
                                     task = %HoprTransportProcess::SessionsManagement(0),
                                     "incoming-data channel disconnected — dropping unrelated packet; \

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -37,7 +37,7 @@ use std::{
 
 use constants::MAXIMUM_MSG_OUTGOING_BUFFER_SIZE;
 use futures::{
-    FutureExt, StreamExt,
+    FutureExt, SinkExt, StreamExt,
     channel::mpsc::{Sender, channel},
     stream::select_with_strategy,
 };
@@ -763,14 +763,21 @@ where
         // Wire incoming: cover-traffic-filtered stream → probe classify → (session dispatch).
         // This stage must run in a background task, so the pipeline drains even when the
         // caller discards the returned HoprSocket (e.g. edge-node builder).
+        //
+        // The channel uses a resilient for_each rather than .forward() so that a disconnected
+        // receiver (HoprSocket dropped without consuming) logs an error and continues rather
+        // than collapsing the entire ingress pipeline. Callers should use HoprSocket::reader()
+        // and actively drain the stream; see hopr-lib builder for the reference drain.
         let (on_incoming_data_tx, on_incoming_data_rx) =
             channel::<ApplicationDataIn>(msg_protocol_bidirectional_channel_capacity);
         let smgr = self.smgr.clone();
+        // Clone before the async move so the original remains available for the HoprSocket return.
+        let unresolved_routing_msg_tx_for_task = unresolved_routing_msg_tx.clone();
         processes.insert(
             HoprTransportProcess::SessionsManagement(0),
-            hopr_utils::spawn_as_abortable!(
+            hopr_utils::spawn_as_abortable!(async move {
                 probe_classifier
-                    .filter_stream(unresolved_routing_msg_tx.clone(), rx_from_protocol)
+                    .filter_stream(unresolved_routing_msg_tx_for_task, rx_from_protocol)
                     .filter_map(move |(pseudonym, data)| {
                         let smgr = smgr.clone();
                         async move {
@@ -790,13 +797,24 @@ where
                             }
                         }
                     })
-                    .map(Ok)
-                    .forward(on_incoming_data_tx)
-                    .inspect(|_| tracing::warn!(
-                        task = %HoprTransportProcess::SessionsManagement(0),
-                        "long-running background task finished"
-                    ))
-            ),
+                    .for_each(move |data| {
+                        let mut tx = on_incoming_data_tx.clone();
+                        async move {
+                            if let Err(_) = tx.send(data).await {
+                                tracing::error!(
+                                    task = %HoprTransportProcess::SessionsManagement(0),
+                                    "incoming-data channel disconnected — dropping unrelated packet; \
+                                     HoprSocket must be consumed or drained by the caller"
+                                );
+                            }
+                        }
+                    })
+                    .await;
+                tracing::warn!(
+                    task = %HoprTransportProcess::SessionsManagement(0),
+                    "long-running background task finished"
+                );
+            }),
         );
 
         // Populate the OnceLock at the end, making sure everything before didn't fail.

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -521,16 +521,14 @@ where
             HoprTransportProcess::MixerForwarder,
             hopr_utils::spawn_as_abortable!(async move {
                 mix_rx
-                    .for_each(|item| {
-                        let mut sink = wire_msg_tx.clone();
-                        async move {
-                            if sink.send(item).await.is_err() {
-                                tracing::error!(
-                                    task = %HoprTransportProcess::MixerForwarder,
-                                    "wire sink dropped — discarding mixed packet"
-                                );
-                            }
+                    .fold(wire_msg_tx, |mut sink, item| async move {
+                        if sink.send(item).await.is_err() {
+                            tracing::error!(
+                                task = %HoprTransportProcess::MixerForwarder,
+                                "wire sink dropped — discarding mixed packet"
+                            );
                         }
+                        sink
                     })
                     .await;
                 tracing::warn!(
@@ -799,7 +797,6 @@ where
         let (on_incoming_data_tx, on_incoming_data_rx) =
             channel::<ApplicationDataIn>(msg_protocol_bidirectional_channel_capacity);
         let smgr = self.smgr.clone();
-        // Clone before the async move so the original remains available for the HoprSocket return.
         let unresolved_routing_msg_tx_for_task = unresolved_routing_msg_tx.clone();
         processes.insert(
             HoprTransportProcess::SessionsManagement(0),
@@ -825,17 +822,15 @@ where
                             }
                         }
                     })
-                    .for_each(move |data| {
-                        let mut tx = on_incoming_data_tx.clone();
-                        async move {
-                            if tx.send(data).await.is_err() {
-                                tracing::error!(
-                                    task = %HoprTransportProcess::SessionsManagement(0),
-                                    "incoming-data channel disconnected — dropping unrelated packet; \
-                                     HoprSocket must be consumed or drained by the caller"
-                                );
-                            }
+                    .fold(on_incoming_data_tx, |mut tx, data| async move {
+                        if tx.send(data).await.is_err() {
+                            tracing::error!(
+                                task = %HoprTransportProcess::SessionsManagement(0),
+                                "incoming-data channel disconnected — dropping unrelated packet; \
+                                 HoprSocket must be consumed or drained by the caller"
+                            );
                         }
+                        tx
                     })
                     .await;
                 tracing::warn!(

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -152,6 +152,8 @@ pub enum HoprTransportProcess {
     OutgoingIndexSync,
     #[strum(to_string = "periodic protocol counter flush")]
     CounterFlush,
+    #[strum(to_string = "mixer→wire forwarder")]
+    MixerForwarder,
     #[cfg(feature = "capture")]
     #[strum(to_string = "packet capture")]
     Capture,
@@ -510,7 +512,33 @@ where
         let (wire_msg_tx, wire_msg_rx) =
             protocol::stream::process_stream_protocol(msg_codec, transport_network.clone()).await?;
 
-        let mixing_channel_tx = hopr_transport_mixer::MixerSink::new(wire_msg_tx, build_mixer_cfg_from_env());
+        // Shared mixing channel: all per-destination clones of `mixing_channel_tx` push into one
+        // heap, so cross-destination packets are mixed together rather than each destination
+        // getting its own independent delay queue. The single forwarder task owns the receiver
+        // (and therefore the heap timer) — no per-clone waker coordination is needed.
+        let (mixing_channel_tx, mix_rx) = hopr_transport_mixer::channel(build_mixer_cfg_from_env());
+        processes.insert(
+            HoprTransportProcess::MixerForwarder,
+            hopr_utils::spawn_as_abortable!(async move {
+                mix_rx
+                    .for_each(|item| {
+                        let mut sink = wire_msg_tx.clone();
+                        async move {
+                            if sink.send(item).await.is_err() {
+                                tracing::error!(
+                                    task = %HoprTransportProcess::MixerForwarder,
+                                    "wire sink dropped — discarding mixed packet"
+                                );
+                            }
+                        }
+                    })
+                    .await;
+                tracing::warn!(
+                    task = %HoprTransportProcess::MixerForwarder,
+                    "long-running background task finished"
+                );
+            }),
+        );
 
         // -- path cache background refresh (only when tokio runtime is available)
         #[cfg(feature = "runtime-tokio")]

--- a/transport/hopr/src/protocol/pipeline/mod.rs
+++ b/transport/hopr/src/protocol/pipeline/mod.rs
@@ -853,4 +853,94 @@ mod tests {
             .await
             .expect("drain task must finish cleanly after sender is dropped");
     }
+
+    // ── SessionsManagement(0) incoming-data dispatcher regression tests ──────────
+    //
+    // Before the fix, `HoprSocket` (which owns `on_incoming_data_rx`) was dropped
+    // immediately after `run_entry`/`run_relay` in hopr-lib's builder. The first
+    // `Unrelated` packet caused `.forward(on_incoming_data_tx)` to return
+    // `SendError(disconnected)`, collapsing `SessionsManagement(0)` and dropping
+    // `rx_from_protocol` — which then caused msg_ingress to fail with
+    // "send failed because receiver is gone", taking down the entire pipeline.
+    //
+    // The fix replaces `.forward()` with a `for_each` loop that logs an error on
+    // disconnected but keeps the task — and thus `rx_from_protocol` — alive.
+
+    /// A disconnected `futures::mpsc::Sender` must not panic; `send` returns `Err`.
+    #[tokio::test]
+    async fn disconnected_sender_returns_err_not_panic() {
+        let (tx, rx) = mpsc::channel::<u8>(4);
+        drop(rx);
+        let mut tx2 = tx.clone();
+        let result = tx2.send(42u8).await;
+        assert!(result.is_err(), "send to disconnected receiver must return Err");
+    }
+
+    /// The `for_each` loop used in `SessionsManagement(0)` must not terminate when
+    /// the receiver is dropped; it must continue consuming the upstream stream.
+    #[tokio::test]
+    async fn session_management_dispatcher_survives_disconnected_sink() {
+        use futures::SinkExt;
+
+        let (data_tx, data_rx) = mpsc::channel::<u8>(4);
+
+        // Drop the receiver immediately — simulates HoprSocket being dropped.
+        drop(data_rx);
+
+        // Upstream stream of 10 items.
+        let upstream = futures::stream::iter(0u8..10);
+
+        // Run the resilient for_each pattern used in SessionsManagement(0).
+        let dispatcher = tokio::spawn(async move {
+            upstream
+                .for_each(move |item| {
+                    let mut tx = data_tx.clone();
+                    async move {
+                        // Error is expected (disconnected); we must NOT abort the stream.
+                        let _ = tx.send(item).await;
+                    }
+                })
+                .await;
+        });
+
+        // Task must complete without panic even though every send fails.
+        dispatcher
+            .await
+            .expect("dispatcher must complete cleanly even with a disconnected sink");
+    }
+
+    /// Regression: previously, the first `Unrelated` packet triggered task exit and
+    /// dropped `rx_from_protocol`.  After the fix the task must run to completion.
+    #[tokio::test]
+    async fn session_management_dispatcher_does_not_drop_upstream_on_disconnected_sink() {
+        use futures::SinkExt;
+
+        let (data_tx, data_rx) = mpsc::channel::<u8>(1);
+        drop(data_rx); // receiver gone from the start
+
+        let (upstream_tx, upstream_rx) = mpsc::channel::<u8>(16);
+        let upstream = upstream_rx; // unbounded receiver as upstream
+
+        let dispatcher = tokio::spawn(async move {
+            upstream
+                .for_each(move |item| {
+                    let mut tx = data_tx.clone();
+                    async move {
+                        let _ = tx.send(item).await;
+                    }
+                })
+                .await;
+        });
+
+        // Send several items; the dispatcher must process them all.
+        let mut sender = upstream_tx;
+        for i in 0u8..20 {
+            sender.send(i).await.expect("upstream send must succeed");
+        }
+        drop(sender); // close upstream → dispatcher finishes
+
+        dispatcher
+            .await
+            .expect("dispatcher must complete when upstream closes, even with disconnected sink");
+    }
 }

--- a/transport/hopr/src/protocol/pipeline/mod.rs
+++ b/transport/hopr/src/protocol/pipeline/mod.rs
@@ -910,7 +910,7 @@ mod tests {
         drop(data_rx); // receiver gone from the start
 
         let (upstream_tx, upstream_rx) = mpsc::channel::<u8>(16);
-        let upstream = upstream_rx; // unbounded receiver as upstream
+        let upstream = upstream_rx;
 
         let dispatcher = tokio::spawn(async move {
             upstream

--- a/transport/hopr/src/protocol/pipeline/mod.rs
+++ b/transport/hopr/src/protocol/pipeline/mod.rs
@@ -854,18 +854,6 @@ mod tests {
             .expect("drain task must finish cleanly after sender is dropped");
     }
 
-    // ── SessionsManagement(0) incoming-data dispatcher regression tests ──────────
-    //
-    // Before the fix, `HoprSocket` (which owns `on_incoming_data_rx`) was dropped
-    // immediately after `run_entry`/`run_relay` in hopr-lib's builder. The first
-    // `Unrelated` packet caused `.forward(on_incoming_data_tx)` to return
-    // `SendError(disconnected)`, collapsing `SessionsManagement(0)` and dropping
-    // `rx_from_protocol` — which then caused msg_ingress to fail with
-    // "send failed because receiver is gone", taking down the entire pipeline.
-    //
-    // The fix replaces `.forward()` with a `for_each` loop that logs an error on
-    // disconnected but keeps the task — and thus `rx_from_protocol` — alive.
-
     /// A disconnected `futures::mpsc::Sender` must not panic; `send` returns `Err`.
     #[tokio::test]
     async fn disconnected_sender_returns_err_not_panic() {

--- a/transport/hopr/src/protocol/pipeline/mod.rs
+++ b/transport/hopr/src/protocol/pipeline/mod.rs
@@ -867,7 +867,8 @@ mod tests {
     /// The `for_each` loop used in `SessionsManagement(0)` must not terminate when
     /// the receiver is dropped; it must continue consuming the upstream stream.
     #[tokio::test]
-    async fn session_management_dispatcher_survives_disconnected_sink() {
+    async fn session_management_dispatcher_survives_disconnected_sink() -> anyhow::Result<()> {
+        use anyhow::Context;
         use futures::SinkExt;
 
         let (data_tx, data_rx) = mpsc::channel::<u8>(4);
@@ -894,13 +895,15 @@ mod tests {
         // Task must complete without panic even though every send fails.
         dispatcher
             .await
-            .expect("dispatcher must complete cleanly even with a disconnected sink");
+            .context("dispatcher must complete cleanly even with a disconnected sink")?;
+        Ok(())
     }
 
     /// Regression: previously, the first `Unrelated` packet triggered task exit and
     /// dropped `rx_from_protocol`.  After the fix the task must run to completion.
     #[tokio::test]
-    async fn session_management_dispatcher_does_not_drop_upstream_on_disconnected_sink() {
+    async fn session_management_dispatcher_does_not_drop_upstream_on_disconnected_sink() -> anyhow::Result<()> {
+        use anyhow::Context;
         use futures::SinkExt;
 
         let (data_tx, data_rx) = mpsc::channel::<u8>(1);
@@ -923,12 +926,13 @@ mod tests {
         // Send several items; the dispatcher must process them all.
         let mut sender = upstream_tx;
         for i in 0u8..20 {
-            sender.send(i).await.expect("upstream send must succeed");
+            sender.send(i).await.context("upstream send must succeed")?;
         }
         drop(sender); // close upstream → dispatcher finishes
 
         dispatcher
             .await
-            .expect("dispatcher must complete when upstream closes, even with disconnected sink");
+            .context("dispatcher must complete when upstream closes, even with disconnected sink")?;
+        Ok(())
     }
 }

--- a/transport/hopr/tests/mixer_shared_heap.rs
+++ b/transport/hopr/tests/mixer_shared_heap.rs
@@ -1,0 +1,73 @@
+/// Regression test for the mixer wiring change introduced in this PR.
+///
+/// # Background
+///
+/// `start_outgoing_ack_pipeline` clones the wire sink once per destination inside
+/// `for_each_concurrent`. Before this fix the wire sink was a `MixerSink`, where every
+/// clone owns a *separate* `BinaryHeap`. Items pushed via clone A are delayed only
+/// against each other; items from clone B form their own independent delay queue. This
+/// means cross-destination packets are never mixed together, silently undermining the
+/// mixer's anonymity goal.
+///
+/// The fix replaces the `MixerSink` with `hopr_transport_mixer::channel`. All
+/// `Sender` clones share one `Arc<Mutex<BinaryHeap>>`, so cross-destination packets
+/// interleave in the single forwarder's output stream.
+///
+/// # What this test checks
+///
+/// Given two `Sender` clones, A and B:
+/// - Push N items tagged with 'A' on clone A, then N items tagged with 'B' on clone B.
+/// - With per-clone heaps (the old, broken topology): the first N items in the output
+///   are all 'A'-tagged (clone A's heap drained first), then all 'B'-tagged.
+///   `bs_in_first_half == 0`.
+/// - With a shared heap (the new, correct topology): 'A' and 'B' items are interleaved
+///   because they compete in the same heap under random delays.
+///   `bs_in_first_half >> 0`.
+use std::time::Duration;
+
+use futures::StreamExt;
+use hopr_transport_mixer::{MixerConfig, channel};
+use tokio::time::timeout;
+
+const PROCESSING_LEEWAY: Duration = Duration::from_millis(500);
+
+/// Items from different `Sender` clones appear interleaved in the receiver output.
+#[tokio::test(flavor = "current_thread")]
+async fn wire_mixer_interleaves_across_clones() {
+    let cfg = MixerConfig::default(); // 10..210ms uniform random delay
+    let (tx_a, rx) = channel::<(u8, u32)>(cfg);
+    let tx_b = tx_a.clone();
+
+    const N: u32 = 200;
+    for i in 0..N {
+        tx_a.send((b'A', i)).expect("send A");
+    }
+    for i in 0..N {
+        tx_b.send((b'B', i)).expect("send B");
+    }
+    drop(tx_a);
+    drop(tx_b);
+
+    // Collect all 2N items. With the default delay range, each item takes up to
+    // ~210ms; N=200 items can all complete well within 2 * 210ms + leeway since
+    // they are queued at the same time and the heap is drained concurrently.
+    let max_wait = Duration::from_millis(210) * 2 + PROCESSING_LEEWAY;
+    let out: Vec<(u8, u32)> = timeout(max_wait, rx.take(2 * N as usize).collect())
+        .await
+        .expect("timed out collecting mixed output");
+
+    assert_eq!(out.len(), 2 * N as usize, "not all items received");
+
+    // Count 'B'-tagged items in the first half of the output.
+    // With a shared heap these should be thoroughly interleaved; at minimum at
+    // least one 'B' must appear before index N (the seam that a per-clone heap
+    // would preserve perfectly). We use a conservative threshold of N/10 to
+    // avoid a flaky failure on a heavily loaded CI runner.
+    let bs_in_first_half = out[..N as usize].iter().filter(|(c, _)| *c == b'B').count();
+    assert!(
+        bs_in_first_half > N as usize / 10,
+        "only {bs_in_first_half}/{N} 'B'-tagged items in the first half — \
+         heap is not shared across Sender clones (first 20: {:?})",
+        &out[..20.min(out.len())]
+    );
+}

--- a/transport/hopr/tests/mixer_shared_heap.rs
+++ b/transport/hopr/tests/mixer_shared_heap.rs
@@ -25,6 +25,7 @@
 ///   `bs_in_first_half >> 0`.
 use std::time::Duration;
 
+use anyhow::Context;
 use futures::StreamExt;
 use hopr_transport_mixer::{MixerConfig, channel};
 use tokio::time::timeout;
@@ -33,17 +34,17 @@ const PROCESSING_LEEWAY: Duration = Duration::from_millis(500);
 
 /// Items from different `Sender` clones appear interleaved in the receiver output.
 #[tokio::test(flavor = "current_thread")]
-async fn wire_mixer_interleaves_across_clones() {
+async fn wire_mixer_interleaves_across_clones() -> anyhow::Result<()> {
     let cfg = MixerConfig::default(); // 10..210ms uniform random delay
     let (tx_a, rx) = channel::<(u8, u32)>(cfg);
     let tx_b = tx_a.clone();
 
     const N: u32 = 200;
     for i in 0..N {
-        tx_a.send((b'A', i)).expect("send A");
+        tx_a.send((b'A', i)).context("send A")?;
     }
     for i in 0..N {
-        tx_b.send((b'B', i)).expect("send B");
+        tx_b.send((b'B', i)).context("send B")?;
     }
     drop(tx_a);
     drop(tx_b);
@@ -54,7 +55,7 @@ async fn wire_mixer_interleaves_across_clones() {
     let max_wait = Duration::from_millis(210) * 2 + PROCESSING_LEEWAY;
     let out: Vec<(u8, u32)> = timeout(max_wait, rx.take(2 * N as usize).collect())
         .await
-        .expect("timed out collecting mixed output");
+        .context("timed out collecting mixed output")?;
 
     assert_eq!(out.len(), 2 * N as usize, "not all items received");
 
@@ -70,4 +71,5 @@ async fn wire_mixer_interleaves_across_clones() {
          heap is not shared across Sender clones (first 20: {:?})",
         &out[..20.min(out.len())]
     );
+    Ok(())
 }

--- a/transport/mixer/Cargo.toml
+++ b/transport/mixer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-mixer"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 edition.workspace = true
 rust-version.workspace = true

--- a/transport/mixer/src/channel.rs
+++ b/transport/mixer/src/channel.rs
@@ -607,4 +607,43 @@ mod tests {
         );
         Ok(())
     }
+
+    /// Regression test: all `Sender` clones push into the same shared heap,
+    /// so items from different clones are drained by the single `Receiver`.
+    ///
+    /// Pre-fix (`MixerSink::clone` with per-clone heap): each clone has its own
+    /// `BinaryHeap`; a separate receiver per clone would be required to observe
+    /// all items. With a single receiver the other clone's items are silently lost.
+    ///
+    /// Post-fix (`Sender`/`Receiver` channel): one shared heap, one receiver
+    /// sees every item regardless of which clone pushed it.
+    #[tokio::test]
+    async fn sender_clones_share_heap() -> anyhow::Result<()> {
+        let cfg = MixerConfig {
+            min_delay: Duration::from_millis(50),
+            delay_range: Duration::from_millis(1),
+            ..MixerConfig::default()
+        };
+        let (tx_a, mut rx) = channel::<u32>(cfg);
+        let tx_b = tx_a.clone();
+
+        tx_a.send(1)?;
+        tx_b.send(2)?;
+        drop(tx_a);
+        drop(tx_b);
+
+        // Single receiver must drain both items — proves the heap is shared.
+        let mut got = vec![
+            timeout(MAXIMUM_SINGLE_DELAY_DURATION + PROCESSING_LEEWAY, rx.next())
+                .await?
+                .expect("first item"),
+            timeout(MAXIMUM_SINGLE_DELAY_DURATION + PROCESSING_LEEWAY, rx.next())
+                .await?
+                .expect("second item"),
+        ];
+        got.sort();
+        assert_eq!(got, vec![1, 2]);
+        assert!(rx.next().await.is_none(), "expected channel closed with no more items");
+        Ok(())
+    }
 }

--- a/transport/mixer/src/sink.rs
+++ b/transport/mixer/src/sink.rs
@@ -118,7 +118,12 @@ where
             let sleep_for = next_release.saturating_duration_since(now);
 
             if sleep_for.is_zero() {
-                continue;
+                // Reachable only because inner.poll_ready returned Pending earlier in
+                // this poll (we pushed the item back with release_at = now). The inner
+                // sink already registered its waker via that poll_ready call, and any
+                // items it had buffered were flushed by the poll_flush call above —
+                // delegate to the lower sink's wake-up signal and yield.
+                return Poll::Pending;
             }
 
             this.timer.reset(sleep_for);
@@ -216,5 +221,60 @@ mod tests {
         assert_eq!(item, 1);
 
         assert!(timeout(Duration::from_millis(10), rx.next()).await.is_err());
+    }
+
+    /// Regression test for the `poll_flush` busy-spin bug.
+    ///
+    /// When `inner.poll_ready` returns `Poll::Pending` (inner sink is full) and
+    /// `inner.poll_flush` returns `Poll::Ready(Ok(()))` (channels are no-op flush),
+    /// the outer loop must return `Poll::Pending` instead of spinning.
+    ///
+    /// If this test hangs, the busy-spin bug has been re-introduced: the executor
+    /// thread is pegged and the timeout future can never fire.
+    #[tokio::test]
+    async fn poll_flush_returns_pending_not_spin_when_inner_full() {
+        use std::convert::Infallible;
+        use futures::Sink;
+
+        struct AlwaysFullNoOpFlushSink;
+
+        impl Sink<u32> for AlwaysFullNoOpFlushSink {
+            type Error = Infallible;
+
+            fn poll_ready(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Infallible>> {
+                Poll::Pending // always full — simulates a saturated mpsc channel
+            }
+
+            fn start_send(self: Pin<&mut Self>, _: u32) -> Result<(), Infallible> {
+                unreachable!("start_send must not be called when poll_ready returns Pending")
+            }
+
+            fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Infallible>> {
+                Poll::Ready(Ok(())) // no-op flush — identical to futures::channel::mpsc
+            }
+
+            fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), Infallible>> {
+                Poll::Ready(Ok(()))
+            }
+        }
+
+        let cfg = MixerConfig {
+            min_delay: Duration::from_millis(0),
+            delay_range: Duration::from_millis(0),
+            capacity: 16,
+            metric_delay_window: 100,
+        };
+        let mut sink = MixerSink::new(AlwaysFullNoOpFlushSink, cfg);
+        sink.start_send_unpin(42u32).unwrap();
+
+        // flush() must return Poll::Pending (inner not ready), allowing the timeout to fire.
+        // If the spin bug is present, poll_flush loops forever on the single-threaded
+        // executor and the timeout can never be polled — the test hangs.
+        let result = timeout(Duration::from_millis(50), sink.flush()).await;
+        assert!(
+            result.is_err(),
+            "flush should have returned Pending (inner is full) and triggered the timeout, \
+             but it completed — inner should not have become ready"
+        );
     }
 }

--- a/utils-session/src/lib.rs
+++ b/utils-session/src/lib.rs
@@ -234,6 +234,21 @@ impl ListenerJoinHandles {
                 .map(|client| client.value().configurator.clone())
         })
     }
+
+    /// Returns all active session configurators for the given bound TCP host.
+    /// Intended for callers that only know the local TCP port they bound.
+    pub fn configurators_for(&self, bound_host: std::net::SocketAddr) -> Vec<HoprSessionConfigurator> {
+        self.0
+            .get(&ListenerId(IpProtocol::TCP, bound_host))
+            .map(|entry| {
+                entry
+                    .get_clients()
+                    .iter()
+                    .map(|client| client.value().configurator.clone())
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
 }
 
 impl Abortable for ListenerJoinHandles {
@@ -921,7 +936,6 @@ mod tests {
     use futures_time::future::FutureExt as TimeFutureExt;
     use hopr_api::types::crypto::crypto_traits::Randomizable;
     use hopr_lib::{
-        HopRouting,
         api::types::{
             internal::{
                 prelude::HoprPseudonym,
@@ -1083,6 +1097,31 @@ mod tests {
 
         let session_id = SessionId::new(5678u64, HoprPseudonym::random());
         assert!(handles.find_configurator(&session_id).is_none());
+    }
+
+    #[test]
+    fn configurators_for_returns_empty_for_unknown_host() {
+        let handles = ListenerJoinHandles::default();
+        let addr: std::net::SocketAddr = "127.0.0.1:9999".parse().unwrap();
+        assert!(handles.configurators_for(addr).is_empty());
+    }
+
+    #[test]
+    fn configurators_for_returns_empty_vec_when_listener_has_no_clients() {
+        let handles = ListenerJoinHandles::default();
+        let addr: std::net::SocketAddr = "127.0.0.1:9091".parse().unwrap();
+        handles.0.insert(ListenerId(IpProtocol::TCP, addr), stub_stored_entry());
+        // Entry exists but has no clients, so the result must be an empty Vec.
+        assert!(handles.configurators_for(addr).is_empty());
+    }
+
+    #[test]
+    fn configurators_for_ignores_udp_listener_on_same_port() {
+        let handles = ListenerJoinHandles::default();
+        let addr: std::net::SocketAddr = "127.0.0.1:9092".parse().unwrap();
+        handles.0.insert(ListenerId(IpProtocol::UDP, addr), stub_stored_entry());
+        // Only TCP listeners are looked up; a UDP entry on the same address must not match.
+        assert!(handles.configurators_for(addr).is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **fix(transport)**: drain `on_incoming_data_rx` on consumer drop — prevents `SessionsManagement(0)` from collapsing when the downstream receiver is gone, which caused msg-ingress panics on live relay nodes
- **feat(utils-session)**: `ListenerJoinHandles::configurators_for(bound_host)` — exposes active `HoprSessionConfigurator` handles for a given TCP binding so callers can reconfigure sessions without needing a `SessionId`
- **fix(hopr-transport-mixer)**: `MixerSink::poll_flush` busy-spin — when inner `poll_ready` returned `Pending` and inner `poll_flush` returned `Ready` (mpsc no-op), the loop computed `sleep_for=0` and `continue`d without yielding, pegging the executor; now returns `Poll::Pending`
- **fix(hopr-transport)**: share mixer heap across wire-sink clones — the ACK pipeline cloned the wire sink per destination; with `MixerSink` each clone had its own `BinaryHeap`, defeating cross-destination mixing; switched to `hopr_transport_mixer::channel` (shared `Arc<Mutex<BinaryHeap>>`, single `MixerForwarder` task)
- **refactor(transport)**: eliminate per-packet Arc clone on `MixerForwarder` and `SessionsManagement(0)` hot paths; deduplicate 20-line drain loop in `build_edge`/`build_full`

## Notes

- Depended on by: hoprnet/edge-client#72
- Consumer issue: gnosis/gnosis_vpn-client#556
- Downstream client PR: gnosis/gnosis_vpn-client#569