### PR TITLE
fix(ci): bump release-version to 0.9.4 to fix vars context error

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
       id-token: write
     steps:
       - name: Release version
-        uses: hoprnet/hopr-workflows/actions/release-version@fa71078959cf9f892185e8df16551720693a2cd1 # 0.9.3
+        uses: hoprnet/hopr-workflows/actions/release-version@fd29bf3c58b72faacc300e068a05b59eb3b180bc # 0.9.4
         with:
           source_branch: ${{ github.ref_name }}
           file: ./hopr/hopr-lib/Cargo.toml


### PR DESCRIPTION
## Summary

- Bumps `actions/release-version` from `0.9.3`/`release-version-v5` to `0.9.4` (hoprnet/hopr-workflows#90)
- The previous action version read `vars.GH_APP_HOPRNET_BOT_CLIENT_ID` inside its composite manifest — the `vars` context is not available there, causing every close-release run to fail at action load with `Unrecognized named-value: 'vars'`
- 0.9.4 adds an optional `github_app_client_id` input with the correct default — non-breaking, no `with:` changes needed

Depends on: https://github.com/hoprnet/hopr-workflows/pull/90 ✓ merged