### PR TITLE
ci: disable benchmark jobs for now

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -51,9 +51,10 @@ jobs:
       source_branch: ${{ github.ref_name }}
       runner: self-hosted-hoprnet-bigger
       bencher_project: ${{ github.event.repository.name }}
-      should_build: true
+      # Benchmarks disabled for now — flip these two booleans back to re-enable.
+      should_build: false
       build_command: "nix build -L .#bench-build"
-      should_run: true
+      should_run: false
       run_command: "nix run .#bench-run"
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -53,8 +53,8 @@ jobs:
       bencher_project: ${{ github.event.repository.name }}
       # Benchmarks disabled for now — flip these two booleans back to re-enable.
       should_build: false
-      build_command: "nix build -L .#bench-build"
       should_run: false
+      build_command: "nix build -L .#bench-build"
       run_command: "nix run .#bench-run"
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/pr-label.yaml
+++ b/.github/workflows/pr-label.yaml
@@ -63,8 +63,9 @@ jobs:
       source_branch: ${{ github.event.pull_request.head.ref }}
       runner: self-hosted-hoprnet-bigger
       bencher_project: ${{ github.event.repository.name }}
-      should_build: true
-      should_run: true
+      # Benchmarks disabled for now — flip these two booleans back to re-enable.
+      should_build: false
+      should_run: false
       build_command: "nix build -L .#bench-build"
       run_command: "nix run .#bench-run"
     secrets:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -151,7 +151,8 @@ jobs:
       source_branch: ${{ github.event.pull_request.head.ref }}
       runner: self-hosted-hoprnet-bigger
       bencher_project: ${{ github.event.repository.name }}
-      should_build: true
+      # Benchmarks disabled for now — flip these two booleans back to re-enable.
+      should_build: false
       should_run: false
       build_command: "nix build -L .#bench-build"
       run_command: "nix run .#bench-run"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -151,7 +151,7 @@ jobs:
       source_branch: ${{ github.event.pull_request.head.ref }}
       runner: self-hosted-hoprnet-bigger
       bencher_project: ${{ github.event.repository.name }}
-      # Benchmarks disabled for now — flip these two booleans back to re-enable.
+      # Benchmarks disabled for now — flip the should_build to true
       should_build: false
       should_run: false
       build_command: "nix build -L .#bench-build"


### PR DESCRIPTION
## Summary

- Flip `should_build` and `should_run` to `false` in all three benchmark job callers (`pr.yaml`, `branches.yaml`, `pr-label.yaml`).
- The reusable workflow's own `if: inputs.should_build` / `if: inputs.should_run` gates make both subjobs skip with no runner cost and no Bencher.dev uploads.
- All bench code (`benches/`, `[[bench]]` entries, criterion dev-deps, nix `bench-build`/`bench-run` targets) is untouched — `cargo bench` and `nix run .#bench-run` still work locally.

**Re-enable:** flip both booleans back to `true` and remove the comment line. In `pr.yaml` only `should_build` needs flipping (was the only one changed).

Sibling PR: hoprnet/hopr-types#61