### PR TITLE
fix(session): supersede stale same-pseudonym session; fix sequencer c…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4019,7 +4019,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-session"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4300,7 +4300,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/protocols/session/Cargo.toml
+++ b/protocols/session/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-protocol-session"
 description = "Contains implementation of Session protocol according to HOPR RFC-0008"
-version = "1.2.1"
+version = "1.2.2"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/protocols/session/src/socket/mod.rs
+++ b/protocols/session/src/socket/mod.rs
@@ -424,7 +424,7 @@ impl<const C: usize, S: SocketState<C> + Clone + 'static> SessionSocket<C, S> {
                 })
             })
             // Put the frames into the correct sequence by Frame Ids
-            .sequencer(cfg.frame_timeout, cfg.frame_size)
+            .sequencer(cfg.frame_timeout, cfg.capacity)
             // Discard frames missing from the sequence and
             // notify the State about emitted or discarded frames
             .filter_map(move |maybe_frame| {

--- a/transport/session/Cargo.toml
+++ b/transport/session/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport-session"
 description = "Session functionality providing session abstraction over the HOPR transport"
-version = "0.23.0"
+version = "0.23.1"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -1403,6 +1403,19 @@ where
         // Use constant application tag for all sessions
         self.sessions.run_pending_tasks();
 
+        // A repeated initiation for a pseudonym that already has a Session means the
+        // initiator has lost or abandoned its side of it (it never received our
+        // SessionEstablished reply, or it reuses its pseudonym on reconnect).
+        // The pseudonym is known only to the initiator, so the existing Session cannot
+        // serve anyone else anymore: close it and let this initiation take the slot over.
+        // Otherwise, re-initiations would keep being rejected with NoSlotsAvailable
+        // until the stale Session gets evicted by the idle timeout.
+        if let Some(stale_slot) = self.sessions.remove(&pseudonym) {
+            self.active_sessions.fetch_sub(1, Ordering::Relaxed);
+            info!(%pseudonym, "closing stale session superseded by a new initiation with the same pseudonym");
+            close_session(pseudonym, stale_slot, ClosureReason::Eviction);
+        }
+
         let session_id = pseudonym;
 
         let (session_tx, session_rx) =
@@ -1423,8 +1436,9 @@ where
         // insert (inside the helper) also prevents a TOCTOU race, so only one concurrent
         // request can claim the slot for a given pseudonym.
         let Some(mut slot_guard) = self.allocate_session_slot(session_id, slot.clone()) else {
-            // No slots available for this pseudonym
-            error!(%pseudonym, "no slots available for this pseudonym");
+            // Either the maximum number of sessions has been reached, or a concurrent
+            // initiation for the same pseudonym has claimed the slot first.
+            error!(%pseudonym, "no session slot available");
             let reason = StartErrorReason::NoSlotsAvailable;
             let data = HoprStartProtocol::SessionError(StartErrorType {
                 challenge: session_req.challenge,
@@ -2749,7 +2763,8 @@ mod tests {
     }
 
     #[test_log::test(tokio::test)]
-    async fn session_manager_should_reject_duplicate_session_for_same_pseudonym() -> anyhow::Result<()> {
+    async fn session_manager_should_supersede_stale_session_on_reinitiation_with_same_pseudonym() -> anyhow::Result<()>
+    {
         use hopr_utils::network_types::prelude::SealedHost;
 
         let bob_mgr: SessionManager<futures::channel::mpsc::UnboundedSender<(DestinationRouting, ApplicationDataOut)>> =
@@ -2795,13 +2810,14 @@ mod tests {
         let active = bob_mgr.active_sessions();
         assert_eq!(active.len(), 1, "should have exactly one active session");
 
-        // Second session initiation with same pseudonym - should be handled gracefully
-        // (returns Ok but sends SessionError to the requester)
+        // Second session initiation with the same pseudonym: the stale session is
+        // closed and the new initiation takes the slot over (a re-initiation means
+        // the initiator has lost or abandoned its side of the old session).
         let result = bob_mgr
             .handle_incoming_session_initiation(
                 pseudonym,
                 StartInitiation {
-                    challenge: MIN_CHALLENGE,
+                    challenge: MIN_CHALLENGE + 1,
                     target: SessionTarget::TcpStream(SealedHost::Plain("127.0.0.1:80".parse()?)),
                     capabilities: ByteCapabilities(Capabilities::empty()),
                     additional_data: 0,
@@ -2809,13 +2825,9 @@ mod tests {
             )
             .await;
 
-        // The second initiation returns Ok but handles the duplicate by sending SessionError
-        assert!(
-            result.is_ok(),
-            "second session initiation should return Ok (error is handled internally)"
-        );
+        assert!(result.is_ok(), "re-initiation should supersede the stale session");
 
-        // Verify still only one session exists
+        // The stale session must have been replaced, not duplicated
         let active = bob_mgr.active_sessions();
         assert_eq!(active.len(), 1, "should still have exactly one active session");
 


### PR DESCRIPTION
2 fixes:<br>  **reconnect permanently rejected.** gvpn reuses its pseudonym on<br>  reconnect. While the Exit still holds the old (possibly zombie) session<br>  for that pseudonym, `allocate_session_slot` returns `None` for the<br>  duplicate — the same signal as a genuinely full pool — so the reconnect<br>  is answered `NoSlotsAvailable` and stays rejected until idle eviction. In<br>  the motivating incident the client retried 27× over \~18s, was rejected<br>  every time, and gave up; the pool was never exhausted. Since a pseudonym<br>  is known only to its initiator, a fresh init for an existing pseudonym<br>  means the old session is dead to everyone — so we close it and let the<br>  new init take over, restoring reconnectability immediately.

**wrong sequencer capacity on reliable sockets.** `frame_size` is<br>  not a frame count, so reliable sockets got a \~1500-frame reorder buffer<br>  instead of the intended 8192 and tracked the wrong config knob. One-line<br>  fix. Stateless/segmentation (UDP) sessions are unaffected — their line<br>  was already correct. Connected to hoprnet/hoprnet#8221