### PR TITLE
fix: update audit.toml

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -14,6 +14,7 @@ ignore = [
   "RUSTSEC-2026-0194", # quick-xml 0.26.0 via pprof → inferno; pprof is dev-only (profiling feature); not reachable in production
   "RUSTSEC-2026-0195", # quick-xml 0.26.0 via pprof → inferno; same root cause as 0194 (different advisory DB entry); dev-only
   "RUSTSEC-2026-0220", # ruint <1.20.0 pulled transitively by nybbles → alloy-trie → alloy; upgrade blocked on alloy bump
+  "RUSTSEC-2026-0249", # `smartstring` unmaintained, requires `opentelemetry-prometheus-text-exporter` > 0.3.0
 ]
 informational_warnings = ["unmaintained"]
 severity_threshold = "low"


### PR DESCRIPTION
Exempt unmaintained `smartstring` from audit, until upstream crates update.