### PR TITLE
chore(coderabbit): tighten defaults — assertive, high-level, comments-only

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -3,9 +3,7 @@
 language: "en-US"
 early_access: false
 tone_instructions: >-
-  Be pedantic and rigorous. Focus on substantive correctness, security,
-  architectural concerns, and high-level design issues. Skip cosmetic or
-  stylistic nits. Never submit an approving review — comments only.
+  Be pedantic and rigorous. Focus on substantive correctness, security, architectural concerns, and high-level design issues. Skip cosmetic or stylistic nits. Never submit an approving review — comments only.
 reviews:
   profile: "assertive"
   # Do NOT enable request_changes_workflow: with it off, CodeRabbit only

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -2,12 +2,28 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 language: "en-US"
 early_access: false
+tone_instructions: >-
+  Be pedantic and rigorous. Focus on substantive correctness, security,
+  architectural concerns, and high-level design issues. Skip cosmetic or
+  stylistic nits. Never submit an approving review — comments only.
 reviews:
-  profile: "chill"
+  profile: "assertive"
+  # Do NOT enable request_changes_workflow: with it off, CodeRabbit only
+  # submits COMMENT reviews — never APPROVED or REQUEST_CHANGES.
   request_changes_workflow: false
   high_level_summary: false
+  review_status: false
+  commit_status: false
+  changed_files_summary: false
+  sequence_diagrams: false
+  related_issues: false
+  related_prs: false
+  suggested_labels: false
+  auto_apply_labels: false
+  suggested_reviewers: false
+  auto_assign_reviewers: false
+  assess_linked_issues: true
   poem: false
-  review_status: true
   collapse_walkthrough: true
   path_filters:
     - "!vendor/**"


### PR DESCRIPTION
## Summary

Tighten CodeRabbit configuration per [hoprnet/hopr-devops#277](https://github.com/hoprnet/hopr-devops/issues/277): switch to an assertive and pedantic review posture, suppress all low-value noise output, and structurally prevent the bot from approving PRs.

- Switch `profile` to `assertive`
- Add `tone_instructions`: pedantic, high-level focus, comments-only — never approve
- Suppress `review_status`, `commit_status`, `changed_files_summary`, `sequence_diagrams`
- Suppress `related_issues`, `related_prs`, `suggested_labels`, `suggested_reviewers`, `auto_apply_labels`, `auto_assign_reviewers`
- Enable `assess_linked_issues` (the one high-level check worth keeping)
- Lock `request_changes_workflow: false` with an inline comment explaining it prevents APPROVED reviews

Refs hoprnet/hopr-devops#277