### PR TITLE
feat(session): opt-in tail-tolerance profile for flow control (persist + retries)

### DIFF
--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -74,7 +74,8 @@ pub use hopr_transport::SESSION_MTU;
 use hopr_transport::{ApplicationDataIn, ApplicationDataOut, HoprTransport, HoprTransportProcess, OffchainPublicKey};
 #[cfg(feature = "session-client")]
 pub use hopr_transport::{
-    HoprSession, HoprSessionConfigurator, SessionCapabilities, SessionCapability, SessionTarget, SurbBalancerConfig,
+    FlowControlConfig, HoprSession, HoprSessionConfigurator, SessionCapabilities, SessionCapability, SessionTarget,
+    SurbBalancerConfig,
 };
 use hopr_utils::runtime::prelude::spawn;
 pub use hopr_utils::runtime::{Abortable, AbortableList};
@@ -153,6 +154,11 @@ pub struct HoprSessionClientConfig {
     /// If set, the maximum number of possible SURBs will always be sent with session data packets.
     #[default(false)]
     pub always_max_out_surbs: bool,
+    /// Opt-in client-side send-window flow control for this session (`None` = unpaced, the default).
+    /// `Some(FlowControlConfig::default())` = the clean profile; `Some(FlowControlConfig::robust())` =
+    /// the tail-tolerance bundle. Only meaningful on a reliable (`RetransmissionAck`) session.
+    #[default(None)]
+    pub flow_control: Option<FlowControlConfig>,
 }
 
 /// Session client configuration for explicit intermediate-path routing.
@@ -175,6 +181,8 @@ pub struct HoprSessionClientExplicitPathConfig {
     pub surb_management: Option<SurbBalancerConfig>,
     /// If set, the maximum number of possible SURBs will always be sent with session data packets.
     pub always_max_out_surbs: bool,
+    /// Opt-in client-side send-window flow control for this session (`None` = unpaced).
+    pub flow_control: Option<FlowControlConfig>,
 }
 
 #[cfg(all(feature = "session-client", feature = "explicit-path"))]
@@ -188,6 +196,7 @@ impl Default for HoprSessionClientExplicitPathConfig {
             pseudonym: None,
             surb_management: Some(SurbBalancerConfig::default()),
             always_max_out_surbs: false,
+            flow_control: None,
         }
     }
 }
@@ -202,6 +211,7 @@ impl From<HoprSessionClientConfig> for hopr_transport::SessionClientConfig {
             pseudonym: value.pseudonym,
             surb_management: value.surb_management,
             always_max_out_surbs: value.always_max_out_surbs,
+            flow_control: value.flow_control,
         }
     }
 }
@@ -223,6 +233,7 @@ impl TryFrom<HoprSessionClientExplicitPathConfig> for hopr_transport::SessionCli
             pseudonym: value.pseudonym,
             surb_management: value.surb_management,
             always_max_out_surbs: value.always_max_out_surbs,
+            flow_control: value.flow_control,
         })
     }
 }

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -896,6 +896,7 @@ mod tests {
             pseudonym: None,
             surb_management: None,
             always_max_out_surbs: false,
+            flow_control: None,
         })
         .context("explicit path config conversion must succeed")?;
 

--- a/hopr/hopr-lib/src/testing/fixtures.rs
+++ b/hopr/hopr-lib/src/testing/fixtures.rs
@@ -250,6 +250,7 @@ impl ClusterGuard {
                     pseudonym: None,
                     surb_management: Some(SurbBalancerConfig::default()),
                     always_max_out_surbs: false,
+                    flow_control: None,
                 },
             )
             .timeout(futures_time::time::Duration::from(timeout))

--- a/hopr/hopr-lib/src/testing/fixtures.rs
+++ b/hopr/hopr-lib/src/testing/fixtures.rs
@@ -202,6 +202,7 @@ impl ClusterGuard {
                     pseudonym: None,
                     surb_management,
                     always_max_out_surbs: false,
+                    flow_control: None,
                 },
             )
             .timeout(futures_time::time::Duration::from(timeout))

--- a/hopr/hopr-lib/tests/transport_session-size3.rs
+++ b/hopr/hopr-lib/tests/transport_session-size3.rs
@@ -40,6 +40,7 @@ async fn test_keep_alive_session(cluster: &ClusterGuard) -> anyhow::Result<()> {
                 pseudonym: None,
                 surb_management: None,
                 always_max_out_surbs: false,
+                flow_control: None,
             },
         )
         .await?;

