### PR TITLE
fix(strategy): size channel-lifecycle funding by ticket face value

### DIFF
--- a/impls/strategy/Cargo.toml
+++ b/impls/strategy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-strategy"
 description = "Contains implementations of different HOPR strategies"
-version = "0.20.0"
+version = "0.20.1"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/impls/strategy/src/channel_lifecycle/config.rs
+++ b/impls/strategy/src/channel_lifecycle/config.rs
@@ -1,10 +1,7 @@
 use std::{collections::HashSet, time::Duration};
 
 use bytesize::ByteSize;
-use hopr_api::{
-    chain::WinningProbability,
-    types::primitive::prelude::{Address, HoprBalance, U256, UnitaryFloatOps},
-};
+use hopr_api::types::primitive::prelude::{Address, HoprBalance, U256};
 use hopr_crypto_packet::prelude::HoprPacket;
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
@@ -80,16 +77,17 @@ pub struct EligibilityConfig {
 /// data volumes.
 ///
 /// The strategy converts each capacity to a wxHOPR amount at runtime using the
-/// live on-chain ticket price and winning probability via [`FundingConfig::resolve`].
+/// live on-chain ticket price via [`FundingConfig::resolve`].
 ///
-/// **Conversion formula** (RFC-0005 §3.2):
+/// **Conversion formula**:
 /// ```text
 /// packets     = ceil(capacity_bytes / HoprPacket::PAYLOAD_SIZE)
-/// funding_wei = ticket_price_wei × packets × assumed_hops / win_prob
+/// funding_wei = ticket_price_wei × packets × assumed_hops
 /// ```
-/// `assumed_hops` is the number of paid downstream relay hops.  Defaulting to 3
-/// (the protocol maximum) ensures the channel is never under-funded when paths
-/// use the full relay depth.
+/// The channel stake covers ticket face value; winning probability does not
+/// affect the amount the sender locks per packet.  `assumed_hops` is the number
+/// of paid downstream relay hops.  Defaulting to 3 (the protocol maximum)
+/// ensures the channel is never under-funded when paths use the full relay depth.
 #[derive(Debug, Clone, PartialEq, smart_default::SmartDefault, Validate, Serialize, Deserialize)]
 pub struct FundingConfig {
     /// Data volume a newly opened channel's stake should be able to carry.
@@ -146,23 +144,15 @@ pub(crate) struct ResolvedFunding {
     pub min_safe_balance_required: HoprBalance,
 }
 
-/// Convert a data `capacity` to a wxHOPR balance using the live ticket economics.
+/// Convert a data `capacity` to a wxHOPR balance using the live ticket price.
 ///
-/// The formula matches the ticket-issuance math in `HoprTicketFactory`:
+/// The channel stake covers ticket face value:
 /// ```text
 /// packets     = ceil(capacity_bytes / HoprPacket::PAYLOAD_SIZE)
-/// funding_wei = ticket_price_wei × packets × hops / win_prob
+/// funding_wei = ticket_price_wei × packets × hops
 /// ```
 /// Returns [`HoprBalance::zero`] for zero capacity.
-/// Falls back to a `win_prob`-independent estimate (`price × packets × hops`)
-/// when `win_prob` is zero or converting it to f64 would produce a non-positive
-/// value, to avoid dividing by zero.
-pub(crate) fn capacity_to_balance(
-    capacity: ByteSize,
-    price: HoprBalance,
-    win_prob: WinningProbability,
-    hops: u32,
-) -> HoprBalance {
+pub(crate) fn capacity_to_balance(capacity: ByteSize, price: HoprBalance, hops: u32) -> HoprBalance {
     let bytes = capacity.as_u64();
     if bytes == 0 {
         return HoprBalance::zero();
@@ -173,35 +163,24 @@ pub(crate) fn capacity_to_balance(
     let packets = bytes.div_ceil(payload);
 
     // ticket_price_wei × packets × hops — saturating; overflow becomes U256::MAX
-    let wei_base = price
+    let wei = price
         .amount()
         .saturating_mul(U256::from(packets))
         .saturating_mul(U256::from(hops));
-
-    // Divide by win_prob (≤ 1.0); fall back to no division if prob is degenerate.
-    let wp: f64 = win_prob.into();
-    let wei = if wp > 0.0 {
-        match wei_base.div_f64(wp) {
-            Ok(v) => v,
-            Err(_) => wei_base, // degenerate: return undiscounted value
-        }
-    } else {
-        wei_base
-    };
 
     HoprBalance::from(wei)
 }
 
 impl FundingConfig {
     /// Resolve all data-capacity fields to wxHOPR amounts at the given ticket
-    /// economics.  Called once per pipeline tick.
-    pub(crate) fn resolve(&self, price: HoprBalance, win_prob: WinningProbability) -> ResolvedFunding {
+    /// price.  Called once per pipeline tick.
+    pub(crate) fn resolve(&self, price: HoprBalance) -> ResolvedFunding {
         let hops = self.assumed_hops;
         ResolvedFunding {
-            initial_balance: capacity_to_balance(self.initial_capacity, price, win_prob, hops),
-            topup_balance: capacity_to_balance(self.topup_capacity, price, win_prob, hops),
-            lower_balance_threshold: capacity_to_balance(self.lower_capacity_threshold, price, win_prob, hops),
-            min_safe_balance_required: capacity_to_balance(self.min_safe_capacity_required, price, win_prob, hops),
+            initial_balance: capacity_to_balance(self.initial_capacity, price, hops),
+            topup_balance: capacity_to_balance(self.topup_capacity, price, hops),
+            lower_balance_threshold: capacity_to_balance(self.lower_capacity_threshold, price, hops),
+            min_safe_balance_required: capacity_to_balance(self.min_safe_capacity_required, price, hops),
         }
     }
 }
@@ -497,36 +476,32 @@ mod config_tests {
     #[test]
     fn zero_capacity_returns_zero() -> anyhow::Result<()> {
         let price = balance_from_wei(PRICE_WEI);
-        let wp = WinningProbability::try_from(1.0f64).context("create win_prob")?;
-        assert_eq!(capacity_to_balance(ByteSize::b(0), price, wp, 3), HoprBalance::zero());
+        assert_eq!(capacity_to_balance(ByteSize::b(0), price, 3), HoprBalance::zero());
         Ok(())
     }
 
     #[test]
-    fn exact_packet_count_win_prob_one() -> anyhow::Result<()> {
+    fn exact_packet_count() -> anyhow::Result<()> {
         // capacity = 10 × PAYLOAD_SIZE → exactly 10 packets
         let price = balance_from_wei(PRICE_WEI);
-        let wp = WinningProbability::try_from(1.0f64).context("create win_prob")?;
         let capacity = ByteSize::b((HoprPacket::PAYLOAD_SIZE * 10) as u64);
-        let result = capacity_to_balance(capacity, price, wp, 3);
-        // expected: PRICE_WEI * 10 packets * 3 hops / 1.0
+        let result = capacity_to_balance(capacity, price, 3);
+        // expected: PRICE_WEI * 10 packets * 3 hops
         let expected = balance_from_wei(PRICE_WEI * 10 * 3);
-        assert_eq!(result, expected, "exact 10 packets, win_prob=1.0");
+        assert_eq!(result, expected, "exact 10 packets");
         Ok(())
     }
 
     #[test]
-    fn half_win_prob_doubles_funding() -> anyhow::Result<()> {
-        // win_prob = 0.5 → face-value doubles vs. win_prob = 1.0
+    fn funding_is_ticket_face_value() -> anyhow::Result<()> {
+        // Regression: funding must equal ticket_price × packets × hops, independent
+        // of winning probability. The previous formula divided by win_prob, which
+        // over-funded channels when win_prob < 1.
         let price = balance_from_wei(PRICE_WEI);
-        let wp_full = WinningProbability::try_from(1.0f64).context("create wp_full")?;
-        let wp_half = WinningProbability::try_from(0.5f64).context("create wp_half")?;
         let capacity = ByteSize::b((HoprPacket::PAYLOAD_SIZE * 10) as u64);
-        let full = capacity_to_balance(capacity, price, wp_full, 3);
-        let half = capacity_to_balance(capacity, price, wp_half, 3);
-        // half should be approximately double full
-        let ratio = half.amount().low_u128() as f64 / full.amount().low_u128() as f64;
-        assert!((ratio - 2.0).abs() < 0.01, "ratio={ratio}");
+        let result = capacity_to_balance(capacity, price, 3);
+        let expected = balance_from_wei(PRICE_WEI * 10 * 3);
+        assert_eq!(result, expected, "10 packets × price × 3 hops");
         Ok(())
     }
 
@@ -534,8 +509,7 @@ mod config_tests {
     fn sub_packet_capacity_rounds_up_to_one_packet() -> anyhow::Result<()> {
         // 1 byte → ceil(1 / PAYLOAD_SIZE) = 1 packet
         let price = balance_from_wei(PRICE_WEI);
-        let wp = WinningProbability::try_from(1.0f64).context("create win_prob")?;
-        let result = capacity_to_balance(ByteSize::b(1), price, wp, 1);
+        let result = capacity_to_balance(ByteSize::b(1), price, 1);
         let expected = balance_from_wei(PRICE_WEI * 1 * 1);
         assert_eq!(result, expected, "1 byte rounds up to 1 packet");
         Ok(())
@@ -544,10 +518,9 @@ mod config_tests {
     #[test]
     fn assumed_hops_scales_linearly() -> anyhow::Result<()> {
         let price = balance_from_wei(PRICE_WEI);
-        let wp = WinningProbability::try_from(1.0f64).context("create win_prob")?;
         let capacity = ByteSize::b(HoprPacket::PAYLOAD_SIZE as u64);
-        let h1 = capacity_to_balance(capacity, price, wp, 1);
-        let h3 = capacity_to_balance(capacity, price, wp, 3);
+        let h1 = capacity_to_balance(capacity, price, 1);
+        let h3 = capacity_to_balance(capacity, price, 3);
         assert_eq!(
             h3.amount(),
             h1.amount().saturating_mul(U256::from(3u64)),
@@ -562,25 +535,24 @@ mod config_tests {
     fn resolve_maps_all_four_fields() -> anyhow::Result<()> {
         let cfg = FundingConfig::default();
         let price = balance_from_wei(PRICE_WEI);
-        let wp = WinningProbability::try_from(1.0f64).context("create win_prob")?;
-        let resolved = cfg.resolve(price, wp);
+        let resolved = cfg.resolve(price);
 
         // Each resolved balance must match what capacity_to_balance produces independently.
         assert_eq!(
             resolved.initial_balance,
-            capacity_to_balance(cfg.initial_capacity, price, wp, cfg.assumed_hops)
+            capacity_to_balance(cfg.initial_capacity, price, cfg.assumed_hops)
         );
         assert_eq!(
             resolved.topup_balance,
-            capacity_to_balance(cfg.topup_capacity, price, wp, cfg.assumed_hops)
+            capacity_to_balance(cfg.topup_capacity, price, cfg.assumed_hops)
         );
         assert_eq!(
             resolved.lower_balance_threshold,
-            capacity_to_balance(cfg.lower_capacity_threshold, price, wp, cfg.assumed_hops)
+            capacity_to_balance(cfg.lower_capacity_threshold, price, cfg.assumed_hops)
         );
         assert_eq!(
             resolved.min_safe_balance_required,
-            capacity_to_balance(cfg.min_safe_capacity_required, price, wp, cfg.assumed_hops)
+            capacity_to_balance(cfg.min_safe_capacity_required, price, cfg.assumed_hops)
         );
         Ok(())
     }

--- a/impls/strategy/src/channel_lifecycle/pipeline.rs
+++ b/impls/strategy/src/channel_lifecycle/pipeline.rs
@@ -443,27 +443,22 @@ where
                 });
         }
 
-        // Fetch ticket economics once per tick.  Both values are needed for
-        // the capacity-to-wxHOPR conversion and for the proactive-funding drain
-        // estimate.  When either value is unavailable the fund and open passes
-        // are skipped; close and finalize still run.
-        let ticket_price = chain.minimum_ticket_price().await.unwrap_or_else(|e| {
-            warn!(%e, "channel-lifecycle: minimum_ticket_price unavailable, using zero");
-            HoprBalance::zero()
-        });
-        let min_ticket_price_wei = ticket_price.amount().low_u128() as f64;
-
-        let win_prob = match chain.minimum_incoming_ticket_win_prob().await {
-            Ok(wp) => Some(wp),
+        // Fetch the ticket price once per tick — the sole economic input to the
+        // capacity-to-wxHOPR conversion and to the proactive-funding drain estimate.
+        // When it is unavailable the fund and open passes are skipped; close and
+        // finalize still run.
+        let ticket_price = match chain.minimum_ticket_price().await {
+            Ok(price) => Some(price),
             Err(e) => {
-                warn!(%e, "channel-lifecycle: minimum_incoming_ticket_win_prob unavailable, skipping fund/open passes");
+                warn!(%e, "channel-lifecycle: minimum_ticket_price unavailable, skipping fund/open passes");
                 None
             }
         };
+        let min_ticket_price_wei = ticket_price.as_ref().map_or(0.0, |p| p.amount().low_u128() as f64);
 
         // Resolve data-capacity config fields to wxHOPR amounts for this tick.
-        // `None` when win_prob is unavailable; fund/open passes are skipped.
-        let funding = win_prob.map(|wp| self.cfg.funding.resolve(ticket_price, wp));
+        // `None` when the ticket price is unavailable; fund/open passes are skipped.
+        let funding = ticket_price.map(|price| self.cfg.funding.resolve(price));
 
         // Share resolved economics with the event-driven funding handler so it
         // can reuse per-tick values rather than issuing fresh chain RPC calls.
@@ -1046,7 +1041,7 @@ mod tests {
         PeerId,
         chain::{
             AccountSelector, ChainEvent, ChainEvents, ChainReadAccountOperations, ChainReadChannelOperations,
-            ChainWriteAccountOperations, ChannelSelector, HoprChainApi, WinningProbability,
+            ChainWriteAccountOperations, ChannelSelector, HoprChainApi,
         },
         node::{
             ActionableEvent, ActionableEventDiscriminant, ActionableEventSource, ComponentStatus,
@@ -1454,7 +1449,7 @@ mod tests {
 
         let node = Arc::new(ChainNode::new(Arc::clone(&connector)));
 
-        // With the Blokli sim's default ticket price of "1 wxHOPR" and win_prob = 1.0,
+        // With the Blokli sim's default ticket price of "1 wxHOPR",
         // ByteSize::b(1) resolves to 1 packet × 1 wxHOPR × 3 hops = 3 wxHOPR.
         // The channel has balance 2 wei ≪ 3 wxHOPR → triggers funding.
         // The safe has 1000 wxHOPR ≫ 3 wxHOPR topup → topup is affordable.
@@ -1942,19 +1937,17 @@ mod tests {
         let connector = Arc::new(connector);
         register_test_safe(&*connector, *BOB).await?;
 
-        let cfg = ChannelLifecycleConfig {
-            funding: FundingConfig {
-                initial_balance,
-                min_safe_balance_required: HoprBalance::from(1_u32),
-                stop_when_unfunded: true,
-                ..Default::default()
-            },
-            ..Default::default()
-        };
+        let cfg = ChannelLifecycleConfig::default();
 
         let inner = fresh_inner_with_chain(cfg, Arc::clone(&connector));
 
-        let result = inner.try_open_channel(*ALICE, initial_balance);
+        let resolved = make_resolved(
+            HoprBalance::from(1_u32), // lower (arbitrary — not the deciding factor here)
+            HoprBalance::from(8_u32), // topup (arbitrary)
+            initial_balance,
+            HoprBalance::from(1_u32), // min_safe (arbitrary)
+        );
+        let result = inner.try_open_channel(*ALICE, initial_balance, &resolved);
 
         // The PendingToClose guard must fire: no tx, in-flight marker cleared.
         assert!(
@@ -2118,12 +2111,11 @@ mod tests {
     /// correct wxHOPR **topup** amount via the live ticket economics fetched from
     /// the Blokli simulator, and the fund pass applies it to an underfunded channel.
     ///
-    /// The Blokli test sim defaults to `ticket_price = "1 wxHOPR"` and
-    /// `min_ticket_winning_probability = 1.0`.  With `assumed_hops = 3` and
-    /// `topup_capacity = 1 byte` (= 1 packet):
+    /// The Blokli test sim defaults to `ticket_price = "1 wxHOPR"`.  With
+    /// `assumed_hops = 3` and `topup_capacity = 1 byte` (= 1 packet):
     ///
     /// ```text
-    /// topup_balance = 1 packet × 1 wxHOPR × 3 hops / 1.0 = 3 wxHOPR
+    /// topup_balance = 1 packet × 1 wxHOPR × 3 hops = 3 wxHOPR
     /// ```
     ///
     /// The channel starts with 0 balance (< resolved threshold), triggering a
@@ -2133,13 +2125,11 @@ mod tests {
     async fn pipeline_funds_underfunded_channel_with_capacity_derived_wxhopr_amount() -> anyhow::Result<()> {
         use super::super::config::capacity_to_balance;
 
-        // Blokli defaults: ticket_price = "1 wxHOPR", win_prob = 1.0, assumed_hops = 3.
-        // capacity_to_balance(ByteSize::b(1), 1 wxHOPR, 1.0, 3) = 3 wxHOPR.
-        // capacity_to_balance(1 byte, 1 wxHOPR, 1.0, 3 hops) = 3 wxHOPR.
+        // Blokli defaults: ticket_price = "1 wxHOPR", assumed_hops = 3.
+        // capacity_to_balance(1 byte, 1 wxHOPR, 3 hops) = 3 wxHOPR.
         let expected_topup = {
             let price = HoprBalance::new_base(1); // 1 wxHOPR (Blokli default)
-            let wp = WinningProbability::try_from(1.0f64).expect("valid win_prob");
-            capacity_to_balance(ByteSize::b(1), price, wp, 3) // topup_capacity = ByteSize::b(1)
+            capacity_to_balance(ByteSize::b(1), price, 3) // topup_capacity = ByteSize::b(1)
         };
 
         // Channel starts at 0 balance — below any non-zero threshold.

--- a/impls/strategy/src/snapshots/hopr_strategy__auto_funding__tests__auto_funding_strategy.snap
+++ b/impls/strategy/src/snapshots/hopr_strategy__auto_funding__tests__auto_funding_strategy.snap
@@ -1,0 +1,176 @@
+---
+source: impls/strategy/src/auto_funding.rs
+expression: "*snapshot.refresh()"
+---
+accounts:
+  0:
+    chain_key: 18f8ae833c85c51fbeba29cef9fbfb53b3bad950
+    keyid: 0
+    multi_addresses: []
+    packet_key: d6affd9ecd20b4fa1ea3fe65162604f01bc8fb859bb8a079b9e70be10eba15a6
+    safe_address: 93534e8ca82510a346dd329115ce7aefd4d35583
+  1:
+    chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
+    keyid: 1
+    multi_addresses: []
+    packet_key: c443eb7d2eb0c95b3fe8ade2a75b7ea008087b5fe22843557273688d1e4d4f22
+    safe_address: 259bed99d230648d7c8a116af59abdd15c9f4f1e
+  2:
+    chain_key: b6021e0860dd9d96c9ff0a73e2e5ba3a466ba234
+    keyid: 2
+    multi_addresses: []
+    packet_key: 8994396d4907dc5e18e209cf958f001afe8f04d7dc1b3a4fd0f9086ee8c610b7
+    safe_address: 0f944bc36fdcf97fff6807174eeb839ecd6035bd
+  3:
+    chain_key: 68499f50ff68d523385dc60686069935d17d762a
+    keyid: 3
+    multi_addresses: []
+    packet_key: 6cc4009e6dd36eea81f3d5b2b7a9f3dd0e78c66a9577e7090ebdd066882712d3
+    safe_address: f982b19d6920ee93a267aec482349ab4a6c8a150
+native_balances:
+  18f8ae833c85c51fbeba29cef9fbfb53b3bad950:
+    __typename: NativeBalance
+    balance: 1 xDai
+  93534e8ca82510a346dd329115ce7aefd4d35583:
+    __typename: NativeBalance
+    balance: 0 xDai
+  bea83ba0fcee21da44a30c893f466e6bf0c29bbb:
+    __typename: NativeBalance
+    balance: 0.999999999999999999 xDai
+  259bed99d230648d7c8a116af59abdd15c9f4f1e:
+    __typename: NativeBalance
+    balance: 0 xDai
+  b6021e0860dd9d96c9ff0a73e2e5ba3a466ba234:
+    __typename: NativeBalance
+    balance: 1 xDai
+  0f944bc36fdcf97fff6807174eeb839ecd6035bd:
+    __typename: NativeBalance
+    balance: 0 xDai
+  68499f50ff68d523385dc60686069935d17d762a:
+    __typename: NativeBalance
+    balance: 1 xDai
+  f982b19d6920ee93a267aec482349ab4a6c8a150:
+    __typename: NativeBalance
+    balance: 0 xDai
+token_balances:
+  18f8ae833c85c51fbeba29cef9fbfb53b3bad950:
+    __typename: HoprBalance
+    balance: 0 wxHOPR
+  93534e8ca82510a346dd329115ce7aefd4d35583:
+    __typename: HoprBalance
+    balance: 1000 wxHOPR
+  bea83ba0fcee21da44a30c893f466e6bf0c29bbb:
+    __typename: HoprBalance
+    balance: 0 wxHOPR
+  259bed99d230648d7c8a116af59abdd15c9f4f1e:
+    __typename: HoprBalance
+    balance: 999.999999999999999995 wxHOPR
+  b6021e0860dd9d96c9ff0a73e2e5ba3a466ba234:
+    __typename: HoprBalance
+    balance: 0 wxHOPR
+  0f944bc36fdcf97fff6807174eeb839ecd6035bd:
+    __typename: HoprBalance
+    balance: 1000 wxHOPR
+  68499f50ff68d523385dc60686069935d17d762a:
+    __typename: HoprBalance
+    balance: 0 wxHOPR
+  f982b19d6920ee93a267aec482349ab4a6c8a150:
+    __typename: HoprBalance
+    balance: 1000 wxHOPR
+safe_allowances:
+  93534e8ca82510a346dd329115ce7aefd4d35583:
+    __typename: SafeHoprAllowance
+    allowance: 10000000000000 wxHOPR
+  259bed99d230648d7c8a116af59abdd15c9f4f1e:
+    __typename: SafeHoprAllowance
+    allowance: 9999999999999.999999999999999995 wxHOPR
+  0f944bc36fdcf97fff6807174eeb839ecd6035bd:
+    __typename: SafeHoprAllowance
+    allowance: 10000000000000 wxHOPR
+  f982b19d6920ee93a267aec482349ab4a6c8a150:
+    __typename: SafeHoprAllowance
+    allowance: 10000000000000 wxHOPR
+deployed_safes:
+  93534e8ca82510a346dd329115ce7aefd4d35583:
+    address: 93534e8ca82510a346dd329115ce7aefd4d35583
+    chain_key: 18f8ae833c85c51fbeba29cef9fbfb53b3bad950
+    owners:
+      - 18f8ae833c85c51fbeba29cef9fbfb53b3bad950
+    module_address: c2ac223dbf64edf995c70c5a3d5599c3fb6d6291
+    registered_nodes: []
+    threshold: "1"
+  259bed99d230648d7c8a116af59abdd15c9f4f1e:
+    address: 259bed99d230648d7c8a116af59abdd15c9f4f1e
+    chain_key: bea83ba0fcee21da44a30c893f466e6bf0c29bbb
+    owners:
+      - bea83ba0fcee21da44a30c893f466e6bf0c29bbb
+    module_address: ff263744a4621e2cac0f4882cc623bee3c9aef8d
+    registered_nodes: []
+    threshold: "1"
+  0f944bc36fdcf97fff6807174eeb839ecd6035bd:
+    address: 0f944bc36fdcf97fff6807174eeb839ecd6035bd
+    chain_key: b6021e0860dd9d96c9ff0a73e2e5ba3a466ba234
+    owners:
+      - b6021e0860dd9d96c9ff0a73e2e5ba3a466ba234
+    module_address: 1613d5898cae268775bb85aa0b7e6e7fbc9dcd47
+    registered_nodes: []
+    threshold: "1"
+  f982b19d6920ee93a267aec482349ab4a6c8a150:
+    address: f982b19d6920ee93a267aec482349ab4a6c8a150
+    chain_key: 68499f50ff68d523385dc60686069935d17d762a
+    owners:
+      - 68499f50ff68d523385dc60686069935d17d762a
+    module_address: c6cf223b5fa5a0002e5f975453407134b848c312
+    registered_nodes: []
+    threshold: "1"
+safe_redeem_stats: {}
+tx_counts:
+  bea83ba0fcee21da44a30c893f466e6bf0c29bbb: 1
+channels:
+  8a0da13eba62860787c9f93a665d2235d8e9632c491dc577ce9dd28d5be8a091:
+    balance: 0.00000000000000001 wxHOPR
+    closure_time: ~
+    concrete_channel_id: 8a0da13eba62860787c9f93a665d2235d8e9632c491dc577ce9dd28d5be8a091
+    destination: 1
+    epoch: 0
+    source: 0
+    status: OPEN
+    ticket_index: "0"
+  6924339470e763ceee49f1a6ce98a95780646ff6fd25744bcb3fc9d231c447ee:
+    balance: 0.00000000000000001 wxHOPR
+    closure_time: ~
+    concrete_channel_id: 6924339470e763ceee49f1a6ce98a95780646ff6fd25744bcb3fc9d231c447ee
+    destination: 2
+    epoch: 0
+    source: 1
+    status: OPEN
+    ticket_index: "0"
+  fa56c9b048679b117d551bd66ddc4835cfb754cbcc34a679512061ec1deef935:
+    balance: 0.000000000000000005 wxHOPR
+    closure_time: "2025-11-10T00:00:00+00:00"
+    concrete_channel_id: fa56c9b048679b117d551bd66ddc4835cfb754cbcc34a679512061ec1deef935
+    destination: 3
+    epoch: 0
+    source: 2
+    status: PENDINGTOCLOSE
+    ticket_index: "0"
+chain_info:
+  channel_closure_grace_period: "300"
+  channel_dst: "0000000000000000000000000000000000000000000000000000000000000000"
+  block_number: 1
+  chain_id: 31337
+  gas_price: "1000000000"
+  ledger_dst: "0000000000000000000000000000000000000000000000000000000000000000"
+  max_fee_per_gas: "3000000000"
+  max_priority_fee_per_gas: "100000000"
+  min_ticket_winning_probability: 1
+  key_binding_fee: 0.01 wxHOPR
+  safe_registry_dst: "0000000000000000000000000000000000000000000000000000000000000000"
+  ticket_price: 1 wxHOPR
+  network: anvil-localhost
+  contract_addresses: "{\"announcements\":\"0x8A791620dd6260079BF849Dc5567aDC3F2FdC318\",\"channels\":\"0xa513E6E4b8f2a923D98304ec87F64353C4D5C853\",\"module_implementation\":\"0x5FC8d32690cc91D4c39d9d3abcBD16989F875707\",\"node_safe_migration\":\"0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e\",\"node_safe_registry\":\"0x0165878A594ca255338adfa4d48449f69242Eb8F\",\"node_stake_factory\":\"0x610178dA211FEF7D417bC0e6FeD39F05609AD788\",\"ticket_price_oracle\":\"0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9\",\"token\":\"0x5FbDB2315678afecb367f032d93F642f64180aa3\",\"winning_probability_oracle\":\"0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9\",\"xhopr_token\":\"0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0\"}"
+  expected_block_time: "5"
+  finality: "3"
+version: "1"
+health: OK
+active_txs: {}


### PR DESCRIPTION
## Summary

- Remove the `/ win_prob` division from `capacity_to_balance` and `FundingConfig::resolve` in the channel-lifecycle strategy
- Channel stake covers ticket face value (`price × packets × hops`); winning probability is irrelevant to how much collateral the sender locks in a channel
- Also fixes a pre-existing test-compilation error (wrong `FundingConfig` field names in one test) and commits a missing insta snapshot

Ports the correction already applied in hopr-strategy standalone ([hoprnet/hopr-strategy#11](https://github.com/hoprnet/hopr-strategy/pull/11)).