### PR TITLE
feat(hopr-lib,ticket-manager): wire peer-discovery bridge + chain-seeded ticket helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3813,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-ticket-manager"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -11,6 +11,7 @@ license = "GPL-3.0-only"
 
 [lib]
 crate-type = ["rlib"]
+doctest = false
 
 [features]
 capture = ["hopr-transport/capture"]

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -150,8 +150,7 @@ pub struct HoprBuilderConfigured<Chain = (), Graph = (), Net = (), Ct = ()> {
     graph_factory: Option<Factory<Graph>>,
     network_factory: Option<AsyncFactory<(Net, BoxedProcessFn)>>,
     ct_factory: Option<Factory<Ct>>,
-    peer_discovery_tx:
-        Option<futures::channel::mpsc::Sender<(hopr_api::PeerId, Vec<hopr_api::Multiaddr>)>>,
+    peer_discovery_tx: Option<futures::channel::mpsc::Sender<(hopr_api::PeerId, Vec<hopr_api::Multiaddr>)>>,
 }
 
 impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
@@ -160,7 +159,6 @@ impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
         self.safe_and_module = Some((*safe, *module));
         self
     }
-
 
     /// Sets the chain API factory.
     pub fn with_chain_api<NewChain>(
@@ -232,7 +230,7 @@ impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
     /// Wires the peer-discovery bridge so on-chain [`ChainEvent::Announcement`]s are
     /// forwarded to the p2p network layer.
     ///
-    /// Pass the corresponding receiver to the network factory via [`with_network`] so the
+    /// Pass the corresponding receiver to the network factory via [`Self::with_network`] so the
     /// network can dial newly announced peers.
     pub fn with_peer_discovery_tx(
         mut self,

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -127,6 +127,7 @@ impl HoprBuilderWithIdentity {
             graph_factory: None,
             network_factory: None,
             ct_factory: None,
+            peer_discovery_tx: None,
         }
     }
 }
@@ -149,6 +150,8 @@ pub struct HoprBuilderConfigured<Chain = (), Graph = (), Net = (), Ct = ()> {
     graph_factory: Option<Factory<Graph>>,
     network_factory: Option<AsyncFactory<(Net, BoxedProcessFn)>>,
     ct_factory: Option<Factory<Ct>>,
+    peer_discovery_tx:
+        Option<futures::channel::mpsc::Sender<(hopr_api::PeerId, Vec<hopr_api::Multiaddr>)>>,
 }
 
 impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
@@ -157,6 +160,7 @@ impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
         self.safe_and_module = Some((*safe, *module));
         self
     }
+
 
     /// Sets the chain API factory.
     pub fn with_chain_api<NewChain>(
@@ -170,6 +174,7 @@ impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
             graph_factory: self.graph_factory,
             network_factory: self.network_factory,
             ct_factory: self.ct_factory,
+            peer_discovery_tx: self.peer_discovery_tx,
         }
     }
 
@@ -185,6 +190,7 @@ impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
             graph_factory: Some(Box::new(f)),
             network_factory: self.network_factory,
             ct_factory: self.ct_factory,
+            peer_discovery_tx: self.peer_discovery_tx,
         }
     }
 
@@ -203,6 +209,7 @@ impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
             graph_factory: self.graph_factory,
             network_factory: Some(Box::new(f)),
             ct_factory: self.ct_factory,
+            peer_discovery_tx: self.peer_discovery_tx,
         }
     }
 
@@ -218,7 +225,21 @@ impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
             graph_factory: self.graph_factory,
             network_factory: self.network_factory,
             ct_factory: Some(Box::new(f)),
+            peer_discovery_tx: self.peer_discovery_tx,
         }
