### PR TITLE
feat: Add custom signer support and implement `withdraw_from_signer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3491,9 +3491,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a6e98ff52f636edc8e3d76844831dfd53cd92146488cc721c0f7bb837fd8052"
+version = "1.14.0"
+source = "git+https://github.com/hoprnet/hopr-api?branch=lukas%2Fadd-custom-withdraw#669e57b29e50887acbcd59bc6e064803213578d2"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -3530,7 +3529,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.21.2"
+version = "0.22.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3657,8 +3656,8 @@ dependencies = [
  "humantime-serde",
  "insta",
  "lazy_static",
- "opentelemetry-prometheus-text-exporter",
- "opentelemetry_sdk",
+ "opentelemetry-prometheus-text-exporter 0.2.1",
+ "opentelemetry_sdk 0.31.0",
  "parking_lot",
  "rand 0.10.1",
  "rstest",
@@ -4080,9 +4079,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "1.9.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d621ab243808540504b0a1e215743d45283e3133e7a4be44d2dd4cb31587a87"
+checksum = "c842b389c9b2b84349733cb67712ae0699f6a6b756670e742206cd7ac447acd2"
 dependencies = [
  "aes",
  "anyhow",
@@ -4108,9 +4107,9 @@ dependencies = [
  "libp2p-identity",
  "multiaddr",
  "num_enum",
- "opentelemetry",
- "opentelemetry-prometheus-text-exporter",
- "opentelemetry_sdk",
+ "opentelemetry 0.32.0",
+ "opentelemetry-prometheus-text-exporter 0.3.0",
+ "opentelemetry_sdk 0.32.1",
  "poly1305",
  "primitive-types 0.14.0",
  "rand 0.10.1",
@@ -5766,13 +5765,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "opentelemetry-prometheus-text-exporter"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897906366b17a89bec845f6051e0c3474049402a09a0711eea180941293bd013"
 dependencies = [
- "opentelemetry",
- "opentelemetry_sdk",
+ "opentelemetry 0.31.0",
+ "opentelemetry_sdk 0.31.0",
+ "smartstring",
+]
+
+[[package]]
+name = "opentelemetry-prometheus-text-exporter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4fe57ea90b12f643a366aa7c4fa5cfb54bd1cf252f55368337e40534b278a68"
+dependencies = [
+ "opentelemetry 0.32.0",
+ "opentelemetry_sdk 0.32.1",
  "smartstring",
 ]
 
@@ -5785,12 +5809,28 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "percent-encoding",
  "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "opentelemetry 0.32.0",
+ "percent-encoding",
+ "portable-atomic",
+ "rand 0.9.4",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3492,7 +3492,8 @@ dependencies = [
 [[package]]
 name = "hopr-api"
 version = "1.14.0"
-source = "git+https://github.com/hoprnet/hopr-api?branch=lukas%2Fadd-custom-withdraw#669e57b29e50887acbcd59bc6e064803213578d2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3161efd861baef8d2ca18cddf9fe8699ad36d737635132ce41486a28c2d0c89"
 dependencies = [
  "async-trait",
  "atomic_enum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3656,8 +3656,8 @@ dependencies = [
  "humantime-serde",
  "insta",
  "lazy_static",
- "opentelemetry-prometheus-text-exporter 0.2.1",
- "opentelemetry_sdk 0.31.0",
+ "opentelemetry-prometheus-text-exporter",
+ "opentelemetry_sdk",
  "parking_lot",
  "rand 0.10.1",
  "rstest",
@@ -4107,9 +4107,9 @@ dependencies = [
  "libp2p-identity",
  "multiaddr",
  "num_enum",
- "opentelemetry 0.32.0",
- "opentelemetry-prometheus-text-exporter 0.3.0",
- "opentelemetry_sdk 0.32.1",
+ "opentelemetry",
+ "opentelemetry-prometheus-text-exporter",
+ "opentelemetry_sdk",
  "poly1305",
  "primitive-types 0.14.0",
  "rand 0.10.1",
@@ -5752,20 +5752,6 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
@@ -5780,41 +5766,13 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-prometheus-text-exporter"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897906366b17a89bec845f6051e0c3474049402a09a0711eea180941293bd013"
-dependencies = [
- "opentelemetry 0.31.0",
- "opentelemetry_sdk 0.31.0",
- "smartstring",
-]
-
-[[package]]
-name = "opentelemetry-prometheus-text-exporter"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4fe57ea90b12f643a366aa7c4fa5cfb54bd1cf252f55368337e40534b278a68"
 dependencies = [
- "opentelemetry 0.32.0",
- "opentelemetry_sdk 0.32.1",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "smartstring",
-]
-
-[[package]]
-name = "opentelemetry_sdk"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
-dependencies = [
- "futures-channel",
- "futures-executor",
- "futures-util",
- "opentelemetry 0.31.0",
- "percent-encoding",
- "rand 0.9.4",
- "thiserror 2.0.18",
- "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -5826,11 +5784,12 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.32.0",
+ "opentelemetry",
  "percent-encoding",
  "portable-atomic",
  "rand 0.9.4",
  "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,8 +189,8 @@ mimalloc = { version = "0.1.52", default-features = false, features = [
   "secure",
 ] }
 
-hopr-api = "1.12.0"
-hopr-types = { version = "1.9.1", features = ["use-bindings"] }
+hopr-api = { git = "https://github.com/hoprnet/hopr-api", branch = "lukas/add-custom-withdraw" }
+hopr-types = { version = "1.9.3", features = ["use-bindings"] }
 hopr-utils = { version = "0.1.0", path = "utils", default-features = false }
 
 hopr-crypto-packet = { version = "1.4.0", path = "crypto/packet", default-features = false, features = [
@@ -207,7 +207,7 @@ hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-fe
 hopr-transport-probe = { version = "0.7.0", path = "transport/probe", default-features = false }
 hopr-transport-session = { version = "0.23.0", path = "transport/session", default-features = false }
 hopr-transport-tag-allocator = { version = "0.1.1", path = "transport/tag-allocator", default-features = false }
-hopr-chain-connector = { version = "0.21.0", path = "impls/connector" }
+hopr-chain-connector = { version = "0.22.0", path = "impls/connector" }
 hopr-strategy = { version = "0.19.2", path = "impls/strategy" }
 hopr-utils-session = { version = "1.2.1", path = "utils-session" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -189,7 +189,7 @@ mimalloc = { version = "0.1.52", default-features = false, features = [
   "secure",
 ] }
 
-hopr-api = { git = "https://github.com/hoprnet/hopr-api", branch = "lukas/add-custom-withdraw" }
+hopr-api = "1.14.0"
 hopr-types = { version = "1.9.3", features = ["use-bindings"] }
 hopr-utils = { version = "0.1.0", path = "utils", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,8 +130,8 @@ moka = { version = "0.12.15", features = ["future", "sync"] }
 more-asserts = "0.3.1"
 multiaddr = "0.18.2"
 oas3 = "0.22.0"
-opentelemetry-prometheus-text-exporter = { version = "0.2.1" }
-opentelemetry_sdk = { version = "0.31.0" }
+opentelemetry-prometheus-text-exporter = { version = "0.3" }
+opentelemetry_sdk = { version = "0.32" }
 temp-env = "0.3.6"
 parameterized = "2.0.0" # ignored in renovate, kept back to 2.0.0 due to conflict with indexmap
 parking_lot = "0.12.5"

--- a/impls/connector/Cargo.toml
+++ b/impls/connector/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-chain-connector"
-version = "0.21.2"
+version = "0.22.0"
 description = "Implementation of HOPR Chain APIs using Blokli client"
 edition.workspace = true
 license.workspace = true

--- a/impls/connector/src/connector/accounts.rs
+++ b/impls/connector/src/connector/accounts.rs
@@ -165,7 +165,7 @@ where
             .map_err(AnnouncementError::processing)?;
 
         Ok(self
-            .send_tx(tx_req, None)
+            .send_tx(tx_req, None, None)
             .map_err(AnnouncementError::processing)
             .await?
             .boxed())
@@ -180,7 +180,20 @@ where
 
         let tx_req = self.payload_generator.transfer(*recipient, balance)?;
 
-        Ok(self.send_tx(tx_req, None).await?.boxed())
+        Ok(self.send_tx(tx_req, None, None).await?.boxed())
+    }
+
+    async fn withdraw_from_signer<Cy: Currency + Send>(
+        &self,
+        signer: &ChainKeypair,
+        balance: Balance<Cy>,
+        recipient: &Address,
+    ) -> Result<BoxFuture<'_, Result<ChainReceipt, Self::Error>>, Self::Error> {
+        self.check_connection_state()?;
+
+        let tx_req = self.payload_generator.transfer(*recipient, balance)?;
+
+        Ok(self.send_tx(tx_req, None, Some(signer.clone())).await?.boxed())
     }
 
     async fn register_safe(
@@ -230,7 +243,7 @@ where
             .map_err(SafeRegistrationError::processing)?;
 
         Ok(self
-            .send_tx(tx_req, None)
+            .send_tx(tx_req, None, None)
             .map_err(SafeRegistrationError::processing)
             .await?
             .boxed())
@@ -518,6 +531,49 @@ mod tests {
             .await?;
         connector
             .withdraw(XDaiBalance::new_base(1), &[1u8; Address::SIZE].into())
+            .await?
+            .await?;
+
+        insta::assert_yaml_snapshot!(*connector.client.snapshot());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn connector_should_withdraw_from_signer() -> anyhow::Result<()> {
+        let blokli_client = BlokliTestStateBuilder::default()
+            .with_balances([([1u8; Address::SIZE].into(), HoprBalance::zero())])
+            .with_balances([([1u8; Address::SIZE].into(), XDaiBalance::zero())])
+            .with_balances([(
+                ChainKeypair::from_secret(&PRIVATE_KEY_1)?.public().to_address(),
+                XDaiBalance::new_base(10),
+            )])
+            .with_balances([(
+                ChainKeypair::from_secret(&PRIVATE_KEY_1)?.public().to_address(),
+                HoprBalance::new_base(1000),
+            )])
+            .with_balances([(
+                ChainKeypair::from_secret(&PRIVATE_KEY_2)?.public().to_address(),
+                XDaiBalance::new_base(10),
+            )])
+            .with_balances([(
+                ChainKeypair::from_secret(&PRIVATE_KEY_2)?.public().to_address(),
+                HoprBalance::new_base(1000),
+            )])
+            .with_hopr_network_chain_info("rotsee")
+            .build_dynamic_client(MODULE_ADDR.into());
+
+        let mut connector = create_connector(blokli_client)?;
+        connector.connect().await?;
+
+        let signer = ChainKeypair::from_secret(&PRIVATE_KEY_2)?;
+
+        connector
+            .withdraw_from_signer(&signer, HoprBalance::new_base(10), &[1u8; Address::SIZE].into())
+            .await?
+            .await?;
+        connector
+            .withdraw_from_signer(&signer, XDaiBalance::new_base(1), &[1u8; Address::SIZE].into())
             .await?
             .await?;
 

--- a/impls/connector/src/connector/channels.rs
+++ b/impls/connector/src/connector/channels.rs
@@ -138,7 +138,7 @@ where
         let tx_req = self.payload_generator.fund_channel(*dst, amount)?;
         tracing::debug!( %dst, %amount, "opening channel");
 
-        Ok(self.send_tx(tx_req, None).await?.boxed())
+        Ok(self.send_tx(tx_req, None, None).await?.boxed())
     }
 
     async fn fund_channel<'a>(
@@ -155,7 +155,7 @@ where
         let tx_req = self.payload_generator.fund_channel(channel.destination, amount)?;
         tracing::debug!(%channel_id, %amount, "funding channel");
 
-        Ok(self.send_tx(tx_req, None).await?.boxed())
+        Ok(self.send_tx(tx_req, None, None).await?.boxed())
     }
 
     async fn close_channel<'a>(
@@ -199,7 +199,7 @@ where
             _ => return Err(ConnectorError::InvalidState("channel closure time has not elapsed")),
         };
 
-        Ok(self.send_tx(tx_req, None).await?.boxed())
+        Ok(self.send_tx(tx_req, None, None).await?.boxed())
     }
 }
 

--- a/impls/connector/src/connector/mod.rs
+++ b/impls/connector/src/connector/mod.rs
@@ -640,6 +640,7 @@ where
         &'a self,
         tx_req: P::TxRequest,
         custom_tx_multiplier: Option<u32>,
+        custom_signer: Option<ChainKeypair>,
     ) -> Result<impl Future<Output = Result<ChainReceipt, ConnectorError>> + Send + 'a, ConnectorError> {
         let chain_info = self.query_cached_chain_info().await?;
         let tx_timeout = custom_tx_multiplier.unwrap_or(self.cfg.tx_timeout_multiplier).max(1)
@@ -647,7 +648,7 @@ where
             * chain_info.expected_block_time;
         Ok(self
             .sequencer
-            .enqueue_transaction(tx_req, tx_timeout.max(MIN_TX_CONFIRM_TIMEOUT))
+            .enqueue_transaction(tx_req, tx_timeout.max(MIN_TX_CONFIRM_TIMEOUT), custom_signer)
             .await?
             .and_then(|tx| {
                 if let Some(tx_exec) = tx.safe_execution

--- a/impls/connector/src/connector/safe.rs
+++ b/impls/connector/src/connector/safe.rs
@@ -99,7 +99,7 @@ where
         tracing::debug!(%balance, %admin, "deploying safe");
 
         Ok(self
-            .send_tx(tx_req, DEPLOY_SAFE_CUSTOM_TX_TIMEOUT_MULTIPLIER.into())
+            .send_tx(tx_req, DEPLOY_SAFE_CUSTOM_TX_TIMEOUT_MULTIPLIER.into(), None)
             .await?
             .boxed())
     }

--- a/impls/connector/src/connector/sequencer.rs
+++ b/impls/connector/src/connector/sequencer.rs
@@ -1,8 +1,16 @@
+use std::{
+    sync::atomic::AtomicU64,
+    time::{Duration, Instant},
+};
+
 use blokli_client::api::{BlokliQueryClient, BlokliTransactionClient};
 use futures::{FutureExt, SinkExt, StreamExt, TryFutureExt};
-use hopr_api::types::{
-    chain::prelude::{GasEstimation, SignableTransaction},
-    crypto::prelude::*,
+use hopr_api::{
+    Address,
+    types::{
+        chain::prelude::{GasEstimation, SignableTransaction},
+        crypto::prelude::*,
+    },
 };
 
 use crate::{
@@ -12,6 +20,7 @@ use crate::{
 
 type TxRequest<T> = (
     T,
+    Option<ChainKeypair>,
     futures::channel::oneshot::Sender<errors::Result<blokli_client::api::TxId>>,
 );
 
@@ -25,6 +34,49 @@ pub struct TransactionSequencer<C, R> {
 
 const TX_QUEUE_CAPACITY: usize = 2048;
 
+struct FixedTti {
+    fixed: Address,
+    tti: std::time::Duration,
+}
+
+impl FixedTti {
+    #[inline]
+    fn duration_for(&self, key: &Address) -> Option<Duration> {
+        if key == &self.fixed {
+            None // expiration cleared => never expires by time
+        } else {
+            Some(self.tti) // standard time-to-idle
+        }
+    }
+}
+
+impl moka::Expiry<Address, std::sync::Arc<AtomicU64>> for FixedTti {
+    fn expire_after_create(&self, key: &Address, _: &std::sync::Arc<AtomicU64>, _: Instant) -> Option<Duration> {
+        self.duration_for(key)
+    }
+
+    fn expire_after_read(
+        &self,
+        key: &Address,
+        _: &std::sync::Arc<AtomicU64>,
+        _: Instant,
+        _: Option<Duration>,
+        _: Instant,
+    ) -> Option<Duration> {
+        self.duration_for(key)
+    }
+
+    fn expire_after_update(
+        &self,
+        key: &Address,
+        _: &std::sync::Arc<AtomicU64>,
+        _: Instant,
+        _: Option<Duration>,
+    ) -> Option<Duration> {
+        self.duration_for(key)
+    }
+}
+
 impl<C, R> TransactionSequencer<C, R>
 where
     C: BlokliQueryClient + BlokliTransactionClient + Send + Sync + 'static,
@@ -35,13 +87,22 @@ where
 
         let client_clone = client.clone();
         let (sender, receiver) = futures::channel::mpsc::channel::<TxRequest<R>>(TX_QUEUE_CAPACITY);
-        let current_nonce = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+
+        // Nonce of our node signer never expires, all other signers expire after 10 minutes
+        let current_nonce = moka::sync::CacheBuilder::new(1024)
+            .expire_after(FixedTti {
+                fixed: signer.public().to_address(),
+                tti: Duration::from_mins(10),
+            })
+            .build();
+
         let current_nonce_clone = current_nonce.clone();
         hopr_utils::runtime::prelude::spawn(
             receiver
-                .then(move |(tx, notifier): (R, _)| {
+                .then(move |(tx, tx_signer, notifier): (R, _, _)| {
                     let client = client_clone.clone();
-                    let signer = signer.clone();
+                    let signer = tx_signer.unwrap_or_else(|| signer.clone());
+                    let signer_addr = signer.public().to_address();
                     let current_nonce = current_nonce.clone();
                     async move {
                         let chain_info = match client.query_chain_info().map_err(ConnectorError::from).await {
@@ -49,12 +110,12 @@ where
                                 tracing::debug!(chain_id = chain_info.chain_id, "chain info retrieved for tx");
                                 chain_info
                             }
-                            Err(e) => return (Err(e), notifier),
+                            Err(e) => return (Err(e), signer_addr, notifier),
                         };
 
                         let parsed_chain_info = match model_to_chain_info(chain_info) {
                             Ok(parsed_chain_info) => parsed_chain_info,
-                            Err(error) => return (Err(error), notifier),
+                            Err(error) => return (Err(error), signer_addr, notifier),
                         };
                         let chain_id = parsed_chain_info.info.chain_id;
                         let gas_estimation = GasEstimation::from(parsed_chain_info);
@@ -63,24 +124,34 @@ where
                         // We always query the transaction count for the signer and use
                         // the maximum between this value and the local counter
                         match client
-                            .query_transaction_count(&signer.public().to_address().into())
+                            .query_transaction_count(&signer_addr.into())
                             .map_err(ConnectorError::from)
                             .await
                         {
                             Ok(tx_count) => {
-                                let prev_nonce =
-                                    current_nonce.fetch_max(tx_count, std::sync::atomic::Ordering::Relaxed);
+                                let prev_nonce = current_nonce
+                                    .entry(signer_addr)
+                                    .or_default()
+                                    .value()
+                                    .fetch_max(tx_count, std::sync::atomic::Ordering::Relaxed);
+
                                 tracing::debug!(prev_nonce, tx_count, "transaction count retrieved");
                             }
-                            Err(e) => return (Err(e), notifier),
+                            Err(e) => return (Err(e), signer_addr, notifier),
                         }
 
-                        let nonce = current_nonce.load(std::sync::atomic::Ordering::Relaxed);
-                        tracing::debug!(nonce, "nonce used for the tx");
+                        // At this point the value must be set, so we can load it
+                        let nonce = current_nonce
+                            .entry(signer_addr)
+                            .or_default()
+                            .value()
+                            .load(std::sync::atomic::Ordering::Relaxed);
+                        tracing::debug!(nonce, signer = %signer_addr, "nonce used for the tx");
+
                         tx.sign_and_encode_to_eip2718(nonce, chain_id, gas_estimation.into(), &signer)
                             .map_err(ConnectorError::from)
                             .and_then(move |tx| {
-                                tracing::debug!(nonce, "submitting transaction");
+                                tracing::debug!(nonce, signer = %signer_addr, "submitting transaction");
                                 let client = client.clone();
                                 async move {
                                     client
@@ -89,11 +160,11 @@ where
                                         .await
                                 }
                             })
-                            .map(|res| (res, notifier))
+                            .map(|res| (res, signer_addr, notifier))
                             .await
                     }
                 })
-                .for_each(move |(res, notifier)| {
+                .for_each(move |(res, signer_addr, notifier)| {
                     // The nonce is incremented when the transaction succeeded or failed due to on-chain
                     // rejection.
                     if res.is_ok()
@@ -101,10 +172,16 @@ where
                             .as_ref()
                             .is_err_and(|error| error.as_transaction_rejection_error().is_some())
                     {
-                        let prev_nonce = current_nonce_clone.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                        tracing::debug!(prev_nonce, ?res, "nonce incremented due to tx success or rejection");
+                        // Increment the nonce
+                        let prev_nonce = current_nonce_clone
+                            .entry(signer_addr)
+                            .or_default()
+                            .value()
+                            .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
+                        tracing::debug!(prev_nonce, signer = %signer_addr, ?res, "nonce incremented due to tx success or rejection");
                     } else {
-                        tracing::warn!(?res, "nonce not incremented due to tx failure other than rejection");
+                        tracing::warn!(?res, signer = %signer_addr, "nonce not incremented due to tx failure other than rejection");
                     }
 
                     if notifier.send(res).is_err() {
@@ -133,12 +210,13 @@ where
         &self,
         transaction: R,
         timeout_until_finalized: std::time::Duration,
+        custom_signer: Option<ChainKeypair>,
     ) -> errors::Result<impl Future<Output = errors::Result<blokli_client::api::types::Transaction>>> {
         let (notifier_tx, notifier_rx) = futures::channel::oneshot::channel();
 
         self.sender
             .clone()
-            .send((transaction, notifier_tx))
+            .send((transaction, custom_signer, notifier_tx))
             .await
             .map_err(|_| ConnectorError::InvalidState("transaction queue dropped"))?;
 

--- a/impls/connector/src/connector/sequencer.rs
+++ b/impls/connector/src/connector/sequencer.rs
@@ -34,6 +34,9 @@ pub struct TransactionSequencer<C, R> {
 
 const TX_QUEUE_CAPACITY: usize = 2048;
 
+// How long until nonces for other signers (than node's own) expire
+const OTHER_SIGNER_NONCE_EXPIRATION: Duration = Duration::from_mins(5);
+
 struct FixedTti {
     fixed: Address,
     tti: std::time::Duration,
@@ -88,11 +91,11 @@ where
         let client_clone = client.clone();
         let (sender, receiver) = futures::channel::mpsc::channel::<TxRequest<R>>(TX_QUEUE_CAPACITY);
 
-        // Nonce of our node signer never expires, all other signers expire after 10 minutes
+        // Nonce of our node signer never expires, all other signers expire after a few minutes
         let current_nonce = moka::sync::CacheBuilder::new(1024)
             .expire_after(FixedTti {
                 fixed: signer.public().to_address(),
-                tti: Duration::from_mins(10),
+                tti: OTHER_SIGNER_NONCE_EXPIRATION,
             })
             .build();
 

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_withdraw_from_signer.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_withdraw_from_signer.snap
@@ -1,0 +1,56 @@
+---
+source: impls/connector/src/connector/accounts.rs
+expression: "*connector.client.snapshot()"
+---
+accounts: {}
+native_balances:
+  "0101010101010101010101010101010101010101":
+    __typename: NativeBalance
+    balance: 1 xDai
+  668430def9eacd2b5064acf85d73fb0b351a1c8c:
+    __typename: NativeBalance
+    balance: 10 xDai
+  bea83ba0fcee21da44a30c893f466e6bf0c29bbb:
+    __typename: NativeBalance
+    balance: 8.999999999999999998 xDai
+token_balances:
+  "0101010101010101010101010101010101010101":
+    __typename: HoprBalance
+    balance: 10 wxHOPR
+  668430def9eacd2b5064acf85d73fb0b351a1c8c:
+    __typename: HoprBalance
+    balance: 1000 wxHOPR
+  bea83ba0fcee21da44a30c893f466e6bf0c29bbb:
+    __typename: HoprBalance
+    balance: 990 wxHOPR
+safe_allowances: {}
+deployed_safes: {}
+safe_redeem_stats: {}
+tx_counts:
+  bea83ba0fcee21da44a30c893f466e6bf0c29bbb: 2
+channels: {}
+chain_info:
+  channel_closure_grace_period: "300"
+  channel_dst: "0000000000000000000000000000000000000000000000000000000000000000"
+  block_number: 1
+  chain_id: 100
+  gas_price: "1000000000"
+  ledger_dst: "0000000000000000000000000000000000000000000000000000000000000000"
+  max_fee_per_gas: "3000000000"
+  max_priority_fee_per_gas: "100000000"
+  min_ticket_winning_probability: 1
+  key_binding_fee: 0.01 wxHOPR
+  safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
+  ticket_price: 1 wxHOPR
+  network: rotsee
+  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  expected_block_time: "5"
+  finality: "3"
+version: "1"
+client_compatibility:
+  api_version: "1"
+  supported_client_versions: ^0.29.1
+  features:
+    - indexes_safe_events
+health: OK
+active_txs: {}

--- a/impls/connector/src/connector/tickets.rs
+++ b/impls/connector/src/connector/tickets.rs
@@ -125,7 +125,7 @@ where
         match self.prepare_ticket_redeem_payload(ticket).await {
             Ok(tx_req) => {
                 Ok(self
-                    .send_tx(tx_req, None)
+                    .send_tx(tx_req, None, None)
                     .await
                     .map_err(|e| TicketRedeemError::ProcessingError(ticket.ticket, e))?
                     .map_err(move |tx_tracking_error|


### PR DESCRIPTION
A change required to perform arbitrary signer transactions. The only API making advantage of this new functionality is `withdraw_from_signer`.

Requires https://github.com/hoprnet/hopr-api/pull/93