### PR TITLE
feat(session): bound data-path frame age stalls surface as loss, not latency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4154,7 +4154,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-session"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4374,7 +4374,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,7 +151,7 @@ hopr-ticket-manager = "0.5.1"
 hopr-transport = { version = "0.40.0", path = "transport/hopr" }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
-hopr-transport-session = { version = "0.25.0", path = "transport/session", default-features = false }
+hopr-transport-session = { version = "0.26.0", path = "transport/session", default-features = false }
 hopr-transport-tag-allocator = { version = "0.1.1", path = "transport/tag-allocator", default-features = false }
 hopr-chain-connector = "0.22.1"
 

--- a/protocols/session/Cargo.toml
+++ b/protocols/session/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-protocol-session"
 description = "Contains implementation of Session protocol according to HOPR RFC-0008"
-version = "1.3.0"
+version = "1.4.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/protocols/session/src/flow_control.rs
+++ b/protocols/session/src/flow_control.rs
@@ -107,6 +107,18 @@ pub struct FlowControlConfig {
     /// frame leaves a gap → stream corruption).
     #[default(2)]
     pub frame_retries: u32,
+
+    /// **Anti-bufferbloat bound (opt-in).** Maximum age of a data-path frame — from its first send
+    /// on the sending side, from entering the ordering buffer on the receiving side.
+    ///
+    /// Older frames are dropped rather than delivered late, so a stall surfaces as clean loss
+    /// instead of a multi-second latency tail (the burst-drain "sawtooth"). A packet arriving
+    /// seconds late is worthless to a real-time consumer, but the latency it adds is not.
+    ///
+    /// Distinct from `frame_timeout`, which bounds how long a *missing* frame is waited for; this
+    /// bounds how stale a *present* frame may be. `None` (default) keeps the previous behaviour.
+    #[default(None)]
+    pub max_frame_age: Option<Duration>,
 }
 
 impl FlowControlConfig {
@@ -130,16 +142,23 @@ impl FlowControlConfig {
             // At least one retry: under reliable-mode flow control an abandoned frame leaves a gap
             // (stream corruption), so `frame_retries` must never clamp the retry budget to 0.
             frame_retries: self.frame_retries.max(1),
+            // A zero bound would drop every frame on sight; treat it as "not set".
+            max_frame_age: self.max_frame_age.filter(|age| !age.is_zero()),
         }
     }
 
     /// The **robust** profile: the clean defaults plus the opt-in tail-tolerance bundle (persist
     /// probe + larger retransmission budget) for deliberately SURB-throttled / high-latency return
     /// paths. See [`Self::persist_stall_parks`] and [`Self::frame_retries`].
+    ///
+    /// The larger retry budget alone would let a transport stall be absorbed as buffering and
+    /// drained afterwards as a multi-second latency sawtooth, so the profile also bounds frame age
+    /// at 2 seconds: past that a frame surfaces as recoverable loss instead of arriving late.
     pub fn robust() -> Self {
         Self {
             persist_stall_parks: 8,
             frame_retries: 8,
+            max_frame_age: Some(Duration::from_secs(2)),
             ..Self::default()
         }
     }
