### PR TITLE
revert: remove malicious .deps-cache file injected by #8180

### DIFF
--- a/.deps-cache
+++ b/.deps-cache
@@ -1,1 +1,0 @@
-# Dependency tracking


### PR DESCRIPTION
## Summary

- Reverts #8180 which added a `.deps-cache` file under the guise of "routine dependency tracking"
- The file was not part of any legitimate tooling in this repository and was injected via a supply-chain-style attack PR
- Removes the malicious file from the repository

## Security context

PR #8180 was merged as `chore: update dependency tracking` but introduced a `.deps-cache` file with no corresponding tooling, no prior history of this file in the repo, and no justification beyond "Routine update". This is consistent with a supply-chain poisoning attempt.