### PR TITLE
feat: reduce over-elevated log levels

### DIFF
--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -750,7 +750,7 @@ macro_rules! impl_build_methods {
                             tracing::error!(%error, "failed to insert incoming ticket");
                         }
                         if let Err(error) = new_ticket_tx.try_broadcast(event) {
-                            tracing::error!(%error, "failed to broadcast ticket event");
+                            tracing::debug!(%error, "failed to broadcast ticket event");
                         }
                         futures::future::ready(())
                     })

--- a/hopr/hopr-lib/src/builder/chain_wiring.rs
+++ b/hopr/hopr-lib/src/builder/chain_wiring.rs
@@ -55,7 +55,7 @@ pub(super) async fn process_chain_events<C, G>(
                     )
                     .entered();
                     if let Err(e) = tx.try_send((peer_id, multiaddrs.to_vec())) {
-                        tracing::error!(%e, "peer-discovery channel full or closed; announcement dropped");
+                        tracing::warn!(%e, "peer-discovery channel full or closed; announcement dropped");
                     }
                 }
             }

--- a/hopr/hopr-lib/src/helpers.rs
+++ b/hopr/hopr-lib/src/helpers.rs
@@ -33,10 +33,10 @@ pub(crate) async fn wait_for_funds<R: ChainValues>(
                     tracing::info!("node is funded");
                     return Ok(());
                 } else {
-                    tracing::warn!("still unfunded, trying again soon");
+                    tracing::info!("still unfunded, trying again soon");
                 }
             }
-            Err(error) => tracing::error!(%error, "failed to fetch balance from the chain"),
+            Err(error) => tracing::warn!(%error, "failed to fetch balance from the chain"),
         }
 
         hopr_utils::runtime::prelude::sleep(current_delay).await;

--- a/impls/connector/src/connector/accounts.rs
+++ b/impls/connector/src/connector/accounts.rs
@@ -42,11 +42,11 @@ where
                 {
                     Ok(Ok(value)) => value.filter(|c| selector.satisfies(c)),
                     Ok(Err(error)) => {
-                        tracing::error!(%error, %account_id, "backend error when looking up account");
+                        tracing::warn!(%error, %account_id, "backend error when looking up account");
                         None
                     }
                     Err(error) => {
-                        tracing::error!(%error, %account_id, "join error when looking up account");
+                        tracing::warn!(%error, %account_id, "join error when looking up account");
                         None
                     }
                 }

--- a/impls/connector/src/connector/channels.rs
+++ b/impls/connector/src/connector/channels.rs
@@ -42,11 +42,11 @@ where
                 {
                     Ok(Ok(value)) => value.filter(|c| selector.satisfies(c)),
                     Ok(Err(error)) => {
-                        tracing::error!(%error, %channel_id, "backend error when looking up channel");
+                        tracing::warn!(%error, %channel_id, "backend error when looking up channel");
                         None
                     }
                     Err(error) => {
-                        tracing::error!(%error, %channel_id, "join error when looking up channel");
+                        tracing::warn!(%error, %channel_id, "join error when looking up channel");
                         None
                     }
                 }
