### PR TITLE
fix(transport): backpressure per-peer egress instead of drop-newest under burst

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3128,7 +3128,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4555,9 +4555,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-utilities"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474fc7b7c21f62689d148928cd178fca6d169cf4a9162a6d2c5f9a6a35d75d6"
+checksum = "c3fb9c92de05424fd684bc1a0ac2f7df91ec2b6958f2733b2ff1c830a4390a34"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -5121,7 +5121,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7026,7 +7026,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "socket2 0.6.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7540,7 +7540,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7598,7 +7598,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8500,7 +8500,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9314,7 +9314,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4305,7 +4305,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.34.1"
+version = "0.35.0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ hopr-protocol-hopr = { version = "4.7.0", path = "protocols/hopr", default-featu
 hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
 hopr-protocol-start = { version = "1.1.0", path = "protocols/start", default-features = false }
 hopr-ticket-manager = { version = "0.5.0", path = "impls/ticket-manager" }
-hopr-transport = { version = "0.34.1", path = "transport/hopr", default-features = false }
+hopr-transport = { version = "0.35.0", path = "transport/hopr", default-features = false }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
 hopr-transport-session = { version = "0.23.0", path = "transport/session", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ validator = { version = "0.21.0", features = ["derive"] }
 
 hopr-api = "1.16.0"
 hopr-types = { version = "2.0.2", features = ["use-bindings"] }
-hopr-utils = { package = "hopr-utilities", version = "0.5.0", default-features = false }
+hopr-utils = { package = "hopr-utilities", version = "0.5.1", default-features = false }
 hopr-utils-session = { version = "1.2.1", path = "utils-session" }
 
 hopr-crypto-packet = { version = "1.4.0", path = "crypto/packet", default-features = false, features = [

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport"
 description = "Implements the main HOPR transport interface for the core library"
-version = "0.34.1"
+version = "0.35.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/hopr/src/config.rs
+++ b/transport/hopr/src/config.rs
@@ -21,6 +21,7 @@ const DEFAULT_COUNTER_FLUSH_INTERVAL: Duration = Duration::from_secs(15);
 const DEFAULT_PER_PEER_CHANNEL_CAPACITY: usize = 5_000;
 const DEFAULT_STREAM_OPEN_TIMEOUT: Duration = Duration::from_secs(2);
 const DEFAULT_FRAME_WRITER_BACKPRESSURE_BYTES: usize = 131_072;
+const DEFAULT_EGRESS_BACKPRESSURE_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Minimum accepted value for [`StreamProtocolConfig::stream_open_timeout`].
 pub const MIN_STREAM_OPEN_TIMEOUT: Duration = Duration::from_millis(1);
@@ -35,6 +36,10 @@ fn default_stream_open_timeout() -> Duration {
 
 fn default_frame_writer_backpressure_bytes() -> usize {
     DEFAULT_FRAME_WRITER_BACKPRESSURE_BYTES
+}
+
+fn default_egress_backpressure_timeout() -> Duration {
+    DEFAULT_EGRESS_BACKPRESSURE_TIMEOUT
 }
 
 fn validate_stream_open_timeout(value: &Duration) -> Result<(), ValidationError> {
@@ -53,18 +58,20 @@ fn validate_stream_open_timeout(value: &Duration) -> Result<(), ValidationError>
     serde(deny_unknown_fields)
 )]
 pub struct StreamProtocolConfig {
-    /// Capacity of the per-peer drop-oldest ring buffer (in packets).
+    /// Capacity of the per-peer egress channel (in packets).
     ///
-    /// The egress drain is fully non-blocking: it enqueues each outgoing packet
-    /// via `try_send`. When the ring is full the oldest buffered packet is evicted
-    /// and the newest enqueued (drop-oldest). The ring absorbs bursts while a
-    /// stream is being opened; once open the write pump continuously drains it,
-    /// so the ring stays near-empty under normal load.
+    /// The egress drain enqueues each outgoing packet via `try_send`. When the
+    /// channel is full the behaviour depends on the stream state: while the stream
+    /// is still opening it drops the newest packet (a slow open for one peer must
+    /// not head-of-line-block others); once the stream is open and its write pump
+    /// is draining, it instead applies bounded backpressure — waiting up to
+    /// `EGRESS_BACKPRESSURE_TIMEOUT` for space so wire-rate backpressure propagates
+    /// upstream — and only drops the newest packet if the peer stays full past that
+    /// timeout. The channel absorbs bursts while a stream is being opened; once open
+    /// the write pump continuously drains it, so it stays near-empty under normal load.
     ///
     /// Sized to absorb a typical SURB pre-fill burst (default SurbBalancer:
-    /// target 7 000 / max 5 000/s). If the producer consistently outruns the
-    /// underlying transport, older packets are dropped as intentional transport
-    /// loss.
+    /// target 7 000 / max 5 000/s).
     ///
     /// Defaults to 5 000.
     #[validate(range(min = 1))]
@@ -103,6 +110,21 @@ pub struct StreamProtocolConfig {
     #[default(default_frame_writer_backpressure_bytes())]
     #[cfg_attr(feature = "serde", serde(default = "default_frame_writer_backpressure_bytes"))]
     pub frame_writer_backpressure_bytes: usize,
+
+    /// Maximum time the egress drain waits on a full — but open and draining — per-peer channel
+    /// before falling back to drop-newest.
+    ///
+    /// While the stream is open, a full channel means the wire is slower than the producer, so
+    /// waiting here propagates wire-rate backpressure up through the mixer and session socket to the
+    /// application writer (no packet loss). The bound ensures a single permanently-stalled peer cannot
+    /// head-of-line-block delivery to other peers indefinitely: after this timeout the packet is
+    /// dropped and the drain moves on. Healthy peers drain far faster than this, so the timeout is not
+    /// hit in normal operation.
+    ///
+    /// Defaults to 2 seconds.
+    #[default(default_egress_backpressure_timeout())]
+    #[cfg_attr(feature = "serde", serde(default = "default_egress_backpressure_timeout"))]
+    pub egress_backpressure_timeout: Duration,
 }
 
 fn default_counter_flush_interval() -> Duration {

--- a/transport/hopr/src/config.rs
+++ b/transport/hopr/src/config.rs
@@ -26,6 +26,9 @@ const DEFAULT_EGRESS_BACKPRESSURE_TIMEOUT: Duration = Duration::from_secs(2);
 /// Minimum accepted value for [`StreamProtocolConfig::stream_open_timeout`].
 pub const MIN_STREAM_OPEN_TIMEOUT: Duration = Duration::from_millis(1);
 
+/// Minimum accepted value for [`StreamProtocolConfig::egress_backpressure_timeout`].
+pub const MIN_EGRESS_BACKPRESSURE_TIMEOUT: Duration = Duration::from_millis(1);
+
 fn default_per_peer_channel_capacity() -> usize {
     DEFAULT_PER_PEER_CHANNEL_CAPACITY
 }
@@ -38,6 +41,7 @@ fn default_frame_writer_backpressure_bytes() -> usize {
     DEFAULT_FRAME_WRITER_BACKPRESSURE_BYTES
 }
 
+#[inline]
 fn default_egress_backpressure_timeout() -> Duration {
     DEFAULT_EGRESS_BACKPRESSURE_TIMEOUT
 }
@@ -47,6 +51,18 @@ fn validate_stream_open_timeout(value: &Duration) -> Result<(), ValidationError>
         Ok(())
     } else {
         Err(ValidationError::new("stream open timeout must be at least 1 ms"))
+    }
+}
+
+fn validate_egress_backpressure_timeout(value: &Duration) -> Result<(), ValidationError> {
+    if MIN_EGRESS_BACKPRESSURE_TIMEOUT <= *value {
+        Ok(())
+    } else {
+        // A zero (or sub-millisecond) timeout would make every full channel fall straight into
+        // drop-newest, silently defeating the backpressure feature — reject it at config time.
+        Err(ValidationError::new(
+            "egress backpressure timeout must be at least 1 ms",
+        ))
     }
 }
 
@@ -121,7 +137,8 @@ pub struct StreamProtocolConfig {
     /// dropped and the drain moves on. Healthy peers drain far faster than this, so the timeout is not
     /// hit in normal operation.
     ///
-    /// Defaults to 2 seconds.
+    /// Defaults to 2 seconds. Must be at least 1 ms — a zero value would defeat the feature.
+    #[validate(custom(function = "validate_egress_backpressure_timeout"))]
     #[default(default_egress_backpressure_timeout())]
     #[cfg_attr(feature = "serde", serde(default = "default_egress_backpressure_timeout"))]
     pub egress_backpressure_timeout: Duration,
@@ -606,6 +623,19 @@ mod tests {
     use super::*;
 
     #[test]
+    fn egress_backpressure_timeout_rejects_sub_minimum_values() {
+        assert!(validate_egress_backpressure_timeout(&Duration::ZERO).is_err());
+        assert!(validate_egress_backpressure_timeout(&Duration::from_micros(500)).is_err());
+        assert!(validate_egress_backpressure_timeout(&MIN_EGRESS_BACKPRESSURE_TIMEOUT).is_ok());
+        assert!(validate_egress_backpressure_timeout(&DEFAULT_EGRESS_BACKPRESSURE_TIMEOUT).is_ok());
+    }
+
+    #[test]
+    fn stream_protocol_config_default_is_valid() {
+        assert!(StreamProtocolConfig::default().validate().is_ok());
+    }
+
+    #[test]
     fn test_valid_domains_for_looks_like_a_domain() {
         assert!(looks_like_domain("localhost"));
         assert!(looks_like_domain("hoprnet.org"));
@@ -834,6 +864,18 @@ mod tests {
     fn stream_protocol_config_zero_stream_open_timeout_is_rejected() {
         let cfg = StreamProtocolConfig {
             stream_open_timeout: Duration::ZERO,
+            ..Default::default()
+        };
+        assert!(cfg.validate().is_err());
+    }
+
+    #[test]
+    fn stream_protocol_config_zero_backpressure_timeout_is_rejected() {
+        // Proves the field `#[validate(custom)]` attribute is actually wired into the derived
+        // `StreamProtocolConfig::validate()` — which the parent `HoprProtocolConfig`/`HoprLibConfig`
+        // invoke via `#[validate(nested)]` at node build time (builder.rs `cfg.validate()?`).
+        let cfg = StreamProtocolConfig {
+            egress_backpressure_timeout: Duration::ZERO,
             ..Default::default()
         };
         assert!(cfg.validate().is_err());

--- a/transport/hopr/src/protocol/stream.rs
+++ b/transport/hopr/src/protocol/stream.rs
@@ -341,8 +341,6 @@ where
                         // Fall back to drop-newest only if the peer stays full past the timeout,
                         // so a stalled peer cannot head-of-line-block other peers forever.
                         use futures_time::future::FutureExt as _;
-                        // Wrap in an async block so `timeout` applies to an opaque std future
-                        // (crossfire's concrete SendFuture does not satisfy the combinator bound).
                         match async { sink.tx.send(msg).await }
                             .timeout(futures_time::time::Duration::from(egress_backpressure_timeout))
                             .await

--- a/transport/hopr/src/protocol/stream.rs
+++ b/transport/hopr/src/protocol/stream.rs
@@ -3,7 +3,7 @@
 
 use std::sync::{
     Arc,
-    atomic::{AtomicUsize, Ordering},
+    atomic::{AtomicBool, AtomicUsize, Ordering},
 };
 
 use crossfire::mpsc;
@@ -49,6 +49,11 @@ lazy_static::lazy_static! {
 struct PeerSink<T: Send + 'static> {
     tx: crossfire::MAsyncTx<mpsc::Array<T>>,
     token: Arc<()>,
+    /// `false` while the outgoing stream is still being opened, `true` once the write pump
+    /// is draining the channel. The egress drain only applies blocking backpressure on a full
+    /// channel when the stream is `ready`; while still opening it uses non-blocking drop-newest,
+    /// so a slow open for one peer never head-of-line-blocks other peers.
+    ready: Arc<AtomicBool>,
 }
 
 impl<T: Send + 'static> PeerSink<T> {
@@ -56,6 +61,7 @@ impl<T: Send + 'static> PeerSink<T> {
         Self {
             tx,
             token: Arc::new(()),
+            ready: Arc::new(AtomicBool::new(false)),
         }
     }
 }
@@ -78,6 +84,7 @@ fn spawn_stream_pumps<S, C>(
     codec: C,
     ingress_from_peers: Sender<(PeerId, <C as Decoder>::Item)>,
     frame_writer_backpressure_bytes: usize,
+    ready: Arc<AtomicBool>,
 ) where
     S: AsyncRead + AsyncWrite + Send + 'static,
     C: Encoder<<C as Decoder>::Item> + Decoder + Send + Sync + Clone + 'static,
@@ -101,20 +108,24 @@ fn spawn_stream_pumps<S, C>(
 
     // Write pump: drain the per-peer channel into the framed stream writer.
     hopr_utils::runtime::prelude::spawn(
-        rx.into_stream()
-            .map(Ok)
-            .forward(frame_writer)
-            .inspect(move |res| {
-                tracing::debug!(%peer, ?res, component = "stream", "writing stream with peer finished");
-            })
-            .then(move |_| async move {
-                if cache_for_write
-                    .get(&peer)
-                    .is_some_and(|s| Arc::ptr_eq(&s.token, &token_write))
-                {
-                    cache_for_write.invalidate(&peer);
-                }
-            }),
+        futures::future::lazy(move |_| {
+            // Flip `ready` only once this task is actually running and about to drain the
+            // channel, so the egress drain never applies blocking backpressure on a peer whose
+            // write pump has not started draining yet.
+            ready.store(true, Ordering::Relaxed);
+        })
+        .then(move |_| rx.into_stream().map(Ok).forward(frame_writer))
+        .inspect(move |res| {
+            tracing::debug!(%peer, ?res, component = "stream", "writing stream with peer finished");
+        })
+        .then(move |_| async move {
+            if cache_for_write
+                .get(&peer)
+                .is_some_and(|s| Arc::ptr_eq(&s.token, &token_write))
+            {
+                cache_for_write.invalidate(&peer);
+            }
+        }),
     );
 
     // Read pump: forward decoded frames to the ingress channel.
@@ -162,7 +173,8 @@ where
     C: Encoder<<C as Decoder>::Item> + Decoder + Send + Sync + Clone + 'static,
     <C as Encoder<<C as Decoder>::Item>>::Error: std::fmt::Debug + std::fmt::Display + Send + Sync + 'static,
     <C as Decoder>::Error: std::fmt::Debug + std::fmt::Display + Send + Sync + 'static,
-    <C as Decoder>::Item: AsRef<[u8]> + Clone + Send + 'static,
+    // `Unpin` is required so the egress drain can `await` a crossfire `send` (backpressure path).
+    <C as Decoder>::Item: AsRef<[u8]> + Clone + Send + Unpin + 'static,
     V: NetworkStreamControl + Clone + Send + Sync + 'static,
 {
     let (tx_out, mut rx_out) = channel::<(PeerId, <C as Decoder>::Item)>(100_000);
@@ -187,6 +199,7 @@ where
     let stream_open_timeout = stream_cfg.stream_open_timeout;
     let frame_writer_backpressure_bytes = stream_cfg.frame_writer_backpressure_bytes;
     let per_peer_channel_capacity = stream_cfg.per_peer_channel_capacity;
+    let egress_backpressure_timeout = stream_cfg.egress_backpressure_timeout;
 
     let open_ctx = Arc::new((control, codec, tx_in));
 
@@ -206,6 +219,7 @@ where
                 let (tx, rx) = mpsc::bounded_async::<<C as Decoder>::Item>(per_peer_channel_capacity);
                 let sink = PeerSink::new(tx);
                 let token = sink.token.clone();
+                let ready = sink.ready.clone();
                 spawn_stream_pumps(
                     peer,
                     stream,
@@ -215,6 +229,7 @@ where
                     codec.clone(),
                     tx_in.clone(),
                     frame_writer_backpressure_bytes,
+                    ready,
                 );
                 cache.insert(peer, sink);
 
@@ -255,6 +270,7 @@ where
                     let (tx, rx) = mpsc::bounded_async::<<C as Decoder>::Item>(per_peer_channel_capacity);
                     let sink = PeerSink::new(tx);
                     let token = sink.token.clone();
+                    let ready = sink.ready.clone();
 
                     if open_count2.fetch_add(1, Ordering::Relaxed) < MAX_CONCURRENT_STREAM_OPENS {
                         hopr_utils::runtime::prelude::spawn(async move {
@@ -286,6 +302,7 @@ where
                                         codec.clone(),
                                         tx_in.clone(),
                                         frame_writer_backpressure_bytes,
+                                        ready,
                                     );
                                 }
                                 Err(error) => {
@@ -315,13 +332,48 @@ where
 
             match sink.tx.try_send(msg) {
                 Ok(()) => tracing::trace!(%peer, "message queued to peer channel"),
-                Err(crossfire::TrySendError::Full(_msg)) => {
-                    // Channel full: drop the newest packet and yield so the write
-                    // pump task can drain space before the next send.
-                    #[cfg(all(feature = "telemetry", not(test)))]
-                    METRIC_RING_BUFFER_DROPPED.increment();
-                    tracing::debug!(%peer, "per-peer egress channel full; dropping newest packet");
-                    hopr_utils::runtime::prelude::yield_now().await;
+                Err(crossfire::TrySendError::Full(msg)) => {
+                    if sink.ready.load(Ordering::Relaxed) {
+                        // Stream is open and draining; a full channel means the wire is slower
+                        // than the producer. Wait (bounded) for space so wire-rate backpressure
+                        // propagates upstream — through the mixer, the outgoing CrossfireSink and
+                        // the session socket — to the application writer, instead of dropping.
+                        // Fall back to drop-newest only if the peer stays full past the timeout,
+                        // so a stalled peer cannot head-of-line-block other peers forever.
+                        use futures_time::future::FutureExt as _;
+                        // Wrap in an async block so `timeout` applies to an opaque std future
+                        // (crossfire's concrete SendFuture does not satisfy the combinator bound).
+                        match async { sink.tx.send(msg).await }
+                            .timeout(futures_time::time::Duration::from(egress_backpressure_timeout))
+                            .await
+                        {
+                            Ok(Ok(())) => {
+                                tracing::trace!(%peer, "message queued to peer channel after backpressure")
+                            }
+                            Ok(Err(_disconnected)) => {
+                                tracing::debug!(%peer, "peer sink disconnected while awaiting space; invalidating cache");
+                                if cache_out.get(&peer).is_some_and(|s| Arc::ptr_eq(&s.token, &sink.token)) {
+                                    cache_out.invalidate(&peer);
+                                }
+                            }
+                            Err(_timeout) => {
+                                #[cfg(all(feature = "telemetry", not(test)))]
+                                METRIC_RING_BUFFER_DROPPED.increment();
+                                tracing::debug!(
+                                    %peer,
+                                    "per-peer egress channel full past backpressure timeout; dropping newest packet"
+                                );
+                            }
+                        }
+                    } else {
+                        // Stream still opening: never block — a slow open for this peer must not
+                        // head-of-line-block delivery to other peers. Drop newest and yield so the
+                        // opener task can make progress.
+                        #[cfg(all(feature = "telemetry", not(test)))]
+                        METRIC_RING_BUFFER_DROPPED.increment();
+                        tracing::debug!(%peer, "per-peer egress channel full during open; dropping newest packet");
+                        hopr_utils::runtime::prelude::yield_now().await;
+                    }
                 }
                 Err(crossfire::TrySendError::Disconnected(_)) => {
                     // Receiver dropped (write pump died): invalidate and reopen on next send.
@@ -911,6 +963,153 @@ mod tests {
         assert!(
             received_bytes >= expected_bytes,
             "expected at least {expected_bytes} bytes to be delivered after stream open; got {received_bytes}"
+        );
+
+        Ok(())
+    }
+
+    /// A writer whose `poll_write` is gated shut until [`release`](GatedWriteIo::release) is called,
+    /// counting the bytes it accepts. This deterministically holds the per-peer channel full while the
+    /// stream is open (`ready == true`), so a burst is forced onto the ready+full egress path with no
+    /// dependence on scheduler/pipe-buffer timing.
+    #[derive(Clone, Default, Debug)]
+    struct GatedWriteIo {
+        open: Arc<std::sync::atomic::AtomicBool>,
+        written: Arc<AtomicUsize>,
+        waker: Arc<Mutex<Option<Waker>>>,
+    }
+
+    impl GatedWriteIo {
+        fn release(&self) {
+            self.open.store(true, Ordering::Relaxed);
+            if let Some(waker) = self.waker.lock().take() {
+                waker.wake();
+            }
+        }
+
+        fn written(&self) -> usize {
+            self.written.load(Ordering::Relaxed)
+        }
+    }
+
+    impl AsyncRead for GatedWriteIo {
+        fn poll_read(self: Pin<&mut Self>, _cx: &mut TaskContext<'_>, _buf: &mut [u8]) -> Poll<std::io::Result<usize>> {
+            Poll::Pending
+        }
+    }
+
+    impl AsyncWrite for GatedWriteIo {
+        fn poll_write(self: Pin<&mut Self>, cx: &mut TaskContext<'_>, buf: &[u8]) -> Poll<std::io::Result<usize>> {
+            if self.open.load(Ordering::Relaxed) {
+                self.written.fetch_add(buf.len(), Ordering::Relaxed);
+                Poll::Ready(Ok(buf.len()))
+            } else {
+                *self.waker.lock() = Some(cx.waker().clone());
+                Poll::Pending
+            }
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, _cx: &mut TaskContext<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn poll_close(self: Pin<&mut Self>, _cx: &mut TaskContext<'_>) -> Poll<std::io::Result<()>> {
+            Poll::Ready(Ok(()))
+        }
+    }
+
+    #[derive(Clone, Debug)]
+    struct GatedControl {
+        io: GatedWriteIo,
+        open_calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl hopr_api::network::traits::NetworkStreamControl for GatedControl {
+        fn accept(
+            self,
+        ) -> Result<impl Stream<Item = (PeerId, impl AsyncRead + AsyncWrite + Send)> + Send, impl std::error::Error>
+        {
+            Ok::<_, std::io::Error>(futures::stream::empty::<(PeerId, GatedWriteIo)>())
+        }
+
+        async fn open(self, _peer: PeerId) -> Result<impl AsyncRead + AsyncWrite + Send, impl std::error::Error> {
+            self.open_calls.fetch_add(1, Ordering::Relaxed);
+            Ok::<_, std::io::Error>(self.io.clone())
+        }
+    }
+
+    /// Regression guard for the egress backpressure fix.
+    ///
+    /// Once the stream is open and draining, a burst that overflows the per-peer channel must apply
+    /// (bounded) backpressure so the producer is slowed to wire rate — no packet loss. Under the old
+    /// `try_send` + drop-newest behavior, every packet that arrived while the channel was full was
+    /// silently dropped.
+    ///
+    /// The [`GatedWriteIo`] writer is held shut so the per-peer channel is deterministically full while
+    /// the stream is open (`ready == true`) — the exact ready+full path — regardless of scheduler
+    /// timing. The writer is released *before* the backpressure timeout: with backpressure the queued
+    /// overflow then drains to the wire (zero loss); with drop-newest the overflow was already gone.
+    #[tokio::test]
+    async fn egress_backpressures_when_open_channel_full() -> anyhow::Result<()> {
+        let io = GatedWriteIo::default();
+        let open_calls = Arc::new(AtomicUsize::new(0));
+        let control = GatedControl {
+            io: io.clone(),
+            open_calls: open_calls.clone(),
+        };
+
+        // Small per-peer channel so a modest burst overflows it while the stream is open.
+        let (mut tx_out, _rx_in) = process_stream_protocol(
+            BytesCodec::new(),
+            control,
+            crate::config::StreamProtocolConfig {
+                per_peer_channel_capacity: 4,
+                // Flush every frame so the per-peer channel (not the FramedWrite buffer) is the
+                // bottleneck that fills — making the ready+full path unambiguous.
+                frame_writer_backpressure_bytes: 1,
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        let peer = PeerId::random();
+        let msg = BytesMut::from(&b"hello"[..]);
+        let n = 50usize;
+        let expected_bytes = n * msg.len();
+
+        // Burst far beyond the per-peer channel capacity while the writer is gated shut. The stream
+        // opens and the write pump starts (ready == true) but cannot drain, so the channel fills and the
+        // drain loop enters the ready+full path for the overflow.
+        for _ in 0..n {
+            tx_out
+                .send((peer, msg.clone()))
+                .await
+                .context("send into egress queue should succeed")?;
+        }
+        assert!(
+            wait_for(2, || open_calls.load(Ordering::Relaxed) >= 1).await,
+            "stream was never opened"
+        );
+
+        // Let the drain loop hit the full channel and enter the (bounded) backpressure wait — well under
+        // EGRESS_BACKPRESSURE_TIMEOUT. Under drop-newest the overflow is already dropped by now.
+        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+
+        // Release the writer: with backpressure the queued overflow now drains; with drop-newest only
+        // the few packets that fit the channel were ever kept.
+        io.release();
+
+        // Allow a single frame to remain buffered inside `FramedWrite` (flushed only on the next write
+        // cycle) — that is a framing artifact, not a drop. Drop-newest would lose the whole overflow
+        // (only ~`per_peer_channel_capacity` packets ever kept), which is far below this bound.
+        let min_delivered = expected_bytes - msg.len();
+        assert!(
+            wait_for(3, || io.written() >= min_delivered).await,
+            "essentially all {n} packets ({expected_bytes} bytes) must reach the wire under egress backpressure; a \
+             regression to drop-newest on a full open channel would lose the overflow (wrote {} bytes, need >= \
+             {min_delivered})",
+            io.written()
         );
 
         Ok(())


### PR DESCRIPTION
## Summary

The per-peer egress drain currently **drops-newest** on a full channel (non-blocking, to avoid a slow peer head-of-line-blocking others). Under a write burst this silently drops forward packets and provides **no end-to-end signal to slow the sender**.

Replace the unconditional drop with **bounded blocking backpressure once the stream is open and draining**, so wire-rate backpressure propagates up through the mixer and the outgoing `CrossfireSink` to the session-socket writer — while preserving the properties the drop-newest design was protecting:

- **stream open (not yet draining):** keep non-blocking drop-newest — a slow open must not
  HOL-block delivery to other peers;
- **stream open + draining, channel full:** bounded `send().await` (`EGRESS_BACKPRESSURE_TIMEOUT`, 2s) — apply backpressure;
- **timeout:** fall back to drop-newest so a permanently stalled peer cannot HOL-block others.