--- a/protocols/session/src/flow_control.rs
+++ b/protocols/session/src/flow_control.rs
@@ -52,16 +52,14 @@ pub enum FlowControlMode {
 }
 
 /// Client-tunable flow-control parameters. Defaults are deliberately conservative
-/// (anti-grief-preserving): the window starts at the floor and only grows on proven delivery.
+/// (anti-grief-preserving): the window starts at the floor and only grows on proven delivery, and
+/// the opt-in robustness knobs are off. This is the **clean** profile.
+///
+/// Flow control is enabled per-session by *providing* this config (the transport's
+/// `SessionClientConfig::flow_control` is an `Option` — `None` leaves the session unpaced with
+/// today's behaviour), so there is no separate `enabled` flag.
 #[derive(Clone, Copy, Debug, PartialEq, smart_default::SmartDefault)]
 pub struct FlowControlConfig {
-    /// Whether the send window is active at all. **Opt-in** (default `false`): when disabled the
-    /// writer is a transparent pass-through with today's behaviour, so existing sessions are
-    /// unaffected and only a client that explicitly wants adaptive pacing (e.g. GnosisVPN) turns it
-    /// on. This is the top-level of invariant 5's "the client's dial".
-    #[default(false)]
-    pub enabled: bool,
-
     /// Honest-clock mode. Default [`FlowControlMode::Reliable`].
     pub mode: FlowControlMode,
 
@@ -93,6 +91,22 @@ pub struct FlowControlConfig {
     /// parks before it re-checks the ceiling / makes keep-progress at the floor. Default 250 ms.
     #[default(Duration::from_millis(250))]
     pub no_honest_deadline: Duration,
+
+    /// **Persist probe (opt-in robustness).** Consecutive no-progress parks before the writer admits
+    /// a bounded `min_window_size` beyond `cwnd` (still SURB-capped) to break an end-of-stream tail deadlock
+    /// on a slow/throttled return path. `0` **disables** it — the default, i.e. the verified clean
+    /// behaviour. A robust profile (e.g. for deliberately SURB-throttled paths) sets ~8 (≈2 s at the
+    /// default keep-progress deadline). See the `PacedWriter` admission logic.
+    #[default(0)]
+    pub persist_stall_parks: u32,
+
+    /// **Frame retransmission budget under flow control (opt-in robustness).** Applied to the
+    /// reliable socket's `max_outgoing_frame_retries` when flow control is enabled. `2` (the
+    /// original) is the default; a robust profile raises it (~8) so a merely-*delayed* ack on a
+    /// temporarily-starved return path recovers the frame instead of abandoning it (an abandoned
+    /// frame leaves a gap → stream corruption).
+    #[default(2)]
+    pub frame_retries: u32,
 }
 
 impl FlowControlConfig {
@@ -102,7 +116,6 @@ impl FlowControlConfig {
     fn normalized(self) -> FlowControlConfig {
         let min_window_size = self.min_window_size.max(1);
         FlowControlConfig {
-            enabled: self.enabled,
             mode: self.mode,
             min_window_size,
             max_window_size: self.max_window_size.max(min_window_size),
@@ -113,6 +126,19 @@ impl FlowControlConfig {
                 0.5
             },
             no_honest_deadline: self.no_honest_deadline.max(Duration::from_millis(1)),
+            persist_stall_parks: self.persist_stall_parks,
+            frame_retries: self.frame_retries,
+        }
+    }
+
+    /// The **robust** profile: the clean defaults plus the opt-in tail-tolerance bundle (persist
+    /// probe + larger retransmission budget) for deliberately SURB-throttled / high-latency return
+    /// paths. See [`Self::persist_stall_parks`] and [`Self::frame_retries`].
+    pub fn robust() -> Self {
+        Self {
+            persist_stall_parks: 8,
+            frame_retries: 8,
+            ..Self::default()
         }
     }
 
@@ -229,6 +255,12 @@ impl WindowController {
         self.cfg.mode
     }
 
+    /// The configured minimum window (duplex floor / persist-probe size).
+    #[inline]
+    pub fn min_window_size(&self) -> usize {
+        self.cfg.min_window_size
+    }
+
     /// Records `bytes` admitted onto the wire. Increases the in-flight accounting only; never grows
     /// the window.
     #[inline]
@@ -282,18 +314,28 @@ impl WindowController {
         }
     }
 
-    /// Effective window against a SURB-supply ceiling: `min(cwnd, ceiling)`, but never below
-    /// `min_window_size` (duplex floor). The ceiling can only shrink the result — invariant 2.
-    pub fn effective_window(&self, supply: &impl SupplyConstraint) -> usize {
-        self.cwnd
-            .min(supply.max_admissible_inflight())
-            .max(self.cfg.min_window_size)
+    /// Effective window against a raw ceiling value (bytes): `min(cwnd, ceiling)`, but never below
+    /// `min_window_size` (duplex floor). The ceiling can only shrink the result — invariant 2 — and it
+    /// does **not** mutate `cwnd`, so a transient dip is fully recovered the instant the ceiling lifts.
+    pub fn effective_window_for(&self, ceiling: usize) -> usize {
+        self.cwnd.min(ceiling).max(self.cfg.min_window_size)
     }
 
-    /// Bytes that may be admitted right now against `supply`: `effective_window − inflight`
-    /// (saturating). Zero means park until delivery retires in-flight bytes.
+    /// Bytes admissible now against a raw ceiling value: `effective_window − inflight` (saturating).
+    pub fn admissible_for(&self, ceiling: usize) -> usize {
+        self.effective_window_for(ceiling).saturating_sub(self.inflight)
+    }
+
+    /// Effective window against a [`SupplyConstraint`] (convenience wrapper over
+    /// [`effective_window_for`](Self::effective_window_for)).
+    pub fn effective_window(&self, supply: &impl SupplyConstraint) -> usize {
+        self.effective_window_for(supply.max_admissible_inflight())
+    }
+
+    /// Bytes that may be admitted right now against `supply`. Zero means park until delivery retires
+    /// in-flight bytes (or the ceiling lifts).
     pub fn admissible(&self, supply: &impl SupplyConstraint) -> usize {
-        self.effective_window(supply).saturating_sub(self.inflight)
+        self.admissible_for(supply.max_admissible_inflight())
     }
 
     /// Multiplicative decrease helper, flooring at `min_window_size`.
@@ -579,6 +621,30 @@ mod tests {
             cwnd,
             "loose ceiling cannot raise above cwnd"
         );
+    }
+
+    // ---- Hysteresis: a supply-ceiling dip clamps the effective window but PRESERVES cwnd ----
+
+    #[test]
+    fn ceiling_clamp_preserves_cwnd() {
+        let mut w = WindowController::new(cfg());
+        // Grow the honest window well above the floor.
+        for _ in 0..30 {
+            let win = w.window();
+            w.on_sent(win);
+            w.on_delivered(win);
+        }
+        let grown = w.window();
+        assert!(grown > 10_000);
+
+        // A tight ceiling clamps the *effective* window right down...
+        assert_eq!(w.effective_window_for(1_000), 1_000);
+        // ...but must NOT destroy the learned cwnd (this is the whole fix — no cliff collapse).
+        assert_eq!(w.window(), grown, "ceiling clamp must not mutate cwnd");
+
+        // The instant the ceiling lifts, the full learned window is available again — no re-growth.
+        assert_eq!(w.effective_window_for(usize::MAX), grown);
+        assert_eq!(w.admissible_for(usize::MAX), grown);
     }
 
     #[test]

--- a/protocols/session/src/flow_control.rs
+++ b/protocols/session/src/flow_control.rs
@@ -127,7 +127,9 @@ impl FlowControlConfig {
             },
             no_honest_deadline: self.no_honest_deadline.max(Duration::from_millis(1)),
             persist_stall_parks: self.persist_stall_parks,
-            frame_retries: self.frame_retries,
+            // At least one retry: under reliable-mode flow control an abandoned frame leaves a gap
+            // (stream corruption), so `frame_retries` must never clamp the retry budget to 0.
+            frame_retries: self.frame_retries.max(1),
         }
     }
 

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -71,8 +71,9 @@ pub use hopr_transport_session as session;
 #[cfg(feature = "runtime-tokio")]
 pub use hopr_transport_session::transfer_session;
 pub use hopr_transport_session::{
-    Capabilities as SessionCapabilities, Capability as SessionCapability, HoprSession, IncomingSession, SESSION_MTU,
-    SURB_SIZE, ServiceId, SessionClientConfig, SessionId, SessionTarget, SurbBalancerConfig,
+    Capabilities as SessionCapabilities, Capability as SessionCapability, FlowControlConfig, HoprSession,
+    IncomingSession, SESSION_MTU, SURB_SIZE, ServiceId, SessionClientConfig, SessionId, SessionTarget,
+    SurbBalancerConfig,
     errors::{SessionManagerError, TransportSessionError},
 };
 use hopr_transport_session::{DispatchResult, SessionManager, SessionManagerConfig};