@@ -459,6 +478,12 @@ impl DeliverySignal for DeliveryClock {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn robust_profile_should_bound_frame_age() {
+        assert_eq!(FlowControlConfig::robust().max_frame_age, Some(Duration::from_secs(2)));
+        assert_eq!(FlowControlConfig::default().max_frame_age, None);
+    }
 
     /// A `SupplyConstraint` with a fixed ceiling and no distress — the "honest, generous supply"
     /// baseline used to isolate the delivery clock.

--- a/protocols/session/src/processing/sequencer.rs
+++ b/protocols/session/src/processing/sequencer.rs
@@ -13,6 +13,48 @@ use tracing::instrument;
 
 use crate::{errors::SessionError, protocol::FrameId};
 
+/// Buffer entry pairing an item with when it entered the buffer.
+///
+/// Ordering delegates entirely to `item`, so the heap behaves exactly as before; `buffered_at`
+/// exists only to age the entry out.
+#[derive(Clone, Copy, Debug)]
+struct Buffered<T> {
+    item: T,
+    buffered_at: Instant,
+}
+
+impl<T: PartialEq> PartialEq for Buffered<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.item.eq(&other.item)
+    }
+}
+
+impl<T: Eq> Eq for Buffered<T> {}
+
+impl<T: PartialOrd> PartialOrd for Buffered<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.item.partial_cmp(&other.item)
+    }
+}
+
+impl<T: Ord> Ord for Buffered<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.item.cmp(&other.item)
+    }
+}
+
+impl<T: PartialOrd<FrameId>> PartialEq<FrameId> for Buffered<T> {
+    fn eq(&self, other: &FrameId) -> bool {
+        self.item.partial_cmp(other) == Some(std::cmp::Ordering::Equal)
+    }
+}
+
+impl<T: PartialOrd<FrameId>> PartialOrd<FrameId> for Buffered<T> {
+    fn partial_cmp(&self, other: &FrameId) -> Option<std::cmp::Ordering> {
+        self.item.partial_cmp(other)
+    }
+}
+
 /// Sequencer is an adaptor for streams, that yield elements that have a natural ordering and
 /// can be compared with [`FrameId`] and puts them in the correct sequence starting with
 /// `FrameId` equal to 1.
@@ -43,10 +85,13 @@ pub struct Sequencer<S: futures::Stream> {
     inner: S,
     #[pin]
     timer: futures_time::task::Sleep,
-    buffer: BinaryHeap<std::cmp::Reverse<S::Item>>,
+    buffer: BinaryHeap<std::cmp::Reverse<Buffered<S::Item>>>,
     next_id: FrameId,
     last_emitted: Instant,
     max_wait: Duration,
+    /// Anti-bufferbloat bound: items buffered longer than this are dropped, not emitted, so a
+    /// stall shows up as loss rather than a latency tail. `None` disables it.
+    max_item_age: Option<Duration>,
     state: State,
 }
 
@@ -59,7 +104,7 @@ where
     ///
     /// The `frame_size` value will be clamped into the `[C, (C - SessionMessage::SEGMENT_OVERHEAD) * SeqIndicator::MAX
     /// + 1]` interval.
-    fn new(inner: S, max_wait: Duration, capacity: usize) -> Self {
+    fn new(inner: S, max_wait: Duration, capacity: usize, max_item_age: Option<Duration>) -> Self {
         assert!(capacity > 0, "capacity should be positive");
         Self {
             inner,
@@ -68,6 +113,7 @@ where
             next_id: 1,
             last_emitted: Instant::now(),
             max_wait,
+            max_item_age: max_item_age.filter(|age| !age.is_zero()),
             state: State::Polling,
         }
     }
@@ -133,7 +179,10 @@ where
                                 } else {
                                     // Push new item to the buffer
                                     tracing::trace!("new item");
-                                    this.buffer.push(std::cmp::Reverse(item));
+                                    this.buffer.push(std::cmp::Reverse(Buffered {
+                                        item,
+                                        buffered_at: Instant::now(),
+                                    }));
                                     *this.state = State::BufferUpdated;
                                 }
                             }
