### PR TITLE
feat: add unordered frame delivery to NoDelay sessions

### DIFF
--- a/hopr/hopr-lib/tests/session_integration_tests.rs
+++ b/hopr/hopr-lib/tests/session_integration_tests.rs
@@ -27,6 +27,7 @@ use tokio::{
 #[rstest]
 #[case(Capabilities::empty())]
 #[case(Capabilities::from(Capability::Segmentation))]
+#[case(Capabilities::from(Capability::NoDelay))]
 #[tokio::test]
 /// Creates paired Hopr sessions bridged to a UDP listener to prove that messages
 /// sent over UDP end up in the remote session buffer regardless of capability set.

--- a/protocols/session/benches/socket_bench.rs
+++ b/protocols/session/benches/socket_bench.rs
@@ -102,5 +102,170 @@ pub fn stateless_socket_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, stateless_socket_benchmark);
+/// Records each `poll_write` as one wire packet, preserving packet boundaries
+/// (the socket flushes each segment individually with the default zero
+/// `max_buffered_segments`, so one write equals one segment).
+#[derive(Clone, Default)]
+struct PacketRecorder(std::sync::Arc<std::sync::Mutex<Vec<Box<[u8]>>>>);
+
+impl AsyncWrite for PacketRecorder {
+    fn poll_write(
+        self: std::pin::Pin<&mut Self>,
+        _: &mut std::task::Context<'_>,
+        buf: &[u8],
+    ) -> std::task::Poll<std::io::Result<usize>> {
+        self.0.lock().unwrap().push(buf.to_vec().into_boxed_slice());
+        std::task::Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(
+        self: std::pin::Pin<&mut Self>,
+        _: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(
+        self: std::pin::Pin<&mut Self>,
+        _: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        std::task::Poll::Ready(Ok(()))
+    }
+}
+
+/// Writes `data` through a stateless socket, capturing the individual wire packets.
+///
+/// Unlike [`alice_send_data`], the socket is not closed: a terminating segment would
+/// be shuffled in front of data segments by [`window_shuffle`] and abort the receive
+/// pipeline early, which is an artifact rather than a datagram workload.
+fn capture_wire_packets(data: &[u8], runtime: &tokio::runtime::Runtime) -> Vec<Box<[u8]>> {
+    use futures::AsyncWriteExt;
+
+    let recorder = PacketRecorder::default();
+    let transport = DuplexIO::from((recorder.clone(), futures::io::empty()));
+
+    runtime.block_on(async move {
+        let mut alice_socket = UnreliableSocket::<MTU>::new_stateless(
+            "alice",
+            transport,
+            SessionSocketConfig::default(),
+            #[cfg(feature = "telemetry")]
+            NoopTracker,
+        )
+        .unwrap();
+        alice_socket.write_all(data).await.unwrap();
+        alice_socket.flush().await.unwrap();
+    });
+
+    let packets = recorder.0.lock().unwrap().drain(..).collect::<Vec<_>>();
+    assert!(!packets.is_empty());
+    packets
+}
+
+/// Deterministically reorders packets within a sliding window of the given size,
+/// approximating the `buffer_unordered(window)` mixing used by the socket tests.
+/// A window of 0 keeps the original order.
+fn window_shuffle(packets: &[Box<[u8]>], window: usize, seed: [u8; 32]) -> Vec<u8> {
+    use rand::{RngExt, SeedableRng, rngs::StdRng};
+
+    let mut rng = StdRng::from_seed(seed);
+    let mut out = Vec::with_capacity(packets.iter().map(|p| p.len()).sum());
+    let mut buf: Vec<&[u8]> = Vec::with_capacity(window + 1);
+
+    for packet in packets {
+        if window == 0 {
+            out.extend_from_slice(packet);
+            continue;
+        }
+        buf.push(packet);
+        if buf.len() > window {
+            let i = rng.random_range(0..buf.len());
+            out.extend_from_slice(buf.swap_remove(i));
+        }
+    }
+    while !buf.is_empty() {
+        let i = rng.random_range(0..buf.len());
+        out.extend_from_slice(buf.swap_remove(i));
+    }
+    out
+}
+
+pub async fn bob_receive_data_with_cfg(data: Vec<u8>, mut recv_data: Vec<u8>, cfg: SessionSocketConfig) -> Vec<u8> {
+    use futures::AsyncReadExt;
+
+    let mut bob_socket = UnreliableSocket::<MTU>::new_stateless(
+        "bob",
+        DuplexIO::from((futures::io::sink(), Cursor::new(data))),
+        cfg,
+        #[cfg(feature = "telemetry")]
+        NoopTracker,
+    )
+    .unwrap();
+    bob_socket.read_to_end(&mut recv_data).await.unwrap();
+
+    recv_data
+}
+
+/// Compares the ordered (sequencing) and unordered (arrival-order) receive pipelines
+/// under packet reordering of increasing severity.
+pub fn stateless_socket_reordering(c: &mut Criterion) {
+    let mut group = c.benchmark_group("stateless_socket_reordering");
+    const SIZE: usize = 1024 * 1024;
+
+    group.sample_size(30);
+    group.throughput(Throughput::Bytes(SIZE as u64));
+
+    let mut alice_data = vec![0u8; SIZE];
+    hopr_types::crypto_random::random_fill(&mut alice_data);
+
+    let runtime = tokio::runtime::Runtime::new().unwrap();
+    let packets = capture_wire_packets(&alice_data, &runtime);
+
+    // Frame ids never time out in the ordered arm: all frames are present in the wire
+    // data, so the sequencer only pays the re-sorting cost, never the gap discard.
+    let ordered_cfg = SessionSocketConfig {
+        frame_timeout: std::time::Duration::from_secs(10),
+        ..Default::default()
+    };
+    let unordered_cfg = SessionSocketConfig {
+        frame_timeout: std::time::Duration::from_secs(10),
+        deliver_in_order: false,
+        ..Default::default()
+    };
+
+    for mixing_factor in [0usize, 10, 32] {
+        let wire_data = window_shuffle(&packets, mixing_factor, [0xEE; 32]);
+
+        // Sanity: ordered mode restores the exact byte stream...
+        let ordered_out = runtime.block_on(bob_receive_data_with_cfg(
+            wire_data.clone(),
+            Vec::with_capacity(SIZE),
+            ordered_cfg,
+        ));
+        assert_eq!(alice_data, ordered_out, "ordered mode must restore the byte stream");
+
+        // ...while unordered mode delivers all bytes, possibly permuted at frame level.
+        let unordered_out = runtime.block_on(bob_receive_data_with_cfg(
+            wire_data.clone(),
+            Vec::with_capacity(SIZE),
+            unordered_cfg,
+        ));
+        let (mut sent_sorted, mut recv_sorted) = (alice_data.clone(), unordered_out);
+        sent_sorted.sort_unstable();
+        recv_sorted.sort_unstable();
+        assert_eq!(sent_sorted, recv_sorted, "unordered mode must deliver all bytes");
+
+        group.bench_with_input(BenchmarkId::new("ordered", mixing_factor), &wire_data, |b, data| {
+            b.to_async(&runtime)
+                .iter(|| bob_receive_data_with_cfg(data.clone(), Vec::with_capacity(SIZE), ordered_cfg));
+        });
+        group.bench_with_input(BenchmarkId::new("unordered", mixing_factor), &wire_data, |b, data| {
+            b.to_async(&runtime)
+                .iter(|| bob_receive_data_with_cfg(data.clone(), Vec::with_capacity(SIZE), unordered_cfg));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, stateless_socket_benchmark, stateless_socket_reordering);
 criterion_main!(benches);

--- a/protocols/session/benches/socket_bench.rs
+++ b/protocols/session/benches/socket_bench.rs
@@ -233,8 +233,16 @@ pub fn stateless_socket_reordering(c: &mut Criterion) {
         ..Default::default()
     };
 
+    let in_order_wire = window_shuffle(&packets, 0, [0xEE; 32]);
+
     for mixing_factor in [0usize, 10, 32] {
         let wire_data = window_shuffle(&packets, mixing_factor, [0xEE; 32]);
+        if mixing_factor > 0 {
+            assert_ne!(
+                in_order_wire, wire_data,
+                "window_shuffle must actually reorder the wire packets"
+            );
+        }
 
         // Sanity: ordered mode restores the exact byte stream...
         let ordered_out = runtime.block_on(bob_receive_data_with_cfg(

--- a/protocols/session/src/processing/sequencer.rs
+++ b/protocols/session/src/processing/sequencer.rs
@@ -318,17 +318,20 @@ mod tests {
         pin_mut!(seq_stream);
 
         // Frame 1 is missing; later frames must still be delivered immediately
-        // (no head-of-line stall, no FrameDiscarded for the gap).
+        // (no head-of-line stall, no FrameDiscarded for the gap). The timeouts turn
+        // a regression to ordered behavior into a failure instead of a hung test.
+        let timeout = futures_time::time::Duration::from_secs(5);
+
         seq_sink.send(2u32).await?;
-        assert_eq!(Some(2), seq_stream.try_next().await?);
+        assert_eq!(Some(2), seq_stream.try_next().timeout(timeout).await??);
 
         seq_sink.send(3u32).await?;
-        assert_eq!(Some(3), seq_stream.try_next().await?);
+        assert_eq!(Some(3), seq_stream.try_next().timeout(timeout).await??);
 
         // The straggler arrives very late and out of order — it must still be
         // delivered, not rejected.
         seq_sink.send(1u32).await?;
-        assert_eq!(Some(1), seq_stream.try_next().await?);
+        assert_eq!(Some(1), seq_stream.try_next().timeout(timeout).await??);
 
         Ok(())
     }

--- a/protocols/session/src/processing/sequencer.rs
+++ b/protocols/session/src/processing/sequencer.rs
@@ -48,6 +48,12 @@ pub struct Sequencer<S: futures::Stream> {
     last_emitted: Instant,
     max_wait: Duration,
     state: State,
+    /// When `false`, the Sequencer is a pass-through: items are yielded in arrival
+    /// order without in-order buffering and without discarding gaps. This is the
+    /// correct delivery mode for datagram sessions (e.g. UDP/WireGuard), where the
+    /// payload tolerates reordering and a missing frame must not stall or discard
+    /// later frames.
+    ordered: bool,
 }
 
 impl<S> Sequencer<S>
@@ -69,6 +75,25 @@ where
             last_emitted: Instant::now(),
             max_wait,
             state: State::Polling,
+            ordered: true,
+        }
+    }
+
+    /// Creates a pass-through (unordered) Sequencer for datagram delivery.
+    ///
+    /// Items are yielded in arrival order; there is no in-order buffering, no
+    /// `max_wait` timer, and gaps are never discarded. The `buffer`/`timer` fields
+    /// are kept inert so the struct type is unchanged.
+    fn new_unordered(inner: S) -> Self {
+        Self {
+            inner,
+            buffer: BinaryHeap::new(),
+            timer: futures_time::task::sleep(Duration::from_millis(1).into()),
+            next_id: 1,
+            last_emitted: Instant::now(),
+            max_wait: Duration::from_millis(1),
+            state: State::Polling,
+            ordered: false,
         }
     }
 }
@@ -90,6 +115,14 @@ where
     #[instrument(name = "Sequencer::poll_next", level = "trace", skip(self, cx), fields(next_frame_id = self.next_id, state = ?self.state))]
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         let mut this = self.project();
+
+        // Datagram mode: yield items as they arrive, in arrival order. No in-order
+        // buffering, no timer, no gap discarding — a slow/late frame must not stall
+        // or drop the frames around it.
+        if !*this.ordered {
+            return this.inner.as_mut().poll_next(cx).map(|opt| opt.map(Ok));
+        }
+
         if *this.next_id == 0 {
             tracing::debug!("end of frame sequence reached");
             return Poll::Ready(None);
@@ -223,6 +256,18 @@ pub trait SequencerExt: futures::Stream {
     {
         Sequencer::new(self, timeout, capacity)
     }
+
+    /// Attaches a pass-through (unordered) [`Sequencer`] for datagram delivery:
+    /// items are yielded in arrival order, gaps are never discarded, and there is
+    /// no `max_wait` timer. Use for UDP/datagram sessions where reordering is
+    /// tolerated by the payload (e.g. WireGuard).
+    fn sequencer_unordered(self) -> Sequencer<Self>
+    where
+        Self::Item: Ord + PartialOrd<FrameId>,
+        Self: Sized,
+    {
+        Sequencer::new_unordered(self)
+    }
 }
 
 impl<T: ?Sized> SequencerExt for T where T: futures::Stream {}
@@ -246,6 +291,44 @@ mod tests {
 
         expected.sort();
         assert_eq!(expected, actual);
+
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn unordered_sequencer_should_yield_items_in_arrival_order() -> anyhow::Result<()> {
+        let input = vec![4u32, 1, 5, 7, 8, 6, 2, 3];
+
+        let actual: Vec<u32> = futures::stream::iter(input.clone())
+            .sequencer_unordered()
+            .try_collect()
+            .timeout(futures_time::time::Duration::from_secs(5))
+            .await??;
+
+        // Pass-through: arrival order is preserved, nothing is reordered or dropped.
+        assert_eq!(input, actual);
+
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn unordered_sequencer_should_not_discard_on_gap_or_late_item() -> anyhow::Result<()> {
+        let (mut seq_sink, seq_stream) = futures::channel::mpsc::unbounded();
+        let seq_stream = seq_stream.sequencer_unordered();
+        pin_mut!(seq_stream);
+
+        // Frame 1 is missing; later frames must still be delivered immediately
+        // (no head-of-line stall, no FrameDiscarded for the gap).
+        seq_sink.send(2u32).await?;
+        assert_eq!(Some(2), seq_stream.try_next().await?);
+
+        seq_sink.send(3u32).await?;
+        assert_eq!(Some(3), seq_stream.try_next().await?);
+
+        // The straggler arrives very late and out of order — it must still be
+        // delivered, not rejected.
+        seq_sink.send(1u32).await?;
+        assert_eq!(Some(1), seq_stream.try_next().await?);
 
         Ok(())
     }

--- a/protocols/session/src/socket/mod.rs
+++ b/protocols/session/src/socket/mod.rs
@@ -1040,11 +1040,12 @@ mod tests {
             ..Default::default()
         };
 
-        // Generous latency expectation so the tiny mixing delays never trigger spurious
-        // retransmissions: in unordered mode a re-sent single-segment frame would be
+        // Generous latency expectation so that scheduler stalls under CI load never
+        // trigger spurious retransmissions: in unordered mode a re-sent frame would be
         // delivered twice (duplicates are legitimate datagram semantics, but would make
         // this multiset assertion flaky).
         let ack_cfg = AcknowledgementStateConfig {
+            expected_packet_latency: Duration::from_millis(1000),
             acknowledgement_delay: Duration::from_millis(5),
             ..Default::default()
         };
@@ -1344,23 +1345,114 @@ mod tests {
         alice_socket.flush().await?;
 
         // Without mixing, the network preserves order, so everything after the lost
-        // first frame arrives byte-exact. The 1 s read timeout (« 5 s frame_timeout)
-        // is the actual no-stall assertion.
-        let start = std::time::Instant::now();
+        // first frame arrives byte-exact. The 2 s read timeout (« 5 s frame_timeout)
+        // is the actual no-stall assertion: ordered mode would hold everything back
+        // until the frame_timeout expires.
         let mut bob_data = [0u8; DATA_SIZE - 1500];
         bob_socket
             .read_exact(&mut bob_data)
-            .timeout(futures_time::time::Duration::from_secs(1))
+            .timeout(futures_time::time::Duration::from_secs(2))
             .await??;
 
-        assert!(
-            start.elapsed() < Duration::from_secs(1),
-            "unordered delivery must not wait for frame_timeout"
-        );
         assert_eq!(&data[1500..], &bob_data[..]);
 
         alice_socket.close().await?;
         bob_socket.close().await?;
+
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn stateless_socket_unordered_delivers_swapped_frames_in_arrival_order() -> anyhow::Result<()> {
+        use hopr_utils::network_types::utils::DuplexIO;
+
+        /// Records each write as one wire packet, preserving segment boundaries.
+        #[derive(Clone, Default)]
+        struct PacketRecorder(std::sync::Arc<std::sync::Mutex<Vec<Box<[u8]>>>>);
+
+        impl futures::io::AsyncWrite for PacketRecorder {
+            fn poll_write(self: Pin<&mut Self>, _: &mut Context<'_>, buf: &[u8]) -> Poll<std::io::Result<usize>> {
+                self.0.lock().unwrap().push(buf.to_vec().into_boxed_slice());
+                Poll::Ready(Ok(buf.len()))
+            }
+
+            fn poll_flush(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+                Poll::Ready(Ok(()))
+            }
+
+            fn poll_close(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<std::io::Result<()>> {
+                Poll::Ready(Ok(()))
+            }
+        }
+
+        // Two full frames, captured at segment granularity and re-fed with ALL of
+        // frame 2's segments ahead of frame 1's. Unlike the mixing tests, this
+        // reordering is fully deterministic.
+        const TWO_FRAMES: usize = 2 * FRAME_SIZE;
+
+        let recorder = PacketRecorder::default();
+        let mut alice_socket = SessionSocket::<MTU, _>::new_stateless(
+            "alice",
+            DuplexIO::from((recorder.clone(), futures::io::empty())),
+            SessionSocketConfig {
+                frame_size: FRAME_SIZE,
+                ..Default::default()
+            },
+            #[cfg(feature = "telemetry")]
+            NoopTracker,
+        )?;
+
+        let data = hopr_types::crypto_random::random_bytes::<TWO_FRAMES>();
+        alice_socket.write_all(&data).await?;
+        alice_socket.flush().await?;
+
+        let packets = recorder.0.lock().unwrap().clone();
+        let frame_id_of = |packet: &[u8]| -> anyhow::Result<u32> {
+            SessionMessage::<MTU>::try_from(packet)?
+                .try_as_segment()
+                .map(|s| s.frame_id)
+                .ok_or_else(|| anyhow::anyhow!("expected a segment"))
+        };
+        let mut wire = Vec::new();
+        for want in [2u32, 1] {
+            for packet in packets.iter().filter(|p| frame_id_of(p).is_ok_and(|id| id == want)) {
+                wire.extend_from_slice(packet);
+            }
+        }
+
+        let mut bob_socket = SessionSocket::<MTU, _>::new_stateless(
+            "bob",
+            DuplexIO::from((futures::io::sink(), futures::io::Cursor::new(wire))),
+            SessionSocketConfig {
+                frame_size: FRAME_SIZE,
+                // Deliberately large: unordered delivery must not depend on it.
+                frame_timeout: Duration::from_secs(5),
+                deliver_in_order: false,
+                ..Default::default()
+            },
+            #[cfg(feature = "telemetry")]
+            NoopTracker,
+        )?;
+
+        // Frame 2 must be delivered first (arrival order), and frame 1 must NOT be
+        // dropped by the `frame already seen` filter although its lower id arrives
+        // after a higher one has been emitted.
+        let mut received = [0u8; TWO_FRAMES];
+        bob_socket
+            .read_exact(&mut received)
+            .timeout(futures_time::time::Duration::from_secs(2))
+            .await??;
+
+        assert_eq!(
+            &data[FRAME_SIZE..],
+            &received[..FRAME_SIZE],
+            "frame 2 must arrive first"
+        );
+        assert_eq!(
+            &data[..FRAME_SIZE],
+            &received[FRAME_SIZE..],
+            "frame 1 must not be discarded"
+        );
 
         Ok(())
     }

--- a/protocols/session/src/socket/mod.rs
+++ b/protocols/session/src/socket/mod.rs
@@ -73,6 +73,18 @@ pub struct SessionSocketConfig {
     /// Default is 2048.
     #[default(2048)]
     pub control_channel_capacity: usize,
+    /// Whether reassembled frames are delivered strictly in `FrameId` order.
+    ///
+    /// When `true` (default), frames are sequenced and a frame missing for longer than
+    /// `frame_timeout` is discarded to avoid head-of-line blocking — the correct
+    /// TCP-like byte-stream behavior.
+    ///
+    /// When `false`, frames are delivered in arrival order without sequencing or gap
+    /// discarding. This is the correct behavior for datagram payloads (e.g. UDP/WireGuard)
+    /// that tolerate reordering, where a late frame from a slow path must not stall or
+    /// drop the frames around it.
+    #[default(true)]
+    pub deliver_in_order: bool,
 }
 
 enum WriteState {
@@ -168,10 +180,15 @@ impl<const C: usize> SessionSocket<C, Stateless<C>> {
 
         let (packets_in_abort_handle, packets_in_abort_reg) = AbortHandle::new_pair();
 
+        // Datagram sessions (e.g. UDP/WireGuard) deliver frames in arrival order without
+        // sequencing; the `already seen` drop is also skipped, since out-of-order frames
+        // are legitimate there.
+        let deliver_in_order = cfg.deliver_in_order;
+
         // Pipeline OUT: Packets incoming from Downstream
         // Continue receiving packets from downstream, unless we received a terminating frame.
         // Once the terminating frame is received, the `packets_in_abort_handle` is triggered, terminating the pipeline.
-        let downstream_frames_out = futures::stream::Abortable::new(packets_in, packets_in_abort_reg)
+        let pre_sequencer = futures::stream::Abortable::new(packets_in, packets_in_abort_reg)
             // Filter-out segments that we've seen already
             .filter_map(move |packet| {
                 let _span = stage1_span.enter();
@@ -181,14 +198,17 @@ impl<const C: usize> SessionSocket<C, Stateless<C>> {
                             #[cfg(feature = "telemetry")]
                             s1.incoming_message(SessionMessageDiscriminants::Segment);
 
-                            // Filter old frame ids to save space in the Reassembler
-                            let last_emitted_id = last_emitted_frame.load(std::sync::atomic::Ordering::Relaxed);
-                            if s.frame_id <= last_emitted_id {
-                                tracing::warn!(frame_id = s.frame_id, last_emitted_id, "frame already seen");
-                                false
-                            } else {
-                                true
+                            // Filter old frame ids to save space in the Reassembler — but only
+                            // under in-order delivery. In datagram mode a frame_id below the last
+                            // emitted one is a legitimately reordered datagram, not a duplicate.
+                            if deliver_in_order {
+                                let last_emitted_id = last_emitted_frame.load(std::sync::atomic::Ordering::Relaxed);
+                                if s.frame_id <= last_emitted_id {
+                                    tracing::warn!(frame_id = s.frame_id, last_emitted_id, "frame already seen");
+                                    return false;
+                                }
                             }
+                            true
                         })
                     }
                     Err(error) => {
@@ -217,9 +237,17 @@ impl<const C: usize> SessionSocket<C, Stateless<C>> {
                         None
                     }
                 })
-            })
-            // Put the frames into the correct sequence by Frame Ids
-            .sequencer(cfg.frame_timeout, cfg.capacity)
+            });
+
+        // Put the frames into the correct sequence by Frame Ids, unless datagram delivery
+        // is requested — both arms yield the same `Sequencer` type.
+        let sequenced = if deliver_in_order {
+            pre_sequencer.sequencer(cfg.frame_timeout, cfg.capacity)
+        } else {
+            pre_sequencer.sequencer_unordered()
+        };
+
+        let downstream_frames_out = sequenced
             // Discard frames missing from the sequence
             .filter_map(move |maybe_frame| {
                 let _span = stage3_span.enter();
@@ -355,6 +383,10 @@ impl<const C: usize, S: SocketState<C> + Clone + 'static> SessionSocket<C, S> {
 
         let (packets_in_abort_handle, packets_in_abort_reg) = AbortHandle::new_pair();
 
+        // Datagram sessions deliver frames in arrival order without sequencing; the
+        // `already seen` drop is also skipped, since out-of-order frames are legitimate.
+        let deliver_in_order = cfg.deliver_in_order;
+
         // Pipeline OUT: Packets incoming from Downstream
         let mut st_1 = state.clone();
         let mut st_2 = state.clone();
@@ -362,7 +394,7 @@ impl<const C: usize, S: SocketState<C> + Clone + 'static> SessionSocket<C, S> {
 
         // Continue receiving packets from downstream, unless we received a terminating frame.
         // Once the terminating frame is received, the `packets_in_abort_handle` is triggered, terminating the pipeline.
-        let downstream_frames_out = futures::stream::Abortable::new(packets_in, packets_in_abort_reg)
+        let pre_sequencer = futures::stream::Abortable::new(packets_in, packets_in_abort_reg)
             // Filter out Session control messages and update the State, pass only Segments onwards
             .filter_map(move |packet| {
                 let _span = tracing::debug_span!(
@@ -378,15 +410,17 @@ impl<const C: usize, S: SocketState<C> + Clone + 'static> SessionSocket<C, S> {
                         #[cfg(feature = "telemetry")]
                         s1.incoming_message(packet.discriminant());
 
-                        // Filter old frame ids to save space in the Reassembler
+                        // Filter old frame ids to save space in the Reassembler — but only under
+                        // in-order delivery; in datagram mode a lower frame_id is a reordered frame.
                         packet.try_as_segment().filter(|s| {
-                            let last_emitted_id = last_emitted_frame.load(std::sync::atomic::Ordering::Relaxed);
-                            if s.frame_id <= last_emitted_id {
-                                tracing::warn!(frame_id = s.frame_id, last_emitted_id, "frame already seen");
-                                false
-                            } else {
-                                true
+                            if deliver_in_order {
+                                let last_emitted_id = last_emitted_frame.load(std::sync::atomic::Ordering::Relaxed);
+                                if s.frame_id <= last_emitted_id {
+                                    tracing::warn!(frame_id = s.frame_id, last_emitted_id, "frame already seen");
+                                    return false;
+                                }
                             }
+                            true
                         })
                     }
                     Err(error) => {
@@ -422,9 +456,17 @@ impl<const C: usize, S: SocketState<C> + Clone + 'static> SessionSocket<C, S> {
                         None
                     }
                 })
-            })
-            // Put the frames into the correct sequence by Frame Ids
-            .sequencer(cfg.frame_timeout, cfg.frame_size)
+            });
+
+        // Put the frames into the correct sequence by Frame Ids, unless datagram delivery
+        // is requested — both arms yield the same `Sequencer` type.
+        let sequenced = if deliver_in_order {
+            pre_sequencer.sequencer(cfg.frame_timeout, cfg.frame_size)
+        } else {
+            pre_sequencer.sequencer_unordered()
+        };
+
+        let downstream_frames_out = sequenced
             // Discard frames missing from the sequence and
             // notify the State about emitted or discarded frames
             .filter_map(move |maybe_frame| {
@@ -855,6 +897,68 @@ mod tests {
     }
 
     #[test_log::test(tokio::test)]
+    async fn stateless_socket_unordered_delivers_all_frames_under_mixing() -> anyhow::Result<()> {
+        // Heavy segment reordering. In ordered mode the sequencer re-sorts frames back
+        // (see `stateless_socket_unidirectional_should_work_with_mixing`). In datagram
+        // (unordered) mode frames are delivered in arrival order — nothing is held back
+        // or discarded for a gap — so all data still arrives, just possibly reordered.
+        let network_cfg = FaultyNetworkConfig {
+            mixing_factor: 10,
+            ..Default::default()
+        };
+
+        let (alice, bob) = setup_alice_bob::<MTU>(network_cfg, None, None);
+
+        let sock_cfg = SessionSocketConfig {
+            frame_size: FRAME_SIZE,
+            deliver_in_order: false,
+            ..Default::default()
+        };
+
+        let mut alice_socket = SessionSocket::<MTU, _>::new_stateless(
+            "alice",
+            alice,
+            sock_cfg,
+            #[cfg(feature = "telemetry")]
+            NoopTracker,
+        )?;
+        let mut bob_socket = SessionSocket::<MTU, _>::new_stateless(
+            "bob",
+            bob,
+            sock_cfg,
+            #[cfg(feature = "telemetry")]
+            NoopTracker,
+        )?;
+
+        let data = hopr_types::crypto_random::random_bytes::<DATA_SIZE>();
+        alice_socket
+            .write_all(&data)
+            .timeout(futures_time::time::Duration::from_secs(2))
+            .await??;
+        alice_socket.flush().await?;
+
+        // `read_exact` only completes if every byte arrives — i.e. no frame was discarded.
+        let mut bob_recv_data = [0u8; DATA_SIZE];
+        bob_socket
+            .read_exact(&mut bob_recv_data)
+            .timeout(futures_time::time::Duration::from_secs(2))
+            .await??;
+
+        // No data lost: the received bytes are the same multiset as sent. Datagram mode
+        // neither discards a gap nor stalls behind a missing frame — the arrival-order
+        // semantics themselves are covered by the `sequencer` unit tests.
+        let (mut sent_sorted, mut recv_sorted) = (data.to_vec(), bob_recv_data.to_vec());
+        sent_sorted.sort_unstable();
+        recv_sorted.sort_unstable();
+        assert_eq!(sent_sorted, recv_sorted, "all frames must be delivered, none discarded");
+
+        alice_socket.close().await?;
+        bob_socket.close().await?;
+
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
     async fn stateful_socket_unidirectional_should_work_with_mixing() -> anyhow::Result<()> {
         let network_cfg = FaultyNetworkConfig {
             mixing_factor: 10,
@@ -902,6 +1006,72 @@ mod tests {
             .timeout(futures_time::time::Duration::from_secs(2))
             .await??;
         assert_eq!(data, bob_recv_data);
+
+        alice_socket.close().await?;
+        bob_socket.close().await?;
+
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn stateful_socket_unordered_delivers_all_frames_under_mixing() -> anyhow::Result<()> {
+        // The stateful (reliable) socket with unordered delivery: retransmission and
+        // acknowledgements still operate on frames, but delivery is in arrival order.
+        // This is the production combination `RetransmissionAck | NoDelay`.
+        let network_cfg = FaultyNetworkConfig {
+            mixing_factor: 10,
+            ..Default::default()
+        };
+
+        let (alice, bob) = setup_alice_bob::<MTU>(network_cfg, None, None);
+
+        let sock_cfg = SessionSocketConfig {
+            frame_size: FRAME_SIZE,
+            deliver_in_order: false,
+            ..Default::default()
+        };
+
+        // Generous latency expectation so the tiny mixing delays never trigger spurious
+        // retransmissions: in unordered mode a re-sent single-segment frame would be
+        // delivered twice (duplicates are legitimate datagram semantics, but would make
+        // this multiset assertion flaky).
+        let ack_cfg = AcknowledgementStateConfig {
+            acknowledgement_delay: Duration::from_millis(5),
+            ..Default::default()
+        };
+
+        let mut alice_socket = SessionSocket::<MTU, _>::new(
+            alice,
+            AcknowledgementState::new("alice", ack_cfg),
+            sock_cfg,
+            #[cfg(feature = "telemetry")]
+            NoopTracker,
+        )?;
+        let mut bob_socket = SessionSocket::<MTU, _>::new(
+            bob,
+            AcknowledgementState::new("bob", ack_cfg),
+            sock_cfg,
+            #[cfg(feature = "telemetry")]
+            NoopTracker,
+        )?;
+
+        let data = hopr_types::crypto_random::random_bytes::<DATA_SIZE>();
+        alice_socket
+            .write_all(&data)
+            .timeout(futures_time::time::Duration::from_secs(2))
+            .await??;
+        alice_socket.flush().await?;
+
+        let mut bob_recv_data = [0u8; DATA_SIZE];
+        bob_socket
+            .read_exact(&mut bob_recv_data)
+            .timeout(futures_time::time::Duration::from_secs(2))
+            .await??;
+
+        let (mut sent_sorted, mut recv_sorted) = (data.to_vec(), bob_recv_data.to_vec());
+        sent_sorted.sort_unstable();
+        recv_sorted.sort_unstable();
+        assert_eq!(sent_sorted, recv_sorted, "all frames must be delivered, none discarded");
 
         alice_socket.close().await?;
         bob_socket.close().await?;
@@ -1107,6 +1277,81 @@ mod tests {
             insta::assert_yaml_snapshot!(alice_tracker);
             insta::assert_yaml_snapshot!(bob_tracker);
         }
+
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn stateless_socket_unordered_does_not_stall_on_missing_frame() -> anyhow::Result<()> {
+        // The first segment (and thus the whole first frame) is lost. In ordered mode the
+        // sequencer holds ALL later frames back until `frame_timeout` elapses and only then
+        // skips the gap (see `stateless_socket_unidirectional_should_should_skip_missing_frames`,
+        // which needs a short 55 ms timeout to finish quickly). In unordered mode the later
+        // frames must flow immediately — even with a `frame_timeout` far larger than the
+        // read timeout used here.
+        let (alice, bob) = setup_alice_bob::<MTU>(
+            FaultyNetworkConfig {
+                avg_delay: Duration::from_millis(10),
+                ids_to_drop: HashSet::from_iter([0_usize]),
+                ..Default::default()
+            },
+            None,
+            None,
+        );
+
+        let alice_cfg = SessionSocketConfig {
+            frame_size: FRAME_SIZE,
+            ..Default::default()
+        };
+
+        let bob_cfg = SessionSocketConfig {
+            frame_size: FRAME_SIZE,
+            // Deliberately huge: unordered delivery must not depend on this value at all.
+            frame_timeout: Duration::from_secs(5),
+            deliver_in_order: false,
+            ..Default::default()
+        };
+
+        let mut alice_socket = SessionSocket::<MTU, _>::new_stateless(
+            "alice",
+            alice,
+            alice_cfg,
+            #[cfg(feature = "telemetry")]
+            NoopTracker,
+        )?;
+        let mut bob_socket = SessionSocket::<MTU, _>::new_stateless(
+            "bob",
+            bob,
+            bob_cfg,
+            #[cfg(feature = "telemetry")]
+            NoopTracker,
+        )?;
+
+        let data = hopr_types::crypto_random::random_bytes::<DATA_SIZE>();
+        alice_socket
+            .write_all(&data)
+            .timeout(futures_time::time::Duration::from_secs(2))
+            .await??;
+        alice_socket.flush().await?;
+
+        // Without mixing, the network preserves order, so everything after the lost
+        // first frame arrives byte-exact. The 1 s read timeout (« 5 s frame_timeout)
+        // is the actual no-stall assertion.
+        let start = std::time::Instant::now();
+        let mut bob_data = [0u8; DATA_SIZE - 1500];
+        bob_socket
+            .read_exact(&mut bob_data)
+            .timeout(futures_time::time::Duration::from_secs(1))
+            .await??;
+
+        assert!(
+            start.elapsed() < Duration::from_secs(1),
+            "unordered delivery must not wait for frame_timeout"
+        );
+        assert_eq!(&data[1500..], &bob_data[..]);
+
+        alice_socket.close().await?;
+        bob_socket.close().await?;
 
         Ok(())
     }

--- a/protocols/session/src/socket/mod.rs
+++ b/protocols/session/src/socket/mod.rs
@@ -83,6 +83,15 @@ pub struct SessionSocketConfig {
     /// discarding. This is the correct behavior for datagram payloads (e.g. UDP/WireGuard)
     /// that tolerate reordering, where a late frame from a slow path must not stall or
     /// drop the frames around it.
+    ///
+    /// Unordered delivery is intended for stateless sockets. On stateful sockets the
+    /// reliability layer's duplicate suppression relies on the ordered receive path:
+    /// without it, retransmitted frames can be delivered to the application twice and
+    /// duplicate segments of already-delivered frames can solicit spurious
+    /// retransmission requests.
+    ///
+    /// Note also the close semantics of arrival-order delivery: a terminating frame that
+    /// overtakes in-flight data frames aborts the receive pipeline without waiting for them.
     #[default(true)]
     pub deliver_in_order: bool,
 }

--- a/transport/session/src/lib.rs
+++ b/transport/session/src/lib.rs
@@ -59,6 +59,11 @@ flagset::flags! {
         RetransmissionNack = 0b000_1010,
         /// Disable packet buffering.
         ///
+        /// Each write is flushed immediately as its own frame, and frames are delivered
+        /// in arrival order: no in-order sequencing and no discarding of frames behind a
+        /// gap. Intended for datagram payloads (e.g. UDP/WireGuard) that tolerate
+        /// reordering.
+        ///
         /// Implies [`Segmentation`].
         NoDelay = 0b0000_1001,
         /// Disable SURB-based egress rate control.

--- a/transport/session/src/lib.rs
+++ b/transport/session/src/lib.rs
@@ -59,10 +59,15 @@ flagset::flags! {
         RetransmissionNack = 0b000_1010,
         /// Disable packet buffering.
         ///
-        /// Each write is flushed immediately as its own frame, and frames are delivered
-        /// in arrival order: no in-order sequencing and no discarding of frames behind a
-        /// gap. Intended for datagram payloads (e.g. UDP/WireGuard) that tolerate
-        /// reordering.
+        /// Each write is flushed immediately as its own frame. Unless a retransmission
+        /// capability is also set, frames are delivered in arrival order: no in-order
+        /// sequencing and no discarding of frames behind a gap. Intended for datagram
+        /// payloads (e.g. UDP/WireGuard) that tolerate reordering; byte-stream payloads
+        /// must not rely on ordering with this capability.
+        ///
+        /// Note the datagram close semantics of arrival-order delivery: a terminating
+        /// frame that overtakes in-flight data frames ends the session without waiting
+        /// for them.
         ///
         /// Implies [`Segmentation`].
         NoDelay = 0b0000_1001,

--- a/transport/session/src/types.rs
+++ b/transport/session/src/types.rs
@@ -88,6 +88,26 @@ pub(crate) fn caps_to_ack_mode(caps: Capabilities) -> AcknowledgementMode {
     }
 }
 
+/// Derives the session socket configuration from the session config and reliability mode.
+///
+/// `NoDelay` flushes each write as its own frame (frame = datagram) and, on unreliable
+/// sockets, switches to unordered (arrival-order) delivery: datagram payloads (e.g.
+/// UDP/WireGuard) tolerate reordering, so a late frame must not stall or discard the
+/// frames around it. Reliable (retransmission) sockets always keep in-order delivery:
+/// their duplicate suppression relies on the ordered receive path, and skipping it would
+/// let retransmitted frames be delivered to the application twice.
+fn session_socket_config(cfg: &HoprSessionConfig, reliable: bool) -> SessionSocketConfig {
+    let no_delay = cfg.capabilities.contains(Capability::NoDelay);
+    SessionSocketConfig {
+        frame_size: cfg.frame_mtu,
+        frame_timeout: cfg.frame_timeout,
+        capacity: SESSION_SOCKET_CAPACITY,
+        flush_immediately: no_delay,
+        deliver_in_order: !no_delay || reliable,
+        ..Default::default()
+    }
+}
+
 /// Indicates the closure reason of a [`HoprSession`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq, strum::Display)]
 pub enum ClosureReason {
@@ -223,26 +243,14 @@ impl HoprSession {
 
         // Based on the requested capabilities, see if we should use the Session protocol
         let inner: Box<dyn AsyncReadWrite> = if cfg.capabilities.contains(Capability::Segmentation) {
-            // `NoDelay` flushes each write as its own frame (frame = datagram), which is
-            // exactly the precondition that makes unordered delivery safe: datagram payloads
-            // (e.g. UDP/WireGuard) tolerate reordering, so frames are delivered in arrival
-            // order rather than sequenced and discarded on a gap. Without `NoDelay`, writes
-            // coalesce into frames (frame != datagram) and strict ordering must be preserved.
-            let no_delay = cfg.capabilities.contains(Capability::NoDelay);
-            let socket_cfg = SessionSocketConfig {
-                frame_size: cfg.frame_mtu,
-                frame_timeout: cfg.frame_timeout,
-                capacity: SESSION_SOCKET_CAPACITY,
-                flush_immediately: no_delay,
-                deliver_in_order: !no_delay,
-                ..Default::default()
-            };
-
             // Need to test the capabilities separately, because any Retransmission capability
             // implies Segmentation, and therefore `is_disjoint` would fail
-            if cfg.capabilities.contains(Capability::RetransmissionAck)
-                || cfg.capabilities.contains(Capability::RetransmissionNack)
-            {
+            let reliable = cfg.capabilities.contains(Capability::RetransmissionAck)
+                || cfg.capabilities.contains(Capability::RetransmissionNack);
+
+            let socket_cfg = session_socket_config(&cfg, reliable);
+
+            if reliable {
                 // TODO: update config values
                 let ack_cfg = AcknowledgementStateConfig {
                     // This is a very coarse assumption, that a single 3-hop packet
@@ -680,6 +688,38 @@ mod tests {
         assert_eq!(bob_sent, alice_recv);
 
         Ok(())
+    }
+
+    #[test]
+    fn no_delay_capability_maps_to_unordered_delivery_only_without_retransmission() {
+        // Plain NoDelay (datagram use-case): immediate flushing, arrival-order delivery.
+        let cfg = HoprSessionConfig {
+            capabilities: Capability::NoDelay.into(),
+            ..Default::default()
+        };
+        let socket_cfg = session_socket_config(&cfg, false);
+        assert!(socket_cfg.flush_immediately);
+        assert!(!socket_cfg.deliver_in_order);
+
+        // Segmentation only: buffered, strictly ordered.
+        let cfg = HoprSessionConfig {
+            capabilities: Capability::Segmentation.into(),
+            ..Default::default()
+        };
+        let socket_cfg = session_socket_config(&cfg, false);
+        assert!(!socket_cfg.flush_immediately);
+        assert!(socket_cfg.deliver_in_order);
+
+        // NoDelay combined with a retransmission capability (reliable socket): the
+        // reliability layer requires the ordered receive path, so only the flushing
+        // behavior of NoDelay applies.
+        let cfg = HoprSessionConfig {
+            capabilities: Capability::NoDelay | Capability::RetransmissionAck,
+            ..Default::default()
+        };
+        let socket_cfg = session_socket_config(&cfg, true);
+        assert!(socket_cfg.flush_immediately);
+        assert!(socket_cfg.deliver_in_order);
     }
 
     #[test_log::test(tokio::test)]

--- a/transport/session/src/types.rs
+++ b/transport/session/src/types.rs
@@ -223,11 +223,18 @@ impl HoprSession {
 
         // Based on the requested capabilities, see if we should use the Session protocol
         let inner: Box<dyn AsyncReadWrite> = if cfg.capabilities.contains(Capability::Segmentation) {
+            // `NoDelay` flushes each write as its own frame (frame = datagram), which is
+            // exactly the precondition that makes unordered delivery safe: datagram payloads
+            // (e.g. UDP/WireGuard) tolerate reordering, so frames are delivered in arrival
+            // order rather than sequenced and discarded on a gap. Without `NoDelay`, writes
+            // coalesce into frames (frame != datagram) and strict ordering must be preserved.
+            let no_delay = cfg.capabilities.contains(Capability::NoDelay);
             let socket_cfg = SessionSocketConfig {
                 frame_size: cfg.frame_mtu,
                 frame_timeout: cfg.frame_timeout,
                 capacity: SESSION_SOCKET_CAPACITY,
-                flush_immediately: cfg.capabilities.contains(Capability::NoDelay),
+                flush_immediately: no_delay,
+                deliver_in_order: !no_delay,
                 ..Default::default()
             };
 
@@ -627,6 +634,92 @@ mod tests {
             DestinationRouting::Return(id.into()),
             HoprSessionConfig {
                 capabilities: Capability::Segmentation.into(),
+                ..Default::default()
+            },
+            (
+                bob_tx,
+                bob_rx
+                    .map(|(_, data)| ApplicationDataIn {
+                        data: data.data,
+                        packet_info: Default::default(),
+                    })
+                    .inspect(|d| debug!("bob rcvd: {}", d.data.total_len())),
+            ),
+            None,
+        )?;
+
+        let alice_sent = hopr_api::types::crypto_random::random_bytes::<DATA_LEN>();
+        let bob_sent = hopr_api::types::crypto_random::random_bytes::<DATA_LEN>();
+
+        let mut bob_recv = [0u8; DATA_LEN];
+        let mut alice_recv = [0u8; DATA_LEN];
+
+        tokio::time::timeout(Duration::from_secs(1), alice_session.write_all(&alice_sent))
+            .await
+            .context("alice write failed")?
+            .context("alice write timed out")?;
+        alice_session.flush().await?;
+
+        tokio::time::timeout(Duration::from_secs(1), bob_session.write_all(&bob_sent))
+            .await
+            .context("bob write failed")?
+            .context("bob write timed out")?;
+        bob_session.flush().await?;
+
+        tokio::time::timeout(Duration::from_secs(1), bob_session.read_exact(&mut bob_recv))
+            .await
+            .context("bob read failed")?
+            .context("bob read timed out")?;
+
+        tokio::time::timeout(Duration::from_secs(1), alice_session.read_exact(&mut alice_recv))
+            .await
+            .context("alice read failed")?
+            .context("alice read timed out")?;
+
+        assert_eq!(alice_sent, bob_recv);
+        assert_eq!(bob_sent, alice_recv);
+
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_session_bidirectional_flow_with_no_delay() -> anyhow::Result<()> {
+        // NoDelay implies Segmentation and switches the socket to immediate flushing and
+        // unordered (arrival-order) delivery. Over the in-order in-memory transport used
+        // here, arrival order equals send order, so byte-exact assertions remain valid;
+        // the unordered delivery semantics themselves are covered by the socket tests in
+        // `hopr-protocol-session`.
+        let dst: Address = (&ChainKeypair::random()).into();
+        let id: SessionId = HoprPseudonym::random();
+        const DATA_LEN: usize = 5000;
+
+        let (alice_tx, bob_rx) = futures::channel::mpsc::unbounded::<(DestinationRouting, ApplicationDataOut)>();
+        let (bob_tx, alice_rx) = futures::channel::mpsc::unbounded::<(DestinationRouting, ApplicationDataOut)>();
+
+        let mut alice_session = HoprSession::new(
+            id,
+            DestinationRouting::forward_only(dst, RoutingOptions::Hops(0.try_into()?)),
+            HoprSessionConfig {
+                capabilities: Capability::NoDelay.into(),
+                ..Default::default()
+            },
+            (
+                alice_tx,
+                alice_rx
+                    .map(|(_, data)| ApplicationDataIn {
+                        data: data.data,
+                        packet_info: Default::default(),
+                    })
+                    .inspect(|d| debug!("alice rcvd: {}", d.data.total_len())),
+            ),
+            None,
+        )?;
+
+        let mut bob_session = HoprSession::new(
+            id,
+            DestinationRouting::Return(id.into()),
+            HoprSessionConfig {
+                capabilities: Capability::NoDelay.into(),
                 ..Default::default()
             },
             (


### PR DESCRIPTION
This is a port of the original PR https://github.com/hoprnet/hoprnet/pull/8150

Removes ordering of frames in sessions which use NoDelay/Segmentation. The assumption is that any application using such session will handle out of order itself.