### PR TITLE
feat: migrate to hopr-types 2.0.0 and remove direct elliptic-curve deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2231,9 +2231,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,15 +30,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "aes"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "aes-gcm"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
  "aead",
- "aes",
+ "aes 0.8.4",
  "cipher 0.4.4",
- "ctr",
+ "ctr 0.9.2",
  "ghash",
  "subtle",
 ]
@@ -154,7 +165,7 @@ dependencies = [
  "c-kzg",
  "derive_more",
  "either",
- "k256",
+ "k256 0.13.4",
  "once_cell",
  "rand 0.8.6",
  "secp256k1 0.30.0",
@@ -264,7 +275,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "borsh",
- "k256",
+ "k256 0.13.4",
  "serde",
  "thiserror 2.0.18",
 ]
@@ -412,7 +423,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "alloy-signer-local",
- "k256",
+ "k256 0.13.4",
  "libc",
  "rand 0.8.6",
  "serde_json",
@@ -437,7 +448,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
  "itoa",
- "k256",
+ "k256 0.13.4",
  "keccak-asm",
  "paste",
  "proptest",
@@ -617,8 +628,8 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "either",
- "elliptic-curve",
- "k256",
+ "elliptic-curve 0.13.8",
+ "k256 0.13.4",
  "thiserror 2.0.18",
 ]
 
@@ -633,7 +644,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-signer",
  "async-trait",
- "k256",
+ "k256 0.13.4",
  "rand 0.8.6",
  "thiserror 2.0.18",
 ]
