### PR TITLE
feat: add DropAbortable wrapper and replace Abortable where applicable

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -10,6 +10,7 @@ ignore = [
   "RUSTSEC-2026-0118", # `hickory-proto` 0.25.2 pulled by libp2p-dns 0.44.0 -> libp2p 0.56.0; no fix for 0.25.x; cannot remove without a major libp2p bump
   "RUSTSEC-2026-0119", # same root cause as 0118 (different advisory DB version); hickory-proto 0.26.x is fixed via hickory-proto 0.26.1
   "RUSTSEC-2026-0173", # `proc-macro-error2` unmaintained; pulled by validator_derive -> validator -> hopr-transport-tag-allocator; drop once validator upgrades or is replaced
+  "RUSTSEC-2026-0185", # needs libp2p-quic and reqwest patch
 ]
 informational_warnings = ["unmaintained"]
 severity_threshold = "low"

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -730,7 +730,10 @@ macro_rules! impl_build_methods {
 
             tracing::info!("starting ticket events processor");
             let (tickets_tx, tickets_rx) = channel(8192);
-            let (tickets_rx_stream, tickets_handle) = futures::stream::abortable(tickets_rx);
+
+            // Need to use DropAbortable, so that the receiver is dropped when aborted and no new items can be sent by the senders.
+            let (tickets_rx_stream, tickets_handle) = hopr_utils::runtime::DropAbortable::new(tickets_rx);
+
             processes.insert(HoprLibProcess::TicketEvents, tickets_handle);
             let new_ticket_tx = pre.ticket_event_subscribers.0.clone();
             let tmgr_clone = ticket_manager.clone();

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -479,6 +479,8 @@ where
         F: Fn(&ChainEvent) -> bool + Send + Sync + 'static,
     {
         debug!(%context, "registering wait for on-chain event");
+
+        // DropAbortable not needed because the stream only generates items when polled
         let (event_stream, handle) = futures::stream::abortable(
             self.chain_api
                 .subscribe()?

--- a/impls/transport/p2p/src/constants.rs
+++ b/impls/transport/p2p/src/constants.rs
@@ -3,6 +3,8 @@ pub const HOPR_SWARM_IDLE_CONNECTION_TIMEOUT: std::time::Duration = std::time::D
 
 // Swarm configuration
 /// The maximum number of concurrently dialed (outbound) peers.
+#[cfg(feature = "runtime-tokio")]
 pub(crate) const HOPR_SWARM_CONCURRENTLY_DIALED_PEER_COUNT: u8 = 255;
 /// The maximum number of concurrently negotiating inbound peers.
+#[cfg(feature = "runtime-tokio")]
 pub(crate) const HOPR_SWARM_CONCURRENTLY_NEGOTIATING_INBOUND_PEER_COUNT: usize = 512;

--- a/impls/transport/p2p/src/swarm.rs
+++ b/impls/transport/p2p/src/swarm.rs
@@ -3,18 +3,17 @@ use std::num::NonZeroU8;
 use std::sync::Arc;
 
 use dashmap::DashSet;
-use futures::{FutureExt, Stream, StreamExt, stream::BoxStream};
+use futures::{FutureExt, Stream, StreamExt};
 use hopr_api::{Multiaddr, OffchainKeypair, network::BoxedProcessFn};
 use hopr_utils::network_types::prelude::is_public_address;
 use libp2p::{
     autonat,
-    identity::PublicKey,
     swarm::{NetworkInfo, SwarmEvent},
 };
 use tracing::{debug, error, info, trace, warn};
 
 use crate::{
-    HoprNetwork, HoprNetworkBehavior, HoprNetworkBehaviorEvent, PeerDiscovery, constants,
+    HoprNetwork, HoprNetworkBehavior, HoprNetworkBehaviorEvent, PeerDiscovery,
     errors::Result,
     utils::{replace_transport_with_unspecified, resolve_dns_if_any},
 };
@@ -52,9 +51,9 @@ impl InactiveNetwork {
     #[cfg(feature = "runtime-tokio")]
     pub async fn build(
         me: libp2p::identity::Keypair,
-        external_discovery_events: BoxStream<'static, PeerDiscovery>,
+        external_discovery_events: futures::stream::BoxStream<'static, PeerDiscovery>,
     ) -> Result<Self> {
-        let me_public: PublicKey = me.public();
+        let me_public: libp2p::identity::PublicKey = me.public();
 
         let swarm = libp2p::SwarmBuilder::with_existing_identity(me)
             .with_tokio()
@@ -91,7 +90,7 @@ impl InactiveNetwork {
                             let v = std::env::var("HOPR_INTERNAL_LIBP2P_MAX_CONCURRENTLY_DIALED_PEER_COUNT")
                                 .ok()
                                 .and_then(|v| v.trim().parse::<u8>().ok())
-                                .unwrap_or(constants::HOPR_SWARM_CONCURRENTLY_DIALED_PEER_COUNT);
+                                .unwrap_or(crate::constants::HOPR_SWARM_CONCURRENTLY_DIALED_PEER_COUNT);
                             v.max(1)
                         })
                         .expect("clamped to >= 1, will never fail"),
@@ -99,13 +98,13 @@ impl InactiveNetwork {
                     .with_max_negotiating_inbound_streams(
                         std::env::var("HOPR_INTERNAL_LIBP2P_MAX_NEGOTIATING_INBOUND_STREAM_COUNT")
                             .and_then(|v| v.parse::<usize>().map_err(|_e| std::env::VarError::NotPresent))
-                            .unwrap_or(constants::HOPR_SWARM_CONCURRENTLY_NEGOTIATING_INBOUND_PEER_COUNT),
+                            .unwrap_or(crate::constants::HOPR_SWARM_CONCURRENTLY_NEGOTIATING_INBOUND_PEER_COUNT),
                     )
                     .with_idle_connection_timeout(
                         std::env::var("HOPR_INTERNAL_LIBP2P_SWARM_IDLE_TIMEOUT")
                             .and_then(|v| v.parse::<u64>().map_err(|_e| std::env::VarError::NotPresent))
                             .map(std::time::Duration::from_secs)
-                            .unwrap_or(constants::HOPR_SWARM_IDLE_CONNECTION_TIMEOUT),
+                            .unwrap_or(crate::constants::HOPR_SWARM_IDLE_CONNECTION_TIMEOUT),
                     )
                 })
                 .build(),

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -303,7 +303,7 @@ where
         let mut probing_tag_allocator = None;
         for (usage, alloc) in tag_allocators {
             match usage {
-                hopr_transport_tag_allocator::Usage::Session => {}
+                hopr_transport_tag_allocator::Usage::Session => {} // TODO: cleanup of Session tag allocators needed (#8199)
                 hopr_transport_tag_allocator::Usage::SessionTerminalTelemetry => {
                     session_telemetry_tag_allocator = Some(alloc)
                 }

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -299,12 +299,11 @@ where
 
         let tag_allocators = hopr_transport_tag_allocator::create_allocators_from_config(&cfg.session.tag_allocator)?;
 
-        let mut session_tag_allocator = None;
         let mut session_telemetry_tag_allocator = None;
         let mut probing_tag_allocator = None;
         for (usage, alloc) in tag_allocators {
             match usage {
-                hopr_transport_tag_allocator::Usage::Session => session_tag_allocator = Some(alloc),
+                hopr_transport_tag_allocator::Usage::Session => {}
                 hopr_transport_tag_allocator::Usage::SessionTerminalTelemetry => {
                     session_telemetry_tag_allocator = Some(alloc)
                 }

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -303,8 +303,8 @@ where
         let mut probing_tag_allocator = None;
         for (usage, alloc) in tag_allocators {
             match usage {
-                hopr_transport_tag_allocator::Usage::Session => {} /* TODO: cleanup of Session tag allocators needed
-                                                                     * (#8199) */
+                // TODO: cleanup of Session tag allocators needed * (#8199)
+                hopr_transport_tag_allocator::Usage::Session => {}
                 hopr_transport_tag_allocator::Usage::SessionTerminalTelemetry => {
                     session_telemetry_tag_allocator = Some(alloc)
                 }

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -303,7 +303,8 @@ where
         let mut probing_tag_allocator = None;
         for (usage, alloc) in tag_allocators {
             match usage {
-                hopr_transport_tag_allocator::Usage::Session => {} // TODO: cleanup of Session tag allocators needed (#8199)
+                hopr_transport_tag_allocator::Usage::Session => {} /* TODO: cleanup of Session tag allocators needed
+                                                                     * (#8199) */
                 hopr_transport_tag_allocator::Usage::SessionTerminalTelemetry => {
                     session_telemetry_tag_allocator = Some(alloc)
                 }

--- a/transport/session/src/balancer/controller.rs
+++ b/transport/session/src/balancer/controller.rs
@@ -343,6 +343,8 @@ where
         let (abort_handle, abort_reg) = AbortHandle::new_pair();
 
         // Start an interval stream at which the balancer will sample and perform updates
+
+        // DropAbortable not needed because the stream only generates items when polled
         let sampling_stream = futures::stream::Abortable::new(
             futures_time::stream::interval(sampling_interval.max(MIN_BALANCER_SAMPLING_INTERVAL).into()),
             abort_reg,

--- a/transport/session/src/utils.rs
+++ b/transport/session/src/utils.rs
@@ -145,6 +145,7 @@ where
     // The stream is suspended until the caller sets a rate via the Controller
     let controller = RateController::new(0, Duration::from_secs(1));
 
+    // DropAbortable not needed because the stream only generates items when polled
     let (ka_stream, abort_handle) = futures::stream::abortable(
         futures::stream::repeat_with(move || match &notification_mode {
             SurbNotificationMode::Target => HoprStartProtocol::KeepAlive(KeepAliveMessage {

--- a/utils-session/src/lib.rs
+++ b/utils-session/src/lib.rs
@@ -593,88 +593,91 @@ pub async fn create_tcp_client_binding<T: SessionFactory>(
     hopr_utils::runtime::prelude::spawn(async move {
         let active_sessions_clone_2 = active_sessions_clone.clone();
 
-        futures::stream::Abortable::new(tokio_stream::wrappers::TcpListenerStream::new(tcp_listener), abort_reg)
-            .and_then(|sock| async { Ok((sock.peer_addr()?, sock)) })
-            .for_each(move |accepted_client| {
-                let data = config_clone.clone();
-                let target = target.clone();
-                let factory = factory.clone();
-                let active_sessions = active_sessions_clone_2.clone();
-                let has_capacity = accepted_client.is_ok() && active_sessions.len() < max_clients;
-                let maybe_pooled = has_capacity.then(|| session_pool.pop()).flatten();
+        hopr_utils::runtime::DropAbortable::new_with_registration(
+            tokio_stream::wrappers::TcpListenerStream::new(tcp_listener),
+            abort_reg,
+        )
+        .and_then(|sock| async { Ok((sock.peer_addr()?, sock)) })
+        .for_each(move |accepted_client| {
+            let data = config_clone.clone();
+            let target = target.clone();
+            let factory = factory.clone();
+            let active_sessions = active_sessions_clone_2.clone();
+            let has_capacity = accepted_client.is_ok() && active_sessions.len() < max_clients;
+            let maybe_pooled = has_capacity.then(|| session_pool.pop()).flatten();
 
-                async move {
-                    match accepted_client {
-                        Ok((sock_addr, mut stream)) => {
-                            debug!(?sock_addr, "incoming TCP connection");
+            async move {
+                match accepted_client {
+                    Ok((sock_addr, mut stream)) => {
+                        debug!(?sock_addr, "incoming TCP connection");
 
-                            // Check that we are still within the quota,
-                            // otherwise shutdown the new client immediately
-                            if active_sessions.len() >= max_clients {
-                                error!(?bind_host, "no more client slots available at listener");
-                                use tokio::io::AsyncWriteExt;
-                                if let Err(error) = stream.shutdown().await {
-                                    error!(%error, ?sock_addr, "failed to shutdown TCP connection");
-                                }
-                                return;
+                        // Check that we are still within the quota,
+                        // otherwise shutdown the new client immediately
+                        if active_sessions.len() >= max_clients {
+                            error!(?bind_host, "no more client slots available at listener");
+                            use tokio::io::AsyncWriteExt;
+                            if let Err(error) = stream.shutdown().await {
+                                error!(%error, ?sock_addr, "failed to shutdown TCP connection");
                             }
+                            return;
+                        }
 
-                            // See if we still have some session pooled
-                            let (session, configurator) = match maybe_pooled {
-                                Some((s, c)) => {
-                                    debug!(session_id = %s.id(), "using pooled session");
-                                    (s, c)
-                                }
-                                None => {
-                                    debug!("no more active sessions in the pool, creating a new one");
-                                    match factory.create_session(destination, target, data).await {
-                                        Ok((s, c)) => (s, c),
-                                        Err(error) => {
-                                            error!(%error, "failed to establish session");
-                                            return;
-                                        }
+                        // See if we still have some session pooled
+                        let (session, configurator) = match maybe_pooled {
+                            Some((s, c)) => {
+                                debug!(session_id = %s.id(), "using pooled session");
+                                (s, c)
+                            }
+                            None => {
+                                debug!("no more active sessions in the pool, creating a new one");
+                                match factory.create_session(destination, target, data).await {
+                                    Ok((s, c)) => (s, c),
+                                    Err(error) => {
+                                        error!(%error, "failed to establish session");
+                                        return;
                                     }
                                 }
-                            };
+                            }
+                        };
 
-                            let session_id = *session.id();
-                            debug!(?sock_addr, %session_id, "new session for incoming TCP connection");
+                        let session_id = *session.id();
+                        debug!(?sock_addr, %session_id, "new session for incoming TCP connection");
 
-                            let (abort_handle, abort_reg) = AbortHandle::new_pair();
-                            active_sessions.insert(
-                                session_id,
-                                ClientEntry {
-                                    sock_addr,
-                                    abort_handle,
-                                    configurator,
+                        let (abort_handle, abort_reg) = AbortHandle::new_pair();
+                        active_sessions.insert(
+                            session_id,
+                            ClientEntry {
+                                sock_addr,
+                                abort_handle,
+                                configurator,
+                            },
+                        );
+
+                        #[cfg(all(feature = "telemetry", not(test)))]
+                        METRIC_ACTIVE_CLIENTS.increment(&["tcp"], 1.0);
+
+                        hopr_utils::runtime::prelude::spawn(
+                            // The stream either terminates naturally (by the client closing the TCP connection)
+                            // or is terminated via the abort handle.
+                            bind_session_to_stream(session, stream, HOPR_TCP_BUFFER_SIZE, Some(abort_reg)).then(
+                                move |_| async move {
+                                    // Regardless how the session ended, remove the abort handle
+                                    // from the map
+                                    active_sessions.remove(&session_id);
+
+                                    debug!(%session_id, "tcp session has ended");
+
+                                    #[cfg(all(feature = "telemetry", not(test)))]
+                                    METRIC_ACTIVE_CLIENTS.decrement(&["tcp"], 1.0);
                                 },
-                            );
-
-                            #[cfg(all(feature = "telemetry", not(test)))]
-                            METRIC_ACTIVE_CLIENTS.increment(&["tcp"], 1.0);
-
-                            hopr_utils::runtime::prelude::spawn(
-                                // The stream either terminates naturally (by the client closing the TCP connection)
-                                // or is terminated via the abort handle.
-                                bind_session_to_stream(session, stream, HOPR_TCP_BUFFER_SIZE, Some(abort_reg)).then(
-                                    move |_| async move {
-                                        // Regardless how the session ended, remove the abort handle
-                                        // from the map
-                                        active_sessions.remove(&session_id);
-
-                                        debug!(%session_id, "tcp session has ended");
-
-                                        #[cfg(all(feature = "telemetry", not(test)))]
-                                        METRIC_ACTIVE_CLIENTS.decrement(&["tcp"], 1.0);
-                                    },
-                                ),
-                            );
-                        }
-                        Err(error) => error!(%error, "failed to accept connection"),
+                            ),
+                        );
                     }
+                    Err(error) => error!(%error, "failed to accept connection"),
                 }
-            })
-            .await;
+            }
+        })
+        .await;
 
         // Once the listener is done, abort all active sessions created by the listener
         active_sessions_clone.iter().for_each(|entry| {

--- a/utils/src/runtime.rs
+++ b/utils/src/runtime.rs
@@ -375,12 +375,28 @@ macro_rules! spawn_as_abortable_named {
 
 /// Wrapper around [`futures::stream::Abortable`] that also automatically drops the inner stream when the abort handle
 /// is fired.
+///
+/// This is mostly useful to make MPSC channels close the channel when the AbortHandle is fired.
+/// If plain `futures::stream::Abortable` is used, the inner stream will not be dropped when the `AbortHandle` is fired,
+/// and therefore the senders can still send items, but the aborted receivers cannot process them.
+///
+/// For unbounded channels, this may cause the channels to keep memory growing indefinitely.
+/// For bounded channels, the senders will continue sending data until the channel is full and the senders will then
+/// become stuck indefinitely.
+///
+/// For streams that do not have active senders and only produce items when polled, this wrapper is not needed and
+/// the standard ` futures::stream::Abortable ` will work just fine.
 pub struct DropAbortable<St> {
     inner: Option<futures::stream::Abortable<St>>,
 }
 
 impl<St> DropAbortable<St> {
-    pub fn new(stream: St, reg: futures::stream::AbortRegistration) -> Self {
+    pub fn new(stream: St) -> (Self, AbortHandle) {
+        let (abort_handle, reg) = futures::stream::AbortHandle::new_pair();
+        (Self::new_with_registration(stream, reg), abort_handle)
+    }
+
+    pub fn new_with_registration(stream: St, reg: futures::stream::AbortRegistration) -> Self {
         Self {
             inner: Some(futures::stream::Abortable::new(stream, reg)),
         }

--- a/utils/src/runtime.rs
+++ b/utils/src/runtime.rs
@@ -841,13 +841,15 @@ mod tests {
         tx.try_send(1).unwrap();
         tx.try_send(2).unwrap();
         tx.try_send(3).unwrap();
-        drop(tx);
 
         // Give some time for processing
         tokio::time::sleep(Duration::from_millis(50)).await;
 
         // Now abort - this should drop the inner stream immediately
         abort_handle.abort();
+
+        // Drop tx after abort to ensure we're testing abort-triggered behavior
+        drop(tx);
 
         // Wait for the task to finish
         let _ = handle.await;
@@ -892,10 +894,8 @@ mod tests {
         let _ = handle.await;
 
         // Now try_send should fail because receiver is gone (channel closed)
-        let result_after_abort = tx.try_send(4);
-        assert!(
-            result_after_abort.is_err(),
-            "Sender should fail after receiver is dropped"
-        );
+        // Must fail specifically due to disconnection, not fullness
+        let err = tx.try_send(4).expect_err("expected channel closure after abort");
+        assert!(err.is_disconnected(), "expected disconnected sender after abort");
     }
 }

--- a/utils/src/runtime.rs
+++ b/utils/src/runtime.rs
@@ -373,6 +373,38 @@ macro_rules! spawn_as_abortable_named {
     }};
 }
 
+/// Wrapper around [`futures::stream::Abortable`] that also automatically drops the inner stream when the abort handle
+/// is fired.
+pub struct DropAbortable<St> {
+    inner: Option<futures::stream::Abortable<St>>,
+}
+
+impl<St> DropAbortable<St> {
+    pub fn new(stream: St, reg: futures::stream::AbortRegistration) -> Self {
+        Self {
+            inner: Some(futures::stream::Abortable::new(stream, reg)),
+        }
+    }
+}
+
+impl<St: futures::Stream + Unpin> futures::Stream for DropAbortable<St> {
+    type Item = St::Item;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<St::Item>> {
+        let this = self.get_mut();
+        let Some(inner) = this.inner.as_mut() else {
+            return Poll::Ready(None);
+        };
+        match Pin::new(inner).poll_next(cx) {
+            Poll::Ready(None) => {
+                this.inner = None; // drops Abortable -> drops the receiver NOW
+                Poll::Ready(None)
+            }
+            other => other,
+        }
+    }
+}
+
 /// Abstraction over tasks that can be aborted (such as join or abort handles).
 #[auto_impl::auto_impl(&, Box, Arc)]
 pub trait Abortable {

--- a/utils/src/runtime.rs
+++ b/utils/src/runtime.rs
@@ -805,4 +805,97 @@ mod tests {
         let order = abort_order.lock().unwrap();
         assert_eq!(*order, vec![3, 2, 1]);
     }
+
+    #[tokio::test]
+    async fn test_drop_abortable_drops_inner_stream_on_abort() {
+        use std::{
+            sync::atomic::{AtomicBool, Ordering},
+            time::Duration,
+        };
+
+        use futures::{channel::mpsc, stream::StreamExt};
+
+        // Track if the receiver was dropped
+        let receiver_dropped = Arc::new(AtomicBool::new(false));
+
+        let (tx, rx) = mpsc::channel::<i32>(16);
+
+        // Clone for the spawn
+        let receiver_dropped_clone = receiver_dropped.clone();
+
+        // Create DropAbortable wrapping a channel stream
+        let (drop_abortable, abort_handle) = DropAbortable::new(rx);
+
+        // Spawn task that processes items from the stream
+        let handle = tokio::spawn(async move {
+            let mut rx = drop_abortable;
+            while let Some(_item) = rx.next().await {
+                // Process items
+            }
+            // Stream ended - this is only reached when stream is fully consumed or dropped
+            receiver_dropped_clone.store(true, Ordering::SeqCst);
+        });
+
+        // Send some items using the original sender (not clone)
+        let mut tx = tx;
+        tx.try_send(1).unwrap();
+        tx.try_send(2).unwrap();
+        tx.try_send(3).unwrap();
+        drop(tx);
+
+        // Give some time for processing
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        // Now abort - this should drop the inner stream immediately
+        abort_handle.abort();
+
+        // Wait for the task to finish
+        let _ = handle.await;
+
+        // Verify the receiver was dropped when abort was triggered
+        assert!(
+            receiver_dropped.load(Ordering::SeqCst),
+            "Receiver should be dropped when abort handle is fired"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_drop_abortable_closes_channel_on_abort() {
+        use std::time::Duration;
+
+        use futures::{channel::mpsc, stream::StreamExt};
+
+        // Small buffer
+        let (tx, rx) = mpsc::channel::<i32>(2);
+
+        let (drop_abortable, abort_handle) = DropAbortable::new(rx);
+
+        // Spawn task that processes items very slowly (never actually)
+        let handle = tokio::spawn(async move {
+            let mut rx = drop_abortable;
+            // Don't process any items - just wait to be aborted
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            while let Some(_item) = rx.next().await {
+                tokio::time::sleep(Duration::from_secs(10)).await;
+            }
+        });
+
+        // Send some items
+        let mut tx = tx;
+        tx.try_send(1).unwrap();
+        tx.try_send(2).unwrap();
+
+        // Abort - this should drop the receiver, closing the channel
+        abort_handle.abort();
+
+        // Wait for the task to finish
+        let _ = handle.await;
+
+        // Now try_send should fail because receiver is gone (channel closed)
+        let result_after_abort = tx.try_send(4);
+        assert!(
+            result_after_abort.is_err(),
+            "Sender should fail after receiver is dropped"
+        );
+    }
 }


### PR DESCRIPTION
This PR adds the `DropAbortable` wrapper for the `Abortable` stream from the `futures` crate.


This is mostly useful to make MPSC channels close the channel when the AbortHandle is fired.
If plain `futures::stream::Abortable` is used, the inner stream will not be dropped when the `AbortHandle` is fired,
and therefore the senders can still send items, but the aborted receivers cannot process them.

- For unbounded channels, this may cause the channels to keep memory growing indefinitely.
- For bounded channels, the senders will continue sending data until the channel is full and the senders will then become stuck indefinitely.

For streams that do not have active senders and only produce items when polled, this wrapper is not needed and
the standard ` futures::stream::Abortable ` will work just fine.

---

## AI Summary

This PR introduces a new `DropAbortable` wrapper and applies it where appropriate to fix a potential resource leak issue with MPSC channels.

### Changes

1. **Added `DropAbortable`** (`utils/src/runtime.rs`):
   - New wrapper around `futures::stream::Abortable` that automatically drops the inner stream when the abort handle is fired
   - This ensures MPSC channel receivers are properly dropped when aborted, preventing senders from continuing to send items that cannot be processed

2. **Replaced `Abortable` with `DropAbortable` in critical places**:
   - `hopr/hopr-lib/src/builder.rs`: Ticket events processor channel - ensures the receiver is dropped when aborted so senders can't continue sending
   - `utils-session/src/lib.rs`: TCP client listener - ensures the TCP listener stream is properly closed when aborted

3. **Added comments explaining when `DropAbortable` is NOT needed**:
   - `hopr/hopr-lib/src/lib.rs`: Chain event subscription
   - `transport/session/src/balancer/controller.rs`: Balancer sampling stream
   - `transport/session/src/utils.rs`: Keep-alive stream

   These are streams that only generate items when polled (like `interval`), so they don't have active senders that could continue sending after abort.

4. **Minor cleanup**:
   - Removed unused `session_tag_allocator` variable in `transport/hopr/src/lib.rs`
   - Added `#[cfg(feature = "runtime-tokio")]` to constants in `impls/transport/p2p/src/constants.rs`
   - Some import/path cleanup in `impls/transport/p2p/src/swarm.rs`

### Why this matters

When using plain `futures::stream::Abortable` with MPSC channels:
- The inner stream (receiver) is NOT dropped when aborted
- Senders can continue sending items indefinitely
- For unbounded channels: memory grows indefinitely
- For bounded channels: senders become stuck when the channel is full

`DropAbortable` ensures the receiver is dropped immediately when aborted, which closes the channel and prevents senders from continuing.