@@ -157,13 +206,28 @@ where
                     // The buffer has been updated, check if we can yield something
                     if let Some(next) = this.buffer.peek().map(|item| &item.0) {
                         if next.eq(this.next_id) {
+                            let stale = this
+                                .max_item_age
+                                .is_some_and(|max_age| next.buffered_at.elapsed() >= max_age);
+
                             *this.next_id = this.next_id.wrapping_add(1);
                             *this.last_emitted = Instant::now();
                             *this.state = State::BufferUpdated;
 
+                            // Anti-bufferbloat: the frame is the one due next, but it has been held
+                            // so long that delivering it would only add latency. Report it as
+                            // discarded — the same signal the consumer already handles for a lost
+                            // frame — instead of emitting it late.
+                            if stale {
+                                let discarded = this.next_id.wrapping_sub(1);
+                                this.buffer.pop();
+                                tracing::trace!(discarded, "discard frame that exceeded max age");
+                                return Poll::Ready(Some(Err(SessionError::FrameDiscarded(discarded))));
+                            }
+
                             tracing::trace!("emit next frame");
 
-                            return Poll::Ready(this.buffer.pop().map(|item| Ok(item.0)));
+                            return Poll::Ready(this.buffer.pop().map(|item| Ok(item.0.item)));
                         } else if this.last_emitted.elapsed() >= *this.max_wait
                             || this.buffer.len() == this.buffer.capacity()
                         {
@@ -198,7 +262,7 @@ where
                             *this.next_id = this.next_id.wrapping_add(1);
                             tracing::trace!("emit next frame when done");
 
-                            Poll::Ready(this.buffer.pop().map(|item| Ok(item.0)))
+                            Poll::Ready(this.buffer.pop().map(|item| Ok(item.0.item)))
                         } else {
                             let discarded = *this.next_id;
                             *this.next_id = this.next_id.wrapping_add(1);
@@ -225,7 +289,22 @@ pub trait SequencerExt: futures::Stream {
         Self::Item: Ord + PartialOrd<FrameId>,
         Self: Sized,
     {
-        Sequencer::new(self, timeout, capacity)
+        Sequencer::new(self, timeout, capacity, None)
+    }
+
+    /// As [`SequencerExt::sequencer`], but discards items buffered longer than `max_item_age`
+    /// instead of emitting them late.
+    fn sequencer_with_max_age(
+        self,
+        timeout: Duration,
+        capacity: usize,
+        max_item_age: Option<Duration>,
+    ) -> Sequencer<Self>
+    where
+        Self::Item: Ord + PartialOrd<FrameId>,
+        Self: Sized,
+    {
+        Sequencer::new(self, timeout, capacity, max_item_age)
     }
 }
 
@@ -250,6 +329,75 @@ mod tests {
 
         expected.sort();
         assert_eq!(expected, actual);
+
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn sequencer_should_discard_entries_that_exceeded_the_max_age() -> anyhow::Result<()> {
+        let (seq_sink, seq_stream) = futures::channel::mpsc::unbounded();
+
+        // `max_wait` is long, so nothing here is discarded for being *missing* — only for being stale.
+        let seq_stream =
+            seq_stream.sequencer_with_max_age(Duration::from_secs(30), 4096, Some(Duration::from_millis(100)));
+
+        pin_mut!(seq_sink);
+        pin_mut!(seq_stream);
+
+        // Frame 2 arrives first and waits in the buffer for the missing frame 1 — a transport stall.
+        seq_sink.send(2u32).await?;
+
+        // Drive the sequencer so frame 2 actually lands in its buffer; until it is polled the item
+        // only sits in the channel and its buffered-at clock has not started.
+        assert!(
+            seq_stream
+                .try_next()
+                .timeout(futures_time::time::Duration::from_millis(50))
+                .await
+                .is_err(),
+            "nothing is emitted while frame 1 is missing"
+        );
+
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+
+        // Frame 1 arrives fresh and is delivered; frame 2 is now 250 ms stale and must be
+        // reported as discarded rather than handed over a quarter of a second late.
+        seq_sink.send(1u32).await?;
+
+        assert_eq!(Some(1), seq_stream.try_next().await?, "the fresh frame is delivered");
+        assert!(
+            matches!(seq_stream.try_next().await, Err(SessionError::FrameDiscarded(2))),
+            "the stale frame must be discarded, not delivered late"
+        );
+
+        Ok(())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn sequencer_should_deliver_entries_within_the_max_age() -> anyhow::Result<()> {
+        let (seq_sink, seq_stream) = futures::channel::mpsc::unbounded();
+
+        let seq_stream =
+            seq_stream.sequencer_with_max_age(Duration::from_secs(30), 4096, Some(Duration::from_secs(30)));
+
+        pin_mut!(seq_sink);
+        pin_mut!(seq_stream);
+
+        // Same out-of-order arrival and the same buffering delay, but comfortably inside the
+        // bound: nothing is dropped.
+        seq_sink.send(2u32).await?;
+        assert!(
+            seq_stream
+                .try_next()
+                .timeout(futures_time::time::Duration::from_millis(50))
+                .await
+                .is_err()
+        );
+        tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+        seq_sink.send(1u32).await?;
+
+        assert_eq!(Some(1), seq_stream.try_next().await?);
+        assert_eq!(Some(2), seq_stream.try_next().await?);
 
         Ok(())
     }

--- a/protocols/session/src/socket/ack_state.rs
+++ b/protocols/session/src/socket/ack_state.rs
@@ -101,6 +101,15 @@ pub struct AcknowledgementStateConfig {
     /// Default is 16 384.
     #[default(16384)]
     pub lookbehind_segments: usize,
+
+    /// Maximum age of an outgoing frame before it is retired as lost instead of retransmitted.
+    ///
+    /// Bounds how stale data on the wire may be after a stall, and feeds the retirement to the
+    /// honest delivery clock so flow control sees the stall as loss.
+    ///
+    /// `None` (default) bounds frames only by [`Self::max_outgoing_frame_retries`] and backoff.
+    #[default(None)]
+    pub max_frame_age: Option<Duration>,
 }
 
 impl AcknowledgementStateConfig {
@@ -113,6 +122,8 @@ impl AcknowledgementStateConfig {
             max_outgoing_frame_retries: self.max_outgoing_frame_retries,
             acknowledgement_delay: self.acknowledgement_delay.max(Duration::from_millis(1)),
             lookbehind_segments: self.lookbehind_segments.max(1024),
+            // A zero bound would retire every frame on sight; treat it as "not set".
+            max_frame_age: self.max_frame_age.filter(|age| !age.is_zero()),
         }
     }
 }
@@ -349,9 +360,21 @@ impl<const C: usize> SocketState<C> for AcknowledgementState<C> {
         let delivery_tap = self.delivery_tap.clone();
         hopr_utils::runtime::prelude::spawn(
             outgoing_frame_retries_rx
-                .map(move |rf: RetriedFrameId| {
-                    // Find out if the frame can be retried again in the future
+                .filter_map(move |rf: RetriedFrameId| {
                     let frame_id = rf.frame_id;
+
+                    // Anti-bufferbloat: data this stale is worthless to the peer, but the latency
+                    // it would add on a burst drain is not. Retire it as lost instead — which also
+                    // tells the honest clock the truth about the stall.
+                    if cfg.max_frame_age.is_some_and(|max_age| rf.age() >= max_age) {
+                        tracing::trace!(frame_id, age = ?rf.age(), "outgoing frame exceeded max age; retiring as lost");
+                        if let Some(tap) = &delivery_tap {
+                            tap.on_lost_frame();
+                        }
+                        return futures::future::ready(None);
+                    }
+
+                    // Find out if the frame can be retried again in the future
                     if let Some(next) = rf.next() {
                         // Register the next retry if still possible
                         let retry_at =
@@ -371,7 +394,7 @@ impl<const C: usize> SocketState<C> for AcknowledgementState<C> {
                         }
                     }
                     tracing::trace!(frame_id, "going to re-send entire frame");
-                    frame_id
+                    futures::future::ready(Some(frame_id))
                 })
                 .flat_map(move |frame_id| {
                     // Find out all the segments of that frame to be retransmitted
@@ -759,6 +782,59 @@ mod tests {
             .take(total_segments * NUM_RETRIES)
             .collect::<Vec<_>>();
         assert_eq!(expected_segments, retransmitted_segments);
+
+        Ok(())
+    }
+
+    /// Runs one unacknowledged frame through the retry pipeline and returns how many segments were
+    /// retransmitted before `run_for` elapsed.
+    async fn retransmissions_with_max_frame_age(max_frame_age: Option<Duration>) -> anyhow::Result<usize> {
+        // A generous retry budget, so the only thing that can cut the retries short is the age bound.
+        let cfg = AcknowledgementStateConfig {
+            mode: AcknowledgementMode::Full,
+            expected_packet_latency: Duration::from_millis(5),
+            max_outgoing_frame_retries: 20,
+            max_frame_age,
+            ..Default::default()
+        };
+
+        let inspector = FrameInspector(FrameDashMap::with_capacity(10));
+        let (ctl_tx, ctl_rx) = bounded_sink_channel::<SessionMessage<MTU>>(1024);
+
+        let mut state = AcknowledgementState::<MTU>::new("test", cfg);
+        state.run(SocketComponents {
+            inspector: inspector.into(),
+            ctl_tx,
+        })?;
+
+        for segment in &segment(hopr_types::crypto_random::random_bytes::<FRAME_SIZE>(), MTU, 1)? {
+            state.segment_sent(segment)?;
+        }
+
+        // Never acknowledge: the frame stays in the retry pipeline for the whole window.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        state.stop()?;
+
+        let ctl_msgs = tokio::time::timeout(Duration::from_millis(100), ctl_rx.collect::<Vec<_>>())
+            .await
+            .context("timeout receiving Control messages")?;
+
+        Ok(ctl_msgs.into_iter().filter_map(|m| m.try_as_segment()).count())
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn ack_state_sender_should_stop_resending_a_frame_that_exceeded_the_max_age() -> anyhow::Result<()> {
+        let unbounded = retransmissions_with_max_frame_age(None).await?;
+        let bounded = retransmissions_with_max_frame_age(Some(Duration::from_millis(50))).await?;
+
+        assert!(
+            unbounded > 0,
+            "the retry pipeline must retransmit at all without an age bound"
+        );
+        assert!(
+            bounded < unbounded,
+            "an age bound must cut retransmissions short: got {bounded} bounded vs {unbounded} unbounded"
+        );
 
         Ok(())
     }

--- a/protocols/session/src/socket/mod.rs
+++ b/protocols/session/src/socket/mod.rs
@@ -73,6 +73,20 @@ pub struct SessionSocketConfig {
     /// Default is 2048.
     #[default(2048)]
     pub control_channel_capacity: usize,
+    /// Maximum time a fully-received frame may sit in the ordering buffer before being discarded
+    /// rather than delivered.
+    ///
+    /// Bounds how stale delivered data can be, so a stall surfaces as clean loss instead of a burst
+    /// of seconds-old frames. Distinct from [`Self::frame_timeout`], which bounds how long a
+    /// *missing* frame is waited for. Default `None` (no bound).
+    ///
+    /// A frame dropped here has already been acknowledged, since the acknowledgement is queued at
+    /// reassembly. That is deliberate: the ack states that the *path* delivered the frame, which it
+    /// did, and the drop is a local freshness policy applied afterwards. Withholding the ack would
+    /// make the sender retransmit data we discarded precisely for being stale, reintroducing the
+    /// latency tail this bound exists to remove.
+    #[default(None)]
+    pub max_frame_age: Option<Duration>,
 }
 
 enum WriteState {
@@ -220,7 +234,7 @@ impl<const C: usize> SessionSocket<C, Stateless<C>> {
                 })
             })
             // Put the frames into the correct sequence by Frame Ids
-            .sequencer(cfg.frame_timeout, cfg.capacity)
+            .sequencer_with_max_age(cfg.frame_timeout, cfg.capacity, cfg.max_frame_age)
             // Discard frames missing from the sequence
             .filter_map(move |maybe_frame| {
                 let _span = stage3_span.enter();
@@ -426,7 +440,7 @@ impl<const C: usize, S: SocketState<C> + Clone + 'static> SessionSocket<C, S> {
                 })
             })
             // Put the frames into the correct sequence by Frame Ids
-            .sequencer(cfg.frame_timeout, cfg.capacity)
+            .sequencer_with_max_age(cfg.frame_timeout, cfg.capacity, cfg.max_frame_age)
             // Discard frames missing from the sequence and
             // notify the State about emitted or discarded frames
             .filter_map(move |maybe_frame| {

--- a/protocols/session/src/utils/mod.rs
+++ b/protocols/session/src/utils/mod.rs
@@ -68,6 +68,9 @@ pub(crate) struct RetriedFrameId {
     pub frame_id: FrameId,
     pub retry_count: usize,
     max_retries: usize,
+    /// When the frame first entered the retry pipeline; carried across retries, so [`Self::age`]
+    /// measures total time in flight rather than time since the last resend.
+    first_sent: std::time::Instant,
 }
 
 impl RetriedFrameId {
@@ -76,6 +79,7 @@ impl RetriedFrameId {
             frame_id,
             retry_count: 1,
             max_retries: 1,
+            first_sent: std::time::Instant::now(),
         }
     }
 
@@ -84,6 +88,7 @@ impl RetriedFrameId {
             frame_id,
             retry_count: 1,
             max_retries,
+            first_sent: std::time::Instant::now(),
         }
     }
 
@@ -93,10 +98,16 @@ impl RetriedFrameId {
                 frame_id: self.frame_id,
                 retry_count: self.retry_count + 1,
                 max_retries: self.max_retries,
+                first_sent: self.first_sent,
             })
         } else {
             None
         }
+    }
+
+    /// How long ago this frame first entered the retry pipeline.
+    pub fn age(&self) -> std::time::Duration {
+        self.first_sent.elapsed()
     }
 }
 

--- a/transport/session/Cargo.toml
+++ b/transport/session/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport-session"
 description = "Session functionality providing session abstraction over the HOPR transport"
-version = "0.25.0"
+version = "0.26.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/session/src/types.rs
+++ b/transport/session/src/types.rs
@@ -239,6 +239,9 @@ impl HoprSession {
                 capacity: SESSION_SOCKET_CAPACITY,
                 flush_immediately: cfg.capabilities.contains(Capability::NoDelay),
                 max_buffered_segments: cfg.max_buffered_segments,
+                // Anti-bufferbloat bound; only meaningful when flow control is enabled, which is
+                // also where the honest clock that observes the resulting loss lives.
+                max_frame_age: flow_control.and_then(|c| c.max_frame_age),
                 ..Default::default()
             };
 
@@ -267,6 +270,9 @@ impl HoprSession {
                     // `.max(1)`: never drop the retry budget to 0 — an abandoned frame under
                     // reliable-mode flow control leaves a gap and corrupts the stream.
                     max_outgoing_frame_retries: fc.map(|c| c.frame_retries.max(1) as usize).unwrap_or(2),
+                    // Retire an outgoing frame that is already too stale to be worth delivering,
+                    // rather than spending the remaining retry budget on it.
+                    max_frame_age: fc.and_then(|c| c.max_frame_age),
                     ..Default::default()
                 };
 


### PR DESCRIPTION
Closes #8323.

**Stack tip.** Sits on #8331 → #8329 → #8328.

A transport stall currently ends as a burst drain: seconds-old frames are retransmitted and delivered late, turning a short outage into a multi-second latency tail — the "sawtooth" seen in the 2026-08-10 incident (~24 s of packets buffered, then drained). For a real-time consumer a frame that arrives seconds late is worthless, but the latency it adds is not.

## What changed

A `max_frame_age` bound, applied on **both** sides of the data path:

- **Sending side** (`AcknowledgementState`, `protocols/session/src/socket/ack_state.rs`) — an outgoing frame whose first send is older than the bound is retired as lost instead of consuming its remaining retransmission budget. Retiring it also feeds the honest delivery clock, so flow control observes the stall as loss rather than as an unexplained pause.
- **Receiving side** (`Sequencer`, `protocols/session/src/processing/sequencer.rs`) — a frame that is due next but has sat in the ordering buffer longer than the bound is reported as discarded rather than handed over late. That is the same signal consumers already handle for a lost frame, so nothing downstream needs to change.

The bound is deliberately distinct from `frame_timeout`: that one caps how long a *missing* frame is waited for, this one caps how stale a *present* frame may be when delivered.

## Defaults

`FlowControlConfig::default()` leaves `max_frame_age` at `None` — the clean profile is unchanged.

`FlowControlConfig::robust()` sets it to **2 s**. That profile already raises the retransmission budget for deliberately SURB-throttled / high-latency return paths, which is exactly the configuration where a stall would otherwise be absorbed as buffering and drained as a latency sawtooth; the bound is what keeps the extra retries from turning into extra delay. Consumers selecting `robust()` pick this up without any configuration.

A zero bound is treated as "not set" during config normalisation, so it can never degenerate into dropping every frame on sight.