### PR TITLE
fix(test): correct channel funding for probabilistic win-prob ticket test

### DIFF
--- a/hopr/hopr-lib/tests/transport_tickets.rs
+++ b/hopr/hopr-lib/tests/transport_tickets.rs
@@ -414,14 +414,19 @@ async fn relay_with_win_prob_higher_than_min_win_prob_should_succeed(
     cluster_fixture: ClusterGuard,
 ) -> anyhow::Result<()> {
     let [src, mid, dst] = cluster_fixture.sample_nodes_with_win_prob_1_intermediaries::<3>();
-    let message_count = 20;
+    // Use enough messages that P(zero wins at 20% win prob) is negligible (0.8^50 ≈ 1.4e-5).
+    let message_count = 50;
 
     let ticket_price = src
         .inner()
         .get_ticket_price()
         .await
         .context("failed to get ticket price")?;
-    let funding_amount = ticket_price.mul(message_count + 2 + PROBING_OVERHEAD);
+    // Each ticket's face value is ticket_price / win_prob (5× for 20% win prob).
+    // Divide by win_prob so the channel capacity covers (message_count + overhead) tickets.
+    let funding_amount = ticket_price
+        .mul(message_count + 2 + PROBING_OVERHEAD)
+        .div_f64(MINIMUM_INCOMING_WIN_PROB)?;
 
     let [_fw_channel, _bw_channel, _telemetry_channel]: [ChannelGuard; 3] = cluster_fixture
         .open_channels(&[&[src, mid, dst], &[dst, mid, src], &[src, dst]], funding_amount)


### PR DESCRIPTION
## Summary

- The `relay_with_win_prob_higher_than_min_win_prob_should_succeed` test was funding the `src→mid` channel with `ticket_price × (N + overhead)` wxHOPR, without accounting for the ticket face value being `ticket_price / win_prob` (5× when `win_prob = 0.2`)
- The channel's unrealized-balance quota exhausted after only `(N + overhead) / 5 ≈ 16` tickets, allowing background probing to consume all capacity before test writes landed
- Zero winning tickets accumulated → `wait_until` timed out

Fix: multiply the funding by `1 / MINIMUM_INCOMING_WIN_PROB` so the channel holds `message_count + overhead` ticket face values, matching the pattern already used in `relay_gets_less_tickets_if_sender_has_lower_win_prob`.

Also raise `message_count` from 20 to 50 so `P(zero wins | 20% prob)` drops from ~1.15% to ~1.4×10⁻⁵, making the test statistically robust.

https://claude.ai/code/session_016DJLJeyaaEDvyv8kSdiwzT