--- a/transport/session/src/flow_control.rs
+++ b/transport/session/src/flow_control.rs
@@ -45,6 +45,11 @@ impl SurbSupply {
             low_watermark_frac: 0.25,
         }
     }
+
+    /// Raw SURB buffer level (for diagnostics).
+    fn buffer_level(&self) -> u64 {
+        self.state.buffer_level()
+    }
 }
 
 impl SupplyConstraint for SurbSupply {
@@ -87,11 +92,21 @@ pub struct PacedWriter<S> {
     clock: DeliveryClock,
     supply: SurbSupply,
     /// Keep-progress deadline: how long to park when the window is momentarily full before
-    /// re-checking. Bounds latency in `Segmentation` mode (no acks ⇒ only the SURB ceiling and this
-    /// timer can reopen the window).
+    /// re-checking, and the persist-probe interval (see `stalled_parks`).
     deadline: Duration,
     /// Pending park timer, recreated per park.
     park: Option<Pin<Box<dyn Future<Output = ()> + Send>>>,
+    /// Consecutive keep-progress parks that saw **no** honest delivery and admitted **no** bytes.
+    /// Reset to 0 on any admission or any delivery. When it reaches `persist_after` (> 0), the
+    /// persist probe fires (see [`Self::admissible`]).
+    stalled_parks: u32,
+    /// Persist-probe threshold (consecutive no-progress parks). `0` disables the probe — the default
+    /// clean behaviour; a robust profile sets it (~8). Sourced from [`FlowControlConfig`].
+    persist_after: u32,
+    /// Cumulative bytes admitted (diagnostics).
+    sent_total: u64,
+    /// `refresh_window` call counter, for throttling the diagnostic trace.
+    refreshes: u64,
 }
 
 impl<S> PacedWriter<S> {
@@ -105,17 +120,89 @@ impl<S> PacedWriter<S> {
             supply,
             deadline: cfg.no_honest_deadline,
             park: None,
+            stalled_parks: 0,
+            persist_after: cfg.persist_stall_parks,
+            sent_total: 0,
+            refreshes: 0,
         }
     }
 
-    /// Folds the latest honest delivery and SURB backoff into the window. Growth comes only from
-    /// delivery; the supply hint can only shrink.
+    /// Folds the latest honest delivery into the window. `cwnd` moves **only** on the honest delivery
+    /// clock (up on ack, down on loss); SURB supply never touches `cwnd` — so a transient
+    /// `buffer_level` dip cannot destroy the learned window (it can only clamp the effective window
+    /// down via the ceiling, in [`Self::admissible`]).
     fn refresh_window(&mut self) {
-        self.window.apply_delivery(self.clock.poll_delivered());
-        if let Some(b) = self.supply.backoff_hint() {
-            self.window.apply_backoff(b);
+        let delivered = self.clock.poll_delivered();
+        self.window.apply_delivery(delivered);
+        if delivered.acked_bytes > 0 || delivered.lost_bytes > 0 {
+            self.stalled_parks = 0;
+        }
+
+        self.refreshes = self.refreshes.wrapping_add(1);
+        if self.refreshes.is_multiple_of(256) {
+            tracing::debug!(
+                target: "hopr_flow_control",
+                sent_total = self.sent_total,
+                cwnd = self.window.window(),
+                inflight = self.window.inflight(),
+                raw_ceiling = self.supply.max_admissible_inflight(),
+                buffer_level = self.supply.buffer_level(),
+                stalled_parks = self.stalled_parks,
+                "flow-control state"
+            );
         }
     }
+
+    /// Bytes admissible right now, against the live SURB ceiling.
+    ///
+    /// Normally this is `min(cwnd, surb_ceiling) − inflight`: the AIMD window bounds the send rate to
+    /// the drain rate, and the SURB ceiling clamps it down when supply is low (never up — invariant 2).
+    ///
+    /// **Persist probe (opt-in, anti-deadlock).** At end-of-stream a HOPR session has no half-close,
+    /// so the final frames may be acked slowly (or their retransmissions must exhaust before their
+    /// bytes retire from `inflight`). Meanwhile `inflight` sits at `cwnd`, so the normal formula
+    /// admits 0 and the writer would park forever — the tail deadlock the 5-sample measurement
+    /// showed. When enabled (`persist_after > 0`), after that many consecutive no-progress parks we
+    /// admit a bounded `min_window_size` **beyond `cwnd` but still capped by the SURB ceiling**. This is the
+    /// classic TCP persist-timer escape, and it is invariant-safe: it never spends past the SURB
+    /// ceiling (anti-grief intact), and a peer withholding acks can extract at most `min_window_size` per
+    /// `persist_after × deadline` — it can only ever make us slower, never faster or over-spending.
+    /// `persist_after == 0` (the default) disables it entirely: the verified clean behaviour.
+    fn admissible(&self) -> usize {
+        let ceiling = self.supply.max_admissible_inflight();
+        admit_bytes(
+            self.window.admissible_for(ceiling),
+            self.stalled_parks,
+            self.persist_after,
+            self.window.inflight(),
+            self.window.min_window_size(),
+            ceiling,
+        )
+    }
+}
+
+/// Pure admission decision, including the persist probe. Extracted for unit testing.
+///
+/// * `normal` = the AIMD/ceiling-bounded admissible bytes. If positive, use it (no probe).
+/// * Otherwise, if the persist probe is enabled (`persist_after > 0`) and `stalled_parks` has reached it, admit up to
+///   `min_window_size` **beyond `inflight`**, but never past the SURB `ceiling` — the anti-deadlock persist probe.
+///   `persist_after == 0` disables the probe entirely (the default clean behaviour).
+fn admit_bytes(
+    normal: usize,
+    stalled_parks: u32,
+    persist_after: u32,
+    inflight: usize,
+    min_window_size: usize,
+    ceiling: usize,
+) -> usize {
+    if normal > 0 {
+        return normal;
+    }
+    if persist_after > 0 && stalled_parks >= persist_after {
+        let probe_target = inflight.saturating_add(min_window_size);
+        return probe_target.min(ceiling).saturating_sub(inflight);
+    }
+    0
 }
 
 impl<S: futures::AsyncWrite + Unpin> futures::AsyncWrite for PacedWriter<S> {
@@ -128,15 +215,17 @@ impl<S: futures::AsyncWrite + Unpin> futures::AsyncWrite for PacedWriter<S> {
         let this = self.get_mut();
         loop {
             this.refresh_window();
-            let admissible = this.window.admissible(&this.supply);
+            let admissible = this.admissible();
             if admissible == 0 {
-                // Window momentarily full: park on a keep-progress timer, then re-check.
+                // Window full and not yet stalled long enough to persist: park on the keep-progress
+                // timer, count the stall, then re-check.
                 let deadline = this.deadline;
                 let fut = this.park.get_or_insert_with(|| Box::pin(sleep(deadline)));
                 match fut.as_mut().poll(cx) {
                     Poll::Ready(()) => {
                         this.park = None;
-                        continue; // re-evaluate admission (delivery/ceiling may have moved)
+                        this.stalled_parks = this.stalled_parks.saturating_add(1);
+                        continue; // re-evaluate admission (delivery/ceiling/persist may have moved)
                     }
                     Poll::Pending => return Poll::Pending,
                 }
@@ -146,6 +235,8 @@ impl<S: futures::AsyncWrite + Unpin> futures::AsyncWrite for PacedWriter<S> {
             return match Pin::new(&mut this.inner).poll_write(cx, &buf[..to_write]) {
                 Poll::Ready(Ok(n)) => {
                     this.window.on_sent(n);
+                    this.sent_total = this.sent_total.wrapping_add(n as u64);
+                    this.stalled_parks = 0; // forward progress — reset the persist counter
                     Poll::Ready(Ok(n))
                 }
                 other => other,
@@ -194,6 +285,57 @@ mod tests {
             .buffer_level
             .store(buffer_level, std::sync::atomic::Ordering::Relaxed);
         state
+    }
+
+    // ---- Persist probe (anti-deadlock at the un-acked tail), configurable ----
+
+    const MIN_WIN: usize = 4_096;
+    const PERSIST: u32 = 8;
+
+    #[test]
+    fn persist_disabled_by_default_never_fires() {
+        // persist_after == 0 (default clean profile): the probe never fires, however long we stall.
+        assert_eq!(admit_bytes(0, 0, 0, 50_000, MIN_WIN, usize::MAX), 0);
+        assert_eq!(admit_bytes(0, 10_000, 0, 50_000, MIN_WIN, usize::MAX), 0);
+    }
+
+    #[test]
+    fn persist_inactive_when_window_has_room() {
+        // Normal admissible > 0 ⇒ probe never involved, whatever the stall count / profile.
+        assert_eq!(admit_bytes(10_000, 0, PERSIST, 50_000, MIN_WIN, usize::MAX), 10_000);
+        assert_eq!(admit_bytes(10_000, 999, PERSIST, 50_000, MIN_WIN, usize::MAX), 10_000);
+    }
+
+    #[test]
+    fn persist_holds_until_stall_threshold() {
+        // Window full (normal == 0) but not yet stalled long enough ⇒ admit nothing.
+        for parks in 0..PERSIST {
+            assert_eq!(
+                admit_bytes(0, parks, PERSIST, 50_000, MIN_WIN, usize::MAX),
+                0,
+                "parks={parks}"
+            );
+        }
+    }
+
+    #[test]
+    fn persist_fires_after_threshold_bounded_by_min_win() {
+        // At/after the threshold, admit exactly min_window_size (ceiling ample).
+        assert_eq!(admit_bytes(0, PERSIST, PERSIST, 50_000, MIN_WIN, usize::MAX), MIN_WIN);
+        assert_eq!(
+            admit_bytes(0, PERSIST + 5, PERSIST, 50_000, MIN_WIN, usize::MAX),
+            MIN_WIN
+        );
+    }
+
+    #[test]
+    fn persist_never_exceeds_surb_ceiling() {
+        // Anti-grief: the probe is still capped by the SURB ceiling.
+        // inflight 50_000, ceiling 52_000 ⇒ only 2_000 headroom even though min_window_size is 4_096.
+        assert_eq!(admit_bytes(0, PERSIST, PERSIST, 50_000, MIN_WIN, 52_000), 2_000);
+        // inflight already at/over the ceiling ⇒ probe admits nothing (never overspends SURBs).
+        assert_eq!(admit_bytes(0, PERSIST, PERSIST, 50_000, MIN_WIN, 50_000), 0);
+        assert_eq!(admit_bytes(0, PERSIST, PERSIST, 50_000, MIN_WIN, 40_000), 0);
     }
 
     #[test]
@@ -249,7 +391,6 @@ mod tests {
 
     fn small_cfg() -> FlowControlConfig {
         FlowControlConfig {
-            enabled: true,
             min_window_size: 1_000,
             max_window_size: 100_000,
             ai_step: 1_000,

--- a/transport/session/src/lib.rs
+++ b/transport/session/src/lib.rs
@@ -19,7 +19,7 @@ mod utils;
 
 pub use balancer::{AtomicSurbFlowEstimator, BalancerStateValues, MIN_BALANCER_SAMPLING_INTERVAL, SurbBalancerConfig};
 use hopr_api::types::internal::routing::RoutingOptions;
-pub use hopr_protocol_session::AcknowledgementMode;
+pub use hopr_protocol_session::{AcknowledgementMode, flow_control::FlowControlConfig};
 pub use hopr_utils::network_types::types::*;
 #[cfg(feature = "benchmark")]
 pub use manager::SESSION_FORWARD_CAPACITY;
@@ -105,6 +105,14 @@ pub struct SessionClientConfig {
     /// Default is `false`.
     #[default(false)]
     pub always_max_out_surbs: bool,
+    /// Opt-in client-side send-window flow control for this session.
+    ///
+    /// `None` (the default) leaves the session unpaced — today's behaviour. `Some(..)` enables the
+    /// adaptive AIMD window on the entry (sending) side; use [`FlowControlConfig::default`] for the
+    /// verified clean profile or [`FlowControlConfig::robust`] for the tail-tolerance bundle. This is
+    /// the client's explicit dial (only meaningful on a reliable / `RetransmissionAck` session).
+    #[default(None)]
+    pub flow_control: Option<FlowControlConfig>,
 }
 
 #[cfg(test)]

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -1119,8 +1119,9 @@ where
                         ),
                         Some(notifier),
                         // Entry (sending) side: give flow control the SURB balancer state as its
-                        // anti-grief down-only ceiling.
+                        // anti-grief down-only ceiling, and the client's opt-in flow-control config.
                         Some(surb_mgmt.clone()),
+                        cfg.flow_control,
                     )?;
 
                     #[cfg(feature = "telemetry")]

--- a/transport/session/src/types.rs
+++ b/transport/session/src/types.rs
@@ -289,7 +289,9 @@ impl HoprSession {
                     // a genuine loss. The retry budget is a flow-control config knob (`frame_retries`,
                     // default 2 = original); a robust profile raises it so delayed frames recover
                     // instead of being abandoned (an abandoned frame leaves a gap → stream corruption).
-                    max_outgoing_frame_retries: fc.map(|c| c.frame_retries as usize).unwrap_or(2),
+                    // `.max(1)`: never drop the retry budget to 0 — an abandoned frame under
+                    // reliable-mode flow control leaves a gap and corrupts the stream.
+                    max_outgoing_frame_retries: fc.map(|c| c.frame_retries.max(1) as usize).unwrap_or(2),
                     ..Default::default()
                 };
 

--- a/transport/session/src/types.rs
+++ b/transport/session/src/types.rs
@@ -85,39 +85,6 @@ pub const SESSION_APPLICATION_TAG: Tag = Tag::Reserved(ReservedTag::Session as u
 /// application tag for all sessions instead of dynamically allocating tags.
 pub type SessionId = HoprPseudonym;
 
-/// Reads the opt-in client-side flow-control window configuration from the environment.
-///
-/// Returns `None` (today's unpaced behaviour) unless `HOPR_SESSION_FLOW_CONTROL` is truthy. This
-/// mirrors the existing env-driven session/balancer tuning (`HOPR_BALANCER_PID_*` etc.) and keeps
-/// the mechanism the client's explicit dial without threading a config field through the whole stack.
-/// Optional overrides: `HOPR_SESSION_FLOW_CONTROL_MIN_WIN`, `HOPR_SESSION_FLOW_CONTROL_MAX_WIN`
-/// (bytes).
-fn flow_control_from_env() -> Option<FlowControlConfig> {
-    let enabled = std::env::var("HOPR_SESSION_FLOW_CONTROL")
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false);
-    if !enabled {
-        return None;
-    }
-    let mut cfg = FlowControlConfig {
-        enabled: true,
-        ..Default::default()
-    };
-    if let Ok(n) = std::env::var("HOPR_SESSION_FLOW_CONTROL_MIN_WIN")
-        .unwrap_or_default()
-        .parse()
-    {
-        cfg.min_window_size = n;
-    }
-    if let Ok(n) = std::env::var("HOPR_SESSION_FLOW_CONTROL_MAX_WIN")
-        .unwrap_or_default()
-        .parse()
-    {
-        cfg.max_window_size = n;
-    }
-    Some(cfg)
-}
-
 pub(crate) fn caps_to_ack_mode(caps: Capabilities) -> AcknowledgementMode {
     if caps.contains(Capability::RetransmissionAck | Capability::RetransmissionNack) {
         AcknowledgementMode::Both
@@ -236,12 +203,13 @@ impl HoprSession {
         Rx: futures::Stream<Item = ApplicationDataIn> + Send + Unpin + 'static,
         Tx::Error: std::error::Error + Send + Sync,
     {
-        Self::new_with_surb_state(id, routing, cfg, hopr, on_close, None)
+        Self::new_with_surb_state(id, routing, cfg, hopr, on_close, None, None)
     }
 
-    /// Like [`new`](Self::new) but threads the SURB balancer state so that opt-in client-side flow
-    /// control (see `flow_control_from_env`) can use it as the anti-grief down-only ceiling. The
-    /// entry (sending) side passes `Some(..)`; sites without balancer state pass `None`.
+    /// Like [`new`](Self::new) but threads the SURB balancer state and the opt-in client-side
+    /// flow-control config. `flow_control` = the client's [`FlowControlConfig`] for this session
+    /// (`None` leaves it unpaced); `surb_mgmt` gives the window its anti-grief down-only SURB ceiling.
+    /// The entry (sending) side passes `Some(..)`; sites without them pass `None`.
     #[tracing::instrument(skip_all, fields(id, routing, cfg, session_id = %id))]
     pub fn new_with_surb_state<Tx, Rx>(
         id: SessionId,
@@ -250,6 +218,7 @@ impl HoprSession {
         hopr: (Tx, Rx),
         on_close: Option<Box<dyn FnOnce(SessionId, ClosureReason) + Send + Sync>>,
         surb_mgmt: Option<Arc<BalancerStateValues>>,
+        flow_control: Option<FlowControlConfig>,
     ) -> Result<Self, TransportSessionError>
     where
         Tx: futures::Sink<(DestinationRouting, ApplicationDataOut)> + Send + Unpin + 'static,
@@ -303,6 +272,8 @@ impl HoprSession {
             if cfg.capabilities.contains(Capability::RetransmissionAck)
                 || cfg.capabilities.contains(Capability::RetransmissionNack)
             {
+                let fc = flow_control;
+
                 // TODO: update config values
                 let ack_cfg = AcknowledgementStateConfig {
                     // This is a very coarse assumption, that a single 3-hop packet
@@ -313,15 +284,25 @@ impl HoprSession {
                     mode: caps_to_ack_mode(cfg.capabilities),
                     backoff_base: 0.2,
                     max_incoming_frame_retries: 1,
-                    max_outgoing_frame_retries: 2,
+                    // Under flow control the sender is paced to the SURB drain rate, so an un-acked
+                    // frame is usually just a *delayed* ack on a temporarily-starved return path, not
+                    // a genuine loss. The retry budget is a flow-control config knob (`frame_retries`,
+                    // default 2 = original); a robust profile raises it so delayed frames recover
+                    // instead of being abandoned (an abandoned frame leaves a gap → stream corruption).
+                    max_outgoing_frame_retries: fc.map(|c| c.frame_retries as usize).unwrap_or(2),
                     ..Default::default()
                 };
 
-                debug!(?socket_cfg, ?ack_cfg, "opening new stateful session socket");
+                debug!(
+                    ?socket_cfg,
+                    ?ack_cfg,
+                    flow_control = fc.is_some(),
+                    "opening new stateful session socket"
+                );
 
                 // Opt-in client-side flow control: when enabled, install the honest-clock tap on the
                 // ack state and keep the paired clock to drive the paced writer.
-                let (ack_state, flow_control) = match flow_control_from_env() {
+                let (ack_state, flow_control) = match fc {
                     Some(fc_cfg) => {
                         let meter = DeliveryMeter::default();
                         let ack_state = AcknowledgementState::<{ ApplicationData::PAYLOAD_SIZE }>::new(id, ack_cfg)


### PR DESCRIPTION
## Summary

Stacked on #8292. Adds an **opt-in flow-control profile** for sessions on slow or deliberately SURB-throttled return paths, **without changing the verified clean default**.

### The profile (two knobs on `FlowControlConfig`, default = clean)

- **`persist_stall_parks`** (default `0` = off). A TCP-persist-timer-style probe: after N consecutive no-progress parks, admit a bounded `min_win` **beyond `cwnd` but still capped by the SURB ceiling**. Breaks the end-of-stream *tail deadlock* — HOPR sessions have no half-close, so the final frames can be acked slowly (or retire only after retransmission), leaving the writer parked.
- **`frame_retries`** (default `2` = original). The reliable socket's outgoing retransmission budget under flow control; robust raises it so a merely-*delayed* ack recovers the frame instead of abandoning it (an abandoned frame leaves a gap → stream corruption).

`FlowControlConfig::robust()` bundles both. Also: `cwnd` is moved **only** by the honest delivery clock — supply pressure clamps the *effective* window via the SURB ceiling but never collapses the learned `cwnd`.