### PR TITLE
feat(transport): enable QUIC on by default across transport/lib crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4075,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.2-rc.9"
+version = "4.0.2-rc.10"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4299,7 +4299,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.35.1"
+version = "0.36.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4382,7 +4382,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-p2p"
-version = "0.9.4"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,13 +171,13 @@ hopr-utils-session = { version = "1.2.1", path = "utils-session" }
 hopr-crypto-packet = { version = "1.4.0", path = "crypto/packet", default-features = false, features = [
   "ed25519",
 ] }
-hopr-lib = { version = "4.0.2-rc.9", path = "hopr/hopr-lib", default-features = false }
+hopr-lib = { version = "4.0.2-rc.10", path = "hopr/hopr-lib" }
 hopr-protocol-app = { version = "1.0.1", path = "protocols/app", default-features = false }
 hopr-protocol-hopr = { version = "4.7.0", path = "protocols/hopr", default-features = false }
 hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
 hopr-protocol-start = { version = "1.1.0", path = "protocols/start", default-features = false }
 hopr-ticket-manager = { version = "0.5.0", path = "impls/ticket-manager" }
-hopr-transport = { version = "0.35.1", path = "transport/hopr", default-features = false }
+hopr-transport = { version = "0.36.0", path = "transport/hopr" }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
 hopr-transport-session = { version = "0.24.0", path = "transport/session", default-features = false }
@@ -186,7 +186,7 @@ hopr-chain-connector = { version = "0.22.0", path = "impls/connector" }
 
 # referential implementations
 hopr-session-server-forwarder = { version = "0.1.0", path = "impls/session-server-forwarder", default-features = false }
-hopr-transport-p2p = { version = "0.9.4", path = "impls/transport/p2p", default-features = false }
+hopr-transport-p2p = { version = "0.10.0", path = "impls/transport/p2p" }
 hopr-ct-full-network = { version = "0.3.0", path = "impls/ct/full-network", default-features = false }
 hopr-network-graph = { version = "0.3.0", path = "impls/graph", default-features = false }
 

--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-lib"
 description = "HOPR library implementing the HOPR protocol"
-version = "4.0.2-rc.9"
+version = "4.0.2-rc.10"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"
@@ -67,7 +67,7 @@ required-features = ["testing"]
 
 [features]
 capture = ["hopr-transport/capture"]
-default = []
+default = ["transport-announce-quic"]
 telemetry = [
   "hopr-transport/telemetry",
   "hopr-network-graph?/telemetry",

--- a/impls/transport/p2p/Cargo.toml
+++ b/impls/transport/p2p/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport-p2p"
 description = "rust-libp2p based p2p transport implementation"
-version = "0.9.4"
+version = "0.10.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"
@@ -17,7 +17,7 @@ include = ["README.md", "src/**/*.rs", "tests/**/*.rs", "Cargo.toml", "LICENSE"]
 crate-type = ["rlib"]
 
 [features]
-default = []
+default = ["transport-quic"]
 telemetry = ["dep:lazy_static", "hopr-api/types-telemetry"]
 runtime-tokio = ["libp2p/tokio", "hopr-transport-probe/runtime-tokio"]
 testing = []

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport"
 description = "Implements the main HOPR transport interface for the core library"
-version = "0.35.1"
+version = "0.36.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"
@@ -24,7 +24,7 @@ include = [
 crate-type = ["rlib"]
 
 [features]
-default = []
+default = ["p2p-announce-quic"]
 all-benchmarks = []
 capture = ["dep:pcap-file"]
 # Test utilities: emulated peer wiring, stub chain API, shared keypair/payload fixtures.

--- a/transport/hopr/src/snapshots/hopr_transport__config__tests__multiaddr_from_domain_host_config.snap
+++ b/transport/hopr/src/snapshots/hopr_transport__config__tests__multiaddr_from_domain_host_config.snap
@@ -1,5 +1,5 @@
 ---
-source: transport/api/src/config.rs
+source: transport/hopr/src/config.rs
 expression: addr.to_string()
 ---
-/dns4/example.com/tcp/443
+/dns4/example.com/udp/443/quic-v1

--- a/transport/hopr/src/snapshots/hopr_transport__config__tests__multiaddr_from_ipv4_host_config.snap
+++ b/transport/hopr/src/snapshots/hopr_transport__config__tests__multiaddr_from_ipv4_host_config.snap
@@ -1,5 +1,5 @@
 ---
-source: transport/api/src/config.rs
+source: transport/hopr/src/config.rs
 expression: addr.to_string()
 ---
-/ip4/1.2.3.4/tcp/9091
+/ip4/1.2.3.4/udp/9091/quic-v1


### PR DESCRIPTION
## Summary

Makes QUIC on-by-default at the transport library layer, so QUIC is enabled for every consumer without needing to opt in — matching what the node binaries (`hoprd`, `edgli`) already turn on explicitly.

The node binaries were already QUIC-on (hoprd's `default` includes `transport-quic`; edgli inherits it via its default `runtime-tokio`). The gap was purely at the library layer, where each crate kept `default = []` and relied on the top-level binary to switch QUIC on. This lands the default in the libraries themselves.