### PR TITLE
feat(transport): reserve Rayon threads for SURB generation to prevent session starvation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4418,9 +4418,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-utilities"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5f44193a6854b1c8dd5339e692eb1e3a7eb4992c534ea2c82b249a0d17211d"
+checksum = "3f60cbe7d588c9ee1bb454db33e6de7e969638a096ac6bdf1406fd7a43e476aa"
 dependencies = [
  "arrayvec",
  "auto_impl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,7 +171,7 @@ validator = { version = "0.20.0", features = ["derive"] }
 
 hopr-api = "1.15.0"
 hopr-types = { version = "2.0.2", features = ["use-bindings"] }
-hopr-utils = { package = "hopr-utilities", version = "0.3.0", default-features = false }
+hopr-utils = { package = "hopr-utilities", version = "0.4.0", default-features = false }
 hopr-utils-session = { version = "1.2.1", path = "utils-session" }
 
 hopr-crypto-packet = { version = "1.4.0", path = "crypto/packet", default-features = false, features = [

--- a/transport/hopr/src/protocol/pipeline/config.rs
+++ b/transport/hopr/src/protocol/pipeline/config.rs
@@ -101,9 +101,15 @@ pub struct PacketPipelineConfig {
     ///
     /// `None` or `Some(0)` both fall back to the default (available parallelism * 8).
     pub output_concurrency: Option<usize>,
-    /// Maximum concurrency when processing incoming packets.
+    /// Maximum concurrency when processing incoming packets (SPHINX decode).
     ///
-    /// `None` or `Some(0)` both fall back to the default (available parallelism * 8).
+    /// `None` or `Some(0)` fall back to the default, which is computed as
+    /// `max(1, pool_thread_count - ENCODE_RESERVED_THREADS)` when the shared Rayon pool has
+    /// been initialised, or `available_parallelism * 8` as a fallback when it has not.
+    ///
+    /// The default is deliberately lower than `output_concurrency` to reserve Rayon threads
+    /// for outgoing packet encode (SURB generation). Flooding the pool with decode work would
+    /// otherwise starve SURB production and collapse download throughput.
     pub input_concurrency: Option<usize>,
     /// Configuration of the packet acknowledgement processing
     #[validate(nested)]

--- a/transport/hopr/src/protocol/pipeline/mod.rs
+++ b/transport/hopr/src/protocol/pipeline/mod.rs
@@ -35,6 +35,24 @@ const QUEUE_SEND_TIMEOUT: std::time::Duration = std::time::Duration::from_millis
 const PACKET_DECODING_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(150);
 const PACKET_ENCODING_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(150);
 
+/// Number of Rayon threads kept permanently free for outgoing packet encode (SURB generation).
+/// The ingress decode concurrency default is `pool_thread_count - ENCODE_RESERVED_THREADS` so
+/// that heavy download traffic cannot starve the upload/SURB replenishment path.
+const ENCODE_RESERVED_THREADS: usize = 2;
+
+/// Ingress gate sampler interval.
+const INGRESS_GATE_SAMPLE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
+
+/// Artificial per-packet delay injected into `wire_in` when the Rayon pool is detected as
+/// congested. 20 ms keeps the decode queue from growing while still allowing acks and keep-alive
+/// SURB packets to drain through at a reasonable pace.
+const INGRESS_THROTTLE_DELAY: std::time::Duration = std::time::Duration::from_millis(20);
+
+/// Pool outstanding-task watermark factor: the gate trips when
+/// `outstanding_tasks > pool_thread_count * INGRESS_POOL_HIGH_WATERMARK_FACTOR`.
+/// A factor of 3 gives one full pool worth of headroom above the cap.
+const INGRESS_POOL_HIGH_WATERMARK_FACTOR: usize = 3;
+
 #[cfg(all(feature = "telemetry", not(test)))]
 lazy_static::lazy_static! {
     static ref METRIC_PACKET_COUNT:  hopr_api::types::telemetry::MultiCounter =  hopr_api::types::telemetry::MultiCounter::new(
@@ -88,6 +106,32 @@ pub enum PacketPipelineProcesses {
     AckIn,
     #[strum(to_string = "HOPR [msg] - mixer")]
     Mixer,
+    #[strum(to_string = "HOPR [msg] - ingress gate")]
+    IngressGateSampler,
+}
+
+/// Monitors the shared Rayon pool and sets `pool_congested` when outstanding tasks exceed
+/// `high_watermark`. The ingress pipeline checks this flag and adds a brief per-packet delay
+/// so that the encode/SURB-generation path always has threads available.
+async fn run_ingress_gate_sampler(
+    pool_congested: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    high_watermark: usize,
+) {
+    loop {
+        hopr_utils::runtime::prelude::sleep(INGRESS_GATE_SAMPLE_INTERVAL).await;
+        let outstanding = hopr_utils::parallelize::cpu::outstanding_tasks();
+        let is_congested = outstanding > high_watermark;
+        let was_congested = pool_congested.swap(is_congested, std::sync::atomic::Ordering::Relaxed);
+        if was_congested != is_congested {
+            tracing::debug!(
+                outstanding,
+                high_watermark,
+                is_congested,
+                "ingress gate state changed — {} throttle on incoming packets",
+                if is_congested { "applying" } else { "removing" },
+            );
+        }
+    }
 }
 
 /// Performs encoding of outgoing Application protocol packets into HOPR protocol outgoing packets.
@@ -746,8 +790,9 @@ where
     let decoder = std::sync::Arc::new(codec.1);
     let ticket_proc = std::sync::Arc::new(ticket_proc);
 
-    // The default maximum concurrency (if not set or zero) is 8 times the number of available cores.
-    // Zero is normalized to the default to prevent deadlock (0 concurrent tasks = no work).
+    // `avail_concurrency` is used as a deep ready-queue for the encode (egress) path where deep
+    // queuing is harmless, and as a fallback when the Rayon pool has not been initialised yet.
+    // Zero is normalised to 1 to prevent deadlock (0 concurrent tasks = no work done ever).
     let avail_concurrency = std::thread::available_parallelism()
         .ok()
         .map(|n| n.get())
@@ -756,7 +801,41 @@ where
         * 8;
 
     let output_concurrency = cfg.output_concurrency.filter(|&n| n > 0).unwrap_or(avail_concurrency);
-    let input_concurrency = cfg.input_concurrency.filter(|&n| n > 0).unwrap_or(avail_concurrency);
+
+    // The ingress decode concurrency is deliberately capped below the Rayon pool size so that
+    // ENCODE_RESERVED_THREADS are always available for outgoing encode / SURB generation.
+    // Without this cap the FIFO pool fills up with decode work under heavy download traffic and
+    // SURB replenishment starves, slowly collapsing the session's download throughput.
+    let pool_threads = hopr_utils::parallelize::cpu::pool_thread_count();
+    let default_input_concurrency = if pool_threads > ENCODE_RESERVED_THREADS {
+        pool_threads - ENCODE_RESERVED_THREADS
+    } else if pool_threads > 0 {
+        1 // pool is tiny but initialised — leave at least 1 decode slot
+    } else {
+        avail_concurrency // pool not initialised yet; fall back to the old behaviour
+    };
+    let input_concurrency = cfg
+        .input_concurrency
+        .filter(|&n| n > 0)
+        .unwrap_or(default_input_concurrency);
+
+    // --- Ingress gate (safety-net backpressure) ---
+    // A background sampler monitors the Rayon pool's outstanding task count. When the pool is
+    // congested (outstanding > pool_threads * INGRESS_POOL_HIGH_WATERMARK_FACTOR), it sets
+    // `pool_congested = true` and the `wire_in` stream inserts a brief per-packet delay so the
+    // encode path always gets CPU time. The gate is fully transparent when the pool is healthy.
+    let pool_congested = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let gate_reader = pool_congested.clone();
+    let high_watermark = pool_threads.max(1) * INGRESS_POOL_HIGH_WATERMARK_FACTOR;
+    let wire_in = wire_in.then(move |(peer, data)| {
+        let congested = gate_reader.load(std::sync::atomic::Ordering::Relaxed);
+        async move {
+            if congested {
+                hopr_utils::runtime::prelude::sleep(INGRESS_THROTTLE_DELAY).await;
+            }
+            (peer, data)
+        }
+    });
 
     processes.insert(
         PacketPipelineProcesses::MsgOut,
@@ -839,6 +918,11 @@ where
             );
         }
     }
+
+    processes.insert(
+        PacketPipelineProcesses::IngressGateSampler,
+        hopr_utils::spawn_as_abortable!(run_ingress_gate_sampler(pool_congested, high_watermark).in_current_span()),
+    );
 
     processes
 }

--- a/transport/hopr/src/protocol/pipeline/mod.rs
+++ b/transport/hopr/src/protocol/pipeline/mod.rs
@@ -40,9 +40,6 @@ const PACKET_ENCODING_TIMEOUT: std::time::Duration = std::time::Duration::from_m
 /// that heavy download traffic cannot starve the upload/SURB replenishment path.
 const ENCODE_RESERVED_THREADS: usize = 2;
 
-/// Ingress gate sampler interval.
-const INGRESS_GATE_SAMPLE_INTERVAL: std::time::Duration = std::time::Duration::from_millis(100);
-
 /// Artificial per-packet delay injected into `wire_in` when the Rayon pool is detected as
 /// congested. 20 ms keeps the decode queue from growing while still allowing acks and keep-alive
 /// SURB packets to drain through at a reasonable pace.
@@ -106,32 +103,6 @@ pub enum PacketPipelineProcesses {
     AckIn,
     #[strum(to_string = "HOPR [msg] - mixer")]
     Mixer,
-    #[strum(to_string = "HOPR [msg] - ingress gate")]
-    IngressGateSampler,
-}
-
-/// Monitors the shared Rayon pool and sets `pool_congested` when outstanding tasks exceed
-/// `high_watermark`. The ingress pipeline checks this flag and adds a brief per-packet delay
-/// so that the encode/SURB-generation path always has threads available.
-async fn run_ingress_gate_sampler(
-    pool_congested: std::sync::Arc<std::sync::atomic::AtomicBool>,
-    high_watermark: usize,
-) {
-    loop {
-        hopr_utils::runtime::prelude::sleep(INGRESS_GATE_SAMPLE_INTERVAL).await;
-        let outstanding = hopr_utils::parallelize::cpu::outstanding_tasks();
-        let is_congested = outstanding > high_watermark;
-        let was_congested = pool_congested.swap(is_congested, std::sync::atomic::Ordering::Relaxed);
-        if was_congested != is_congested {
-            tracing::debug!(
-                outstanding,
-                high_watermark,
-                is_congested,
-                "ingress gate state changed — {} throttle on incoming packets",
-                if is_congested { "applying" } else { "removing" },
-            );
-        }
-    }
 }
 
 /// Performs encoding of outgoing Application protocol packets into HOPR protocol outgoing packets.
@@ -820,21 +791,15 @@ where
         .unwrap_or(default_input_concurrency);
 
     // --- Ingress gate (safety-net backpressure) ---
-    // A background sampler monitors the Rayon pool's outstanding task count. When the pool is
-    // congested (outstanding > pool_threads * INGRESS_POOL_HIGH_WATERMARK_FACTOR), it sets
-    // `pool_congested = true` and the `wire_in` stream inserts a brief per-packet delay so the
-    // encode path always gets CPU time. The gate is fully transparent when the pool is healthy.
-    let pool_congested = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
-    let gate_reader = pool_congested.clone();
+    // outstanding_tasks() is a single atomic load, so checking it per-packet is cheaper than
+    // maintaining a sampler task + shared AtomicBool. The delay is only incurred when the pool is
+    // actually congested, which is also when packets arrive fastest.
     let high_watermark = pool_threads.max(1) * INGRESS_POOL_HIGH_WATERMARK_FACTOR;
-    let wire_in = wire_in.then(move |(peer, data)| {
-        let congested = gate_reader.load(std::sync::atomic::Ordering::Relaxed);
-        async move {
-            if congested {
-                hopr_utils::runtime::prelude::sleep(INGRESS_THROTTLE_DELAY).await;
-            }
-            (peer, data)
+    let wire_in = wire_in.then(move |(peer, data)| async move {
+        if hopr_utils::parallelize::cpu::outstanding_tasks() > high_watermark {
+            hopr_utils::runtime::prelude::sleep(INGRESS_THROTTLE_DELAY).await;
         }
+        (peer, data)
     });
 
     processes.insert(
@@ -918,11 +883,6 @@ where
             );
         }
     }
-
-    processes.insert(
-        PacketPipelineProcesses::IngressGateSampler,
-        hopr_utils::spawn_as_abortable!(run_ingress_gate_sampler(pool_congested, high_watermark).in_current_span()),
-    );
 
     processes
 }

--- a/transport/hopr/src/protocol/pipeline/mod.rs
+++ b/transport/hopr/src/protocol/pipeline/mod.rs
@@ -794,7 +794,8 @@ where
     // outstanding_tasks() is a single atomic load, so checking it per-packet is cheaper than
     // maintaining a sampler task + shared AtomicBool. The delay is only incurred when the pool is
     // actually congested, which is also when packets arrive fastest.
-    let high_watermark = pool_threads.max(1) * INGRESS_POOL_HIGH_WATERMARK_FACTOR;
+    let effective_pool = if pool_threads > 0 { pool_threads } else { avail_concurrency.max(1) };
+    let high_watermark = effective_pool * INGRESS_POOL_HIGH_WATERMARK_FACTOR;
     let wire_in = wire_in.then(move |(peer, data)| async move {
         if hopr_utils::parallelize::cpu::outstanding_tasks() > high_watermark {
             hopr_utils::runtime::prelude::sleep(INGRESS_THROTTLE_DELAY).await;

--- a/transport/hopr/src/protocol/pipeline/mod.rs
+++ b/transport/hopr/src/protocol/pipeline/mod.rs
@@ -794,7 +794,11 @@ where
     // outstanding_tasks() is a single atomic load, so checking it per-packet is cheaper than
     // maintaining a sampler task + shared AtomicBool. The delay is only incurred when the pool is
     // actually congested, which is also when packets arrive fastest.
-    let effective_pool = if pool_threads > 0 { pool_threads } else { avail_concurrency.max(1) };
+    let effective_pool = if pool_threads > 0 {
+        pool_threads
+    } else {
+        avail_concurrency.max(1)
+    };
     let high_watermark = effective_pool * INGRESS_POOL_HIGH_WATERMARK_FACTOR;
     let wire_in = wire_in.then(move |(peer, data)| async move {
         if hopr_utils::parallelize::cpu::outstanding_tasks() > high_watermark {


### PR DESCRIPTION
## Summary

Prevents SURB starvation under heavy one-directional download by reserving Rayon threads for SPHINX encode and adding a per-packet backpressure gate on the incoming packet path.

**Root cause:** `input_concurrency` on the decode stage defaulted to `available_parallelism * 8` (e.g. 64 on 8 cores) while the shared Rayon pool has only `pool_threads` workers. Under heavy download, decode tasks filled the pool queue, leaving nothing for SURB generation (SPHINX encode). The Exit's SURB ring buffer drained, triggering self-throttling, collapsing download throughput.

**Changes:**

- `utils/src/parallelize/mod.rs`: expose `pool_thread_count()` backed by an `AtomicUsize` set in `init_thread_pool`
- `transport/hopr/src/protocol/pipeline/mod.rs`: cap `input_concurrency` default to `pool_thread_count - 2`; add an inline per-packet gate that calls `outstanding_tasks()` (a single atomic load) and injects a 20 ms delay when the pool exceeds `pool_threads * 3` outstanding tasks
- `transport/hopr/src/protocol/pipeline/config.rs`: updated doc comment for `input_concurrency`
- `utils/Cargo.toml`: version bump `0.3.0 → 0.3.1` (new public API)