### PR TITLE
fix(transport): prevent Rayon encoding overflow via CrossfireSink backpressure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1313,7 +1313,7 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
@@ -1378,7 +1378,7 @@ version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "event-listener-strategy",
  "pin-project-lite",
 ]
@@ -3145,11 +3145,10 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -3160,7 +3159,7 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "pin-project-lite",
 ]
 
@@ -5932,7 +5931,7 @@ dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
  "equivalent",
- "event-listener 5.4.1",
+ "event-listener 5.4.2",
  "futures-util",
  "parking_lot",
  "portable-atomic",

--- a/transport/hopr/src/constants.rs
+++ b/transport/hopr/src/constants.rs
@@ -3,7 +3,14 @@ use std::time::Duration;
 /// The maximum waiting time for a message send to produce a half-key challenge reply
 pub const PACKET_QUEUE_TIMEOUT_MILLISECONDS: std::time::Duration = std::time::Duration::from_millis(15000);
 
-pub(crate) const MAXIMUM_MSG_OUTGOING_BUFFER_SIZE: usize = 200_000;
+/// Maximum number of outgoing application-layer packets buffered before the writer
+/// observes backpressure (`Poll::Pending` on `poll_write`).
+///
+/// Caps the burst submitted to `then_concurrent(8×N_cpus)` so tail packets never
+/// exceed `PACKET_ENCODING_TIMEOUT` (150 ms). With Sphinx encoding at ~21 ms/packet
+/// and 256 slots, the worst-case Rayon queue depth stays well under the timeout on
+/// machines with up to ~36 cores. Safe formula: `≤ 7 × available_parallelism()`.
+pub(crate) const MAXIMUM_MSG_OUTGOING_BUFFER_SIZE: usize = 256;
 
 /// Time within Start protocol must finish session initiation.
 /// This base value is always multiplied by the (max) number of hops, times 2 (for both-ways).