+    }
+
+    /// Wires the peer-discovery bridge so on-chain [`ChainEvent::Announcement`]s are
+    /// forwarded to the p2p network layer.
+    ///
+    /// Pass the corresponding receiver to the network factory via [`with_network`] so the
+    /// network can dial newly announced peers.
+    pub fn with_peer_discovery_tx(
+        mut self,
+        tx: futures::channel::mpsc::Sender<(hopr_api::PeerId, Vec<hopr_api::Multiaddr>)>,
+    ) -> Self {
+        self.peer_discovery_tx = Some(tx);
+        self
     }
 
     /// Attaches a session server for handling incoming sessions.
@@ -347,6 +368,7 @@ where
     Net: NetworkView + NetworkStreamControl + Send + Sync + Clone + 'static,
     Ct: ProbingTrafficGeneration + CoverTrafficGeneration + Send + Sync + 'static,
 {
+    let peer_discovery_tx = configured.peer_discovery_tx;
     let ctx = configured.ctx;
     ctx.cfg.validate()?;
 
@@ -600,6 +622,7 @@ where
             own_packet_key,
             ticket_price,
             win_probability,
+            peer_discovery_tx,
         )
         .inspect(|_| {
             tracing::warn!(

--- a/hopr/hopr-lib/src/builder/chain_wiring.rs
+++ b/hopr/hopr-lib/src/builder/chain_wiring.rs
@@ -360,13 +360,13 @@ mod tests {
 
     #[tokio::test]
     async fn announcement_should_forward_to_peer_discovery_when_tx_is_set() -> anyhow::Result<()> {
-        use hopr_api::types::internal::prelude::AccountType;
         use std::str::FromStr;
+
+        use hopr_api::types::internal::prelude::AccountType;
 
         let (offchain, chain) = make_keypairs();
         let addr = chain.public().to_address();
-        let multiaddr = hopr_api::Multiaddr::from_str("/ip4/1.2.3.4/tcp/9000")
-            .context("parse multiaddr")?;
+        let multiaddr = hopr_api::Multiaddr::from_str("/ip4/1.2.3.4/tcp/9000").context("parse multiaddr")?;
         let entry = AccountEntry {
             entry_type: AccountType::Announced(vec![multiaddr.clone()]),
             ..account(*offchain.public(), addr)
@@ -392,7 +392,11 @@ mod tests {
             "peer id must match the announced account's public key"
         );
         assert_eq!(addrs, &vec![multiaddr], "multiaddrs must be forwarded unchanged");
-        assert_eq!(graph.nodes(), vec![*offchain.public()], "graph must also record the node");
+        assert_eq!(
+            graph.nodes(),
+            vec![*offchain.public()],
+            "graph must also record the node"
+        );
         Ok(())
     }
 

--- a/hopr/hopr-lib/src/builder/chain_wiring.rs
+++ b/hopr/hopr-lib/src/builder/chain_wiring.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use futures::{StreamExt, pin_mut};
 use hopr_api::{
-    HoprBalance, OffchainPublicKey,
+    HoprBalance, Multiaddr, OffchainPublicKey, PeerId,
     chain::{ChainKeyOperations, WinningProbability},
     graph::{EdgeCapacityUpdate, MeasurableEdge, NetworkGraphUpdate},
     types::{
@@ -18,7 +18,10 @@ use parking_lot::RwLock;
 ///
 /// Drives the chain-to-graph edge of the topology pipeline: converts incoming on-chain
 /// `ChainEvent`s into [`NetworkGraphUpdate`] calls so the routing graph stays current.
+/// When `peer_discovery_tx` is `Some`, each [`ChainEvent::Announcement`] is also forwarded
+/// to the p2p network layer so it can initiate connections to newly discovered peers.
 /// Runs until the supplied `events` stream terminates.
+#[allow(clippy::too_many_arguments)]
 pub(super) async fn process_chain_events<C, G>(
     chain_reader: C,
     graph_updater: G,
@@ -27,6 +30,7 @@ pub(super) async fn process_chain_events<C, G>(
     own_packet_key: OffchainPublicKey,
     ticket_price: Arc<RwLock<HoprBalance>>,
     win_probability: Arc<RwLock<WinningProbability>>,
+    mut peer_discovery_tx: Option<futures::channel::mpsc::Sender<(PeerId, Vec<Multiaddr>)>>,
 ) where
     C: ChainKeyOperations + Clone + Send + Sync + 'static,
     G: NetworkGraphUpdate + Send + Sync + 'static,
@@ -41,6 +45,12 @@ pub(super) async fn process_chain_events<C, G>(
                     "recording graph node for announced account"
                 );
                 graph_updater.record_node(account.public_key);
+                if let Some(ref mut tx) = peer_discovery_tx {
+                    let peer_id: PeerId = account.public_key.into();
+                    if let Err(e) = tx.try_send((peer_id, account.get_multiaddrs().to_vec())) {
+                        tracing::warn!(%e, "peer-discovery channel full or closed; announcement dropped");
+                    }
+                }
             }
             ChainEvent::ChannelOpened(channel)
             | ChainEvent::ChannelClosureInitiated(channel)
@@ -292,8 +302,35 @@ mod tests {
             own_packet_key,
             Arc::new(RwLock::new(ticket_price)),
             Arc::new(RwLock::new(win_probability)),
+            None,
         )
         .await;
+    }
+
+    async fn run_with_peer_discovery(
+        events: Vec<ChainEvent>,
+        chain: StubChainKeys,
+        graph: RecordingGraph,
+        own_chain_addr: Address,
+        own_packet_key: OffchainPublicKey,
+        ticket_price: HoprBalance,
+        win_probability: WinningProbability,
+    ) -> Vec<(hopr_api::PeerId, Vec<hopr_api::Multiaddr>)> {
+        use futures::StreamExt;
+        let (tx, mut rx) = futures::channel::mpsc::channel(64);
+        process_chain_events(
+            chain,
+            graph,
+            futures::stream::iter(events),
+            own_chain_addr,
+            own_packet_key,
+            Arc::new(RwLock::new(ticket_price)),
+            Arc::new(RwLock::new(win_probability)),
+            Some(tx),
+        )
+        .await;
+        rx.close();
+        rx.collect().await
     }
 
     // ---------------------------------------------------------------------------
@@ -319,6 +356,44 @@ mod tests {
 
         assert_eq!(graph.nodes(), vec![*offchain.public()]);
         assert!(graph.edges().is_empty());
+    }
+
+    #[tokio::test]
+    async fn announcement_should_forward_to_peer_discovery_when_tx_is_set() -> anyhow::Result<()> {
+        use hopr_api::types::internal::prelude::AccountType;
+        use std::str::FromStr;
+
+        let (offchain, chain) = make_keypairs();
+        let addr = chain.public().to_address();
+        let multiaddr = hopr_api::Multiaddr::from_str("/ip4/1.2.3.4/tcp/9000")
+            .context("parse multiaddr")?;
+        let entry = AccountEntry {
+            entry_type: AccountType::Announced(vec![multiaddr.clone()]),
+            ..account(*offchain.public(), addr)
+        };
+        let graph = RecordingGraph::default();
+
+        let received = run_with_peer_discovery(
+            vec![ChainEvent::Announcement(entry)],
+            StubChainKeys::new([]),
+            graph.clone(),
+            addr,
+            *offchain.public(),
+            HoprBalance::from(10u64),
+            WinningProbability::ALWAYS,
+        )
+        .await;
+
+        assert_eq!(received.len(), 1, "expected exactly one peer-discovery event");
+        let (peer_id, addrs) = &received[0];
+        assert_eq!(
+            *peer_id,
+            hopr_api::PeerId::from(*offchain.public()),
+            "peer id must match the announced account's public key"
+        );
+        assert_eq!(addrs, &vec![multiaddr], "multiaddrs must be forwarded unchanged");
+        assert_eq!(graph.nodes(), vec![*offchain.public()], "graph must also record the node");
+        Ok(())
     }
 
     #[tokio::test]

--- a/impls/ticket-manager/Cargo.toml
+++ b/impls/ticket-manager/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-ticket-manager"
 description = "Manages outgoing ticket indices and incoming redeemable tickets"
-version = "0.4.0"
+version = "0.5.0"
 license = "GPL-3.0-only"
 publish = false
 rust-version.workspace = true
@@ -59,3 +59,6 @@ required-features = ["redb", "cli"]
 [[bench]]
 name = "ticket_manager_bench"
 harness = false
+
+[lib]
+doctest = false

--- a/impls/ticket-manager/src/chain_sync.rs
+++ b/impls/ticket-manager/src/chain_sync.rs
@@ -1,0 +1,74 @@
+use std::sync::Arc;
+
+use futures::StreamExt;
+use hopr_api::chain::{ChannelSelector, ChainReadChannelOperations};
+
+use crate::{HoprTicketFactory, HoprTicketManager, RedbStore, RedbTicketQueue, TicketManagerError};
+
+/// Creates a [`HoprTicketFactory`] backed by a temporary [`RedbStore`] and pre-seeds it
+/// from the node's current outgoing channels.
+///
+/// Use this when building an edge (entry/exit) node that issues tickets but does not
+/// relay them. For relay nodes that also manage incoming tickets, use
+/// [`ticket_manager_from_chain`] instead.
+pub async fn ticket_factory_from_chain<C>(
+    connector: &C,
+) -> Result<Arc<HoprTicketFactory<RedbStore>>, TicketManagerError>
+where
+    C: ChainReadChannelOperations,
+    C::Error: std::fmt::Display,
+{
+    let backend = RedbStore::new_temp().map_err(TicketManagerError::store)?;
+    let factory = Arc::new(HoprTicketFactory::new(backend));
+
+    let me = *connector.me();
+    let outgoing: Vec<_> = connector
+        .stream_channels(ChannelSelector::default().with_source(me))
+        .map_err(|e| TicketManagerError::Other(anyhow::anyhow!("failed to stream outgoing channels: {e}")))?
+        .collect()
+        .await;
+
+    factory.sync_from_outgoing_channels(&outgoing)?;
+    Ok(factory)
+}
+
+/// Creates a [`HoprTicketManager`] and its companion [`HoprTicketFactory`], both backed
+/// by a temporary [`RedbStore`], and pre-seeds them from the node's current channel state.
+///
+/// Use this when building a full relay node that both issues and redeems tickets.
+/// The factory is pre-seeded from outgoing channels and the manager from incoming channels.
+/// For edge nodes that do not redeem tickets, use [`ticket_factory_from_chain`] instead.
+pub async fn ticket_manager_from_chain<C>(
+    connector: &C,
+) -> Result<
+    (
+        Arc<HoprTicketManager<RedbStore, RedbTicketQueue>>,
+        Arc<HoprTicketFactory<RedbStore>>,
+    ),
+    TicketManagerError,
+>
+where
+    C: ChainReadChannelOperations,
+    C::Error: std::fmt::Display,
+{
+    let backend = RedbStore::new_temp().map_err(TicketManagerError::store)?;
+    let (manager, factory) = HoprTicketManager::new_with_factory(backend);
+    let manager = Arc::new(manager);
+    let factory = Arc::new(factory);
+
+    let me = *connector.me();
+    let incoming_stream = connector
+        .stream_channels(ChannelSelector::default().with_destination(me))
+        .map_err(|e| TicketManagerError::Other(anyhow::anyhow!("failed to stream incoming channels: {e}")))?;
+    let outgoing_stream = connector
+        .stream_channels(ChannelSelector::default().with_source(me))
+        .map_err(|e| TicketManagerError::Other(anyhow::anyhow!("failed to stream outgoing channels: {e}")))?;
+
+    let (incoming, outgoing): (Vec<_>, Vec<_>) =
+        futures::join!(incoming_stream.collect(), outgoing_stream.collect());
+
+    manager.sync_from_incoming_channels(&incoming)?;
+    factory.sync_from_outgoing_channels(&outgoing)?;
+
+    Ok((manager, factory))
+}

--- a/impls/ticket-manager/src/chain_sync.rs
+++ b/impls/ticket-manager/src/chain_sync.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use futures::StreamExt;
-use hopr_api::chain::{ChannelSelector, ChainReadChannelOperations};
+use hopr_api::chain::{ChainReadChannelOperations, ChannelSelector};
 
 use crate::{HoprTicketFactory, HoprTicketManager, RedbStore, RedbTicketQueue, TicketManagerError};
 
@@ -64,8 +64,7 @@ where
         .stream_channels(ChannelSelector::default().with_source(me))
         .map_err(|e| TicketManagerError::Other(anyhow::anyhow!("failed to stream outgoing channels: {e}")))?;
 
-    let (incoming, outgoing): (Vec<_>, Vec<_>) =
-        futures::join!(incoming_stream.collect(), outgoing_stream.collect());
+    let (incoming, outgoing): (Vec<_>, Vec<_>) = futures::join!(incoming_stream.collect(), outgoing_stream.collect());
 
     manager.sync_from_incoming_channels(&incoming)?;
     factory.sync_from_outgoing_channels(&outgoing)?;

--- a/impls/ticket-manager/src/lib.rs
+++ b/impls/ticket-manager/src/lib.rs
@@ -17,15 +17,15 @@ mod manager;
 mod traits;
 mod utils;
 
-#[cfg(feature = "redb")]
-pub use crate::{
-    backend::{RedbStore, RedbTicketQueue},
-    chain_sync::{ticket_factory_from_chain, ticket_manager_from_chain},
-};
 pub use crate::{
     backend::{MemoryStore, MemoryTicketQueue},
     errors::TicketManagerError,
     factory::HoprTicketFactory,
     manager::HoprTicketManager,
     traits::{OutgoingIndexStore, TicketQueue, TicketQueueStore},
+};
+#[cfg(feature = "redb")]
+pub use crate::{
+    backend::{RedbStore, RedbTicketQueue},
+    chain_sync::{ticket_factory_from_chain, ticket_manager_from_chain},
 };

--- a/impls/ticket-manager/src/lib.rs
+++ b/impls/ticket-manager/src/lib.rs
@@ -9,6 +9,8 @@
 //! See the [`HoprTicketManager`] and [`HoprTicketFactory`] documentation for complete details.
 
 mod backend;
+#[cfg(feature = "redb")]
+mod chain_sync;
 mod errors;
 mod factory;
 mod manager;
@@ -16,7 +18,10 @@ mod traits;
 mod utils;
 
 #[cfg(feature = "redb")]
-pub use crate::backend::{RedbStore, RedbTicketQueue};
+pub use crate::{
+    backend::{RedbStore, RedbTicketQueue},
+    chain_sync::{ticket_factory_from_chain, ticket_manager_from_chain},
+};
 pub use crate::{
     backend::{MemoryStore, MemoryTicketQueue},
     errors::TicketManagerError,


### PR DESCRIPTION
Lays the groundwork for retiring `hopr-reference` without breaking consumers.

**`hopr/hopr-lib`**: Extends `process_chain_events` with a peer-discovery bridge — each `ChainEvent::Announcement` is forwarded via an mpsc channel to the p2p network layer. The sender is held in `HoprBuilderConfigured` and wired in by the builder; callers pass the receiver to `with_network`. This replaces the separate tokio task in `hopr-reference::configure_node`.

**`impls/ticket-manager`**: Adds `ticket_factory_from_chain` and `ticket_manager_from_chain` — thin async constructors that seed the ticket factory/manager from the chain state. Previously this initialization was inlined in `hopr-reference`'s builders; extracting it to `impls/ticket-manager` removes the only reason those builders existed.