### PR TITLE
fix(transport): enable periodic SURB balance notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2120,9 +2120,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/transport/hopr/src/config.rs
+++ b/transport/hopr/src/config.rs
@@ -405,6 +405,10 @@ fn default_max_managed_sessions() -> usize {
     DEFAULT_MAXIMUM_MANAGED_SESSIONS
 }
 
+fn default_session_surb_balance_notify_period() -> Option<Duration> {
+    Some(Duration::from_secs(60))
+}
+
 fn validate_session_idle_timeout(value: &Duration) -> Result<(), ValidationError> {
     if SESSION_IDLE_MIN_TIMEOUT <= *value {
         Ok(())
@@ -500,6 +504,19 @@ pub struct SessionGlobalConfig {
         serde(default = "default_session_balancer_buffer_duration", with = "humantime_serde")
     )]
     pub balancer_minimum_surb_buffer_duration: Duration,
+
+    /// How often the Exit reports its true SURB buffer level to the Entry, as an absolute
+    /// correction of the Entry's dead-reckoned estimate. Without it, cumulative packet loss
+    /// silently inflates the estimate until the Exit runs out of SURBs and can no longer
+    /// send reply data.
+    ///
+    /// Default is 60 seconds. Set to `null` to disable; minimum effective period is 1 second.
+    #[default(default_session_surb_balance_notify_period())]
+    #[cfg_attr(
+        feature = "serde",
+        serde(default = "default_session_surb_balance_notify_period", with = "humantime_serde")
+    )]
+    pub surb_balance_notify_period: Option<Duration>,
 
     /// Tag allocator partition configuration.
     #[validate(nested)]

--- a/transport/hopr/src/config.rs
+++ b/transport/hopr/src/config.rs
@@ -433,6 +433,17 @@ fn validate_balancer_buffer_duration(value: &Duration) -> Result<(), ValidationE
     }
 }
 
+fn validate_surb_balance_notify_period(value: &Duration) -> Result<(), ValidationError> {
+    // `custom` on an `Option` field skips `None` and passes the inner value on `Some`.
+    if *value >= Duration::from_secs(1) {
+        Ok(())
+    } else {
+        Err(ValidationError::new(
+            "SURB balance notify period must be at least 1 second",
+        ))
+    }
+}
+
 /// Global configuration of Sessions and the Session manager.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Validate, smart_default::SmartDefault)]
 #[cfg_attr(
@@ -511,10 +522,14 @@ pub struct SessionGlobalConfig {
     /// send reply data.
     ///
     /// Default is 60 seconds. Set to `null` to disable; minimum effective period is 1 second.
+    #[validate(custom(function = "validate_surb_balance_notify_period"))]
     #[default(default_session_surb_balance_notify_period())]
     #[cfg_attr(
         feature = "serde",
-        serde(default = "default_session_surb_balance_notify_period", with = "humantime_serde")
+        serde(
+            default = "default_session_surb_balance_notify_period",
+            with = "humantime_serde::option"
+        )
     )]
     pub surb_balance_notify_period: Option<Duration>,
 

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -347,7 +347,9 @@ where
                 initial_return_session_egress_rate: 10,
                 minimum_surb_buffer_duration: cfg.session.balancer_minimum_surb_buffer_duration,
                 maximum_surb_buffer_size: cfg.packet.surb_store.rb_capacity,
-                surb_balance_notify_period: None,
+                // Periodic absolute correction of the Entry's SURB buffer estimate;
+                // without it, cumulative packet loss silently starves the Exit of SURBs.
+                surb_balance_notify_period: SessionManagerConfig::default().surb_balance_notify_period,
                 surb_target_notify: true,
                 maximum_sessions: cfg.session.maximum_managed_sessions,
                 ..Default::default()

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -347,9 +347,7 @@ where
                 initial_return_session_egress_rate: 10,
                 minimum_surb_buffer_duration: cfg.session.balancer_minimum_surb_buffer_duration,
                 maximum_surb_buffer_size: cfg.packet.surb_store.rb_capacity,
-                // Periodic absolute correction of the Entry's SURB buffer estimate;
-                // without it, cumulative packet loss silently starves the Exit of SURBs.
-                surb_balance_notify_period: SessionManagerConfig::default().surb_balance_notify_period,
+                surb_balance_notify_period: cfg.session.surb_balance_notify_period,
                 surb_target_notify: true,
                 maximum_sessions: cfg.session.maximum_managed_sessions,
                 ..Default::default()

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -300,8 +300,13 @@ pub struct SessionManagerConfig {
     /// Keep in mind that each notification also costs 1 SURB, so the notification period should
     /// not be too frequent.
     ///
-    /// Default is None (no notification sent to the client), minimum is 1 second.
-    #[default(None)]
+    /// These notifications are the only absolute correction of the Entry's dead-reckoned
+    /// estimate of the Exit's SURB buffer. Without them, every packet lost in either
+    /// direction permanently inflates the Entry's estimate, until the Exit silently runs
+    /// out of SURBs and can no longer send any reply data.
+    ///
+    /// Default is 60 seconds (None disables the notifications), minimum is 1 second.
+    #[default(Some(Duration::from_secs(60)))]
     pub surb_balance_notify_period: Option<Duration>,
 
     /// If set, the Session initiator (Entry) will notify the Session recipient (Exit) about


### PR DESCRIPTION
Long-running sessions go permanently silent downstream after a roughly
  constant amount of traffic (reported as the "~50-100 MB" session crash).

  Root cause: the Entry estimates the Exit's SURB buffer by open-loop dead
  reckoning (`produced - consumed`), counting a SURB as produced at send
  time. Any SURB-bearing packet lost before reaching the Exit inflates the
  Entry's estimate but not the Exit's real stock. The estimate drifts high,
  one direction only, until it hits the target buffer size — at which point
  the Entry stops replenishing, the Exit reaches zero SURBs, and it can no
  longer send reply data or even a distress signal. Drift ∝ volume × loss
  rate, hence death at a near-constant volume.

  The absolute correction already exists (`KeepAliveFlag::BalancerState`:
  the Exit reports its true level, the Entry overwrites its estimate) but
  was never turned on — the notify period defaulted to `None` and was also
  hardcoded `None` in production wiring, so the correction stream never ran.

  ## Evidence

  Reproduced on a local cluster (edgli client + 3-node hoprd + deterministic
  relay packet-drop), isolating this change as the only variable — Exit
  notification off vs on, everything else identical:

  | loss | notify | delivered (of 50 MB) | corrections | outcome |
  |------|--------|----------------------|-------------|---------|
  | 2%   | none   | 3.85 MB (7.3%)       | 0           | stall   |
  | 2%   | on     | 30.3 MB (57.8%)      | 63          | sustained (7.9×) |
  | 5%   | none   | 3.25 MB (6.2%)       | 0           | stall   |
  | 5%   | on     | 28.6 MB (54.6%)      | 23          | sustained (8.8×) |

  With notification off the Exit starves after a near-constant ~3.5 MB with
  zero corrections logged; with it on, corrections reset the drift and the
  session keeps delivering ~8–9× more. Overhead is one SURB per period
  (~0.025% of the SURB budget at 60s). Lossless transfers are unaffected
  (100% both ways).