### PR TITLE
feat(protocol): drop SURBs whose return path starts at an unpayable relayer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4120,7 +4120,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-hopr"
-version = "5.0.0"
+version = "5.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4237,7 +4237,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -144,11 +144,11 @@ hopr-crypto-packet = { version = "1.4.0", path = "crypto/packet", default-featur
 ] }
 hopr-lib = { version = "4.0.2-rc.10", path = "hopr/hopr-lib" }
 hopr-protocol-app = { version = "1.0.1", path = "protocols/app", default-features = false }
-hopr-protocol-hopr = { version = "5.0.0", path = "protocols/hopr", default-features = false }
+hopr-protocol-hopr = { version = "5.1.0", path = "protocols/hopr", default-features = false }
 hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
 hopr-protocol-start = { version = "1.1.0", path = "protocols/start", default-features = false }
 hopr-ticket-manager = "0.5.1"
-hopr-transport = { version = "0.38.0", path = "transport/hopr" }
+hopr-transport = { version = "0.39.0", path = "transport/hopr" }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
 hopr-transport-session = { version = "0.25.0", path = "transport/session", default-features = false }

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -672,6 +672,7 @@ where
         let proc = chain_wiring::process_chain_events(
             chain_reader,
             graph_updater,
+            transport_api.surb_store().clone(),
             chain_events,
             own_chain_addr,
             own_packet_key,

--- a/hopr/hopr-lib/src/builder/chain_wiring.rs
+++ b/hopr/hopr-lib/src/builder/chain_wiring.rs
@@ -8,10 +8,13 @@ use hopr_api::{
     types::{
         chain::chain_events::ChainEvent,
         internal::prelude::ChannelStatus,
-        primitive::prelude::{Address, UnitaryFloatOps},
+        primitive::{
+            prelude::{Address, UnitaryFloatOps},
+            traits::KeyIdMapping,
+        },
     },
 };
-use hopr_transport::{NeighborTelemetry, PathTelemetry};
+use hopr_transport::{NeighborTelemetry, PathTelemetry, SurbStore};
 use parking_lot::RwLock;
 use tracing::Instrument;
 
@@ -30,11 +33,16 @@ lazy_static::lazy_static! {
 /// `ChainEvent`s into [`NetworkGraphUpdate`] calls so the routing graph stays current.
 /// When `peer_discovery_tx` is `Some`, each [`ChainEvent::Announcement`] is also forwarded
 /// to the p2p network layer so it can initiate connections to newly discovered peers.
+///
+/// Status changes on *our own outgoing* channels are also reported to `surb_store`, so SURBs whose
+/// return path starts at a relayer we can no longer pay are shed rather than replied with.
+///
 /// Runs until the supplied `events` stream terminates.
 #[allow(clippy::too_many_arguments)]
-pub(super) async fn process_chain_events<C, G>(
+pub(super) async fn process_chain_events<C, G, S>(
     chain_reader: C,
     graph_updater: G,
+    surb_store: S,
     events: impl futures::Stream<Item = ChainEvent> + Send + 'static,
     own_chain_addr: Address,
     own_packet_key: OffchainPublicKey,
@@ -44,6 +52,7 @@ pub(super) async fn process_chain_events<C, G>(
 ) where
     C: ChainKeyOperations + Clone + Send + Sync + 'static,
     G: NetworkGraphUpdate + Send + Sync + 'static,
+    S: SurbStore + Send + Sync + 'static,
 {
     pin_mut!(events);
 
@@ -148,6 +157,26 @@ pub(super) async fn process_chain_events<C, G>(
                                 dest: to,
                             }),
                         ));
+
+                        // Only our own outgoing channels matter for SURBs: `to` is then the peer
+                        // we would have to pay as the first relayer of a stored SURB's return path.
+                        if src_addr == own_chain_addr {
+                            match chain_reader.key_id_mapper_ref().map_key_to_id(&to) {
+                                // Matched exhaustively on purpose: a wildcard would silently
+                                // revalidate any future non-payable status, handing out SURBs that
+                                // cannot be paid for, with no compiler warning.
+                                Some(relayer) => match channel.status {
+                                    ChannelStatus::Closed | ChannelStatus::PendingToClose(_) => {
+                                        surb_store.invalidate_relayer(&relayer)
+                                    }
+                                    ChannelStatus::Open => surb_store.revalidate_relayer(&relayer),
+                                },
+                                None => tracing::warn!(
+                                    %channel,
+                                    "no key id for own channel counterparty; SURB validity not updated"
+                                ),
+                            }
+                        }
                     }
                     Ok(None) => {
                         tracing::error!(
@@ -196,6 +225,7 @@ mod tests {
             primitive::prelude::Address,
         },
     };
+    use hopr_transport::MemorySurbStore;
     use parking_lot::RwLock;
 
     use super::process_chain_events;
@@ -208,37 +238,43 @@ mod tests {
     #[error("stub: {0}")]
     struct StubError(String);
 
-    #[derive(Debug, Clone)]
-    struct NoopMapper;
+    /// Maps only the keys it was given; empty by default, in which case it maps nothing.
+    #[derive(Debug, Clone, Default)]
+    struct StubMapper(HashMap<OffchainPublicKey, HoprKeyIdent>);
 
-    impl KeyIdMapping<HoprKeyIdent, OffchainPublicKey> for NoopMapper {
-        fn map_key_to_id(&self, _key: &OffchainPublicKey) -> Option<HoprKeyIdent> {
-            None
+    impl KeyIdMapping<HoprKeyIdent, OffchainPublicKey> for StubMapper {
+        fn map_key_to_id(&self, key: &OffchainPublicKey) -> Option<HoprKeyIdent> {
+            self.0.get(key).copied()
         }
 
-        fn map_id_to_public(&self, _id: &HoprKeyIdent) -> Option<OffchainPublicKey> {
-            None
+        fn map_id_to_public(&self, id: &HoprKeyIdent) -> Option<OffchainPublicKey> {
+            self.0.iter().find_map(|(k, v)| (v == id).then_some(*k))
         }
     }
 
     #[derive(Debug, Clone)]
     struct StubChainKeys {
         keys: HashMap<Address, OffchainPublicKey>,
-        mapper: NoopMapper,
+        mapper: StubMapper,
     }
 
     impl StubChainKeys {
         fn new(pairs: impl IntoIterator<Item = (Address, OffchainPublicKey)>) -> Self {
             Self {
                 keys: pairs.into_iter().collect(),
-                mapper: NoopMapper,
+                mapper: StubMapper::default(),
             }
+        }
+
+        fn with_key_ids(mut self, ids: impl IntoIterator<Item = (OffchainPublicKey, HoprKeyIdent)>) -> Self {
+            self.mapper = StubMapper(ids.into_iter().collect());
+            self
         }
     }
 
     impl ChainKeyOperations for StubChainKeys {
         type Error = StubError;
-        type Mapper = NoopMapper;
+        type Mapper = StubMapper;
 
         fn chain_key_to_packet_key(&self, chain: &Address) -> Result<Option<OffchainPublicKey>, Self::Error> {
             Ok(self.keys.get(chain).copied())
@@ -367,6 +403,7 @@ mod tests {
         process_chain_events(
             chain,
             graph,
+            MemorySurbStore::default(),
             futures::stream::iter(events),
             own_chain_addr,
             own_packet_key,
@@ -376,6 +413,28 @@ mod tests {
         )
         .await;
         rx.collect().await
+    }
+
+    /// Runs the event loop against a caller-supplied SURB store, so the test can inspect it after.
+    async fn run_with_surb_store(
+        events: Vec<ChainEvent>,
+        chain: StubChainKeys,
+        surb_store: MemorySurbStore,
+        own_chain_addr: Address,
+        own_packet_key: OffchainPublicKey,
+    ) {
+        process_chain_events(
+            chain,
+            RecordingGraph::default(),
+            surb_store,
+            futures::stream::iter(events),
+            own_chain_addr,
+            own_packet_key,
+            Arc::new(RwLock::new(HoprBalance::from(1u32))),
+            Arc::new(RwLock::new(WinningProbability::ALWAYS)),
+            None,
+        )
+        .await;
     }
 
     // ---------------------------------------------------------------------------
@@ -712,6 +771,7 @@ mod tests {
         process_chain_events(
             StubChainKeys::new([]),
             RecordingGraph::default(),
+            MemorySurbStore::default(),
             futures::stream::iter(vec![ChainEvent::Announcement(account(*offchain.public(), addr))]),
             addr,
             *offchain.public(),
@@ -720,5 +780,89 @@ mod tests {
             Some(tx),
         )
         .await;
+    }
+
+    // ---------------------------------------------------------------------------
+    // SURB store invalidation
+    // ---------------------------------------------------------------------------
+
+    /// Sets up `me -> peer` with `peer` mapped to key id 1, and runs the given channel events.
+    async fn run_own_channel_events(
+        statuses: impl IntoIterator<Item = ChannelStatus>,
+    ) -> (MemorySurbStore, HoprKeyIdent) {
+        let (me_offchain, me_chain) = make_keypairs();
+        let (peer_offchain, peer_chain) = make_keypairs();
+        let (me_addr, peer_addr) = (me_chain.public().to_address(), peer_chain.public().to_address());
+        let peer_id = HoprKeyIdent::from(1u32);
+
+        let stub = StubChainKeys::new([(me_addr, *me_offchain.public()), (peer_addr, *peer_offchain.public())])
+            .with_key_ids([(*peer_offchain.public(), peer_id)]);
+
+        let surb_store = MemorySurbStore::default();
+        let events = statuses
+            .into_iter()
+            .map(|status| ChainEvent::ChannelOpened(channel(me_addr, peer_addr, 100, status)))
+            .collect();
+
+        run_with_surb_store(events, stub, surb_store.clone(), me_addr, *me_offchain.public()).await;
+
+        (surb_store, peer_id)
+    }
+
+    #[tokio::test]
+    async fn closing_an_own_outgoing_channel_should_invalidate_that_relayer() {
+        let (store, peer_id) =
+            run_own_channel_events([ChannelStatus::PendingToClose(std::time::SystemTime::now())]).await;
+        assert!(store.is_relayer_invalidated(&peer_id), "PendingToClose must invalidate");
+
+        let (store, peer_id) = run_own_channel_events([ChannelStatus::Closed]).await;
+        assert!(store.is_relayer_invalidated(&peer_id), "Closed must invalidate");
+    }
+
+    #[tokio::test]
+    async fn reopening_an_own_outgoing_channel_should_revalidate_that_relayer() {
+        let (store, peer_id) = run_own_channel_events([ChannelStatus::Closed, ChannelStatus::Open]).await;
+        assert!(!store.is_relayer_invalidated(&peer_id), "re-opening must revalidate");
+    }
+
+    #[tokio::test]
+    async fn a_channel_that_is_not_ours_should_not_invalidate_anything() {
+        // Same topology, but the event is for a channel between two other parties.
+        let (me_offchain, me_chain) = make_keypairs();
+        let (a_offchain, a_chain) = make_keypairs();
+        let (b_offchain, b_chain) = make_keypairs();
+        let (me_addr, a_addr, b_addr) = (
+            me_chain.public().to_address(),
+            a_chain.public().to_address(),
+            b_chain.public().to_address(),
+        );
+        let b_id = HoprKeyIdent::from(1u32);
+
+        let stub = StubChainKeys::new([
+            (me_addr, *me_offchain.public()),
+            (a_addr, *a_offchain.public()),
+            (b_addr, *b_offchain.public()),
+        ])
+        .with_key_ids([(*b_offchain.public(), b_id)]);
+
+        let store = MemorySurbStore::default();
+        run_with_surb_store(
+            vec![ChainEvent::ChannelClosed(channel(
+                a_addr,
+                b_addr,
+                100,
+                ChannelStatus::Closed,
+            ))],
+            stub,
+            store.clone(),
+            me_addr,
+            *me_offchain.public(),
+        )
+        .await;
+
+        assert!(
+            !store.is_relayer_invalidated(&b_id),
+            "someone else's channel must not affect our SURBs"
+        );
     }
 }

--- a/protocols/hopr/Cargo.toml
+++ b/protocols/hopr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-protocol-hopr"
-version = "5.0.0"
+version = "5.1.0"
 description = "Contains implementation of the HOPR protocol as specified in RFC-0004 & RFC-0005"
 edition.workspace = true
 license.workspace = true

--- a/protocols/hopr/src/surb_store.rs
+++ b/protocols/hopr/src/surb_store.rs
@@ -182,6 +182,9 @@ pub struct SurbStoreConfig {
 pub struct MemorySurbStore {
     pseudonym_openers: moka::sync::Cache<HoprPseudonym, moka::sync::Cache<HoprSurbId, ReplyOpener>>,
     surbs_per_pseudonym: moka::sync::Cache<HoprPseudonym, SurbRingBuffer<HoprSurb>>,
+    /// Relayers this node can no longer pay. Holds at most a handful of entries (our own closing
+    /// channels), so a plain set behind an `RwLock` beats a concurrent map on this read-heavy path.
+    invalidated_relayers: Arc<parking_lot::RwLock<std::collections::HashSet<HoprKeyIdent>>>,
     cfg: Arc<SurbStoreConfig>,
 }
 
@@ -210,7 +213,29 @@ impl MemorySurbStore {
                 })
                 .max_capacity(cfg.max_pseudonyms.max(MINIMUM_SURBS_PER_PSEUDONYM) as u64)
                 .build(),
+            invalidated_relayers: Default::default(),
             cfg: cfg.into(),
+        }
+    }
+
+    /// Whether `relayer` is currently unusable as a return path's first hop.
+    pub fn is_relayer_invalidated(&self, relayer: &HoprKeyIdent) -> bool {
+        self.invalidated_relayers.read().contains(relayer)
+    }
+
+    /// Whether a stored SURB can still be used to reply: its first relayer must still be payable.
+    ///
+    /// A direct return path is exempt — its "first relayer" is the final recipient, which needs no
+    /// channel (RFC-0003 §3.2, RFC-0006 §6.1). Without that exemption, closing an unrelated channel
+    /// to a session's originator would discard perfectly good SURBs.
+    fn is_surb_usable(&self, surb: &HoprSurb) -> bool {
+        match surb.additional_data_receiver.proof_of_relay_values().chain_length() {
+            // Direct return path: the "first relayer" is the final recipient, which needs no channel.
+            1 => true,
+            // A chain length is hops + 1, so 0 cannot occur on a well-formed SURB. Refuse it rather
+            // than let a malformed value pass as "direct" and bypass the check below.
+            0 => false,
+            _ => !self.invalidated_relayers.read().contains(&surb.first_relayer),
         }
     }
 }
@@ -229,11 +254,15 @@ impl SurbStore for MemorySurbStore {
         let surbs_for_pseudonym = self.surbs_per_pseudonym.get(&pseudonym)?;
 
         match matcher {
-            SurbMatcher::Pseudonym(_) => surbs_for_pseudonym.pop_one().map(|popped_surb| FoundSurb {
-                sender_id: HoprSenderId::from_pseudonym_and_id(&pseudonym, popped_surb.id),
-                surb: popped_surb.surb,
-                remaining: popped_surb.remaining,
-            }),
+            // SURBs whose return path no longer has a usable first edge are dropped on the way,
+            // rather than handed out only to have the reply fail to be paid for.
+            SurbMatcher::Pseudonym(_) => surbs_for_pseudonym
+                .pop_next_valid(|_, surb| self.is_surb_usable(surb))
+                .map(|popped_surb| FoundSurb {
+                    sender_id: HoprSenderId::from_pseudonym_and_id(&pseudonym, popped_surb.id),
+                    surb: popped_surb.surb,
+                    remaining: popped_surb.remaining,
+                }),
             // The following code intentionally only checks the SURB at the popping end of the
             // ring buffer and does not search the entire RB.
             // This is because the exact match use-case is suited only for situations
@@ -281,6 +310,23 @@ impl SurbStore for MemorySurbStore {
                     .build()
             })
             .insert(sender_id.surb_id(), opener);
+    }
+
+    #[tracing::instrument(skip_all, level = "trace")]
+    fn invalidate_relayer(&self, relayer: &HoprKeyIdent) {
+        if self.invalidated_relayers.write().insert(*relayer) {
+            tracing::info!(
+                %relayer,
+                "invalidating stored SURBs whose return path starts with this relayer"
+            );
+        }
+    }
+
+    #[tracing::instrument(skip_all, level = "trace")]
+    fn revalidate_relayer(&self, relayer: &HoprKeyIdent) {
+        if self.invalidated_relayers.write().remove(relayer) {
+            tracing::info!(%relayer, "relayer is usable again for SURB return paths");
+        }
     }
 
     #[tracing::instrument(skip_all, level = "trace", fields(?sender_id), ret)]
@@ -343,11 +389,6 @@ impl<S> SurbRingBuffer<S> {
         rb.len()
     }
 
-    /// Pops the next SURB and its ID, in the buffer's [`SurbPopOrder`].
-    pub fn pop_one(&self) -> Option<PoppedSurb<S>> {
-        self.pop_next_valid(|_, _| true)
-    }
-
     /// Pops the next SURB that `is_valid` accepts, in the buffer's [`SurbPopOrder`].
     ///
     /// **Destructive:** rejected entries are discarded, not skipped, so an unusable SURB neither is
@@ -404,9 +445,147 @@ impl<S> SurbRingBuffer<S> {
 
 #[cfg(test)]
 mod tests {
+    use hopr_api::types::crypto::crypto_traits::Randomizable;
+    use hopr_crypto_packet::sphinx::prelude::SphinxHeaderSpec;
     use rstest::rstest;
 
     use super::*;
+
+    impl<S> SurbRingBuffer<S> {
+        /// Pops the next SURB regardless of validity — the buffer-ordering tests below are about
+        /// which end is consumed, not about which SURBs are usable.
+        fn pop_any(&self) -> Option<PoppedSurb<S>> {
+            self.pop_next_valid(|_, _| true)
+        }
+    }
+
+    /// Builds a SURB with the given first relayer and PoR chain length (= return path length).
+    ///
+    /// Only those two fields are read by the store, so the SURB is assembled straight from its
+    /// wire layout — `first_relayer | alpha | header | sender_key | additional_data_receiver` —
+    /// whose parser performs no cryptographic validation. That avoids a full Sphinx key exchange
+    /// per fixture and keeps the chain length exactly controllable.
+    fn surb_via(first_relayer: HoprKeyIdent, chain_length: u8) -> anyhow::Result<HoprSurb> {
+        let mut bytes = vec![0u8; HoprSurb::SIZE];
+
+        let key_id_size = HoprSphinxHeaderSpec::KEY_ID_SIZE.get();
+        bytes[..key_id_size].copy_from_slice(first_relayer.as_ref());
+
+        // The chain length is the leading byte of the receiver's proof-of-relay values, which
+        // in turn lead the trailing `additional_data_receiver` block.
+        bytes[HoprSurb::SIZE - HoprSphinxHeaderSpec::SURB_RECEIVER_DATA_SIZE] = chain_length;
+
+        let surb = HoprSurb::try_from(bytes.as_slice())?;
+
+        // Guard the hand-rolled layout: a wrong offset would silently yield chain length 0 and
+        // make the assertions below pass for the wrong reason.
+        assert_eq!(first_relayer, surb.first_relayer, "fixture: wrong first relayer");
+        assert_eq!(
+            chain_length,
+            surb.additional_data_receiver.proof_of_relay_values().chain_length(),
+            "fixture: wrong chain length"
+        );
+
+        Ok(surb)
+    }
+
+    /// A return path with one intermediate relayer: `me -> relayer -> recipient`.
+    const TWO_HOP: u8 = 2;
+    /// A return path straight to the recipient, which needs no payment channel.
+    const DIRECT: u8 = 1;
+
+    #[test]
+    fn memory_surb_store_should_skip_surbs_whose_first_relayer_was_invalidated() -> anyhow::Result<()> {
+        let (dead, alive) = (HoprKeyIdent::from(1u32), HoprKeyIdent::from(2u32));
+
+        let store = MemorySurbStore::default();
+        let pseudonym = HoprPseudonym::random();
+
+        // Two SURBs return via the dead relay, one via a healthy one; all are two-hop.
+        store.insert_surbs(
+            pseudonym,
+            vec![
+                ([1u8; 8], surb_via(dead, TWO_HOP)?),
+                ([2u8; 8], surb_via(dead, TWO_HOP)?),
+                ([3u8; 8], surb_via(alive, TWO_HOP)?),
+            ],
+        );
+
+        store.invalidate_relayer(&dead);
+
+        let found = store
+            .find_surb(SurbMatcher::Pseudonym(pseudonym))
+            .ok_or(anyhow::anyhow!("expected a usable SURB"))?;
+        assert_eq!([3u8; 8], found.sender_id.surb_id(), "must skip past the dead relayer");
+        assert_eq!(
+            0, found.remaining,
+            "the invalidated SURBs must be discarded, not left behind"
+        );
+
+        assert!(
+            store.find_surb(SurbMatcher::Pseudonym(pseudonym)).is_none(),
+            "no usable SURB should remain"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn memory_surb_store_should_not_invalidate_surbs_with_a_direct_return_path() -> anyhow::Result<()> {
+        // A single-element path means the "first relayer" is the final recipient, which needs no
+        // payment channel — closing a channel to it must not discard the SURB.
+        let recipient = HoprKeyIdent::from(1u32);
+
+        let store = MemorySurbStore::default();
+        let pseudonym = HoprPseudonym::random();
+
+        store.insert_surbs(pseudonym, vec![([7u8; 8], surb_via(recipient, DIRECT)?)]);
+        store.invalidate_relayer(&recipient);
+
+        let found = store
+            .find_surb(SurbMatcher::Pseudonym(pseudonym))
+            .ok_or(anyhow::anyhow!("a direct-return-path SURB must stay usable"))?;
+        assert_eq!([7u8; 8], found.sender_id.surb_id());
+
+        Ok(())
+    }
+
+    #[test]
+    fn memory_surb_store_should_reject_a_surb_with_a_malformed_chain_length() -> anyhow::Result<()> {
+        // A chain length is hops + 1, so 0 is malformed. It must not pass as "direct" and thereby
+        // skip the invalidation check.
+        let relayer = HoprKeyIdent::from(1u32);
+
+        let store = MemorySurbStore::default();
+        let pseudonym = HoprPseudonym::random();
+
+        store.insert_surbs(pseudonym, vec![([5u8; 8], surb_via(relayer, 0)?)]);
+        store.invalidate_relayer(&relayer);
+
+        assert!(store.find_surb(SurbMatcher::Pseudonym(pseudonym)).is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn memory_surb_store_should_make_a_relayer_usable_again_after_revalidation() -> anyhow::Result<()> {
+        let relayer = HoprKeyIdent::from(1u32);
+
+        let store = MemorySurbStore::default();
+        let pseudonym = HoprPseudonym::random();
+
+        store.insert_surbs(pseudonym, vec![([9u8; 8], surb_via(relayer, TWO_HOP)?)]);
+
+        store.invalidate_relayer(&relayer);
+        store.revalidate_relayer(&relayer);
+
+        let found = store
+            .find_surb(SurbMatcher::Pseudonym(pseudonym))
+            .ok_or(anyhow::anyhow!("expected the revalidated SURB"))?;
+        assert_eq!([9u8; 8], found.sender_id.surb_id());
+
+        Ok(())
+    }
 
     #[test]
     fn surb_store_config_should_default_to_fifo() {
@@ -430,12 +609,12 @@ mod tests {
         rb.push([([4u8; 8], 0)]);
 
         for (i, expected_id) in expected.into_iter().enumerate() {
-            let popped = rb.pop_one().ok_or(anyhow::anyhow!("expected pop"))?;
+            let popped = rb.pop_any().ok_or(anyhow::anyhow!("expected pop"))?;
             assert_eq!(expected_id, popped.id, "unexpected id at index {i}");
             assert_eq!(expected.len() - 1 - i, popped.remaining, "unexpected remaining");
         }
 
-        assert!(rb.pop_one().is_none(), "buffer should be drained");
+        assert!(rb.pop_any().is_none(), "buffer should be drained");
 
         Ok(())
     }
@@ -450,19 +629,19 @@ mod tests {
         let len = rb.push([([2u8; 8], 0)]);
         assert_eq!(2, len);
 
-        let popped = rb.pop_one().ok_or(anyhow::anyhow!("expected pop"))?;
+        let popped = rb.pop_any().ok_or(anyhow::anyhow!("expected pop"))?;
         assert_eq!([1u8; 8], popped.id);
         assert_eq!(1, popped.remaining);
 
-        let popped = rb.pop_one().ok_or(anyhow::anyhow!("expected pop"))?;
+        let popped = rb.pop_any().ok_or(anyhow::anyhow!("expected pop"))?;
         assert_eq!([2u8; 8], popped.id);
         assert_eq!(0, popped.remaining);
 
         let len = rb.push([([1u8; 8], 0), ([2u8; 8], 0)]);
         assert_eq!(2, len);
 
-        assert_eq!([1u8; 8], rb.pop_one().ok_or(anyhow::anyhow!("expected pop"))?.id);
-        assert_eq!([2u8; 8], rb.pop_one().ok_or(anyhow::anyhow!("expected pop"))?.id);
+        assert_eq!([1u8; 8], rb.pop_any().ok_or(anyhow::anyhow!("expected pop"))?.id);
+        assert_eq!([2u8; 8], rb.pop_any().ok_or(anyhow::anyhow!("expected pop"))?.id);
 
         Ok(())
     }
@@ -477,19 +656,19 @@ mod tests {
         let len = rb.push([([2u8; 8], 0)]);
         assert_eq!(2, len);
 
-        let popped = rb.pop_one().ok_or(anyhow::anyhow!("expected pop"))?;
+        let popped = rb.pop_any().ok_or(anyhow::anyhow!("expected pop"))?;
         assert_eq!([2u8; 8], popped.id);
         assert_eq!(1, popped.remaining);
 
-        let popped = rb.pop_one().ok_or(anyhow::anyhow!("expected pop"))?;
+        let popped = rb.pop_any().ok_or(anyhow::anyhow!("expected pop"))?;
         assert_eq!([1u8; 8], popped.id);
         assert_eq!(0, popped.remaining);
 
         let len = rb.push([([1u8; 8], 0), ([2u8; 8], 0)]);
         assert_eq!(2, len);
 
-        assert_eq!([2u8; 8], rb.pop_one().ok_or(anyhow::anyhow!("expected pop"))?.id);
-        assert_eq!([1u8; 8], rb.pop_one().ok_or(anyhow::anyhow!("expected pop"))?.id);
+        assert_eq!([2u8; 8], rb.pop_any().ok_or(anyhow::anyhow!("expected pop"))?.id);
+        assert_eq!([1u8; 8], rb.pop_any().ok_or(anyhow::anyhow!("expected pop"))?.id);
 
         Ok(())
     }
@@ -521,7 +700,7 @@ mod tests {
 
         assert!(rb.pop_next_valid(|_, _| false).is_none());
         // The buffer is fully drained by the exhaustive search.
-        assert!(rb.pop_one().is_none());
+        assert!(rb.pop_any().is_none());
 
         Ok(())
     }
@@ -536,7 +715,7 @@ mod tests {
         for i in 0..1_000u32 {
             rb.push([(((i as u64).to_be_bytes()), 0)]);
             if i % 3 == 0 {
-                rb.pop_one();
+                rb.pop_any();
             }
             assert!(rb.surbs.lock().len() <= 8, "length exceeded capacity");
         }

--- a/protocols/hopr/src/surb_store.rs
+++ b/protocols/hopr/src/surb_store.rs
@@ -234,8 +234,26 @@ impl MemorySurbStore {
             1 => true,
             // A chain length is hops + 1, so 0 cannot occur on a well-formed SURB. Refuse it rather
             // than let a malformed value pass as "direct" and bypass the check below.
-            0 => false,
-            _ => !self.invalidated_relayers.read().contains(&surb.first_relayer),
+            //
+            // The length is an unvalidated byte off a SURB minted by the counterparty, so this is a
+            // statement about that peer, not a local fault we could act on: `warn`, not `error`.
+            0 => {
+                tracing::warn!(
+                    first_relayer = %surb.first_relayer,
+                    "refusing a malformed SURB declaring a zero-length return path"
+                );
+                false
+            }
+            _ => {
+                let usable = !self.invalidated_relayers.read().contains(&surb.first_relayer);
+                if !usable {
+                    tracing::trace!(
+                        first_relayer = %surb.first_relayer,
+                        "refusing a SURB whose first relayer is invalidated"
+                    );
+                }
+                usable
+            }
         }
     }
 }

--- a/protocols/hopr/src/traits.rs
+++ b/protocols/hopr/src/traits.rs
@@ -44,6 +44,21 @@ pub trait SurbStore {
     ///
     /// The operation should happen reasonably fast, as it is called from the packet processing code.
     fn find_reply_opener(&self, sender_id: &HoprSenderId) -> Option<ReplyOpener>;
+
+    /// Marks the edge from this node to `relayer` as unusable, so stored SURBs whose return path
+    /// starts there are no longer handed out.
+    ///
+    /// Used by the replying side once the payment channel towards `relayer` is closing or closed:
+    /// replying over it would only burn the SURB. SURBs with a direct return path are unaffected —
+    /// their first relayer is the final recipient and needs no channel.
+    ///
+    /// Defaults to a no-op, for stores that do not track edge validity.
+    fn invalidate_relayer(&self, _relayer: &HoprKeyIdent) {}
+
+    /// Reverts [`SurbStore::invalidate_relayer`] once the channel towards `relayer` re-opens.
+    ///
+    /// Defaults to a no-op, for stores that do not track edge validity.
+    fn revalidate_relayer(&self, _relayer: &HoprKeyIdent) {}
 }
 
 /// Trait defining encoder for [outgoing HOPR packets](OutgoingPacket).

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport"
 description = "Implements the main HOPR transport interface for the core library"
-version = "0.38.0"
+version = "0.39.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -61,7 +61,7 @@ use hopr_api::{
 };
 use hopr_crypto_packet::prelude::PacketSignal;
 pub use hopr_protocol_app::prelude::{ApplicationData, ApplicationDataIn, ApplicationDataOut, Tag};
-use hopr_protocol_hopr::MemorySurbStore;
+pub use hopr_protocol_hopr::{MemorySurbStore, SurbStore};
 pub use hopr_transport_probe::{NeighborTelemetry, PathTelemetry, errors::ProbeError, ping::PingQueryReplier};
 use hopr_transport_probe::{
     Probe,
@@ -1056,6 +1056,14 @@ where
     /// Returns a reference to the network graph.
     pub fn graph(&self) -> &Graph {
         &self.graph
+    }
+
+    /// Returns a reference to the SURB store.
+    ///
+    /// Exposed so that chain-level channel events can invalidate stored SURBs whose return path
+    /// starts with a relayer this node can no longer pay.
+    pub fn surb_store(&self) -> &MemorySurbStore {
+        &self.path_planner.surb_store
     }
 
     #[tracing::instrument(level = "debug", skip(self))]


### PR DESCRIPTION
Closes #8326.

**Stacked on #8328** (`kauki/refactor/surb-store/lifo-vecdeque`) — review that one first; this PR's diff is only the top commit.

A stored SURB can only be used to reply if this node can still pay the first relayer of its return path. Once the outgoing payment channel to that relayer closes, replying with the SURB just burns it.

## What the replying side can actually see

A SURB is opaque apart from two fields, and those two are exactly what is needed:

- `first_relayer` — the only edge on the return path this node pays for.
- `additional_data_receiver.proof_of_relay_values().chain_length()` — the return path length.

The rest of the path stays encrypted and does not need to be known.