### PR TITLE
fix(connector): populate address caches unconditionally on account subscription

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3508,7 +3508,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "ahash",
  "anyhow",

--- a/impls/connector/Cargo.toml
+++ b/impls/connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-chain-connector"
-version = "0.21.1"
+version = "0.21.2"
 description = "Implementation of HOPR Chain APIs using Blokli client"
 edition.workspace = true
 license.workspace = true

--- a/impls/connector/src/connector/keys.rs
+++ b/impls/connector/src/connector/keys.rs
@@ -283,4 +283,84 @@ mod tests {
 
         Ok(())
     }
+
+    // Regression test: address caches (chain_to_packet, packet_to_chain) must be populated
+    // from the subscription stream regardless of whether backend.insert_account succeeds.
+    // Previously these were only updated inside `if let Ok(...) = &res { ... }`, so a transient
+    // backend failure left the caches empty.  packet_key_to_chain_key would then immediately
+    // cache None from the (also-failing) backend fallback and the mapping was permanently lost.
+    #[tokio::test]
+    async fn connector_address_caches_populated_from_subscription_despite_backend_insert_failure() -> anyhow::Result<()>
+    {
+        use crate::connector::BlockchainConnectorConfig;
+
+        let client_keypair = OffchainKeypair::random();
+        let client_chain_addr = Address::from([42u8; Address::SIZE]);
+        let client_account = AccountEntry {
+            public_key: *client_keypair.public(),
+            chain_addr: client_chain_addr,
+            entry_type: AccountType::NotAnnounced,
+            safe_address: None,
+            key_id: 1.into(),
+        };
+
+        // Pre-load the client account so the subscription delivers it on connect.
+        let blokli_client = BlokliTestStateBuilder::default()
+            .with_accounts([(client_account, HoprBalance::new_base(0), XDaiBalance::new_base(0))])
+            .build_static_client();
+
+        let connector = create_connector(blokli_client)?;
+
+        // sync_tolerance = 0: connect() returns immediately (min_accounts = 0) so the
+        // backend-failing account event is processed asynchronously after connect() returns.
+        let cfg = BlockchainConnectorConfig {
+            sync_tolerance: 0,
+            ..connector.cfg
+        };
+        let mapper = super::HoprKeyMapper {
+            id_to_key: moka::sync::Cache::builder()
+                .max_capacity(10)
+                .build_with_hasher(ahash::RandomState::default()),
+            key_to_id: moka::sync::Cache::builder()
+                .max_capacity(10)
+                .build_with_hasher(ahash::RandomState::default()),
+            backend: std::sync::Arc::new(MockErrorBackend),
+        };
+        let mut connector = crate::connector::HoprBlockchainConnector::new(
+            connector.chain_key.clone(),
+            cfg,
+            (*connector.client).clone(),
+            MockErrorBackend,
+            connector.payload_generator,
+        );
+        connector.mapper = mapper;
+        connector.connect().await?;
+
+        // Wait until the subscription loop has populated both address caches.
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let packet_to_chain_ready =
+                    connector.packet_key_to_chain_key(client_keypair.public()).ok() == Some(Some(client_chain_addr));
+                let chain_to_packet_ready =
+                    connector.chain_key_to_packet_key(&client_chain_addr).ok() == Some(Some(*client_keypair.public()));
+                if packet_to_chain_ready && chain_to_packet_ready {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await?;
+
+        // The address caches must be populated even though insert_account failed.
+        assert_eq!(
+            Some(client_chain_addr),
+            connector.packet_key_to_chain_key(client_keypair.public())?
+        );
+        assert_eq!(
+            Some(*client_keypair.public()),
+            connector.chain_key_to_packet_key(&client_chain_addr)?
+        );
+
+        Ok(())
+    }
 }

--- a/impls/connector/src/connector/mod.rs
+++ b/impls/connector/src/connector/mod.rs
@@ -291,17 +291,27 @@ where
                     hopr_utils::runtime::prelude::spawn_blocking(move || {
                         mapper.key_to_id.insert(account.public_key, Some(account.key_id));
                         mapper.id_to_key.insert(account.key_id, Some(account.public_key));
+                        chain_to_packet.insert(account.chain_addr, Some(account.public_key));
+                        packet_to_chain.insert(account.public_key, Some(account.chain_addr));
                         graph.write().add_node(account.key_id);
-                        mapper.backend.insert_account(account.clone()).map(|old| (account, old))
-                    })
-                    .map_err(ConnectorError::backend)
-                    .and_then(move |res| {
-                        if let Ok((upserted_account, _)) = &res {
-                            // Rather update the cached entry than invalidating it
-                            chain_to_packet.insert(upserted_account.chain_addr, Some(upserted_account.public_key));
-                            packet_to_chain.insert(upserted_account.public_key, Some(upserted_account.chain_addr));
+                        let old = mapper
+                            .backend
+                            .insert_account(account.clone())
+                            .map_err(ConnectorError::backend)?;
+                        if let Some(old_account) = &old {
+                            if old_account.chain_addr != account.chain_addr {
+                                chain_to_packet.invalidate(&old_account.chain_addr);
+                            }
+                            if old_account.public_key != account.public_key {
+                                packet_to_chain.invalidate(&old_account.public_key);
+                            }
                         }
-                        futures::future::ready(res.map(SubscribedEventType::Account).map_err(ConnectorError::backend))
+                        Ok::<_, ConnectorError>((account, old))
+                    })
+                    .map(|result| {
+                        result
+                            .map_err(ConnectorError::backend)?
+                            .map(SubscribedEventType::Account)
                     })
                 })
                 .fuse();


### PR DESCRIPTION
The `chain_to_packet` and `packet_to_chain` address cache inserts were previously gated on a successful `backend.insert_account`, so a transient backend failure left the caches unpopulated while the `key_to_id` / `id_to_key` caches were already written — causing the next `packet_key_to_chain_key` call to miss, fall back to the (also-failing) backend, and permanently cache `None`, which matched the three simultaneous cache misses observed in production when UK_0 could not route SURB ACKs back to the gnosis_vpn-client. The fix moves both inserts unconditionally before the backend call, adds stale-entry invalidation when an account's addresses change on update, and covers the regression with a test that verifies both lookups succeed even when `MockErrorBackend` rejects every `insert_account`.