### PR TITLE
chore(build): compile with tokio_unstable for improved coop yielding

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,8 +1,24 @@
-# [build]
-# rustflags = ["-Wunused-crate-dependencies"]
 # Nightly only
 #rustflags = [ "-Zlocation-detail=none" ]
 #rustdocflags = ["--enable-index-page", "-Z", "unstable-options"]
+
+[build]
+# Build the whole workspace (and its dependencies) with `--cfg tokio_unstable`.
+#
+# This unlocks Tokio's unstable APIs — in particular the cooperative-scheduling
+# primitives (`tokio::task::coop`) that `hopr-utilities` uses for improved,
+# budget-aware yielding on the async hot paths (transport, session, mixer). The
+# flag has to be set for the *whole* build because a Tokio feature toggled by a
+# downstream crate only takes effect if the `tokio` crate itself is compiled
+# with the same cfg — so setting it here propagates it to `hopr-utilities` and
+# every other crate in the graph.
+#
+# `--check-cfg` declares `tokio_unstable` as an expected cfg so the workspace
+# stays clean under `-D warnings` (otherwise every crate would emit an
+# `unexpected_cfgs` lint). If you override `RUSTFLAGS` on the command line
+# (e.g. for flamegraph/linker flags), remember to re-add both flags — env
+# `RUSTFLAGS` replaces, rather than extends, this list.
+rustflags = ["--cfg", "tokio_unstable", "--check-cfg", "cfg(tokio_unstable)"]
 
 [install]
 root = ".cargo/"

--- a/README.md
+++ b/README.md
@@ -112,6 +112,36 @@ nix run .#check
 
 This will in particular run `clippy` for the entire Rust codebase.
 
+#### Build configuration (`tokio_unstable`)
+
+The workspace is built with `--cfg tokio_unstable`, configured centrally in
+[`.cargo/config.toml`](./.cargo/config.toml):
+
+```toml
+[build]
+rustflags = ["--cfg", "tokio_unstable", "--check-cfg", "cfg(tokio_unstable)"]
+```
+
+This enables Tokio's unstable cooperative-scheduling APIs (`tokio::task::coop`),
+which [`hopr-utilities`](https://github.com/hoprnet/hopr-utilities) uses for
+improved, budget-aware yielding on the async hot paths (transport, session,
+mixer). A Tokio feature toggled by a downstream crate only takes effect if the
+`tokio` crate itself is compiled with the same cfg, so the flag is applied to
+the entire build graph — which is what propagates the improved yielding down
+into `hopr-utilities`. The paired `--check-cfg` keeps the workspace warning-free
+under `-D warnings`.
+
+The Nix dev/CI shells set `CARGO_BUILD_RUSTFLAGS` themselves (for the linker),
+and Cargo lets that environment variable **replace** — not extend — the
+`.cargo/config.toml` value. So the flag is re-exported (appended to the existing
+rustflags) in each `mkDevShell` in [`flake.nix`](./flake.nix); the
+`.cargo/config.toml` entry is what covers a plain, non-Nix `cargo build`. If you
+export `RUSTFLAGS`/`CARGO_BUILD_RUSTFLAGS` yourself, re-add both flags, e.g.:
+
+```bash
+RUSTFLAGS="--cfg tokio_unstable --check-cfg cfg(tokio_unstable) -Clink-arg=-fuse-ld=lld" cargo bench --no-run -p hopr-crypto-packet
+```
+
 ## Test
 
 Run all tests: `cargo test`.
@@ -140,8 +170,11 @@ Coverage reports are generated using LLVM source-based instrumentation and uploa
 1. Perform a build of your chosen benchmark with `--no-rosegment` linker flag:
 
    ```
-   RUSTFLAGS="-Clink-arg=-fuse-ld=lld -Clink-arg=-Wl,--no-rosegment" cargo bench --no-run -p hopr-crypto-packet
+   RUSTFLAGS="--cfg tokio_unstable --check-cfg cfg(tokio_unstable) -Clink-arg=-fuse-ld=lld -Clink-arg=-Wl,--no-rosegment" cargo bench --no-run -p hopr-crypto-packet
    ```
+
+   > `RUSTFLAGS` replaces the `.cargo/config.toml` value, so the `tokio_unstable`
+   > flags are repeated here (see [Build configuration](#build-configuration-tokio_unstable)).
 
    Use `mold` instead of `lld` if needed.
 

--- a/flake.nix
+++ b/flake.nix
@@ -133,6 +133,17 @@
             rustToolchainFile = ./rust-toolchain-nightly.toml;
           };
 
+          # Build the workspace with `--cfg tokio_unstable` so `hopr-utilities`
+          # (and the whole graph) gets Tokio's improved cooperative yielding.
+          # nix-lib's shells set CARGO_BUILD_RUSTFLAGS (linker flag), and Cargo
+          # lets that env var *replace* the .cargo/config.toml rustflags — so we
+          # append the cfg here rather than rely on the config file, which only
+          # covers non-Nix `cargo` invocations. `--check-cfg` keeps the workspace
+          # clean under `-D warnings`. See README "Build configuration".
+          tokioUnstableHook = ''
+            export CARGO_BUILD_RUSTFLAGS="''${CARGO_BUILD_RUSTFLAGS:-} --cfg tokio_unstable --check-cfg cfg(tokio_unstable)"
+          '';
+
           libraryBuildArgs = {
             inherit src depsSrc rev;
             cargoExtraArgs = "";
@@ -389,6 +400,7 @@
             ];
             shellHook = ''
               export GITHUB_TOKEN="''${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
+              ${tokioUnstableHook}
               ${pre-commit-check.shellHook}
             '';
           };
@@ -412,6 +424,7 @@
             shellHook = ''
               # Fix macOS dylib loading for nightly rustfmt (rust-overlay symlink issue)
               export DYLD_LIBRARY_PATH="${nightlyToolchain}/lib:$DYLD_LIBRARY_PATH"
+              ${tokioUnstableHook}
               ${pre-commit-check.shellHook}
             '';
           };
