### PR TITLE
chore: bump blokli-client and types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,14 +114,15 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1172e33a862030da77768c11cf17a1f801590de94cf518392b65207f15810c8"
+checksum = "d9677ab3454c237abe6307805bea17a7912b3a516b606c7b4d3d948b9fede137"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-core",
  "alloy-eips",
+ "alloy-ens",
  "alloy-genesis",
  "alloy-json-rpc",
  "alloy-network",
@@ -150,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b44937ce84d2cbf1ee4010667bd9214bb7db134a91dd9ffa6b1b8b1d6b030449"
+checksum = "1f0f42ee16e9eaffa4df5aa3a17b1df88dd222310d13152ab91357a2551fd054"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -177,9 +178,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb0bdd61ddff726026676450e7e6a52c68aa39d98f2d60d05ad7caaea5b8100"
+checksum = "db388e804269d977d60fa7530ccfefe9184ca48d4055dad3ec7e649a29186a06"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -191,9 +192,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1475c7edc6780b1759ccdb7960e28d29856ecbed47cfcf9e25be6a5f48b0cfb"
+checksum = "69937abc65310c6eb739e540b107688943b61f38e7dcf9fde769367d3608d657"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -296,9 +297,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154b0f566ebbfc256b63c8d643c6a299f40a6fcd50a9d756c1d191487dd06483"
+checksum = "52010e7c255f45b0ef3ca18144cbfbe0c044b055fe53f59323f3df5d95f265b1"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -318,10 +319,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-genesis"
-version = "2.1.0"
+name = "alloy-ens"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a930a68a6f0ac19231bc2f5f0bf13fad3a26fa7df2525354890c72366c2998"
+checksum = "88c3d803649b2023413a5b84892ed3874977dfa8b8d5481dea05488f20f6f4ef"
+dependencies = [
+ "alloy-contract",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-sol-types",
+ "async-trait",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-genesis"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60fa6337a6af8bae818de3030448827bf55c1321c90c7d1f6f3b79257ead2a"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -359,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e92108767c8c95b5e521570e039e374e65198c4179a98d200412c083d6c26d5"
+checksum = "24d7ff4d7f1503d12edda9b241904a309d6e1d5bcee3f0ffdc4d3d3f16f366b8"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -374,9 +389,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4546c9fae2861d4159ee3b25c44ab3edb90f21b849e86cf2086cacb1d56d8ac"
+checksum = "44ff1439d901b44f6ff840545f82d65e66830ee33fb33cae495a566d66e0ccc8"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -400,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2c325d5934445209c8d22fc67d27e2cf9fb79054b8154d9e522d6a4ee3a4f7"
+checksum = "fb920286c4a71fb0ff3bbb207a640a531a42fceef5b43d4a943f7d5265789876"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -413,9 +428,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b1e225c8715a0aaefeec2e5f5390881b6bc11606bb81c3470ba219eb04c350"
+checksum = "bd2d06c4044c3ae7f9b7a70c9a7bb3bde9a08e99f4d9aa91001e17a182b562dc"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -463,9 +478,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4536d25780fcf51a338c26153c526c99649be1273600684ef10b397a207d4a"
+checksum = "329375f50202cc6b2dcc8c6b1e53b716cbbebbeea54e931befc4f3b628dfc469"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -526,9 +541,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8d765656f02f993fa0565abeb3554ccd6a0d72ea44ce0558b983136639bd6b"
+checksum = "52bffef2c5714f578f267bb959b47908b95728f1f3e2073a96d928f4441c148d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -549,9 +564,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a05ef5b11fad72068e6f011c21445bc5b596ac850644c4a14c30d845ce56de8"
+checksum = "a64449cae1cf37c4907b10ccca1613b71809f9a1f3ad6e2b4cc14d08e2e4947f"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -561,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c1fa8062c379d4fb51d28361cd02cd6a18a49fa79831c16831449b65408aa6c"
+checksum = "261411a259d346a69078237e2997a7ce0faba006baf5b1937023316d5ef07bf4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -573,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06bfe79149dd53de5b196aa3c96db0500b7cf0ed72dbd1a31bac7660bc7cc65"
+checksum = "4fe7fa70c3af4b2de7f670b50d680700e0f979ce3a0ab7725958b51ffc3b16c2"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
@@ -588,9 +603,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41d1a11f58b456c199e04591befc64cb236fa2574a7275a07b98b173727bd39"
+checksum = "04f60a196df184facc9acbb61bd765a36cfb3c9d27eb6b43d5bd26340df1b96a"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -609,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf028ac8bcb161ad7c104243e710cece8e1a794f65ee6c35c4c4d693c8e80ee"
+checksum = "07758cbde42596b66da52bb661d77e253c3f7f9b3f553faf07adbadeb6419502"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -620,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5f392f2f56b2417ea6b74e1e116c6f35df5ab5fce4dc422e277d72ee18ff7b"
+checksum = "bc43a73bc1bf7044898e1b0dcefaba45d0cfac3e379bb5ca29cc3e3a04c61451"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -635,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78de3d4ed62e2c90e16be166d0ddfe41944bb5979752703199073acf976083f2"
+checksum = "372ff9be2b61c2cd6d33cfcef9bd5865962c0628c932767f5154443aba2c9746"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -724,9 +739,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f42ee1ef30d4d3d8b4ea5794937fccfc69e2bb1cd5bcf42d62afc57b049081"
+checksum = "830c87b05870c80c8d2cfb9245feaff36468893f19fc124c7ff563cabda6386c"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -747,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee68bc7d713e033eeaaecb8fd13d5d8a41af97226c4388930ad459285b8e9f70"
+checksum = "23ecd298fb0e6a31bd90c72efba2728e3d7569f1c89a3719576fb0e4e40b0fc8"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -779,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2cd27809c88c413e5542dbd5a8eff8c12f0086af920e881ae586d3a787d5e5"
+checksum = "e50185b84799c8b5f016a0c9da74309fe28d1c70fbe590a4e8d9cae6df3eebb0"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1601,9 +1616,9 @@ dependencies = [
 
 [[package]]
 name = "blokli-client"
-version = "0.30.0"
+version = "0.30.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c4a03b3618185436fc74269e51c6945a55a3347eb05bde61a5fd3750d28401"
+checksum = "b6da9d0a178246498baf5e4b9f753affb25c14116ea8fbf75552841c6231a429"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -3775,9 +3790,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-bindings"
-version = "4.9.1"
+version = "4.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1afa8766e3b7c9ac7f770e5330bb08f91af6db385a1b388239814fc03f7c171a"
+checksum = "0375fb0dc90a31484ae7620ce71681203f5ed1ee670cab51e02fb3b7a9d351dc"
 dependencies = [
  "alloy",
  "anyhow",
@@ -4343,9 +4358,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "2.0.0"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24293a5ce7289056c4e01b8d91beebc8663cdcca8ffbc24d847f3f22af4f274"
+checksum = "3aabecd53d5211c4a81f046d27bad0f7ad64659afcb5b88e0e410ecaa8928bf3"
 dependencies = [
  "aes 0.9.1",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ backon = { version = "1.6.0", default-features = false }
 base64 = "0.22.1"
 bimap = "0.6.3"
 bitvec = "1.1.1"
-blokli-client = "0.30.0"
+blokli-client = "0.30.2"
 bloomfilter = { version = "3.0.1" }
 bytesize = { version = "2.4.0", features = ["serde"] }
 bytes = "1.12.0"
@@ -186,7 +186,7 @@ tracing = { version = "0.1.44", features = ["release_max_level_debug"] }
 validator = { version = "0.20.0", features = ["derive"] }
 
 hopr-api = "1.15.0"
-hopr-types = { version = "2.0.0", features = ["use-bindings"] }
+hopr-types = { version = "2.0.2", features = ["use-bindings"] }
 hopr-utils = { version = "0.3.0", path = "utils", default-features = false }
 hopr-utils-session = { version = "1.2.1", path = "utils-session" }
 

--- a/flake.nix
+++ b/flake.nix
@@ -140,7 +140,7 @@
           ticketInspectorBuildArgs = {
             inherit src depsSrc rev;
             cargoExtraArgs = "-p hopr-ticket-manager --bin ticket-inspector -F redb,serde,cli";
-            cargoToml = ./logic/ticket-manager/Cargo.toml;
+            cargoToml = ./impls/ticket-manager/Cargo.toml;
           };
 
           # Shared preBuild hook to fix stale sandbox paths in cached utoipa-swagger-ui build script outputs

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_announce_new_account_with_multiaddresses.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_announce_new_account_with_multiaddresses.snap
@@ -35,7 +35,7 @@ chain_info:
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
   network: rotsee
-  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  contract_addresses: "{\"announcements\":\"0x078B2D5C9b13e256699902704D1f9Beb79Fc51A2\",\"channels\":\"0xD8C91008c68cd87E7C52Ea1a2C6f6dC6A5236008\",\"module_implementation\":\"0x300Cb87f686c4FF5d975951c225969af4433ADf5\",\"node_safe_migration\":\"0x04e079e7FC8E445b58d048200847206c692Deb48\",\"node_safe_registry\":\"0x1267F2Ad0a70C975Cb4e2C810C4F2b42a455Cc09\",\"node_stake_factory\":\"0x607b6559FE4c2bB5d97de65F0CEC5DB444824634\",\"ticket_price_oracle\":\"0x9cd65f0b11B3028EadA50dE57E46C12848608fAB\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x9344093c5ac613BDBAC939E33fF760C9e6dF9F1f\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_announce_new_account_without_multiaddresses.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_announce_new_account_without_multiaddresses.snap
@@ -34,7 +34,7 @@ chain_info:
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
   network: rotsee
-  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  contract_addresses: "{\"announcements\":\"0x078B2D5C9b13e256699902704D1f9Beb79Fc51A2\",\"channels\":\"0xD8C91008c68cd87E7C52Ea1a2C6f6dC6A5236008\",\"module_implementation\":\"0x300Cb87f686c4FF5d975951c225969af4433ADf5\",\"node_safe_migration\":\"0x04e079e7FC8E445b58d048200847206c692Deb48\",\"node_safe_registry\":\"0x1267F2Ad0a70C975Cb4e2C810C4F2b42a455Cc09\",\"node_stake_factory\":\"0x607b6559FE4c2bB5d97de65F0CEC5DB444824634\",\"ticket_price_oracle\":\"0x9cd65f0b11B3028EadA50dE57E46C12848608fAB\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x9344093c5ac613BDBAC939E33fF760C9e6dF9F1f\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_reannounce_when_existing_account_has_same_multiaddresses.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_reannounce_when_existing_account_has_same_multiaddresses.snap
@@ -54,7 +54,7 @@ chain_info:
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
   network: rotsee
-  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  contract_addresses: "{\"announcements\":\"0x078B2D5C9b13e256699902704D1f9Beb79Fc51A2\",\"channels\":\"0xD8C91008c68cd87E7C52Ea1a2C6f6dC6A5236008\",\"module_implementation\":\"0x300Cb87f686c4FF5d975951c225969af4433ADf5\",\"node_safe_migration\":\"0x04e079e7FC8E445b58d048200847206c692Deb48\",\"node_safe_registry\":\"0x1267F2Ad0a70C975Cb4e2C810C4F2b42a455Cc09\",\"node_stake_factory\":\"0x607b6559FE4c2bB5d97de65F0CEC5DB444824634\",\"ticket_price_oracle\":\"0x9cd65f0b11B3028EadA50dE57E46C12848608fAB\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x9344093c5ac613BDBAC939E33fF760C9e6dF9F1f\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_register_any_safe_when_node_already_registered.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_register_any_safe_when_node_already_registered.snap
@@ -44,7 +44,7 @@ chain_info:
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
   network: rotsee
-  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  contract_addresses: "{\"announcements\":\"0x078B2D5C9b13e256699902704D1f9Beb79Fc51A2\",\"channels\":\"0xD8C91008c68cd87E7C52Ea1a2C6f6dC6A5236008\",\"module_implementation\":\"0x300Cb87f686c4FF5d975951c225969af4433ADf5\",\"node_safe_migration\":\"0x04e079e7FC8E445b58d048200847206c692Deb48\",\"node_safe_registry\":\"0x1267F2Ad0a70C975Cb4e2C810C4F2b42a455Cc09\",\"node_stake_factory\":\"0x607b6559FE4c2bB5d97de65F0CEC5DB444824634\",\"ticket_price_oracle\":\"0x9cd65f0b11B3028EadA50dE57E46C12848608fAB\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x9344093c5ac613BDBAC939E33fF760C9e6dF9F1f\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_register_safe_that_does_not_exist.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_not_register_safe_that_does_not_exist.snap
@@ -27,7 +27,7 @@ chain_info:
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
   network: rotsee
-  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  contract_addresses: "{\"announcements\":\"0x078B2D5C9b13e256699902704D1f9Beb79Fc51A2\",\"channels\":\"0xD8C91008c68cd87E7C52Ea1a2C6f6dC6A5236008\",\"module_implementation\":\"0x300Cb87f686c4FF5d975951c225969af4433ADf5\",\"node_safe_migration\":\"0x04e079e7FC8E445b58d048200847206c692Deb48\",\"node_safe_registry\":\"0x1267F2Ad0a70C975Cb4e2C810C4F2b42a455Cc09\",\"node_stake_factory\":\"0x607b6559FE4c2bB5d97de65F0CEC5DB444824634\",\"ticket_price_oracle\":\"0x9cd65f0b11B3028EadA50dE57E46C12848608fAB\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x9344093c5ac613BDBAC939E33fF760C9e6dF9F1f\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_reannounce_when_existing_account_has_no_multiaddresses.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_reannounce_when_existing_account_has_no_multiaddresses.snap
@@ -55,7 +55,7 @@ chain_info:
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
   network: rotsee
-  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  contract_addresses: "{\"announcements\":\"0x078B2D5C9b13e256699902704D1f9Beb79Fc51A2\",\"channels\":\"0xD8C91008c68cd87E7C52Ea1a2C6f6dC6A5236008\",\"module_implementation\":\"0x300Cb87f686c4FF5d975951c225969af4433ADf5\",\"node_safe_migration\":\"0x04e079e7FC8E445b58d048200847206c692Deb48\",\"node_safe_registry\":\"0x1267F2Ad0a70C975Cb4e2C810C4F2b42a455Cc09\",\"node_stake_factory\":\"0x607b6559FE4c2bB5d97de65F0CEC5DB444824634\",\"ticket_price_oracle\":\"0x9cd65f0b11B3028EadA50dE57E46C12848608fAB\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x9344093c5ac613BDBAC939E33fF760C9e6dF9F1f\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_register_safe.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_register_safe.snap
@@ -37,7 +37,7 @@ chain_info:
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
   network: rotsee
-  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  contract_addresses: "{\"announcements\":\"0x078B2D5C9b13e256699902704D1f9Beb79Fc51A2\",\"channels\":\"0xD8C91008c68cd87E7C52Ea1a2C6f6dC6A5236008\",\"module_implementation\":\"0x300Cb87f686c4FF5d975951c225969af4433ADf5\",\"node_safe_migration\":\"0x04e079e7FC8E445b58d048200847206c692Deb48\",\"node_safe_registry\":\"0x1267F2Ad0a70C975Cb4e2C810C4F2b42a455Cc09\",\"node_stake_factory\":\"0x607b6559FE4c2bB5d97de65F0CEC5DB444824634\",\"ticket_price_oracle\":\"0x9cd65f0b11B3028EadA50dE57E46C12848608fAB\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x9344093c5ac613BDBAC939E33fF760C9e6dF9F1f\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_register_safe_that_has_nodes_registered_already.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_register_safe_that_has_nodes_registered_already.snap
@@ -38,7 +38,7 @@ chain_info:
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
   network: rotsee
-  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  contract_addresses: "{\"announcements\":\"0x078B2D5C9b13e256699902704D1f9Beb79Fc51A2\",\"channels\":\"0xD8C91008c68cd87E7C52Ea1a2C6f6dC6A5236008\",\"module_implementation\":\"0x300Cb87f686c4FF5d975951c225969af4433ADf5\",\"node_safe_migration\":\"0x04e079e7FC8E445b58d048200847206c692Deb48\",\"node_safe_registry\":\"0x1267F2Ad0a70C975Cb4e2C810C4F2b42a455Cc09\",\"node_stake_factory\":\"0x607b6559FE4c2bB5d97de65F0CEC5DB444824634\",\"ticket_price_oracle\":\"0x9cd65f0b11B3028EadA50dE57E46C12848608fAB\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x9344093c5ac613BDBAC939E33fF760C9e6dF9F1f\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_withdraw.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_withdraw.snap
@@ -37,7 +37,7 @@ chain_info:
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
   network: rotsee
-  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  contract_addresses: "{\"announcements\":\"0x078B2D5C9b13e256699902704D1f9Beb79Fc51A2\",\"channels\":\"0xD8C91008c68cd87E7C52Ea1a2C6f6dC6A5236008\",\"module_implementation\":\"0x300Cb87f686c4FF5d975951c225969af4433ADf5\",\"node_safe_migration\":\"0x04e079e7FC8E445b58d048200847206c692Deb48\",\"node_safe_registry\":\"0x1267F2Ad0a70C975Cb4e2C810C4F2b42a455Cc09\",\"node_stake_factory\":\"0x607b6559FE4c2bB5d97de65F0CEC5DB444824634\",\"ticket_price_oracle\":\"0x9cd65f0b11B3028EadA50dE57E46C12848608fAB\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x9344093c5ac613BDBAC939E33fF760C9e6dF9F1f\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_withdraw_from_signer.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__accounts__tests__connector_should_withdraw_from_signer.snap
@@ -43,7 +43,7 @@ chain_info:
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
   network: rotsee
-  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  contract_addresses: "{\"announcements\":\"0x078B2D5C9b13e256699902704D1f9Beb79Fc51A2\",\"channels\":\"0xD8C91008c68cd87E7C52Ea1a2C6f6dC6A5236008\",\"module_implementation\":\"0x300Cb87f686c4FF5d975951c225969af4433ADf5\",\"node_safe_migration\":\"0x04e079e7FC8E445b58d048200847206c692Deb48\",\"node_safe_registry\":\"0x1267F2Ad0a70C975Cb4e2C810C4F2b42a455Cc09\",\"node_stake_factory\":\"0x607b6559FE4c2bB5d97de65F0CEC5DB444824634\",\"ticket_price_oracle\":\"0x9cd65f0b11B3028EadA50dE57E46C12848608fAB\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x9344093c5ac613BDBAC939E33fF760C9e6dF9F1f\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_close_incoming_channel.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_close_incoming_channel.snap
@@ -92,7 +92,7 @@ chain_info:
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
   network: rotsee
-  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  contract_addresses: "{\"announcements\":\"0x078B2D5C9b13e256699902704D1f9Beb79Fc51A2\",\"channels\":\"0xD8C91008c68cd87E7C52Ea1a2C6f6dC6A5236008\",\"module_implementation\":\"0x300Cb87f686c4FF5d975951c225969af4433ADf5\",\"node_safe_migration\":\"0x04e079e7FC8E445b58d048200847206c692Deb48\",\"node_safe_registry\":\"0x1267F2Ad0a70C975Cb4e2C810C4F2b42a455Cc09\",\"node_stake_factory\":\"0x607b6559FE4c2bB5d97de65F0CEC5DB444824634\",\"ticket_price_oracle\":\"0x9cd65f0b11B3028EadA50dE57E46C12848608fAB\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x9344093c5ac613BDBAC939E33fF760C9e6dF9F1f\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_finalize_channel_closure.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_finalize_channel_closure.snap
@@ -92,7 +92,7 @@ chain_info:
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
   network: rotsee
-  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  contract_addresses: "{\"announcements\":\"0x078B2D5C9b13e256699902704D1f9Beb79Fc51A2\",\"channels\":\"0xD8C91008c68cd87E7C52Ea1a2C6f6dC6A5236008\",\"module_implementation\":\"0x300Cb87f686c4FF5d975951c225969af4433ADf5\",\"node_safe_migration\":\"0x04e079e7FC8E445b58d048200847206c692Deb48\",\"node_safe_registry\":\"0x1267F2Ad0a70C975Cb4e2C810C4F2b42a455Cc09\",\"node_stake_factory\":\"0x607b6559FE4c2bB5d97de65F0CEC5DB444824634\",\"ticket_price_oracle\":\"0x9cd65f0b11B3028EadA50dE57E46C12848608fAB\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x9344093c5ac613BDBAC939E33fF760C9e6dF9F1f\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_fund_channel.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_fund_channel.snap
@@ -92,7 +92,7 @@ chain_info:
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
   network: rotsee
-  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  contract_addresses: "{\"announcements\":\"0x078B2D5C9b13e256699902704D1f9Beb79Fc51A2\",\"channels\":\"0xD8C91008c68cd87E7C52Ea1a2C6f6dC6A5236008\",\"module_implementation\":\"0x300Cb87f686c4FF5d975951c225969af4433ADf5\",\"node_safe_migration\":\"0x04e079e7FC8E445b58d048200847206c692Deb48\",\"node_safe_registry\":\"0x1267F2Ad0a70C975Cb4e2C810C4F2b42a455Cc09\",\"node_stake_factory\":\"0x607b6559FE4c2bB5d97de65F0CEC5DB444824634\",\"ticket_price_oracle\":\"0x9cd65f0b11B3028EadA50dE57E46C12848608fAB\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x9344093c5ac613BDBAC939E33fF760C9e6dF9F1f\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_initiate_channel_closure.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_initiate_channel_closure.snap
@@ -92,7 +92,7 @@ chain_info:
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
   network: rotsee
-  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  contract_addresses: "{\"announcements\":\"0x078B2D5C9b13e256699902704D1f9Beb79Fc51A2\",\"channels\":\"0xD8C91008c68cd87E7C52Ea1a2C6f6dC6A5236008\",\"module_implementation\":\"0x300Cb87f686c4FF5d975951c225969af4433ADf5\",\"node_safe_migration\":\"0x04e079e7FC8E445b58d048200847206c692Deb48\",\"node_safe_registry\":\"0x1267F2Ad0a70C975Cb4e2C810C4F2b42a455Cc09\",\"node_stake_factory\":\"0x607b6559FE4c2bB5d97de65F0CEC5DB444824634\",\"ticket_price_oracle\":\"0x9cd65f0b11B3028EadA50dE57E46C12848608fAB\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x9344093c5ac613BDBAC939E33fF760C9e6dF9F1f\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_open_channel.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__channels__tests__connector_should_open_channel.snap
@@ -92,7 +92,7 @@ chain_info:
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
   network: rotsee
-  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  contract_addresses: "{\"announcements\":\"0x078B2D5C9b13e256699902704D1f9Beb79Fc51A2\",\"channels\":\"0xD8C91008c68cd87E7C52Ea1a2C6f6dC6A5236008\",\"module_implementation\":\"0x300Cb87f686c4FF5d975951c225969af4433ADf5\",\"node_safe_migration\":\"0x04e079e7FC8E445b58d048200847206c692Deb48\",\"node_safe_registry\":\"0x1267F2Ad0a70C975Cb4e2C810C4F2b42a455Cc09\",\"node_stake_factory\":\"0x607b6559FE4c2bB5d97de65F0CEC5DB444824634\",\"ticket_price_oracle\":\"0x9cd65f0b11B3028EadA50dE57E46C12848608fAB\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x9344093c5ac613BDBAC939E33fF760C9e6dF9F1f\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__safe__tests__connector_should_query_existing_safe.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__safe__tests__connector_should_query_existing_safe.snap
@@ -36,7 +36,7 @@ chain_info:
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
   network: rotsee
-  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  contract_addresses: "{\"announcements\":\"0x078B2D5C9b13e256699902704D1f9Beb79Fc51A2\",\"channels\":\"0xD8C91008c68cd87E7C52Ea1a2C6f6dC6A5236008\",\"module_implementation\":\"0x300Cb87f686c4FF5d975951c225969af4433ADf5\",\"node_safe_migration\":\"0x04e079e7FC8E445b58d048200847206c692Deb48\",\"node_safe_registry\":\"0x1267F2Ad0a70C975Cb4e2C810C4F2b42a455Cc09\",\"node_stake_factory\":\"0x607b6559FE4c2bB5d97de65F0CEC5DB444824634\",\"ticket_price_oracle\":\"0x9cd65f0b11B3028EadA50dE57E46C12848608fAB\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x9344093c5ac613BDBAC939E33fF760C9e6dF9F1f\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_on_closed_channel.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_on_closed_channel.snap
@@ -92,7 +92,7 @@ chain_info:
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
   network: rotsee
-  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  contract_addresses: "{\"announcements\":\"0x078B2D5C9b13e256699902704D1f9Beb79Fc51A2\",\"channels\":\"0xD8C91008c68cd87E7C52Ea1a2C6f6dC6A5236008\",\"module_implementation\":\"0x300Cb87f686c4FF5d975951c225969af4433ADf5\",\"node_safe_migration\":\"0x04e079e7FC8E445b58d048200847206c692Deb48\",\"node_safe_registry\":\"0x1267F2Ad0a70C975Cb4e2C810C4F2b42a455Cc09\",\"node_stake_factory\":\"0x607b6559FE4c2bB5d97de65F0CEC5DB444824634\",\"ticket_price_oracle\":\"0x9cd65f0b11B3028EadA50dE57E46C12848608fAB\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x9344093c5ac613BDBAC939E33fF760C9e6dF9F1f\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_on_non_existing_channel.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_on_non_existing_channel.snap
@@ -91,7 +91,7 @@ chain_info:
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
   network: rotsee
-  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  contract_addresses: "{\"announcements\":\"0x078B2D5C9b13e256699902704D1f9Beb79Fc51A2\",\"channels\":\"0xD8C91008c68cd87E7C52Ea1a2C6f6dC6A5236008\",\"module_implementation\":\"0x300Cb87f686c4FF5d975951c225969af4433ADf5\",\"node_safe_migration\":\"0x04e079e7FC8E445b58d048200847206c692Deb48\",\"node_safe_registry\":\"0x1267F2Ad0a70C975Cb4e2C810C4F2b42a455Cc09\",\"node_stake_factory\":\"0x607b6559FE4c2bB5d97de65F0CEC5DB444824634\",\"ticket_price_oracle\":\"0x9cd65f0b11B3028EadA50dE57E46C12848608fAB\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x9344093c5ac613BDBAC939E33fF760C9e6dF9F1f\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_amount_higher_than_channel_stake.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_amount_higher_than_channel_stake.snap
@@ -91,7 +91,7 @@ chain_info:
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
   network: rotsee
-  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  contract_addresses: "{\"announcements\":\"0x078B2D5C9b13e256699902704D1f9Beb79Fc51A2\",\"channels\":\"0xD8C91008c68cd87E7C52Ea1a2C6f6dC6A5236008\",\"module_implementation\":\"0x300Cb87f686c4FF5d975951c225969af4433ADf5\",\"node_safe_migration\":\"0x04e079e7FC8E445b58d048200847206c692Deb48\",\"node_safe_registry\":\"0x1267F2Ad0a70C975Cb4e2C810C4F2b42a455Cc09\",\"node_stake_factory\":\"0x607b6559FE4c2bB5d97de65F0CEC5DB444824634\",\"ticket_price_oracle\":\"0x9cd65f0b11B3028EadA50dE57E46C12848608fAB\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x9344093c5ac613BDBAC939E33fF760C9e6dF9F1f\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_old_index.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_old_index.snap
@@ -91,7 +91,7 @@ chain_info:
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
   network: rotsee
-  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  contract_addresses: "{\"announcements\":\"0x078B2D5C9b13e256699902704D1f9Beb79Fc51A2\",\"channels\":\"0xD8C91008c68cd87E7C52Ea1a2C6f6dC6A5236008\",\"module_implementation\":\"0x300Cb87f686c4FF5d975951c225969af4433ADf5\",\"node_safe_migration\":\"0x04e079e7FC8E445b58d048200847206c692Deb48\",\"node_safe_registry\":\"0x1267F2Ad0a70C975Cb4e2C810C4F2b42a455Cc09\",\"node_stake_factory\":\"0x607b6559FE4c2bB5d97de65F0CEC5DB444824634\",\"ticket_price_oracle\":\"0x9cd65f0b11B3028EadA50dE57E46C12848608fAB\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x9344093c5ac613BDBAC939E33fF760C9e6dF9F1f\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_previous_epoch.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_not_redeem_ticket_with_previous_epoch.snap
@@ -91,7 +91,7 @@ chain_info:
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
   network: rotsee
-  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  contract_addresses: "{\"announcements\":\"0x078B2D5C9b13e256699902704D1f9Beb79Fc51A2\",\"channels\":\"0xD8C91008c68cd87E7C52Ea1a2C6f6dC6A5236008\",\"module_implementation\":\"0x300Cb87f686c4FF5d975951c225969af4433ADf5\",\"node_safe_migration\":\"0x04e079e7FC8E445b58d048200847206c692Deb48\",\"node_safe_registry\":\"0x1267F2Ad0a70C975Cb4e2C810C4F2b42a455Cc09\",\"node_stake_factory\":\"0x607b6559FE4c2bB5d97de65F0CEC5DB444824634\",\"ticket_price_oracle\":\"0x9cd65f0b11B3028EadA50dE57E46C12848608fAB\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x9344093c5ac613BDBAC939E33fF760C9e6dF9F1f\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_redeem_ticket.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_redeem_ticket.snap
@@ -98,7 +98,7 @@ chain_info:
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
   network: rotsee
-  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  contract_addresses: "{\"announcements\":\"0x078B2D5C9b13e256699902704D1f9Beb79Fc51A2\",\"channels\":\"0xD8C91008c68cd87E7C52Ea1a2C6f6dC6A5236008\",\"module_implementation\":\"0x300Cb87f686c4FF5d975951c225969af4433ADf5\",\"node_safe_migration\":\"0x04e079e7FC8E445b58d048200847206c692Deb48\",\"node_safe_registry\":\"0x1267F2Ad0a70C975Cb4e2C810C4F2b42a455Cc09\",\"node_stake_factory\":\"0x607b6559FE4c2bB5d97de65F0CEC5DB444824634\",\"ticket_price_oracle\":\"0x9cd65f0b11B3028EadA50dE57E46C12848608fAB\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x9344093c5ac613BDBAC939E33fF760C9e6dF9F1f\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"

--- a/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_redeem_ticket_and_increase_redeemed_stats.snap
+++ b/impls/connector/src/connector/snapshots/hopr_chain_connector__connector__tickets__tests__connector_should_redeem_ticket_and_increase_redeemed_stats.snap
@@ -98,7 +98,7 @@ chain_info:
   safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
   ticket_price: 1 wxHOPR
   network: rotsee
-  contract_addresses: "{\"announcements\":\"0xe08E8EfAc66c83a5e2cE9E0a696f8416A5AB6136\",\"channels\":\"0x81a79fcDe8FFE6452e51D8E0493B37C2a5a09c57\",\"module_implementation\":\"0x5F36592e29D90558bc629a4afd87D37d38d9a595\",\"node_safe_migration\":\"0xb9a6F18b40f632869dEFa4bbB2212c63767Eb159\",\"node_safe_registry\":\"0x8cDf9A10646403C9aA797610D4C782aD26D334f4\",\"node_stake_factory\":\"0x6827eC1Bf6232B07f30C2F2924Ea681412b07687\",\"ticket_price_oracle\":\"0xca2c60433eC6a10dDEabBbE3Ce7f9737b1a0628C\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x5136Bac09C78af89bDA56F5086A3F3E2Ee4EAfCa\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
+  contract_addresses: "{\"announcements\":\"0x078B2D5C9b13e256699902704D1f9Beb79Fc51A2\",\"channels\":\"0xD8C91008c68cd87E7C52Ea1a2C6f6dC6A5236008\",\"module_implementation\":\"0x300Cb87f686c4FF5d975951c225969af4433ADf5\",\"node_safe_migration\":\"0x04e079e7FC8E445b58d048200847206c692Deb48\",\"node_safe_registry\":\"0x1267F2Ad0a70C975Cb4e2C810C4F2b42a455Cc09\",\"node_stake_factory\":\"0x607b6559FE4c2bB5d97de65F0CEC5DB444824634\",\"ticket_price_oracle\":\"0x9cd65f0b11B3028EadA50dE57E46C12848608fAB\",\"token\":\"0xD4fdec44DB9D44B8f2b6d529620f9C0C7066A2c1\",\"winning_probability_oracle\":\"0x9344093c5ac613BDBAC939E33fF760C9e6dF9F1f\",\"xhopr_token\":\"0xD057604A14982FE8D88c5fC25Aac3267eA142a08\"}"
   expected_block_time: "5"
   finality: "3"
 version: "1"

--- a/impls/connector/src/reader.rs
+++ b/impls/connector/src/reader.rs
@@ -51,7 +51,13 @@ where
     async fn balance<Cy: Currency, A: Into<Address> + Send>(&self, address: A) -> Result<Balance<Cy>, Self::Error> {
         let address = address.into();
         if Cy::is::<WxHOPR>() {
-            Ok(self.0.query_token_balance(&address.into()).await?.balance.0.parse()?)
+            Ok(self
+                .0
+                .query_token_balance(&address.into(), blokli_client::types::Token::WxHOPR)
+                .await?
+                .balance
+                .0
+                .parse()?)
         } else if Cy::is::<XDai>() {
             Ok(self.0.query_native_balance(&address.into()).await?.balance.0.parse()?)
         } else {


### PR DESCRIPTION
Bumps `blokli-client` to `0.30.2` and `hopr-types` to `2.0.2`.
Fixes a stale path in `flake.nix` for the ticket inspector.