### PR TITLE
fix(transport): relax SURB balance notify period default from 2s to 15s

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4299,7 +4299,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.35.0"
+version = "0.35.1"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,7 @@ hopr-protocol-hopr = { version = "4.7.0", path = "protocols/hopr", default-featu
 hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
 hopr-protocol-start = { version = "1.1.0", path = "protocols/start", default-features = false }
 hopr-ticket-manager = { version = "0.5.0", path = "impls/ticket-manager" }
-hopr-transport = { version = "0.35.0", path = "transport/hopr", default-features = false }
+hopr-transport = { version = "0.35.1", path = "transport/hopr", default-features = false }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
 hopr-transport-session = { version = "0.24.0", path = "transport/session", default-features = false }

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport"
 description = "Implements the main HOPR transport interface for the core library"
-version = "0.35.0"
+version = "0.35.1"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/hopr/src/config.rs
+++ b/transport/hopr/src/config.rs
@@ -480,12 +480,13 @@ fn default_max_managed_sessions() -> usize {
     DEFAULT_MAXIMUM_MANAGED_SESSIONS
 }
 
-/// Transport-layer default for the SURB balance notification period. Deliberately overrides the
-/// `SessionManagerConfig` default (60s) with a tighter 15s cadence so the Entry's dead-reckoned
-/// estimate of the Exit's SURB buffer is corrected often enough to keep the SURB balancer from
-/// under-producing (and starving the Exit) under drift, without the per-session keep-alive overhead
-/// of the previous 2s cadence. The 1s floor is enforced downstream by
-/// `SessionManager::new` (`MIN_SURB_BUFFER_NOTIFICATION_PERIOD`).
+/// Transport-layer default for the SURB balance notification period; this is the effective default
+/// for [`SessionGlobalConfig::surb_balance_notify_period`] (15s). It deliberately overrides the
+/// lower-level fallback in `SessionManagerConfig` (whose own field default is 60s) with a tighter
+/// 15s cadence, so the Entry's dead-reckoned estimate of the Exit's SURB buffer is corrected often
+/// enough to keep the SURB balancer from under-producing (and starving the Exit) under drift,
+/// without the per-session keep-alive overhead of the previous 2s cadence. The 1s floor is enforced
+/// downstream by `SessionManager::new` (`MIN_SURB_BUFFER_NOTIFICATION_PERIOD`).
 fn default_session_surb_balance_notify_period() -> Option<Duration> {
     Some(Duration::from_secs(15))
 }

--- a/transport/hopr/src/config.rs
+++ b/transport/hopr/src/config.rs
@@ -481,11 +481,13 @@ fn default_max_managed_sessions() -> usize {
 }
 
 /// Transport-layer default for the SURB balance notification period. Deliberately overrides the
-/// `SessionManagerConfig` default (60s) with a tighter 2s cadence so the Entry's dead-reckoned
-/// estimate of the Exit's SURB buffer is corrected quickly. The 1s floor is enforced downstream by
+/// `SessionManagerConfig` default (60s) with a tighter 15s cadence so the Entry's dead-reckoned
+/// estimate of the Exit's SURB buffer is corrected often enough to keep the SURB balancer from
+/// under-producing (and starving the Exit) under drift, without the per-session keep-alive overhead
+/// of the previous 2s cadence. The 1s floor is enforced downstream by
 /// `SessionManager::new` (`MIN_SURB_BUFFER_NOTIFICATION_PERIOD`).
 fn default_session_surb_balance_notify_period() -> Option<Duration> {
-    Some(Duration::from_secs(2))
+    Some(Duration::from_secs(15))
 }
 
 fn validate_session_idle_timeout(value: &Duration) -> Result<(), ValidationError> {
@@ -600,7 +602,7 @@ pub struct SessionGlobalConfig {
     /// silently inflates the estimate until the Exit runs out of SURBs and can no longer
     /// send reply data.
     ///
-    /// Default is 60 seconds. Set to `null` to disable; minimum effective period is 1 second.
+    /// Default is 15 seconds. Set to `null` to disable; minimum effective period is 1 second.
     #[validate(custom(function = "validate_surb_balance_notify_period"))]
     #[default(default_session_surb_balance_notify_period())]
     #[cfg_attr(


### PR DESCRIPTION
## Summary

Relaxes the transport-layer default for `SessionGlobalConfig::surb_balance_notify_period` from **2s → 15s**.