@@ -436,6 +449,7 @@
               gnupg
               perl
             ];
+            shellHook = tokioUnstableHook;
           };
 
           testShell = nixLib.mkDevShell {
@@ -449,6 +463,7 @@
               foundry-bin
             ];
             shellHook = ''
+              ${tokioUnstableHook}
               uv sync --frozen
               unset SOURCE_DATE_EPOCH
               ${pkgs.lib.optionalString pkgs.stdenv.isLinux "autoPatchelf ./.venv"}
@@ -467,6 +482,7 @@
               hopli.packages.${system}.hopli
             ];
             shellHook = ''
+              ${tokioUnstableHook}
               uv sync --frozen
               unset SOURCE_DATE_EPOCH
               ${pkgs.lib.optionalString pkgs.stdenv.isLinux "autoPatchelf ./.venv"}
@@ -486,6 +502,7 @@
               cargo-shear
             ];
             shellHook = ''
+              ${tokioUnstableHook}
               ${pre-commit-check.shellHook}
             '';
             rustToolchain = pkgs.rust-bin.selectLatestNightlyWith (toolchain: toolchain.default);
@@ -498,6 +515,7 @@
               sqlite
               cargo-nextest
             ];
+            shellHook = tokioUnstableHook;
           };
 
           run-check = nixLib.mkCheckApp { inherit system; };


### PR DESCRIPTION
## Summary

Compile the workspace with `--cfg tokio_unstable` so that `hopr-utilities` — and the rest of the dependency graph — benefit from Tokio's **improved, budget-aware cooperative yielding** (`tokio::task::coop`) on the async hot paths (transport, session, mixer). A Tokio feature toggled by a downstream crate only takes effect if the `tokio` crate itself is compiled with the same cfg, so the flag has to apply to the **whole** build — which is what propagates the improved yielding down into `hopr-utilities`.

## Changes

- **`.cargo/config.toml`** — `[build] rustflags = ["--cfg", "tokio_unstable", "--check-cfg", "cfg(tokio_unstable)"]`. Covers a plain, non-Nix `cargo build`. The paired `--check-cfg` declares the cfg as expected so the workspace stays clean under `-D warnings` (otherwise every crate emits an `unexpected_cfgs` lint).
- **`flake.nix`** — the Nix dev/CI shells set `CARGO_BUILD_RUSTFLAGS` (the `lld` linker flag) via `nix-lib`, and Cargo lets that env var **replace** — not extend — the `.cargo/config.toml` value. So a shared `tokioUnstableHook` re-exports the flags (appended to the existing rustflags) in **every `mkDevShell`**, keeping `tokio_unstable` in effect under Nix rather than being silently dropped.
- **`README.md`** — new "Build configuration (`tokio_unstable`)" section under *Develop*, and the flamegraph example updated (env `RUSTFLAGS` replaces, not extends, the config value).

## Verification

- Default dev shell exports `CARGO_BUILD_RUSTFLAGS=-C link-arg=-fuse-ld=lld --cfg tokio_unstable --check-cfg cfg(tokio_unstable)` (linker flag preserved).
- `cargo check` builds clean — no `unexpected_cfgs` warnings — so it is safe under the `-D warnings` CI.

## Note / follow-up (reviewer input welcome)

This covers non-Nix `cargo` and **all Nix dev/CI shells**. The Nix *package* builds (`nix build` → `nix-lib`'s crane `mkRustPackage`) take their rustflags from `nix-lib` internals, not from this repo — so if any CI gate builds via `nix build .#…` rather than inside a shell, propagating `tokio_unstable` there needs `nix-lib` to expose a rustflags/env passthrough. Flagging rather than guessing at `nix-lib`'s API. Happy to thread it through once we confirm how those builders take extra flags.

https://claude.ai/code/session_01DgqM8mBtWmUyw8ohgnXT9T