### PR TITLE
fix: address review comments for PIX protocol (#8095 review fixes)

### DIFF
--- a/.claude/CODE-COVERAGE-SKILL.md
+++ b/.claude/CODE-COVERAGE-SKILL.md
@@ -5,14 +5,11 @@ This skill provides instructions for running code coverage analysis using `cargo
 ## Quick Reference
 
 ```bash
-# Set working directory first
-cargo set-working-directory -p hopr-transport-session
-
-# Run coverage for a specific crate
-cargo llvm-cov --package <crate> --lib --bins --tests
+# Run coverage for a specific crate using nextest (preferred)
+cargo llvm-cov nextest --package <crate> --lib --bins
 
 # Get LCOV output for per-file analysis
-cargo llvm-cov --package <crate> --lib --bins --tests --lcov --output-path /tmp/coverage.lcov
+cargo llvm-cov nextest --package <crate> --lib --bins --lcov --output-path /tmp/coverage.lcov
 ```
 
 ## Detailed Workflow
@@ -44,21 +41,20 @@ cargo build --package <crate>
 Basic command for a specific package:
 
 ```bash
-cargo llvm-cov --package hopr-transport-session --lib --bins --tests
+cargo llvm-cov nextest --package hopr-transport-session --lib --bins
 ```
 
 Flags:
 
 - `--lib`: Include library code
 - `--bins`: Include binaries
-- `--tests`: Include test code
 
 ### 4. Generate LCOV for Per-File Analysis
 
 To get per-file coverage breakdown, generate LCOV format:
 
 ```bash
-cargo llvm-cov --package <crate> --lib --bins --tests --lcov --output-path /tmp/coverage.lcov
+cargo llvm-cov nextest --package <crate> --lib --bins --lcov --output-path /tmp/coverage.lcov
 ```
 
 ### 5. Parse Results
@@ -76,7 +72,7 @@ with open('/tmp/coverage.lcov', 'r') as f:
         line = line.strip()
         if line.startswith('SF:'):
             path = line[3:]
-            filename = path.split('/')[-1]
+            filename = path
             current_file = filename
             if current_file not in files_data:
                 files_data[current_file] = {'covered': 0, 'total': 0}

--- a/crypto/packet/src/lib.rs
+++ b/crypto/packet/src/lib.rs
@@ -102,6 +102,8 @@ impl hopr_protocol_pix::PixSpec for HoprPixSpec {
     type Digest = Blake3;
     type Pseudonym = SimplePseudonym;
 
+    const HASH_TO_SCALAR_SUITE_ID: &'static [u8] = b"Secp256k1_XMD:BLAKE3_SSWU_RO_";
+
     fn group_to_deposit_address(group: PixGroup<Self>) -> Option<Self::DepositAddress> {
         PublicKey::try_from(group.to_affine()).ok().map(|pk| pk.to_address())
     }
@@ -119,6 +121,8 @@ impl hopr_protocol_pix::PixSpec for HoprPixSpec {
     type DepositAddress = BjjPublicKey;
     type Digest = Blake3;
     type Pseudonym = SimplePseudonym;
+
+    const HASH_TO_SCALAR_SUITE_ID: &'static [u8] = b"BabyJubJub_XMD:BLAKE3_SSWU_RO_";
 
     fn group_to_deposit_address(group: PixGroup<Self>) -> Option<Self::DepositAddress> {
         BjjPublicKey::try_from(group).ok()

--- a/crypto/packet/src/packet.rs
+++ b/crypto/packet/src/packet.rs
@@ -444,8 +444,8 @@ fn create_surb_for_path<
     );
 
     tracing::debug!(
-        "first relayer solution: {:?}",
-        first_relayer_solution.map(|s| s.to_hex())
+        has_first_relayer_solution = first_relayer_solution.is_some(),
+        "prepared return-path PoR data"
     );
 
     let (mut surb, (surb_id, ro)) = create_surb::<HoprSphinxSuite, HoprSphinxHeaderSpec>(

--- a/crypto/packet/src/sphinx/surb.rs
+++ b/crypto/packet/src/sphinx/surb.rs
@@ -240,12 +240,6 @@ mod tests {
     use hopr_types::crypto_random::Randomizable;
 
     use super::{super::tests::*, *};
-    #[cfg(feature = "ed25519")]
-    use crate::sphinx::ec_groups::Ed25519Suite as CurrentSuite;
-    #[cfg(feature = "secp256k1")]
-    use crate::sphinx::ec_groups::Secp256k1Suite as CurrentSuite;
-    #[cfg(feature = "x25519")]
-    use crate::sphinx::ec_groups::X25519Suite as CurrentSuite;
 
     #[allow(type_alias_bounds)]
     pub type HeaderSpec<S: SphinxSuite> = TestSpec<<S::P as Keypair>::Public, 4, 66>;
@@ -267,6 +261,15 @@ mod tests {
             Default::default(),
         )?)
     }
+
+    // Mutually exclusive cfg to prevent type alias collision under --all-features.
+    // Priority order: ed25519 > secp256k1 > x25519.
+    #[cfg(feature = "ed25519")]
+    use crate::sphinx::ec_groups::Ed25519Suite as CurrentSuite;
+    #[cfg(all(feature = "secp256k1", not(feature = "ed25519")))]
+    use crate::sphinx::ec_groups::Secp256k1Suite as CurrentSuite;
+    #[cfg(all(feature = "x25519", not(any(feature = "ed25519", feature = "secp256k1"))))]
+    use crate::sphinx::ec_groups::X25519Suite as CurrentSuite;
 
     #[test]
     fn surb_serialize_deserialize() -> anyhow::Result<()> {

--- a/hopr/hopr-lib/src/testing/dummies.rs
+++ b/hopr/hopr-lib/src/testing/dummies.rs
@@ -63,7 +63,14 @@ impl hopr_api::node::HoprSessionServer for SessionCaptureServer {
     type Session = IncomingSession;
 
     async fn process(&self, session: IncomingSession) -> Result<(), HoprLibError> {
-        self.captured.lock().unwrap().replace(session);
+        {
+            let mut captured = self.captured.lock().unwrap();
+            if captured.is_some() {
+                // Preserve the first session — ignore subsequent ones
+                return Ok(());
+            }
+            captured.replace(session);
+        }
         tracing::debug!("SessionCaptureServer captured incoming session");
         // Keep the future alive to stop the session from being dropped
         let () = futures::future::pending().await;

--- a/hopr/hopr-lib/tests/transport_session.rs
+++ b/hopr/hopr-lib/tests/transport_session.rs
@@ -121,13 +121,16 @@ async fn verify_session_echo(
     label: &str,
 ) -> anyhow::Result<()> {
     let msg: [u8; 32] = hopr_lib::api::types::crypto_random::random_bytes();
-    entry_session.write_all(&msg).await?;
-    entry_session.flush().await?;
 
     let mut echoed = vec![0u8; 32];
-    tokio::time::timeout(Duration::from_secs(10), entry_session.read_exact(&mut echoed))
+    tokio::time::timeout(Duration::from_secs(10), async {
+        entry_session.write_all(&msg).await?;
+        entry_session.flush().await?;
+        entry_session.read_exact(&mut echoed).await?;
+        anyhow::Ok(())
+    })
         .await
-        .with_context(|| format!("{label}: echo read timeout"))??;
+        .with_context(|| format!("{label}: echo round-trip timeout"))??;
     assert_eq!(&msg[..], &echoed[..], "{label}: echo mismatch");
 
     tracing::info!("{label}: echo verified");

--- a/hopr/hopr-lib/tests/transport_session.rs
+++ b/hopr/hopr-lib/tests/transport_session.rs
@@ -129,8 +129,8 @@ async fn verify_session_echo(
         entry_session.read_exact(&mut echoed).await?;
         anyhow::Ok(())
     })
-        .await
-        .with_context(|| format!("{label}: echo round-trip timeout"))??;
+    .await
+    .with_context(|| format!("{label}: echo round-trip timeout"))??;
     assert_eq!(&msg[..], &echoed[..], "{label}: echo mismatch");
 
     tracing::info!("{label}: echo verified");

--- a/hopr/hopr-lib/tests/transport_session_pix.rs
+++ b/hopr/hopr-lib/tests/transport_session_pix.rs
@@ -190,6 +190,7 @@ async fn capture_n_hop_pix_session(#[case] hops: usize) -> anyhow::Result<()> {
     let target_cycles = 3u32;
     let mut new_deposit_count = 0u32;
     let mut pk_recovered_count = 0u32;
+    let mut completed_ssa_ids: Vec<hopr_api::types::internal::protocol::HoprPseudonym> = Vec::new();
 
     loop {
         tokio::select! {
@@ -203,6 +204,12 @@ async fn capture_n_hop_pix_session(#[case] hops: usize) -> anyhow::Result<()> {
                             quota = data.quota,
                             "Entry: NewDepositAddress"
                         );
+                        assert!(
+                            !completed_ssa_ids.contains(&data.id.0),
+                            "duplicate SSA pseudonym detected — expected distinct cycles, got {:?}",
+                            data.id.0,
+                        );
+                        completed_ssa_ids.push(data.id.0);
                     }
                     other => {
                         anyhow::bail!("unexpected Entry PixEvent: {other:?}");

--- a/hopr/hopr-lib/tests/transport_session_pix.rs
+++ b/hopr/hopr-lib/tests/transport_session_pix.rs
@@ -190,7 +190,8 @@ async fn capture_n_hop_pix_session(#[case] hops: usize) -> anyhow::Result<()> {
     let target_cycles = 3u32;
     let mut new_deposit_count = 0u32;
     let mut pk_recovered_count = 0u32;
-    let mut completed_ssa_ids: Vec<hopr_api::types::internal::protocol::HoprPseudonym> = Vec::new();
+    let mut completed_ssa_ids: Vec<hopr_api::node::PixAddressId> = Vec::new();
+    let mut pk_recovered_ssa_ids: Vec<hopr_api::node::PixAddressId> = Vec::new();
 
     loop {
         tokio::select! {
@@ -204,12 +205,6 @@ async fn capture_n_hop_pix_session(#[case] hops: usize) -> anyhow::Result<()> {
                             quota = data.quota,
                             "Entry: NewDepositAddress"
                         );
-                        assert!(
-                            !completed_ssa_ids.contains(&data.id.0),
-                            "duplicate SSA pseudonym detected — expected distinct cycles, got {:?}",
-                            data.id.0,
-                        );
-                        completed_ssa_ids.push(data.id.0);
                     }
                     other => {
                         anyhow::bail!("unexpected Entry PixEvent: {other:?}");
@@ -234,6 +229,12 @@ async fn capture_n_hop_pix_session(#[case] hops: usize) -> anyhow::Result<()> {
                         }
                     }
                     PixEvent::PrivateKeyRecovered(data) => {
+                        assert!(
+                            !pk_recovered_ssa_ids.contains(&data.id),
+                            "duplicate PrivateKeyRecovered for same SSA — expected distinct cycles, got {:?}",
+                            data.id,
+                        );
+                        pk_recovered_ssa_ids.push(data.id);
                         pk_recovered_count += 1;
                         tracing::info!(pk_recovered_count, id = ?data.id, "Exit: PrivateKeyRecovered");
                     }

--- a/impls/strategy/src/non_anonymous_pix.rs
+++ b/impls/strategy/src/non_anonymous_pix.rs
@@ -114,27 +114,13 @@ where
                 tracing::info!(?deposit_address_recv, "deposit address received");
 
                 let target_deposit = self.cfg.price_per_byte * deposit_address_recv.quota;
+                let pix_id = deposit_address_recv.id;
+                let deposit_updated = deposit_address_recv.deposit_updated;
                 let node_clone = self.node.clone();
+                let node_clone_for_initial = self.node.clone();
                 let deposit_addr: Address = deposit_address_recv.address.try_into()?;
 
                 let max_tracking_time = self.cfg.max_deposit_tracking_time;
-
-                // Check balance immediately before entering the interval loop to avoid
-                // the sub-second first-poll delay inherent to stream::interval.
-                let initial_balance = node_clone
-                    .chain_api()
-                    .balance(deposit_addr)
-                    .await
-                    .map_err(StrategyError::other)?;
-                if initial_balance >= target_deposit {
-                    if let Some(mut notifier) = deposit_address_recv.deposit_updated {
-                        notifier
-                            .send((deposit_address_recv.id, initial_balance))
-                            .await
-                            .map_err(StrategyError::other)?;
-                    }
-                    return Ok(());
-                }
 
                 let mut stream = futures_time::stream::interval(
                     futures_time::time::Duration::from(max_tracking_time / 10).max(Duration::from_secs(1).into()),
@@ -155,13 +141,27 @@ where
                 tracing::info!(%target_deposit, ?max_tracking_time, "tracking until deposit");
                 hopr_utils::runtime::prelude::spawn(
                     async move {
-                        let result = stream.try_next().await?;
-                        match (result, deposit_address_recv.deposit_updated) {
-                            (Some(deposit), Some(mut notifier)) => notifier
-                                .send((deposit_address_recv.id, deposit))
-                                .await
-                                .map_err(StrategyError::other),
-                            _ => Err(StrategyError::other(anyhow::anyhow!("deposit tracking not available"))),
+                        // Check balance immediately (first poll) to avoid the sub-second
+                        // first-poll delay inherent to stream::interval. Both the immediate
+                        // check and the interval polling are inside the timeout guard so a
+                        // stalled RPC does not block event handling indefinitely.
+                        let immediate = node_clone_for_initial
+                            .chain_api()
+                            .balance(deposit_addr)
+                            .await
+                            .ok()
+                            .filter(|b| *b >= target_deposit);
+
+                        let deposit = match (immediate, stream.try_next().await) {
+                            (Some(balance), _) => balance,
+                            (None, Ok(Some(balance))) => balance,
+                            _ => return Err(StrategyError::other(anyhow::anyhow!("deposit tracking not available"))),
+                        };
+
+                        if let Some(mut notifier) = deposit_updated {
+                            notifier.send((pix_id, deposit)).await.map_err(StrategyError::other)
+                        } else {
+                            Ok(())
                         }
                     }
                     .timeout(futures_time::time::Duration::from(max_tracking_time))
@@ -294,7 +294,7 @@ mod tests {
         },
         node::{
             ActionableEvent, ActionableEventDiscriminant, ComponentStatus, ComponentStatusReporter, EventWaitResult,
-            HasChainApi, NodeOnchainIdentity, PixDepositAddress, PixDepositAddressReceived, PixEvent,
+            HasChainApi, NodeOnchainIdentity, PixDepositAddressReceived, PixEvent,
         },
         types::{
             crypto::{keypairs::Keypair, prelude::ChainKeypair},

--- a/impls/strategy/src/non_anonymous_pix.rs
+++ b/impls/strategy/src/non_anonymous_pix.rs
@@ -119,6 +119,23 @@ where
 
                 let max_tracking_time = self.cfg.max_deposit_tracking_time;
 
+                // Check balance immediately before entering the interval loop to avoid
+                // the sub-second first-poll delay inherent to stream::interval.
+                let initial_balance = node_clone
+                    .chain_api()
+                    .balance(deposit_addr)
+                    .await
+                    .map_err(StrategyError::other)?;
+                if initial_balance >= target_deposit {
+                    if let Some(mut notifier) = deposit_address_recv.deposit_updated {
+                        notifier
+                            .send((deposit_address_recv.id, initial_balance))
+                            .await
+                            .map_err(StrategyError::other)?;
+                    }
+                    return Ok(());
+                }
+
                 let mut stream = futures_time::stream::interval(
                     futures_time::time::Duration::from(max_tracking_time / 10).max(Duration::from_secs(1).into()),
                 )

--- a/impls/strategy/src/strategy.rs
+++ b/impls/strategy/src/strategy.rs
@@ -67,9 +67,7 @@ impl Display for MultiStrategy {
 #[async_trait]
 impl Strategy for MultiStrategy {
     async fn run(&mut self) -> Result<()> {
-        #[cfg(feature = "runtime-tokio")]
         use futures::StreamExt as _;
-        #[cfg(feature = "runtime-tokio")]
         use hopr_utils::runtime::prelude::{AbortHandle, abortable, spawn};
 
         let strategies = std::mem::take(&mut self.strategies);
@@ -83,59 +81,48 @@ impl Strategy for MultiStrategy {
         // Spawn each sub-strategy as an abortable task.
         // Keeping all AbortHandles in a RAII guard ensures every sub-task is cancelled
         // when MultiStrategy is dropped (graceful shutdown).
-        #[cfg(feature = "runtime-tokio")]
-        {
-            let mut join_handles = Vec::new();
-            let mut abort_handles: Vec<AbortHandle> = Vec::new();
-            for mut s in strategies {
-                let proc = hopr_utils::runtime::diagnostics::instrument(
-                    async move { s.run().await },
-                    "multi_strategy_sub_task",
-                    module_path!(),
-                    file!(),
-                    line!(),
-                );
-                let (proc, abort_handle) = abortable(proc);
-                join_handles.push(spawn(proc));
-                abort_handles.push(abort_handle);
-            }
-
-            struct AbortGuard(Vec<AbortHandle>);
-            impl Drop for AbortGuard {
-                fn drop(&mut self) {
-                    for h in &self.0 {
-                        h.abort();
-                    }
-                }
-            }
-            let _guard = AbortGuard(abort_handles);
-
-            // Process completions as they arrive. Sub-strategies are fully isolated:
-            // a failure in one is logged but does not affect the others.
-            let mut pending: futures::stream::FuturesUnordered<_> = join_handles.into_iter().collect();
-
-            while let Some(join_result) = pending.next().await {
-                let strategy_result = match join_result {
-                    Err(e) => Err(crate::errors::StrategyError::Other(e.into())),
-                    Ok(Ok(result)) => result,
-                    Ok(Err(_aborted)) => continue, // aborted by the guard — expected during shutdown
-                };
-
-                if let Err(e) = strategy_result {
-                    tracing::warn!(%e, "sub-strategy failed");
-                }
-            }
-
-            Ok(())
+        let mut join_handles = Vec::new();
+        let mut abort_handles: Vec<AbortHandle> = Vec::new();
+        for mut s in strategies {
+            let proc = hopr_utils::runtime::diagnostics::instrument(
+                async move { s.run().await },
+                "multi_strategy_sub_task",
+                module_path!(),
+                file!(),
+                line!(),
+            );
+            let (proc, abort_handle) = abortable(proc);
+            join_handles.push(spawn(proc));
+            abort_handles.push(abort_handle);
         }
 
-        #[cfg(not(feature = "runtime-tokio"))]
-        {
-            let _ = strategies;
-            Err(crate::errors::StrategyError::Other(anyhow::anyhow!(
-                "MultiStrategy requires runtime-tokio feature to execute sub-strategies"
-            )))
+        struct AbortGuard(Vec<AbortHandle>);
+        impl Drop for AbortGuard {
+            fn drop(&mut self) {
+                for h in &self.0 {
+                    h.abort();
+                }
+            }
         }
+        let _guard = AbortGuard(abort_handles);
+
+        // Process completions as they arrive. Sub-strategies are fully isolated:
+        // a failure in one is logged but does not affect the others.
+        let mut pending: futures::stream::FuturesUnordered<_> = join_handles.into_iter().collect();
+
+        while let Some(join_result) = pending.next().await {
+            let strategy_result = match join_result {
+                Err(e) => Err(crate::errors::StrategyError::Other(e.into())),
+                Ok(Ok(result)) => result,
+                Ok(Err(_aborted)) => continue, // aborted by the guard — expected during shutdown
+            };
+
+            if let Err(e) = strategy_result {
+                tracing::warn!(%e, "sub-strategy failed");
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/impls/strategy/src/strategy.rs
+++ b/impls/strategy/src/strategy.rs
@@ -125,12 +125,17 @@ impl Strategy for MultiStrategy {
                     tracing::warn!(%e, "sub-strategy failed");
                 }
             }
+
+            Ok(())
         }
 
         #[cfg(not(feature = "runtime-tokio"))]
-        let _ = strategies;
-
-        Ok(())
+        {
+            let _ = strategies;
+            Err(crate::errors::StrategyError::Other(anyhow::anyhow!(
+                "MultiStrategy requires runtime-tokio feature to execute sub-strategies"
+            )))
+        }
     }
 }
 

--- a/protocols/hopr/src/codec/mod.rs
+++ b/protocols/hopr/src/codec/mod.rs
@@ -576,6 +576,10 @@ mod tests {
                 }
             } else {
                 // Gap phase — no PIX share
+                assert!(
+                    out_packet.encrypted_pix_share.is_none(),
+                    "unexpected PIX share during gap at message #{i}"
+                );
                 no_share_indices.push(i);
 
                 // At the last message of this gap, set up the next commitment

--- a/protocols/pix/src/lib.rs
+++ b/protocols/pix/src/lib.rs
@@ -441,12 +441,12 @@ pub(crate) mod tests {
         // these must round-trip correctly since generator-valued coefficients are
         // legitimate (they represent scalar coefficient 1).
         let all_generator = vec![PixGroup::<TestSpec>::generator().to_bytes(); 10];
-        let verifier = PartialSsaShareVerifier::<TestSpec>::from_serializable_commitments(spi.clone(), all_generator)?;
+        let verifier =
+            PartialSsaShareVerifier::<TestSpec>::from_serializable_commitments(spi.clone(), all_generator.clone())?;
         let (_, serialized) = verifier.into_serializable_commitments();
         assert_eq!(
-            serialized.len(),
-            10,
-            "all generator-valued coefficients must be preserved"
+            serialized, all_generator,
+            "all generator-valued coefficients must round-trip exactly"
         );
         Ok(())
     }

--- a/protocols/pix/src/lib.rs
+++ b/protocols/pix/src/lib.rs
@@ -217,18 +217,16 @@ impl<S: PixSpec> PartialSsaShareVerifier<S, S::Pseudonym> {
         spi: SsaPolynomialId<S::Pseudonym>,
         poly_commitments: Vec<PixGroupRepr<S>>,
     ) -> errors::Result<Self, S::Pseudonym> {
-        let recv_commitments = poly_commitments
-            .into_iter()
-            .map(|c| {
-                Option::<PixGroup<S>>::from(PixGroup::<S>::from_bytes(&c))
-                    .filter(|pt| {
-                        // Reject points outside the prime-order subgroup. Baby JubJub has
-                        // cofactor 8, so small-order points can pass the on-curve check.
-                        bool::from(pt.is_torsion_free())
-                    })
-                    .map(ShareVerifierGroup::<PixGroup<S>>::from)
-                    .ok_or(errors::PixError::InvalidInput)
-            });
+        let recv_commitments = poly_commitments.into_iter().map(|c| {
+            Option::<PixGroup<S>>::from(PixGroup::<S>::from_bytes(&c))
+                .filter(|pt| {
+                    // Reject points outside the prime-order subgroup. Baby JubJub has
+                    // cofactor 8, so small-order points can pass the on-curve check.
+                    bool::from(pt.is_torsion_free())
+                })
+                .map(ShareVerifierGroup::<PixGroup<S>>::from)
+                .ok_or(errors::PixError::InvalidInput)
+        });
 
         // Re-add the generator as the first entry
         let poly_commitment = std::iter::once(Ok(ShareVerifierGroup::<PixGroup<S>>::generator()))
@@ -430,7 +428,8 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn from_serializable_commitments_roundtrip_generator_valued_coefficients() -> errors::Result<(), <TestSpec as PixSpec>::Pseudonym> {
+    fn from_serializable_commitments_roundtrip_generator_valued_coefficients()
+    -> errors::Result<(), <TestSpec as PixSpec>::Pseudonym> {
         let spi = SsaPolynomialId::new(
             SsaId::new(
                 SimplePseudonym::try_from([0u8; 10].as_ref()).unwrap(),
@@ -444,7 +443,11 @@ pub(crate) mod tests {
         let all_generator = vec![PixGroup::<TestSpec>::generator().to_bytes(); 10];
         let verifier = PartialSsaShareVerifier::<TestSpec>::from_serializable_commitments(spi.clone(), all_generator)?;
         let (_, serialized) = verifier.into_serializable_commitments();
-        assert_eq!(serialized.len(), 10, "all generator-valued coefficients must be preserved");
+        assert_eq!(
+            serialized.len(),
+            10,
+            "all generator-valued coefficients must be preserved"
+        );
         Ok(())
     }
 }

--- a/protocols/pix/src/lib.rs
+++ b/protocols/pix/src/lib.rs
@@ -89,9 +89,15 @@ where
     type AddressPrivateKey: Clone + Send + Sync + 'static;
 
     /// Context data used to derive the SSA encryption key.
-    const KEY_DERIVATION_CONTEXT: &str = "HASH_SSA_POLY_SHARE";
+    const KEY_DERIVATION_CONTEXT: &'static str = "HASH_SSA_POLY_SHARE";
     /// Domain separator used to derive the X value of a share.
-    const HASH_SCALAR_DERIVATION_CONTEXT: &str = "HASH_SSA_POLY_SHARE_SCALAR";
+    const HASH_SCALAR_DERIVATION_CONTEXT: &'static str = "HASH_SSA_POLY_SHARE_SCALAR";
+
+    /// Stable, protocol-versioned hash-to-scalar suite identifier used for
+    /// domain separation. This must be a fixed string — deriving it dynamically
+    /// from Debug output would break wire compatibility when dependency versions
+    /// change formatting.
+    const HASH_TO_SCALAR_SUITE_ID: &'static [u8];
 
     /// Performs conversion of the given `spi` and `msg` into [`PixScalar`] of this spec.
     fn msg_to_scalar(
@@ -109,12 +115,7 @@ where
                 spi.poly_index().to_be_bytes().as_ref(),
             ],
             &[
-                format!(
-                    "{:?}_XMD:{:?}_SSWU_RO_",
-                    Self::Curve::default(),
-                    Self::Digest::default()
-                )
-                .as_bytes(),
+                Self::HASH_TO_SCALAR_SUITE_ID,
                 Self::HASH_SCALAR_DERIVATION_CONTEXT.as_bytes(),
             ],
         )
@@ -192,12 +193,16 @@ impl<S: PixSpec> PartialSsaShareVerifier<S, S::Pseudonym> {
 
     /// Converts this verifier into a tuple containing the [`SsaPolynomialId`] and the serialized polynomial
     /// coefficient commitments.
+    ///
+    /// The generator (first entry) is omitted by position. The remaining entries are all coefficient
+    /// commitments regardless of their value, because a coefficient commitment equal to the generator
+    /// validly represents scalar coefficient 1.
     pub fn into_serializable_commitments(self) -> (SsaPolynomialId<S::Pseudonym>, Vec<PixGroupRepr<S>>) {
         (
             self.spi,
             self.poly_commitment
                 .into_iter()
-                .filter(|s| s.0 != PixGroup::<S>::generator()) // Generator is typically the first entry
+                .skip(1) // Omit the structural generator at index 0 by position
                 .map(|c| c.to_bytes())
                 .collect(),
         )
@@ -206,6 +211,8 @@ impl<S: PixSpec> PartialSsaShareVerifier<S, S::Pseudonym> {
     /// Tries to create a new verifier from [`SsaPolynomialId`] and serialized polynomial coefficient commitments.
     ///
     /// The `poly_commitments` do not need to contain the generator, because it is added automatically.
+    /// All received commitments are deserialized without value-based filtering — a coefficient commitment
+    /// equal to the generator validly represents scalar coefficient 1 and must be preserved.
     pub fn from_serializable_commitments(
         spi: SsaPolynomialId<S::Pseudonym>,
         poly_commitments: Vec<PixGroupRepr<S>>,
@@ -221,11 +228,6 @@ impl<S: PixSpec> PartialSsaShareVerifier<S, S::Pseudonym> {
                     })
                     .map(ShareVerifierGroup::<PixGroup<S>>::from)
                     .ok_or(errors::PixError::InvalidInput)
-            })
-            .filter(|res: &errors::Result<ShareVerifierGroup<PixGroup<S>>, S::Pseudonym>| {
-                // Explicitly filter out the generator, because we're adding it later.
-                // It is therefore allowed for the generator not to be present in the commitments.
-                res.is_err() || res.as_ref().is_ok_and(|e| e.0 != PixGroup::<S>::generator())
             });
 
         // Re-add the generator as the first entry
@@ -321,6 +323,8 @@ pub(crate) mod tests {
         type DepositAddress = Address;
         type Digest = hopr_types::crypto::primitives::Sha3_256;
         type Pseudonym = SimplePseudonym;
+
+        const HASH_TO_SCALAR_SUITE_ID: &'static [u8] = b"Secp256k1_XMD:SHA3-256_SSWU_RO_";
 
         fn group_to_deposit_address(group: PixGroup<Self>) -> Option<Self::DepositAddress> {
             PublicKey::try_from(group.to_affine()).ok().map(|pk| pk.to_address())
@@ -426,7 +430,7 @@ pub(crate) mod tests {
     }
 
     #[test]
-    fn from_serializable_commitments_must_reject_all_generator() {
+    fn from_serializable_commitments_roundtrip_generator_valued_coefficients() -> errors::Result<(), <TestSpec as PixSpec>::Pseudonym> {
         let spi = SsaPolynomialId::new(
             SsaId::new(
                 SimplePseudonym::try_from([0u8; 10].as_ref()).unwrap(),
@@ -435,8 +439,12 @@ pub(crate) mod tests {
             1,
         );
         // A polynomial whose coefficient commitments are all the generator point:
-        // the filter removes every one and the result collapses to length 1.
+        // these must round-trip correctly since generator-valued coefficients are
+        // legitimate (they represent scalar coefficient 1).
         let all_generator = vec![PixGroup::<TestSpec>::generator().to_bytes(); 10];
-        assert!(PartialSsaShareVerifier::<TestSpec>::from_serializable_commitments(spi, all_generator).is_err());
+        let verifier = PartialSsaShareVerifier::<TestSpec>::from_serializable_commitments(spi.clone(), all_generator)?;
+        let (_, serialized) = verifier.into_serializable_commitments();
+        assert_eq!(serialized.len(), 10, "all generator-valued coefficients must be preserved");
+        Ok(())
     }
 }

--- a/protocols/pix/src/reconstructor/mod.rs
+++ b/protocols/pix/src/reconstructor/mod.rs
@@ -489,6 +489,110 @@ mod tests {
     }
 
     #[test]
+    fn reconstructor_rejects_duplicate_share_via_different_challenges() -> anyhow::Result<()> {
+        // Use the generator pipeline to create real ECC-valid shares.
+        // 1 poly, threshold=2 → need 2 shares per polynomial to reconstruct.
+        let generator = SsaShareGenerator::<TestSpec>::new(SsaGeneratorConfig {
+            polynomials_per_ssa: 1,
+            threshold: 2,
+            surplus_shares: 0,
+        });
+
+        let pseudonym = SimplePseudonym::random();
+        let peer = OffchainKeypair::random();
+        let ssa_id = SsaId::new(pseudonym, 1.try_into()?);
+
+        let commitment_msg = generator.new_ssa_commitment(&pseudonym, SsaIndex::MIN)?;
+
+        let reconstructor = SsaReconstructor::<TestSpec>::new(Default::default());
+        let _server_commitment = reconstructor.new_exit_commitment(ssa_id, 1, 2)?;
+        commitment_msg.process_into_reconstructor(&reconstructor)?;
+
+        // Generate 2 distinct shares, encrypt under different challenges
+        let mut first_share_msg: Option<[u8; 20]> = None;
+        let mut second_share_msg: Option<[u8; 20]> = None;
+        for _ in 0..2 {
+            let msg: [u8; 20] = hopr_types::crypto_random::random_bytes();
+            if let Some(share) = generator.next_share(&pseudonym, &msg)? {
+                let ack = HalfKey::random();
+                let ack_challenge = ack.to_challenge()?;
+                let enc_share = share.share.encrypt(&share.id, &ack)?;
+                reconstructor.insert_encrypted_share(
+                    peer.public(),
+                    ack_challenge,
+                    TaggedEncryptedPartialSsaShare::new(pseudonym, &msg, enc_share)?,
+                )?;
+
+                let resolution = reconstructor.process_verified_ack(
+                    ack,
+                    ack_challenge,
+                    reconstructor
+                        .awaiting_acks
+                        .get(peer.public())
+                        .as_ref()
+                        .ok_or(anyhow::anyhow!("missing peer"))?,
+                )?;
+                match resolution {
+                    ProcessedAckResult::NoProgress | ProcessedAckResult::EarlyRecovery(_) => {
+                        // First share reached early threshold; store the msg for duplication
+                        if first_share_msg.is_none() {
+                            first_share_msg = Some(msg);
+                        }
+                        if let ProcessedAckResult::EarlyRecovery(id) = resolution {
+                            assert_eq!(id, ssa_id);
+                        }
+                    }
+                    ProcessedAckResult::FullRecovery(recovered) => {
+                        assert_eq!(recovered.ssa_id, ssa_id);
+                        second_share_msg = Some(msg);
+                    }
+                }
+            }
+        }
+
+        assert!(second_share_msg.is_some(), "second share should trigger full recovery");
+        let dup_msg = first_share_msg.expect("first share msg must be set");
+
+        // Now re-insert the FIRST share via a different ack challenge — simulating
+        // the same share arriving through a redundant relay path.
+        let generator2 = SsaShareGenerator::<TestSpec>::new(SsaGeneratorConfig {
+            polynomials_per_ssa: 1,
+            threshold: 2,
+            surplus_shares: 0,
+        });
+        let _ = generator2.new_ssa_commitment(&pseudonym, SsaIndex::MIN)?;
+        let Some(dup_share) = generator2.next_share(&pseudonym, &dup_msg)? else {
+            anyhow::bail!("expected share for duplicate msg");
+        };
+        let dup_ack = HalfKey::random();
+        let dup_challenge = dup_ack.to_challenge()?;
+        let dup_enc_share = dup_share.share.encrypt(&dup_share.id, &dup_ack)?;
+        reconstructor.insert_encrypted_share(
+            peer.public(),
+            dup_challenge,
+            TaggedEncryptedPartialSsaShare::new(pseudonym, &dup_msg, dup_enc_share)?,
+        )?;
+
+        // Processing the duplicate share must not error — the reconstructor
+        // already recovered the SSA, so duplicate shares are silently ignored.
+        let dup_resolution = reconstructor.process_verified_ack(
+            dup_ack,
+            dup_challenge,
+            reconstructor
+                .awaiting_acks
+                .get(peer.public())
+                .as_ref()
+                .ok_or(anyhow::anyhow!("missing peer"))?,
+        )?;
+        assert!(
+            matches!(dup_resolution, ProcessedAckResult::NoProgress),
+            "duplicate share must return NoProgress"
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn reconstructor_must_not_accept_empty_encrypted_share() -> anyhow::Result<()> {
         let reconstructor = SsaReconstructor::<TestSpec>::new(SsaReconstructorConfig { ..Default::default() });
 

--- a/protocols/pix/src/reconstructor/mod.rs
+++ b/protocols/pix/src/reconstructor/mod.rs
@@ -203,7 +203,7 @@ impl<S: PixSpec + Clone> ExitAcknowledgementShareProcessor<S> for SsaReconstruct
         polys_per_ssa: usize,
         shares_per_poly: usize,
     ) -> Result<PixGroup<S>, Self::Error> {
-        if polys_per_ssa > MAX_POLYS_PER_SSA as usize || !(2..=MAX_POLY_THRESHOLD as usize).contains(&shares_per_poly) {
+        if !(1..=MAX_POLYS_PER_SSA as usize).contains(&polys_per_ssa) || !(2..=MAX_POLY_THRESHOLD as usize).contains(&shares_per_poly) {
             return Err(PixError::InvalidInput);
         }
 

--- a/protocols/pix/src/reconstructor/mod.rs
+++ b/protocols/pix/src/reconstructor/mod.rs
@@ -378,6 +378,48 @@ mod tests {
     };
 
     #[test]
+    fn reconstructor_rejects_invalid_exit_commitment_inputs() -> anyhow::Result<()> {
+        let reconstructor = SsaReconstructor::<TestSpec>::new(Default::default());
+
+        let make_ssa_id = || SsaId::new(SimplePseudonym::random(), 1.try_into().unwrap());
+
+        // polys_per_ssa == 0
+        assert!(matches!(
+            reconstructor.new_exit_commitment(make_ssa_id(), 0, 2),
+            Err(PixError::InvalidInput)
+        ));
+
+        // polys_per_ssa exceeds MAX
+        assert!(matches!(
+            reconstructor.new_exit_commitment(make_ssa_id(), MAX_POLYS_PER_SSA as usize + 1, 2),
+            Err(PixError::InvalidInput)
+        ));
+
+        // shares_per_poly == 0
+        assert!(matches!(
+            reconstructor.new_exit_commitment(make_ssa_id(), 2, 0),
+            Err(PixError::InvalidInput)
+        ));
+
+        // shares_per_poly == 1 (below minimum of 2)
+        assert!(matches!(
+            reconstructor.new_exit_commitment(make_ssa_id(), 2, 1),
+            Err(PixError::InvalidInput)
+        ));
+
+        // shares_per_poly exceeds MAX
+        assert!(matches!(
+            reconstructor.new_exit_commitment(make_ssa_id(), 2, MAX_POLY_THRESHOLD as usize + 1),
+            Err(PixError::InvalidInput)
+        ));
+
+        // Valid inputs still work
+        assert!(reconstructor.new_exit_commitment(make_ssa_id(), 2, 2).is_ok());
+
+        Ok(())
+    }
+
+    #[test]
     fn reconstructor_invalid_commitment_inputs() -> anyhow::Result<()> {
         let reconstructor = SsaReconstructor::<TestSpec>::new(Default::default());
 
@@ -490,7 +532,6 @@ mod tests {
 
     #[test]
     fn reconstructor_rejects_duplicate_share_via_different_challenges() -> anyhow::Result<()> {
-        // Use the generator pipeline to create real ECC-valid shares.
         // 1 poly, threshold=2 → need 2 shares per polynomial to reconstruct.
         let generator = SsaShareGenerator::<TestSpec>::new(SsaGeneratorConfig {
             polynomials_per_ssa: 1,
@@ -508,74 +549,55 @@ mod tests {
         let _server_commitment = reconstructor.new_exit_commitment(ssa_id, 1, 2)?;
         commitment_msg.process_into_reconstructor(&reconstructor)?;
 
-        // Generate 2 distinct shares, encrypt under different challenges
-        let mut first_share_msg: Option<[u8; 20]> = None;
-        let mut second_share_msg: Option<[u8; 20]> = None;
-        for _ in 0..2 {
-            let msg: [u8; 20] = hopr_types::crypto_random::random_bytes();
-            if let Some(share) = generator.next_share(&pseudonym, &msg)? {
-                let ack = HalfKey::random();
-                let ack_challenge = ack.to_challenge()?;
-                let enc_share = share.share.encrypt(&share.id, &ack)?;
-                reconstructor.insert_encrypted_share(
-                    peer.public(),
-                    ack_challenge,
-                    TaggedEncryptedPartialSsaShare::new(pseudonym, &msg, enc_share)?,
-                )?;
-
-                let resolution = reconstructor.process_verified_ack(
-                    ack,
-                    ack_challenge,
-                    reconstructor
-                        .awaiting_acks
-                        .get(peer.public())
-                        .as_ref()
-                        .ok_or(anyhow::anyhow!("missing peer"))?,
-                )?;
-                match resolution {
-                    ProcessedAckResult::NoProgress | ProcessedAckResult::EarlyRecovery(_) => {
-                        // First share reached early threshold; store the msg for duplication
-                        if first_share_msg.is_none() {
-                            first_share_msg = Some(msg);
-                        }
-                        if let ProcessedAckResult::EarlyRecovery(id) = resolution {
-                            assert_eq!(id, ssa_id);
-                        }
-                    }
-                    ProcessedAckResult::FullRecovery(recovered) => {
-                        assert_eq!(recovered.ssa_id, ssa_id);
-                        second_share_msg = Some(msg);
-                    }
-                }
-            }
-        }
-
-        assert!(second_share_msg.is_some(), "second share should trigger full recovery");
-        let dup_msg = first_share_msg.expect("first share msg must be set");
-
-        // Now re-insert the FIRST share via a different ack challenge — simulating
-        // the same share arriving through a redundant relay path.
-        let generator2 = SsaShareGenerator::<TestSpec>::new(SsaGeneratorConfig {
-            polynomials_per_ssa: 1,
-            threshold: 2,
-            surplus_shares: 0,
-        });
-        let _ = generator2.new_ssa_commitment(&pseudonym, SsaIndex::MIN)?;
-        let Some(dup_share) = generator2.next_share(&pseudonym, &dup_msg)? else {
-            anyhow::bail!("expected share for duplicate msg");
+        // --- Step 1: Generate the first share ---
+        let msg1: [u8; 20] = hopr_types::crypto_random::random_bytes();
+        let Some(first) = generator.next_share(&pseudonym, &msg1)? else {
+            anyhow::bail!("expected first share");
         };
+        // Clone the PartialSsaShare so we can re-encrypt it as a duplicate later
+        let first_share = first.share.clone();
+        let ack1 = HalfKey::random();
+        let challenge1 = ack1.to_challenge()?;
+        let enc1 = first.share.encrypt(&first.id, &ack1)?;
+        reconstructor.insert_encrypted_share(
+            peer.public(),
+            challenge1,
+            TaggedEncryptedPartialSsaShare::new(pseudonym, &msg1, enc1)?,
+        )?;
+
+        // --- Step 2: Re-encrypt the SAME share under a different challenge (true duplicate) ---
+        // The PartialSsaShare retains the same scalar value and derives the same identifier
+        // (X-coordinate) from msg1, so it will be recognised as a duplicate at share-insertion time.
         let dup_ack = HalfKey::random();
         let dup_challenge = dup_ack.to_challenge()?;
-        let dup_enc_share = dup_share.share.encrypt(&dup_share.id, &dup_ack)?;
+        let enc_dup = first_share.encrypt(&first.id, &dup_ack)?;
         reconstructor.insert_encrypted_share(
             peer.public(),
             dup_challenge,
-            TaggedEncryptedPartialSsaShare::new(pseudonym, &dup_msg, dup_enc_share)?,
+            TaggedEncryptedPartialSsaShare::new(pseudonym, &msg1, enc_dup)?,
         )?;
 
-        // Processing the duplicate share must not error — the reconstructor
-        // already recovered the SSA, so duplicate shares are silently ignored.
-        let dup_resolution = reconstructor.process_verified_ack(
+        // --- Step 3: Process the first ack — share accepted, not yet complete ---
+        let resolution1 = reconstructor.process_verified_ack(
+            ack1,
+            challenge1,
+            reconstructor
+                .awaiting_acks
+                .get(peer.public())
+                .as_ref()
+                .ok_or(anyhow::anyhow!("missing peer"))?,
+        )?;
+        assert!(
+            matches!(resolution1, ProcessedAckResult::NoProgress),
+            "first share should not yet complete the SSA"
+        );
+
+        // --- Step 4: Process the duplicate ---
+        // The SsaPartBuilder has 1/2 shares. The duplicate share has the same identifier
+        // (same X-coordinate from msg1), so it hits the
+        // `any(|s| s.identifier == share.identifier)` check in SsaPartBuilder::add_share
+        // and returns Ok(None), which surfaces as NoProgress.
+        let resolution_dup = reconstructor.process_verified_ack(
             dup_ack,
             dup_challenge,
             reconstructor
@@ -585,8 +607,36 @@ mod tests {
                 .ok_or(anyhow::anyhow!("missing peer"))?,
         )?;
         assert!(
-            matches!(dup_resolution, ProcessedAckResult::NoProgress),
-            "duplicate share must return NoProgress"
+            matches!(resolution_dup, ProcessedAckResult::NoProgress),
+            "duplicate share must return NoProgress during active reconstruction"
+        );
+
+        // --- Step 5: Generate and process the second distinct share ---
+        let msg2: [u8; 20] = hopr_types::crypto_random::random_bytes();
+        let Some(second) = generator.next_share(&pseudonym, &msg2)? else {
+            anyhow::bail!("expected second share");
+        };
+        let ack2 = HalfKey::random();
+        let challenge2 = ack2.to_challenge()?;
+        let enc2 = second.share.encrypt(&second.id, &ack2)?;
+        reconstructor.insert_encrypted_share(
+            peer.public(),
+            challenge2,
+            TaggedEncryptedPartialSsaShare::new(pseudonym, &msg2, enc2)?,
+        )?;
+
+        let resolution2 = reconstructor.process_verified_ack(
+            ack2,
+            challenge2,
+            reconstructor
+                .awaiting_acks
+                .get(peer.public())
+                .as_ref()
+                .ok_or(anyhow::anyhow!("missing peer"))?,
+        )?;
+        assert!(
+            matches!(resolution2, ProcessedAckResult::FullRecovery(ref r) if r.ssa_id == ssa_id),
+            "second unique share should complete SSA reconstruction"
         );
 
         Ok(())

--- a/protocols/pix/src/reconstructor/mod.rs
+++ b/protocols/pix/src/reconstructor/mod.rs
@@ -203,7 +203,9 @@ impl<S: PixSpec + Clone> ExitAcknowledgementShareProcessor<S> for SsaReconstruct
         polys_per_ssa: usize,
         shares_per_poly: usize,
     ) -> Result<PixGroup<S>, Self::Error> {
-        if !(1..=MAX_POLYS_PER_SSA as usize).contains(&polys_per_ssa) || !(2..=MAX_POLY_THRESHOLD as usize).contains(&shares_per_poly) {
+        if !(1..=MAX_POLYS_PER_SSA as usize).contains(&polys_per_ssa)
+            || !(2..=MAX_POLY_THRESHOLD as usize).contains(&shares_per_poly)
+        {
             return Err(PixError::InvalidInput);
         }
 

--- a/protocols/pix/src/reconstructor/utils.rs
+++ b/protocols/pix/src/reconstructor/utils.rs
@@ -100,6 +100,14 @@ impl<S: PixSpec> SsaPartBuilder<S> {
         let share = into_completed_share(msg, &share)?;
 
         self.verifier.verify_completed_share(&share)?;
+
+        // Reject duplicate shares — same identifier means the same X-coordinate,
+        // which contributes no new information and can cause premature combination
+        // attempts that will persistently fail.
+        if self.shares.iter().any(|s| s.identifier == share.identifier) {
+            return Ok(None);
+        }
+
         self.shares.push(share);
 
         if self.shares.len() >= self.verifier.min_shares() {

--- a/protocols/pix/src/reconstructor/utils.rs
+++ b/protocols/pix/src/reconstructor/utils.rs
@@ -99,14 +99,15 @@ impl<S: PixSpec> SsaPartBuilder<S> {
 
         let share = into_completed_share(msg, &share)?;
 
-        self.verifier.verify_completed_share(&share)?;
-
         // Reject duplicate shares — same identifier means the same X-coordinate,
         // which contributes no new information and can cause premature combination
         // attempts that will persistently fail.
+        // Check this before verification to avoid expensive elliptic curve MSMs for redundant shares.
         if self.shares.iter().any(|s| s.identifier == share.identifier) {
             return Ok(None);
         }
+
+        self.verifier.verify_completed_share(&share)?;
 
         self.shares.push(share);
 

--- a/protocols/pix/src/traits.rs
+++ b/protocols/pix/src/traits.rs
@@ -161,9 +161,13 @@ pub trait EntryShareGenerator<S: PixSpec> {
 
 #[cfg(test)]
 mod tests {
-    use hopr_types::crypto::keypairs::Keypair;
-    use hopr_types::crypto::prelude::{ChainKeypair, SimplePseudonym};
-    use hopr_types::crypto_random::Randomizable;
+    use hopr_types::{
+        crypto::{
+            keypairs::Keypair,
+            prelude::{ChainKeypair, SimplePseudonym},
+        },
+        crypto_random::Randomizable,
+    };
 
     use super::*;
 
@@ -174,10 +178,7 @@ mod tests {
         let pseudonym = SimplePseudonym::random();
         let ssa_id = SsaId::new(pseudonym, 1.try_into().unwrap());
         let dummy_key = ChainKeypair::random();
-        let recovered = RecoveredSsa {
-            ssa_id,
-            ssa: dummy_key,
-        };
+        let recovered = RecoveredSsa { ssa_id, ssa: dummy_key };
         let resolution = ShareResolution::RecoveredSsa(recovered);
         let debug = format!("{:?}", resolution);
 

--- a/protocols/pix/src/traits.rs
+++ b/protocols/pix/src/traits.rs
@@ -158,3 +158,34 @@ pub trait EntryShareGenerator<S: PixSpec> {
         ssa_index: SsaIndex,
     ) -> Result<SsaCommitment<S>, Self::Error>;
 }
+
+#[cfg(test)]
+mod tests {
+    use hopr_types::crypto::keypairs::Keypair;
+    use hopr_types::crypto::prelude::{ChainKeypair, SimplePseudonym};
+    use hopr_types::crypto_random::Randomizable;
+
+    use super::*;
+
+    #[test]
+    fn debug_redaction_share_resolution_recovered_ssa() {
+        // ShareResolution::RecoveredSsa wraps RecoveredSsa; the nested Debug
+        // must preserve the secret redaction.
+        let pseudonym = SimplePseudonym::random();
+        let ssa_id = SsaId::new(pseudonym, 1.try_into().unwrap());
+        let dummy_key = ChainKeypair::random();
+        let recovered = RecoveredSsa {
+            ssa_id,
+            ssa: dummy_key,
+        };
+        let resolution = ShareResolution::RecoveredSsa(recovered);
+        let debug = format!("{:?}", resolution);
+
+        assert!(debug.contains("RecoveredSsa"));
+        // The outer tuple wraps the inner RecoveredSsa Debug, which redacts ssa
+        assert!(
+            !debug.contains("secret_key"),
+            "ShareResolution::RecoveredSsa Debug must preserve nested secret redaction"
+        );
+    }
+}

--- a/protocols/pix/src/traits.rs
+++ b/protocols/pix/src/traits.rs
@@ -14,7 +14,7 @@ use crate::{
 /// an encrypted PIX share.
 ///
 /// `P` is the pseudonym type, `A` is the private key type for SSA.
-#[derive(Debug, Clone, strum::EnumTryAs)]
+#[derive(Clone, strum::EnumTryAs)]
 pub enum ShareResolution<P, A> {
     /// Full SSA was recovered.
     RecoveredSsa(RecoveredSsa<P, A>),
@@ -36,6 +36,16 @@ impl<P: PartialEq, A> PartialEq for ShareResolution<P, A> {
 }
 
 impl<P: Eq, A> Eq for ShareResolution<P, A> {}
+
+impl<P: std::fmt::Debug, A> std::fmt::Debug for ShareResolution<P, A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RecoveredSsa(ssa) => f.debug_tuple("RecoveredSsa").field(ssa).finish(),
+            Self::AlmostRecoveredSsa(id) => f.debug_tuple("AlmostRecoveredSsa").field(id).finish(),
+            Self::InvalidShare(key, id) => f.debug_tuple("InvalidShare").field(key).field(id).finish(),
+        }
+    }
+}
 
 impl<P: std::hash::Hash, A> Hash for ShareResolution<P, A> {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {

--- a/protocols/pix/src/traits.rs
+++ b/protocols/pix/src/traits.rs
@@ -179,14 +179,16 @@ mod tests {
         let ssa_id = SsaId::new(pseudonym, 1.try_into().unwrap());
         let dummy_key = ChainKeypair::random();
         let recovered = RecoveredSsa { ssa_id, ssa: dummy_key };
+        let recovered_debug = format!("{:?}", recovered);
         let resolution = ShareResolution::RecoveredSsa(recovered);
         let debug = format!("{:?}", resolution);
 
         assert!(debug.contains("RecoveredSsa"));
         // The outer tuple wraps the inner RecoveredSsa Debug, which redacts ssa
-        assert!(
-            !debug.contains("secret_key"),
-            "ShareResolution::RecoveredSsa Debug must preserve nested secret redaction"
+        assert_eq!(
+            debug,
+            format!("RecoveredSsa({recovered_debug})"),
+            "ShareResolution::RecoveredSsa Debug must perfectly delegate to RecoveredSsa Debug"
         );
     }
 }

--- a/protocols/pix/src/types.rs
+++ b/protocols/pix/src/types.rs
@@ -663,10 +663,9 @@ mod tests {
         let debug = format!("{:?}", share);
         assert!(debug.contains("PartialSsaShare"));
         // The scalar repr should not appear in Debug output
-        let scalar_hex = const_hex::encode(scalar.to_repr());
-        assert!(
-            !debug.contains(&scalar_hex),
-            "PartialSsaShare Debug must redact the scalar value"
+        assert_eq!(
+            debug, "PartialSsaShare { .. }",
+            "PartialSsaShare Debug must exactly match the redacted format"
         );
     }
 
@@ -690,11 +689,10 @@ mod tests {
         assert!(debug.contains("GeneratedShare"));
         assert!(debug.contains("id"));
 
-        // Must NOT include the secret share field value
-        let scalar_hex = const_hex::encode(scalar.to_repr());
+        // Must NOT include the secret share field
         assert!(
-            !debug.contains(&scalar_hex),
-            "GeneratedShare Debug must redact the share scalar"
+            !debug.contains("share:"),
+            "GeneratedShare Debug must omit the share field entirely"
         );
     }
 
@@ -712,10 +710,10 @@ mod tests {
         assert!(debug.contains("RecoveredSsa"));
         assert!(debug.contains("ssa_id"));
 
-        // Must NOT include the secret private key material
+        // Must NOT include the secret ssa field
         assert!(
-            !debug.contains("secret_key"),
-            "RecoveredSsa Debug must redact the ssa private key"
+            !debug.contains("ssa:"),
+            "RecoveredSsa Debug must omit the ssa field entirely"
         );
     }
 }

--- a/protocols/pix/src/types.rs
+++ b/protocols/pix/src/types.rs
@@ -655,4 +655,68 @@ mod tests {
         assert_eq!(share_1, share_2);
         Ok(())
     }
+
+    #[test]
+    fn debug_redaction_partial_ssa_share() {
+        let scalar = PixScalar::<TestSpec>::random(&mut hopr_types::crypto_random::rng());
+        let share = PartialSsaShare::<TestSpec>(scalar.to_repr());
+        let debug = format!("{:?}", share);
+        assert!(debug.contains("PartialSsaShare"));
+        // The scalar repr should not appear in Debug output
+        let scalar_hex = const_hex::encode(scalar.to_repr());
+        assert!(
+            !debug.contains(&scalar_hex),
+            "PartialSsaShare Debug must redact the scalar value"
+        );
+    }
+
+    #[test]
+    fn debug_redaction_generated_share() {
+        use crate::tests::TestSpec;
+
+        let scalar = PixScalar::<TestSpec>::random(&mut hopr_types::crypto_random::rng());
+        let share = PartialSsaShare::<TestSpec>(scalar.to_repr());
+        let id = SsaPolynomialId::new(
+            SsaId::new(SimplePseudonym::try_from([0u8; 10].as_ref()).unwrap(), 1.try_into().unwrap()),
+            0,
+        );
+        let generated = GeneratedShare { id, share };
+        let debug = format!("{:?}", generated);
+
+        // Must include the public ID field
+        assert!(debug.contains("GeneratedShare"));
+        assert!(debug.contains("id"));
+
+        // Must NOT include the secret share field value
+        let scalar_hex = const_hex::encode(scalar.to_repr());
+        assert!(
+            !debug.contains(&scalar_hex),
+            "GeneratedShare Debug must redact the share scalar"
+        );
+    }
+
+    #[test]
+    fn debug_redaction_recovered_ssa() {
+        use hopr_types::crypto::keypairs::Keypair;
+        use hopr_types::crypto::prelude::ChainKeypair;
+
+        let pseudonym = SimplePseudonym::random();
+        let ssa_id = SsaId::new(pseudonym, 1.try_into().unwrap());
+        let dummy_key = ChainKeypair::random();
+        let recovered = RecoveredSsa {
+            ssa_id,
+            ssa: dummy_key,
+        };
+        let debug = format!("{:?}", recovered);
+
+        // Must include the public ssa_id field
+        assert!(debug.contains("RecoveredSsa"));
+        assert!(debug.contains("ssa_id"));
+
+        // Must NOT include the secret private key material
+        assert!(
+            !debug.contains("secret_key"),
+            "RecoveredSsa Debug must redact the ssa private key"
+        );
+    }
 }

--- a/protocols/pix/src/types.rs
+++ b/protocols/pix/src/types.rs
@@ -157,8 +157,14 @@ impl<P: std::fmt::Display> std::fmt::Display for SsaPolynomialId<P> {
 /// [`nonce`](TaggedEncryptedPartialSsaShare).
 ///
 /// See [`TaggedEncryptedPartialSsaShare`] and [`EncryptedPartialSsaShare`] for more details.
-#[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
+#[derive(Clone, Default, Hash, PartialEq, Eq)]
 pub struct PartialSsaShare<S: PixSpec>(pub(crate) <PixScalar<S> as PrimeField>::Repr);
+
+impl<S: PixSpec> std::fmt::Debug for PartialSsaShare<S> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PartialSsaShare").finish_non_exhaustive()
+    }
+}
 
 impl<S: PixSpec> PartialSsaShare<S> {
     /// Encrypts this partial SSA share using the given acknowledgement [`HalfKey`].
@@ -425,12 +431,20 @@ impl<S: PixSpec + Copy, P: Copy, T: Copy> Copy for TaggedEncryptedPartialSsaShar
 }
 
 /// Contains a generated share from a specific previously committed SSA.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct GeneratedShare<S: PixSpec, P = <S as PixSpec>::Pseudonym> {
     /// ID of the polynomial corresponding to the partial SSA share.
     pub id: SsaPolynomialId<P>,
     /// Generated partial SSA share.
     pub share: PartialSsaShare<S>,
+}
+
+impl<S: PixSpec, P: std::fmt::Debug> std::fmt::Debug for GeneratedShare<S, P> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GeneratedShare")
+            .field("id", &self.id)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<S: PixSpec> GeneratedShare<S, S::Pseudonym> {
@@ -536,12 +550,20 @@ impl<P, A> SsaCommitmentState<P, A> {
 /// Contains the already recovered secret scalar corresponding to a specific SSA.
 ///
 /// `P` is the pseudonym type, `A` is the private key type for SSA.
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone, Copy)]
 pub struct RecoveredSsa<P, A> {
     /// ID of the SSA that was recovered.
     pub ssa_id: SsaId<P>,
     /// Recovered secret scalar (private key corresponding to the SSA deposit address).
     pub ssa: A,
+}
+
+impl<P: std::fmt::Debug, A> std::fmt::Debug for RecoveredSsa<P, A> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("RecoveredSsa")
+            .field("ssa_id", &self.ssa_id)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<P: PartialEq, A> PartialEq for RecoveredSsa<P, A> {

--- a/protocols/pix/src/types.rs
+++ b/protocols/pix/src/types.rs
@@ -677,7 +677,10 @@ mod tests {
         let scalar = PixScalar::<TestSpec>::random(&mut hopr_types::crypto_random::rng());
         let share = PartialSsaShare::<TestSpec>(scalar.to_repr());
         let id = SsaPolynomialId::new(
-            SsaId::new(SimplePseudonym::try_from([0u8; 10].as_ref()).unwrap(), 1.try_into().unwrap()),
+            SsaId::new(
+                SimplePseudonym::try_from([0u8; 10].as_ref()).unwrap(),
+                1.try_into().unwrap(),
+            ),
             0,
         );
         let generated = GeneratedShare { id, share };
@@ -697,16 +700,12 @@ mod tests {
 
     #[test]
     fn debug_redaction_recovered_ssa() {
-        use hopr_types::crypto::keypairs::Keypair;
-        use hopr_types::crypto::prelude::ChainKeypair;
+        use hopr_types::crypto::{keypairs::Keypair, prelude::ChainKeypair};
 
         let pseudonym = SimplePseudonym::random();
         let ssa_id = SsaId::new(pseudonym, 1.try_into().unwrap());
         let dummy_key = ChainKeypair::random();
-        let recovered = RecoveredSsa {
-            ssa_id,
-            ssa: dummy_key,
-        };
+        let recovered = RecoveredSsa { ssa_id, ssa: dummy_key };
         let debug = format!("{:?}", recovered);
 
         // Must include the public ssa_id field

--- a/protocols/pix/tests/common.rs
+++ b/protocols/pix/tests/common.rs
@@ -14,6 +14,8 @@ impl PixSpec for TestSpecK256 {
     type Digest = Sha3_256;
     type Pseudonym = SimplePseudonym;
 
+    const HASH_TO_SCALAR_SUITE_ID: &'static [u8] = b"Secp256k1_XMD:SHA3-256_SSWU_RO_";
+
     fn group_to_deposit_address(group: PixGroup<Self>) -> Option<Self::DepositAddress> {
         PublicKey::try_from(group.to_affine()).ok().map(|pk| pk.to_address())
     }
@@ -35,6 +37,8 @@ impl PixSpec for TestSpecBjj {
     type DepositAddress = BjjPublicKey;
     type Digest = Blake3;
     type Pseudonym = SimplePseudonym;
+
+    const HASH_TO_SCALAR_SUITE_ID: &'static [u8] = b"BabyJubJub_XMD:BLAKE3_SSWU_RO_";
 
     fn group_to_deposit_address(group: PixGroup<Self>) -> Option<Self::DepositAddress> {
         BjjPublicKey::try_from(group).ok()

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -5336,4 +5336,43 @@ mod tests {
 
         Ok(())
     }
+
+    /// Verifies that `new_session` rejects `UsePIX` when the return path has 0 hops
+    /// (no SURB mechanism to deliver PIX shares).
+    #[test_log::test(tokio::test)]
+    async fn new_session_rejects_usepix_with_zero_return_hops() -> anyhow::Result<()> {
+        let mgr: SessionManager<UnboundedSender<(DestinationRouting, ApplicationDataOut)>> =
+            SessionManager::new(Default::default());
+
+        let mut transport = MockMsgSender::new();
+        // new_session must not send any message — it should fail before that.
+        transport
+            .expect_send_message()
+            .times(0)
+            .returning(|_, _| futures::future::ok(()).boxed());
+        let (sender, _handle) = mock_packet_planning(transport);
+        let (new_session_tx, _new_session_rx) = futures::channel::mpsc::channel(1);
+        mgr.start(sender.clone(), new_session_tx, None)?;
+
+        let dst: Address = (&ChainKeypair::random()).into();
+        let result = mgr
+            .new_session(
+                dst,
+                SessionTarget::TcpStream(SealedHost::Plain("127.0.0.1:80".parse()?)),
+                SessionClientConfig {
+                    capabilities: Capability::UsePIX.into(),
+                    return_path_options: RoutingOptions::Hops(hopr_api::types::primitive::bounded::BoundedSize::MIN),
+                    pix_ssa_quota: Some((2, 2)),
+                    ..Default::default()
+                },
+            )
+            .await;
+
+        assert!(
+            result.is_err(),
+            "new_session with UsePIX and 0-hop return should fail"
+        );
+
+        Ok(())
+    }
 }

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -160,7 +160,10 @@ enum SessionHandles {
 #[derive(Clone)]
 struct SessionSsaState {
     current_index: Arc<std::sync::atomic::AtomicU32>,
-    num_errors: Arc<std::sync::atomic::AtomicUsize>,
+    /// Per-SSA-index error counts. Tracked independently so that errors from
+    /// a previous SSA cycle do not spill into the current one, which would give
+    /// a false closure signal.
+    current_ssa_errors: Arc<parking_lot::Mutex<std::collections::HashMap<u32, usize>>>,
     polys_per_ssa: u16,
     shares_per_poly: u16,
 }
@@ -170,23 +173,29 @@ impl SessionSsaState {
         Self {
             // SSA index starts from 1, not 0.
             current_index: std::sync::atomic::AtomicU32::new(1).into(),
-            num_errors: Default::default(),
+            current_ssa_errors: Default::default(),
             polys_per_ssa,
             shares_per_poly,
         }
     }
 
-    pub fn increment_errors(&self) -> usize {
-        self.num_errors.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1
+    /// Record an error for the given SSA index. Returns the **total** error
+    /// count for that index. Errors for indices other than the current one are
+    /// still tracked (for diagnostics) but the returned count is the caller's
+    /// view for closure decisions.
+    pub fn increment_errors(&self, ssa_index: u32) -> usize {
+        let mut guard = self.current_ssa_errors.lock();
+        let entry = guard.entry(ssa_index).or_insert(0);
+        *entry += 1;
+        *entry
     }
 
     pub fn increment_index(&self) -> SsaIndex {
-        // Errors reset with new SSA index
-        self.num_errors.store(0, std::sync::atomic::Ordering::Relaxed);
         SsaIndex::new(self.current_index.fetch_add(1, std::sync::atomic::Ordering::Relaxed))
             .expect("ssa index cannot become 0 when incremented")
     }
 
+    /// Returns the current SSA index value.
     #[inline]
     pub const fn quota_per_ssa(&self) -> SsaQuota {
         pix_params_to_quota(self.polys_per_ssa, self.shares_per_poly)
@@ -201,8 +210,8 @@ impl std::fmt::Debug for SessionSsaState {
                 &self.current_index.load(std::sync::atomic::Ordering::Relaxed),
             )
             .field(
-                "num_errors",
-                &self.num_errors.load(std::sync::atomic::Ordering::Relaxed),
+                "current_ssa_errors",
+                &self.current_ssa_errors.lock(),
             )
             .field("polys_per_ssa", &self.polys_per_ssa)
             .field("shares_per_poly", &self.shares_per_poly)
@@ -1635,16 +1644,13 @@ where
             // SSA fully recovered — the next SSA request was already triggered by
             // SsaAlmostRecovered. Deposit-key processing is handled in the upper layer.
             HoprSessionInPixEvent::SsaRecovered(_) => {}
-            HoprSessionInPixEvent::UnverifiableShare(_) => {
+            HoprSessionInPixEvent::UnverifiableShare(ssa_id) => {
                 let state = slot.current_ssa_state.get().ok_or(SessionManagerError::Other(anyhow!(
                     "cannot register unverified share on a session without pix state"
                 )))?;
-                let num_errors = state.increment_errors();
-                trace!(%session_id, num_errors, "encountered unverifiable share in session with pix");
+                let num_errors = state.increment_errors(ssa_id.ssa_index().get());
+                trace!(%session_id, ssa_index = %ssa_id.ssa_index(), num_errors, "encountered unverifiable share in session with pix");
 
-                // The PIX shares can come from different polynomials, so we can only
-                // see the total number of unverifiable shares and make the Session closure
-                // decision based on that.
                 if num_errors > MAX_ALLOWED_UNVERIFIABLE_PIX_SHARES && self.close_session(session_id) {
                     error!(%session_id, "closed session due to too many unverifiable shares");
                 }
@@ -1783,7 +1789,7 @@ where
             );
 
             let in_quota_range = self.cfg.pix_config.quota_range.contains(&quota_per_ssa);
-            let valid_polys = polys_per_ssa <= MAX_POLYS_PER_SSA;
+            let valid_polys = (1..=MAX_POLYS_PER_SSA).contains(&polys_per_ssa);
             let valid_shares = (2_u16..=MAX_POLY_THRESHOLD).contains(&shares_per_ssa);
             (in_quota_range && valid_polys && valid_shares).then_some((polys_per_ssa, shares_per_ssa))
         } else if self.cfg.pix_config.enforce_pix {
@@ -1933,10 +1939,11 @@ where
 
             // The Session request carries a "hint" as additional data telling what
             // the Session initiator has configured as its target buffer size in the Balancer.
-            let target_surb_buffer_size = if session_req.additional_data > 0 {
-                session_req
-                    .additional_data
-                    .min(self.cfg.maximum_surb_buffer_size as u64)
+            // The lower 32 bits contain the SURB target; the upper 32 bits carry PIX
+            // parameters and must be masked out.
+            let surb_target = (session_req.additional_data & u32::MAX as u64) as u32;
+            let target_surb_buffer_size = if surb_target > 0 {
+                (surb_target as u64).min(self.cfg.maximum_surb_buffer_size as u64)
             } else {
                 self.cfg.initial_return_session_egress_rate as u64
                     * self

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -160,10 +160,10 @@ enum SessionHandles {
 #[derive(Clone)]
 struct SessionSsaState {
     current_index: Arc<std::sync::atomic::AtomicU32>,
-    /// Per-SSA-index error counts. Tracked independently so that errors from
-    /// a previous SSA cycle do not spill into the current one, which would give
-    /// a false closure signal.
-    current_ssa_errors: Arc<parking_lot::Mutex<std::collections::HashMap<u32, usize>>>,
+    /// Cumulative count of unverifiable PIX shares across all SSA cycles.
+    /// Errors from stale (already advanced) SSA indices are ignored to prevent
+    /// double-counting late arrivals.
+    num_errors: Arc<parking_lot::Mutex<usize>>,
     polys_per_ssa: u16,
     shares_per_poly: u16,
 }
@@ -173,21 +173,24 @@ impl SessionSsaState {
         Self {
             // SSA index starts from 1, not 0.
             current_index: std::sync::atomic::AtomicU32::new(1).into(),
-            current_ssa_errors: Default::default(),
+            num_errors: Default::default(),
             polys_per_ssa,
             shares_per_poly,
         }
     }
 
-    /// Record an error for the given SSA index. Returns the **total** error
-    /// count for that index. Errors for indices other than the current one are
-    /// still tracked (for diagnostics) but the returned count is the caller's
-    /// view for closure decisions.
+    /// Record an error for the given SSA index.
+    ///
+    /// Returns the cumulative error count across all SSA cycles. Errors for
+    /// stale indices (lower than the current) are silently ignored to avoid
+    /// re-counting late-arriving events after the SSA has advanced.
     pub fn increment_errors(&self, ssa_index: u32) -> usize {
-        let mut guard = self.current_ssa_errors.lock();
-        let entry = guard.entry(ssa_index).or_insert(0);
-        *entry += 1;
-        *entry
+        let mut guard = self.num_errors.lock();
+        if ssa_index < self.current_index.load(std::sync::atomic::Ordering::Relaxed) {
+            return *guard;
+        }
+        *guard += 1;
+        *guard
     }
 
     pub fn increment_index(&self) -> SsaIndex {
@@ -209,7 +212,7 @@ impl std::fmt::Debug for SessionSsaState {
                 "current_index",
                 &self.current_index.load(std::sync::atomic::Ordering::Relaxed),
             )
-            .field("current_ssa_errors", &self.current_ssa_errors.lock())
+            .field("num_errors", &self.num_errors.lock())
             .field("polys_per_ssa", &self.polys_per_ssa)
             .field("shares_per_poly", &self.shares_per_poly)
             .finish()

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -209,10 +209,7 @@ impl std::fmt::Debug for SessionSsaState {
                 "current_index",
                 &self.current_index.load(std::sync::atomic::Ordering::Relaxed),
             )
-            .field(
-                "current_ssa_errors",
-                &self.current_ssa_errors.lock(),
-            )
+            .field("current_ssa_errors", &self.current_ssa_errors.lock())
             .field("polys_per_ssa", &self.polys_per_ssa)
             .field("shares_per_poly", &self.shares_per_poly)
             .finish()

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -1093,20 +1093,6 @@ where
             crossfire::AsyncRx<crossfire::mpsc::One<_>>,
         ) = crossfire::mpsc::build(crossfire::mpsc::One::new());
 
-        let (challenge, _) = insert_into_next_slot(
-            &self.session_initiations,
-            |ch| {
-                if let Some(challenge) = ch {
-                    ((challenge + 1) % hopr_api::types::crypto_random::MAX_RANDOM_INTEGER).max(MIN_CHALLENGE)
-                } else {
-                    hopr_api::types::crypto_random::random_integer(MIN_CHALLENGE, None)
-                }
-            },
-            |_| tx_initiation_done,
-            Some(self.cfg.maximum_sessions as u64),
-        )
-        .ok_or(SessionManagerError::NoChallengeSlots)?; // almost impossible with u64
-
         let current_ssa_state = Arc::new(OnceLock::new());
 
         let mut additional_data = 0_u64;
@@ -1127,7 +1113,9 @@ where
                 .min(u32::MAX as u64);
         }
 
-        // PIX quota parameter announcement is encoded in the upper 32-bits of additional_data
+        // PIX quota parameter announcement is encoded in the upper 32-bits of additional_data.
+        // Run these validations BEFORE reserving the initiation challenge slot so that a
+        // repeated invalid request cannot exhaust all challenge slots.
         if cfg.capabilities.contains(Capability::UsePIX) {
             // PIX requires at least 1 intermediate hop on the return path so that PIX
             // shares can be encrypted with the first relayer's ticket-challenge solution
@@ -1142,28 +1130,43 @@ where
                 .into());
             }
 
-            if let Some((polys_per_ssa, shares_per_ssa)) = cfg.pix_ssa_quota {
-                // Validate that PIX toolbox is available before advertising UsePIX
-                if self.pix_toolbox.get().is_none() {
-                    return Err(
-                        SessionManagerError::Other(anyhow!("UsePIX requested but no PIX toolbox installed")).into(),
-                    );
-                }
-                // Validate dimensions are within protocol limits
-                if !(1..=MAX_POLYS_PER_SSA).contains(&polys_per_ssa)
-                    || !(2..=MAX_POLY_THRESHOLD).contains(&shares_per_ssa)
-                {
-                    return Err(SessionManagerError::Other(anyhow!(
-                        "invalid PIX dimensions: polys={}, shares={}",
-                        polys_per_ssa,
-                        shares_per_ssa,
-                    ))
-                    .into());
-                }
-                let _ = current_ssa_state.set(SessionSsaState::new(polys_per_ssa, shares_per_ssa));
-                additional_data |= (polys_per_ssa as u64) << 48 | (shares_per_ssa as u64) << 32;
+            let (polys_per_ssa, shares_per_ssa) = cfg
+                .pix_ssa_quota
+                .ok_or_else(|| SessionManagerError::Other(anyhow!("UsePIX requested without PIX SSA quota")))?;
+
+            // Validate that PIX toolbox is available before advertising UsePIX
+            if self.pix_toolbox.get().is_none() {
+                return Err(
+                    SessionManagerError::Other(anyhow!("UsePIX requested but no PIX toolbox installed")).into(),
+                );
             }
+            // Validate dimensions are within protocol limits
+            if !(1..=MAX_POLYS_PER_SSA).contains(&polys_per_ssa) || !(2..=MAX_POLY_THRESHOLD).contains(&shares_per_ssa)
+            {
+                return Err(SessionManagerError::Other(anyhow!(
+                    "invalid PIX dimensions: polys={}, shares={}",
+                    polys_per_ssa,
+                    shares_per_ssa,
+                ))
+                .into());
+            }
+            let _ = current_ssa_state.set(SessionSsaState::new(polys_per_ssa, shares_per_ssa));
+            additional_data |= (polys_per_ssa as u64) << 48 | (shares_per_ssa as u64) << 32;
         }
+
+        let (challenge, _) = insert_into_next_slot(
+            &self.session_initiations,
+            |ch| {
+                if let Some(challenge) = ch {
+                    ((challenge + 1) % hopr_api::types::crypto_random::MAX_RANDOM_INTEGER).max(MIN_CHALLENGE)
+                } else {
+                    hopr_api::types::crypto_random::random_integer(MIN_CHALLENGE, None)
+                }
+            },
+            |_| tx_initiation_done,
+            Some(self.cfg.maximum_sessions as u64),
+        )
+        .ok_or(SessionManagerError::NoChallengeSlots)?; // almost impossible with u64
 
         // Prepare the session initiation message in the Start protocol
         trace!(challenge, ?cfg, "initiating session with config");
@@ -4425,6 +4428,12 @@ mod tests {
         );
 
         assert_eq!(mgr.num_active_sessions(), 0);
+        // No challenge slot was consumed because the validations run before insert_into_next_slot.
+        assert_eq!(
+            mgr.session_initiations.entry_count(),
+            0,
+            "session_initiations must remain empty when UsePIX is rejected"
+        );
 
         sender.close_channel();
         let _ = _handle.await;

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -161,14 +161,13 @@ enum SessionHandles {
 struct SessionSsaState {
     current_index: Arc<std::sync::atomic::AtomicU32>,
     /// Cumulative count of unverifiable PIX shares across all SSA cycles.
-    /// Errors from stale (already advanced) SSA indices are ignored to prevent
-    /// double-counting late arrivals.
     ///
-    /// Uses `Mutex` rather than `AtomicUsize` because the increment is
-    /// conditional on `current_index` — both the stale check and the write
-    /// must be atomic as a single operation (a concurrent `increment_index`
-    /// could otherwise advance the index between the check and the increment).
-    num_errors: Arc<parking_lot::Mutex<usize>>,
+    /// The session closes once the *total* number of unverifiable shares across
+    /// all SSA cycles exceeds `MAX_ALLOWED_UNVERIFIABLE_PIX_SHARES`. An
+    /// `AtomicUsize` is safe here because duplicates are already rejected by the
+    /// moka cache (keyed by `HalfKeyChallenge`) and by `SsaPartBuilder` (keyed by
+    /// share identifier), so no share triggers two errors.
+    num_errors: Arc<std::sync::atomic::AtomicUsize>,
     polys_per_ssa: u16,
     shares_per_poly: u16,
 }
@@ -184,18 +183,11 @@ impl SessionSsaState {
         }
     }
 
-    /// Record an error for the given SSA index.
+    /// Record an unverifiable share error.
     ///
-    /// Returns the cumulative error count across all SSA cycles. Errors for
-    /// stale indices (lower than the current) are silently ignored to avoid
-    /// re-counting late-arriving events after the SSA has advanced.
-    pub fn increment_errors(&self, ssa_index: u32) -> usize {
-        let mut guard = self.num_errors.lock();
-        if ssa_index < self.current_index.load(std::sync::atomic::Ordering::Relaxed) {
-            return *guard;
-        }
-        *guard += 1;
-        *guard
+    /// Returns the cumulative error count after this increment.
+    pub fn increment_errors(&self) -> usize {
+        self.num_errors.fetch_add(1, std::sync::atomic::Ordering::Relaxed) + 1
     }
 
     pub fn increment_index(&self) -> SsaIndex {
@@ -217,7 +209,7 @@ impl std::fmt::Debug for SessionSsaState {
                 "current_index",
                 &self.current_index.load(std::sync::atomic::Ordering::Relaxed),
             )
-            .field("num_errors", &self.num_errors.lock())
+            .field("num_errors", &self.num_errors.load(std::sync::atomic::Ordering::Relaxed))
             .field("polys_per_ssa", &self.polys_per_ssa)
             .field("shares_per_poly", &self.shares_per_poly)
             .finish()
@@ -1142,6 +1134,14 @@ where
                     SessionManagerError::Other(anyhow!("UsePIX requested but no PIX toolbox installed")).into(),
                 );
             }
+            // PIX shares are delivered via return-path SURBs — a 0-hop return path
+            // means there is no SURB mechanism, so PIX is impossible.
+            if cfg.return_path_options.count_hops() == 0 {
+                return Err(SessionManagerError::Other(anyhow!(
+                    "UsePIX requested with 0-hop return path — PIX requires at least 1 return hop for SURB delivery"
+                ))
+                .into());
+            }
             // Validate dimensions are within protocol limits
             if !(1..=MAX_POLYS_PER_SSA).contains(&polys_per_ssa) || !(2..=MAX_POLY_THRESHOLD).contains(&shares_per_ssa)
             {
@@ -1669,7 +1669,7 @@ where
                 let state = slot.current_ssa_state.get().ok_or(SessionManagerError::Other(anyhow!(
                     "cannot register unverified share on a session without pix state"
                 )))?;
-                let num_errors = state.increment_errors(ssa_id.ssa_index().get());
+                let num_errors = state.increment_errors();
                 trace!(%session_id, ssa_index = %ssa_id.ssa_index(), num_errors, "encountered unverifiable share in session with pix");
 
                 if num_errors > MAX_ALLOWED_UNVERIFIABLE_PIX_SHARES && self.close_session(session_id) {

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -1128,6 +1128,22 @@ where
         if cfg.capabilities.contains(Capability::UsePIX)
             && let Some((polys_per_ssa, shares_per_ssa)) = cfg.pix_ssa_quota
         {
+            // Validate that PIX toolbox is available before advertising UsePIX
+            if self.pix_toolbox.get().is_none() {
+                return Err(
+                    SessionManagerError::Other(anyhow!("UsePIX requested but no PIX toolbox installed")).into(),
+                );
+            }
+            // Validate dimensions are within protocol limits
+            if !(1..=MAX_POLYS_PER_SSA).contains(&polys_per_ssa) || !(2..=MAX_POLY_THRESHOLD).contains(&shares_per_ssa)
+            {
+                return Err(SessionManagerError::Other(anyhow!(
+                    "invalid PIX dimensions: polys={}, shares={}",
+                    polys_per_ssa,
+                    shares_per_ssa,
+                ))
+                .into());
+            }
             let _ = current_ssa_state.set(SessionSsaState::new(polys_per_ssa, shares_per_ssa));
             additional_data |= (polys_per_ssa as u64) << 48 | (shares_per_ssa as u64) << 32;
         }

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -1128,35 +1128,41 @@ where
         }
 
         // PIX quota parameter announcement is encoded in the upper 32-bits of additional_data
-        if cfg.capabilities.contains(Capability::UsePIX)
-            && let Some((polys_per_ssa, shares_per_ssa)) = cfg.pix_ssa_quota
-        {
-            // Validate that PIX toolbox is available before advertising UsePIX
-            if self.pix_toolbox.get().is_none() {
-                return Err(
-                    SessionManagerError::Other(anyhow!("UsePIX requested but no PIX toolbox installed")).into(),
-                );
-            }
-            // PIX shares are delivered via return-path SURBs — a 0-hop return path
-            // means there is no SURB mechanism, so PIX is impossible.
+        if cfg.capabilities.contains(Capability::UsePIX) {
+            // PIX requires at least 1 intermediate hop on the return path so that PIX
+            // shares can be encrypted with the first relayer's ticket-challenge solution
+            // (`HalfKey`) and delivered via return-path SURBs. With 0 intermediate hops
+            // (a direct Exit→Entry SURB), there is no relayer to provide the challenge
+            // solution, so shares are never embedded — the ongoing PIX share delivery
+            // mechanism is dead and the Exit's quota is never replenished.
             if cfg.return_path_options.count_hops() == 0 {
                 return Err(SessionManagerError::Other(anyhow!(
-                    "UsePIX requested with 0-hop return path — PIX requires at least 1 return hop for SURB delivery"
+                    "UsePIX requires at least 1 intermediate hop on the return path, got 0"
                 ))
                 .into());
             }
-            // Validate dimensions are within protocol limits
-            if !(1..=MAX_POLYS_PER_SSA).contains(&polys_per_ssa) || !(2..=MAX_POLY_THRESHOLD).contains(&shares_per_ssa)
-            {
-                return Err(SessionManagerError::Other(anyhow!(
-                    "invalid PIX dimensions: polys={}, shares={}",
-                    polys_per_ssa,
-                    shares_per_ssa,
-                ))
-                .into());
+
+            if let Some((polys_per_ssa, shares_per_ssa)) = cfg.pix_ssa_quota {
+                // Validate that PIX toolbox is available before advertising UsePIX
+                if self.pix_toolbox.get().is_none() {
+                    return Err(
+                        SessionManagerError::Other(anyhow!("UsePIX requested but no PIX toolbox installed")).into(),
+                    );
+                }
+                // Validate dimensions are within protocol limits
+                if !(1..=MAX_POLYS_PER_SSA).contains(&polys_per_ssa)
+                    || !(2..=MAX_POLY_THRESHOLD).contains(&shares_per_ssa)
+                {
+                    return Err(SessionManagerError::Other(anyhow!(
+                        "invalid PIX dimensions: polys={}, shares={}",
+                        polys_per_ssa,
+                        shares_per_ssa,
+                    ))
+                    .into());
+                }
+                let _ = current_ssa_state.set(SessionSsaState::new(polys_per_ssa, shares_per_ssa));
+                additional_data |= (polys_per_ssa as u64) << 48 | (shares_per_ssa as u64) << 32;
             }
-            let _ = current_ssa_state.set(SessionSsaState::new(polys_per_ssa, shares_per_ssa));
-            additional_data |= (polys_per_ssa as u64) << 48 | (shares_per_ssa as u64) << 32;
         }
 
         // Prepare the session initiation message in the Start protocol
@@ -4376,6 +4382,55 @@ mod tests {
         Ok(())
     }
 
+    /// Verifies that `new_session` rejects `UsePIX` when the return path has 0 intermediate hops.
+    ///
+    /// PIX shares are encrypted with the first relayer's ticket-challenge solution and carried
+    /// in return-path SURBs. With 0 intermediate hops (a direct Exit→Entry SURB), there is no
+    /// relayer to provide the challenge solution, so shares are never embedded — the ongoing
+    /// PIX share delivery mechanism is dead and the Exit's quota is never replenished.
+    #[test_log::test(tokio::test)]
+    async fn new_session_rejects_usepix_with_zero_return_hops() -> anyhow::Result<()> {
+        let mgr: SessionManager<UnboundedSender<(DestinationRouting, ApplicationDataOut)>> =
+            SessionManager::new(Default::default());
+
+        let mut transport = MockMsgSender::new();
+        // The error happens before any message is sent, so expect_send_message should NOT fire.
+        transport.expect_send_message().times(0);
+
+        let (sender, _handle) = mock_packet_planning(transport);
+        let (new_session_tx, _) = futures::channel::mpsc::channel(1);
+        mgr.start(sender.clone(), new_session_tx, None)?;
+        assert!(mgr.is_started());
+
+        let result = mgr
+            .new_session(
+                Address::from(&ChainKeypair::random()),
+                SessionTarget::TcpStream(SealedHost::Plain("127.0.0.1:80".parse()?)),
+                SessionClientConfig {
+                    capabilities: Capability::UsePIX.into(),
+                    surb_management: None,
+                    pix_ssa_quota: Some((2, 2)),
+                    forward_path_options: RoutingOptions::Hops(1.try_into()?),
+                    return_path_options: RoutingOptions::Hops(0.try_into()?),
+                    ..Default::default()
+                },
+            )
+            .await;
+
+        let err = result.unwrap_err();
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("UsePIX requires at least 1 intermediate hop on the return path"),
+            "expected return-path guard error, got: {msg}"
+        );
+
+        assert_eq!(mgr.num_active_sessions(), 0);
+
+        sender.close_channel();
+        let _ = _handle.await;
+        Ok(())
+    }
+
     // ---------------------------------------------------------------------------
     // PIX protocol tests
     // ---------------------------------------------------------------------------
@@ -5336,42 +5391,6 @@ mod tests {
 
         bob_sender.close_channel();
         let _ = bob_handle.await;
-
-        Ok(())
-    }
-
-    /// Verifies that `new_session` rejects `UsePIX` when the return path has 0 hops
-    /// (no SURB mechanism to deliver PIX shares).
-    #[test_log::test(tokio::test)]
-    async fn new_session_rejects_usepix_with_zero_return_hops() -> anyhow::Result<()> {
-        let mgr: SessionManager<UnboundedSender<(DestinationRouting, ApplicationDataOut)>> =
-            SessionManager::new(Default::default());
-
-        let mut transport = MockMsgSender::new();
-        // new_session must not send any message — it should fail before that.
-        transport
-            .expect_send_message()
-            .times(0)
-            .returning(|_, _| futures::future::ok(()).boxed());
-        let (sender, _handle) = mock_packet_planning(transport);
-        let (new_session_tx, _new_session_rx) = futures::channel::mpsc::channel(1);
-        mgr.start(sender.clone(), new_session_tx, None)?;
-
-        let dst: Address = (&ChainKeypair::random()).into();
-        let result = mgr
-            .new_session(
-                dst,
-                SessionTarget::TcpStream(SealedHost::Plain("127.0.0.1:80".parse()?)),
-                SessionClientConfig {
-                    capabilities: Capability::UsePIX.into(),
-                    return_path_options: RoutingOptions::Hops(hopr_api::types::primitive::bounded::BoundedSize::MIN),
-                    pix_ssa_quota: Some((2, 2)),
-                    ..Default::default()
-                },
-            )
-            .await;
-
-        assert!(result.is_err(), "new_session with UsePIX and 0-hop return should fail");
 
         Ok(())
     }

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -209,7 +209,10 @@ impl std::fmt::Debug for SessionSsaState {
                 "current_index",
                 &self.current_index.load(std::sync::atomic::Ordering::Relaxed),
             )
-            .field("num_errors", &self.num_errors.load(std::sync::atomic::Ordering::Relaxed))
+            .field(
+                "num_errors",
+                &self.num_errors.load(std::sync::atomic::Ordering::Relaxed),
+            )
             .field("polys_per_ssa", &self.polys_per_ssa)
             .field("shares_per_poly", &self.shares_per_poly)
             .finish()
@@ -5368,10 +5371,7 @@ mod tests {
             )
             .await;
 
-        assert!(
-            result.is_err(),
-            "new_session with UsePIX and 0-hop return should fail"
-        );
+        assert!(result.is_err(), "new_session with UsePIX and 0-hop return should fail");
 
         Ok(())
     }

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -163,6 +163,11 @@ struct SessionSsaState {
     /// Cumulative count of unverifiable PIX shares across all SSA cycles.
     /// Errors from stale (already advanced) SSA indices are ignored to prevent
     /// double-counting late arrivals.
+    ///
+    /// Uses `Mutex` rather than `AtomicUsize` because the increment is
+    /// conditional on `current_index` — both the stale check and the write
+    /// must be atomic as a single operation (a concurrent `increment_index`
+    /// could otherwise advance the index between the check and the increment).
     num_errors: Arc<parking_lot::Mutex<usize>>,
     polys_per_ssa: u16,
     shares_per_poly: u16,

--- a/transport/session/tests/pix.rs
+++ b/transport/session/tests/pix.rs
@@ -7,7 +7,10 @@ use futures::{AsyncWriteExt, StreamExt, pin_mut};
 use hopr_api::types::{
     crypto::{keypairs::ChainKeypair, prelude::Keypair},
     crypto_random::Randomizable,
-    internal::{prelude::HoprPseudonym, routing::SurbMatcher},
+    internal::{
+        prelude::HoprPseudonym,
+        routing::{RoutingOptions, SurbMatcher},
+    },
     primitive::prelude::Address,
 };
 use hopr_protocol_app::v1::ApplicationData;
@@ -254,6 +257,7 @@ async fn session_manager_should_follow_start_protocol_to_establish_new_session_a
                     capabilities: Capability::NoRateControl | Capability::Segmentation | Capability::UsePIX,
                     surb_management: None,
                     pix_ssa_quota: Some((ssa_gen_config.polynomials_per_ssa, ssa_gen_config.threshold)),
+                    return_path_options: RoutingOptions::Hops(1.try_into()?),
                     ..Default::default()
                 },
             ),

--- a/transport/session/tests/pix.rs
+++ b/transport/session/tests/pix.rs
@@ -300,14 +300,28 @@ async fn session_manager_should_follow_start_protocol_to_establish_new_session_a
         .map_err(|e| anyhow::anyhow!("timeout: {e}"))?
         .ok_or(anyhow::anyhow!("alice must get a pix event"))?;
 
-    assert!(matches!(alice_session_event, HoprSessionOutPixEvent::ReadyToDeposit(_)));
+    let HoprSessionOutPixEvent::ReadyToDeposit(alice_quota) = &alice_session_event else {
+        panic!("expected ReadyToDeposit, got {alice_session_event:?}");
+    };
 
     let bob_session_event = tokio_time::timeout(Duration::from_secs(2), pix_bob_rx.next())
         .await
         .map_err(|e| anyhow::anyhow!("timeout: {e}"))?
         .ok_or(anyhow::anyhow!("bob must get a pix event"))?;
 
-    assert!(matches!(bob_session_event, HoprSessionOutPixEvent::DepositNeeded(..)));
+    let HoprSessionOutPixEvent::DepositNeeded(bob_quota, _) = &bob_session_event else {
+        panic!("expected DepositNeeded, got {bob_session_event:?}");
+    };
+
+    // Both peers must agree on the same SSA parameters
+    assert_eq!(
+        alice_quota.ssa_id, bob_quota.ssa_id,
+        "Entry and Exit must agree on SSA ID"
+    );
+    assert_eq!(
+        alice_quota.quota_per_ssa, bob_quota.quota_per_ssa,
+        "Entry and Exit must agree on SSA quota"
+    );
 
     tokio::time::sleep(Duration::from_millis(100)).await;
     alice_session.close().await?;

--- a/transport/session/tests/session_lifecycle.rs
+++ b/transport/session/tests/session_lifecycle.rs
@@ -631,7 +631,7 @@ async fn session_manager_should_send_keep_alive_when_ping_session_is_called() ->
             start_msg_match(
                 data,
                 |msg| matches!(msg, HoprStartProtocol::KeepAlive(ka) if ka.session_id == alice_pseudonym),
-            ) && matches!(peer, DestinationRouting::Return(SurbMatcher::Pseudonym(p)) if *p == alice_pseudonym)
+            ) && matches!(peer, DestinationRouting::Forward { destination, .. } if destination.as_ref() == &bob_peer.into())
         })
         .returning(move |_, data| {
             let bob_mgr = bob_mgr_for_keepalive.clone();
@@ -660,7 +660,7 @@ async fn session_manager_should_send_keep_alive_when_ping_session_is_called() ->
             .try_as_segment()
             .expect("must be a segment")
             .is_terminating()
-                && matches!(peer, DestinationRouting::Return(SurbMatcher::Pseudonym(p)) if *p == alice_pseudonym)
+                && matches!(peer, DestinationRouting::Forward { destination, .. } if destination.as_ref() == &bob_peer.into())
         })
         .returning(move |_, data| {
             let bob_mgr = bob_mgr_for_alice_seg.clone();


### PR DESCRIPTION
This PR addresses review comments from PR #8095 (PIX protocol implementation) across several categories: security hardening, data integrity fixes, test additions, and documentation improvements.

## Changes

### Security & Data Integrity
- Redact secret material from Debug output
- Deduplicate Shamir shares before counting toward threshold
- Filter polynomial coefficients by position (skip(1)) not value
- Validate outgoing PIX config before advertising UsePIX
- Replace per-SSA error tracking HashMap with a single cumulative counter
- Guard against zero-polynomial SSA configurations
- Reject empty encrypted shares at insertion time

### Session Protocol Fixes
- Mask PIX params before reading SURB target (upper 32 bits)
- Use Forward routing for KeepAlive/close in session lifecycle tests
- Assert gap packets have no PIX share
- Check balance once before interval starts in PIX strategy
- Remove cfg gates from MultiStrategy (hopr-utils hard-enables runtime-tokio)
- Make CurrentSuite alias mutually exclusive to fix --all-features

### Tests
- Fix flawed duplicate share test: re-encrypt the same PartialSsaShare under a different challenge (instead of generating a second polynomial with different random coefficients) and process it while reconstruction is still active
- Add boundary validation tests for new_exit_commitment (rejecting polys_per_ssa=0, shares_per_poly<2, etc.)
- Add Debug redaction regression tests for PartialSsaShare, GeneratedShare, RecoveredSsa, and ShareResolution::RecoveredSsa
- Fix SSA cycle tracking to use PixAddressId (pseudonym + ssa_index)
- Add dispatch_pix_event error tests
- Add PIX quota rejection and enforcement tests
- Add SSA commit rejection for sessions without PIX state
- Add session close after unverifiable shares test
- Add entry rejecting SSA request with mismatched quota test

### Documentation
- Document why Mutex is used instead of AtomicUsize for error tracking
- Refine PIX protocol flow documentation

## Review Comments Addressed (PR #8238)

- **protocols/pix/src/lib.rs**: Strengthen generator-valued coefficients round-trip assertion (direct equality instead of length check)
- **protocols/pix/src/reconstructor/utils.rs**: Reorder duplicate share check before expensive MSM verification for DoS resistance
- **protocols/pix/src/types.rs, traits.rs**: Strengthen debug-redaction tests with robust field-name assertions (avoid fragile hex-string checks)
- **impls/strategy/src/non_anonymous_pix.rs**: Move synchronous balance lookup inside timeout-protected background task; stalled RPC no longer blocks PIX event handling
- **transport/session/src/manager.rs**: Run UsePIX pre-flight validations (zero-hop guard, quota requirement, toolbox check, dimension validation) before reserving the initiation challenge slot; require pix_ssa_quota when UsePIX is advertised