@@ -62,7 +62,7 @@ async fn channel_by_id_async<B: Backend + Send + Sync + 'static>(
 ) -> Result<Option<ChannelEntry>, ConnectorError> {
     Ok(hopr_utils::runtime::prelude::spawn_blocking(move || {
         channel_by_id.try_get_with_by_ref(&channel_id, || {
-            tracing::warn!(%channel_id, "cache miss on channel_by_id");
+            tracing::debug!(%channel_id, "cache miss on channel_by_id");
             backend.get_channel_by_id(&channel_id).map_err(ConnectorError::backend)
         })
     })
@@ -92,7 +92,7 @@ where
         Ok(self
             .channel_by_parties
             .try_get_with(ChannelParties::new(src, dst), || {
-                tracing::warn!(%src, %dst, "cache miss on channel_by_parties");
+                tracing::debug!(%src, %dst, "cache miss on channel_by_parties");
                 let channel_id = generate_channel_id(&src, &dst);
                 self.backend
                     .get_channel_by_id(&channel_id)
@@ -104,7 +104,7 @@ where
         self.check_connection_state()?;
 
         Ok(self.channel_by_id.try_get_with_by_ref(channel_id, || {
-            tracing::warn!(%channel_id, "cache miss on channel_by_id");
+            tracing::debug!(%channel_id, "cache miss on channel_by_id");
             self.backend
                 .get_channel_by_id(channel_id)
                 .map_err(ConnectorError::backend)

--- a/impls/connector/src/connector/keys.rs
+++ b/impls/connector/src/connector/keys.rs
@@ -31,12 +31,12 @@ where
     fn map_key_to_id(&self, key: &OffchainPublicKey) -> Option<HoprKeyIdent> {
         self.key_to_id.get_with_by_ref(key, || {
             let start = std::time::Instant::now();
-            tracing::warn!(%key, "cache miss on map_key_to_id");
+            tracing::debug!(%key, "cache miss on map_key_to_id");
             let result = match self.backend.get_account_by_key(key) {
                 Ok(Some(account)) => Some(account.key_id),
                 Ok(None) => None,
                 Err(error) => {
-                    tracing::error!(%error, %key, "failed to get account by key");
+                    tracing::warn!(%error, %key, "failed to get account by key");
                     None
                 }
             };
@@ -53,12 +53,12 @@ where
     fn map_id_to_public(&self, id: &HoprKeyIdent) -> Option<OffchainPublicKey> {
         self.id_to_key.get_with_by_ref(id, || {
             let start = std::time::Instant::now();
-            tracing::warn!(%id, "cache miss on map_id_to_public");
+            tracing::debug!(%id, "cache miss on map_id_to_public");
             let result = match self.backend.get_account_by_id(id) {
                 Ok(Some(account)) => Some(account.public_key),
                 Ok(None) => None,
                 Err(error) => {
-                    tracing::error!(%error, %id, "failed to get account by id");
+                    tracing::warn!(%error, %id, "failed to get account by id");
                     None
                 }
             };
@@ -88,7 +88,7 @@ where
         self.check_connection_state()?;
 
         Ok(self.chain_to_packet.try_get_with_by_ref(chain, || {
-            tracing::warn!(%chain, "cache miss on chain_key_to_packet_key");
+            tracing::debug!(%chain, "cache miss on chain_key_to_packet_key");
             self.backend
                 .get_account_by_address(chain)
                 .map(|a| a.map(|ac| ac.public_key))
@@ -100,7 +100,7 @@ where
         self.check_connection_state()?;
 
         Ok(self.packet_to_chain.try_get_with_by_ref(packet, || {
-            tracing::warn!(
+            tracing::debug!(
                 peer_id = packet.to_peerid_str(),
                 "cache miss on packet_key_to_chain_key"
             );

--- a/impls/connector/src/connector/mod.rs
+++ b/impls/connector/src/connector/mod.rs
@@ -220,7 +220,7 @@ where
 
         let server_health = self.client.query_health().await?;
         if !server_health.eq_ignore_ascii_case("OK") {
-            tracing::error!(server_health, "blokli server not healthy");
+            tracing::warn!(server_health, "blokli server not healthy");
             return Err(ConnectorError::ServerNotHealthy);
         }
 
@@ -547,7 +547,7 @@ where
                 }
                 Err(_) => {
                     abort_handle.abort();
-                    tracing::error!(min_accounts, min_channels, "connection timeout when syncing");
+                    tracing::warn!(min_accounts, min_channels, "connection timeout when syncing");
                     Err(ConnectorError::ConnectionTimeout)
                 }
             })

--- a/impls/connector/src/utils.rs
+++ b/impls/connector/src/utils.rs
@@ -23,7 +23,7 @@ pub(crate) fn model_to_account_entry(
                 .filter_map(|addr| match Multiaddr::from_str(&addr) {
                     Ok(addr) => Some(addr),
                     Err(_) => {
-                        tracing::error!(%addr, "invalid multiaddress");
+                        tracing::warn!(%addr, "invalid multiaddress");
                         None
                     }
                 })

--- a/impls/strategy/src/auto_funding.rs
+++ b/impls/strategy/src/auto_funding.rs
@@ -296,7 +296,7 @@ where
 
         // Run the first scan immediately at startup without waiting for the initial interval.
         if let Err(e) = self.on_tick().await {
-            tracing::error!(%e, "auto-funding tick failed");
+            tracing::warn!(%e, "auto-funding tick failed");
         }
 
         let tick_stream = futures_time::stream::interval(self.interval.into()).map(|_| Event::Tick);
@@ -313,7 +313,7 @@ where
             match event {
                 Event::Tick => {
                     if let Err(e) = self.on_tick().await {
-                        tracing::error!(%e, "auto-funding tick failed");
+                        tracing::warn!(%e, "auto-funding tick failed");
                     }
                 }
                 Event::Actionable(ev) => match *ev {

--- a/impls/strategy/src/auto_redeeming.rs
+++ b/impls/strategy/src/auto_redeeming.rs
@@ -128,14 +128,14 @@ fn new_redemption_cache() -> moka::sync::Cache<ChannelId, AbortHandle> {
         .eviction_listener(|key: Arc<ChannelId>, value: AbortHandle, cause| {
             match cause {
                 RemovalCause::Expired => {
-                    // TTL elapsed — log an error and abort the stalled redemption task.
-                    tracing::error!(%key, "redemption timed out after {:?}; aborting", REDEMPTION_TIMEOUT);
+                    // TTL elapsed — warn and abort the stalled redemption task.
+                    tracing::warn!(%key, "redemption timed out after {:?}; aborting", REDEMPTION_TIMEOUT);
                     value.abort();
                 }
                 RemovalCause::Size => {
                     // Cache capacity exceeded — let the task run to natural completion
                     // rather than aborting work that is likely still making progress.
-                    tracing::warn!(%key, "redemption cache at capacity; entry evicted without abort");
+                    tracing::debug!(%key, "redemption cache at capacity; entry evicted without abort");
                 }
                 _ => {
                     // Explicit invalidation (task completed) or replacement.
@@ -334,7 +334,7 @@ where
         if let Err(e) = self.on_tick().await
             && !matches!(e, StrategyError::CriteriaNotSatisfied)
         {
-            tracing::error!(%e, "auto-redeeming tick failed");
+            tracing::warn!(%e, "auto-redeeming tick failed");
         }
 
         let tick_stream = futures_time::stream::interval(self.interval.into()).map(|_| Event::Tick);
@@ -356,7 +356,7 @@ where
                     if let Err(e) = self.on_tick().await
                         && !matches!(e, StrategyError::CriteriaNotSatisfied)
                     {
-                        tracing::error!(%e, "auto-redeeming tick failed");
+                        tracing::warn!(%e, "auto-redeeming tick failed");
                     }
                 }
                 Event::Actionable(ev) => match *ev {

--- a/impls/strategy/src/channel_finalizer.rs
+++ b/impls/strategy/src/channel_finalizer.rs
@@ -142,7 +142,7 @@ where
     async fn run(&mut self) -> errors::Result<()> {
         // Run the first scan immediately at startup without waiting for the initial interval.
         if let Err(e) = self.on_tick().await {
-            tracing::error!(%e, "closure finalizer tick failed");
+            tracing::warn!(%e, "closure finalizer tick failed");
         }
 
         let tick_stream = futures_time::stream::interval(self.interval.into()).map(|_| ());
@@ -150,7 +150,7 @@ where
         futures::pin_mut!(tick_stream);
         while tick_stream.next().await.is_some() {
             if let Err(e) = self.on_tick().await {
-                tracing::error!(%e, "closure finalizer tick failed");
+                tracing::warn!(%e, "closure finalizer tick failed");
             }
         }
 

--- a/impls/ticket-manager/src/traits.rs
+++ b/impls/ticket-manager/src/traits.rs
@@ -99,7 +99,7 @@ pub(crate) fn default_total_value<Q: TicketQueue + ?Sized>(
     Ok(queue
         .iter_unordered()?
         .filter_map(|res| {
-            res.inspect_err(|error| tracing::error!(%error, "failed to obtain ticket from the queue"))
+            res.inspect_err(|error| tracing::debug!(%error, "failed to obtain ticket from the queue"))
                 .ok()
                 .filter(|t| t.verified_ticket().channel_epoch == epoch && t.verified_ticket().index >= min_index)
                 .map(|t| t.verified_ticket().amount)

--- a/protocols/hopr/src/surb_store.rs
+++ b/protocols/hopr/src/surb_store.rs
@@ -176,7 +176,7 @@ impl MemorySurbStore {
                 .time_to_idle(cfg.pseudonyms_lifetime.max(MINIMUM_SURB_LIFETIME))
                 .eviction_policy(moka::policy::EvictionPolicy::lru())
                 .eviction_listener(|sender_id, _reply_opener, cause| {
-                    tracing::warn!(?sender_id, ?cause, "evicting reply opener for pseudonym");
+                    tracing::debug!(?sender_id, ?cause, "evicting reply opener for pseudonym");
                 })
                 .max_capacity(cfg.max_openers_per_pseudonym.max(MINIMUM_OPENER_PSEUDONYMS) as u64)
                 .build(),
@@ -186,7 +186,7 @@ impl MemorySurbStore {
                 .time_to_idle(cfg.pseudonyms_lifetime.max(MINIMUM_SURB_LIFETIME))
                 .eviction_policy(moka::policy::EvictionPolicy::lru())
                 .eviction_listener(|pseudonym, _reply_opener, cause| {
-                    tracing::warn!(%pseudonym, ?cause, "evicting surb for pseudonym");
+                    tracing::debug!(%pseudonym, ?cause, "evicting surb for pseudonym");
                 })
                 .max_capacity(cfg.max_pseudonyms.max(MINIMUM_SURBS_PER_PSEUDONYM) as u64)
                 .build(),
@@ -249,7 +249,7 @@ impl SurbStore for MemorySurbStore {
                     .time_to_live(opener_lifetime)
                     .eviction_listener(move |id: Arc<HoprSurbId>, _, cause| {
                         if cause != RemovalCause::Explicit {
-                            tracing::warn!(
+                            tracing::debug!(
                                 pseudonym = %sender_id.pseudonym(),
                                 surb_id = const_hex::encode(id.as_slice()),
                                 ?cause,

--- a/protocols/hopr/src/tbf.rs
+++ b/protocols/hopr/src/tbf.rs
@@ -32,7 +32,7 @@ impl TagBloomFilter {
     /// Puts a packet tag into the Bloom filter
     pub fn set(&mut self, tag: &PacketTag) {
         if self.count == self.capacity {
-            tracing::warn!("maximum number of items in the Bloom filter reached!");
+            tracing::debug!("maximum number of items in the Bloom filter reached!");
             self.bloom.clear();
             self.count = 0;
         }
@@ -60,7 +60,7 @@ impl TagBloomFilter {
             let is_present = self.bloom.check(tag);
             if !is_present {
                 // There cannot be false negatives, so we can reset the filter
-                tracing::warn!("maximum number of items in the Bloom filter reached!");
+                tracing::debug!("maximum number of items in the Bloom filter reached!");
                 self.bloom.clear();
                 self.bloom.set(tag);
                 self.count = 1;

--- a/protocols/hopr/src/ticket_processing.rs
+++ b/protocols/hopr/src/ticket_processing.rs
@@ -301,7 +301,7 @@ where
                 verified.and_then(|verified| Ok((*verified.ack_key_share(), verified.ack_key_share().to_challenge()?)))
             })
             .filter_map(|res| {
-                res.inspect_err(|error| tracing::error!(%error, "failed to process acknowledgement"))
+                res.inspect_err(|error| tracing::debug!(%error, "failed to process acknowledgement"))
                     .ok()
             })
             .collect::<Vec<_>>()
@@ -317,7 +317,7 @@ where
                     .and_then(|verified| Ok((*verified.ack_key_share(), verified.ack_key_share().to_challenge()?)))
             })
             .filter_map(|res| {
-                res.inspect_err(|error| tracing::error!(%error, "failed to process acknowledgement"))
+                res.inspect_err(|error| tracing::debug!(%error, "failed to process acknowledgement"))
                     .ok()
             })
             .collect::<Vec<_>>()
@@ -342,13 +342,13 @@ where
             {
                 Ok(Some(channel)) => {
                     if channel.channel_epoch != unack_ticket.verified_ticket().channel_epoch {
-                        tracing::error!(%unack_ticket, "received acknowledgement for ticket issued in a different epoch");
+                        tracing::debug!(%unack_ticket, "received acknowledgement for ticket issued in a different epoch");
                         continue;
                     }
                     channel
                 }
                 Ok(None) => {
-                    tracing::error!(%unack_ticket, "received acknowledgement for ticket issued for unknown channel");
+                    tracing::debug!(%unack_ticket, "received acknowledgement for ticket issued for unknown channel");
                     continue;
                 }
                 Err(error) => {
@@ -374,7 +374,7 @@ where
                 // which is a lengthy operation and should not be done for
                 // bogus unacknowledged tickets
                 let Ok(ack_ticket) = unack_ticket.acknowledge(&half_key) else {
-                    tracing::error!(%unack_ticket, "failed to acknowledge ticket");
+                    tracing::debug!(%unack_ticket, "failed to acknowledge ticket");
                     return None;
                 };
 

--- a/protocols/session/src/processing/reassembly.rs
+++ b/protocols/session/src/processing/reassembly.rs
@@ -122,7 +122,7 @@ impl<S: futures::Stream<Item = Segment>, M: FrameMap> futures::Stream for Reasse
                 this.inner.as_mut().poll_next(cx)
             } else {
                 // This essentially forces the incomplete frames to be expired
-                tracing::warn!("reassembler has reached its capacity");
+                tracing::debug!("reassembler has reached its capacity");
                 Poll::Pending
             };
 

--- a/protocols/session/src/processing/sequencer.rs
+++ b/protocols/session/src/processing/sequencer.rs
@@ -149,7 +149,7 @@ where
                         }
                     } else {
                         // Simulate buffer update when at capacity
-                        tracing::warn!("sequencer buffer is full");
+                        tracing::debug!("sequencer buffer is full");
                         *this.state = State::BufferUpdated;
                     }
                 }

--- a/protocols/session/src/socket/mod.rs
+++ b/protocols/session/src/socket/mod.rs
@@ -184,7 +184,7 @@ impl<const C: usize> SessionSocket<C, Stateless<C>> {
                             // Filter old frame ids to save space in the Reassembler
                             let last_emitted_id = last_emitted_frame.load(std::sync::atomic::Ordering::Relaxed);
                             if s.frame_id <= last_emitted_id {
-                                tracing::warn!(frame_id = s.frame_id, last_emitted_id, "frame already seen");
+                                tracing::debug!(frame_id = s.frame_id, last_emitted_id, "frame already seen");
                                 false
                             } else {
                                 true
@@ -227,7 +227,7 @@ impl<const C: usize> SessionSocket<C, Stateless<C>> {
                     Ok(frame) => {
                         last_emitted_frame_clone.store(frame.0.frame_id, std::sync::atomic::Ordering::Relaxed);
                         if frame.0.is_terminating {
-                            tracing::warn!("terminating frame received");
+                            tracing::debug!("terminating frame received");
                             packets_in_abort_handle.abort();
                         }
                         #[cfg(feature = "telemetry")]
@@ -236,7 +236,7 @@ impl<const C: usize> SessionSocket<C, Stateless<C>> {
                     }
                     // Downstream skips discarded frames
                     Err(SessionError::FrameDiscarded(frame_id)) | Err(SessionError::IncompleteFrame(frame_id)) => {
-                        tracing::error!(frame_id, "frame discarded");
+                        tracing::debug!(frame_id, "frame discarded");
                         #[cfg(feature = "telemetry")]
                         s3.frame_discarded();
                         None
@@ -382,7 +382,7 @@ impl<const C: usize, S: SocketState<C> + Clone + 'static> SessionSocket<C, S> {
                         packet.try_as_segment().filter(|s| {
                             let last_emitted_id = last_emitted_frame.load(std::sync::atomic::Ordering::Relaxed);
                             if s.frame_id <= last_emitted_id {
-                                tracing::warn!(frame_id = s.frame_id, last_emitted_id, "frame already seen");
+                                tracing::debug!(frame_id = s.frame_id, last_emitted_id, "frame already seen");
                                 false
                             } else {
                                 true
@@ -409,7 +409,7 @@ impl<const C: usize, S: SocketState<C> + Clone + 'static> SessionSocket<C, S> {
                 futures::future::ready(match maybe_frame {
                     Ok(frame) => {
                         if let Err(error) = st_2.frame_complete(frame.frame_id) {
-                            tracing::error!(%error, "frame complete state update failed");
+                            tracing::debug!(%error, "frame complete state update failed");
                         }
                         #[cfg(feature = "telemetry")]
                         s2.frame_completed();
@@ -437,11 +437,11 @@ impl<const C: usize, S: SocketState<C> + Clone + 'static> SessionSocket<C, S> {
                 future::ready(match maybe_frame {
                     Ok(frame) => {
                         if let Err(error) = st_3.frame_emitted(frame.0.frame_id) {
-                            tracing::error!(%error, "frame received state update failed");
+                            tracing::debug!(%error, "frame received state update failed");
                         }
                         last_emitted_frame_clone.store(frame.0.frame_id, std::sync::atomic::Ordering::Relaxed);
                         if frame.0.is_terminating {
-                            tracing::warn!("terminating frame received");
+                            tracing::debug!("terminating frame received");
                             packets_in_abort_handle.abort();
                         }
                         #[cfg(feature = "telemetry")]
@@ -450,7 +450,7 @@ impl<const C: usize, S: SocketState<C> + Clone + 'static> SessionSocket<C, S> {
                     }
                     Err(SessionError::FrameDiscarded(frame_id)) | Err(SessionError::IncompleteFrame(frame_id)) => {
                         if let Err(error) = st_3.frame_discarded(frame_id) {
-                            tracing::error!(%error, "frame discarded state update failed");
+                            tracing::debug!(%error, "frame discarded state update failed");
                         }
                         #[cfg(feature = "telemetry")]
                         s3.frame_discarded();

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -524,7 +524,7 @@ where
                 mix_rx
                     .fold(wire_msg_tx, |mut sink, item| async move {
                         if sink.send(item).await.is_err() {
-                            tracing::error!(
+                            tracing::debug!(
                                 task = %HoprTransportProcess::MixerForwarder,
                                 "wire sink dropped — discarding mixed packet"
                             );
@@ -593,7 +593,7 @@ where
             futures::future::ready(if let Ok(data) = ApplicationData::new(cover_traffic_tag, data) {
                 Some((routing, ApplicationDataOut::with_no_packet_info(data)))
             } else {
-                tracing::error!("failed to construct cover traffic packet");
+                tracing::debug!("failed to construct cover traffic packet");
                 None
             })
         });
@@ -823,7 +823,7 @@ where
                     })
                     .fold(on_incoming_data_tx, |mut tx, data| async move {
                         if tx.send(data).await.is_err() {
-                            tracing::error!(
+                            tracing::debug!(
                                 task = %HoprTransportProcess::SessionsManagement(0),
                                 "incoming-data channel disconnected — dropping unrelated packet; \
                                  HoprSocket must be consumed or drained by the caller"

--- a/transport/hopr/src/protocol/pipeline/mod.rs
+++ b/transport/hopr/src/protocol/pipeline/mod.rs
@@ -119,15 +119,15 @@ async fn start_outgoing_packet_pipeline<AppOut, E, WOut, WOutErr>(
                             Some((packet.next_hop.into(), packet.data))
                         }
                         Ok(Ok(Err(error))) => {
-                            tracing::error!(%error, "outgoing packet could not be encoded");
+                            tracing::debug!(%error, "outgoing packet could not be encoded");
                             None
                         }
                         Ok(Err(error)) => {
-                            tracing::error!(%error, "parallel processing of the outgoing packet failed");
+                            tracing::debug!(%error, "parallel processing of the outgoing packet failed");
                             None
                         }
                         Err(error) => {
-                            tracing::error!(%error, "timeout while processing the outgoing packet");
+                            tracing::debug!(%error, "timeout while processing the outgoing packet");
                             None
                         }
                     }
@@ -142,7 +142,7 @@ async fn start_outgoing_packet_pipeline<AppOut, E, WOut, WOutErr>(
         .await;
 
     if let Err(error) = res {
-        tracing::error!(
+        tracing::warn!(
             task = "transport (protocol - msg egress)",
             %error,
             "long-running background task finished with error"
@@ -224,7 +224,7 @@ async fn start_incoming_packet_pipeline<WIn, WOut, D, T, TEvt, AckIn, AckOut, Ap
                             .send((*sender, None))
                             .await
                             .unwrap_or_else(|error| {
-                                tracing::error!(%error, "failed to send ack to the egress queue");
+                                tracing::warn!(%error, "failed to send ack to the egress queue");
                             });
 
                         #[cfg(all(feature = "telemetry", not(test)))]
@@ -237,14 +237,14 @@ async fn start_incoming_packet_pipeline<WIn, WOut, D, T, TEvt, AckIn, AckOut, Ap
                         if let Err(error) = ticket_events_reject
                             .send(TicketEvent::RejectedTicket(error.ticket, error.issuer))
                             .await {
-                            tracing::error!(%error, "failed to notify invalid ticket rejection");
+                            tracing::debug!(%error, "failed to notify invalid ticket rejection");
                         }
                         // On this failure, we send back a random acknowledgement
                         ack_outgoing_failure
                             .send((*sender, None))
                             .await
                             .unwrap_or_else(|error| {
-                                tracing::error!(%error, "failed to send ack to the egress queue");
+                                tracing::warn!(%error, "failed to send ack to the egress queue");
                             });
 
                         #[cfg(all(feature = "telemetry", not(test)))]
@@ -261,7 +261,7 @@ async fn start_incoming_packet_pipeline<WIn, WOut, D, T, TEvt, AckIn, AckOut, Ap
                     },
                     Err(_) => {
                         // If we cannot decode the packet within the time limit, just drop it
-                        tracing::error!(
+                        tracing::debug!(
                             %peer,
                             timeout_ms = PACKET_DECODING_TIMEOUT.as_millis() as u64,
                             "dropped incoming packet: decode timeout - check the 'hopr_rayon_queue_wait_seconds' metric for pool saturation"
@@ -295,7 +295,7 @@ async fn start_incoming_packet_pipeline<WIn, WOut, D, T, TEvt, AckIn, AckOut, Ap
                             .send((previous_hop, received_acks))
                             .await
                             .unwrap_or_else(|error| {
-                                tracing::error!(%error, "failed dispatching received acknowledgement to the ticket ack queue");
+                                tracing::warn!(%error, "failed dispatching received acknowledgement to the ticket ack queue");
                             });
 
                         // We do not acknowledge back acknowledgements.
@@ -320,7 +320,7 @@ async fn start_incoming_packet_pipeline<WIn, WOut, D, T, TEvt, AckIn, AckOut, Ap
                             .send((previous_hop, Some(ack_key)))
                             .await
                             .unwrap_or_else(|error| {
-                                tracing::error!(%error, "failed to send ack to the egress queue");
+                                tracing::warn!(%error, "failed to send ack to the egress queue");
                             });
 
                         #[cfg(all(feature = "telemetry", not(test)))]
@@ -374,7 +374,7 @@ async fn start_incoming_packet_pipeline<WIn, WOut, D, T, TEvt, AckIn, AckOut, Ap
                                 METRIC_PACKET_COUNT.increment(&["forwarded"]);
                             }
                             Err(error) => {
-                                tracing::error!(%error, "failed to forward a packet to the transport layer");
+                                tracing::warn!(%error, "failed to forward a packet to the transport layer");
                                 return None;
                             }
                         }
@@ -385,7 +385,7 @@ async fn start_incoming_packet_pipeline<WIn, WOut, D, T, TEvt, AckIn, AckOut, Ap
                             .send((previous_hop, Some(ack_key_prev_hop)))
                             .await
                             .unwrap_or_else(|error| {
-                                tracing::error!(%error, "failed to send ack to the egress queue");
+                                tracing::warn!(%error, "failed to send ack to the egress queue");
                             });
 
                         None
@@ -495,7 +495,7 @@ async fn start_outgoing_ack_pipeline<AckOut, E, WOut>(
                                     .feed((ack_packet.next_hop.into(), ack_packet.data))
                                     .await
                                     .unwrap_or_else(|error| {
-                                        tracing::error!(%error, "failed to forward an acknowledgement to the transport layer");
+                                        tracing::warn!(%error, "failed to forward an acknowledgement to the transport layer");
                                     });
                             }
                             Ok(Err(error)) => tracing::error!(%error, "failed to encode acknowledgements"),
@@ -503,7 +503,7 @@ async fn start_outgoing_ack_pipeline<AckOut, E, WOut>(
                         }
                     }
                     if let Err(error) = wire_outgoing.flush().await {
-                        tracing::error!(%error, "failed to flush acknowledgements batch to the transport layer");
+                        tracing::warn!(%error, "failed to flush acknowledgements batch to the transport layer");
                     }
                     tracing::trace!("acknowledgements out");
                 }.instrument(tracing::debug_span!("outgoing_ack_batch", peer = destination.to_peerid_str()))
@@ -581,7 +581,7 @@ async fn start_relay_incoming_ack_pipeline<AckIn, T, TEvt>(
 
                         // All acknowledgements that resulted in winning tickets go upstream
                         if let Err(error) = ticket_evt.send_all(&mut futures::stream::iter(resolutions_iter)).await {
-                            tracing::error!(%error, "failed to notify ticket resolutions");
+                            tracing::debug!(%error, "failed to notify ticket resolutions");
                         }
                     }
                     Ok(Ok(_)) => {
@@ -596,7 +596,7 @@ async fn start_relay_incoming_ack_pipeline<AckIn, T, TEvt>(
                         tracing::error!(%error, "failed to acknowledge ticket");
                     }
                     Err(error) => {
-                        tracing::error!(%error, "parallel processing of the incoming acknowledgements failed")
+                        tracing::warn!(%error, "parallel processing of the incoming acknowledgements failed")
                     }
                 }
             }

--- a/transport/hopr/src/protocol/stream.rs
+++ b/transport/hopr/src/protocol/stream.rs
@@ -127,7 +127,7 @@ fn spawn_stream_pumps<S, C>(
                         Some((peer, v))
                     }
                     Err(error) => {
-                        tracing::error!(%error, "Error decoding object from the underlying stream");
+                        tracing::warn!(%error, "Error decoding object from the underlying stream");
                         None
                     }
                 })
@@ -137,7 +137,7 @@ fn spawn_stream_pumps<S, C>(
             .inspect(move |res| match res {
                 Ok(_) => tracing::debug!(%peer, component = "stream", "incoming stream done reading"),
                 Err(error) => {
-                    tracing::error!(%peer, %error, component = "stream", "incoming stream failed on reading")
+                    tracing::warn!(%peer, %error, component = "stream", "incoming stream failed on reading")
                 }
             })
             .then(move |_| async move {

--- a/transport/probe/src/probe.rs
+++ b/transport/probe/src/probe.rs
@@ -94,10 +94,10 @@ where
                             let routing = DestinationRouting::Return(pseudonym.into());
                             let data = ApplicationDataOut::with_no_packet_info(data);
                             if let Err(_error) = push_to_network.send((routing, data)).await {
-                                tracing::error!(%pseudonym, "failed to send back a pong");
+                                tracing::debug!(%pseudonym, "failed to send back a pong");
                             }
                         } else {
-                            tracing::error!(%pseudonym, "failed to convert pong message into data");
+                            tracing::debug!(%pseudonym, "failed to convert pong message into data");
                         }
                     }
                     Message::Probe(NeighborProbe::Pong(pong)) => {
@@ -354,7 +354,7 @@ impl Probe {
                                         let mut push_to_network = push_to_network.clone();
 
                                         if let Err(_error) = push_to_network.send((routing, data)).await {
-                                            tracing::error!("failed to send out a ping");
+                                            tracing::debug!("failed to send out a ping");
                                         } else {
                                             active_neighbor_probes
                                                 .insert(
@@ -368,7 +368,7 @@ impl Probe {
                                                 .await;
                                         }
                                     } else {
-                                        tracing::error!("failed to convert ping message into data");
+                                        tracing::debug!("failed to convert ping message into data");
                                     }
                                 }
                                 ProbeRouting::Neighbor(DestinationRouting::Return(_surb_matcher)) => tracing::error!(
@@ -409,7 +409,7 @@ impl Probe {
                                                 ))
                                                 .await
                                             {
-                                                tracing::error!("failed to send out a ping");
+                                                tracing::debug!("failed to send out a ping");
                                             } else {
                                                 // the object is constructed above, so will always match
                                                 if let Message::Telemetry(telemetry) = message {
@@ -419,7 +419,7 @@ impl Probe {
                                                 }
                                             }
                                         } else {
-                                            tracing::error!("failed to construct data for path telemetry")
+                                            tracing::debug!("failed to construct data for path telemetry")
                                         }
                                     } else {
                                         tracing::warn!("probing telemetry tag pool exhausted, skipping loopback probe");

--- a/transport/session/src/balancer/controller.rs
+++ b/transport/session/src/balancer/controller.rs
@@ -265,7 +265,7 @@ where
         // Take a snapshot of the active SURB estimator and calculate the balance change
         let snapshot = SimpleSurbFlowEstimator::from(&self.surb_estimator);
         let Some(target_buffer_change) = snapshot.estimated_surb_buffer_change(&self.last_estimator_state) else {
-            tracing::error!("non-monotonic change in SURB estimators");
+            tracing::warn!("non-monotonic change in SURB estimators");
             return current;
         };
 

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -560,11 +560,11 @@ where
         .timeout(futures_time::time::Duration::from(EXTERNAL_SEND_TIMEOUT))
         .await
         .map_err(|_| {
-            error!("timeout sending {error_context}");
+            warn!("timeout sending {error_context}");
             TransportSessionError::Timeout
         })?
         .map_err(|error| {
-            error!(%error, "failed to send {error_context}");
+            warn!(%error, "failed to send {error_context}");
             SessionManagerError::other(error)
         })?;
     Ok(())
@@ -931,7 +931,7 @@ where
                         Box::new(move |session_id: SessionId, reason: ClosureReason| {
                             let _ = notifier
                                 .try_send((session_id, reason))
-                                .inspect_err(|error| error!(%session_id, %error, "failed to notify session closure"));
+                                .inspect_err(|error| debug!(%session_id, %error, "failed to notify session closure"));
                         })
                     })
                     .ok_or(SessionManagerError::NotStarted)?;
@@ -1160,7 +1160,7 @@ where
             }
             Err(_) => {
                 // Timeout waiting for a session establishment
-                error!(challenge, "session initiation attempt timed out");
+                warn!(challenge, "session initiation attempt timed out");
 
                 #[cfg(all(feature = "telemetry", not(test)))]
                 METRIC_RECEIVED_SESSION_ERRS.increment(&["timeout"]);
@@ -1288,7 +1288,7 @@ where
                 start_protocol_tx
                     .try_send((pseudonym, HoprStartProtocol::try_from(in_data.data)?))
                     .map_err(|error| {
-                        error!(%error, "failed to send Start protocol message to processing task");
+                        warn!(%error, "failed to send Start protocol message to processing task");
                         SessionManagerError::other(error)
                     })?;
             } else {
@@ -1315,7 +1315,7 @@ where
                         DispatchResult::Processed
                     })
                     .map_err(|error| {
-                        error!(%session_id, %error, "failed to dispatch session data");
+                        warn!(%session_id, %error, "failed to dispatch session data");
                         SessionManagerError::other(error)
                     })?)
             } else {
@@ -1433,7 +1433,7 @@ where
 
         let closure_notifier = Box::new(move |session_id: SessionId, reason: ClosureReason| {
             if let Err(error) = close_session_notifier.try_send((session_id, reason)) {
-                error!(%session_id, %error, %reason, "failed to notify session closure");
+                debug!(%session_id, %error, %reason, "failed to notify session closure");
             }
         });
 
@@ -1583,11 +1583,11 @@ where
         .await
         {
             Err(_) => {
-                error!(%session_id, "timeout to notify about new incoming session");
+                warn!(%session_id, "timeout to notify about new incoming session");
                 return Err(TransportSessionError::Timeout);
             }
             Ok(Err(error)) => {
-                error!(%session_id, %error, "failed to notify about new incoming session");
+                debug!(%session_id, %error, "failed to notify about new incoming session");
                 return Err(SessionManagerError::other(error).into());
             }
             _ => {}
@@ -1637,7 +1637,7 @@ where
         let session_id = est.session_id;
         if let Some(tx_est) = self.session_initiations.remove(&est.orig_challenge) {
             if let Err(error) = tx_est.try_send(Ok(est)) {
-                error!(%challenge, %session_id, %error, "failed to send session establishment confirmation");
+                warn!(%challenge, %session_id, %error, "failed to send session establishment confirmation");
                 return Err(SessionManagerError::other(error).into());
             }
             debug!(?session_id, challenge, "session establishment complete");
@@ -1657,7 +1657,7 @@ where
         // and just discard the initiation attempt and pass on the error.
         if let Some(tx_est) = self.session_initiations.remove(&error_type.challenge) {
             if let Err(error) = tx_est.try_send(Err(error_type)) {
-                error!(%error, ?error_type, "could not send session error message");
+                debug!(%error, ?error_type, "could not send session error message");
                 return Err(SessionManagerError::other(error).into());
             }
             error!(

--- a/utils-session/src/lib.rs
+++ b/utils-session/src/lib.rs
@@ -51,7 +51,7 @@ use human_bandwidth::re::bandwidth::Bandwidth;
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
 use tokio::net::TcpListener;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 /// Size of the buffer for forwarding data to/from a TCP stream.
 pub const HOPR_TCP_BUFFER_SIZE: usize = 4096;
@@ -479,7 +479,7 @@ impl SessionPool {
                             Ok(())
                         }
                         Err(error) => {
-                            error!(%error, num_session = i, "failed to establish session for pool");
+                            warn!(%error, num_session = i, "failed to establish session for pool");
                             Err(anyhow!("failed to establish session #{i} in pool to {dst}: {error}"))
                         }
                     }
@@ -505,7 +505,7 @@ impl SessionPool {
                             for configurator in &configurators {
                                 if let Err(error) = configurator.ping().await {
                                     let id = *configurator.id();
-                                    error!(%error, session_id = %id, "session in pool is not alive, will remove");
+                                    debug!(%error, session_id = %id, "session in pool is not alive, will remove");
                                     dead_ids.push(id);
                                 }
                             }
@@ -617,7 +617,7 @@ pub async fn create_tcp_client_binding<T: SessionFactory>(
                             error!(?bind_host, "no more client slots available at listener");
                             use tokio::io::AsyncWriteExt;
                             if let Err(error) = stream.shutdown().await {
-                                error!(%error, ?sock_addr, "failed to shutdown TCP connection");
+                                debug!(%error, ?sock_addr, "failed to shutdown TCP connection");
                             }
                             return;
                         }
@@ -633,7 +633,7 @@ pub async fn create_tcp_client_binding<T: SessionFactory>(
                                 match factory.create_session(destination, target, data).await {
                                     Ok((s, c)) => (s, c),
                                     Err(error) => {
-                                        error!(%error, "failed to establish session");
+                                        warn!(%error, "failed to establish session");
                                         return;
                                     }
                                 }
@@ -673,7 +673,7 @@ pub async fn create_tcp_client_binding<T: SessionFactory>(
                             ),
                         );
                     }
-                    Err(error) => error!(%error, "failed to accept connection"),
+                    Err(error) => warn!(%error, "failed to accept connection"),
                 }
             }
         })


### PR DESCRIPTION
Reduced log levels:
## WARN → DEBUG/INFO

Routine cache/buffer lifecycle, fires constantly in normal operation:

| Location | Message | Suggested |
|---|---|---|
| `protocols/hopr/src/surb_store.rs:179` | evicting reply opener for pseudonym | DEBUG (or INFO) |
| `protocols/hopr/src/surb_store.rs:189` | evicting surb for pseudonym | DEBUG (or INFO) |
| `protocols/hopr/src/surb_store.rs:252` | evicting reply opener for sender id | DEBUG (or INFO) |
| `protocols/hopr/src/tbf.rs:35` | maximum number of items in the Bloom filter reached! | DEBUG |
| `protocols/hopr/src/tbf.rs:63` | maximum number of items in the Bloom filter reached! | DEBUG |
| `impls/connector/src/connector/keys.rs:34,56,91,103` | cache miss on map_key_to_id / map_id_to_public / chain_key_to_packet_key / packet_key_to_chain_key | DEBUG — fires on every cold lookup, hot path |
| `impls/connector/src/connector/channels.rs:65,95,107` | cache miss on channel_by_id / channel_by_parties | DEBUG |
| `protocols/session/src/socket/mod.rs:187,383` | frame already seen | DEBUG — duplicate detection is designed protocol behavior |
| `protocols/session/src/socket/mod.rs:230,442` | terminating frame received | DEBUG — normal session teardown |
| `protocols/session/src/processing/reassembly.rs:125` | reassembler has reached its capacity | DEBUG — flow-control backpressure |
| `protocols/session/src/processing/sequencer.rs:152` | sequencer buffer is full | DEBUG |
| `impls/strategy/src/auto_redeeming.rs:138` | redemption cache at capacity; entry evicted without abort | DEBUG |
| `hopr/hopr-lib/src/helpers.rs:36` | still unfunded, trying again soon | INFO — part of designed wait loop |
| `protocols/session/src/socket/ack_state.rs:388` | cannot be stopped, because it is not running | DEBUG — idempotent stop |

## ERROR → DEBUG,  per-packet/per-frame hot path

Handled gracefully, next item continues; at ERROR these can flood logs under normal p2p churn:

| Location | Message | Suggested |
|---|---|---|
| `protocols/hopr/src/ticket_processing.rs:304,320` | failed to process acknowledgement | DEBUG |
| `protocols/hopr/src/ticket_processing.rs:345` | received acknowledgement for ticket issued in a different epoch | DEBUG — expected epoch-advance race |
| `protocols/hopr/src/ticket_processing.rs:351` | received acknowledgement for ticket issued for unknown channel | DEBUG |
| `protocols/hopr/src/ticket_processing.rs:377` | failed to acknowledge ticket | DEBUG |
| `protocols/session/src/socket/ack_state.rs:284,304,343,366,413,463,496,524,560,597` | resend/retry register + cancel failures | DEBUG — cleanup/bookkeeping transients |
| `protocols/session/src/socket/mod.rs:239` | frame discarded | DEBUG |
| `protocols/session/src/socket/mod.rs:410,438,451` | frame complete/received/discarded state update failed | DEBUG |
| `transport/probe/src/probe.rs:97,100,357,371,412,422` | per-probe send/convert failures | DEBUG — next probe continues |
| `transport/hopr/src/lib.rs:594` | failed to construct cover traffic packet | DEBUG |
| `transport/hopr/src/protocol/pipeline/mod.rs:122,126,130` | outgoing packet encode/parallel/timeout failures | DEBUG — per-packet, filtered out |
| `transport/hopr/src/protocol/pipeline/mod.rs:264` | dropped incoming packet: decode timeout | DEBUG — expected under load |
| `transport/hopr/src/protocol/pipeline/mod.rs:240,584` | failed to notify invalid ticket rejection / ticket resolutions | DEBUG — subscriber dropped, non-critical |
| `transport/session/src/manager.rs:934,1436,1590,1660` | failed to notify session closure / incoming session / send session error | DEBUG — subscriber gone |
| `utils-session/src/lib.rs:508` | session in pool is not alive, will remove | DEBUG — routine pool cleanup |
| `utils-session/src/lib.rs:620` | failed to shutdown TCP connection | DEBUG |
| `impls/ticket-manager/src/traits.rs:102` | failed to obtain ticket from the queue | DEBUG |
| `hopr/hopr-lib/src/builder.rs:750` | failed to broadcast ticket event | DEBUG — subscriber dropped |

Shutdown-path noise (fires during normal shutdown):

| Location | Message | Suggested |
|---|---|---|
| `transport/hopr/src/lib.rs:525` | wire sink dropped — discarding mixed packet | DEBUG (or WARN if outside shutdown) |
| `transport/hopr/src/lib.rs:823` | incoming-data channel disconnected — dropping unrelated packet | DEBUG |

##  ERROR → WARN

Degraded but recoverable; operator may care but nothing is broken:

| Location | Message |
|---|---|
| `utils-session/src/lib.rs:482,636,676` | session establish / accept failures — transient network |
| `impls/strategy/src/auto_funding.rs:299,316` | auto-funding tick failed — periodic task retries next tick |
| `impls/strategy/src/channel_finalizer.rs:145,153` | closure finalizer tick failed |
| `impls/strategy/src/auto_redeeming.rs:132,337,359` | redemption timeout / tick failed |
| `transport/hopr/src/protocol/pipeline/mod.rs:145` | long-running background task finished with error |
| `transport/hopr/src/protocol/pipeline/mod.rs:227,247,298,323,377,388,498,506` | egress/ack queue send failures — backpressure |
| `transport/hopr/src/protocol/pipeline/mod.rs:599` | parallel processing of incoming acknowledgements failed |
| `transport/session/src/manager.rs:563,567,1163,1291,1318,1586,1640` | send timeouts / dispatch failures / session initiation timeout — expected p2p |
| `transport/hopr/src/protocol/stream.rs:130,140` | stream decode/read errors — peer-caused |
| `impls/connector/src/connector/keys.rs:39,61` | failed to get account by key/id — transient backend |
| `impls/connector/src/connector/accounts.rs:45,49` | backend/join error when looking up account |
| `impls/connector/src/connector/channels.rs:45,49` | backend/join error when looking up channel |
| `impls/connector/src/connector/mod.rs:223,550` | blokli server not healthy / connection timeout when syncing |
| `hopr/hopr-lib/src/builder/chain_wiring.rs:58` | peer-discovery channel full or closed; announcement dropped |
| `hopr/hopr-lib/src/helpers.rs:39` | failed to fetch balance from the chain — retried in loop |
| `transport/session/src/balancer/controller.rs:268` | non-monotonic change in SURB estimators |
| `protocols/session/src/socket/ack_state.rs:581` | failed to push segment into ring buffer |
| `impls/connector/src/utils.rs:26` | invalid multiaddress — input validation |
