### PR TITLE
perf(ticket-manager): eliminate per-packet redb read in unrealized_value

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ For `hopr-lib` multi-node throughput cluster tests:
 cargo nextest run -p hopr-lib --features testing --test 'cluster_throughput-size3' -j 1
 cargo nextest run -p hopr-lib --features testing --test 'cluster_throughput-size5' -j 1 --run-ignored all
 # OFAT matrices (all variants, ~60–120 s bootstrap):
-cargo nextest run -p hopr-lib --features testing --test 'cluster_throughput-matrix' -j 1 --run-ignored all
+cargo nextest run -p hopr-lib --features session-client --test 'cluster_throughput-matrix' -j 1 --run-ignored all
 ```
 
 For profiling the packet pipeline against a real-QUIC cluster (mock chain):

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4239,7 +4239,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-ticket-manager"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ahash",
  "anyhow",

--- a/impls/ticket-manager/Cargo.toml
+++ b/impls/ticket-manager/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-ticket-manager"
 description = "Manages outgoing ticket indices and incoming redeemable tickets"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/impls/ticket-manager/src/backend/mod.rs
+++ b/impls/ticket-manager/src/backend/mod.rs
@@ -27,20 +27,47 @@ pub struct ValueCachedQueue<Q> {
     queue: Q,
     // Caches total ticket value per channel epoch
     value_cache: hashbrown::HashMap<u32, HoprBalance>,
+    // Epoch of tickets currently in the queue. All queued tickets share the same epoch
+    // (invariant maintained by the ticket manager); this avoids calling peek() when
+    // the current epoch is needed, which would otherwise require I/O on the redb backend.
+    current_epoch: Option<u32>,
 }
 
 impl<Q: TicketQueue> ValueCachedQueue<Q> {
     pub fn new(queue: Q) -> Result<Self, Q::Error> {
         let mut value_cache = hashbrown::HashMap::<u32, HoprBalance>::new();
+        let mut current_epoch: Option<u32> = None;
         // Load all pre-existing ticket values into the cache
         queue.iter_unordered()?.filter_map(|res| res.ok()).for_each(|ticket| {
+            let epoch = ticket.verified_ticket().channel_epoch;
+            current_epoch = Some(epoch);
             value_cache
-                .entry(ticket.verified_ticket().channel_epoch)
+                .entry(epoch)
                 .or_default()
                 .add_assign(ticket.verified_ticket().amount);
         });
 
-        Ok(Self { queue, value_cache })
+        Ok(Self {
+            queue,
+            value_cache,
+            current_epoch,
+        })
+    }
+
+    /// Returns the total unrealized value of tickets in the queue without any I/O.
+    ///
+    /// Reads the cached value for the tracked current epoch directly from memory.
+    /// Returns zero when the queue is empty or when no value has been accumulated
+    /// for the current epoch (e.g. after all tickets have been popped).
+    ///
+    /// This is the fast path for [`crate::utils::UnrealizedValue::unrealized_value`]
+    /// with `min_index = None` — it avoids calling [`TicketQueue::peek`] on the
+    /// underlying queue, which may do I/O on persistent backends.
+    pub fn cached_unrealized_value(&self) -> HoprBalance {
+        self.current_epoch
+            .and_then(|epoch| self.value_cache.get(&epoch))
+            .copied()
+            .unwrap_or_default()
     }
 }
 
@@ -56,8 +83,10 @@ impl<Q: TicketQueue> TicketQueue for ValueCachedQueue<Q> {
     }
 
     fn push(&mut self, ticket: RedeemableTicket) -> Result<(), Self::Error> {
+        let epoch = ticket.verified_ticket().channel_epoch;
+        self.current_epoch = Some(epoch);
         self.value_cache
-            .entry(ticket.verified_ticket().channel_epoch)
+            .entry(epoch)
             .or_default()
             .add_assign(ticket.verified_ticket().amount);
         self.queue.push(ticket)
@@ -153,6 +182,87 @@ pub mod tests {
 
         let queue_2 = ValueCachedQueue::new(queue_1)?;
         assert_eq!(total_value_per_epoch, queue_2.value_cache);
+
+        Ok(())
+    }
+
+    /// Regression guard: `cached_unrealized_value` must never call the underlying
+    /// queue's `peek()`. A cache miss on the redb backend opens a read transaction;
+    /// calling it per packet would block the Rayon crypto worker on I/O.
+    #[test]
+    fn cached_unrealized_value_never_calls_peek() -> anyhow::Result<()> {
+        use std::sync::{
+            Arc,
+            atomic::{AtomicUsize, Ordering},
+        };
+
+        use hopr_api::chain::{HoprBalance, RedeemableTicket};
+
+        use crate::TicketQueue;
+
+        /// Spy that wraps `MemoryTicketQueue` and counts every `peek()` call.
+        struct PeekSpy {
+            inner: memory::MemoryTicketQueue,
+            peek_count: Arc<AtomicUsize>,
+        }
+
+        impl TicketQueue for PeekSpy {
+            type Error = <memory::MemoryTicketQueue as TicketQueue>::Error;
+
+            fn len(&self) -> Result<usize, Self::Error> {
+                self.inner.len()
+            }
+
+            fn push(&mut self, t: RedeemableTicket) -> Result<(), Self::Error> {
+                self.inner.push(t)
+            }
+
+            fn pop(&mut self) -> Result<Option<RedeemableTicket>, Self::Error> {
+                self.inner.pop()
+            }
+
+            fn peek(&self) -> Result<Option<RedeemableTicket>, Self::Error> {
+                self.peek_count.fetch_add(1, Ordering::Relaxed);
+                self.inner.peek()
+            }
+
+            fn iter_unordered(
+                &self,
+            ) -> Result<impl Iterator<Item = Result<RedeemableTicket, Self::Error>>, Self::Error> {
+                self.inner.iter_unordered()
+            }
+        }
+
+        let peek_count = Arc::new(AtomicUsize::new(0));
+        let spy = PeekSpy {
+            inner: memory::MemoryTicketQueue::default(),
+            peek_count: peek_count.clone(),
+        };
+        let mut queue = ValueCachedQueue::new(spy)?;
+
+        // Empty queue: cached_unrealized_value must return zero with no peek calls.
+        assert_eq!(queue.cached_unrealized_value(), HoprBalance::default());
+        assert_eq!(peek_count.load(Ordering::Relaxed), 0, "peek called on empty queue");
+
+        // Push tickets from a single epoch to keep the test invariant clean.
+        // generate_tickets() spans epochs 1..=2; we use only the highest epoch.
+        let all_tickets = generate_tickets()?;
+        let current_epoch = all_tickets
+            .iter()
+            .map(|t| t.verified_ticket().channel_epoch)
+            .max()
+            .unwrap_or(1);
+        let tickets: Vec<_> = all_tickets
+            .into_iter()
+            .filter(|t| t.verified_ticket().channel_epoch == current_epoch)
+            .collect();
+        let expected_value: HoprBalance = tickets.iter().map(|t| t.verified_ticket().amount).sum();
+        fill_queue(&mut queue, tickets.into_iter())?;
+
+        for _ in 0..10 {
+            assert_eq!(queue.cached_unrealized_value(), expected_value);
+        }
+        assert_eq!(peek_count.load(Ordering::Relaxed), 0, "peek called during cached_unrealized_value");
 
         Ok(())
     }

--- a/impls/ticket-manager/src/backend/mod.rs
+++ b/impls/ticket-manager/src/backend/mod.rs
@@ -84,7 +84,7 @@ impl<Q: TicketQueue> TicketQueue for ValueCachedQueue<Q> {
 
     fn push(&mut self, ticket: RedeemableTicket) -> Result<(), Self::Error> {
         let epoch = ticket.verified_ticket().channel_epoch;
-        self.current_epoch = Some(epoch);
+        self.current_epoch = Some(epoch.max(self.current_epoch.unwrap_or(0)));
         self.value_cache
             .entry(epoch)
             .or_default()

--- a/impls/ticket-manager/src/backend/mod.rs
+++ b/impls/ticket-manager/src/backend/mod.rs
@@ -262,7 +262,11 @@ pub mod tests {
         for _ in 0..10 {
             assert_eq!(queue.cached_unrealized_value(), expected_value);
         }
-        assert_eq!(peek_count.load(Ordering::Relaxed), 0, "peek called during cached_unrealized_value");
+        assert_eq!(
+            peek_count.load(Ordering::Relaxed),
+            0,
+            "peek called during cached_unrealized_value"
+        );
 
         Ok(())
     }

--- a/impls/ticket-manager/src/backend/mod.rs
+++ b/impls/ticket-manager/src/backend/mod.rs
@@ -100,6 +100,9 @@ impl<Q: TicketQueue> TicketQueue for ValueCachedQueue<Q> {
                 .entry(ticket.verified_ticket().channel_epoch)
                 .or_default()
                 .sub_assign(ticket.verified_ticket().amount);
+            // Keep current_epoch consistent with what remains in the queue after the pop.
+            // If the queue still has tickets, they share the same epoch; if empty, reset to None.
+            self.current_epoch = self.queue.peek()?.map(|t| t.verified_ticket().channel_epoch);
         }
         Ok(ticket)
     }

--- a/impls/ticket-manager/src/utils.rs
+++ b/impls/ticket-manager/src/utils.rs
@@ -188,6 +188,16 @@ impl<Q: TicketQueue> UnrealizedValue for CachedQueueMap<Q> {
             // when a new winning ticket has been added, redeemed or neglected, all of which are fairly rare operations.
             let queue = ticket_queue.queue.read();
 
+            if min_index.is_none() {
+                // Fast path: the current epoch and its aggregated value are tracked in memory
+                // by `ValueCachedQueue`. No peek() call needed — avoids a redb read transaction
+                // on the hot per-packet decode path (decoder.rs:validate_and_replace_ticket).
+                return Ok(Some(queue.0.cached_unrealized_value()));
+            }
+
+            // Slow path: a minimum index was given, so we must peek to learn the current epoch
+            // and then do a full scan via total_value.
+            //
             // Get the epoch of the first extractable ticket in the queue.
             // The ticket insertion takes care that there are no tickets
             // with epochs other than the current epoch.


### PR DESCRIPTION
## Summary

Eliminates a redb read transaction fired on every forwarded packet by `CachedQueueMap::unrealized_value(.., None)`, which is called per packet on the Rayon decode worker (`decoder.rs:validate_and_replace_ticket`).

Depends on: #8244 (stress harness needed for verification)
Part of: #8250 (throughput gap epic), closes #8254