### PR TITLE
feat(transport): replace futures::mpsc bounded channels with strict-capacity crossfire channels

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3748,7 +3748,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-session"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -3887,7 +3887,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -3997,11 +3997,12 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-probe"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
  "const-hex",
+ "crossfire",
  "futures",
  "futures-concurrency",
  "hex-literal",
@@ -4136,13 +4137,14 @@ dependencies = [
 
 [[package]]
 name = "hopr-utils"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "arrayvec",
  "assertables",
  "async-lock",
  "auto_impl",
+ "crossfire",
  "flume",
  "futures",
  "futures-time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,6 @@ order = [
 
 [workspace.dependencies]
 ahash = "0.8.12"
-atomic_enum = "0.3.0"
 anyhow = "1.0.103"
 aquamarine = "0.6.0"
 arrayvec = { version = "0.7.7" }
@@ -71,6 +70,7 @@ async_channel_io = "0.3.0"
 async-lock = "3.4.2"
 async-trait = "0.1.89"
 asynchronous-codec = { version = "0.7.0" }
+atomic_enum = "0.3.0"
 auto_impl = "1.3.0"
 backon = { version = "1.6.0", default-features = false }
 base64 = "0.22.1"
@@ -88,10 +88,12 @@ chrono = { version = "0.4.45", default-features = false, features = [
 ] }
 clap = { version = "4.6.1", features = ["derive", "env", "string"] }
 const_format = "0.2.36"
+const-hex = "1.19.1"
 criterion = { version = "0.8.2", default-features = false, features = [
   "cargo_bench_support",
   "async_tokio",
 ] }
+crossfire = { version = "3.1.18", default-features = false }
 curve25519-dalek = { version = "4.1.3", features = ["rand_core"] }
 dashmap = { version = "6.2.1", features = ["inline"] }
 flagset = "0.4.7"
@@ -101,20 +103,19 @@ futures = { version = "0.3.32", default-features = false, features = [
   "async-await",
 ] }
 futures-concurrency = "7.7.1"
-futures-timer = "3.0.4"
 futures-time = "3.1.0"
+futures-timer = "3.0.4"
 generic-array = "1.4.3"
 halfbrown = "0.4.0"
 hashbrown = "0.17.1"
-const-hex = "1.19.1"
 hex-literal = "1.1.0"
 hickory-resolver = { version = "0.26.1", default-features = false, features = [
   "system-config",
 ] }
 human-bandwidth = { version = "0.1.4", features = ["serde"] }
 humantime-serde = "1.1.1"
-insta = { version = "1.48.0", features = ["yaml", "redactions"] }
 indexmap = { version = "2.14.0" }
+insta = { version = "1.48.0", features = ["yaml", "redactions"] }
 k256 = { version = "0.13.4", features = ["arithmetic", "ecdh", "hash2curve"] }
 lazy_static = "1.5.0"
 libc = "0.2" # intentionally minor-pinned
@@ -125,6 +126,9 @@ libp2p-identity = { version = "0.2.14", features = [
   "rand",
 ] }
 libp2p-stream = { version = "0.4.0-alpha" }
+mimalloc = { version = "0.1.52", default-features = false, features = [
+  "secure",
+] }
 mockall = "0.15.0"
 moka = { version = "0.12.15", features = ["future", "sync"] }
 more-asserts = "0.3.1"
@@ -132,7 +136,6 @@ multiaddr = "0.18.2"
 oas3 = "0.22.0"
 opentelemetry-prometheus-text-exporter = { version = "0.3" }
 opentelemetry_sdk = { version = "0.32" }
-temp-env = "0.3.6"
 parameterized = "2.0.0" # ignored in renovate, kept back to 2.0.0 due to conflict with indexmap
 parking_lot = "0.12.5"
 pcap-file = "2.0.0"
@@ -145,28 +148,28 @@ pid = "4.0.0"
 pin-project = "1.1.13"
 postcard = { version = "1.1.3", default-features = false, features = ["alloc"] }
 proc-macro-regex = "~1.1.0"
-crossfire = { version = "3.1.18", default-features = false }
 quinn-udp = { version = "0.6.1", default-features = false }
-rayon = "1.12.0"
 rand = { version = "0.10.1", features = ["thread_rng"] }
 rand_distr = "0.6.0"
-smallvec = "1.15.2"
+rayon = "1.12.0"
 redb = "4.1.0"
 ringbuffer = "0.16.0"
-rust-stream-ext-concurrent = "2.0.0"
 rstest = { version = "0.26.1" }
+rust-stream-ext-concurrent = "2.0.0"
 serde = { version = "1.0.228", features = ["derive"] }
 serde_bytes = "0.11.19"
 serde_cbor_2 = "0.13.0"
 serde_json = "1.0.150"
 serde_repr = "0.1.20"
-serde_with = { version = "3.21.0", features = ["base64"] }
 serde-saphyr = "0.0.28"
+serde_with = { version = "3.21.0", features = ["base64"] }
 serial_test = "3.5.0"
+smallvec = "1.15.2"
 smart-default = "0.7.1"
 socket2 = "0.6.4"
 strum = { version = "0.28.0", features = ["derive"] }
 subtle = "2.6.1"
+temp-env = "0.3.6"
 tempfile = "3.27.0"
 test-log = { version = "0.2.21", features = ["trace"] }
 thiserror = "2.0.18"
@@ -176,44 +179,41 @@ tokio = { version = "1.52.3", features = [
   "macros",
   "tracing",
 ] }
+tokio-retry = "0.3.2"
+tokio-stream = { version = "0.1.18", features = ["net"] }
 tokio-util = { version = "0.7.18", default-features = false, features = [
   "codec",
   "compat",
 ] }
-tokio-retry = "0.3.2"
-tokio-stream = { version = "0.1.18", features = ["net"] }
 tracing = { version = "0.1.44", features = ["release_max_level_debug"] }
 typenum = "1.20.1"
 validator = { version = "0.20.0", features = ["derive"] }
-mimalloc = { version = "0.1.52", default-features = false, features = [
-  "secure",
-] }
 
 hopr-api = "1.14.0"
 hopr-types = { version = "1.9.3", features = ["use-bindings"] }
-hopr-utils = { version = "0.1.0", path = "utils", default-features = false }
+hopr-utils = { version = "0.2.0", path = "utils", default-features = false }
+hopr-utils-session = { version = "1.2.1", path = "utils-session" }
 
 hopr-crypto-packet = { version = "1.4.0", path = "crypto/packet", default-features = false, features = [
   "ed25519",
 ] }
-hopr-lib = { version = "4.0.2-rc.4", path = "hopr/hopr-lib", default-features = false }
+hopr-lib = { version = "4.0.2-rc.5", path = "hopr/hopr-lib", default-features = false }
 hopr-protocol-app = { version = "1.0.1", path = "protocols/app", default-features = false }
 hopr-protocol-hopr = { version = "4.7.0", path = "protocols/hopr", default-features = false }
-hopr-protocol-session = { version = "1.1.1", path = "protocols/session", default-features = false }
+hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
 hopr-protocol-start = { version = "1.1.0", path = "protocols/start", default-features = false }
+hopr-strategy = { version = "0.19.2", path = "impls/strategy" }
 hopr-ticket-manager = { version = "0.5.0", path = "impls/ticket-manager" }
-hopr-transport = { version = "0.31.0", path = "transport/hopr", default-features = false }
+hopr-transport = { version = "0.32.0", path = "transport/hopr", default-features = false }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
-hopr-transport-probe = { version = "0.7.0", path = "transport/probe", default-features = false }
+hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
 hopr-transport-session = { version = "0.23.0", path = "transport/session", default-features = false }
 hopr-transport-tag-allocator = { version = "0.1.1", path = "transport/tag-allocator", default-features = false }
 hopr-chain-connector = { version = "0.22.0", path = "impls/connector" }
-hopr-strategy = { version = "0.19.2", path = "impls/strategy" }
-hopr-utils-session = { version = "1.2.1", path = "utils-session" }
 
 # referential implementations
 hopr-session-server-forwarder = { version = "0.1.0", path = "impls/session-server-forwarder", default-features = false }
-hopr-transport-p2p = { version = "0.9.1", path = "impls/transport/p2p", default-features = false }
+hopr-transport-p2p = { version = "0.9.4", path = "impls/transport/p2p", default-features = false }
 hopr-ct-full-network = { version = "0.3.0", path = "impls/ct/full-network", default-features = false }
 hopr-network-graph = { version = "0.3.0", path = "impls/graph", default-features = false }
 

--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -15,6 +15,7 @@ include = ["README.md", "src/**/*.rs", "Cargo.toml", "LICENSE"]
 
 [lib]
 crate-type = ["rlib"]
+doctest = false
 
 
 [features]

--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -15,7 +15,6 @@ include = ["README.md", "src/**/*.rs", "Cargo.toml", "LICENSE"]
 
 [lib]
 crate-type = ["rlib"]
-doctest = false
 
 
 [features]

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -30,7 +30,7 @@ mod chain_wiring;
 
 use std::{future::Future, pin::Pin, sync::Arc, time::Duration};
 
-use futures::{FutureExt, StreamExt, channel::mpsc::channel};
+use futures::{FutureExt, StreamExt};
 pub use hopr_api::types::crypto::{
     keypairs::Keypair,
     prelude::{ChainKeypair, OffchainKeypair},
@@ -46,7 +46,10 @@ use hopr_api::{
 };
 use hopr_transport::{HoprTransport, IncomingSession};
 use hopr_utils::{
-    network_types::addr::is_public_address,
+    network_types::{
+        addr::is_public_address,
+        crossfire_sink::{CrossfireSink, bounded_sink_channel},
+    },
     runtime::{AbortableList, prelude::spawn},
 };
 use validator::Validate;
@@ -77,7 +80,7 @@ lazy_static::lazy_static! {
 const PEER_DISCOVERY_CHANNEL_CAPACITY: usize = 2048;
 
 type PeerDiscoveryRx =
-    Arc<parking_lot::Mutex<Option<futures::channel::mpsc::Receiver<(hopr_api::PeerId, Vec<hopr_api::Multiaddr>)>>>>;
+    Arc<parking_lot::Mutex<Option<futures::stream::BoxStream<'static, (hopr_api::PeerId, Vec<hopr_api::Multiaddr>)>>>>;
 
 /// Type-erased factory closure producing `T` from a [`BuildCtx`] reference.
 type Factory<T> = Box<dyn FnOnce(&BuildCtx) -> T + Send>;
@@ -99,7 +102,7 @@ impl BuildCtx {
     /// Take the peer-discovery receiver. Returns `Some` on the first call, `None` afterwards.
     pub fn take_peer_discovery_rx(
         &self,
-    ) -> Option<futures::channel::mpsc::Receiver<(hopr_api::PeerId, Vec<hopr_api::Multiaddr>)>> {
+    ) -> Option<futures::stream::BoxStream<'static, (hopr_api::PeerId, Vec<hopr_api::Multiaddr>)>> {
         self.peer_discovery_rx.lock().take()
     }
 }
@@ -131,7 +134,8 @@ pub struct HoprBuilderWithIdentity {
 impl HoprBuilderWithIdentity {
     /// Sets the node configuration and produces the configured builder.
     pub fn with_config(self, cfg: HoprLibConfig) -> HoprBuilderConfigured {
-        let (peer_discovery_tx, peer_discovery_rx) = futures::channel::mpsc::channel(PEER_DISCOVERY_CHANNEL_CAPACITY);
+        let (peer_discovery_tx, peer_discovery_rx) =
+            bounded_sink_channel::<(hopr_api::PeerId, Vec<hopr_api::Multiaddr>)>(PEER_DISCOVERY_CHANNEL_CAPACITY);
         HoprBuilderConfigured {
             ctx: BuildCtx {
                 chain_key: self.chain_key,
@@ -167,7 +171,7 @@ pub struct HoprBuilderConfigured<Chain = (), Graph = (), Net = (), Ct = ()> {
     graph_factory: Option<Factory<Graph>>,
     network_factory: Option<AsyncFactory<Result<(Net, BoxedProcessFn), HoprLibError>>>,
     ct_factory: Option<Factory<Ct>>,
-    peer_discovery_tx: futures::channel::mpsc::Sender<(hopr_api::PeerId, Vec<hopr_api::Multiaddr>)>,
+    peer_discovery_tx: CrossfireSink<(hopr_api::PeerId, Vec<hopr_api::Multiaddr>)>,
 }
 
 impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
@@ -729,7 +733,7 @@ macro_rules! impl_build_methods {
             let mut processes = pre.processes;
 
             tracing::info!("starting ticket events processor");
-            let (tickets_tx, tickets_rx) = channel(8192);
+            let (tickets_tx, tickets_rx) = bounded_sink_channel::<TicketEvent>(8192);
 
             // Need to use DropAbortable, so that the receiver is dropped when aborted and no new items can be sent by the senders.
             let (tickets_rx_stream, tickets_handle) = hopr_utils::runtime::DropAbortable::new(tickets_rx);
@@ -923,7 +927,7 @@ where
         futures::channel::mpsc::Sender<IncomingSession>,
         AbortableList<HoprLibProcess>,
     ) {
-        let (tx, _rx) = channel::<IncomingSession>(1);
+        let (tx, _rx) = futures::channel::mpsc::channel::<IncomingSession>(1);
         let processes = AbortableList::<HoprLibProcess>::default();
         (self, tx, processes)
     }

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -46,10 +46,7 @@ use hopr_api::{
 };
 use hopr_transport::{HoprTransport, IncomingSession};
 use hopr_utils::{
-    network_types::{
-        addr::is_public_address,
-        crossfire_sink::{CrossfireSink, bounded_sink_channel},
-    },
+    network_types::{addr::is_public_address, crossfire_sink::bounded_sink_channel},
     runtime::{AbortableList, prelude::spawn},
 };
 use validator::Validate;
@@ -80,7 +77,7 @@ lazy_static::lazy_static! {
 const PEER_DISCOVERY_CHANNEL_CAPACITY: usize = 2048;
 
 type PeerDiscoveryRx =
-    Arc<parking_lot::Mutex<Option<futures::stream::BoxStream<'static, (hopr_api::PeerId, Vec<hopr_api::Multiaddr>)>>>>;
+    Arc<parking_lot::Mutex<Option<futures::channel::mpsc::Receiver<(hopr_api::PeerId, Vec<hopr_api::Multiaddr>)>>>>;
 
 /// Type-erased factory closure producing `T` from a [`BuildCtx`] reference.
 type Factory<T> = Box<dyn FnOnce(&BuildCtx) -> T + Send>;
@@ -102,7 +99,7 @@ impl BuildCtx {
     /// Take the peer-discovery receiver. Returns `Some` on the first call, `None` afterwards.
     pub fn take_peer_discovery_rx(
         &self,
-    ) -> Option<futures::stream::BoxStream<'static, (hopr_api::PeerId, Vec<hopr_api::Multiaddr>)>> {
+    ) -> Option<futures::channel::mpsc::Receiver<(hopr_api::PeerId, Vec<hopr_api::Multiaddr>)>> {
         self.peer_discovery_rx.lock().take()
     }
 }
@@ -134,8 +131,10 @@ pub struct HoprBuilderWithIdentity {
 impl HoprBuilderWithIdentity {
     /// Sets the node configuration and produces the configured builder.
     pub fn with_config(self, cfg: HoprLibConfig) -> HoprBuilderConfigured {
-        let (peer_discovery_tx, peer_discovery_rx) =
-            bounded_sink_channel::<(hopr_api::PeerId, Vec<hopr_api::Multiaddr>)>(PEER_DISCOVERY_CHANNEL_CAPACITY);
+        let (peer_discovery_tx, peer_discovery_rx) = futures::channel::mpsc::channel::<(
+            hopr_api::PeerId,
+            Vec<hopr_api::Multiaddr>,
+        )>(PEER_DISCOVERY_CHANNEL_CAPACITY);
         HoprBuilderConfigured {
             ctx: BuildCtx {
                 chain_key: self.chain_key,
@@ -171,7 +170,7 @@ pub struct HoprBuilderConfigured<Chain = (), Graph = (), Net = (), Ct = ()> {
     graph_factory: Option<Factory<Graph>>,
     network_factory: Option<AsyncFactory<Result<(Net, BoxedProcessFn), HoprLibError>>>,
     ct_factory: Option<Factory<Ct>>,
-    peer_discovery_tx: CrossfireSink<(hopr_api::PeerId, Vec<hopr_api::Multiaddr>)>,
+    peer_discovery_tx: futures::channel::mpsc::Sender<(hopr_api::PeerId, Vec<hopr_api::Multiaddr>)>,
 }
 
 impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
@@ -265,7 +264,7 @@ impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
     ) -> HoprBuilderWithSession<Chain, Graph, Net, Ct> {
         let incoming_session_capacity = self.ctx.cfg.incoming_session_capacity.max(1);
 
-        let (session_tx, session_rx) = channel::<IncomingSession>(incoming_session_capacity);
+        let (session_tx, session_rx) = futures::channel::mpsc::channel::<IncomingSession>(incoming_session_capacity);
 
         tracing::debug!(capacity = incoming_session_capacity, "spawning session server");
         let session_diag = hopr_utils::runtime::diagnostics::ConcurrentDiagnostics::new(

--- a/hopr/hopr-lib/src/builder/chain_wiring.rs
+++ b/hopr/hopr-lib/src/builder/chain_wiring.rs
@@ -30,7 +30,7 @@ pub(super) async fn process_chain_events<C, G>(
     own_packet_key: OffchainPublicKey,
     ticket_price: Arc<RwLock<HoprBalance>>,
     win_probability: Arc<RwLock<WinningProbability>>,
-    mut peer_discovery_tx: Option<futures::channel::mpsc::Sender<(PeerId, Vec<Multiaddr>)>>,
+    mut peer_discovery_tx: Option<hopr_utils::network_types::crossfire_sink::CrossfireSink<(PeerId, Vec<Multiaddr>)>>,
 ) where
     C: ChainKeyOperations + Clone + Send + Sync + 'static,
     G: NetworkGraphUpdate + Send + Sync + 'static,

--- a/hopr/hopr-lib/src/builder/chain_wiring.rs
+++ b/hopr/hopr-lib/src/builder/chain_wiring.rs
@@ -30,7 +30,7 @@ pub(super) async fn process_chain_events<C, G>(
     own_packet_key: OffchainPublicKey,
     ticket_price: Arc<RwLock<HoprBalance>>,
     win_probability: Arc<RwLock<WinningProbability>>,
-    mut peer_discovery_tx: Option<hopr_utils::network_types::crossfire_sink::CrossfireSink<(PeerId, Vec<Multiaddr>)>>,
+    mut peer_discovery_tx: Option<futures::channel::mpsc::Sender<(PeerId, Vec<Multiaddr>)>>,
 ) where
     C: ChainKeyOperations + Clone + Send + Sync + 'static,
     G: NetworkGraphUpdate + Send + Sync + 'static,

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -286,7 +286,7 @@ pub fn prepare_tokio_runtime(
 /// Type alias used to send and receive transport data via a running HOPR node.
 pub type HoprTransportIO = hopr_transport::socket::HoprSocket<
     futures::stream::BoxStream<'static, ApplicationDataIn>,
-    futures::channel::mpsc::Sender<(DestinationRouting, ApplicationDataOut)>,
+    hopr_utils::network_types::crossfire_sink::CrossfireSink<(DestinationRouting, ApplicationDataOut)>,
 >;
 
 type TicketEvents = (

--- a/protocols/session/Cargo.toml
+++ b/protocols/session/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-protocol-session"
 description = "Contains implementation of Session protocol according to HOPR RFC-0008"
-version = "1.1.1"
+version = "1.2.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"
@@ -59,7 +59,7 @@ thiserror = { workspace = true }
 tokio = { workspace = true, optional = true }
 tracing = { workspace = true }
 
-hopr-utils = { workspace = true, features = ["runtime-tokio"] }
+hopr-utils = { workspace = true, features = ["runtime-tokio", "network-types"] }
 hopr-crypto-packet = { workspace = true }
 hopr-types = { workspace = true, features = ["primitive", "random"] }
 
@@ -100,6 +100,9 @@ harness = false
 [target.'cfg(target_os = "linux")'.dependencies]
 mimalloc = { workspace = true, optional = true }
 tikv-jemallocator = { workspace = true, optional = true }
+
+[lib]
+doctest = false
 
 [package.metadata.cargo-machete]
 ignored = ["serde_bytes"]

--- a/protocols/session/src/socket/ack_state.rs
+++ b/protocols/session/src/socket/ack_state.rs
@@ -578,9 +578,7 @@ impl<const C: usize> SocketState<C> for AcknowledgementState<C> {
 
         // Since segments are re-sent via Control stream, they are not later fed again
         // into the ring buffer.
-        if !ctx.rb_tx.push(segment.clone()) {
-            tracing::error!("failed to push segment into ring buffer");
-        }
+        ctx.rb_tx.push(segment.clone());
 
         // When the last segment of a frame has been sent,
         // add it to outgoing retries (if the full ack mode is enabled).

--- a/protocols/session/src/socket/ack_state.rs
+++ b/protocols/session/src/socket/ack_state.rs
@@ -6,8 +6,9 @@ use std::{
     time::{Duration, Instant},
 };
 
-use futures::{FutureExt, StreamExt, channel::mpsc::Sender};
+use futures::{FutureExt, StreamExt};
 use futures_time::stream::StreamExt as TimeStreamExt;
+use hopr_utils::network_types::crossfire_sink::{CrossfireSink, bounded_sink_channel};
 use tracing::Instrument;
 
 use crate::{
@@ -121,9 +122,9 @@ struct AcknowledgementStateContext<const C: usize> {
     rb_rx: RingBufferView<Segment>,
     incoming_frame_retries_tx: SkipDelaySender<RetriedFrameId>,
     outgoing_frame_retries_tx: SkipDelaySender<RetriedFrameId>,
-    ack_tx: futures::channel::mpsc::Sender<FrameId>,
+    ack_tx: CrossfireSink<FrameId>,
     inspector: FrameInspector,
-    ctl_tx: Sender<SessionMessage<C>>,
+    ctl_tx: CrossfireSink<SessionMessage<C>>,
 }
 
 #[cfg_attr(doc, aquamarine::aquamarine)]
@@ -250,7 +251,7 @@ impl<const C: usize> SocketState<C> for AcknowledgementState<C> {
         let (rb_tx, rb_rx) = searchable_ringbuffer(self.cfg.lookbehind_segments);
 
         // Full frame acknowledgements get a special channel with fixed capacity
-        let (ack_tx, ack_rx) = futures::channel::mpsc::channel(2 * self.cfg.lookbehind_segments);
+        let (ack_tx, ack_rx) = bounded_sink_channel::<FrameId>(2 * self.cfg.lookbehind_segments);
 
         let context = self.context.insert(AcknowledgementStateContext {
             rb_tx,
@@ -379,8 +380,8 @@ impl<const C: usize> SocketState<C> for AcknowledgementState<C> {
         if let Some(mut ctx) = self.context.take() {
             ctx.outgoing_frame_retries_tx.force_close();
             ctx.incoming_frame_retries_tx.force_close();
-            ctx.ack_tx.close_channel();
-            ctx.ctl_tx.close_channel();
+            // ack_tx and ctl_tx close when their last clone is dropped;
+            // dropping ctx here drops the originals, spawned-task clones drop when those tasks complete.
 
             self.started.store(false, std::sync::atomic::Ordering::Relaxed);
             tracing::debug!("state has been stopped");
@@ -626,7 +627,7 @@ mod tests {
         };
 
         let inspector = FrameInspector(FrameDashMap::with_capacity(10));
-        let (ctl_tx, ctl_rx) = futures::channel::mpsc::channel(1024);
+        let (ctl_tx, ctl_rx) = bounded_sink_channel::<SessionMessage<MTU>>(1024);
 
         let mut state = AcknowledgementState::<MTU>::new("test", cfg);
         state.run(SocketComponents {
@@ -671,7 +672,7 @@ mod tests {
         };
 
         let inspector = FrameInspector(FrameDashMap::with_capacity(10));
-        let (ctl_tx, ctl_rx) = futures::channel::mpsc::channel(1024);
+        let (ctl_tx, ctl_rx) = bounded_sink_channel::<SessionMessage<MTU>>(1024);
 
         let mut state = AcknowledgementState::<MTU>::new("test", cfg);
         state.run(SocketComponents {
@@ -735,7 +736,7 @@ mod tests {
         };
 
         let inspector = FrameInspector(FrameDashMap::with_capacity(10));
-        let (ctl_tx, ctl_rx) = futures::channel::mpsc::channel(1024);
+        let (ctl_tx, ctl_rx) = bounded_sink_channel::<SessionMessage<MTU>>(1024);
 
         let mut state = AcknowledgementState::<MTU>::new("test", cfg);
         state.run(SocketComponents {
@@ -768,7 +769,7 @@ mod tests {
         };
 
         let inspector = FrameInspector(FrameDashMap::with_capacity(10));
-        let (ctl_tx, ctl_rx) = futures::channel::mpsc::channel(1024);
+        let (ctl_tx, ctl_rx) = bounded_sink_channel::<SessionMessage<MTU>>(1024);
 
         let mut state = AcknowledgementState::<MTU>::new("test", cfg);
         state.run(SocketComponents {
@@ -804,7 +805,7 @@ mod tests {
         };
 
         let inspector = FrameInspector(FrameDashMap::with_capacity(10));
-        let (ctl_tx, ctl_rx) = futures::channel::mpsc::channel(1024);
+        let (ctl_tx, ctl_rx) = bounded_sink_channel::<SessionMessage<MTU>>(1024);
 
         let mut state = AcknowledgementState::<MTU>::new("test", cfg);
         state.run(SocketComponents {
@@ -844,7 +845,7 @@ mod tests {
         };
 
         let inspector = FrameInspector(FrameDashMap::with_capacity(10));
-        let (ctl_tx, ctl_rx) = futures::channel::mpsc::channel(1024);
+        let (ctl_tx, ctl_rx) = bounded_sink_channel::<SessionMessage<MTU>>(1024);
 
         let mut state = AcknowledgementState::<MTU>::new("test", cfg);
         state.run(SocketComponents {
@@ -913,7 +914,7 @@ mod tests {
         };
 
         let mut inspector = FrameInspector(FrameDashMap::with_capacity(10));
-        let (ctl_tx, ctl_rx) = futures::channel::mpsc::channel(1024);
+        let (ctl_tx, ctl_rx) = bounded_sink_channel::<SessionMessage<MTU>>(1024);
 
         let segments = segment(hopr_types::crypto_random::random_bytes::<FRAME_SIZE>(), MTU, 1)?;
 
@@ -959,7 +960,7 @@ mod tests {
         };
 
         let mut inspector = FrameInspector(FrameDashMap::with_capacity(10));
-        let (ctl_tx, ctl_rx) = futures::channel::mpsc::channel(1024);
+        let (ctl_tx, ctl_rx) = bounded_sink_channel::<SessionMessage<MTU>>(1024);
 
         let segments = segment(hopr_types::crypto_random::random_bytes::<FRAME_SIZE>(), MTU, 1)?;
 
@@ -1002,7 +1003,7 @@ mod tests {
         };
 
         let mut inspector = FrameInspector(FrameDashMap::with_capacity(10));
-        let (ctl_tx, ctl_rx) = futures::channel::mpsc::channel(1024);
+        let (ctl_tx, ctl_rx) = bounded_sink_channel::<SessionMessage<MTU>>(1024);
 
         let segments = segment(hopr_types::crypto_random::random_bytes::<{ 2 * FRAME_SIZE }>(), MTU, 1)?;
 
@@ -1067,7 +1068,7 @@ mod tests {
         };
 
         let mut inspector = FrameInspector(FrameDashMap::with_capacity(10));
-        let (ctl_tx, ctl_rx) = futures::channel::mpsc::channel(1024);
+        let (ctl_tx, ctl_rx) = bounded_sink_channel::<SessionMessage<MTU>>(1024);
 
         let segments = segment(hopr_types::crypto_random::random_bytes::<{ 2 * FRAME_SIZE }>(), MTU, 1)?;
 

--- a/protocols/session/src/socket/mod.rs
+++ b/protocols/session/src/socket/mod.rs
@@ -302,7 +302,9 @@ impl<const C: usize, S: SocketState<C> + Clone + 'static> SessionSocket<C, S> {
             capacity = cfg.control_channel_capacity,
             "creating session control channel"
         );
-        let (ctl_tx, ctl_rx) = futures::channel::mpsc::channel(cfg.control_channel_capacity.max(128));
+        let (ctl_tx, ctl_rx) = hopr_utils::network_types::crossfire_sink::bounded_sink_channel::<SessionMessage<C>>(
+            cfg.control_channel_capacity.max(128),
+        );
         state.run(SocketComponents {
             inspector: Some(inspector.clone()),
             ctl_tx,

--- a/protocols/session/src/socket/state.rs
+++ b/protocols/session/src/socket/state.rs
@@ -1,4 +1,4 @@
-use futures::channel::mpsc::Sender;
+use hopr_utils::network_types::crossfire_sink::CrossfireSink;
 
 use crate::{
     errors::SessionError,
@@ -18,7 +18,8 @@ pub struct SocketComponents<const C: usize> {
     /// Allows emitting control messages to the socket.
     ///
     /// It is a regular `SessionMessage` injected into the downstream.
-    pub ctl_tx: Sender<SessionMessage<C>>,
+    /// Strict-capacity bounded channel — capacity never inflates regardless of clone count.
+    pub ctl_tx: CrossfireSink<SessionMessage<C>>,
 }
 
 /// Abstraction of the `SessionSocket` state.

--- a/protocols/session/src/utils/mod.rs
+++ b/protocols/session/src/utils/mod.rs
@@ -9,7 +9,6 @@ use std::{
     time::{Duration, Instant},
 };
 
-use futures::StreamExt;
 use ringbuffer::{AllocRingBuffer, RingBuffer};
 
 use crate::{
@@ -17,18 +16,19 @@ use crate::{
     protocol::{FrameId, Segment, SeqIndicator, SeqNum},
 };
 
-#[derive(Debug)]
-pub(crate) struct RingBufferProducer<T>(futures::channel::mpsc::Sender<T>);
+#[derive(Clone)]
+pub(crate) struct RingBufferProducer<T>(Arc<parking_lot::FairMutex<AllocRingBuffer<T>>>);
 
-impl<T> Clone for RingBufferProducer<T> {
-    fn clone(&self) -> Self {
-        Self(self.0.clone())
+impl<T> std::fmt::Debug for RingBufferProducer<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("RingBufferProducer").finish()
     }
 }
 
 impl<T> RingBufferProducer<T> {
     pub fn push(&mut self, item: T) -> bool {
-        self.0.try_send(item).is_ok()
+        self.0.lock().enqueue(item);
+        true
     }
 }
 
@@ -47,20 +47,9 @@ impl<T: Clone> RingBufferView<T> {
     }
 }
 
-pub(crate) fn searchable_ringbuffer<T: Send + Sync + 'static>(
-    capacity: usize,
-) -> (RingBufferProducer<T>, RingBufferView<T>) {
-    // The channel gets the same capacity as RB in case the task cannot keep up (due to locking)
-    let (rb_tx, rb_rx) = futures::channel::mpsc::channel(capacity);
+pub(crate) fn searchable_ringbuffer<T: Send + 'static>(capacity: usize) -> (RingBufferProducer<T>, RingBufferView<T>) {
     let rb = Arc::new(parking_lot::FairMutex::new(AllocRingBuffer::new(capacity)));
-
-    let rb_clone = rb.clone();
-    hopr_utils::runtime::prelude::spawn(rb_rx.for_each(move |s| {
-        rb_clone.lock().enqueue(s);
-        futures::future::ready(())
-    }));
-
-    (RingBufferProducer(rb_tx), RingBufferView(rb))
+    (RingBufferProducer(rb.clone()), RingBufferView(rb))
 }
 
 const MAX_BACKOFF: Duration = Duration::from_secs(300);

--- a/protocols/session/src/utils/mod.rs
+++ b/protocols/session/src/utils/mod.rs
@@ -26,9 +26,8 @@ impl<T> std::fmt::Debug for RingBufferProducer<T> {
 }
 
 impl<T> RingBufferProducer<T> {
-    pub fn push(&mut self, item: T) -> bool {
+    pub fn push(&mut self, item: T) {
         self.0.lock().enqueue(item);
-        true
     }
 }
 

--- a/protocols/session/src/utils/skip_queue.rs
+++ b/protocols/session/src/utils/skip_queue.rs
@@ -120,7 +120,9 @@ impl<T> Drop for SkipDelayReceiver<T> {
         self.0.clear_poison();
         let mut queue = self.0.lock().expect("cannot panic because poison is cleared");
         queue.is_closed = true;
-        queue.rx_waker = None;
+        if let Some(waker) = queue.rx_waker.take() {
+            waker.wake();
+        }
     }
 }
 
@@ -203,7 +205,9 @@ impl<T> SkipDelaySender<T> {
         queue.clear_poison();
         let mut queue = queue.lock().expect("cannot panic because poison is cleared");
         queue.is_closed = true;
-        queue.rx_waker = None;
+        if let Some(waker) = queue.rx_waker.take() {
+            waker.wake();
+        }
     }
 
     /// Forces closure of the queue (regardless of any remaining senders).

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -22,7 +22,6 @@ include = [
 
 [lib]
 crate-type = ["rlib"]
-doctest = false
 
 [features]
 default = []

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport"
 description = "Implements the main HOPR transport interface for the core library"
-version = "0.31.0"
+version = "0.32.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"
@@ -22,6 +22,7 @@ include = [
 
 [lib]
 crate-type = ["rlib"]
+doctest = false
 
 [features]
 default = []

--- a/transport/hopr/src/capture.rs
+++ b/transport/hopr/src/capture.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, fs::File};
 
 use bytes::Bytes;
-use futures::{StreamExt, pin_mut};
+use futures::StreamExt;
 use hopr_api::types::{
     crypto::types::OffchainPublicKey,
     internal::{
@@ -98,12 +98,12 @@ impl PacketWriter for PcapPacketWriter {
 /// Creates a queue that processes captured packets into a [`PacketWriter`].
 pub fn packet_capture_channel(
     writer: Box<dyn PacketWriter + Send>,
-) -> (futures::channel::mpsc::Sender<CapturedPacket>, AbortHandle) {
-    let (sender, receiver) = futures::channel::mpsc::channel(20_000);
+) -> (crossfire::MAsyncTx<crossfire::mpsc::Array<CapturedPacket>>, AbortHandle) {
+    let (sender, receiver) = crossfire::mpsc::bounded_async::<CapturedPacket>(20_000);
     let writer = std::sync::Arc::new(std::sync::Mutex::new(writer));
     let ah = hopr_utils::spawn_as_abortable!(async move {
-        pin_mut!(receiver);
-        while let Some(packet) = receiver.next().await {
+        let mut rx_stream = receiver.into_stream();
+        while let Some(packet) = rx_stream.next().await {
             let writer = writer.clone();
             match hopr_utils::runtime::prelude::spawn_blocking(move || {
                 writer
@@ -301,7 +301,7 @@ impl<'a> From<PacketBeforeTransit<'a>> for CapturedPacket {
 pub struct CapturePacketCodec<C> {
     inner: std::sync::Arc<C>,
     packet_key: OffchainPublicKey,
-    sender: futures::channel::mpsc::Sender<CapturedPacket>,
+    sender: crossfire::MAsyncTx<crossfire::mpsc::Array<CapturedPacket>>,
 }
 
 impl<C> Clone for CapturePacketCodec<C> {
@@ -318,7 +318,7 @@ impl<C> CapturePacketCodec<C> {
     pub fn new(
         inner: C,
         packet_key: OffchainPublicKey,
-        sender: futures::channel::mpsc::Sender<CapturedPacket>,
+        sender: crossfire::MAsyncTx<crossfire::mpsc::Array<CapturedPacket>>,
     ) -> Self {
         Self {
             inner: std::sync::Arc::new(inner),
@@ -342,7 +342,7 @@ impl<C: PacketDecoder + Send + Sync> PacketDecoder for CapturePacketCodec<C> {
     fn decode(&self, peer: PeerId, data: Bytes) -> Result<IncomingPacket, IncomingPacketError<Self::Error>> {
         let packet = self.inner.decode(peer, data)?;
 
-        if let Err(error) = self.sender.clone().try_send(
+        if let Err(error) = self.sender.try_send(
             PacketBeforeTransit::IncomingPacket {
                 me: self.packet_key,
                 packet: &packet,
@@ -355,7 +355,7 @@ impl<C: PacketDecoder + Send + Sync> PacketDecoder for CapturePacketCodec<C> {
         if let IncomingPacket::Forwarded(fwd_packet) = &packet {
             let IncomingForwardedPacket { next_hop, data, .. } = fwd_packet.as_ref();
 
-            if let Err(error) = self.sender.clone().try_send(
+            if let Err(error) = self.sender.try_send(
                 PacketBeforeTransit::OutgoingPacket {
                     me: self.packet_key,
                     next_hop: *next_hop,
@@ -391,7 +391,7 @@ impl<C: PacketEncoder + Send + Sync> PacketEncoder for CapturePacketCodec<C> {
 
         let packet = self.inner.encode_packet(data, routing, signals)?;
 
-        if let Err(error) = self.sender.clone().try_send(
+        if let Err(error) = self.sender.try_send(
             PacketBeforeTransit::OutgoingPacket {
                 me: self.packet_key,
                 next_hop: packet.next_hop,
@@ -417,7 +417,7 @@ impl<C: PacketEncoder + Send + Sync> PacketEncoder for CapturePacketCodec<C> {
     ) -> Result<OutgoingPacket, Self::Error> {
         let packet_ack = self.inner.encode_acknowledgements(acks, destination)?;
 
-        if let Err(error) = self.sender.clone().try_send(
+        if let Err(error) = self.sender.try_send(
             PacketBeforeTransit::OutgoingAck {
                 me: self.packet_key,
                 is_random: false,
@@ -435,7 +435,6 @@ impl<C: PacketEncoder + Send + Sync> PacketEncoder for CapturePacketCodec<C> {
 
 #[cfg(test)]
 mod tests {
-    use futures::{SinkExt, pin_mut};
     use hex_literal::hex;
     use hopr_api::types::{
         crypto::{
@@ -466,7 +465,6 @@ mod tests {
 
         File::create("/tmp/start_capturing")?;
         let (pcap, ah) = packet_capture_channel(Box::new(File::create("test.pcap").and_then(PcapPacketWriter::new)?));
-        pin_mut!(pcap);
 
         let packet = IncomingPacket::Final(
             IncomingFinalPacket {
@@ -489,9 +487,7 @@ mod tests {
             .index(10)
             .build_signed(&ChainKeypair::random(), &Hash::default())?;
 
-        let _ = pcap
-            .send(PacketBeforeTransit::IncomingPacket { me, packet: &packet }.into())
-            .await;
+        let _ = pcap.try_send(PacketBeforeTransit::IncomingPacket { me, packet: &packet }.into());
 
         let msg = SessionMessage::<1000>::Segment(Segment {
             frame_id: 1,
@@ -514,9 +510,7 @@ mod tests {
             .into(),
         );
 
-        let _ = pcap
-            .send(PacketBeforeTransit::IncomingPacket { me, packet: &packet }.into())
-            .await;
+        let _ = pcap.try_send(PacketBeforeTransit::IncomingPacket { me, packet: &packet }.into());
 
         let msg = SessionMessage::<1000>::Segment(Segment {
             frame_id: 2,
@@ -539,9 +533,7 @@ mod tests {
             .into(),
         );
 
-        let _ = pcap
-            .send(PacketBeforeTransit::IncomingPacket { me, packet: &packet }.into())
-            .await;
+        let _ = pcap.try_send(PacketBeforeTransit::IncomingPacket { me, packet: &packet }.into());
 
         let msg = SessionMessage::<1000>::Acknowledge(FrameAcknowledgements::try_from(vec![1, 2, 100])?);
 
@@ -557,9 +549,7 @@ mod tests {
             .into(),
         );
 
-        let _ = pcap
-            .send(PacketBeforeTransit::IncomingPacket { me, packet: &packet }.into())
-            .await;
+        let _ = pcap.try_send(PacketBeforeTransit::IncomingPacket { me, packet: &packet }.into());
 
         let msg = SessionMessage::<1000>::Request(SegmentRequest::from_iter([
             (15 as FrameId, [0b10100001].into()),
@@ -578,9 +568,7 @@ mod tests {
             .into(),
         );
 
-        let _ = pcap
-            .send(PacketBeforeTransit::IncomingPacket { me, packet: &packet }.into())
-            .await;
+        let _ = pcap.try_send(PacketBeforeTransit::IncomingPacket { me, packet: &packet }.into());
 
         let kp = OffchainKeypair::random();
         let packet = IncomingPacket::Acknowledgement(
@@ -595,9 +583,7 @@ mod tests {
             .into(),
         );
 
-        let _ = pcap
-            .send(PacketBeforeTransit::IncomingPacket { me, packet: &packet }.into())
-            .await;
+        let _ = pcap.try_send(PacketBeforeTransit::IncomingPacket { me, packet: &packet }.into());
 
         let packet = IncomingPacket::Forwarded(
             IncomingForwardedPacket {
@@ -612,9 +598,7 @@ mod tests {
             .into(),
         );
 
-        let _ = pcap
-            .send(PacketBeforeTransit::IncomingPacket { me, packet: &packet }.into())
-            .await;
+        let _ = pcap.try_send(PacketBeforeTransit::IncomingPacket { me, packet: &packet }.into());
 
         let hk = HalfKey::random().to_challenge()?;
         let packet = PacketBeforeTransit::OutgoingPacket {
@@ -635,7 +619,7 @@ mod tests {
             signals: PacketSignal::OutOfSurbs.into(),
         };
 
-        let _ = pcap.send(packet.into()).await;
+        let _ = pcap.try_send(packet.into());
 
         let hk = HalfKey::random().to_challenge()?;
         let packet = PacketBeforeTransit::OutgoingPacket {
@@ -654,7 +638,7 @@ mod tests {
             signals: None.into(),
         };
 
-        let _ = pcap.send(packet.into()).await;
+        let _ = pcap.try_send(packet.into());
 
         let hk = HalfKey::random().to_challenge()?;
         let packet = PacketBeforeTransit::OutgoingPacket {
@@ -673,7 +657,7 @@ mod tests {
             signals: None.into(),
         };
 
-        let _ = pcap.send(packet.into()).await;
+        let _ = pcap.try_send(packet.into());
 
         let hk = HalfKey::random().to_challenge()?;
         let packet = PacketBeforeTransit::OutgoingPacket {
@@ -699,7 +683,7 @@ mod tests {
             signals: None.into(),
         };
 
-        let _ = pcap.send(packet.into()).await;
+        let _ = pcap.try_send(packet.into());
 
         let hk = HalfKey::random().to_challenge()?;
         let packet = PacketBeforeTransit::OutgoingPacket {
@@ -723,7 +707,7 @@ mod tests {
             signals: None.into(),
         };
 
-        let _ = pcap.send(packet.into()).await;
+        let _ = pcap.try_send(packet.into());
 
         let hk = HalfKey::random().to_challenge()?;
         let packet = PacketBeforeTransit::OutgoingPacket {
@@ -747,7 +731,7 @@ mod tests {
             signals: None.into(),
         };
 
-        let _ = pcap.send(packet.into()).await;
+        let _ = pcap.try_send(packet.into());
 
         let hk = HalfKey::random().to_challenge()?;
         let packet = PacketBeforeTransit::OutgoingPacket {
@@ -772,7 +756,7 @@ mod tests {
             signals: None.into(),
         };
 
-        let _ = pcap.send(packet.into()).await;
+        let _ = pcap.try_send(packet.into());
 
         let hk = HalfKey::random().to_challenge()?;
         let packet = PacketBeforeTransit::OutgoingPacket {
@@ -786,7 +770,7 @@ mod tests {
             signals: None.into(),
         };
 
-        let _ = pcap.send(packet.into()).await;
+        let _ = pcap.try_send(packet.into());
 
         let kp = OffchainKeypair::random();
 
@@ -800,7 +784,7 @@ mod tests {
             is_random: false,
         };
 
-        let _ = pcap.send(packet.into()).await;
+        let _ = pcap.try_send(packet.into());
 
         let packet = PacketBeforeTransit::OutgoingAck {
             me,
@@ -812,7 +796,7 @@ mod tests {
             is_random: true,
         };
 
-        let _ = pcap.send(packet.into()).await;
+        let _ = pcap.try_send(packet.into());
 
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -36,11 +36,7 @@ use std::{
 };
 
 use constants::MAXIMUM_MSG_OUTGOING_BUFFER_SIZE;
-use futures::{
-    FutureExt, SinkExt, StreamExt,
-    channel::mpsc::{Sender, channel},
-    stream::select_with_strategy,
-};
+use futures::{FutureExt, SinkExt, StreamExt, channel::mpsc::Sender, stream::select_with_strategy};
 pub use hopr_api::{
     Multiaddr, PeerId,
     network::{Health, traits::NetworkView},
@@ -79,7 +75,13 @@ use hopr_transport_session::{DispatchResult, SessionManager, SessionManagerConfi
 #[cfg(feature = "telemetry")]
 pub use hopr_transport_session::{SessionAckMode, SessionLifecycleState};
 pub use hopr_transport_tag_allocator::TagAllocatorConfig;
-use hopr_utils::{network_types::prelude::*, runtime::AbortableList};
+use hopr_utils::{
+    network_types::{
+        crossfire_sink::{CrossfireSink, bounded_sink_channel},
+        prelude::*,
+    },
+    runtime::AbortableList,
+};
 pub use multiaddr::Protocol;
 use rust_stream_ext_concurrent::then_concurrent::StreamThenConcurrentExt;
 use tracing::{Instrument, debug, error, trace, warn};
@@ -159,7 +161,7 @@ pub enum HoprTransportProcess {
 }
 
 /// HOPR protocol specific instantiation of the SessionManager.
-type HoprSessionManager = SessionManager<Sender<(DestinationRouting, ApplicationDataOut)>>;
+type HoprSessionManager = SessionManager<CrossfireSink<(DestinationRouting, ApplicationDataOut)>>;
 
 /// Allows configuration of one specific [`HoprSession`].
 ///
@@ -374,7 +376,7 @@ where
     ) -> errors::Result<(
         HoprSocket<
             futures::stream::BoxStream<'static, ApplicationDataIn>,
-            futures::channel::mpsc::Sender<(DestinationRouting, ApplicationDataOut)>,
+            CrossfireSink<(DestinationRouting, ApplicationDataOut)>,
         >,
         AbortableList<HoprTransportProcess>,
     )>
@@ -410,7 +412,7 @@ where
     ) -> errors::Result<(
         HoprSocket<
             futures::stream::BoxStream<'static, ApplicationDataIn>,
-            futures::channel::mpsc::Sender<(DestinationRouting, ApplicationDataOut)>,
+            CrossfireSink<(DestinationRouting, ApplicationDataOut)>,
         >,
         AbortableList<HoprTransportProcess>,
     )>
@@ -444,7 +446,7 @@ where
     ) -> errors::Result<(
         HoprSocket<
             futures::stream::BoxStream<'static, ApplicationDataIn>,
-            futures::channel::mpsc::Sender<(DestinationRouting, ApplicationDataOut)>,
+            CrossfireSink<(DestinationRouting, ApplicationDataOut)>,
         >,
         AbortableList<HoprTransportProcess>,
     )>
@@ -483,7 +485,7 @@ where
     ) -> errors::Result<(
         HoprSocket<
             futures::stream::BoxStream<'static, ApplicationDataIn>,
-            futures::channel::mpsc::Sender<(DestinationRouting, ApplicationDataOut)>,
+            CrossfireSink<(DestinationRouting, ApplicationDataOut)>,
         >,
         AbortableList<HoprTransportProcess>,
     )>
@@ -496,7 +498,7 @@ where
         let mut processes = AbortableList::<HoprTransportProcess>::default();
 
         let (unresolved_routing_msg_tx, unresolved_routing_msg_rx) =
-            channel::<(DestinationRouting, ApplicationDataOut)>(MAXIMUM_MSG_OUTGOING_BUFFER_SIZE);
+            bounded_sink_channel::<(DestinationRouting, ApplicationDataOut)>(MAXIMUM_MSG_OUTGOING_BUFFER_SIZE);
 
         // -- transport medium
 
@@ -564,7 +566,7 @@ where
             "creating protocol bidirectional channel"
         );
         let (tx_from_protocol, rx_from_protocol) =
-            channel::<(HoprPseudonym, ApplicationDataIn)>(msg_protocol_bidirectional_channel_capacity);
+            bounded_sink_channel::<(HoprPseudonym, ApplicationDataIn)>(msg_protocol_bidirectional_channel_capacity);
 
         // === START === cover traffic control
         // Allocate a cover traffic tag from the session telemetry partition to avoid
@@ -734,8 +736,9 @@ where
             .filter(|&c| c > 0)
             .unwrap_or(128);
         debug!(capacity = manual_ping_channel_capacity, "Creating manual ping channel");
-        let (manual_ping_tx, manual_ping_rx) =
-            channel::<(OffchainPublicKey, PingQueryReplier)>(manual_ping_channel_capacity);
+        let (manual_ping_tx, manual_ping_rx_raw) =
+            crossfire::mpsc::bounded_async::<(OffchainPublicKey, PingQueryReplier)>(manual_ping_channel_capacity);
+        let manual_ping_rx = manual_ping_rx_raw.into_stream();
 
         let probe = Probe::new(self.cfg.probe, self.probing_tag_allocator.clone());
 
@@ -794,7 +797,7 @@ where
         // than collapsing the entire ingress pipeline. Callers should use HoprSocket::reader()
         // and actively drain the stream; see hopr-lib builder for the reference drain.
         let (on_incoming_data_tx, on_incoming_data_rx) =
-            channel::<ApplicationDataIn>(msg_protocol_bidirectional_channel_capacity);
+            bounded_sink_channel::<ApplicationDataIn>(msg_protocol_bidirectional_channel_capacity);
         let smgr = self.smgr.clone();
         let unresolved_routing_msg_tx_for_task = unresolved_routing_msg_tx.clone();
         processes.insert(

--- a/transport/hopr/src/protocol/pipeline/mod.rs
+++ b/transport/hopr/src/protocol/pipeline/mod.rs
@@ -694,12 +694,15 @@ where
         lazy_static::initialize(&METRIC_VALIDATION_ERRORS);
     }
 
-    let (outgoing_ack_tx, outgoing_ack_rx) =
-        futures::channel::mpsc::channel::<(OffchainPublicKey, Option<HalfKey>)>(cfg.ack_config.ack_out_buffer_size);
+    let (outgoing_ack_tx, outgoing_ack_rx) = hopr_utils::network_types::crossfire_sink::bounded_sink_channel::<(
+        OffchainPublicKey,
+        Option<HalfKey>,
+    )>(cfg.ack_config.ack_out_buffer_size);
 
-    let (incoming_ack_tx, incoming_ack_rx) = futures::channel::mpsc::channel::<(OffchainPublicKey, Vec<Acknowledgement>)>(
-        cfg.ack_config.ticket_ack_buffer_size,
-    );
+    let (incoming_ack_tx, incoming_ack_rx) = hopr_utils::network_types::crossfire_sink::bounded_sink_channel::<(
+        OffchainPublicKey,
+        Vec<Acknowledgement>,
+    )>(cfg.ack_config.ticket_ack_buffer_size);
 
     // Attach timeouts to all Sinks so that the pipelines are not blocked when
     // some channel is not being timely processed

--- a/transport/probe/Cargo.toml
+++ b/transport/probe/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-transport-probe"
-version = "0.7.0"
+version = "0.8.0"
 description = "Probing mechanism of the discovered network topology"
 edition.workspace = true
 license.workspace = true
@@ -23,6 +23,7 @@ runtime-tokio = ["hopr-utils/runtime-tokio"]
 [dependencies]
 anyhow = { workspace = true }
 async-trait = { workspace = true }
+crossfire = { workspace = true }
 futures = { workspace = true }
 futures-concurrency = { workspace = true }
 const-hex = { workspace = true }

--- a/transport/probe/src/ping.rs
+++ b/transport/probe/src/ping.rs
@@ -11,7 +11,7 @@ use tracing::{debug, warn};
 use crate::errors::{ProbeError, Result};
 
 /// Heartbeat send ping TX type
-pub type HeartbeatSendPingTx = Sender<(OffchainPublicKey, PingQueryReplier)>;
+pub type HeartbeatSendPingTx = crossfire::MAsyncTx<crossfire::mpsc::Array<(OffchainPublicKey, PingQueryReplier)>>;
 
 /// Configuration for the `Ping` mechanism
 #[derive(Debug, Clone, PartialEq, Eq, smart_default::SmartDefault)]
@@ -69,7 +69,7 @@ impl Pinger {
         let (tx, mut rx) = channel::<PingQueryResult>(1);
         let replier = PingQueryReplier::new(tx);
 
-        if let Err(error) = self.send_ping.clone().try_send((*peer, replier)) {
+        if let Err(error) = self.send_ping.try_send((*peer, replier)) {
             warn!(%peer, %error, "Failed to initiate a ping request");
         }
 
@@ -142,11 +142,12 @@ mod tests {
 
     #[tokio::test]
     async fn pinger_should_return_an_error_if_the_latency_is_longer_than_the_configure_timeout() -> anyhow::Result<()> {
-        let (tx, mut rx) = futures::channel::mpsc::channel::<(OffchainPublicKey, PingQueryReplier)>(256);
+        let (tx, rx) = crossfire::mpsc::bounded_async::<(OffchainPublicKey, PingQueryReplier)>(256);
 
         let delay = Duration::from_millis(10);
         let delaying_channel = tokio::task::spawn(async move {
-            while let Some((_peer, replier)) = rx.next().await {
+            let mut rx_stream = rx.into_stream();
+            while let Some((_peer, replier)) = rx_stream.next().await {
                 tokio::time::sleep(delay).await;
 
                 replier.notify(Ok(delay));

--- a/transport/probe/src/probe.rs
+++ b/transport/probe/src/probe.rs
@@ -197,7 +197,7 @@ impl Probe {
     where
         T: futures::Sink<(DestinationRouting, ApplicationDataOut)> + Clone + Send + Sync + Unpin + 'static,
         T::Error: Send,
-        V: futures::Stream<Item = (OffchainPublicKey, PingQueryReplier)> + Send + Sync + 'static,
+        V: futures::Stream<Item = (OffchainPublicKey, PingQueryReplier)> + Send + 'static,
         Tr: ProbingTrafficGeneration + Send + Sync + 'static,
         G: NetworkGraphView + NetworkGraphUpdate + Clone + Send + Sync + 'static,
     {

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-utils"
 description = "Shared utility crates for HOPR: async runtime, network types, parallelisation, statistics, platform, and testing helpers"
-version = "0.1.0"
+version = "0.2.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"
@@ -25,6 +25,7 @@ async-lock = ["dep:async-lock"]
 
 # network-types module (from hopr-network-types)
 network-types = [
+  "dep:crossfire",
   "dep:arrayvec",
   "dep:flume",
   "dep:futures-time",
@@ -74,6 +75,8 @@ async-lock = { workspace = true, optional = true }
 indexmap = { workspace = true }
 futures = { workspace = true }
 tokio = { workspace = true, optional = true, features = ["time", "sync"] }
+
+crossfire = { workspace = true, optional = true }
 
 # network-types
 arrayvec = { workspace = true, optional = true }

--- a/utils/src/network_types/crossfire_sink.rs
+++ b/utils/src/network_types/crossfire_sink.rs
@@ -35,10 +35,6 @@ pub struct CrossfireSink<T: 'static> {
     pending: Option<PendingFut<T>>,
 }
 
-// CrossfireSink does not use structural pinning — no field is accessed exclusively through
-// Pin<&mut CrossfireSink<T>>. Moving a CrossfireSink after pinning is safe.
-impl<T: 'static> Unpin for CrossfireSink<T> {}
-
 // SAFETY: All &self methods (try_send, clone) only access `tx: MAsyncTx<Array<T>>` which
 // is Sync. The `pending` and `buffered` fields are accessed exclusively via &mut self
 // (Sink trait methods), making concurrent &self access free of data races.

--- a/utils/src/network_types/crossfire_sink.rs
+++ b/utils/src/network_types/crossfire_sink.rs
@@ -140,7 +140,7 @@ impl<T: Send + Unpin + 'static> futures::Sink<T> for CrossfireSink<T> {
 }
 
 /// Creates a strict-capacity bounded MPSC channel returning a [`CrossfireSink`] sender
-/// and a [`Stream`] receiver.
+/// and a [`futures::stream::BoxStream`] receiver.
 ///
 /// The channel holds at most `capacity` items at any time, independent of how many times
 /// the sender is cloned. This contrasts with `futures::channel::mpsc::channel(N)`, where

--- a/utils/src/network_types/crossfire_sink.rs
+++ b/utils/src/network_types/crossfire_sink.rs
@@ -1,0 +1,243 @@
+use std::{
+    future::Future,
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use futures::StreamExt;
+
+type PendingFut<T> = Pin<Box<dyn Future<Output = Result<(), crossfire::SendError<T>>> + Send + 'static>>;
+
+/// Error type for [`CrossfireSink`].
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum CrossfireSinkError {
+    /// The channel receiver has been dropped.
+    #[error("channel receiver disconnected")]
+    Disconnected,
+}
+
+/// A [`futures::Sink`] backed by a bounded crossfire MPSC channel sender.
+///
+/// Enforces strict capacity: unlike `futures::channel::mpsc::Sender`, cloning this sink
+/// does **not** add extra slots to the channel. When the channel is full, `poll_ready`
+/// returns `Poll::Pending` and registers a waker, allowing combinators such as
+/// [`crate::network_types::timeout::TimeoutSink`] to arm their timers correctly.
+///
+/// Construct via [`bounded_sink_channel`].
+pub struct CrossfireSink<T: 'static> {
+    tx: crossfire::MAsyncTx<crossfire::mpsc::Array<T>>,
+    /// Item buffered by `start_send`, awaiting forwarding to the channel.
+    buffered: Option<T>,
+    /// In-flight send future created when `try_send` returned `Full` during `poll_ready`.
+    ///
+    /// This is what makes `poll_ready` return `Pending` when the channel is saturated,
+    /// which is necessary for `TimeoutSink::poll_ready` to arm its deadline timer.
+    pending: Option<PendingFut<T>>,
+}
+
+// CrossfireSink does not use structural pinning — no field is accessed exclusively through
+// Pin<&mut CrossfireSink<T>>. Moving a CrossfireSink after pinning is safe.
+impl<T: 'static> Unpin for CrossfireSink<T> {}
+
+// SAFETY: All &self methods (try_send, clone) only access `tx: MAsyncTx<Array<T>>` which
+// is Sync. The `pending` and `buffered` fields are accessed exclusively via &mut self
+// (Sink trait methods), making concurrent &self access free of data races.
+unsafe impl<T: Send + 'static> Sync for CrossfireSink<T> {}
+
+impl<T: 'static> std::fmt::Debug for CrossfireSink<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CrossfireSink")
+            .field("buffered", &self.buffered.is_some())
+            .field("pending", &self.pending.is_some())
+            .finish_non_exhaustive()
+    }
+}
+
+impl<T: Send + 'static> Clone for CrossfireSink<T> {
+    fn clone(&self) -> Self {
+        // Each clone starts idle — no buffered item and no in-flight future.
+        // Cloning does not expand channel capacity.
+        Self {
+            tx: self.tx.clone(),
+            buffered: None,
+            pending: None,
+        }
+    }
+}
+
+impl<T: 'static> CrossfireSink<T> {
+    /// Attempts to send `item` without waiting for channel space.
+    ///
+    /// Returns `Err(TrySendError::Full(item))` when the channel is at capacity,
+    /// or `Err(TrySendError::Disconnected(item))` when all receivers have been dropped.
+    /// Never inflates channel capacity — capacity is strict regardless of clone count.
+    pub fn try_send(&self, item: T) -> Result<(), crossfire::TrySendError<T>> {
+        self.tx.try_send(item)
+    }
+}
+
+impl<T: Send + Unpin + 'static> futures::Sink<T> for CrossfireSink<T> {
+    type Error = CrossfireSinkError;
+
+    fn poll_ready(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        let this = self.get_mut();
+        loop {
+            if let Some(mut fut) = this.pending.take() {
+                // Poll the in-flight send future. While it is Pending the channel is full,
+                // so we return Pending here — this is the waker registration point for
+                // TimeoutSink.
+                match fut.as_mut().poll(cx) {
+                    Poll::Ready(Ok(())) => return Poll::Ready(Ok(())),
+                    Poll::Ready(Err(_)) => return Poll::Ready(Err(CrossfireSinkError::Disconnected)),
+                    Poll::Pending => {
+                        this.pending = Some(fut);
+                        return Poll::Pending;
+                    }
+                }
+            } else if let Some(item) = this.buffered.take() {
+                // An item was stored by `start_send`. Try to place it in the channel.
+                match this.tx.try_send(item) {
+                    Ok(()) => return Poll::Ready(Ok(())),
+                    Err(crossfire::TrySendError::Full(item)) => {
+                        // Channel is full. Create an owned send future so the waker from the
+                        // next poll_ready call is registered with the crossfire scheduler.
+                        let tx = this.tx.clone();
+                        this.pending = Some(Box::pin(async move { tx.send(item).await }));
+                        // Loop once more to immediately poll the new future with the current
+                        // waker, so we don't miss a wake-up that arrived between try_send
+                        // and now.
+                    }
+                    Err(crossfire::TrySendError::Disconnected(_)) => {
+                        return Poll::Ready(Err(CrossfireSinkError::Disconnected));
+                    }
+                }
+            } else {
+                return Poll::Ready(Ok(()));
+            }
+        }
+    }
+
+    fn start_send(self: Pin<&mut Self>, item: T) -> Result<(), Self::Error> {
+        let this = self.get_mut();
+        debug_assert!(
+            this.buffered.is_none() && this.pending.is_none(),
+            "start_send called without a preceding successful poll_ready"
+        );
+        this.buffered = Some(item);
+        Ok(())
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // Drive buffered/pending to completion.
+        self.poll_ready(cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        // Flush the remaining buffered item. The channel closes automatically when
+        // all CrossfireSink clones are dropped.
+        self.poll_flush(cx)
+    }
+}
+
+/// Creates a strict-capacity bounded MPSC channel returning a [`CrossfireSink`] sender
+/// and a [`Stream`] receiver.
+///
+/// The channel holds at most `capacity` items at any time, independent of how many times
+/// the sender is cloned. This contrasts with `futures::channel::mpsc::channel(N)`, where
+/// each live `Sender` clone silently adds one extra slot.
+pub fn bounded_sink_channel<T: Send + Unpin + 'static>(
+    capacity: usize,
+) -> (CrossfireSink<T>, futures::stream::BoxStream<'static, T>) {
+    let (tx, rx) = crossfire::mpsc::bounded_async::<T>(capacity);
+    let sink = CrossfireSink {
+        tx,
+        buffered: None,
+        pending: None,
+    };
+    (sink, rx.into_stream().boxed())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use anyhow::Context as _;
+    use futures::SinkExt;
+
+    use super::*;
+    use crate::network_types::timeout::{SinkTimeoutError, TimeoutSinkExt};
+
+    #[test_log::test(tokio::test)]
+    async fn capacity_should_be_buffer_not_buffer_plus_clones() -> anyhow::Result<()> {
+        let capacity = 4usize;
+        let (tx, _rx) = bounded_sink_channel::<u32>(capacity);
+
+        // Clone the sender many times — this inflates capacity in futures::mpsc but not here.
+        let _clones: Vec<_> = (0..100).map(|_| tx.clone()).collect();
+
+        // Fill exactly `capacity` items via a separate clone so `tx` stays idle.
+        let mut filler = tx.clone();
+        for i in 0..capacity as u32 {
+            filler.send(i).await.context("send within capacity")?;
+        }
+
+        // A send beyond capacity must block. We race it against a short sleep: if the
+        // sleep wins, the send correctly blocked; if the send wins first, capacity grew.
+        let mut overflow = tx.clone();
+        tokio::select! {
+            result = overflow.send(999u32) => {
+                anyhow::bail!(
+                    "send on full channel should block regardless of clone count, got: {result:?}"
+                );
+            }
+            _ = tokio::time::sleep(Duration::from_millis(20)) => {
+                // Correct: send blocked because capacity is strictly 4, not 4 + clones.
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn sink_should_return_error_when_receiver_dropped() -> anyhow::Result<()> {
+        let (mut tx, rx) = bounded_sink_channel::<u32>(4);
+        drop(rx);
+
+        let result = tx.send(42u32).await;
+        assert!(
+            matches!(result, Err(CrossfireSinkError::Disconnected)),
+            "expected Disconnected, got {result:?}"
+        );
+
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn with_timeout_should_fire_when_channel_is_full() -> anyhow::Result<()> {
+        let capacity = 2usize;
+        let (mut tx, _rx) = bounded_sink_channel::<u32>(capacity);
+
+        // Fill to capacity; _rx is held but not polled, so the channel stays full.
+        for i in 0..capacity as u32 {
+            tx.send(i).await.context("send within capacity")?;
+        }
+
+        // TimeoutSink::poll_ready fires only when inner poll_ready returns Pending.
+        // CrossfireSink::poll_ready returns Pending only when it holds a buffered item
+        // that cannot be sent (channel full).
+        //
+        // `feed` calls poll_ready then start_send but does NOT flush — so the first
+        // feed stores 999 in CrossfireSink's buffer without blocking (poll_ready sees
+        // an empty sink → Ready). The second feed's poll_ready finds the buffered item,
+        // attempts try_send → Full → Pending, allowing TimeoutSink to arm its timer.
+        let mut timed_tx = (&mut tx).with_timeout(Duration::from_millis(10));
+        timed_tx.feed(999u32).await.context("first feed should succeed")?;
+        let result = timed_tx.feed(998u32).await;
+        assert!(
+            matches!(result, Err(SinkTimeoutError::Timeout)),
+            "expected Timeout when channel is full and sink has buffered item, got {result:?}"
+        );
+
+        Ok(())
+    }
+}

--- a/utils/src/network_types/mod.rs
+++ b/utils/src/network_types/mod.rs
@@ -15,6 +15,7 @@ pub mod utils;
 pub mod capture;
 
 pub mod addr;
+pub mod crossfire_sink;
 pub mod timeout;
 
 #[doc(hidden)]


### PR DESCRIPTION
## Summary

Fixes #8201. `futures::channel::mpsc::channel(N)` silently inflates capacity by one slot per `Sender` clone, making effective capacity `N + num_senders`. Backpressure in multi-clone pipeline stages was therefore never applied, enabling unbounded memory growth under high load.

- Introduce `CrossfireSink<T>` adapter in `hopr-utils` — a `futures::Sink` backed by `crossfire`'s strict-capacity bounded MPSC sender. `poll_ready` returns `Pending` when the channel is full, so `TimeoutSink` timers fire correctly.
- Migrate all bounded backpressure channels (A/B/C, F/G, K/L, O) to `crossfire` via `bounded_sink_channel` or raw `MAsyncTx`. Channel N (`peer_discovery_tx`) stays as `futures::mpsc` — the sender is never cloned (no inflation) and the receiver must be `Sync` for `HoprLibp2pNetworkBuilder::new`.
- Channels D/E (heartbeat ping, packet capture) intentionally use `try_send` / drop-on-full — migrated to raw `MAsyncTx` with that semantic preserved.
- Eliminate channel J (`searchable_ringbuffer`): `RingBufferProducer` now holds `Arc<FairMutex<AllocRingBuffer<T>>>` directly, removing a spurious spawned task per socket.
- Fix pre-existing bug in `SkipDelayQueue`: `finalize_closure` and `SkipDelayReceiver::drop` dropped `rx_waker` without calling `wake()`, leaving waiting tasks stuck forever on channel close. Fixed both sites.