### PR TITLE
fix(session): flush contiguous loss-gap in one frame_timeout window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2120,9 +2120,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -3748,7 +3748,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-session"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "anyhow",
  "aquamarine",

--- a/protocols/session/Cargo.toml
+++ b/protocols/session/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-protocol-session"
 description = "Contains implementation of Session protocol according to HOPR RFC-0008"
-version = "1.2.0"
+version = "1.2.1"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/protocols/session/src/processing/sequencer.rs
+++ b/protocols/session/src/processing/sequencer.rs
@@ -169,7 +169,11 @@ where
                         {
                             let discarded = *this.next_id;
                             *this.next_id = this.next_id.wrapping_add(1);
-                            *this.last_emitted = Instant::now();
+                            // `last_emitted` is intentionally NOT reset here: it is only reset
+                            // when an actual frame is emitted. Resetting it per discarded id would
+                            // drain a contiguous gap of K missing frames at 1 frame per `max_wait`
+                            // (a K x max_wait delivery stall of frames already sitting in the
+                            // buffer), instead of flushing the whole gap once `max_wait` elapses.
                             *this.state = State::BufferUpdated;
 
                             tracing::trace!(discarded, "discard frame");
@@ -409,6 +413,44 @@ mod tests {
         assert!(matches!(rx.next().await, Some(Ok(6))));
         assert!(matches!(rx.next().await, Some(Ok(7))));
         assert!(matches!(rx.next().await, Some(Ok(8))));
+
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn sequencer_should_drain_contiguous_gap_within_single_timeout_window() -> anyhow::Result<()> {
+        let timeout = Duration::from_millis(50);
+        let (tx, rx) = futures::channel::mpsc::unbounded();
+
+        pin_mut!(tx);
+        tx.send_all(&mut futures::stream::iter([1u32, 2, 10, 11, 12]).map(Ok))
+            .await?;
+
+        let rx = rx.sequencer(timeout, 4096);
+        pin_mut!(rx);
+
+        assert_eq!(Some(1), rx.try_next().await?);
+        assert_eq!(Some(2), rx.try_next().await?);
+
+        let now = Instant::now();
+        for expected in 3u32..=9 {
+            assert!(matches!(
+                rx.next().await,
+                Some(Err(SessionError::FrameDiscarded(id))) if id == expected
+            ));
+        }
+        assert_eq!(Some(10), rx.try_next().await?);
+        assert_eq!(Some(11), rx.try_next().await?);
+        assert_eq!(Some(12), rx.try_next().await?);
+
+        // The 7-frame gap must be flushed after one timeout window,
+        // not at a rate of one frame per window.
+        assert!(
+            now.elapsed() < 3 * timeout,
+            "gap drain took {:?}, expected well under {:?}",
+            now.elapsed(),
+            7 * timeout
+        );
 
         Ok(())
     }


### PR DESCRIPTION
When the next expected frame is missing, the sequencer discards frame ids to advance. It reset `last_emitted` on every discard, so a contiguous gap of K missing frames was drained at one id per `frame_timeout` (800ms) — a K x 800ms delivery stall of frames already buffered behind the gap.

Reset `last_emitted` only on an actual frame emission, not per discard, so once `frame_timeout` elapses the whole contiguous gap is flushed in a single window and buffered later frames are delivered immediately.

Adds a regression test asserting a 7-frame gap drains within one window, not seven.