### PR TITLE
feat(ci): migrate workflows to Workload Identity Provider auth

### DIFF
--- a/.github/workflows/branches.yaml
+++ b/.github/workflows/branches.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write # zizmor: ignore[excessive-permissions]
 
 concurrency:
   group: branches-${{ github.ref_name }}-${{ github.sha }}
@@ -16,7 +17,7 @@ concurrency:
 jobs:
   coverage:
     name: Coverage
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@69d61153fe24338ea983dd657496f0bc8b4cd819 # workflow-tests-v5
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.ref_name }}
       enable_unit_tests: false
@@ -38,7 +39,6 @@ jobs:
       runner_integration: depot-ubuntu-24.04-8
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      codecov_token: ${{ secrets.CODECOV_TOKEN }}
   benchmarks:
     name: Benchmarks
     needs: coverage

--- a/.github/workflows/build-dappnode.yaml
+++ b/.github/workflows/build-dappnode.yaml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@ac3e0b6137b0ba470a30c373aab2ceba9e0879e4 # master
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@ac3e0b6137b0ba470a30c373aab2ceba9e0879e4 # setup-gcp-v4
         with:
           login_artifact_registry: 'false'
           install_sdk: 'true'

--- a/.github/workflows/build-dappnode.yaml
+++ b/.github/workflows/build-dappnode.yaml
@@ -19,11 +19,6 @@ on:
       labels:
         required: true
         type: string
-    secrets:
-      GCP_SA_GITHUB_RUNNER:
-        required: true
-      GH_RUNNER_TOKEN:
-        required: true
   workflow_dispatch:
     inputs:
       network:
@@ -48,6 +43,7 @@ jobs:
     runs-on: depot-ubuntu-24.04
     permissions:
       contents: read
+      id-token: write
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -106,9 +102,8 @@ jobs:
 
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@12c56020e16036982e6cc529848edeedfc705865 # master
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@ac3e0b6137b0ba470a30c373aab2ceba9e0879e4 # master
         with:
-          google_credentials: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
           login_artifact_registry: 'false'
           install_sdk: 'true'
 

--- a/.github/workflows/build-dappnode.yaml
+++ b/.github/workflows/build-dappnode.yaml
@@ -19,6 +19,9 @@ on:
       labels:
         required: true
         type: string
+    secrets:
+      GH_RUNNER_TOKEN:
+        required: true
   workflow_dispatch:
     inputs:
       network:

--- a/.github/workflows/clean-pr.yaml
+++ b/.github/workflows/clean-pr.yaml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@ac3e0b6137b0ba470a30c373aab2ceba9e0879e4 # master
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@ac3e0b6137b0ba470a30c373aab2ceba9e0879e4 # setup-gcp-v4
         with:
           login_artifact_registry: 'true'
           install_sdk: 'true'

--- a/.github/workflows/clean-pr.yaml
+++ b/.github/workflows/clean-pr.yaml
@@ -16,6 +16,7 @@ jobs:
     permissions:
       actions: write
       contents: read
+      id-token: write
     timeout-minutes: 10
     steps:
       - name: Harden Runner
@@ -32,9 +33,8 @@ jobs:
 
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@12c56020e16036982e6cc529848edeedfc705865 # master
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@ac3e0b6137b0ba470a30c373aab2ceba9e0879e4 # master
         with:
-          google_credentials: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
           login_artifact_registry: 'true'
           install_sdk: 'true'
 

--- a/.github/workflows/generate-dappnode-pr.yaml
+++ b/.github/workflows/generate-dappnode-pr.yaml
@@ -16,6 +16,9 @@ on:
       network:
         required: true
         type: string
+    secrets:
+      GH_RUNNER_TOKEN:
+        required: true
   workflow_dispatch:
     inputs:
       network:

--- a/.github/workflows/generate-dappnode-pr.yaml
+++ b/.github/workflows/generate-dappnode-pr.yaml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@ac3e0b6137b0ba470a30c373aab2ceba9e0879e4 # master
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@ac3e0b6137b0ba470a30c373aab2ceba9e0879e4 # setup-gcp-v4
         with:
           login_artifact_registry: 'false'
           install_sdk: 'true'

--- a/.github/workflows/generate-dappnode-pr.yaml
+++ b/.github/workflows/generate-dappnode-pr.yaml
@@ -16,11 +16,6 @@ on:
       network:
         required: true
         type: string
-    secrets:
-      GCP_SA_GITHUB_RUNNER:
-        required: true
-      GH_RUNNER_TOKEN:
-        required: true
   workflow_dispatch:
     inputs:
       network:
@@ -42,6 +37,7 @@ jobs:
     runs-on: depot-ubuntu-24.04
     permissions:
       contents: read
+      id-token: write
     timeout-minutes: 60
     steps:
       - name: Harden Runner
@@ -85,9 +81,8 @@ jobs:
 
       - name: Setup GCP
         id: gcp