@@ -875,6 +886,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-bn254"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-poly",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.5",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1001,6 +1044,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-poly"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+dependencies = [
+ "ahash",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "ark-serialize"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,10 +1085,22 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
 dependencies = [
+ "ark-serialize-derive",
  "ark-std 0.5.0",
  "arrayvec",
  "digest 0.10.7",
  "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1077,9 +1147,9 @@ checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "asn1-rs"
@@ -1332,6 +1402,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "babyjubjub-ec"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e657c11493f07dd18f0c6055b58e77ca71e30ed34f2804468b22f89e36dc0a"
+dependencies = [
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "elliptic-curve 0.14.1",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hash2curve",
+ "num-traits",
+ "rand_core 0.10.1",
+ "serde",
+ "serdect 0.4.3",
+ "sha2 0.11.0",
+ "subtle",
+ "taceo-ark-babyjubjub",
+]
+
+[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,6 +1454,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
 
 [[package]]
 name = "base256emoji"
@@ -1470,17 +1568,17 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.3"
+version = "1.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2468ef7d57b3fb7e16b576e8377cdbde2320c60e1491e961d11da40fc4f02a2d"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
 dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -1518,12 +1616,12 @@ dependencies = [
  "futures",
  "futures-time",
  "hex",
- "hopr-types",
+ "hopr-types 1.11.2",
  "http",
  "indexmap 2.14.0",
  "launchdarkly-sdk-transport",
  "parking_lot",
- "rand 0.10.1",
+ "rand 0.10.2",
  "reqwest",
  "semver 1.0.28",
  "serde",
@@ -1725,11 +1823,12 @@ dependencies = [
 
 [[package]]
 name = "chacha20"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
 dependencies = [
  "cfg-if",
+ "cipher 0.5.2",
  "cpufeatures 0.3.0",
  "rand_core 0.10.1",
 ]
@@ -1743,7 +1842,7 @@ dependencies = [
  "aead",
  "chacha20 0.9.1",
  "cipher 0.4.4",
- "poly1305",
+ "poly1305 0.8.0",
  "zeroize",
 ]
 
@@ -1801,12 +1900,12 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34d8227fe1ba289043aeb13792056ff80fd6de1a9f49137a5f499de8e8c78ea"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
  "block-buffer 0.12.0",
- "crypto-common 0.2.1",
+ "crypto-common 0.2.2",
  "inout 0.2.2",
 ]
 
@@ -1949,6 +2048,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-str"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2015,6 +2120,12 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -2166,6 +2277,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
+dependencies = [
+ "cpubits",
+ "ctutils",
+ "getrandom 0.4.2",
+ "hybrid-array",
+ "num-traits",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2178,11 +2305,13 @@ dependencies = [
 
 [[package]]
 name = "crypto-common"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
+ "getrandom 0.4.2",
  "hybrid-array",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2195,12 +2324,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaca1c4b237092596f64d571e9db6ce4109c4ef9742e27590f1709594461f21"
+dependencies = [
+ "cipher 0.5.2",
+]
+
+[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+ "subtle",
 ]
 
 [[package]]
@@ -2213,8 +2352,24 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
- "rand_core 0.6.4",
+ "fiat-crypto 0.2.9",
+ "rustc_version 0.4.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
+ "rand_core 0.10.1",
  "rustc_version 0.4.1",
  "serde",
  "subtle",
@@ -2403,7 +2558,17 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
  "zeroize",
 ]
 
@@ -2492,7 +2657,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
- "const-oid",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
  "subtle",
 ]
@@ -2504,7 +2669,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer 0.12.0",
- "crypto-common 0.2.1",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
  "ctutils",
 ]
 
@@ -2549,13 +2715,29 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
- "elliptic-curve",
- "rfc6979",
- "serdect",
- "signature",
- "spki",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "serdect 0.2.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0681a4fc24c767085329728d8dfba959af91228aa4610cca4f8ce317ba46ae0"
+dependencies = [
+ "der 0.8.1",
+ "digest 0.11.3",
+ "elliptic-curve 0.14.1",
+ "rfc6979 0.6.0",
+ "serdect 0.4.3",
+ "signature 3.0.0",
+ "spki 0.8.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -2564,9 +2746,19 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "serde",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "pkcs8 0.11.0",
+ "serdect 0.4.3",
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -2575,12 +2767,28 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
- "merlin",
- "rand_core 0.6.4",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "serde",
  "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "ed25519 3.0.0",
+ "keccak",
+ "rand_core 0.10.1",
+ "serde",
+ "sha2 0.11.0",
+ "signature 3.0.0",
+ "strobe-rs",
  "subtle",
  "zeroize",
 ]
@@ -2612,17 +2820,38 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
  "digest 0.10.7",
- "ff",
+ "ff 0.13.1",
  "generic-array 0.14.7",
- "group",
- "hkdf",
- "pkcs8",
+ "group 0.13.0",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
- "serdect",
+ "sec1 0.7.3",
+ "serdect 0.2.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d65aa39b3a5c1c9c1b745c9a019234bb7a21b77abcb4f4d266d706e2d577d65"
+dependencies = [
+ "base16ct 1.0.0",
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "digest 0.11.3",
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hkdf 0.13.0",
+ "hybrid-array",
+ "pkcs8 0.11.0",
+ "rand_core 0.10.1",
+ "sec1 0.8.1",
+ "serdect 0.4.3",
  "subtle",
  "zeroize",
 ]
@@ -2778,7 +3007,7 @@ dependencies = [
  "launchdarkly-sdk-transport",
  "log",
  "pin-project",
- "rand 0.10.1",
+ "rand 0.10.2",
  "tokio",
 ]
 
@@ -2821,10 +3050,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ff"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1f686ab92a9fb0eaf188f6c6c87b89490baa6fdb0db4544ba4dc47f7942489f"
+dependencies = [
+ "rand_core 0.10.1",
+ "subtle",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
@@ -3117,7 +3362,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2e55f16dcf0e9c00efbe2e655ffe45fc98e7066b52bc92f8a79e64060a79351"
 dependencies = [
  "rustversion",
- "serde_core",
  "typenum",
  "zeroize",
 ]
@@ -3207,8 +3451,20 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fd1a1c7a5206c5b7a3f5a0d7ccd3ff85d0c8f5133d62a02680255b0004af5f4"
+dependencies = [
+ "ff 0.14.0",
+ "rand 0.10.2",
+ "rand_core 0.10.1",
  "subtle",
 ]
 
@@ -3252,6 +3508,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash2curve"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1eaf40612d7d854743e7189228a6d528f0f6e8502cf6a0cb831d28a218b7f3f6"
+dependencies = [
+ "digest 0.11.3",
+ "elliptic-curve 0.14.1",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3269,6 +3535,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
  "foldhash 0.1.5",
  "rayon",
 ]
@@ -3361,7 +3628,7 @@ dependencies = [
  "idna",
  "ipnet",
  "jni",
- "rand 0.10.1",
+ "rand 0.10.2",
  "thiserror 2.0.18",
  "tinyvec",
  "tokio",
@@ -3407,7 +3674,7 @@ dependencies = [
  "jni",
  "once_cell",
  "prefix-trie",
- "rand 0.10.1",
+ "rand 0.10.2",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
@@ -3453,7 +3720,7 @@ dependencies = [
  "ndk-context",
  "once_cell",
  "parking_lot",
- "rand 0.10.1",
+ "rand 0.10.2",
  "resolv-conf",
  "smallvec",
  "system-configuration",
@@ -3469,6 +3736,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
  "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -3491,9 +3767,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3161efd861baef8d2ca18cddf9fe8699ad36d737635132ce41486a28c2d0c89"
+checksum = "8c76f9c17f903a3a0487c7eb0766914baf94380cd7a9112043310e4bc4dc9547"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -3501,7 +3777,7 @@ dependencies = [
  "chrono",
  "futures",
  "futures-concurrency",
- "hopr-types",
+ "hopr-types 2.0.0",
  "libp2p-identity",
  "multiaddr",
  "serde",
@@ -3571,14 +3847,10 @@ dependencies = [
  "bimap",
  "const-hex",
  "criterion",
- "curve25519-dalek",
- "elliptic-curve",
  "flagset",
- "generic-array 1.4.3",
  "hex-literal",
- "hopr-types",
+ "hopr-types 2.0.0",
  "hopr-utils",
- "k256",
  "lazy_static",
  "mimalloc",
  "parameterized",
@@ -3591,7 +3863,6 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tracing",
- "typenum",
 ]
 
 [[package]]
@@ -3660,7 +3931,7 @@ dependencies = [
  "opentelemetry-prometheus-text-exporter",
  "opentelemetry_sdk",
  "parking_lot",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rstest",
  "serde",
  "serde-saphyr",
@@ -3692,7 +3963,7 @@ dependencies = [
  "insta",
  "parking_lot",
  "petgraph",
- "rand 0.10.1",
+ "rand 0.10.2",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -3705,7 +3976,7 @@ version = "1.0.1"
 dependencies = [
  "anyhow",
  "hopr-crypto-packet",
- "hopr-types",
+ "hopr-types 2.0.0",
  "serde",
  "serde_bytes",
  "strum 0.28.0",
@@ -3766,7 +4037,7 @@ dependencies = [
  "hex-literal",
  "hopr-crypto-packet",
  "hopr-protocol-app",
- "hopr-types",
+ "hopr-types 2.0.0",
  "hopr-utils",
  "indexmap 2.14.0",
  "insta",
@@ -3776,7 +4047,7 @@ dependencies = [
  "parameterized",
  "parking_lot",
  "pin-project",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rand_distr",
  "ringbuffer",
  "serde",
@@ -3873,7 +4144,7 @@ dependencies = [
  "hopr-utils",
  "parking_lot",
  "postcard",
- "rand 0.10.1",
+ "rand 0.10.2",
  "redb",
  "serde",
  "serde_json",
@@ -3952,7 +4223,7 @@ dependencies = [
  "criterion",
  "futures",
  "futures-timer",
- "hopr-types",
+ "hopr-types 2.0.0",
  "humantime-serde",
  "insta",
  "lazy_static",
@@ -4016,7 +4287,7 @@ dependencies = [
  "lazy_static",
  "moka",
  "more-asserts",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rstest",
  "serde",
  "smart-default",
@@ -4053,7 +4324,7 @@ dependencies = [
  "parking_lot",
  "pid",
  "pin-project",
- "rand 0.10.1",
+ "rand 0.10.2",
  "serde",
  "serde_repr",
  "smart-default",
@@ -4081,30 +4352,80 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "1.9.3"
+version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c842b389c9b2b84349733cb67712ae0699f6a6b756670e742206cd7ac447acd2"
+checksum = "ffe8de530de5d86e896cc67ffa9b57496626d381112442800b18cd7b41e440c4"
 dependencies = [
- "aes",
+ "aes 0.9.1",
+ "aquamarine",
+ "arrayvec",
+ "async-trait",
+ "babyjubjub-ec",
+ "bigdecimal",
+ "blake3",
+ "chacha20 0.10.1",
+ "chrono",
+ "cipher 0.5.2",
+ "const-hex",
+ "ctr 0.10.1",
+ "curve25519-dalek 5.0.0",
+ "digest 0.11.3",
+ "ed25519-dalek 3.0.0",
+ "float-cmp",
+ "generic-array 1.4.3",
+ "hash2curve",
+ "hex-literal",
+ "k256 0.14.0",
+ "lazy_static",
+ "libp2p-identity",
+ "multiaddr",
+ "num_enum",
+ "poly1305 0.9.1",
+ "primitive-types 0.14.0",
+ "rand 0.10.2",
+ "rayon",
+ "regex",
+ "secp256k1 0.31.1",
+ "sha2 0.11.0",
+ "sha3 0.12.0",
+ "smart-default",
+ "strum 0.28.0",
+ "subtle",
+ "thiserror 2.0.18",
+ "tracing",
+ "typenum",
+ "zeroize",
+]
+
+[[package]]
+name = "hopr-types"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e24293a5ce7289056c4e01b8d91beebc8663cdcca8ffbc24d847f3f22af4f274"
+dependencies = [
+ "aes 0.9.1",
  "anyhow",
  "aquamarine",
  "arrayvec",
  "async-trait",
+ "babyjubjub-ec",
  "bigdecimal",
  "blake3",
- "chacha20 0.9.1",
+ "chacha20 0.10.1",
  "chrono",
- "cipher 0.4.4",
+ "cipher 0.5.2",
  "const-hex",
- "ctr",
- "curve25519-dalek",
- "digest 0.10.7",
- "ed25519-dalek",
+ "ctr 0.10.1",
+ "curve25519-dalek 5.0.0",
+ "digest 0.11.3",
+ "ed25519-dalek 3.0.0",
+ "elliptic-curve 0.14.1",
  "float-cmp",
- "generic-array 1.4.3",
+ "hash2curve",
  "hex-literal",
  "hopr-bindings",
- "k256",
+ "hybrid-array",
+ "k256 0.14.0",
  "lazy_static",
  "libp2p-identity",
  "multiaddr",
@@ -4112,19 +4433,20 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-prometheus-text-exporter",
  "opentelemetry_sdk",
- "poly1305",
+ "poly1305 0.9.1",
  "primitive-types 0.14.0",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rayon",
  "regex",
+ "rlp 0.6.1",
  "scrypt",
  "secp256k1 0.31.1",
  "serde",
  "serde_bytes",
  "serde_json",
  "serde_with",
- "sha2 0.10.9",
- "sha3 0.10.9",
+ "sha2 0.11.0",
+ "sha3 0.12.0",
  "smart-default",
  "strum 0.28.0",
  "subtle",
@@ -4149,7 +4471,7 @@ dependencies = [
  "futures",
  "futures-time",
  "hickory-resolver 0.26.1",
- "hopr-types",
+ "hopr-types 2.0.0",
  "indexmap 2.14.0",
  "lazy_static",
  "libc",
@@ -4158,7 +4480,7 @@ dependencies = [
  "parameterized",
  "pcap-file",
  "pin-project",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rayon",
  "serde",
  "serde_bytes",
@@ -4270,7 +4592,10 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
 dependencies = [
+ "serde",
+ "subtle",
  "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -4790,21 +5115,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e3919bbaa2945715f0bb6d3934a173d1e9a59ac23767fbaaef277265a7411b"
 dependencies = [
  "cfg-if",
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
  "once_cell",
- "serdect",
+ "serdect 0.2.0",
  "sha2 0.10.9",
- "signature",
 ]
 
 [[package]]
-name = "keccak"
-version = "0.1.6"
+name = "k256"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
+checksum = "93f50113171a713f4a4231ef82eb26703607139b35dcb56241f0ceab2ae1f7d8"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cpubits",
+ "ecdsa 0.17.0",
+ "elliptic-curve 0.14.1",
+ "hash2curve",
+ "primeorder",
+ "serdect 0.4.3",
+ "sha2 0.11.0",
+ "signature 3.0.0",
+ "wnaf",
 ]
 
 [[package]]
@@ -5045,8 +5377,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9525f3831544f7ae497bde79adf114ef127b0fbbb97edbbf692a80408636421c"
 dependencies = [
  "bs58",
- "ed25519-dalek",
- "hkdf",
+ "ed25519-dalek 2.2.0",
+ "hkdf 0.12.4",
  "multihash",
  "prost",
  "rand 0.8.6",
@@ -5377,18 +5709,6 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
-
-[[package]]
-name = "merlin"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58c38e2799fc0978b65dfff8023ec7843e2330bb462f19198840b34b6582397d"
-dependencies = [
- "byteorder",
- "keccak 0.1.6",
- "rand_core 0.6.4",
- "zeroize",
-]
 
 [[package]]
 name = "mimalloc"
@@ -6073,8 +6393,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -6105,7 +6435,17 @@ checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
+]
+
+[[package]]
+name = "poly1305"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2d0073b297041425c7c3df6eb4792d598a15323fe63346852b092eca02904c"
+dependencies = [
+ "cpufeatures 0.3.0",
+ "universal-hash 0.6.1",
 ]
 
 [[package]]
@@ -6117,7 +6457,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "opaque-debug",
- "universal-hash",
+ "universal-hash 0.5.1",
 ]
 
 [[package]]
@@ -6207,6 +6547,33 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "primefield"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c555a6e4eb7d4e158fcb028c835c3b8642206ddc279b5c6b202ef9a8bdb592f4"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "crypto-common 0.2.2",
+ "ff 0.14.0",
+ "rand_core 0.10.1",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c9f42978c78a00e3d68f69fc03e57a234debae69da4020a4fb588fcdcd07b06"
+dependencies = [
+ "elliptic-curve 0.14.1",
+ "once_cell",
+ "primefield",
+ "serdect 0.4.3",
+ "wnaf",
 ]
 
 [[package]]
@@ -6512,11 +6879,11 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "chacha20 0.10.0",
+ "chacha20 0.10.1",
  "getrandom 0.4.2",
  "rand_core 0.10.1",
 ]
@@ -6573,7 +6940,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d431c2703ccf129de4d45253c03f49ebb22b97d6ad79ee3ecfc7e3f4862c1d8"
 dependencies = [
  "num-traits",
- "rand 0.10.1",
+ "rand 0.10.2",
 ]
 
 [[package]]
@@ -6667,9 +7034,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -6766,6 +7133,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4a459cddafb3fe76b31fd8f1108007566c40301feb64dc7b54656eb7388172b"
+dependencies = [
+ "crypto-bigint 0.7.5",
+ "hmac 0.13.0",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6790,6 +7167,16 @@ name = "rlp"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
+dependencies = [
+ "bytes",
+ "rustc-hex",
+]
+
+[[package]]
+name = "rlp"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa24e92bb2a83198bb76d661a71df9f7076b8c420b8696e4d3d97d50d94479e3"
 dependencies = [
  "bytes",
  "rustc-hex",
@@ -6863,7 +7250,7 @@ dependencies = [
  "proptest",
  "rand 0.8.6",
  "rand 0.9.4",
- "rlp",
+ "rlp 0.5.2",
  "ruint-macro",
  "serde_core",
  "valuable",
@@ -7050,7 +7437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f874456e72520ff1375a06c588eaf074b0f01f9e9e1aada45bd9b7954a6e42c"
 dependencies = [
  "cfg-if",
- "cipher 0.5.1",
+ "cipher 0.5.2",
 ]
 
 [[package]]
@@ -7120,11 +7507,26 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.10",
  "generic-array 0.14.7",
- "pkcs8",
- "serdect",
+ "pkcs8 0.10.2",
+ "serdect 0.2.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "sec1"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56d437c2f19203ce5f7122e507831de96f3d2d4d3be5af44a0b0a09d8a80e4d"
+dependencies = [
+ "base16ct 1.0.0",
+ "ctutils",
+ "der 0.8.1",
+ "hybrid-array",
+ "serdect 0.4.3",
  "subtle",
  "zeroize",
 ]
@@ -7348,7 +7750,17 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
+ "serde",
+]
+
+[[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
  "serde",
 ]
 
@@ -7401,22 +7813,23 @@ dependencies = [
 
 [[package]]
 name = "sha3"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
-dependencies = [
- "digest 0.10.7",
- "keccak 0.1.6",
-]
-
-[[package]]
-name = "sha3"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
  "digest 0.11.3",
- "keccak 0.2.0",
+ "keccak",
+]
+
+[[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
+ "sponge-cursor",
 ]
 
 [[package]]
@@ -7462,6 +7875,16 @@ checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "digest 0.11.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -7544,7 +7967,7 @@ dependencies = [
  "aes-gcm",
  "blake2",
  "chacha20poly1305",
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "ring",
  "rustc_version 0.4.1",
@@ -7588,8 +8011,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
+]
+
+[[package]]
+name = "sponge-cursor"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0219bd7d979d58245a4f41f695e1ac9f8befdffadd7f61f1bae9e39abc6620"
 
 [[package]]
 name = "stable_deref_trait"
@@ -7602,6 +8041,19 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
+name = "strobe-rs"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83561175f0a962dea437885589480d216d8741debf853e0d36edd526344fd273"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "keccak",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "strsim"
@@ -7736,6 +8188,18 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "taceo-ark-babyjubjub"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b5a2cc31c90e79778c4f6375e5d9828171d320db3f8c911a8ad47af4a70069"
+dependencies = [
+ "ark-bn254",
+ "ark-ec",
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
 ]
 
 [[package]]
@@ -7989,7 +8453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a129d95275ebf4c493ec53bf0f8cd95f5ac161bc4f381700809a54f595d4470"
 dependencies = [
  "pin-project-lite",
- "rand 0.10.1",
+ "rand 0.10.2",
  "tokio",
 ]
 
@@ -8252,6 +8716,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "universal-hash"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4987bdc12753382e0bec4a65c50738ffaabc998b9cdd1f952fb5f39b0048a96"
+dependencies = [
+ "crypto-common 0.2.2",
+ "ctutils",
+]
+
+[[package]]
 name = "unsigned-varint"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8296,9 +8770,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -8963,6 +9437,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wnaf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab12e7090f27e2ffd9322651492942d50c2926094af30601e1964337db39daf1"
+dependencies = [
+ "ff 0.14.0",
+ "group 0.14.0",
+ "hybrid-array",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8983,7 +9468,7 @@ version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
 dependencies = [
- "curve25519-dalek",
+ "curve25519-dalek 4.1.3",
  "rand_core 0.6.4",
  "serde",
  "zeroize",
@@ -9133,18 +9618,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,7 +94,6 @@ criterion = { version = "0.8.2", default-features = false, features = [
   "async_tokio",
 ] }
 crossfire = { version = "3.1.18", default-features = false }
-curve25519-dalek = { version = "4.1.3", features = ["rand_core"] }
 dashmap = { version = "6.2.1", features = ["inline"] }
 flagset = "0.4.7"
 flume = { version = "0.12.0", default-features = false, features = ["async"] }
@@ -105,7 +104,6 @@ futures = { version = "0.3.32", default-features = false, features = [
 futures-concurrency = "7.7.1"
 futures-time = "3.1.0"
 futures-timer = "3.0.4"
-generic-array = "1.4.3"
 halfbrown = "0.4.0"
 hashbrown = "0.17.1"
 hex-literal = "1.1.0"
@@ -116,7 +114,6 @@ human-bandwidth = { version = "0.1.4", features = ["serde"] }
 humantime-serde = "1.1.1"
 indexmap = { version = "2.14.0" }
 insta = { version = "1.48.0", features = ["yaml", "redactions"] }
-k256 = { version = "0.13.4", features = ["arithmetic", "ecdh", "hash2curve"] }
 lazy_static = "1.5.0"
 libc = "0.2" # intentionally minor-pinned
 libp2p = { version = "0.56.0", default-features = false }
@@ -186,11 +183,10 @@ tokio-util = { version = "0.7.18", default-features = false, features = [
   "compat",
 ] }
 tracing = { version = "0.1.44", features = ["release_max_level_debug"] }
-typenum = "1.20.1"
 validator = { version = "0.20.0", features = ["derive"] }
 
-hopr-api = "1.14.0"
-hopr-types = { version = "1.9.3", features = ["use-bindings"] }
+hopr-api = "1.15.0"
+hopr-types = { version = "2.0.0", features = ["use-bindings"] }
 hopr-utils = { version = "0.2.0", path = "utils", default-features = false }
 hopr-utils-session = { version = "1.2.1", path = "utils-session" }
 

--- a/crypto/packet/Cargo.toml
+++ b/crypto/packet/Cargo.toml
@@ -30,12 +30,7 @@ rayon = ["hopr-utils/parallelize-rayon"]
 ed25519 = []
 x25519 = []
 secp256k1 = []
-serde = [
-  "dep:serde",
-  "dep:serde_bytes",
-  "flagset/serde",
-  "hopr-types/serde",
-]
+serde = ["dep:serde", "dep:serde_bytes", "flagset/serde", "hopr-types/serde"]
 allocator-mimalloc = [
   "dep:mimalloc",
 ] # Use mimalloc as the global allocator on Linux

--- a/crypto/packet/Cargo.toml
+++ b/crypto/packet/Cargo.toml
@@ -34,10 +34,6 @@ serde = [
   "dep:serde",
   "dep:serde_bytes",
   "flagset/serde",
-  "generic-array/serde",
-  "elliptic-curve/serde",
-  "curve25519-dalek/serde",
-  "k256/serde",
   "hopr-types/serde",
 ]
 allocator-mimalloc = [
@@ -57,12 +53,7 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 
 bimap = { workspace = true }
-curve25519-dalek = { workspace = true }
-elliptic-curve = "0.13.8"
-generic-array = { workspace = true }
-k256 = { workspace = true, features = ["arithmetic", "ecdh", "hash2curve"] }
 subtle = { workspace = true }
-typenum = { workspace = true }
 
 hopr-utils = { workspace = true, features = ["parallelize"] }
 hopr-types = { workspace = true, features = [

--- a/crypto/packet/src/lib.rs
+++ b/crypto/packet/src/lib.rs
@@ -104,7 +104,7 @@ mod tests {
         );
 
         assert!(
-            hopr_packet_len <= 1492 - 32, // 32 bytes was measured as the libp2p QUIC overhead
+            hopr_packet_len <= 1492 - 31, // 31 bytes was measured as the libp2p QUIC overhead
             "HOPR packet of {hopr_packet_len} bytes must fit within a layer 4 packet with libp2p overhead"
         );
     }

--- a/crypto/packet/src/sphinx/ec_groups.rs
+++ b/crypto/packet/src/sphinx/ec_groups.rs
@@ -161,6 +161,7 @@ impl GroupElement<Secp256k1Scalar> for Secp256k1Point {
     type AlphaLen = hopr_types::primitive::typenum::U33;
 
     fn to_alpha(&self) -> Alpha<hopr_types::primitive::typenum::U33> {
+        debug_assert!(self.is_valid(), "to_alpha called on identity point");
         let mut ret = Alpha::<hopr_types::primitive::typenum::U33>::default();
         // Copy only if the point is not the identity, we do not care here about constant-time here.
         if !bool::from(self.0.is_identity()) {

--- a/crypto/packet/src/sphinx/ec_groups.rs
+++ b/crypto/packet/src/sphinx/ec_groups.rs
@@ -106,7 +106,10 @@ impl GroupElement<elliptic_curve::Scalar<Secp256k1>> for elliptic_curve::Project
 
     fn to_alpha(&self) -> Alpha<hopr_types::primitive::typenum::U33> {
         let mut ret = Alpha::<hopr_types::primitive::typenum::U33>::default();
-        ret.copy_from_slice(self.to_affine().to_sec1_point(true).as_ref());
+        // Copy only if the point is not the identity, we do not care here about constant-time here.
+        if !bool::from(self.is_identity()) {
+            ret.copy_from_slice(self.to_affine().to_sec1_point(true).as_ref());
+        }
         ret
     }
 

--- a/crypto/packet/src/sphinx/ec_groups.rs
+++ b/crypto/packet/src/sphinx/ec_groups.rs
@@ -1,4 +1,8 @@
 use hopr_types::crypto::errors::Result;
+#[cfg(feature = "x25519")]
+use hopr_types::crypto::primitives::Curve25519MontgomeryPoint;
+#[cfg(any(feature = "x25519", feature = "ed25519"))]
+use hopr_types::crypto::primitives::{Curve25519CompressedPoint, Curve25519Point, Curve25519Scalar, IsIdentity};
 #[cfg(feature = "secp256k1")]
 use {
     hopr_types::crypto::crypto_traits::elliptic_curve::{
@@ -8,12 +12,6 @@ use {
     },
     hopr_types::crypto::prelude::{CryptoError, Secp256k1},
 };
-#[cfg(any(feature = "x25519", feature = "ed25519"))]
-use hopr_types::crypto::primitives::{
-    Curve25519CompressedPoint, Curve25519Point, Curve25519Scalar, IsIdentity,
-};
-#[cfg(feature = "x25519")]
-use hopr_types::crypto::primitives::Curve25519MontgomeryPoint;
 
 use super::shared_keys::{Alpha, GroupElement, Scalar, SphinxSuite};
 
@@ -191,8 +189,8 @@ mod tests {
     #[cfg(feature = "secp256k1")]
     #[test]
     fn test_extract_key_from_group_element() {
-        use hopr_types::crypto::crypto_traits::elliptic_curve;
-        use hopr_types::crypto::prelude::Secp256k1;
+        use hopr_types::crypto::{crypto_traits::elliptic_curve, prelude::Secp256k1};
+
         use super::super::shared_keys::GroupElement;
 
         let salt = [0xde, 0xad, 0xbe, 0xef];
@@ -208,8 +206,8 @@ mod tests {
     #[cfg(feature = "secp256k1")]
     #[test]
     fn test_expand_key_from_group_element() {
-        use hopr_types::crypto::crypto_traits::elliptic_curve;
-        use hopr_types::crypto::prelude::Secp256k1;
+        use hopr_types::crypto::{crypto_traits::elliptic_curve, prelude::Secp256k1};
+
         use super::super::shared_keys::GroupElement;
 
         let salt = [0xde, 0xad, 0xbe, 0xef];

--- a/crypto/packet/src/sphinx/ec_groups.rs
+++ b/crypto/packet/src/sphinx/ec_groups.rs
@@ -1,19 +1,24 @@
 use hopr_types::crypto::errors::Result;
 #[cfg(feature = "secp256k1")]
 use {
-    elliptic_curve::{
-        Group,
-        ops::MulByGenerator,
-        sec1::{FromEncodedPoint, ToEncodedPoint},
+    hopr_types::crypto::crypto_traits::elliptic_curve::{
+        self, AffinePoint, Group,
+        field::FieldBytes,
+        sec1::{FromSec1Point, Sec1Point, ToSec1Point},
     },
-    hopr_types::crypto::prelude::CryptoError,
-    k256::{AffinePoint, EncodedPoint},
+    hopr_types::crypto::prelude::{CryptoError, Secp256k1},
 };
+#[cfg(any(feature = "x25519", feature = "ed25519"))]
+use hopr_types::crypto::primitives::{
+    Curve25519CompressedPoint, Curve25519Point, Curve25519Scalar, IsIdentity,
+};
+#[cfg(feature = "x25519")]
+use hopr_types::crypto::primitives::Curve25519MontgomeryPoint;
 
 use super::shared_keys::{Alpha, GroupElement, Scalar, SphinxSuite};
 
 #[cfg(any(feature = "x25519", feature = "ed25519"))]
-impl Scalar for curve25519_dalek::scalar::Scalar {
+impl Scalar for Curve25519Scalar {
     fn random() -> Self {
         let bytes = hopr_types::crypto_random::random_bytes::<32>();
         Self::from_bytes(&bytes).unwrap()
@@ -25,19 +30,19 @@ impl Scalar for curve25519_dalek::scalar::Scalar {
 }
 
 #[cfg(feature = "secp256k1")]
-impl Scalar for k256::Scalar {
+impl Scalar for elliptic_curve::Scalar<Secp256k1> {
     fn random() -> Self {
         // Beware, this is not constant-time
         let mut rng = hopr_types::crypto_random::rng();
-        let mut bytes = k256::FieldBytes::default();
+        let mut bytes = FieldBytes::<Secp256k1>::default();
         use elliptic_curve::PrimeField;
         use hopr_types::crypto_random::Rng;
         // Needs manual implementation due to incompatible rand crates
-        // k256::Scalar::generate_vartime(&mut hopr_types::crypto_random::rng())
+        // elliptic_curve::Scalar::<Secp256k1>::generate_vartime(&mut hopr_types::crypto_random::rng())
 
         loop {
             rng.fill_bytes(&mut bytes);
-            if let Some(scalar) = k256::Scalar::from_repr(bytes).into() {
+            if let Some(scalar) = elliptic_curve::Scalar::<Secp256k1>::from_repr(bytes).into() {
                 return scalar;
             }
         }
@@ -49,77 +54,77 @@ impl Scalar for k256::Scalar {
 }
 
 #[cfg(feature = "x25519")]
-impl GroupElement<curve25519_dalek::scalar::Scalar> for curve25519_dalek::MontgomeryPoint {
-    type AlphaLen = typenum::U32;
+impl GroupElement<Curve25519Scalar> for Curve25519MontgomeryPoint {
+    type AlphaLen = hopr_types::primitive::typenum::U32;
 
-    fn to_alpha(&self) -> Alpha<typenum::U32> {
+    fn to_alpha(&self) -> Alpha<hopr_types::primitive::typenum::U32> {
         self.0.into()
     }
 
-    fn from_alpha(alpha: Alpha<typenum::U32>) -> Result<Self> {
-        Ok(curve25519_dalek::MontgomeryPoint(alpha.into()))
+    fn from_alpha(alpha: Alpha<hopr_types::primitive::typenum::U32>) -> Result<Self> {
+        Ok(Curve25519MontgomeryPoint(alpha.into()))
     }
 
-    fn generate(scalar: &curve25519_dalek::scalar::Scalar) -> Self {
-        curve25519_dalek::EdwardsPoint::mul_base(scalar).to_montgomery()
+    fn generate(scalar: &Curve25519Scalar) -> Self {
+        Curve25519Point::mul_base(scalar).to_montgomery()
     }
 
     fn is_valid(&self) -> bool {
-        use curve25519_dalek::traits::IsIdentity;
+        use IsIdentity;
         !self.is_identity()
     }
 }
 
 #[cfg(feature = "ed25519")]
-impl GroupElement<curve25519_dalek::scalar::Scalar> for curve25519_dalek::EdwardsPoint {
-    type AlphaLen = typenum::U32;
+impl GroupElement<Curve25519Scalar> for Curve25519Point {
+    type AlphaLen = hopr_types::primitive::typenum::U32;
 
-    fn to_alpha(&self) -> Alpha<typenum::U32> {
+    fn to_alpha(&self) -> Alpha<hopr_types::primitive::typenum::U32> {
         self.compress().0.into()
     }
 
-    fn from_alpha(alpha: Alpha<typenum::U32>) -> Result<Self> {
-        curve25519_dalek::edwards::CompressedEdwardsY(alpha.into())
+    fn from_alpha(alpha: Alpha<hopr_types::primitive::typenum::U32>) -> Result<Self> {
+        Curve25519CompressedPoint(alpha.into())
             .decompress()
             .ok_or(hopr_types::crypto::errors::CryptoError::InvalidInputValue("alpha"))
     }
 
-    fn generate(scalar: &curve25519_dalek::scalar::Scalar) -> Self {
-        curve25519_dalek::EdwardsPoint::mul_base(scalar)
+    fn generate(scalar: &Curve25519Scalar) -> Self {
+        Curve25519Point::mul_base(scalar)
     }
 
     fn is_valid(&self) -> bool {
         // Ed25519 scalars always come clamped (pre-multiplied by the curve's co-factor)
         // and therefore cannot result into points of small order.
         // See `x25519_scalar_from_bytes` for more details.
-        use curve25519_dalek::traits::IsIdentity;
+        use IsIdentity;
         !self.is_identity()
     }
 }
 
 #[cfg(feature = "secp256k1")]
-impl GroupElement<k256::Scalar> for k256::ProjectivePoint {
-    type AlphaLen = typenum::U33;
+impl GroupElement<elliptic_curve::Scalar<Secp256k1>> for elliptic_curve::ProjectivePoint<Secp256k1> {
+    type AlphaLen = hopr_types::primitive::typenum::U33;
 
-    fn to_alpha(&self) -> Alpha<typenum::U33> {
-        let mut ret = Alpha::<typenum::U33>::default();
-        ret.copy_from_slice(self.to_affine().to_encoded_point(true).as_ref());
+    fn to_alpha(&self) -> Alpha<hopr_types::primitive::typenum::U33> {
+        let mut ret = Alpha::<hopr_types::primitive::typenum::U33>::default();
+        ret.copy_from_slice(self.to_affine().to_sec1_point(true).as_ref());
         ret
     }
 
-    fn from_alpha(alpha: Alpha<typenum::U33>) -> Result<Self> {
-        EncodedPoint::from_bytes(alpha)
+    fn from_alpha(alpha: Alpha<hopr_types::primitive::typenum::U33>) -> Result<Self> {
+        Sec1Point::<Secp256k1>::from_bytes(alpha)
             .map_err(|_| CryptoError::InvalidInputValue("alpha"))
             .and_then(|ep| {
-                AffinePoint::from_encoded_point(&ep)
+                AffinePoint::from_sec1_point(&ep)
                     .into_option()
                     .ok_or(CryptoError::InvalidInputValue("alpha"))
             })
-            .map(k256::ProjectivePoint::from)
+            .map(elliptic_curve::ProjectivePoint::<Secp256k1>::from)
     }
 
-    fn generate(scalar: &k256::Scalar) -> Self {
-        k256::ProjectivePoint::mul_by_generator(scalar)
+    fn generate(scalar: &elliptic_curve::Scalar<Secp256k1>) -> Self {
+        elliptic_curve::ProjectivePoint::<Secp256k1>::mul_by_generator(scalar)
     }
 
     fn is_valid(&self) -> bool {
@@ -130,10 +135,10 @@ impl GroupElement<k256::Scalar> for k256::ProjectivePoint {
 // TODO: invert this, so that each SphinxSuite takes this as a type argument
 /// Default packet block size for the Sphinx protocol.
 ///
-/// Currently, 1038 bytes.
-pub type DefaultSphinxPacketSize = typenum::Sum<typenum::U1024, typenum::U14>;
+/// Currently, 1040 bytes.
+pub type DefaultSphinxPacketSize = hopr_types::primitive::hybrid_array::sizes::U1040;
 
-pub use typenum::Unsigned;
+pub use hopr_types::primitive::typenum::Unsigned;
 
 /// Represents an instantiation of the Sphinx protocol using secp256k1 elliptic curve and `ChainKeypair`
 #[cfg(feature = "secp256k1")]
@@ -143,8 +148,8 @@ pub struct Secp256k1Suite;
 
 #[cfg(feature = "secp256k1")]
 impl SphinxSuite for Secp256k1Suite {
-    type E = k256::Scalar;
-    type G = k256::ProjectivePoint;
+    type E = elliptic_curve::Scalar<Secp256k1>;
+    type G = elliptic_curve::ProjectivePoint<Secp256k1>;
     type P = hopr_types::crypto::keypairs::ChainKeypair;
     type PRP = hopr_types::crypto::lioness::LionessBlake3ChaCha20<DefaultSphinxPacketSize>;
 }
@@ -157,8 +162,8 @@ pub struct Ed25519Suite;
 
 #[cfg(feature = "ed25519")]
 impl SphinxSuite for Ed25519Suite {
-    type E = curve25519_dalek::scalar::Scalar;
-    type G = curve25519_dalek::edwards::EdwardsPoint;
+    type E = Curve25519Scalar;
+    type G = Curve25519Point;
     type P = hopr_types::crypto::keypairs::OffchainKeypair;
     type PRP = hopr_types::crypto::lioness::LionessBlake3ChaCha20<DefaultSphinxPacketSize>;
 }
@@ -171,8 +176,8 @@ pub struct X25519Suite;
 
 #[cfg(feature = "x25519")]
 impl SphinxSuite for X25519Suite {
-    type E = curve25519_dalek::scalar::Scalar;
-    type G = curve25519_dalek::montgomery::MontgomeryPoint;
+    type E = Curve25519Scalar;
+    type G = Curve25519MontgomeryPoint;
     type P = hopr_types::crypto::keypairs::OffchainKeypair;
     type PRP = hopr_types::crypto::lioness::LionessBlake3ChaCha20<DefaultSphinxPacketSize>;
 }
@@ -186,10 +191,12 @@ mod tests {
     #[cfg(feature = "secp256k1")]
     #[test]
     fn test_extract_key_from_group_element() {
+        use hopr_types::crypto::crypto_traits::elliptic_curve;
+        use hopr_types::crypto::prelude::Secp256k1;
         use super::super::shared_keys::GroupElement;
 
         let salt = [0xde, 0xad, 0xbe, 0xef];
-        let pt = k256::ProjectivePoint::GENERATOR;
+        let pt = elliptic_curve::ProjectivePoint::<Secp256k1>::GENERATOR;
 
         let key = pt.extract_key("test", &salt);
         assert_eq!(
@@ -201,10 +208,12 @@ mod tests {
     #[cfg(feature = "secp256k1")]
     #[test]
     fn test_expand_key_from_group_element() {
+        use hopr_types::crypto::crypto_traits::elliptic_curve;
+        use hopr_types::crypto::prelude::Secp256k1;
         use super::super::shared_keys::GroupElement;
 
         let salt = [0xde, 0xad, 0xbe, 0xef];
-        let pt = k256::ProjectivePoint::GENERATOR;
+        let pt = elliptic_curve::ProjectivePoint::<Secp256k1>::GENERATOR;
 
         let key = pt.extract_key("test", &salt);
 

--- a/crypto/packet/src/sphinx/ec_groups.rs
+++ b/crypto/packet/src/sphinx/ec_groups.rs
@@ -4,16 +4,70 @@ use hopr_types::crypto::primitives::Curve25519MontgomeryPoint;
 #[cfg(any(feature = "x25519", feature = "ed25519"))]
 use hopr_types::crypto::primitives::{Curve25519CompressedPoint, Curve25519Point, Curve25519Scalar, IsIdentity};
 #[cfg(feature = "secp256k1")]
-use {
-    hopr_types::crypto::crypto_traits::elliptic_curve::{
-        self, AffinePoint, Group,
+use hopr_types::crypto::{
+    crypto_traits::elliptic_curve::{
+        self, Group,
         field::FieldBytes,
         sec1::{FromSec1Point, Sec1Point, ToSec1Point},
     },
-    hopr_types::crypto::prelude::{CryptoError, Secp256k1},
+    keypairs::ChainKeypair,
+    prelude::{CryptoError, Secp256k1},
+    types::PublicKey,
 };
 
 use super::shared_keys::{Alpha, GroupElement, Scalar, SphinxSuite};
+
+/// Newtype for secp256k1 scalars — avoids Rust 2024 coherence issues
+/// that arise when using transparent type aliases to `elliptic_curve::Scalar<Secp256k1>`.
+#[cfg(feature = "secp256k1")]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Secp256k1Scalar(pub elliptic_curve::Scalar<Secp256k1>);
+
+/// Newtype for secp256k1 projective points — avoids Rust 2024 coherence issues
+/// that arise when using transparent type aliases to `elliptic_curve::ProjectivePoint<Secp256k1>`.
+#[cfg(feature = "secp256k1")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Secp256k1Point(pub elliptic_curve::ProjectivePoint<Secp256k1>);
+
+#[cfg(feature = "secp256k1")]
+impl Default for Secp256k1Point {
+    fn default() -> Self {
+        Self(elliptic_curve::ProjectivePoint::<Secp256k1>::IDENTITY)
+    }
+}
+
+// Forwarding impls needed by SphinxSuite trait bounds
+#[cfg(feature = "secp256k1")]
+impl std::ops::Mul for Secp256k1Scalar {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        Self(self.0 * rhs.0)
+    }
+}
+
+#[cfg(feature = "secp256k1")]
+impl<'a> std::ops::Mul<&'a Secp256k1Scalar> for Secp256k1Point {
+    type Output = Self;
+
+    fn mul(self, rhs: &'a Secp256k1Scalar) -> Self::Output {
+        Self(self.0 * rhs.0)
+    }
+}
+
+#[cfg(feature = "secp256k1")]
+impl From<&ChainKeypair> for Secp256k1Scalar {
+    fn from(value: &ChainKeypair) -> Self {
+        Self(elliptic_curve::Scalar::<Secp256k1>::from(value))
+    }
+}
+
+#[cfg(feature = "secp256k1")]
+impl From<&PublicKey> for Secp256k1Point {
+    fn from(value: &PublicKey) -> Self {
+        Self(elliptic_curve::ProjectivePoint::<Secp256k1>::from(value))
+    }
+}
 
 #[cfg(any(feature = "x25519", feature = "ed25519"))]
 impl Scalar for Curve25519Scalar {
@@ -28,7 +82,7 @@ impl Scalar for Curve25519Scalar {
 }
 
 #[cfg(feature = "secp256k1")]
-impl Scalar for elliptic_curve::Scalar<Secp256k1> {
+impl Scalar for Secp256k1Scalar {
     fn random() -> Self {
         // Beware, this is not constant-time
         let mut rng = hopr_types::crypto_random::rng();
@@ -41,13 +95,15 @@ impl Scalar for elliptic_curve::Scalar<Secp256k1> {
         loop {
             rng.fill_bytes(&mut bytes);
             if let Some(scalar) = elliptic_curve::Scalar::<Secp256k1>::from_repr(bytes).into() {
-                return scalar;
+                return Secp256k1Scalar(scalar);
             }
         }
     }
 
     fn from_bytes(bytes: &[u8]) -> Result<Self> {
-        hopr_types::crypto::utils::k256_scalar_from_bytes(bytes)
+        Ok(Secp256k1Scalar(hopr_types::crypto::utils::k256_scalar_from_bytes(
+            bytes,
+        )?))
     }
 }
 
@@ -101,14 +157,14 @@ impl GroupElement<Curve25519Scalar> for Curve25519Point {
 }
 
 #[cfg(feature = "secp256k1")]
-impl GroupElement<elliptic_curve::Scalar<Secp256k1>> for elliptic_curve::ProjectivePoint<Secp256k1> {
+impl GroupElement<Secp256k1Scalar> for Secp256k1Point {
     type AlphaLen = hopr_types::primitive::typenum::U33;
 
     fn to_alpha(&self) -> Alpha<hopr_types::primitive::typenum::U33> {
         let mut ret = Alpha::<hopr_types::primitive::typenum::U33>::default();
         // Copy only if the point is not the identity, we do not care here about constant-time here.
-        if !bool::from(self.is_identity()) {
-            ret.copy_from_slice(self.to_affine().to_sec1_point(true).as_ref());
+        if !bool::from(self.0.is_identity()) {
+            ret.copy_from_slice(self.0.to_affine().to_sec1_point(true).as_ref());
         }
         ret
     }
@@ -117,19 +173,21 @@ impl GroupElement<elliptic_curve::Scalar<Secp256k1>> for elliptic_curve::Project
         Sec1Point::<Secp256k1>::from_bytes(alpha)
             .map_err(|_| CryptoError::InvalidInputValue("alpha"))
             .and_then(|ep| {
-                AffinePoint::from_sec1_point(&ep)
+                <Secp256k1 as elliptic_curve::CurveArithmetic>::AffinePoint::from_sec1_point(&ep)
                     .into_option()
                     .ok_or(CryptoError::InvalidInputValue("alpha"))
             })
-            .map(elliptic_curve::ProjectivePoint::<Secp256k1>::from)
+            .map(|ap| Secp256k1Point(elliptic_curve::ProjectivePoint::<Secp256k1>::from(ap)))
     }
 
-    fn generate(scalar: &elliptic_curve::Scalar<Secp256k1>) -> Self {
-        elliptic_curve::ProjectivePoint::<Secp256k1>::mul_by_generator(scalar)
+    fn generate(scalar: &Secp256k1Scalar) -> Self {
+        Secp256k1Point(elliptic_curve::ProjectivePoint::<Secp256k1>::mul_by_generator(
+            &scalar.0,
+        ))
     }
 
     fn is_valid(&self) -> bool {
-        !bool::from(self.is_identity())
+        !bool::from(self.0.is_identity())
     }
 }
 
@@ -149,8 +207,8 @@ pub struct Secp256k1Suite;
 
 #[cfg(feature = "secp256k1")]
 impl SphinxSuite for Secp256k1Suite {
-    type E = elliptic_curve::Scalar<Secp256k1>;
-    type G = elliptic_curve::ProjectivePoint<Secp256k1>;
+    type E = Secp256k1Scalar;
+    type G = Secp256k1Point;
     type P = hopr_types::crypto::keypairs::ChainKeypair;
     type PRP = hopr_types::crypto::lioness::LionessBlake3ChaCha20<DefaultSphinxPacketSize>;
 }
@@ -194,10 +252,10 @@ mod tests {
     fn test_extract_key_from_group_element() {
         use hopr_types::crypto::{crypto_traits::elliptic_curve, prelude::Secp256k1};
 
-        use super::super::shared_keys::GroupElement;
+        use super::{super::shared_keys::GroupElement, Secp256k1Point};
 
         let salt = [0xde, 0xad, 0xbe, 0xef];
-        let pt = elliptic_curve::ProjectivePoint::<Secp256k1>::GENERATOR;
+        let pt = Secp256k1Point(elliptic_curve::ProjectivePoint::<Secp256k1>::GENERATOR);
 
         let key = pt.extract_key("test", &salt);
         assert_eq!(
@@ -211,10 +269,10 @@ mod tests {
     fn test_expand_key_from_group_element() {
         use hopr_types::crypto::{crypto_traits::elliptic_curve, prelude::Secp256k1};
 
-        use super::super::shared_keys::GroupElement;
+        use super::{super::shared_keys::GroupElement, Secp256k1Point};
 
         let salt = [0xde, 0xad, 0xbe, 0xef];
-        let pt = elliptic_curve::ProjectivePoint::<Secp256k1>::GENERATOR;
+        let pt = Secp256k1Point(elliptic_curve::ProjectivePoint::<Secp256k1>::GENERATOR);
 
         let key = pt.extract_key("test", &salt);
 

--- a/crypto/packet/src/sphinx/packet.rs
+++ b/crypto/packet/src/sphinx/packet.rs
@@ -6,9 +6,8 @@ use std::{
 
 use hopr_types::{
     crypto::{crypto_traits::PRP, prelude::*},
-    primitive::prelude::*,
+    primitive::{prelude::*, typenum::Unsigned},
 };
-use hopr_types::primitive::typenum::Unsigned;
 
 use super::{
     derivation::derive_packet_tag,
@@ -448,7 +447,9 @@ impl<S: SphinxSuite, H: SphinxHeaderSpec, const P: usize> MetaPacket<S, H, P> {
         let decrypted = self.payload_mut();
         let prp = S::new_prp_init(&secret)?.into_init::<S::PRP>();
         #[allow(deprecated)]
-        prp.inverse(hopr_types::crypto::crypto_traits::Block::<S::PRP>::from_mut_slice(decrypted));
+        prp.inverse(hopr_types::crypto::crypto_traits::Block::<S::PRP>::from_mut_slice(
+            decrypted,
+        ));
 
         Ok(match fwd_header {
             ForwardedHeader::Relayed {
@@ -486,14 +487,18 @@ impl<S: SphinxSuite, H: SphinxHeaderSpec, const P: usize> MetaPacket<S, H, P> {
                     for secret in local_surb.shared_secrets.into_iter().rev() {
                         let prp = S::new_prp_init(&secret)?.into_init::<S::PRP>();
                         #[allow(deprecated)]
-                        prp.forward(hopr_types::crypto::crypto_traits::Block::<S::PRP>::from_mut_slice(decrypted));
+                        prp.forward(hopr_types::crypto::crypto_traits::Block::<S::PRP>::from_mut_slice(
+                            decrypted,
+                        ));
                     }
 
                     // Invert the initial encryption using the sender key
                     let prp =
                         S::new_reply_prp_init(&local_surb.sender_key, receiver_data.as_ref())?.into_init::<S::PRP>();
                     #[allow(deprecated)]
-                    prp.inverse(hopr_types::crypto::crypto_traits::Block::<S::PRP>::from_mut_slice(decrypted));
+                    prp.inverse(hopr_types::crypto::crypto_traits::Block::<S::PRP>::from_mut_slice(
+                        decrypted,
+                    ));
                 }
 
                 // Remove all the data before the actual decrypted payload

--- a/crypto/packet/src/sphinx/packet.rs
+++ b/crypto/packet/src/sphinx/packet.rs
@@ -8,7 +8,7 @@ use hopr_types::{
     crypto::{crypto_traits::PRP, prelude::*},
     primitive::prelude::*,
 };
-use typenum::Unsigned;
+use hopr_types::primitive::typenum::Unsigned;
 
 use super::{
     derivation::derive_packet_tag,
@@ -260,7 +260,7 @@ impl<S: SphinxSuite, H: SphinxHeaderSpec> PartialPacket<S, H> {
             // The following won't panic, because PaddedPayload<P> is guaranteed to be S::PRP::BlockSize bytes-long
             // However, it would be nicer to make PaddedPayload take P as a typenum parameter
             // and enforce this invariant at compile time.
-            let block = crypto_traits::Block::<S::PRP>::from_mut_slice(&mut payload);
+            let block = hopr_types::crypto::crypto_traits::Block::<S::PRP>::from_mut_slice(&mut payload);
             prp.forward(block);
         }
 
@@ -434,6 +434,7 @@ impl<S: SphinxSuite, H: SphinxHeaderSpec, const P: usize> MetaPacket<S, H, P> {
         F: FnMut(&H::PacketReceiverData) -> Option<ReplyOpener>,
         &'a Alpha<<S::G as GroupElement<S::E>>::AlphaLen>: From<&'a <S::P as Keypair>::Public>,
     {
+        #[allow(deprecated)]
         let (alpha, secret) = SharedKeys::<S::E, S::G>::forward_transform(
             Alpha::<<S::G as GroupElement<S::E>>::AlphaLen>::from_slice(self.alpha()),
             &(node_keypair.into()),
@@ -446,7 +447,8 @@ impl<S: SphinxSuite, H: SphinxHeaderSpec, const P: usize> MetaPacket<S, H, P> {
         // Perform initial decryption over the payload
         let decrypted = self.payload_mut();
         let prp = S::new_prp_init(&secret)?.into_init::<S::PRP>();
-        prp.inverse(decrypted.into());
+        #[allow(deprecated)]
+        prp.inverse(hopr_types::crypto::crypto_traits::Block::<S::PRP>::from_mut_slice(decrypted));
 
         Ok(match fwd_header {
             ForwardedHeader::Relayed {
@@ -483,13 +485,15 @@ impl<S: SphinxSuite, H: SphinxHeaderSpec, const P: usize> MetaPacket<S, H, P> {
                     // to reverse the decryption done by individual hops
                     for secret in local_surb.shared_secrets.into_iter().rev() {
                         let prp = S::new_prp_init(&secret)?.into_init::<S::PRP>();
-                        prp.forward(decrypted.into());
+                        #[allow(deprecated)]
+                        prp.forward(hopr_types::crypto::crypto_traits::Block::<S::PRP>::from_mut_slice(decrypted));
                     }
 
                     // Invert the initial encryption using the sender key
                     let prp =
                         S::new_reply_prp_init(&local_surb.sender_key, receiver_data.as_ref())?.into_init::<S::PRP>();
-                    prp.inverse(decrypted.into());
+                    #[allow(deprecated)]
+                    prp.inverse(hopr_types::crypto::crypto_traits::Block::<S::PRP>::from_mut_slice(decrypted));
                 }
 
                 // Remove all the data before the actual decrypted payload

--- a/crypto/packet/src/sphinx/packet.rs
+++ b/crypto/packet/src/sphinx/packet.rs
@@ -252,14 +252,14 @@ impl<S: SphinxSuite, H: SphinxHeaderSpec> PartialPacket<S, H> {
     }
 
     /// Transform this partial packet into an actual [`MetaPacket`] using the given payload.
-    #[allow(deprecated)] // Until the dependency updates to newer versions of `generic-array`
     pub fn into_meta_packet<const P: usize>(self, mut payload: PaddedPayload<P>) -> MetaPacket<S, H, P> {
         for iv_key in self.prp_inits {
             let prp = iv_key.into_init::<S::PRP>();
             // The following won't panic, because PaddedPayload<P> is guaranteed to be S::PRP::BlockSize bytes-long
             // However, it would be nicer to make PaddedPayload take P as a typenum parameter
             // and enforce this invariant at compile time.
-            let block = hopr_types::crypto::crypto_traits::Block::<S::PRP>::from_mut_slice(&mut payload);
+            let block = <&mut hopr_types::crypto::crypto_traits::Block<S::PRP>>::try_from(payload.as_mut())
+                .expect("block size mismatch");
             prp.forward(block);
         }
 
@@ -433,9 +433,8 @@ impl<S: SphinxSuite, H: SphinxHeaderSpec, const P: usize> MetaPacket<S, H, P> {
         F: FnMut(&H::PacketReceiverData) -> Option<ReplyOpener>,
         &'a Alpha<<S::G as GroupElement<S::E>>::AlphaLen>: From<&'a <S::P as Keypair>::Public>,
     {
-        #[allow(deprecated)]
         let (alpha, secret) = SharedKeys::<S::E, S::G>::forward_transform(
-            Alpha::<<S::G as GroupElement<S::E>>::AlphaLen>::from_slice(self.alpha()),
+            <&Alpha<<S::G as GroupElement<S::E>>::AlphaLen>>::try_from(self.alpha()).expect("alpha length mismatch"),
             &(node_keypair.into()),
             node_keypair.public().into(),
         )?;
@@ -446,10 +445,10 @@ impl<S: SphinxSuite, H: SphinxHeaderSpec, const P: usize> MetaPacket<S, H, P> {
         // Perform initial decryption over the payload
         let decrypted = self.payload_mut();
         let prp = S::new_prp_init(&secret)?.into_init::<S::PRP>();
-        #[allow(deprecated)]
-        prp.inverse(hopr_types::crypto::crypto_traits::Block::<S::PRP>::from_mut_slice(
-            decrypted,
-        ));
+        prp.inverse(
+            <&mut hopr_types::crypto::crypto_traits::Block<S::PRP>>::try_from(&mut *decrypted)
+                .expect("block size mismatch"),
+        );
 
         Ok(match fwd_header {
             ForwardedHeader::Relayed {
@@ -486,19 +485,19 @@ impl<S: SphinxSuite, H: SphinxHeaderSpec, const P: usize> MetaPacket<S, H, P> {
                     // to reverse the decryption done by individual hops
                     for secret in local_surb.shared_secrets.into_iter().rev() {
                         let prp = S::new_prp_init(&secret)?.into_init::<S::PRP>();
-                        #[allow(deprecated)]
-                        prp.forward(hopr_types::crypto::crypto_traits::Block::<S::PRP>::from_mut_slice(
-                            decrypted,
-                        ));
+                        prp.forward(
+                            <&mut hopr_types::crypto::crypto_traits::Block<S::PRP>>::try_from(&mut *decrypted)
+                                .expect("block size mismatch"),
+                        );
                     }
 
                     // Invert the initial encryption using the sender key
                     let prp =
                         S::new_reply_prp_init(&local_surb.sender_key, receiver_data.as_ref())?.into_init::<S::PRP>();
-                    #[allow(deprecated)]
-                    prp.inverse(hopr_types::crypto::crypto_traits::Block::<S::PRP>::from_mut_slice(
-                        decrypted,
-                    ));
+                    prp.inverse(
+                        <&mut hopr_types::crypto::crypto_traits::Block<S::PRP>>::try_from(&mut *decrypted)
+                            .expect("block size mismatch"),
+                    );
                 }
 
                 // Remove all the data before the actual decrypted payload

--- a/crypto/packet/src/sphinx/routing.rs
+++ b/crypto/packet/src/sphinx/routing.rs
@@ -13,7 +13,7 @@ use hopr_types::{
     crypto_random::random_fill,
     primitive::prelude::*,
 };
-use typenum::Unsigned;
+use hopr_types::primitive::typenum::Unsigned;
 
 use super::{
     derivation::{generate_key, generate_key_iv},
@@ -427,8 +427,11 @@ pub fn forward_header<H: SphinxHeaderSpec>(
     let mut uh: H::UH =
         generate_key(secret, HASH_KEY_TAG, None).map_err(|_| CryptoError::InvalidInputValue("mac_key"))?;
     uh.update_padded(&header[0..H::HEADER_LEN]);
-    uh.verify(header[H::HEADER_LEN..H::HEADER_LEN + H::TAG_SIZE].into())
-        .map_err(|_| CryptoError::TagMismatch)?;
+    #[allow(deprecated)]
+    uh.verify(hopr_types::crypto::crypto_traits::Block::<H::UH>::from_slice(
+        &header[H::HEADER_LEN..H::HEADER_LEN + H::TAG_SIZE],
+    ))
+    .map_err(|_| CryptoError::TagMismatch)?;
 
     // Decrypt the header using the key=stream
     let mut prg = H::new_prg(secret)?;

--- a/crypto/packet/src/sphinx/routing.rs
+++ b/crypto/packet/src/sphinx/routing.rs
@@ -11,9 +11,8 @@ use hopr_types::{
         types::Pseudonym,
     },
     crypto_random::random_fill,
-    primitive::prelude::*,
+    primitive::{prelude::*, typenum::Unsigned},
 };
-use hopr_types::primitive::typenum::Unsigned;
 
 use super::{
     derivation::{generate_key, generate_key_iv},

--- a/crypto/packet/src/sphinx/shared_keys.rs
+++ b/crypto/packet/src/sphinx/shared_keys.rs
@@ -139,6 +139,10 @@ impl<E: Scalar, G: GroupElement<E>> SharedKeys<E, G> {
         let b_k_checked = E::from_bytes(b_k.as_ref())?;
         let alpha_new = alpha_point.mul(&b_k_checked);
 
+        if !alpha_new.is_valid() {
+            return Err(CryptoError::CalculationError);
+        }
+
         Ok((alpha_new.to_alpha(), secret))
     }
 }

--- a/crypto/packet/src/sphinx/shared_keys.rs
+++ b/crypto/packet/src/sphinx/shared_keys.rs
@@ -1,12 +1,14 @@
 use std::{marker::PhantomData, ops::Mul};
 
-use generic_array::{ArrayLength, GenericArray};
-use hopr_types::crypto::prelude::*;
+use hopr_types::{
+    crypto::prelude::*,
+    primitive::hybrid_array::{Array, ArraySize},
+};
 
 use super::derivation::{create_kdf_instance, generate_key_iv};
 
 /// Represents a shared secret with a remote peer.
-pub type SharedSecret = SecretValue<typenum::U32>;
+pub type SharedSecret = SecretValue<hopr_types::primitive::typenum::U32>;
 
 /// Types representing a valid non-zero scalar of an additive abelian group.
 pub trait Scalar: Mul<Output = Self> + Sized {
@@ -19,14 +21,14 @@ pub trait Scalar: Mul<Output = Self> + Sized {
 
 /// Represents the Alpha value of a certain length in the Sphinx protocol
 /// The length of the alpha value is directly dependent on the group element.
-pub type Alpha<A> = GenericArray<u8, A>;
+pub type Alpha<A> = Array<u8, A>;
 
 /// Generic additive abelian group element with an associated scalar type.
 /// It also comes with the associated Alpha value size.
 /// A group element is considered valid if it is not neutral or a torsion element of small order.
 pub trait GroupElement<E: Scalar>: Clone + for<'a> Mul<&'a E, Output = Self> {
     /// Length of the Alpha value - a binary representation of the group element.
-    type AlphaLen: ArrayLength;
+    type AlphaLen: ArraySize;
 
     /// Converts the group element to a binary format suitable for representing the Alpha value.
     fn to_alpha(&self) -> Alpha<Self::AlphaLen>;

--- a/crypto/packet/src/sphinx/surb.rs
+++ b/crypto/packet/src/sphinx/surb.rs
@@ -2,7 +2,7 @@ use std::fmt::Formatter;
 
 use hopr_types::{crypto::prelude::*, crypto_random::Randomizable, primitive::prelude::*};
 use subtle::ConstantTimeEq;
-use typenum::Unsigned;
+use hopr_types::primitive::typenum::Unsigned;
 
 use super::{
     routing::{RoutingInfo, SphinxHeaderSpec},
@@ -147,10 +147,13 @@ impl<'a, S: SphinxSuite, H: SphinxHeaderSpec> TryFrom<&'a [u8]> for SURB<S, H> {
                 first_relayer: value[0..H::KEY_ID_SIZE.get()]
                     .try_into()
                     .map_err(|_| GeneralError::ParseError("SURB.first_relayer".into()))?,
-                alpha: Alpha::<<S::G as GroupElement<S::E>>::AlphaLen>::from_slice(
-                    &value[H::KEY_ID_SIZE.get()..H::KEY_ID_SIZE.get() + alpha],
-                )
-                .clone(),
+                alpha: {
+                    #[allow(deprecated)]
+                    Alpha::<<S::G as GroupElement<S::E>>::AlphaLen>::from_slice(
+                        &value[H::KEY_ID_SIZE.get()..H::KEY_ID_SIZE.get() + alpha],
+                    )
+                    .clone()
+                },
                 header: value[H::KEY_ID_SIZE.get() + alpha..H::KEY_ID_SIZE.get() + alpha + RoutingInfo::<H>::SIZE]
                     .try_into()
                     .map_err(|_| GeneralError::ParseError("SURB.header".into()))?,

--- a/crypto/packet/src/sphinx/surb.rs
+++ b/crypto/packet/src/sphinx/surb.rs
@@ -1,8 +1,11 @@
 use std::fmt::Formatter;
 
-use hopr_types::{crypto::prelude::*, crypto_random::Randomizable, primitive::prelude::*};
+use hopr_types::{
+    crypto::prelude::*,
+    crypto_random::Randomizable,
+    primitive::{prelude::*, typenum::Unsigned},
+};
 use subtle::ConstantTimeEq;
-use hopr_types::primitive::typenum::Unsigned;
 
 use super::{
     routing::{RoutingInfo, SphinxHeaderSpec},

--- a/protocols/session/src/protocol/mod.rs
+++ b/protocols/session/src/protocol/mod.rs
@@ -233,6 +233,7 @@ mod tests {
     use super::*;
     use crate::{
         protocol::{FrameId, SegmentId},
+        session_socket_mtu,
         utils::segment,
     };
 
@@ -246,7 +247,7 @@ mod tests {
             SessionMessage::<{ ApplicationData::PAYLOAD_SIZE }>::SEGMENT_OVERHEAD
         );
         assert_eq!(
-            1026,
+            session_socket_mtu::<{ ApplicationData::PAYLOAD_SIZE }>() + 6,
             SessionMessage::<{ ApplicationData::PAYLOAD_SIZE }>::MAX_MESSAGE_LENGTH
         );
     }

--- a/protocols/session/src/protocol/mod.rs
+++ b/protocols/session/src/protocol/mod.rs
@@ -246,7 +246,7 @@ mod tests {
             SessionMessage::<{ ApplicationData::PAYLOAD_SIZE }>::SEGMENT_OVERHEAD
         );
         assert_eq!(
-            1024,
+            1026,
             SessionMessage::<{ ApplicationData::PAYLOAD_SIZE }>::MAX_MESSAGE_LENGTH
         );
     }

--- a/protocols/session/src/protocol/mod.rs
+++ b/protocols/session/src/protocol/mod.rs
@@ -247,7 +247,9 @@ mod tests {
             SessionMessage::<{ ApplicationData::PAYLOAD_SIZE }>::SEGMENT_OVERHEAD
         );
         assert_eq!(
-            session_socket_mtu::<{ ApplicationData::PAYLOAD_SIZE }>() + 6,
+            session_socket_mtu::<{ ApplicationData::PAYLOAD_SIZE }>()
+                + SessionMessage::<{ ApplicationData::PAYLOAD_SIZE }>::SEGMENT_OVERHEAD
+                - SessionMessage::<{ ApplicationData::PAYLOAD_SIZE }>::HEADER_SIZE,
             SessionMessage::<{ ApplicationData::PAYLOAD_SIZE }>::MAX_MESSAGE_LENGTH
         );
     }

--- a/transport/session/src/lib.rs
+++ b/transport/session/src/lib.rs
@@ -121,6 +121,7 @@ mod tests {
     #[test]
     fn test_session_mtu() {
         assert_eq!(SESSION_MTU, session_socket_mtu::<{ ApplicationData::PAYLOAD_SIZE }>());
+        assert_eq!(1020, SESSION_MTU); // Needs to be changed when HOPR packet payload size changes
     }
 
     #[test]

--- a/transport/session/src/lib.rs
+++ b/transport/session/src/lib.rs
@@ -121,7 +121,6 @@ mod tests {
     #[test]
     fn test_session_mtu() {
         assert_eq!(SESSION_MTU, session_socket_mtu::<{ ApplicationData::PAYLOAD_SIZE }>());
-        assert_eq!(1018, SESSION_MTU);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Bump `hopr-types` from 1.9.3 to 2.0.0 and `hopr-api` from 1.14.0 to 1.15.0
- Replace `generic-array` + `typenum` with `hybrid-array` (via hopr-types re-exports) in `crypto/packet`
- Replace `k256::*` types with generic `elliptic_curve::*<Secp256k1>` through hopr-types re-exports
- Replace `curve25519-dalek::*` types with hopr-types aliases (`Curve25519Scalar`, etc.)
- Remove 5 direct dependencies: `curve25519-dalek`, `elliptic-curve`, `generic-array`, `k256`, `typenum`
- Update `DefaultSphinxPacketSize` to `hybrid_array::sizes::U1040` (1040 bytes)

## Packet size bump
The packet size(before this PR) was 1038 bytes, now was bumped to 1040. The reason for this bump, is because the previous calculation was wrong and even at 1038 the HOPR packet was not fitting an MTU, causing two Quic packets per HOPR packet.
This adjustments increases it further, because `hybrid-array` dependency does not support the length of 1038 bytes, but the first supported size is 1040. 
This arguably does not make the situation worse. As a follow up experiments, the packet size will be further increased to fill up the two Quic packets completely.