### PR TITLE
fix: update the way graph values are entered for graph edge latencies

### DIFF
--- a/hopr/hopr-lib/src/testing/wiring.rs
+++ b/hopr/hopr-lib/src/testing/wiring.rs
@@ -54,6 +54,7 @@ where
         *packet_key.public(),
         path_cfg.edge_penalty,
         path_cfg.min_ack_rate,
+        path_cfg.max_plausible_loopback_rtt,
     ));
     let graph_for_ct = graph.clone();
     let safe_address = config.safe_module.safe_address;

--- a/impls/graph/src/petgraph/graph.rs
+++ b/impls/graph/src/petgraph/graph.rs
@@ -30,6 +30,7 @@ pub struct ChannelGraph {
     pub(crate) me: OffchainPublicKey,
     pub(crate) edge_penalty: f64,
     pub(crate) min_ack_rate: f64,
+    pub(crate) max_plausible_loopback_rtt: std::time::Duration,
     pub(crate) inner: Arc<RwLock<InnerGraph>>,
 }
 
@@ -43,7 +44,7 @@ impl ChannelGraph {
     /// Production code should prefer [`with_edge_params`](Self::with_edge_params) to
     /// receive values from `PathPlannerConfig`.
     pub fn new(me: OffchainPublicKey) -> Self {
-        Self::with_edge_params(me, 0.5, 0.1)
+        Self::with_edge_params(me, 0.5, 0.1, std::time::Duration::from_secs(30))
     }
 
     /// Creates a new channel graph with custom edge scoring parameters.
@@ -51,7 +52,14 @@ impl ChannelGraph {
     /// * `me` – offchain public key of the local node (added as the first graph node).
     /// * `edge_penalty` – penalty multiplier for edges lacking probe-based quality observations.
     /// * `min_ack_rate` – minimum acceptable message acknowledgment rate for path selection.
-    pub fn with_edge_params(me: OffchainPublicKey, edge_penalty: f64, min_ack_rate: f64) -> Self {
+    /// * `max_plausible_loopback_rtt` – upper bound on a loopback probe RTT considered plausible; measurements above it
+    ///   are discarded during attribution.
+    pub fn with_edge_params(
+        me: OffchainPublicKey,
+        edge_penalty: f64,
+        min_ack_rate: f64,
+        max_plausible_loopback_rtt: std::time::Duration,
+    ) -> Self {
         let mut graph = DiGraph::new();
         let mut indices = BiHashMap::new();
 
@@ -62,6 +70,7 @@ impl ChannelGraph {
             me,
             edge_penalty,
             min_ack_rate,
+            max_plausible_loopback_rtt,
             inner: Arc::new(RwLock::new(InnerGraph { graph, indices })),
         }
     }

--- a/impls/graph/src/petgraph/update.rs
+++ b/impls/graph/src/petgraph/update.rs
@@ -116,14 +116,19 @@ impl hopr_api::graph::NetworkGraphUpdate for ChannelGraph {
                 // target edge as its new intermediate measurement.
                 //
                 // `timestamp()` is the probe's creation time (unix epoch millis), so the
-                // RTT is the elapsed time until now. Values above the plausibility cap
-                // (clock skew, stale telemetry) are discarded instead of poisoning the
-                // latency EMA with an absurd measurement.
+                // RTT is the elapsed time until now. A timestamp in the future (backward
+                // clock drift) underflows and is discarded rather than recorded as a
+                // zero-duration RTT. Values above the plausibility cap (clock skew, stale
+                // telemetry) are likewise discarded instead of poisoning the latency EMA.
                 let now_ms = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()
                     .as_millis();
-                let total_rtt = std::time::Duration::from_millis(now_ms.saturating_sub(telemetry.timestamp()) as u64);
+                let Some(elapsed_ms) = now_ms.checked_sub(telemetry.timestamp()) else {
+                    tracing::debug!("loopback probe timestamp in the future, skipping attribution");
+                    return;
+                };
+                let total_rtt = std::time::Duration::from_millis(elapsed_ms as u64);
                 if total_rtt > self.max_plausible_loopback_rtt {
                     tracing::debug!(
                         rtt_ms = total_rtt.as_millis(),
@@ -813,6 +818,40 @@ mod tests {
         assert!(
             obs.intermediate_qos().is_none(),
             "implausible RTT must not produce an intermediate measurement"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn loopback_future_timestamp_should_be_ignored() -> anyhow::Result<()> {
+        // Backward clock drift can place the probe's creation timestamp in the future,
+        // so `now - timestamp` underflows. Such a probe is discarded rather than
+        // recorded as a zero-duration RTT, which would poison the latency EMA toward 0.
+        let me = pubkey_from(&SECRET_0);
+        let a = pubkey_from(&SECRET_1);
+        let b = pubkey_from(&SECRET_2);
+
+        let graph = ChannelGraph::new(me);
+        graph.add_node(a);
+        graph.add_node(b);
+        graph.add_edge(&me, &a)?;
+        graph.add_edge(&a, &b)?;
+        graph.add_edge(&b, &me)?; // return edge
+
+        let telemetry: Result<
+            EdgeTransportTelemetry<TestNeighbor, LoopbackTestPath>,
+            NetworkGraphError<LoopbackTestPath>,
+        > = Ok(EdgeTransportTelemetry::Loopback(LoopbackTestPath::new(
+            [0, 1, 2, 0, 0],
+            now_unix_ms() + 5_000, // timestamp 5 s in the future
+        )));
+        graph.record_edge(hopr_api::graph::MeasurableEdge::Probe(telemetry));
+
+        let obs = graph.edge(&a, &b).context("edge a→b should exist")?;
+        assert!(
+            obs.intermediate_qos().is_none(),
+            "future timestamp must not produce an intermediate measurement"
         );
 
         Ok(())

--- a/impls/graph/src/petgraph/update.rs
+++ b/impls/graph/src/petgraph/update.rs
@@ -114,7 +114,25 @@ impl hopr_api::graph::NetworkGraphUpdate for ChannelGraph {
                 // For each edge (including the target), use intermediate QoS if available,
                 // otherwise fall back to immediate QoS. The residual is attributed to the
                 // target edge as its new intermediate measurement.
-                let total_rtt = std::time::Duration::from_millis(telemetry.timestamp() as u64);
+                //
+                // `timestamp()` is the probe's creation time (unix epoch millis), so the
+                // RTT is the elapsed time until now. Values above the plausibility cap
+                // (clock skew, stale telemetry) are discarded instead of poisoning the
+                // latency EMA with an absurd measurement.
+                const MAX_PLAUSIBLE_LOOPBACK_RTT: std::time::Duration = std::time::Duration::from_secs(30);
+                let now_ms = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_millis();
+                let total_rtt =
+                    std::time::Duration::from_millis(now_ms.saturating_sub(telemetry.timestamp()) as u64);
+                if total_rtt > MAX_PLAUSIBLE_LOOPBACK_RTT {
+                    tracing::debug!(
+                        rtt_ms = total_rtt.as_millis(),
+                        "implausible loopback probe RTT, skipping attribution"
+                    );
+                    return;
+                }
                 let mut known_latency = std::time::Duration::ZERO;
 
                 for &edge in &edges {
@@ -222,6 +240,7 @@ impl hopr_api::graph::NetworkGraphUpdate for ChannelGraph {
 #[cfg(test)]
 mod tests {
     use anyhow::Context;
+    use assertables::assert_in_delta;
     use hex_literal::hex;
     use hopr_api::{
         OffchainPublicKey,
@@ -542,14 +561,25 @@ mod tests {
         }
     }
 
-    /// Helper to send a loopback probe with the given path and timestamp.
-    fn send_loopback(graph: &ChannelGraph, path_id: [u64; 5], timestamp_ms: u128) {
+    /// Current unix epoch time in milliseconds, mirroring how production code derives RTT.
+    fn now_unix_ms() -> u128 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis()
+    }
+
+    /// Helper to send a loopback probe with the given path and desired RTT.
+    ///
+    /// The telemetry timestamp is set `rtt_ms` in the past so the receiver
+    /// computes an elapsed RTT of approximately `rtt_ms`.
+    fn send_loopback(graph: &ChannelGraph, path_id: [u64; 5], rtt_ms: u128) {
         let telemetry: Result<
             EdgeTransportTelemetry<TestNeighbor, LoopbackTestPath>,
             NetworkGraphError<LoopbackTestPath>,
         > = Ok(EdgeTransportTelemetry::Loopback(LoopbackTestPath::new(
             path_id,
-            timestamp_ms,
+            now_unix_ms() - rtt_ms,
         )));
         graph.record_edge(hopr_api::graph::MeasurableEdge::Probe(telemetry));
     }
@@ -588,9 +618,10 @@ mod tests {
         let qos = obs
             .intermediate_qos()
             .context("intermediate QoS should be present on a→b")?;
-        assert_eq!(
-            qos.average_latency().context("latency should be set")?,
-            std::time::Duration::from_millis(200),
+        assert_in_delta!(
+            qos.average_latency().context("latency should be set")?.as_millis(),
+            200,
+            25
         );
 
         // me→a should NOT have intermediate QoS from this probe
@@ -627,11 +658,11 @@ mod tests {
         let qos = obs
             .intermediate_qos()
             .context("intermediate QoS should be present on b→c")?;
-        assert_eq!(
-            qos.average_latency().context("latency should be set")?,
-            std::time::Duration::from_millis(300),
-            "no preceding intermediate latencies, so full RTT is attributed"
-        );
+        assert_in_delta!(
+            qos.average_latency().context("latency should be set")?.as_millis(),
+            300,
+            25
+        ); // no preceding intermediate latencies, so full RTT is attributed
 
         // Earlier edges should NOT have intermediate QoS from this probe
         let obs_me_a = graph.edge(&me, &a).context("edge me→a should exist")?;
@@ -683,11 +714,11 @@ mod tests {
         let qos = obs
             .intermediate_qos()
             .context("intermediate QoS should be present on b→c")?;
-        assert_eq!(
-            qos.average_latency().context("latency should be set")?,
-            std::time::Duration::from_millis(180),
-            "300ms total - 80ms (me→a) - 40ms (a→b) = 180ms attributed to b→c"
-        );
+        assert_in_delta!(
+            qos.average_latency().context("latency should be set")?.as_millis(),
+            180,
+            25
+        ); // 300ms total - 80ms (me→a) - 40ms (a→b) = 180ms attributed to b→c
 
         Ok(())
     }
@@ -723,11 +754,11 @@ mod tests {
         let qos = obs
             .intermediate_qos()
             .context("intermediate QoS should be present on a→b")?;
-        assert_eq!(
-            qos.average_latency().context("latency should be set")?,
-            std::time::Duration::from_millis(140),
-            "200ms total - 60ms (me→a immediate) = 140ms attributed to a→b"
-        );
+        assert_in_delta!(
+            qos.average_latency().context("latency should be set")?.as_millis(),
+            140,
+            25
+        ); // 200ms total - 60ms (me→a immediate) = 140ms attributed to a→b
 
         Ok(())
     }
@@ -756,6 +787,34 @@ mod tests {
         assert!(
             obs.intermediate_qos().is_none(),
             "invalid path bytes should not produce any intermediate measurement"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn loopback_implausible_rtt_should_be_ignored() -> anyhow::Result<()> {
+        // Regression: a raw epoch timestamp was once misread as the RTT itself,
+        // poisoning the latency EMA with a ~56-year measurement. Any computed
+        // RTT above the plausibility cap must be discarded.
+        let me = pubkey_from(&SECRET_0);
+        let a = pubkey_from(&SECRET_1);
+        let b = pubkey_from(&SECRET_2);
+
+        let graph = ChannelGraph::new(me);
+        graph.add_node(a);
+        graph.add_node(b);
+        graph.add_edge(&me, &a)?;
+        graph.add_edge(&a, &b)?;
+        graph.add_edge(&b, &me)?; // return edge
+
+        // Timestamp 90 s in the past → RTT far above the 30 s cap.
+        send_loopback(&graph, [0, 1, 2, 0, 0], 90_000);
+
+        let obs = graph.edge(&a, &b).context("edge a→b should exist")?;
+        assert!(
+            obs.intermediate_qos().is_none(),
+            "implausible RTT must not produce an intermediate measurement"
         );
 
         Ok(())
@@ -815,11 +874,11 @@ mod tests {
         let qos = obs
             .intermediate_qos()
             .context("intermediate QoS should be present on me→a")?;
-        assert_eq!(
-            qos.average_latency().context("latency should be set")?,
-            std::time::Duration::from_millis(50),
-            "100ms total - 50ms (me→a immediate) = 50ms attributed to me→a"
-        );
+        assert_in_delta!(
+            qos.average_latency().context("latency should be set")?.as_millis(),
+            50,
+            25
+        ); // 100ms total - 50ms (me→a immediate) = 50ms attributed to me→a
 
         // Immediate QoS should still be intact
         let imm = obs

--- a/impls/graph/src/petgraph/update.rs
+++ b/impls/graph/src/petgraph/update.rs
@@ -119,14 +119,12 @@ impl hopr_api::graph::NetworkGraphUpdate for ChannelGraph {
                 // RTT is the elapsed time until now. Values above the plausibility cap
                 // (clock skew, stale telemetry) are discarded instead of poisoning the
                 // latency EMA with an absurd measurement.
-                const MAX_PLAUSIBLE_LOOPBACK_RTT: std::time::Duration = std::time::Duration::from_secs(30);
                 let now_ms = std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()
                     .as_millis();
-                let total_rtt =
-                    std::time::Duration::from_millis(now_ms.saturating_sub(telemetry.timestamp()) as u64);
-                if total_rtt > MAX_PLAUSIBLE_LOOPBACK_RTT {
+                let total_rtt = std::time::Duration::from_millis(now_ms.saturating_sub(telemetry.timestamp()) as u64);
+                if total_rtt > self.max_plausible_loopback_rtt {
                     tracing::debug!(
                         rtt_ms = total_rtt.as_millis(),
                         "implausible loopback probe RTT, skipping attribution"
@@ -794,9 +792,9 @@ mod tests {
 
     #[tokio::test]
     async fn loopback_implausible_rtt_should_be_ignored() -> anyhow::Result<()> {
-        // Regression: a raw epoch timestamp was once misread as the RTT itself,
-        // poisoning the latency EMA with a ~56-year measurement. Any computed
-        // RTT above the plausibility cap must be discarded.
+        // Adversarial mitigation: an attacker who withholds a probe past the
+        // plausibility cap before replaying it would otherwise poison the latency
+        // EMA with an inflated measurement. Any computed RTT above the cap is discarded.
         let me = pubkey_from(&SECRET_0);
         let a = pubkey_from(&SECRET_1);
         let b = pubkey_from(&SECRET_2);
@@ -808,7 +806,7 @@ mod tests {
         graph.add_edge(&a, &b)?;
         graph.add_edge(&b, &me)?; // return edge
 
-        // Timestamp 90 s in the past → RTT far above the 30 s cap.
+        // Probe withheld 90 s before replay: computed RTT far above the 30 s cap.
         send_loopback(&graph, [0, 1, 2, 0, 0], 90_000);
 
         let obs = graph.edge(&a, &b).context("edge a→b should exist")?;

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -341,6 +341,10 @@ where
                     .and_then(|s| s.parse::<u64>().ok().map(Duration::from_millis))
                     .unwrap_or_else(|| SessionManagerConfig::default().max_frame_timeout)
                     .max(Duration::from_millis(100)),
+                max_buffered_segments: std::env::var("HOPR_SESSION_MAX_BUFFERED_SEGMENTS")
+                    .ok()
+                    .and_then(|s| s.parse::<usize>().ok())
+                    .unwrap_or_else(|| SessionManagerConfig::default().max_buffered_segments),
                 initiation_timeout_base: SESSION_INITIATION_TIMEOUT_BASE,
                 idle_timeout: cfg.session.idle_timeout,
                 balancer_sampling_interval: cfg.session.balancer_sampling_interval,

--- a/transport/hopr/src/path/planner.rs
+++ b/transport/hopr/src/path/planner.rs
@@ -76,6 +76,11 @@ pub struct PathPlannerConfig {
     /// Defaults to 10_000_000 (~10 MiB in wxHOPR tokens).
     #[default = 10_000_000]
     pub capacity_reference: u128,
+    /// Upper bound on a loopback probe's round-trip time considered plausible.
+    /// Measurements above this cap (clock skew, stale telemetry) are discarded
+    /// instead of poisoning the latency EMA with an absurd value.
+    #[default(Duration::from_secs(30))]
+    pub max_plausible_loopback_rtt: Duration,
 }
 
 fn validate_unit_interval(value: f64) -> std::result::Result<(), ValidationError> {

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -241,6 +241,13 @@ pub struct SessionManagerConfig {
     #[default(Duration::from_millis(800))]
     pub max_frame_timeout: Duration,
 
+    /// Maximum number of segments to buffer in the downstream transport of a Session's socket.
+    /// If 0 is given, the transport is unbuffered.
+    ///
+    /// Default is 0.
+    #[default(0)]
+    pub max_buffered_segments: usize,
+
     /// The base timeout for initiation of Session initiation.
     ///
     /// The actual timeout is adjusted according to the number of hops for that Session:
@@ -529,6 +536,7 @@ fn session_config(cfg: &SessionManagerConfig, capabilities: crate::Capabilities)
         capabilities,
         frame_mtu: cfg.frame_mtu,
         frame_timeout: cfg.max_frame_timeout,
+        max_buffered_segments: cfg.max_buffered_segments,
     }
 }
 

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -1790,6 +1790,26 @@ mod tests {
     use super::*;
     use crate::{Capabilities, balancer::SurbBalancerConfig, types::SessionTarget};
 
+    #[test]
+    fn session_config_forwards_max_buffered_segments() {
+        assert_eq!(
+            SessionManagerConfig::default().max_buffered_segments,
+            0,
+            "default must leave the transport unbuffered"
+        );
+
+        for segments in [0, 64] {
+            let cfg = SessionManagerConfig {
+                max_buffered_segments: segments,
+                ..Default::default()
+            };
+            assert_eq!(
+                session_config(&cfg, Capabilities::empty()).max_buffered_segments,
+                segments
+            );
+        }
+    }
+
     #[async_trait::async_trait]
     trait SendMsg {
         async fn send_message(

--- a/transport/session/src/snapshots/hopr_transport_session__types__tests__hopr_session_config_default_snapshot.snap
+++ b/transport/session/src/snapshots/hopr_transport_session__types__tests__hopr_session_config_default_snapshot.snap
@@ -1,7 +1,9 @@
 ---
 source: transport/session/src/types.rs
+assertion_line: 487
 expression: cfg
 ---
 capabilities: 0
 frame_mtu: 1500
 frame_timeout: 800ms
+max_buffered_segments: 0

--- a/transport/session/src/types.rs
+++ b/transport/session/src/types.rs
@@ -151,6 +151,12 @@ pub struct HoprSessionConfig {
     #[default(Duration::from_millis(800))]
     #[serde(with = "humantime_serde")]
     pub frame_timeout: Duration,
+    /// Maximum number of segments to buffer in the downstream transport.
+    /// If 0 is given, the transport is unbuffered.
+    ///
+    /// Default is 0.
+    #[default(0)]
+    pub max_buffered_segments: usize,
 }
 
 /// Represents the Session protocol socket over HOPR.
@@ -228,6 +234,7 @@ impl HoprSession {
                 frame_timeout: cfg.frame_timeout,
                 capacity: SESSION_SOCKET_CAPACITY,
                 flush_immediately: cfg.capabilities.contains(Capability::NoDelay),
+                max_buffered_segments: cfg.max_buffered_segments,
                 ..Default::default()
             };
 


### PR DESCRIPTION
 ## Fix loopback probe RTT computation poisoning path selection

  `update.rs` treated `PathTelemetry.timestamp` (epoch millis at probe
  creation) as the total RTT. Every loopback-probed edge got a ~56-year
  latency EMA, 79% of candidate paths saturated `total_latency_ms` at
  u32::MAX, and the latency factor cancelled out of path selection —
  relays were picked cost-only at random (observed: New Delhi relay for
  Poland→Iowa traffic).

  ### Changes
  - Compute RTT as `now - timestamp`; discard implausible values (>30s)
    so clock skew can't poison the EMA again. Regression test added.
  - Make session socket `max_buffered_segments` configurable via
    `HOPR_SESSION_MAX_BUFFERED_SEGMENTS` (was hardcoded 0), mirroring
    `HOPR_SESSION_FRAME_TIMEOUT_MS`. Defaults unchanged.

  ### Results (rotsee)
  - Latency saturation: 342/432 candidates → 0
  - Frame reassembly errors under bulk load: 854 → 2
    (with `max_buffered_segments=64`, `frame_timeout=1500ms`)