--- a/transport/hopr/src/constants.rs
+++ b/transport/hopr/src/constants.rs
@@ -28,8 +28,8 @@ mod tests {
     fn outgoing_buffer_size_within_backpressure_limit() {
         assert!(
             MAXIMUM_MSG_OUTGOING_BUFFER_SIZE <= 256,
-            "MAXIMUM_MSG_OUTGOING_BUFFER_SIZE={MAXIMUM_MSG_OUTGOING_BUFFER_SIZE} exceeds the \
-             safe threshold; tail packets will exceed PACKET_ENCODING_TIMEOUT under burst writes"
+            "MAXIMUM_MSG_OUTGOING_BUFFER_SIZE={MAXIMUM_MSG_OUTGOING_BUFFER_SIZE} exceeds the safe threshold; tail \
+             packets will exceed PACKET_ENCODING_TIMEOUT under burst writes"
         );
     }
 
@@ -38,8 +38,10 @@ mod tests {
     /// receiving an unbounded burst.
     #[test]
     fn outgoing_channel_signals_backpressure_when_full() {
-        use std::pin::Pin;
-        use std::task::{Context, Poll};
+        use std::{
+            pin::Pin,
+            task::{Context, Poll},
+        };
 
         use futures::Sink;
         use hopr_utils::network_types::crossfire_sink::bounded_sink_channel;
@@ -64,7 +66,9 @@ mod tests {
         );
 
         // One extra item: buffer it, then poll_ready must indicate the channel is saturated.
-        Pin::new(&mut sink).start_send(MAXIMUM_MSG_OUTGOING_BUFFER_SIZE).unwrap();
+        Pin::new(&mut sink)
+            .start_send(MAXIMUM_MSG_OUTGOING_BUFFER_SIZE)
+            .unwrap();
         assert!(
             matches!(Pin::new(&mut sink).poll_ready(&mut cx), Poll::Pending),
             "CrossfireSink must return Poll::Pending when channel is at capacity ({})",

--- a/transport/hopr/src/constants.rs
+++ b/transport/hopr/src/constants.rs
@@ -15,3 +15,60 @@ pub(crate) const MAXIMUM_MSG_OUTGOING_BUFFER_SIZE: usize = 256;
 /// Time within Start protocol must finish session initiation.
 /// This base value is always multiplied by the (max) number of hops, times 2 (for both-ways).
 pub(crate) const SESSION_INITIATION_TIMEOUT_BASE: Duration = Duration::from_secs(5);
+
+#[cfg(test)]
+mod tests {
+    use super::MAXIMUM_MSG_OUTGOING_BUFFER_SIZE;
+
+    /// Guard against accidentally inflating `MAXIMUM_MSG_OUTGOING_BUFFER_SIZE` back to a large
+    /// value that would overflow the Rayon encoding queue.
+    ///
+    /// Safe formula: ≤ 7 × available_parallelism. 256 covers machines with up to ~36 cores.
+    #[test]
+    fn outgoing_buffer_size_within_backpressure_limit() {
+        assert!(
+            MAXIMUM_MSG_OUTGOING_BUFFER_SIZE <= 256,
+            "MAXIMUM_MSG_OUTGOING_BUFFER_SIZE={MAXIMUM_MSG_OUTGOING_BUFFER_SIZE} exceeds the \
+             safe threshold; tail packets will exceed PACKET_ENCODING_TIMEOUT under burst writes"
+        );
+    }
+
+    /// Verify that `CrossfireSink` signals backpressure (`Poll::Pending`) once the channel
+    /// reaches `MAXIMUM_MSG_OUTGOING_BUFFER_SIZE`, preventing the Rayon encoding queue from
+    /// receiving an unbounded burst.
+    #[test]
+    fn outgoing_channel_signals_backpressure_when_full() {
+        use std::pin::Pin;
+        use std::task::{Context, Poll};
+
+        use futures::Sink;
+        use hopr_utils::network_types::crossfire_sink::bounded_sink_channel;
+
+        let (mut sink, _rx) = bounded_sink_channel::<usize>(MAXIMUM_MSG_OUTGOING_BUFFER_SIZE);
+        let waker = futures::task::noop_waker_ref();
+        let mut cx = Context::from_waker(waker);
+
+        // Standard Sink protocol: each poll_ready → start_send pair sends one item.
+        // At i=0 the channel is empty; at i=N-1 the final item is buffered.
+        for i in 0..MAXIMUM_MSG_OUTGOING_BUFFER_SIZE {
+            assert!(
+                matches!(Pin::new(&mut sink).poll_ready(&mut cx), Poll::Ready(Ok(()))),
+                "poll_ready must be Ready before capacity is reached (item {i})"
+            );
+            Pin::new(&mut sink).start_send(i).unwrap();
+        }
+        // This poll_ready sends the last buffered item; channel is now exactly full.
+        assert!(
+            matches!(Pin::new(&mut sink).poll_ready(&mut cx), Poll::Ready(Ok(()))),
+            "poll_ready must be Ready when flushing the final item into a full-but-not-yet-full channel"
+        );
+
+        // One extra item: buffer it, then poll_ready must indicate the channel is saturated.
+        Pin::new(&mut sink).start_send(MAXIMUM_MSG_OUTGOING_BUFFER_SIZE).unwrap();
+        assert!(
+            matches!(Pin::new(&mut sink).poll_ready(&mut cx), Poll::Pending),
+            "CrossfireSink must return Poll::Pending when channel is at capacity ({})",
+            MAXIMUM_MSG_OUTGOING_BUFFER_SIZE
+        );
+    }
+}


### PR DESCRIPTION
## Summary

`MAXIMUM_MSG_OUTGOING_BUFFER_SIZE` (the `CrossfireSink` capacity for outgoing packets) was 200,000. This let `write_all` submit a full 2,060-packet burst to `then_concurrent(8×N_cpus)` without backpressure. With Sphinx encoding at ~21 ms/packet, tail packets exceeded `PACKET_ENCODING_TIMEOUT = 150 ms` and were silently dropped, causing frame discards.

Reducing the constant to **256** caps the burst the Rayon encoding pool can receive. `CrossfireSink::poll_ready` returns `Poll::Pending` on item 257, which propagates up through `AsyncWriteSink::poll_write` → `SessionSocket::poll_write` → the caller's `write_all` naturally suspends. Safe bound: `≤ 7 × available_parallelism` covers machines with up to ~36 cores.

## Tests

- `outgoing_buffer_size_within_backpressure_limit` — asserts `MAXIMUM_MSG_OUTGOING_BUFFER_SIZE ≤ 256`; fires if the constant is accidentally inflated.
- `outgoing_channel_signals_backpressure_when_full` — drives a `CrossfireSink` to exactly capacity via the standard `Sink` protocol and asserts the next `poll_ready` returns `Poll::Pending`.

Depends on: https://github.com/hoprnet/hopr-utilities/pull/3

https://claude.ai/code/session_01DgqM8mBtWmUyw8ohgnXT9T