-        uses: hoprnet/hopr-workflows/actions/setup-gcp@12c56020e16036982e6cc529848edeedfc705865 # master
+        uses: hoprnet/hopr-workflows/actions/setup-gcp@ac3e0b6137b0ba470a30c373aab2ceba9e0879e4 # master
         with:
-          google_credentials: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
           login_artifact_registry: 'false'
           install_sdk: 'true'
 

--- a/.github/workflows/pr-label.yaml
+++ b/.github/workflows/pr-label.yaml
@@ -48,7 +48,6 @@ jobs:
       dappnode_repository: ${{ matrix.dappnode_repository }}
       labels: ${{ format('{0},', join(github.event.pull_request.labels.*.name, ',')) }}
     secrets:
-      GCP_SA_GITHUB_RUNNER: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
       GH_RUNNER_TOKEN: ${{ secrets.GH_RUNNER_TOKEN }}
 
   benchmarks:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write # zizmor: ignore[excessive-permissions]
 
 concurrency:
   group: ${{ github.event.pull_request.head.ref || github.ref_name }}-pr
@@ -113,7 +114,7 @@ jobs:
 
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@69d61153fe24338ea983dd657496f0bc8b4cd819 # workflow-tests-v5
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@798d791de5c5485c3043049781dfd0938539a36a # workflow-tests-v6
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       enable_unit_tests: true
@@ -137,7 +138,6 @@ jobs:
       runner_integration: depot-ubuntu-24.04-8
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
-      codecov_token: ${{ secrets.CODECOV_TOKEN }}
 
   benchmarks:
     name: Benchmarks

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,9 +39,10 @@ jobs:
     runs-on: depot-ubuntu-24.04
     permissions:
       contents: write
+      id-token: write
     steps:
       - name: Release version
-        uses: hoprnet/hopr-workflows/actions/release-version@4e3c270b51ed1817bc0b0f6996dfc8a7b0e757c1 # release-version-v2
+        uses: hoprnet/hopr-workflows/actions/release-version@fa71078959cf9f892185e8df16551720693a2cd1 # release-version-v2
         with:
           source_branch: ${{ github.ref_name }}
           file: ./hopr/hopr-lib/Cargo.toml
@@ -53,8 +54,7 @@ jobs:
           zulip_email: ${{ secrets.ZULIP_EMAIL }}
           zulip_channel: HOPRd
           zulip_topic: Releases
-          gcp_service_account: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
-          github_token: ${{ secrets.GH_RUNNER_TOKEN }}
+          github_app_private_key: ${{ secrets.GH_APP_HOPRNET_BOT_PRIVATE_KEY }}
   build-dappnode:
     name: Build dappNode
     needs:
@@ -62,11 +62,9 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     uses: ./.github/workflows/generate-dappnode-pr.yaml
     with:
       source_repo: ${{ github.repository }}
       source_branch: ${{ github.ref_name }}
       network: dufour
-    secrets:
-      GCP_SA_GITHUB_RUNNER: ${{ secrets.GCP_SA_GITHUB_RUNNER }}
-      GH_RUNNER_TOKEN: ${{ secrets.GH_RUNNER_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
       id-token: write
     steps:
       - name: Release version
-        uses: hoprnet/hopr-workflows/actions/release-version@fa71078959cf9f892185e8df16551720693a2cd1 # release-version-v2
+        uses: hoprnet/hopr-workflows/actions/release-version@fa71078959cf9f892185e8df16551720693a2cd1 # 0.9.3
         with:
           source_branch: ${{ github.ref_name }}
           file: ./hopr/hopr-lib/Cargo.toml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,3 +68,5 @@ jobs:
       source_repo: ${{ github.repository }}
       source_branch: ${{ github.ref_name }}
       network: dufour
+    secrets:
+      GH_RUNNER_TOKEN: ${{ secrets.GH_RUNNER_TOKEN }}


### PR DESCRIPTION
## Summary

- Pins all `hoprnet/hopr-workflows` action/workflow refs to new OIDC-enabled SHAs
- Removes legacy `gcp_service_account` and `google_credentials` GCP service account inputs from all affected jobs
- Adds `id-token: write` permission to every consumer job for OIDC token minting
- Adds `github_app_private_key: ${{ secrets.GH_APP_HOPRNET_BOT_PRIVATE_KEY }}` to all `release-version` invocations
- Retains `GH_RUNNER_TOKEN` in `build-dappnode.yaml` and `generate-dappnode-pr.yaml` contracts — these workflows access `dappnode/DAppNodePackage-Hopr*` (external org), which cannot use the hoprnet WIF identity; PAT remains required for cross-org operations
- Removes `GCP_SA_GITHUB_RUNNER` from `pr-label.yaml`'s secrets passthrough (it was forwarding a secret that `build-dappnode.yaml` no longer declares)

Part of the org-wide WIF migration following the GitHub security incident. Reference: hoprnet/blokli#377