### PR TITLE
feat(transport): expose typed MixerConfig and lower default delay spread to 20ms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3604,6 +3604,7 @@ dependencies = [
  "hopr-transport",
  "hopr-utils",
  "humantime-serde",
+ "insta",
  "lazy_static",
  "parking_lot",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3589,7 +3589,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.3-rc.4"
+version = "4.0.2-rc.4"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -86,6 +86,7 @@ hopr-transport = { workspace = true }
 
 [dev-dependencies]
 hopr-utils = { workspace = true, features = ["runtime-tokio"] }
+insta = { workspace = true }
 serde-saphyr = { workspace = true }
 tokio = { workspace = true }
 

--- a/hopr/hopr-lib/src/config.rs
+++ b/hopr/hopr-lib/src/config.rs
@@ -3,9 +3,10 @@ use std::time::Duration;
 use hopr_api::types::primitive::prelude::*;
 pub use hopr_transport::{
     TagAllocatorConfig,
+    build_mixer_cfg_from_env,
     config::{
-        HoprPacketPipelineConfig, HoprProtocolConfig, HostConfig, HostType, ProbeConfig, SessionGlobalConfig,
-        TransportConfig, looks_like_domain,
+        HoprPacketPipelineConfig, HoprProtocolConfig, HostConfig, HostType, MixerConfig,
+        ProbeConfig, SessionGlobalConfig, TransportConfig, looks_like_domain,
     },
 };
 use validator::{Validate, ValidationError};
@@ -143,6 +144,26 @@ mod tests {
         let yaml = serde_saphyr::to_string(&cfg)?;
         let cfg_after_serde: super::HoprLibConfig = serde_saphyr::from_str(&yaml)?;
         assert_eq!(cfg, cfg_after_serde);
+
+        Ok(())
+    }
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn explicit_mixer_section_round_trips() -> Result<(), Box<dyn std::error::Error>> {
+        use std::time::Duration;
+
+        let mut cfg = super::HoprLibConfig::default();
+        cfg.protocol.mixer = super::MixerConfig {
+            min_delay: Duration::from_millis(5),
+            delay_range: Duration::from_millis(50),
+            capacity: 1_000,
+            ..Default::default()
+        };
+        let yaml = serde_saphyr::to_string(&cfg)?;
+        let parsed: super::HoprLibConfig = serde_saphyr::from_str(&yaml)?;
+        assert_eq!(cfg, parsed);
+        assert!(!yaml.contains("metric_delay_window"));
 
         Ok(())
     }

--- a/hopr/hopr-lib/src/config.rs
+++ b/hopr/hopr-lib/src/config.rs
@@ -149,7 +149,7 @@ mod tests {
 
     #[cfg(feature = "serde")]
     #[test]
-    fn explicit_mixer_section_round_trips() -> Result<(), Box<dyn std::error::Error>> {
+    fn explicit_mixer_section_round_trips() -> anyhow::Result<()> {
         use std::time::Duration;
 
         let mut cfg = super::HoprLibConfig::default();
@@ -159,10 +159,7 @@ mod tests {
             capacity: 1_000,
             ..Default::default()
         };
-        let yaml = serde_saphyr::to_string(&cfg)?;
-        let parsed: super::HoprLibConfig = serde_saphyr::from_str(&yaml)?;
-        assert_eq!(cfg, parsed);
-        assert!(!yaml.contains("metric_delay_window"));
+        insta::assert_yaml_snapshot!(cfg.protocol.mixer);
 
         Ok(())
     }

--- a/hopr/hopr-lib/src/config.rs
+++ b/hopr/hopr-lib/src/config.rs
@@ -161,6 +161,10 @@ mod tests {
         };
         insta::assert_yaml_snapshot!(cfg.protocol.mixer);
 
+        let yaml = serde_saphyr::to_string(&cfg.protocol.mixer)?;
+        let parsed: super::MixerConfig = serde_saphyr::from_str(&yaml)?;
+        assert_eq!(cfg.protocol.mixer, parsed);
+
         Ok(())
     }
 }

--- a/hopr/hopr-lib/src/config.rs
+++ b/hopr/hopr-lib/src/config.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 use hopr_api::types::primitive::prelude::*;
 pub use hopr_transport::{
     TagAllocatorConfig,
-    build_mixer_cfg_from_env,
     config::{
         HoprPacketPipelineConfig, HoprProtocolConfig, HostConfig, HostType, MixerConfig,
         ProbeConfig, SessionGlobalConfig, TransportConfig, looks_like_domain,

--- a/hopr/hopr-lib/src/snapshots/hopr_lib__config__tests__explicit_mixer_section_round_trips.snap
+++ b/hopr/hopr-lib/src/snapshots/hopr_lib__config__tests__explicit_mixer_section_round_trips.snap
@@ -1,0 +1,7 @@
+---
+source: hopr/hopr-lib/src/config.rs
+expression: cfg.protocol.mixer
+---
+min_delay: 5ms
+delay_range: 50ms
+capacity: 1000

--- a/hopr/reference/src/testing/hopr.rs
+++ b/hopr/reference/src/testing/hopr.rs
@@ -55,6 +55,7 @@ pub fn create_hopr_instance_config(host_port: u16, safe: NodeSafeConfig, winn_pr
                 },
                 ..Default::default()
             },
+            mixer: Default::default(),
             path_planner: Default::default(),
             counter_flush_interval: Default::default(),
         },

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -34,6 +34,7 @@ serde = [
   "hopr-api/serde",
   "hopr-protocol-app/serde",
   "hopr-protocol-hopr/serde",
+  "hopr-transport-mixer/serde",
   "hopr-transport-tag-allocator/serde",
 ]
 
@@ -86,7 +87,7 @@ hopr-crypto-packet = { workspace = true, features = ["ed25519"] }
 hopr-protocol-app = { workspace = true }
 hopr-protocol-hopr = { workspace = true, features = ["rayon"] }
 hopr-ticket-manager = { workspace = true }
-hopr-transport-mixer = { workspace = true, features = ["serde"] }
+hopr-transport-mixer = { workspace = true }
 hopr-transport-probe = { workspace = true }
 hopr-transport-session = { workspace = true }
 hopr-transport-tag-allocator = { workspace = true }

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -86,7 +86,7 @@ hopr-crypto-packet = { workspace = true, features = ["ed25519"] }
 hopr-protocol-app = { workspace = true }
 hopr-protocol-hopr = { workspace = true, features = ["rayon"] }
 hopr-ticket-manager = { workspace = true }
-hopr-transport-mixer = { workspace = true }
+hopr-transport-mixer = { workspace = true, features = ["serde"] }
 hopr-transport-probe = { workspace = true }
 hopr-transport-session = { workspace = true }
 hopr-transport-tag-allocator = { workspace = true }

--- a/transport/hopr/src/config.rs
+++ b/transport/hopr/src/config.rs
@@ -8,6 +8,7 @@ use std::{
 
 use hopr_api::Multiaddr;
 pub use hopr_protocol_hopr::{HoprCodecConfig, HoprUnacknowledgedTicketProcessorConfig, SurbStoreConfig};
+pub use hopr_transport_mixer::config::MixerConfig;
 pub use hopr_transport_probe::config::ProbeConfig;
 use hopr_transport_session::{MIN_BALANCER_SAMPLING_INTERVAL, MIN_SURB_BUFFER_DURATION};
 use proc_macro_regex::regex;
@@ -45,6 +46,9 @@ pub struct HoprProtocolConfig {
     #[validate(nested)]
     #[cfg_attr(feature = "serde", serde(default))]
     pub session: SessionGlobalConfig,
+    /// Mixer configuration.
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub mixer: MixerConfig,
     /// Path planner configuration
     #[validate(nested)]
     #[cfg_attr(feature = "serde", serde(skip))]

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -516,7 +516,9 @@ where
         // heap, so cross-destination packets are mixed together rather than each destination
         // getting its own independent delay queue. The single forwarder task owns the receiver
         // (and therefore the heap timer) — no per-clone waker coordination is needed.
-        let (mixing_channel_tx, mix_rx) = hopr_transport_mixer::channel(build_mixer_cfg_from_env());
+        let mut mixer_cfg = self.cfg.mixer;
+        mixer_cfg.metric_delay_window = 5 * mixer_cfg.delay_range.as_millis() as u64;
+        let (mixing_channel_tx, mix_rx) = hopr_transport_mixer::channel(mixer_cfg);
         processes.insert(
             HoprTransportProcess::MixerForwarder,
             hopr_utils::spawn_as_abortable!(async move {
@@ -1033,7 +1035,12 @@ where
     }
 }
 
-fn build_mixer_cfg_from_env() -> MixerConfig {
+/// Builds a [`MixerConfig`] from environment variables with compiled-in defaults as fallback.
+///
+/// - `HOPR_INTERNAL_MIXER_MINIMUM_DELAY_IN_MS` — minimum delay in milliseconds
+/// - `HOPR_INTERNAL_MIXER_DELAY_RANGE_IN_MS` — delay spread in milliseconds
+/// - `HOPR_INTERNAL_MIXER_CAPACITY` — mixer buffer capacity
+pub fn build_mixer_cfg_from_env() -> MixerConfig {
     let mixer_cfg = MixerConfig {
         min_delay: std::time::Duration::from_millis(
             std::env::var("HOPR_INTERNAL_MIXER_MINIMUM_DELAY_IN_MS")

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -62,7 +62,6 @@ use hopr_api::{
 use hopr_crypto_packet::prelude::PacketSignal;
 pub use hopr_protocol_app::prelude::{ApplicationData, ApplicationDataIn, ApplicationDataOut, Tag};
 use hopr_protocol_hopr::MemorySurbStore;
-use hopr_transport_mixer::MixerConfig;
 pub use hopr_transport_probe::{NeighborTelemetry, PathTelemetry, errors::ProbeError, ping::PingQueryReplier};
 use hopr_transport_probe::{
     Probe,
@@ -1035,46 +1034,6 @@ where
     }
 }
 
-/// Builds a [`MixerConfig`] from environment variables with compiled-in defaults as fallback.
-///
-/// - `HOPR_INTERNAL_MIXER_MINIMUM_DELAY_IN_MS` — minimum delay in milliseconds
-/// - `HOPR_INTERNAL_MIXER_DELAY_RANGE_IN_MS` — delay spread in milliseconds
-/// - `HOPR_INTERNAL_MIXER_CAPACITY` — mixer buffer capacity
-pub fn build_mixer_cfg_from_env() -> MixerConfig {
-    let mixer_cfg = MixerConfig {
-        min_delay: std::time::Duration::from_millis(
-            std::env::var("HOPR_INTERNAL_MIXER_MINIMUM_DELAY_IN_MS")
-                .map(|v| {
-                    v.trim()
-                        .parse::<u64>()
-                        .unwrap_or(hopr_transport_mixer::config::HOPR_MIXER_MINIMUM_DEFAULT_DELAY_IN_MS)
-                })
-                .unwrap_or(hopr_transport_mixer::config::HOPR_MIXER_MINIMUM_DEFAULT_DELAY_IN_MS),
-        ),
-        delay_range: std::time::Duration::from_millis(
-            std::env::var("HOPR_INTERNAL_MIXER_DELAY_RANGE_IN_MS")
-                .map(|v| {
-                    v.trim()
-                        .parse::<u64>()
-                        .unwrap_or(hopr_transport_mixer::config::HOPR_MIXER_DEFAULT_DELAY_RANGE_IN_MS)
-                })
-                .unwrap_or(hopr_transport_mixer::config::HOPR_MIXER_DEFAULT_DELAY_RANGE_IN_MS),
-        ),
-        capacity: {
-            let capacity = std::env::var("HOPR_INTERNAL_MIXER_CAPACITY")
-                .ok()
-                .and_then(|s| s.trim().parse::<usize>().ok())
-                .filter(|&c| c > 0)
-                .unwrap_or(hopr_transport_mixer::config::HOPR_MIXER_CAPACITY);
-            debug!(capacity = capacity, "Setting mixer capacity");
-            capacity
-        },
-        ..MixerConfig::default()
-    };
-    debug!(?mixer_cfg, "Mixer configuration");
-
-    mixer_cfg
-}
 
 // ---------------------------------------------------------------------------
 // NetworkView impl for HoprTransport — wraps OnceLock<Net> access

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -516,7 +516,9 @@ where
         // getting its own independent delay queue. The single forwarder task owns the receiver
         // (and therefore the heap timer) — no per-clone waker coordination is needed.
         let mut mixer_cfg = self.cfg.mixer;
-        mixer_cfg.metric_delay_window = 5 * mixer_cfg.delay_range.as_millis() as u64;
+        mixer_cfg.metric_delay_window = u64::try_from(5 * mixer_cfg.delay_range.as_millis())
+            .unwrap_or(u64::MAX)
+            .max(1);
         let (mixing_channel_tx, mix_rx) = hopr_transport_mixer::channel(mixer_cfg);
         processes.insert(
             HoprTransportProcess::MixerForwarder,

--- a/transport/hopr/tests/snapshots/not_running__mixer_config_default_values_snapshot.snap
+++ b/transport/hopr/tests/snapshots/not_running__mixer_config_default_values_snapshot.snap
@@ -3,6 +3,5 @@ source: transport/api/tests/not_running.rs
 expression: cfg
 ---
 min_delay: 0s
-delay_range: 200ms
+delay_range: 20ms
 capacity: 20000
-metric_delay_window: 100

--- a/transport/mixer/src/config.rs
+++ b/transport/mixer/src/config.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 pub const HOPR_MIXER_MINIMUM_DEFAULT_DELAY_IN_MS: u64 = 0;
-pub const HOPR_MIXER_DEFAULT_DELAY_RANGE_IN_MS: u64 = 200;
+pub const HOPR_MIXER_DEFAULT_DELAY_RANGE_IN_MS: u64 = 20;
 pub const HOPR_MIXER_DELAY_METRIC_WINDOW: u64 = 100;
 pub const HOPR_MIXER_CAPACITY: usize = 20_000;
 
@@ -24,6 +24,7 @@ pub struct MixerConfig {
     #[default(HOPR_MIXER_CAPACITY)]
     pub capacity: usize,
     #[default(HOPR_MIXER_DELAY_METRIC_WINDOW)]
+    #[cfg_attr(feature = "serde", serde(skip))]
     pub metric_delay_window: u64,
 }
 

--- a/transport/mixer/src/config.rs
+++ b/transport/mixer/src/config.rs
@@ -5,6 +5,7 @@ pub const HOPR_MIXER_DEFAULT_DELAY_RANGE_IN_MS: u64 = 20;
 pub const HOPR_MIXER_DELAY_METRIC_WINDOW: u64 = 100;
 pub const HOPR_MIXER_CAPACITY: usize = 20_000;
 
+#[cfg(feature = "serde")]
 fn default_metric_delay_window() -> u64 {
     HOPR_MIXER_DELAY_METRIC_WINDOW
 }

--- a/transport/mixer/src/config.rs
+++ b/transport/mixer/src/config.rs
@@ -5,6 +5,10 @@ pub const HOPR_MIXER_DEFAULT_DELAY_RANGE_IN_MS: u64 = 20;
 pub const HOPR_MIXER_DELAY_METRIC_WINDOW: u64 = 100;
 pub const HOPR_MIXER_CAPACITY: usize = 20_000;
 
+fn default_metric_delay_window() -> u64 {
+    HOPR_MIXER_DELAY_METRIC_WINDOW
+}
+
 /// Mixer configuration.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, smart_default::SmartDefault)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -24,7 +28,7 @@ pub struct MixerConfig {
     #[default(HOPR_MIXER_CAPACITY)]
     pub capacity: usize,
     #[default(HOPR_MIXER_DELAY_METRIC_WINDOW)]
-    #[cfg_attr(feature = "serde", serde(skip))]
+    #[cfg_attr(feature = "serde", serde(skip_serializing, default = "default_metric_delay_window"))]
     pub metric_delay_window: u64,
 }
 


### PR DESCRIPTION
## Summary

- Lowers `HOPR_MIXER_DEFAULT_DELAY_RANGE_IN_MS` from 200 ms → 20 ms
- Adds `mixer: MixerConfig` as a typed, non-optional field on `HoprProtocolConfig` (default = 0 ms min, 20 ms range, 20 000 capacity)