### PR TITLE
fix(graph)!: emit the channel balance and push a recomputed ticket face value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4056,7 +4056,8 @@ dependencies = [
 [[package]]
 name = "hopr-api"
 version = "2.0.0"
-source = "git+https://github.com/hoprnet/hopr-api?rev=ee65b340cf09fd6031735477cc1171d7610694a3#ee65b340cf09fd6031735477cc1171d7610694a3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b888d2f2d08002d003db1789f732c812ebe2709375780cc6b12eeba09930452c"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -4093,7 +4094,8 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.2"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=ad0fd7e4b35ac462846011ec7446fd404f5bcf44#ad0fd7e4b35ac462846011ec7446fd404f5bcf44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a053b62b7fb08927b8bc1f271018c122151d8bafbdcd3e0081a09322b13fcdae"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4149,7 +4151,8 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=ad0fd7e4b35ac462846011ec7446fd404f5bcf44#ad0fd7e4b35ac462846011ec7446fd404f5bcf44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7985d0e77c83e9ae107dcc53012eeb736b83edeb83cf3522a3d1b7ab1e66fa9"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4212,7 +4215,8 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=ad0fd7e4b35ac462846011ec7446fd404f5bcf44#ad0fd7e4b35ac462846011ec7446fd404f5bcf44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1104069d205e792651562e8648e2403f815169c4c822ba00678b82fa1911fa2e"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4339,7 +4343,8 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.2"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=ad0fd7e4b35ac462846011ec7446fd404f5bcf44#ad0fd7e4b35ac462846011ec7446fd404f5bcf44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbedcb10d008c7a1831ceb89c213ab2a0242405e24d99886839553fca725ca89"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4444,7 +4449,8 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.5"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=ad0fd7e4b35ac462846011ec7446fd404f5bcf44#ad0fd7e4b35ac462846011ec7446fd404f5bcf44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e9a987efe3013cf7f3809d5f87aec29d5588a695a6af718dd406f5d0f5806b"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4613,7 +4619,8 @@ dependencies = [
 [[package]]
 name = "hopr-utilities"
 version = "0.9.0"
-source = "git+https://github.com/hoprnet/hopr-utilities?rev=68e648be4aa9f1442c75df4006a53db414932f7e#68e648be4aa9f1442c75df4006a53db414932f7e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de9a46fe251a9aa6ee3ab7e2edd7720ac6f09ad4f01566dd6c056913615cc43"
 dependencies = [
  "anyhow",
  "arrayvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4056,7 +4056,7 @@ dependencies = [
 [[package]]
 name = "hopr-api"
 version = "2.0.0"
-source = "git+https://github.com/hoprnet/hopr-api?rev=4739d419926904f609ebc8ef8d71e7d35e2bd967#4739d419926904f609ebc8ef8d71e7d35e2bd967"
+source = "git+https://github.com/hoprnet/hopr-api?rev=ee65b340cf09fd6031735477cc1171d7610694a3#ee65b340cf09fd6031735477cc1171d7610694a3"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -4093,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.2"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=f990e535f82e55a7785b25f0e355db890a0277ae#f990e535f82e55a7785b25f0e355db890a0277ae"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=81399f427c7bf93aba1ccc3c432382c7e379b6e7#81399f427c7bf93aba1ccc3c432382c7e379b6e7"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4149,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=f990e535f82e55a7785b25f0e355db890a0277ae#f990e535f82e55a7785b25f0e355db890a0277ae"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=81399f427c7bf93aba1ccc3c432382c7e379b6e7#81399f427c7bf93aba1ccc3c432382c7e379b6e7"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4212,7 +4212,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=f990e535f82e55a7785b25f0e355db890a0277ae#f990e535f82e55a7785b25f0e355db890a0277ae"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=81399f427c7bf93aba1ccc3c432382c7e379b6e7#81399f427c7bf93aba1ccc3c432382c7e379b6e7"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4339,7 +4339,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.2"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=f990e535f82e55a7785b25f0e355db890a0277ae#f990e535f82e55a7785b25f0e355db890a0277ae"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=81399f427c7bf93aba1ccc3c432382c7e379b6e7#81399f427c7bf93aba1ccc3c432382c7e379b6e7"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4444,7 +4444,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.5"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=f990e535f82e55a7785b25f0e355db890a0277ae#f990e535f82e55a7785b25f0e355db890a0277ae"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=81399f427c7bf93aba1ccc3c432382c7e379b6e7#81399f427c7bf93aba1ccc3c432382c7e379b6e7"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4613,7 +4613,7 @@ dependencies = [
 [[package]]
 name = "hopr-utilities"
 version = "0.9.0"
-source = "git+https://github.com/hoprnet/hopr-utilities?rev=1d3693356538025710791ea1f8797b8f5ecd5380#1d3693356538025710791ea1f8797b8f5ecd5380"
+source = "git+https://github.com/hoprnet/hopr-utilities?rev=68e648be4aa9f1442c75df4006a53db414932f7e#68e648be4aa9f1442c75df4006a53db414932f7e"
 dependencies = [
  "anyhow",
  "arrayvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4093,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.2"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=eca69c009cfa74eabbe2570378d9052e1be3a949#eca69c009cfa74eabbe2570378d9052e1be3a949"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=e476452adf8303fbf161c7a835edf2c1ecc7bc8d#e476452adf8303fbf161c7a835edf2c1ecc7bc8d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4149,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=eca69c009cfa74eabbe2570378d9052e1be3a949#eca69c009cfa74eabbe2570378d9052e1be3a949"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=e476452adf8303fbf161c7a835edf2c1ecc7bc8d#e476452adf8303fbf161c7a835edf2c1ecc7bc8d"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4212,7 +4212,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=eca69c009cfa74eabbe2570378d9052e1be3a949#eca69c009cfa74eabbe2570378d9052e1be3a949"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=e476452adf8303fbf161c7a835edf2c1ecc7bc8d#e476452adf8303fbf161c7a835edf2c1ecc7bc8d"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4339,7 +4339,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.2"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=eca69c009cfa74eabbe2570378d9052e1be3a949#eca69c009cfa74eabbe2570378d9052e1be3a949"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=e476452adf8303fbf161c7a835edf2c1ecc7bc8d#e476452adf8303fbf161c7a835edf2c1ecc7bc8d"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4444,7 +4444,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.5"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=eca69c009cfa74eabbe2570378d9052e1be3a949#eca69c009cfa74eabbe2570378d9052e1be3a949"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=e476452adf8303fbf161c7a835edf2c1ecc7bc8d#e476452adf8303fbf161c7a835edf2c1ecc7bc8d"
 dependencies = [
  "async-broadcast",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1787,9 +1787,9 @@ dependencies = [
 
 [[package]]
 name = "blokli-client"
-version = "0.30.2"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6da9d0a178246498baf5e4b9f753affb25c14116ea8fbf75552841c6231a429"
+checksum = "1645e71eacbae4cf304636a390a08b5c03cf068a814923dbd1631d5558f7ddeb"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4055,9 +4055,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cf2b4ca36321e18c6aa0a28b8d2760f9c272f14f22fbe28cc64b0a35fce91e"
+version = "2.0.0"
+source = "git+https://github.com/hoprnet/hopr-api?rev=d41e096dee73803ff6aa4c2dc4af83af5baae15f#d41e096dee73803ff6aa4c2dc4af83af5baae15f"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -4093,9 +4092,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8326d358c768a169662397a7cd566a6fc4d4b8e394f285cd7cfcc7a6f6e866"
+version = "0.22.2"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=eca69c009cfa74eabbe2570378d9052e1be3a949#eca69c009cfa74eabbe2570378d9052e1be3a949"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4108,7 +4106,7 @@ dependencies = [
  "futures-concurrency",
  "futures-time",
  "hopr-api",
- "hopr-utilities 0.6.0",
+ "hopr-utilities",
  "moka",
  "parking_lot",
  "petgraph",
@@ -4133,7 +4131,7 @@ dependencies = [
  "flagset",
  "hex-literal",
  "hopr-types",
- "hopr-utilities 0.8.0",
+ "hopr-utilities",
  "lazy_static",
  "mimalloc",
  "parameterized",
@@ -4150,9 +4148,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-ct-full-network"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c670d644ce0535d3fb6beb3b9ade0c67f0a24d6309b888f64f61dd0b9eb51eb3"
+version = "0.4.0"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=eca69c009cfa74eabbe2570378d9052e1be3a949#eca69c009cfa74eabbe2570378d9052e1be3a949"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4160,7 +4157,7 @@ dependencies = [
  "futures-time",
  "hopr-api",
  "hopr-network-graph",
- "hopr-utilities 0.6.0",
+ "hopr-utilities",
  "smart-default",
  "tracing",
  "validator",
@@ -4188,7 +4185,7 @@ dependencies = [
  "hopr-ticket-manager",
  "hopr-transport",
  "hopr-transport-p2p",
- "hopr-utilities 0.8.0",
+ "hopr-utilities",
  "humantime-serde",
  "insta",
  "lazy_static",
@@ -4214,15 +4211,14 @@ dependencies = [
 
 [[package]]
 name = "hopr-network-graph"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a6a2b0a711541ceaa4a8fd47aec604ae2879d70d20f5b51a1057c0403e64f5d"
+version = "0.5.0"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=eca69c009cfa74eabbe2570378d9052e1be3a949#eca69c009cfa74eabbe2570378d9052e1be3a949"
 dependencies = [
  "anyhow",
  "bimap",
  "futures",
  "hopr-api",
- "hopr-utilities 0.8.0",
+ "hopr-utilities",
  "indexmap 2.14.0",
  "lazy_static",
  "parking_lot",
@@ -4263,7 +4259,7 @@ dependencies = [
  "hopr-chain-connector",
  "hopr-crypto-packet",
  "hopr-ticket-manager",
- "hopr-utilities 0.8.0",
+ "hopr-utilities",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4301,7 +4297,7 @@ dependencies = [
  "hopr-crypto-packet",
  "hopr-protocol-app",
  "hopr-types",
- "hopr-utilities 0.8.0",
+ "hopr-utilities",
  "indexmap 2.14.0",
  "insta",
  "lazy_static",
@@ -4342,9 +4338,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-ticket-manager"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8009dca8550d8803bc730bb89e26a68316df041d4a131287e79b5e4fc9d4a413"
+version = "0.5.2"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=eca69c009cfa74eabbe2570378d9052e1be3a949#eca69c009cfa74eabbe2570378d9052e1be3a949"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4353,7 +4348,7 @@ dependencies = [
  "futures",
  "hashbrown 0.17.1",
  "hopr-api",
- "hopr-utilities 0.6.0",
+ "hopr-utilities",
  "parking_lot",
  "postcard",
  "redb",
@@ -4397,7 +4392,7 @@ dependencies = [
  "hopr-transport-probe",
  "hopr-transport-session",
  "hopr-transport-tag-allocator",
- "hopr-utilities 0.8.0",
+ "hopr-utilities",
  "humantime-serde",
  "insta",
  "lazy_static",
@@ -4448,9 +4443,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-p2p"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e553e6688d8bf422a47cf382673752fbe3086f168e33dde006160481ec317a"
+version = "0.9.5"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=eca69c009cfa74eabbe2570378d9052e1be3a949#eca69c009cfa74eabbe2570378d9052e1be3a949"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4458,7 +4452,7 @@ dependencies = [
  "dashmap",
  "futures",
  "hopr-api",
- "hopr-utilities 0.6.0",
+ "hopr-utilities",
  "libp2p",
  "libp2p-stream",
  "multiaddr",
@@ -4483,7 +4477,7 @@ dependencies = [
  "hopr-crypto-packet",
  "hopr-protocol-app",
  "hopr-transport-tag-allocator",
- "hopr-utilities 0.8.0",
+ "hopr-utilities",
  "humantime-serde",
  "insta",
  "lazy_static",
@@ -4516,7 +4510,7 @@ dependencies = [
  "hopr-protocol-app",
  "hopr-protocol-session",
  "hopr-protocol-start",
- "hopr-utilities 0.8.0",
+ "hopr-utilities",
  "humantime-serde",
  "insta",
  "lazy_static",
@@ -4618,9 +4612,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-utilities"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c557ecaad14224e4ae1df1be73449c24241f4b34e20129b11b8d0e38062eb6a6"
+version = "0.9.0"
+source = "git+https://github.com/hoprnet/hopr-utilities?rev=4080d369835ff3e586a683539ef201efa0783b4b#4080d369835ff3e586a683539ef201efa0783b4b"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4633,35 +4626,6 @@ dependencies = [
  "futures-time",
  "hickory-resolver 0.26.1",
  "hopr-api",
- "hopr-types",
- "indexmap 2.14.0",
- "lazy_static",
- "libp2p-identity",
- "multiaddr",
- "pin-project",
- "rand 0.10.2",
- "serde_json",
- "socket2 0.6.5",
- "strum",
- "thiserror 2.0.20",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "hopr-utilities"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4173135d8a520496af92e32148649ab74007239a1082021b491dec6c3905dc87"
-dependencies = [
- "arrayvec",
- "auto_impl",
- "const-hex",
- "crossfire",
- "flume",
- "futures",
- "futures-time",
- "hickory-resolver 0.26.1",
  "hopr-types",
  "indexmap 2.14.0",
  "lazy_static",
@@ -4697,7 +4661,7 @@ dependencies = [
  "hopr-api",
  "hopr-lib",
  "hopr-transport",
- "hopr-utilities 0.8.0",
+ "hopr-utilities",
  "human-bandwidth",
  "lazy_static",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4093,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.2"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=81399f427c7bf93aba1ccc3c432382c7e379b6e7#81399f427c7bf93aba1ccc3c432382c7e379b6e7"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=ad0fd7e4b35ac462846011ec7446fd404f5bcf44#ad0fd7e4b35ac462846011ec7446fd404f5bcf44"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4149,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=81399f427c7bf93aba1ccc3c432382c7e379b6e7#81399f427c7bf93aba1ccc3c432382c7e379b6e7"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=ad0fd7e4b35ac462846011ec7446fd404f5bcf44#ad0fd7e4b35ac462846011ec7446fd404f5bcf44"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4212,7 +4212,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=81399f427c7bf93aba1ccc3c432382c7e379b6e7#81399f427c7bf93aba1ccc3c432382c7e379b6e7"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=ad0fd7e4b35ac462846011ec7446fd404f5bcf44#ad0fd7e4b35ac462846011ec7446fd404f5bcf44"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4339,7 +4339,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.2"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=81399f427c7bf93aba1ccc3c432382c7e379b6e7#81399f427c7bf93aba1ccc3c432382c7e379b6e7"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=ad0fd7e4b35ac462846011ec7446fd404f5bcf44#ad0fd7e4b35ac462846011ec7446fd404f5bcf44"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4444,7 +4444,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.5"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=81399f427c7bf93aba1ccc3c432382c7e379b6e7#81399f427c7bf93aba1ccc3c432382c7e379b6e7"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=ad0fd7e4b35ac462846011ec7446fd404f5bcf44#ad0fd7e4b35ac462846011ec7446fd404f5bcf44"
 dependencies = [
  "async-broadcast",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4056,7 +4056,7 @@ dependencies = [
 [[package]]
 name = "hopr-api"
 version = "2.0.0"
-source = "git+https://github.com/hoprnet/hopr-api?rev=d41e096dee73803ff6aa4c2dc4af83af5baae15f#d41e096dee73803ff6aa4c2dc4af83af5baae15f"
+source = "git+https://github.com/hoprnet/hopr-api?rev=4739d419926904f609ebc8ef8d71e7d35e2bd967#4739d419926904f609ebc8ef8d71e7d35e2bd967"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -4093,7 +4093,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.2"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=e476452adf8303fbf161c7a835edf2c1ecc7bc8d#e476452adf8303fbf161c7a835edf2c1ecc7bc8d"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=f990e535f82e55a7785b25f0e355db890a0277ae#f990e535f82e55a7785b25f0e355db890a0277ae"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4149,7 +4149,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.4.0"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=e476452adf8303fbf161c7a835edf2c1ecc7bc8d#e476452adf8303fbf161c7a835edf2c1ecc7bc8d"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=f990e535f82e55a7785b25f0e355db890a0277ae#f990e535f82e55a7785b25f0e355db890a0277ae"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4212,7 +4212,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.5.0"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=e476452adf8303fbf161c7a835edf2c1ecc7bc8d#e476452adf8303fbf161c7a835edf2c1ecc7bc8d"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=f990e535f82e55a7785b25f0e355db890a0277ae#f990e535f82e55a7785b25f0e355db890a0277ae"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4339,7 +4339,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.2"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=e476452adf8303fbf161c7a835edf2c1ecc7bc8d#e476452adf8303fbf161c7a835edf2c1ecc7bc8d"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=f990e535f82e55a7785b25f0e355db890a0277ae#f990e535f82e55a7785b25f0e355db890a0277ae"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4444,7 +4444,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.5"
-source = "git+https://github.com/hoprnet/hopr-impls?rev=e476452adf8303fbf161c7a835edf2c1ecc7bc8d#e476452adf8303fbf161c7a835edf2c1ecc7bc8d"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=f990e535f82e55a7785b25f0e355db890a0277ae#f990e535f82e55a7785b25f0e355db890a0277ae"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4613,7 +4613,7 @@ dependencies = [
 [[package]]
 name = "hopr-utilities"
 version = "0.9.0"
-source = "git+https://github.com/hoprnet/hopr-utilities?rev=4080d369835ff3e586a683539ef201efa0783b4b#4080d369835ff3e586a683539ef201efa0783b4b"
+source = "git+https://github.com/hoprnet/hopr-utilities?rev=1d3693356538025710791ea1f8797b8f5ecd5380#1d3693356538025710791ea1f8797b8f5ecd5380"
 dependencies = [
  "anyhow",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,9 +139,9 @@ validator = { version = "0.21.0", features = ["derive"] }
 # `hopr_api::chain::DeployedSafe` two distinct types. `version` alongside `git` is the "multiple
 # locations" form: git wins locally, the version requirement survives packaging. Revert to plain
 # versions once hopr-api 2.0.0, hopr-utilities 0.9.0 and the hopr-impls crates are published.
-hopr-api = { version = "2.0.0", git = "https://github.com/hoprnet/hopr-api", rev = "4739d419926904f609ebc8ef8d71e7d35e2bd967" }
+hopr-api = { version = "2.0.0", git = "https://github.com/hoprnet/hopr-api", rev = "ee65b340cf09fd6031735477cc1171d7610694a3" }
 hopr-types = { version = "2.2.1", features = ["use-bindings"] }
-hopr-utils = { package = "hopr-utilities", version = "0.9.0", git = "https://github.com/hoprnet/hopr-utilities", rev = "1d3693356538025710791ea1f8797b8f5ecd5380", default-features = false }
+hopr-utils = { package = "hopr-utilities", version = "0.9.0", git = "https://github.com/hoprnet/hopr-utilities", rev = "68e648be4aa9f1442c75df4006a53db414932f7e", default-features = false }
 hopr-utils-session = { version = "1.2.1", path = "utils-session" }
 
 hopr-crypto-packet = { version = "1.4.0", path = "crypto/packet", default-features = false, features = [
@@ -152,21 +152,21 @@ hopr-protocol-app = { version = "1.0.1", path = "protocols/app", default-feature
 hopr-protocol-hopr = { version = "6.0.0", path = "protocols/hopr", default-features = false }
 hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
 hopr-protocol-start = { version = "1.1.0", path = "protocols/start", default-features = false }
-hopr-ticket-manager = { version = "0.5.2", git = "https://github.com/hoprnet/hopr-impls", rev = "f990e535f82e55a7785b25f0e355db890a0277ae" }
+hopr-ticket-manager = { version = "0.5.2", git = "https://github.com/hoprnet/hopr-impls", rev = "81399f427c7bf93aba1ccc3c432382c7e379b6e7" }
 hopr-transport = { version = "0.44.0", path = "transport/hopr" }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
 hopr-transport-session = { version = "0.26.2", path = "transport/session", default-features = false }
 hopr-transport-tag-allocator = { version = "0.1.1", path = "transport/tag-allocator", default-features = false }
-hopr-chain-connector = { version = "0.22.2", git = "https://github.com/hoprnet/hopr-impls", rev = "f990e535f82e55a7785b25f0e355db890a0277ae" }
+hopr-chain-connector = { version = "0.22.2", git = "https://github.com/hoprnet/hopr-impls", rev = "81399f427c7bf93aba1ccc3c432382c7e379b6e7" }
 
 # referential implementations (published to crates.io)
-hopr-session-server-forwarder = { version = "0.1.1", git = "https://github.com/hoprnet/hopr-impls", rev = "f990e535f82e55a7785b25f0e355db890a0277ae", default-features = false }
-hopr-transport-p2p = { version = "0.9.5", git = "https://github.com/hoprnet/hopr-impls", rev = "f990e535f82e55a7785b25f0e355db890a0277ae", features = [
+hopr-session-server-forwarder = { version = "0.1.1", git = "https://github.com/hoprnet/hopr-impls", rev = "81399f427c7bf93aba1ccc3c432382c7e379b6e7", default-features = false }
+hopr-transport-p2p = { version = "0.9.5", git = "https://github.com/hoprnet/hopr-impls", rev = "81399f427c7bf93aba1ccc3c432382c7e379b6e7", features = [
   "transport-quic",
 ] }
-hopr-ct-full-network = { version = "0.4.0", git = "https://github.com/hoprnet/hopr-impls", rev = "f990e535f82e55a7785b25f0e355db890a0277ae", default-features = false }
-hopr-network-graph = { version = "0.5.0", git = "https://github.com/hoprnet/hopr-impls", rev = "f990e535f82e55a7785b25f0e355db890a0277ae", default-features = false }
+hopr-ct-full-network = { version = "0.4.0", git = "https://github.com/hoprnet/hopr-impls", rev = "81399f427c7bf93aba1ccc3c432382c7e379b6e7", default-features = false }
+hopr-network-graph = { version = "0.5.0", git = "https://github.com/hoprnet/hopr-impls", rev = "81399f427c7bf93aba1ccc3c432382c7e379b6e7", default-features = false }
 
 [profile.dev]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,9 +134,14 @@ tokio-util = { version = "0.7.19", default-features = false, features = [
 tracing = { version = "0.1.44", features = ["release_max_level_debug"] }
 validator = { version = "0.21.0", features = ["derive"] }
 
-hopr-api = "1.22.0"
+# TEMPORARY: pinned to unreleased branches so this change compiles and is tested end to end,
+# and pinned together so a single hopr-api major is in the graph — two majors coexisting makes
+# `hopr_api::chain::DeployedSafe` two distinct types. `version` alongside `git` is the "multiple
+# locations" form: git wins locally, the version requirement survives packaging. Revert to plain
+# versions once hopr-api 2.0.0, hopr-utilities 0.9.0 and the hopr-impls crates are published.
+hopr-api = { version = "2.0.0", git = "https://github.com/hoprnet/hopr-api", rev = "d41e096dee73803ff6aa4c2dc4af83af5baae15f" }
 hopr-types = { version = "2.2.1", features = ["use-bindings"] }
-hopr-utils = { package = "hopr-utilities", version = "0.8.0", default-features = false }
+hopr-utils = { package = "hopr-utilities", version = "0.9.0", git = "https://github.com/hoprnet/hopr-utilities", rev = "4080d369835ff3e586a683539ef201efa0783b4b", default-features = false }
 hopr-utils-session = { version = "1.2.1", path = "utils-session" }
 
 hopr-crypto-packet = { version = "1.4.0", path = "crypto/packet", default-features = false, features = [
@@ -147,19 +152,19 @@ hopr-protocol-app = { version = "1.0.1", path = "protocols/app", default-feature
 hopr-protocol-hopr = { version = "6.0.0", path = "protocols/hopr", default-features = false }
 hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
 hopr-protocol-start = { version = "1.1.0", path = "protocols/start", default-features = false }
-hopr-ticket-manager = "0.5.1"
+hopr-ticket-manager = { version = "0.5.2", git = "https://github.com/hoprnet/hopr-impls", rev = "eca69c009cfa74eabbe2570378d9052e1be3a949" }
 hopr-transport = { version = "0.44.0", path = "transport/hopr" }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
 hopr-transport-session = { version = "0.26.2", path = "transport/session", default-features = false }
 hopr-transport-tag-allocator = { version = "0.1.1", path = "transport/tag-allocator", default-features = false }
-hopr-chain-connector = "0.22.1"
+hopr-chain-connector = { version = "0.22.2", git = "https://github.com/hoprnet/hopr-impls", rev = "eca69c009cfa74eabbe2570378d9052e1be3a949" }
 
 # referential implementations (published to crates.io)
-hopr-session-server-forwarder = { version = "0.1.0", default-features = false }
-hopr-transport-p2p = { version = "0.9.4", features = ["transport-quic"] }
-hopr-ct-full-network = { version = "0.3.0", default-features = false }
-hopr-network-graph = { version = "0.3.4", default-features = false }
+hopr-session-server-forwarder = { version = "0.1.1", git = "https://github.com/hoprnet/hopr-impls", rev = "eca69c009cfa74eabbe2570378d9052e1be3a949", default-features = false }
+hopr-transport-p2p = { version = "0.9.5", git = "https://github.com/hoprnet/hopr-impls", rev = "eca69c009cfa74eabbe2570378d9052e1be3a949", features = ["transport-quic"] }
+hopr-ct-full-network = { version = "0.4.0", git = "https://github.com/hoprnet/hopr-impls", rev = "eca69c009cfa74eabbe2570378d9052e1be3a949", default-features = false }
+hopr-network-graph = { version = "0.5.0", git = "https://github.com/hoprnet/hopr-impls", rev = "eca69c009cfa74eabbe2570378d9052e1be3a949", default-features = false }
 
 [profile.dev]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,7 +162,9 @@ hopr-chain-connector = { version = "0.22.2", git = "https://github.com/hoprnet/h
 
 # referential implementations (published to crates.io)
 hopr-session-server-forwarder = { version = "0.1.1", git = "https://github.com/hoprnet/hopr-impls", rev = "eca69c009cfa74eabbe2570378d9052e1be3a949", default-features = false }
-hopr-transport-p2p = { version = "0.9.5", git = "https://github.com/hoprnet/hopr-impls", rev = "eca69c009cfa74eabbe2570378d9052e1be3a949", features = ["transport-quic"] }
+hopr-transport-p2p = { version = "0.9.5", git = "https://github.com/hoprnet/hopr-impls", rev = "eca69c009cfa74eabbe2570378d9052e1be3a949", features = [
+  "transport-quic",
+] }
 hopr-ct-full-network = { version = "0.4.0", git = "https://github.com/hoprnet/hopr-impls", rev = "eca69c009cfa74eabbe2570378d9052e1be3a949", default-features = false }
 hopr-network-graph = { version = "0.5.0", git = "https://github.com/hoprnet/hopr-impls", rev = "eca69c009cfa74eabbe2570378d9052e1be3a949", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,21 +152,21 @@ hopr-protocol-app = { version = "1.0.1", path = "protocols/app", default-feature
 hopr-protocol-hopr = { version = "6.0.0", path = "protocols/hopr", default-features = false }
 hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
 hopr-protocol-start = { version = "1.1.0", path = "protocols/start", default-features = false }
-hopr-ticket-manager = { version = "0.5.2", git = "https://github.com/hoprnet/hopr-impls", rev = "81399f427c7bf93aba1ccc3c432382c7e379b6e7" }
+hopr-ticket-manager = { version = "0.5.2", git = "https://github.com/hoprnet/hopr-impls", rev = "ad0fd7e4b35ac462846011ec7446fd404f5bcf44" }
 hopr-transport = { version = "0.44.0", path = "transport/hopr" }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
 hopr-transport-session = { version = "0.26.2", path = "transport/session", default-features = false }
 hopr-transport-tag-allocator = { version = "0.1.1", path = "transport/tag-allocator", default-features = false }
-hopr-chain-connector = { version = "0.22.2", git = "https://github.com/hoprnet/hopr-impls", rev = "81399f427c7bf93aba1ccc3c432382c7e379b6e7" }
+hopr-chain-connector = { version = "0.22.2", git = "https://github.com/hoprnet/hopr-impls", rev = "ad0fd7e4b35ac462846011ec7446fd404f5bcf44" }
 
 # referential implementations (published to crates.io)
-hopr-session-server-forwarder = { version = "0.1.1", git = "https://github.com/hoprnet/hopr-impls", rev = "81399f427c7bf93aba1ccc3c432382c7e379b6e7", default-features = false }
-hopr-transport-p2p = { version = "0.9.5", git = "https://github.com/hoprnet/hopr-impls", rev = "81399f427c7bf93aba1ccc3c432382c7e379b6e7", features = [
+hopr-session-server-forwarder = { version = "0.1.1", git = "https://github.com/hoprnet/hopr-impls", rev = "ad0fd7e4b35ac462846011ec7446fd404f5bcf44", default-features = false }
+hopr-transport-p2p = { version = "0.9.5", git = "https://github.com/hoprnet/hopr-impls", rev = "ad0fd7e4b35ac462846011ec7446fd404f5bcf44", features = [
   "transport-quic",
 ] }
-hopr-ct-full-network = { version = "0.4.0", git = "https://github.com/hoprnet/hopr-impls", rev = "81399f427c7bf93aba1ccc3c432382c7e379b6e7", default-features = false }
-hopr-network-graph = { version = "0.5.0", git = "https://github.com/hoprnet/hopr-impls", rev = "81399f427c7bf93aba1ccc3c432382c7e379b6e7", default-features = false }
+hopr-ct-full-network = { version = "0.4.0", git = "https://github.com/hoprnet/hopr-impls", rev = "ad0fd7e4b35ac462846011ec7446fd404f5bcf44", default-features = false }
+hopr-network-graph = { version = "0.5.0", git = "https://github.com/hoprnet/hopr-impls", rev = "ad0fd7e4b35ac462846011ec7446fd404f5bcf44", default-features = false }
 
 [profile.dev]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,9 +139,9 @@ validator = { version = "0.21.0", features = ["derive"] }
 # `hopr_api::chain::DeployedSafe` two distinct types. `version` alongside `git` is the "multiple
 # locations" form: git wins locally, the version requirement survives packaging. Revert to plain
 # versions once hopr-api 2.0.0, hopr-utilities 0.9.0 and the hopr-impls crates are published.
-hopr-api = { version = "2.0.0", git = "https://github.com/hoprnet/hopr-api", rev = "ee65b340cf09fd6031735477cc1171d7610694a3" }
+hopr-api = { version = "2.0.0" }
 hopr-types = { version = "2.2.1", features = ["use-bindings"] }
-hopr-utils = { package = "hopr-utilities", version = "0.9.0", git = "https://github.com/hoprnet/hopr-utilities", rev = "68e648be4aa9f1442c75df4006a53db414932f7e", default-features = false }
+hopr-utils = { package = "hopr-utilities", version = "0.9.0", default-features = false }
 hopr-utils-session = { version = "1.2.1", path = "utils-session" }
 
 hopr-crypto-packet = { version = "1.4.0", path = "crypto/packet", default-features = false, features = [
@@ -152,21 +152,19 @@ hopr-protocol-app = { version = "1.0.1", path = "protocols/app", default-feature
 hopr-protocol-hopr = { version = "6.0.0", path = "protocols/hopr", default-features = false }
 hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
 hopr-protocol-start = { version = "1.1.0", path = "protocols/start", default-features = false }
-hopr-ticket-manager = { version = "0.5.2", git = "https://github.com/hoprnet/hopr-impls", rev = "ad0fd7e4b35ac462846011ec7446fd404f5bcf44" }
+hopr-ticket-manager = { version = "0.5.2" }
 hopr-transport = { version = "0.44.0", path = "transport/hopr" }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
 hopr-transport-session = { version = "0.26.2", path = "transport/session", default-features = false }
 hopr-transport-tag-allocator = { version = "0.1.1", path = "transport/tag-allocator", default-features = false }
-hopr-chain-connector = { version = "0.22.2", git = "https://github.com/hoprnet/hopr-impls", rev = "ad0fd7e4b35ac462846011ec7446fd404f5bcf44" }
+hopr-chain-connector = { version = "0.22.2" }
 
 # referential implementations (published to crates.io)
-hopr-session-server-forwarder = { version = "0.1.1", git = "https://github.com/hoprnet/hopr-impls", rev = "ad0fd7e4b35ac462846011ec7446fd404f5bcf44", default-features = false }
-hopr-transport-p2p = { version = "0.9.5", git = "https://github.com/hoprnet/hopr-impls", rev = "ad0fd7e4b35ac462846011ec7446fd404f5bcf44", features = [
-  "transport-quic",
-] }
-hopr-ct-full-network = { version = "0.4.0", git = "https://github.com/hoprnet/hopr-impls", rev = "ad0fd7e4b35ac462846011ec7446fd404f5bcf44", default-features = false }
-hopr-network-graph = { version = "0.5.0", git = "https://github.com/hoprnet/hopr-impls", rev = "ad0fd7e4b35ac462846011ec7446fd404f5bcf44", default-features = false }
+hopr-session-server-forwarder = { version = "0.1.1", default-features = false }
+hopr-transport-p2p = { version = "0.9.5", features = ["transport-quic"] }
+hopr-ct-full-network = { version = "0.4.0", default-features = false }
+hopr-network-graph = { version = "0.5.0", default-features = false }
 
 [profile.dev]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -152,21 +152,21 @@ hopr-protocol-app = { version = "1.0.1", path = "protocols/app", default-feature
 hopr-protocol-hopr = { version = "6.0.0", path = "protocols/hopr", default-features = false }
 hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
 hopr-protocol-start = { version = "1.1.0", path = "protocols/start", default-features = false }
-hopr-ticket-manager = { version = "0.5.2", git = "https://github.com/hoprnet/hopr-impls", rev = "eca69c009cfa74eabbe2570378d9052e1be3a949" }
+hopr-ticket-manager = { version = "0.5.2", git = "https://github.com/hoprnet/hopr-impls", rev = "e476452adf8303fbf161c7a835edf2c1ecc7bc8d" }
 hopr-transport = { version = "0.44.0", path = "transport/hopr" }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
 hopr-transport-session = { version = "0.26.2", path = "transport/session", default-features = false }
 hopr-transport-tag-allocator = { version = "0.1.1", path = "transport/tag-allocator", default-features = false }
-hopr-chain-connector = { version = "0.22.2", git = "https://github.com/hoprnet/hopr-impls", rev = "eca69c009cfa74eabbe2570378d9052e1be3a949" }
+hopr-chain-connector = { version = "0.22.2", git = "https://github.com/hoprnet/hopr-impls", rev = "e476452adf8303fbf161c7a835edf2c1ecc7bc8d" }
 
 # referential implementations (published to crates.io)
-hopr-session-server-forwarder = { version = "0.1.1", git = "https://github.com/hoprnet/hopr-impls", rev = "eca69c009cfa74eabbe2570378d9052e1be3a949", default-features = false }
-hopr-transport-p2p = { version = "0.9.5", git = "https://github.com/hoprnet/hopr-impls", rev = "eca69c009cfa74eabbe2570378d9052e1be3a949", features = [
+hopr-session-server-forwarder = { version = "0.1.1", git = "https://github.com/hoprnet/hopr-impls", rev = "e476452adf8303fbf161c7a835edf2c1ecc7bc8d", default-features = false }
+hopr-transport-p2p = { version = "0.9.5", git = "https://github.com/hoprnet/hopr-impls", rev = "e476452adf8303fbf161c7a835edf2c1ecc7bc8d", features = [
   "transport-quic",
 ] }
-hopr-ct-full-network = { version = "0.4.0", git = "https://github.com/hoprnet/hopr-impls", rev = "eca69c009cfa74eabbe2570378d9052e1be3a949", default-features = false }
-hopr-network-graph = { version = "0.5.0", git = "https://github.com/hoprnet/hopr-impls", rev = "eca69c009cfa74eabbe2570378d9052e1be3a949", default-features = false }
+hopr-ct-full-network = { version = "0.4.0", git = "https://github.com/hoprnet/hopr-impls", rev = "e476452adf8303fbf161c7a835edf2c1ecc7bc8d", default-features = false }
+hopr-network-graph = { version = "0.5.0", git = "https://github.com/hoprnet/hopr-impls", rev = "e476452adf8303fbf161c7a835edf2c1ecc7bc8d", default-features = false }
 
 [profile.dev]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,9 +139,9 @@ validator = { version = "0.21.0", features = ["derive"] }
 # `hopr_api::chain::DeployedSafe` two distinct types. `version` alongside `git` is the "multiple
 # locations" form: git wins locally, the version requirement survives packaging. Revert to plain
 # versions once hopr-api 2.0.0, hopr-utilities 0.9.0 and the hopr-impls crates are published.
-hopr-api = { version = "2.0.0", git = "https://github.com/hoprnet/hopr-api", rev = "d41e096dee73803ff6aa4c2dc4af83af5baae15f" }
+hopr-api = { version = "2.0.0", git = "https://github.com/hoprnet/hopr-api", rev = "4739d419926904f609ebc8ef8d71e7d35e2bd967" }
 hopr-types = { version = "2.2.1", features = ["use-bindings"] }
-hopr-utils = { package = "hopr-utilities", version = "0.9.0", git = "https://github.com/hoprnet/hopr-utilities", rev = "4080d369835ff3e586a683539ef201efa0783b4b", default-features = false }
+hopr-utils = { package = "hopr-utilities", version = "0.9.0", git = "https://github.com/hoprnet/hopr-utilities", rev = "1d3693356538025710791ea1f8797b8f5ecd5380", default-features = false }
 hopr-utils-session = { version = "1.2.1", path = "utils-session" }
 
 hopr-crypto-packet = { version = "1.4.0", path = "crypto/packet", default-features = false, features = [
@@ -152,21 +152,21 @@ hopr-protocol-app = { version = "1.0.1", path = "protocols/app", default-feature
 hopr-protocol-hopr = { version = "6.0.0", path = "protocols/hopr", default-features = false }
 hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
 hopr-protocol-start = { version = "1.1.0", path = "protocols/start", default-features = false }
-hopr-ticket-manager = { version = "0.5.2", git = "https://github.com/hoprnet/hopr-impls", rev = "e476452adf8303fbf161c7a835edf2c1ecc7bc8d" }
+hopr-ticket-manager = { version = "0.5.2", git = "https://github.com/hoprnet/hopr-impls", rev = "f990e535f82e55a7785b25f0e355db890a0277ae" }
 hopr-transport = { version = "0.44.0", path = "transport/hopr" }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
 hopr-transport-session = { version = "0.26.2", path = "transport/session", default-features = false }
 hopr-transport-tag-allocator = { version = "0.1.1", path = "transport/tag-allocator", default-features = false }
-hopr-chain-connector = { version = "0.22.2", git = "https://github.com/hoprnet/hopr-impls", rev = "e476452adf8303fbf161c7a835edf2c1ecc7bc8d" }
+hopr-chain-connector = { version = "0.22.2", git = "https://github.com/hoprnet/hopr-impls", rev = "f990e535f82e55a7785b25f0e355db890a0277ae" }
 
 # referential implementations (published to crates.io)
-hopr-session-server-forwarder = { version = "0.1.1", git = "https://github.com/hoprnet/hopr-impls", rev = "e476452adf8303fbf161c7a835edf2c1ecc7bc8d", default-features = false }
-hopr-transport-p2p = { version = "0.9.5", git = "https://github.com/hoprnet/hopr-impls", rev = "e476452adf8303fbf161c7a835edf2c1ecc7bc8d", features = [
+hopr-session-server-forwarder = { version = "0.1.1", git = "https://github.com/hoprnet/hopr-impls", rev = "f990e535f82e55a7785b25f0e355db890a0277ae", default-features = false }
+hopr-transport-p2p = { version = "0.9.5", git = "https://github.com/hoprnet/hopr-impls", rev = "f990e535f82e55a7785b25f0e355db890a0277ae", features = [
   "transport-quic",
 ] }
-hopr-ct-full-network = { version = "0.4.0", git = "https://github.com/hoprnet/hopr-impls", rev = "e476452adf8303fbf161c7a835edf2c1ecc7bc8d", default-features = false }
-hopr-network-graph = { version = "0.5.0", git = "https://github.com/hoprnet/hopr-impls", rev = "e476452adf8303fbf161c7a835edf2c1ecc7bc8d", default-features = false }
+hopr-ct-full-network = { version = "0.4.0", git = "https://github.com/hoprnet/hopr-impls", rev = "f990e535f82e55a7785b25f0e355db890a0277ae", default-features = false }
+hopr-network-graph = { version = "0.5.0", git = "https://github.com/hoprnet/hopr-impls", rev = "f990e535f82e55a7785b25f0e355db890a0277ae", default-features = false }
 
 [profile.dev]
 panic = "abort"

--- a/hopr/hopr-lib/src/builder/chain_wiring.rs
+++ b/hopr/hopr-lib/src/builder/chain_wiring.rs
@@ -4,7 +4,7 @@ use futures::{SinkExt, StreamExt, pin_mut};
 use hopr_api::{
     HoprBalance, Multiaddr, OffchainPublicKey, PeerId,
     chain::{ChainKeyOperations, WinningProbability},
-    graph::{EdgeCapacityUpdate, MeasurableEdge, NetworkGraphUpdate},
+    graph::{EdgeBalanceUpdate, MeasurableEdge, NetworkGraphUpdate},
     types::{
         chain::chain_events::ChainEvent,
         internal::prelude::ChannelStatus,
@@ -131,28 +131,22 @@ pub(super) async fn process_chain_events<C, G, S>(
 
                 match keys {
                     Ok(Some((from, to))) => {
-                        let capacity =
-                            match channel.status {
-                                ChannelStatus::Closed | ChannelStatus::PendingToClose(_) => None,
-                                _ => ticket_price.read().div_f64(win_probability.read().as_f64()).ok().map(
-                                    |ticket_value| {
-                                        channel
-                                            .balance
-                                            .amount()
-                                            .checked_div(ticket_value.amount())
-                                            .map(|v| v.low_u128())
-                                            .unwrap_or(u128::MAX)
-                                    },
-                                ),
-                            };
+                        // Emit the raw balance, not a ticket count. Dividing by the ticket face
+                        // value here would bake a live ticket price and winning probability into
+                        // every edge, so each price change would stale the whole graph at once.
+                        // Consumers apply the face value when they evaluate a path instead.
+                        let balance = match channel.status {
+                            ChannelStatus::Closed | ChannelStatus::PendingToClose(_) => None,
+                            _ => Some(channel.balance.amount()),
+                        };
 
                         tracing::debug!(
-                            %channel, ?capacity,
-                            "recording graph edge for channel capacity"
+                            %channel, ?balance,
+                            "recording graph edge for channel balance"
                         );
-                        graph_updater.record_edge(MeasurableEdge::<NeighborTelemetry, PathTelemetry>::Capacity(
-                            Box::new(EdgeCapacityUpdate {
-                                capacity,
+                        graph_updater.record_edge(MeasurableEdge::<NeighborTelemetry, PathTelemetry>::Balance(
+                            Box::new(EdgeBalanceUpdate {
+                                balance,
                                 src: from,
                                 dest: to,
                             }),
@@ -195,13 +189,37 @@ pub(super) async fn process_chain_events<C, G, S>(
             ChainEvent::WinningProbabilityIncreased(prob) | ChainEvent::WinningProbabilityDecreased(prob) => {
                 tracing::debug!(%prob, "recording winning probability change");
                 *win_probability.write() = prob;
+                push_ticket_face_value(&graph_updater, &ticket_price, &win_probability);
             }
             ChainEvent::TicketPriceChanged(price) => {
                 tracing::debug!(%price, "recording ticket price change");
                 *ticket_price.write() = price;
+                push_ticket_face_value(&graph_updater, &ticket_price, &win_probability);
             }
             _ => {}
         }
+    }
+}
+
+/// Recomputes the single-hop ticket face value and pushes it into the graph.
+///
+/// `price / win_probability` is the amount that makes the expected payout per packet equal the
+/// ticket price, i.e. one ticket's face value. Edges store only a balance, so this is the one place
+/// pricing enters path selection — and a change costs a single write rather than an edge sweep.
+fn push_ticket_face_value<G>(
+    graph: &G,
+    ticket_price: &Arc<RwLock<HoprBalance>>,
+    win_probability: &Arc<RwLock<WinningProbability>>,
+) where
+    G: NetworkGraphUpdate,
+{
+    match ticket_price.read().div_f64(win_probability.read().as_f64()) {
+        Ok(face_value) => {
+            let face_value = face_value.amount();
+            tracing::debug!(%face_value, "recording ticket face value change");
+            graph.set_ticket_face_value(face_value);
+        }
+        Err(error) => tracing::error!(%error, "failed to derive the ticket face value; leaving the previous one"),
     }
 }
 
@@ -217,7 +235,7 @@ mod tests {
     use hopr_api::{
         HoprBalance, OffchainPublicKey,
         chain::{ChainKeyOperations, HoprKeyIdent, KeyIdMapping, WinningProbability},
-        graph::{EdgeCapacityUpdate, MeasurableEdge, MeasurablePath, MeasurablePeer, NetworkGraphUpdate},
+        graph::{EdgeBalanceUpdate, MeasurableEdge, MeasurablePath, MeasurablePeer, NetworkGraphUpdate},
         types::{
             chain::chain_events::ChainEvent,
             crypto::prelude::{ChainKeypair, Keypair, OffchainKeypair},
@@ -292,7 +310,8 @@ mod tests {
     #[derive(Debug, Clone)]
     enum GraphCall {
         Node(OffchainPublicKey),
-        Edge(Box<EdgeCapacityUpdate>),
+        Edge(Box<EdgeBalanceUpdate>),
+        FaceValue(hopr_api::graph::traits::ChannelBalance),
     }
 
     #[derive(Debug, Clone, Default)]
@@ -305,10 +324,17 @@ mod tests {
             self.calls.lock().unwrap().clone()
         }
 
-        fn edges(&self) -> Vec<EdgeCapacityUpdate> {
+        fn edges(&self) -> Vec<EdgeBalanceUpdate> {
             self.recorded()
                 .into_iter()
                 .filter_map(|c| if let GraphCall::Edge(e) = c { Some(*e) } else { None })
+                .collect()
+        }
+
+        fn face_values(&self) -> Vec<hopr_api::graph::traits::ChannelBalance> {
+            self.recorded()
+                .into_iter()
+                .filter_map(|c| if let GraphCall::FaceValue(v) = c { Some(v) } else { None })
                 .collect()
         }
 
@@ -321,13 +347,17 @@ mod tests {
     }
 
     impl NetworkGraphUpdate for RecordingGraph {
+        fn set_ticket_face_value(&self, ticket_face_value: hopr_api::graph::traits::ChannelBalance) {
+            self.calls.lock().unwrap().push(GraphCall::FaceValue(ticket_face_value));
+        }
+
         fn record_edge<N, P>(&self, update: MeasurableEdge<N, P>)
         where
             N: MeasurablePeer + Clone + Send + Sync + 'static,
             P: MeasurablePath + Clone + Send + Sync + 'static,
         {
-            if let MeasurableEdge::Capacity(cap) = update {
-                self.calls.lock().unwrap().push(GraphCall::Edge(cap));
+            if let MeasurableEdge::Balance(balance) = update {
+                self.calls.lock().unwrap().push(GraphCall::Edge(balance));
             }
         }
 
@@ -514,7 +544,7 @@ mod tests {
         let graph = RecordingGraph::default();
         let stub = StubChainKeys::new([(src_addr, *src_offchain.public()), (dst_addr, *dst_offchain.public())]);
 
-        // price=10, win_prob=1.0, balance=100 → capacity = 100/(10/1.0) = 10
+        // The balance is emitted as-is; pricing no longer enters the per-edge value.
         run(
             vec![ChainEvent::ChannelOpened(channel(
                 src_addr,
@@ -533,7 +563,10 @@ mod tests {
 
         let edges = graph.edges();
         assert_eq!(edges.len(), 1);
-        assert_eq!(edges[0].capacity, Some(10));
+        assert_eq!(
+            edges[0].balance,
+            Some(hopr_api::graph::traits::ChannelBalance::from(100u64))
+        );
         assert_eq!(edges[0].src, *src_offchain.public());
         assert_eq!(edges[0].dest, *dst_offchain.public());
     }
@@ -548,7 +581,7 @@ mod tests {
         let graph = RecordingGraph::default();
         let stub = StubChainKeys::new([(src_addr, *src_offchain.public()), (dst_addr, *dst_offchain.public())]);
 
-        // price=10, win_prob=1.0, balance=50 after decrease → capacity = 50/10 = 5
+        // The decreased balance is emitted as-is.
         run(
             vec![ChainEvent::ChannelBalanceDecreased(
                 channel(src_addr, dst_addr, 50, ChannelStatus::Open),
@@ -565,7 +598,10 @@ mod tests {
 
         let edges = graph.edges();
         assert_eq!(edges.len(), 1);
-        assert_eq!(edges[0].capacity, Some(5));
+        assert_eq!(
+            edges[0].balance,
+            Some(hopr_api::graph::traits::ChannelBalance::from(50u64))
+        );
     }
 
     #[tokio::test]
@@ -596,7 +632,7 @@ mod tests {
 
         let edges = graph.edges();
         assert_eq!(edges.len(), 1);
-        assert_eq!(edges[0].capacity, None);
+        assert_eq!(edges[0].balance, None);
     }
 
     /// Regression test: before the fix, ChannelClosureInitiated was a no-op and the
@@ -631,13 +667,13 @@ mod tests {
         let edges = graph.edges();
         assert_eq!(edges.len(), 1, "closure-initiated must emit a graph update");
         assert_eq!(
-            edges[0].capacity, None,
-            "closure-initiated must zero out the capacity so routing stops using this edge"
+            edges[0].balance, None,
+            "closure-initiated must clear the balance so routing stops using this edge"
         );
     }
 
     #[tokio::test]
-    async fn ticket_price_change_affects_subsequent_capacity() {
+    async fn ticket_price_change_pushes_a_new_face_value() {
         let (src_offchain, src_chain) = make_keypairs();
         let (dst_offchain, dst_chain) = make_keypairs();
         let src_addr = src_chain.public().to_address();
@@ -646,7 +682,7 @@ mod tests {
         let graph = RecordingGraph::default();
         let stub = StubChainKeys::new([(src_addr, *src_offchain.public()), (dst_addr, *dst_offchain.public())]);
 
-        // initial price=10; after price change to 20, balance=200 → 200/(20/1.0) = 10
+        // A price change recomputes the face value: 20 / 1.0 = 20. The balance is untouched.
         run(
             vec![
                 ChainEvent::TicketPriceChanged(HoprBalance::from(20u64)),
@@ -661,13 +697,23 @@ mod tests {
         )
         .await;
 
+        assert_eq!(
+            graph.face_values(),
+            vec![hopr_api::graph::traits::ChannelBalance::from(20u64)],
+            "a price change must push exactly one recomputed face value"
+        );
+
         let edges = graph.edges();
         assert_eq!(edges.len(), 1);
-        assert_eq!(edges[0].capacity, Some(10));
+        assert_eq!(
+            edges[0].balance,
+            Some(hopr_api::graph::traits::ChannelBalance::from(200u64)),
+            "the emitted balance must not depend on the price"
+        );
     }
 
     #[tokio::test]
-    async fn win_probability_change_affects_subsequent_capacity() -> anyhow::Result<()> {
+    async fn win_probability_change_pushes_a_new_face_value() -> anyhow::Result<()> {
         let (src_offchain, src_chain) = make_keypairs();
         let (dst_offchain, dst_chain) = make_keypairs();
         let src_addr = src_chain.public().to_address();
@@ -676,7 +722,7 @@ mod tests {
         let graph = RecordingGraph::default();
         let stub = StubChainKeys::new([(src_addr, *src_offchain.public()), (dst_addr, *dst_offchain.public())]);
 
-        // initial win_prob=1.0; after decrease to 0.5, balance=100, price=10 → 100/(10/0.5) = 5
+        // A winning-probability change recomputes the face value: 10 / 0.5 = 20.
         let new_prob = WinningProbability::try_from_f64(0.5).context("0.5 is a valid winning probability")?;
         run(
             vec![
@@ -692,9 +738,19 @@ mod tests {
         )
         .await;
 
+        assert_eq!(
+            graph.face_values(),
+            vec![hopr_api::graph::traits::ChannelBalance::from(20u64)],
+            "a winning-probability change must push exactly one recomputed face value"
+        );
+
         let edges = graph.edges();
         assert_eq!(edges.len(), 1);
-        assert_eq!(edges[0].capacity, Some(5));
+        assert_eq!(
+            edges[0].balance,
+            Some(hopr_api::graph::traits::ChannelBalance::from(100u64)),
+            "the emitted balance must not depend on the winning probability"
+        );
         Ok(())
     }
 

--- a/hopr/hopr-lib/src/builder/chain_wiring.rs
+++ b/hopr/hopr-lib/src/builder/chain_wiring.rs
@@ -224,6 +224,10 @@ fn push_ticket_face_value<G>(
     let price = *ticket_price.read();
     let probability = win_probability.read().as_f64();
 
+    // The `f64` carries the probability, it does not convert it. `as_f64` packs the 56-bit encoded
+    // value into the mantissa of a number in [1, 2), and `div_f64` strips it straight back out and
+    // divides in `U256` — the balance never becomes a float, and a whole probability short-circuits
+    // to the identity. A hand-rolled integer division here would gain nothing but the guards.
     match price.div_f64(probability) {
         Ok(face_value) => {
             let face_value = face_value.amount();

--- a/hopr/hopr-lib/src/builder/chain_wiring.rs
+++ b/hopr/hopr-lib/src/builder/chain_wiring.rs
@@ -56,6 +56,12 @@ pub(super) async fn process_chain_events<C, G, S>(
 {
     pin_mut!(events);
 
+    // Seed the face value before the first event. Startup replays on-chain state as channel events,
+    // and a pricing event only follows if the price actually changes — so without this the graph
+    // would record balances while `ticket_face_value()` was still `None`, and selection would price
+    // every path off the fallback until the next price change happened to arrive.
+    push_ticket_face_value(&graph_updater, &ticket_price, &win_probability);
+
     // Tracks the node's currently-open channel IDs per direction so `hopr_channels_count`
     // can be maintained incrementally from channel events. The initial on-chain state is
     // replayed as `ChannelOpened` events by the state-sync subscription at startup, so the
@@ -213,7 +219,12 @@ fn push_ticket_face_value<G>(
 ) where
     G: NetworkGraphUpdate,
 {
-    match ticket_price.read().div_f64(win_probability.read().as_f64()) {
+    // Both guards are released before the division: holding one while taking the other is a lock
+    // order this code would then be obliged to honour everywhere else.
+    let price = *ticket_price.read();
+    let probability = win_probability.read().as_f64();
+
+    match price.div_f64(probability) {
         Ok(face_value) => {
             let face_value = face_value.amount();
             tracing::debug!(%face_value, "recording ticket face value change");
@@ -693,8 +704,11 @@ mod tests {
 
         assert_eq!(
             graph.face_values(),
-            vec![hopr_api::graph::traits::Balance::from(20u64)],
-            "a price change must push exactly one recomputed face value"
+            vec![
+                hopr_api::graph::traits::Balance::from(10u64),
+                hopr_api::graph::traits::Balance::from(20u64),
+            ],
+            "the seeded face value, then the one recomputed from the price change"
         );
 
         let edges = graph.edges();
@@ -734,8 +748,11 @@ mod tests {
 
         assert_eq!(
             graph.face_values(),
-            vec![hopr_api::graph::traits::Balance::from(20u64)],
-            "a winning-probability change must push exactly one recomputed face value"
+            vec![
+                hopr_api::graph::traits::Balance::from(10u64),
+                hopr_api::graph::traits::Balance::from(20u64),
+            ],
+            "the seeded face value, then the one recomputed from the probability change"
         );
 
         let edges = graph.edges();
@@ -746,6 +763,44 @@ mod tests {
             "the emitted balance must not depend on the winning probability"
         );
         Ok(())
+    }
+
+    /// Startup replays on-chain state as channel events, and a pricing event follows only if the
+    /// price actually changed. Without a seed the graph would then hold balances while
+    /// `ticket_face_value()` was still `None`, and selection would price every path off the
+    /// fallback for as long as the price happened to stay put.
+    #[tokio::test]
+    async fn a_face_value_is_seeded_before_any_pricing_event() {
+        let (src_offchain, src_chain) = make_keypairs();
+        let (dst_offchain, dst_chain) = make_keypairs();
+        let src_addr = src_chain.public().to_address();
+        let dst_addr = dst_chain.public().to_address();
+
+        let graph = RecordingGraph::default();
+        let stub = StubChainKeys::new([(src_addr, *src_offchain.public()), (dst_addr, *dst_offchain.public())]);
+
+        // Only a channel event: exactly the startup replay, with no price or probability change.
+        run(
+            vec![ChainEvent::ChannelOpened(channel(
+                src_addr,
+                dst_addr,
+                200,
+                ChannelStatus::Open,
+            ))],
+            stub,
+            graph.clone(),
+            src_addr,
+            *src_offchain.public(),
+            HoprBalance::from(10u64),
+            WinningProbability::ALWAYS,
+        )
+        .await;
+
+        assert_eq!(
+            graph.face_values(),
+            vec![hopr_api::graph::traits::Balance::from(10u64)],
+            "the graph must know the price before it records a balance it will be compared against"
+        );
     }
 
     #[tokio::test]

--- a/hopr/hopr-lib/src/builder/chain_wiring.rs
+++ b/hopr/hopr-lib/src/builder/chain_wiring.rs
@@ -311,7 +311,7 @@ mod tests {
     enum GraphCall {
         Node(OffchainPublicKey),
         Edge(Box<EdgeBalanceUpdate>),
-        FaceValue(hopr_api::graph::traits::ChannelBalance),
+        FaceValue(hopr_api::graph::traits::Balance),
     }
 
     #[derive(Debug, Clone, Default)]
@@ -331,7 +331,7 @@ mod tests {
                 .collect()
         }
 
-        fn face_values(&self) -> Vec<hopr_api::graph::traits::ChannelBalance> {
+        fn face_values(&self) -> Vec<hopr_api::graph::traits::Balance> {
             self.recorded()
                 .into_iter()
                 .filter_map(|c| if let GraphCall::FaceValue(v) = c { Some(v) } else { None })
@@ -347,7 +347,7 @@ mod tests {
     }
 
     impl NetworkGraphUpdate for RecordingGraph {
-        fn set_ticket_face_value(&self, ticket_face_value: hopr_api::graph::traits::ChannelBalance) {
+        fn set_ticket_face_value(&self, ticket_face_value: hopr_api::graph::traits::Balance) {
             self.calls.lock().unwrap().push(GraphCall::FaceValue(ticket_face_value));
         }
 
@@ -563,10 +563,7 @@ mod tests {
 
         let edges = graph.edges();
         assert_eq!(edges.len(), 1);
-        assert_eq!(
-            edges[0].balance,
-            Some(hopr_api::graph::traits::ChannelBalance::from(100u64))
-        );
+        assert_eq!(edges[0].balance, Some(hopr_api::graph::traits::Balance::from(100u64)));
         assert_eq!(edges[0].src, *src_offchain.public());
         assert_eq!(edges[0].dest, *dst_offchain.public());
     }
@@ -598,10 +595,7 @@ mod tests {
 
         let edges = graph.edges();
         assert_eq!(edges.len(), 1);
-        assert_eq!(
-            edges[0].balance,
-            Some(hopr_api::graph::traits::ChannelBalance::from(50u64))
-        );
+        assert_eq!(edges[0].balance, Some(hopr_api::graph::traits::Balance::from(50u64)));
     }
 
     #[tokio::test]
@@ -699,7 +693,7 @@ mod tests {
 
         assert_eq!(
             graph.face_values(),
-            vec![hopr_api::graph::traits::ChannelBalance::from(20u64)],
+            vec![hopr_api::graph::traits::Balance::from(20u64)],
             "a price change must push exactly one recomputed face value"
         );
 
@@ -707,7 +701,7 @@ mod tests {
         assert_eq!(edges.len(), 1);
         assert_eq!(
             edges[0].balance,
-            Some(hopr_api::graph::traits::ChannelBalance::from(200u64)),
+            Some(hopr_api::graph::traits::Balance::from(200u64)),
             "the emitted balance must not depend on the price"
         );
     }
@@ -740,7 +734,7 @@ mod tests {
 
         assert_eq!(
             graph.face_values(),
-            vec![hopr_api::graph::traits::ChannelBalance::from(20u64)],
+            vec![hopr_api::graph::traits::Balance::from(20u64)],
             "a winning-probability change must push exactly one recomputed face value"
         );
 
@@ -748,7 +742,7 @@ mod tests {
         assert_eq!(edges.len(), 1);
         assert_eq!(
             edges[0].balance,
-            Some(hopr_api::graph::traits::ChannelBalance::from(100u64)),
+            Some(hopr_api::graph::traits::Balance::from(100u64)),
             "the emitted balance must not depend on the winning probability"
         );
         Ok(())

--- a/hopr/hopr-lib/tests/transport_p2p-size3.rs
+++ b/hopr/hopr-lib/tests/transport_p2p-size3.rs
@@ -157,7 +157,13 @@ async fn probe_warmup_should_populate_graph_edges_for_all_peers(cluster: &Cluste
             .network_peer_observations(peer)
             .context("peer should have observations in the graph")?;
 
-        assert!(obs.score() > 0.0, "score should be positive for {peer}");
+        // `score` is `Option<f64>` since hopr-api 2.0.0: `None` is unobserved, `Some(0.0)` is
+        // measured and unusable. A probed neighbour must be the former of neither.
+        assert!(
+            obs.score().is_some_and(|score| score > 0.0),
+            "score should be observed and positive for {peer}, got {:?}",
+            obs.score()
+        );
     }
 
     Ok(())
@@ -184,7 +190,11 @@ async fn all_network_peers_should_return_scored_entries(cluster: &ClusterGuard) 
             .all_network_peers(0.0)
             .await
             .context("failed to get all network peers")?;
-        if all_peers.len() >= expected_count && all_peers.iter().all(|(_, obs)| obs.score() > 0.0) {
+        if all_peers.len() >= expected_count
+            && all_peers
+                .iter()
+                .all(|(_, obs)| obs.score().is_some_and(|score| score > 0.0))
+        {
             break;
         }
         sleep(Duration::from_secs(2)).await;
@@ -193,7 +203,11 @@ async fn all_network_peers_should_return_scored_entries(cluster: &ClusterGuard) 
     assert!(!all_peers.is_empty(), "should have at least one peer with score > 0");
 
     for (peer_id, obs) in &all_peers {
-        assert!(obs.score() > 0.0, "peer {peer_id} score should be positive");
+        assert!(
+            obs.score().is_some_and(|score| score > 0.0),
+            "peer {peer_id} score should be observed and positive, got {:?}",
+            obs.score()
+        );
         assert!(
             obs.last_update().as_millis() > 0,
             "peer {peer_id} should have a last_update timestamp"

--- a/hopr/hopr-lib/tests/transport_p2p-size3.rs
+++ b/hopr/hopr-lib/tests/transport_p2p-size3.rs
@@ -140,7 +140,10 @@ async fn probe_warmup_should_populate_graph_edges_for_all_peers(cluster: &Cluste
             node.inner()
                 .transport()
                 .network_peer_observations(peer)
-                .and_then(|obs| obs.immediate_qos().map(|imm| imm.average_probe_rate() > 0.0))
+                .and_then(|obs| {
+                    obs.immediate_qos()
+                        .map(|imm| imm.average_probe_rate().is_some_and(|r| r > 0.0))
+                })
                 .unwrap_or(false)
         });
         if scored_all {

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -1237,7 +1237,8 @@ where
             .filter_map(|peer| {
                 let observation = self.graph.edge(me, &peer);
                 if let Some(info) = observation {
-                    if info.score() >= minimum_score {
+                    // An unobserved edge has no score and cannot clear any threshold.
+                    if info.score().is_some_and(|score| score >= minimum_score) {
                         Some((peer, info))
                     } else {
                         None

--- a/transport/hopr/src/path/planner.rs
+++ b/transport/hopr/src/path/planner.rs
@@ -1128,7 +1128,9 @@ mod tests {
             obs.record(EdgeWeightType::Connected(true));
             obs.record(EdgeWeightType::Immediate(Ok(std::time::Duration::from_millis(50))));
             obs.record(EdgeWeightType::Intermediate(Ok(std::time::Duration::from_millis(50))));
-            obs.record(EdgeWeightType::Balance(Some(hopr_api::graph::traits::Balance::from(1000u64))));
+            obs.record(EdgeWeightType::Balance(Some(hopr_api::graph::traits::Balance::from(
+                1000u64,
+            ))));
         });
     }
 

--- a/transport/hopr/src/path/planner.rs
+++ b/transport/hopr/src/path/planner.rs
@@ -186,7 +186,7 @@ fn capacity_factor(c: u128, reference: u128) -> f64 {
 /// derived from the per-path aggregates.  Factors are neutral (1.0) when the
 /// corresponding aggregate is unavailable to avoid penalising unprobed paths.
 /// For 0-hop routes (`hops == 0`) the capacity factor is always 1.0 — direct
-/// `me -> dest` packets use no payment channel, so `capacity_floor = None` is expected.
+/// `me -> dest` packets use no payment channel, so `fundable_tickets_floor = None` is expected.
 fn composite_weight(pwc: &PathWithMetrics, hops: usize, params: WeightingParams) -> f64 {
     let lat = pwc
         .total_latency_ms
@@ -195,7 +195,7 @@ fn composite_weight(pwc: &PathWithMetrics, hops: usize, params: WeightingParams)
     let cap = if hops == 0 {
         1.0
     } else {
-        pwc.capacity_floor
+        pwc.fundable_tickets_floor
             .map(|c| capacity_factor(c, params.capacity_reference))
             .unwrap_or(1.0)
     };
@@ -310,7 +310,7 @@ where
             total_latency_ms = ?pwm.total_latency_ms,
             min_probe_success_rate = ?pwm.min_probe_success_rate,
             min_ack_rate = ?pwm.min_ack_rate,
-            capacity_floor = ?pwm.capacity_floor,
+            fundable_tickets_floor = ?pwm.fundable_tickets_floor,
             "weighted candidate path",
         );
     }
@@ -1128,7 +1128,7 @@ mod tests {
             obs.record(EdgeWeightType::Connected(true));
             obs.record(EdgeWeightType::Immediate(Ok(std::time::Duration::from_millis(50))));
             obs.record(EdgeWeightType::Intermediate(Ok(std::time::Duration::from_millis(50))));
-            obs.record(EdgeWeightType::Capacity(Some(1000)));
+            obs.record(EdgeWeightType::Balance(Some(hopr_api::graph::traits::Balance::from(1000u64))));
         });
     }
 
@@ -1916,14 +1916,14 @@ mod tests {
         }
     }
 
-    fn make_pwm(cost: f64, latency_ms: Option<u32>, capacity_floor: Option<u128>) -> PathWithMetrics {
+    fn make_pwm(cost: f64, latency_ms: Option<u32>, fundable_tickets_floor: Option<u128>) -> PathWithMetrics {
         PathWithMetrics {
             path: vec![],
             cost,
             total_latency_ms: latency_ms,
             min_probe_success_rate: None,
             min_ack_rate: None,
-            capacity_floor,
+            fundable_tickets_floor,
         }
     }
 

--- a/transport/hopr/src/path/selector.rs
+++ b/transport/hopr/src/path/selector.rs
@@ -367,8 +367,9 @@ where
         shorter_length: std::num::NonZeroUsize,
         take: usize,
         existing: &[PathWithMetrics],
+        // The caller's snapshot, so both phases of one query cost against the same face value.
+        ticket_face_value: Option<hopr_api::graph::traits::Balance>,
     ) -> Vec<PathWithMetrics> {
-        let ticket_face_value = self.graph.ticket_face_value();
         let value_fn = MetricsValueFn {
             inner: EdgeValueFn::forward_without_self_loopback(
                 shorter_length,
@@ -474,7 +475,8 @@ where
                 && let Some(shorter) = std::num::NonZeroUsize::new(length.get() - 1)
             {
                 let remaining = self.max_paths - found.len();
-                let extended = self.compute_extended_forward_paths(&src, &dest, shorter, remaining, &found);
+                let extended =
+                    self.compute_extended_forward_paths(&src, &dest, shorter, remaining, &found, ticket_face_value);
                 tracing::debug!(
                     direction,
                     phase = 2,

--- a/transport/hopr/src/path/selector.rs
+++ b/transport/hopr/src/path/selector.rs
@@ -123,11 +123,13 @@ where
 
             // Probe rate: taking the min of immediate and intermediate guards against nodes that
             // look good on direct probes but degrade under multi-hop load.
+            // `and_then`, not `map`: a stream with no observations contributes nothing to the min
+            // rather than contributing a zero it never measured.
             let edge_probe = observed
                 .immediate_qos()
-                .map(|m| m.average_probe_rate())
+                .and_then(|m| m.average_probe_rate())
                 .into_iter()
-                .chain(observed.intermediate_qos().map(|m| m.average_probe_rate()))
+                .chain(observed.intermediate_qos().and_then(|m| m.average_probe_rate()))
                 .reduce(f64::min);
             let min_probe_success_rate = opt_min(prev.min_probe_success_rate, edge_probe);
 

--- a/transport/hopr/src/path/selector.rs
+++ b/transport/hopr/src/path/selector.rs
@@ -27,7 +27,7 @@ struct PathCostWithMetrics {
     total_latency_ms: Option<u32>,
     min_probe_success_rate: Option<f64>,
     min_ack_rate: Option<f64>,
-    capacity_floor: Option<u128>,
+    fundable_tickets_floor: Option<u128>,
 }
 
 impl PartialOrd for PathCostWithMetrics {
@@ -50,7 +50,7 @@ impl From<(PathCostWithMetrics, Vec<OffchainPublicKey>)> for PathWithMetrics {
             total_latency_ms: metrics.total_latency_ms,
             min_probe_success_rate: metrics.min_probe_success_rate,
             min_ack_rate: metrics.min_ack_rate,
-            capacity_floor: metrics.capacity_floor,
+            fundable_tickets_floor: metrics.fundable_tickets_floor,
         }
     }
 }
@@ -71,6 +71,12 @@ fn opt_min<T: PartialOrd>(a: Option<T>, b: Option<T>) -> Option<T> {
 /// available during DFS, so no extra graph lookups are needed.
 struct MetricsValueFn<W: EdgeObservableRead> {
     inner: EdgeValueFn<f64, W>,
+    /// Face value used to express each edge's balance as a count of single-hop tickets.
+    ///
+    /// Read once per query rather than stored on any edge: deriving a count at query time is
+    /// safe, whereas deriving it at edge-update time is what made a price change stale the
+    /// whole graph.
+    ticket_face_value: Option<hopr_api::graph::traits::ChannelBalance>,
 }
 
 impl<W> ValueFn for MetricsValueFn<W>
@@ -86,7 +92,7 @@ where
             total_latency_ms: Some(0),
             min_probe_success_rate: None,
             min_ack_rate: None,
-            capacity_floor: None,
+            fundable_tickets_floor: None,
         }
     }
 
@@ -96,12 +102,13 @@ where
             total_latency_ms: None,
             min_probe_success_rate: None,
             min_ack_rate: None,
-            capacity_floor: None,
+            fundable_tickets_floor: None,
         })
     }
 
     fn into_value_fn(self) -> BasicValueFn<Self::Value, Self::Weight> {
         let inner = self.inner.into_value_fn();
+        let ticket_face_value = self.ticket_face_value;
         Arc::new(move |prev: PathCostWithMetrics, observed: &W, idx: usize| {
             let cost = inner(prev.cost, observed, idx);
 
@@ -127,15 +134,30 @@ where
             let edge_ack = observed.immediate_qos().and_then(|m| m.ack_rate());
             let min_ack_rate = opt_min(prev.min_ack_rate, edge_ack);
 
-            let edge_cap = observed.intermediate_qos().and_then(|m| m.capacity());
-            let capacity_floor = opt_min(prev.capacity_floor, edge_cap);
+            // Expressed in single-hop tickets, not base units: the weighting factor below is a
+            // log ratio, and a base-unit balance would compress every realistic channel into a
+            // sliver of its output range.
+            let edge_tickets = observed.intermediate_qos().and_then(|m| m.balance()).map(|balance| {
+                let face_value = ticket_face_value.unwrap_or_else(hopr_api::graph::traits::ChannelBalance::one);
+                let tickets = if face_value.is_zero() {
+                    hopr_api::graph::traits::ChannelBalance::zero()
+                } else {
+                    balance / face_value
+                };
+                if tickets > hopr_api::graph::traits::ChannelBalance::from(u128::MAX) {
+                    u128::MAX
+                } else {
+                    tickets.low_u128()
+                }
+            });
+            let fundable_tickets_floor = opt_min(prev.fundable_tickets_floor, edge_tickets);
 
             PathCostWithMetrics {
                 cost,
                 total_latency_ms,
                 min_probe_success_rate,
                 min_ack_rate,
-                capacity_floor,
+                fundable_tickets_floor,
             }
         })
     }
@@ -153,7 +175,7 @@ where
 ///
 /// A path is "fully measured" — and therefore preferred over unmeasured alternatives —
 /// when `total_latency_ms` is known AND either `hops == 0` (direct path, no channel
-/// expected) OR `capacity_floor` is also known.  This prevents 0-hop direct paths from
+/// expected) OR `fundable_tickets_floor` is also known.  This prevents 0-hop direct paths from
 /// being demoted simply because they carry no channel-capacity data.
 pub fn prune_for_consistency(candidates: Vec<PathWithMetrics>, floor: usize, hops: usize) -> Vec<PathWithMetrics> {
     // floor == 0 means "no pruning" — caller opts out entirely.
@@ -162,7 +184,7 @@ pub fn prune_for_consistency(candidates: Vec<PathWithMetrics>, floor: usize, hop
     }
 
     let fully_measured =
-        |p: &PathWithMetrics| p.total_latency_ms.is_some() && (hops == 0 || p.capacity_floor.is_some());
+        |p: &PathWithMetrics| p.total_latency_ms.is_some() && (hops == 0 || p.fundable_tickets_floor.is_some());
 
     let (mut populated, unpopulated): (Vec<_>, Vec<_>) = candidates.into_iter().partition(|p| fully_measured(p));
 
@@ -336,8 +358,15 @@ where
         take: usize,
         existing: &[PathWithMetrics],
     ) -> Vec<PathWithMetrics> {
+        let ticket_face_value = self.graph.ticket_face_value();
         let value_fn = MetricsValueFn {
-            inner: EdgeValueFn::forward_without_self_loopback(self.edge_penalty, self.min_ack_rate),
+            inner: EdgeValueFn::forward_without_self_loopback(
+                shorter_length,
+                self.edge_penalty,
+                self.min_ack_rate,
+                ticket_face_value,
+            ),
+            ticket_face_value,
         };
         let raw = self
             .graph
@@ -413,7 +442,13 @@ where
                 length,
                 self.max_paths,
                 MetricsValueFn {
-                    inner: EdgeValueFn::forward(length, self.edge_penalty, self.min_ack_rate),
+                    inner: EdgeValueFn::forward(
+                        length,
+                        self.edge_penalty,
+                        self.min_ack_rate,
+                        self.graph.ticket_face_value(),
+                    ),
+                    ticket_face_value: self.graph.ticket_face_value(),
                 },
             );
             tracing::debug!(
@@ -448,7 +483,13 @@ where
                 length,
                 self.max_paths,
                 MetricsValueFn {
-                    inner: EdgeValueFn::returning(length, self.edge_penalty, self.min_ack_rate),
+                    inner: EdgeValueFn::returning(
+                        length,
+                        self.edge_penalty,
+                        self.min_ack_rate,
+                        self.graph.ticket_face_value(),
+                    ),
+                    ticket_face_value: self.graph.ticket_face_value(),
                 },
             );
             tracing::debug!(direction, count = found.len(), "[return] candidates");
@@ -533,7 +574,9 @@ mod tests {
             obs.record(EdgeWeightType::Connected(true));
             obs.record(EdgeWeightType::Immediate(Ok(Duration::from_millis(50))));
             obs.record(EdgeWeightType::Intermediate(Ok(Duration::from_millis(50))));
-            obs.record(EdgeWeightType::Capacity(Some(1000)));
+            obs.record(EdgeWeightType::Balance(Some(
+                hopr_api::graph::traits::ChannelBalance::from(1000u64),
+            )));
         });
     }
 
@@ -977,18 +1020,18 @@ mod tests {
             total_latency_ms: latency_ms,
             min_probe_success_rate: None,
             min_ack_rate: None,
-            capacity_floor: None,
+            fundable_tickets_floor: None,
         }
     }
 
-    fn make_path_with_capacity(latency_ms: Option<u32>, capacity_floor: Option<u128>) -> PathWithMetrics {
+    fn make_path_with_tickets(latency_ms: Option<u32>, fundable_tickets_floor: Option<u128>) -> PathWithMetrics {
         PathWithMetrics {
             path: vec![],
             cost: 1.0,
             total_latency_ms: latency_ms,
             min_probe_success_rate: None,
             min_ack_rate: None,
-            capacity_floor,
+            fundable_tickets_floor,
         }
     }
 
@@ -1069,7 +1112,7 @@ mod tests {
     fn prune_drops_high_latency_first() {
         // 30 paths with strictly increasing latency, floor=8 → keep lowest 8
         let candidates: Vec<_> = (0..30u32)
-            .map(|i| make_path_with_capacity(Some(i * 10), Some(1_000_000)))
+            .map(|i| make_path_with_tickets(Some(i * 10), Some(1_000_000)))
             .collect();
         let result = prune_for_consistency(candidates, 8, 1);
         assert_eq!(result.len(), 8);
@@ -1084,9 +1127,9 @@ mod tests {
         // total=9 > floor=8: all 3 populated are kept (populated always preferred),
         // then 5 unpopulated fill the remaining slots.
         let mut candidates: Vec<_> = vec![
-            make_path_with_capacity(Some(10), Some(1_000)),
-            make_path_with_capacity(Some(30), Some(1_000)),
-            make_path_with_capacity(Some(20), Some(1_000)),
+            make_path_with_tickets(Some(10), Some(1_000)),
+            make_path_with_tickets(Some(30), Some(1_000)),
+            make_path_with_tickets(Some(20), Some(1_000)),
         ];
         candidates.extend((0..6).map(|_| make_path_with_latency(None)));
         let result = prune_for_consistency(candidates, 8, 1);
@@ -1113,8 +1156,8 @@ mod tests {
         // Old formula: target_populated = 8.saturating_sub(10) = 0 → both populated dropped.
         // Correct: keep up to 8 populated (only 2 exist), fill 6 remaining with unpopulated.
         let mut candidates: Vec<_> = vec![
-            make_path_with_capacity(Some(10), Some(1_000)),
-            make_path_with_capacity(Some(20), Some(1_000)),
+            make_path_with_tickets(Some(10), Some(1_000)),
+            make_path_with_tickets(Some(20), Some(1_000)),
         ];
         candidates.extend((0..10).map(|_| make_path_with_latency(None)));
         let result = prune_for_consistency(candidates, 8, 1);
@@ -1128,7 +1171,7 @@ mod tests {
     #[test]
     fn prune_exact_floor_is_unchanged() {
         let candidates: Vec<_> = (0..8)
-            .map(|i| make_path_with_capacity(Some(i * 10), Some(1_000)))
+            .map(|i| make_path_with_tickets(Some(i * 10), Some(1_000)))
             .collect();
         let result = prune_for_consistency(candidates, 8, 1);
         assert_eq!(result.len(), 8);
@@ -1136,10 +1179,10 @@ mod tests {
 
     #[test]
     fn prune_0_hop_with_measured_latency_and_no_capacity_is_populated() {
-        // 0-hop: capacity_floor = None is expected; path should be treated as "fully measured"
+        // 0-hop: fundable_tickets_floor = None is expected; path should be treated as "fully measured"
         // if latency is known.
         let mut candidates: Vec<_> = vec![
-            make_path_with_capacity(Some(50), None), // 0-hop: no capacity, latency known
+            make_path_with_tickets(Some(50), None), // 0-hop: no capacity, latency known
         ];
         candidates.extend((0..10).map(|_| make_path_with_latency(None)));
         let result = prune_for_consistency(candidates, 8, 0);
@@ -1150,27 +1193,27 @@ mod tests {
     }
 
     #[test]
-    fn prune_multi_hop_without_capacity_floor_is_unpopulated() {
+    fn prune_multi_hop_without_fundable_tickets_floor_is_unpopulated() {
         // A 1-hop path with measured latency but NO capacity is unmeasured (unpopulated).
         // It should be demoted below paths that have both latency and capacity.
         let candidates: Vec<_> = vec![
-            make_path_with_capacity(Some(50), Some(1_000)), // fully measured
-            make_path_with_capacity(Some(50), Some(1_000)), // fully measured
-            make_path_with_capacity(Some(50), Some(1_000)), // fully measured
-            make_path_with_capacity(Some(50), Some(1_000)), // fully measured
-            make_path_with_capacity(Some(50), Some(1_000)), // fully measured
-            make_path_with_capacity(Some(50), Some(1_000)), // fully measured
-            make_path_with_capacity(Some(50), Some(1_000)), // fully measured
-            make_path_with_capacity(Some(50), Some(1_000)), // fully measured
-            make_path_with_capacity(Some(40), None),        // missing capacity → unpopulated
+            make_path_with_tickets(Some(50), Some(1_000)), // fully measured
+            make_path_with_tickets(Some(50), Some(1_000)), // fully measured
+            make_path_with_tickets(Some(50), Some(1_000)), // fully measured
+            make_path_with_tickets(Some(50), Some(1_000)), // fully measured
+            make_path_with_tickets(Some(50), Some(1_000)), // fully measured
+            make_path_with_tickets(Some(50), Some(1_000)), // fully measured
+            make_path_with_tickets(Some(50), Some(1_000)), // fully measured
+            make_path_with_tickets(Some(50), Some(1_000)), // fully measured
+            make_path_with_tickets(Some(40), None),        // missing capacity → unpopulated
         ];
         let result = prune_for_consistency(candidates, 8, 1);
         assert_eq!(result.len(), 8);
         // The path with missing capacity should not survive when all 8 slots are filled
         // by fully measured paths.
-        let has_missing_cap = result.iter().any(|p| p.capacity_floor.is_none());
+        let has_missing_balance = result.iter().any(|p| p.fundable_tickets_floor.is_none());
         assert!(
-            !has_missing_cap,
+            !has_missing_balance,
             "path without capacity floor must be pruned when fully-measured paths fill the floor"
         );
     }
@@ -1179,9 +1222,9 @@ mod tests {
     fn prune_for_consistency_floor_zero_returns_all() {
         // floor == 0 must be treated as "no pruning" — all candidates survive unchanged.
         let candidates = vec![
-            make_path_with_capacity(Some(10), Some(1_000)),
-            make_path_with_capacity(Some(20), None),
-            make_path_with_capacity(None, None),
+            make_path_with_tickets(Some(10), Some(1_000)),
+            make_path_with_tickets(Some(20), None),
+            make_path_with_tickets(None, None),
         ];
         let result = prune_for_consistency(candidates, 0, 1);
         assert_eq!(result.len(), 3, "floor=0 must return all candidates");
@@ -1206,7 +1249,9 @@ mod tests {
             graph.upsert_edge(src, dst, |obs| {
                 obs.record(EdgeWeightType::Connected(true));
                 obs.record(EdgeWeightType::Immediate(Ok(Duration::from_millis(lat_ms))));
-                obs.record(EdgeWeightType::Capacity(Some(1000)));
+                obs.record(EdgeWeightType::Balance(Some(
+                    hopr_api::graph::traits::ChannelBalance::from(1000u64),
+                )));
             });
         };
 
@@ -1235,7 +1280,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn path_metrics_capacity_floor_is_min() -> anyhow::Result<()> {
+    async fn path_metrics_fundable_tickets_floor_is_min() -> anyhow::Result<()> {
         let me = pubkey(&SECRET_0);
         let hop = pubkey(&SECRET_1);
         let dest = pubkey(&SECRET_2);
@@ -1246,12 +1291,16 @@ mod tests {
         graph.upsert_edge(&me, &hop, |obs| {
             obs.record(EdgeWeightType::Connected(true));
             obs.record(EdgeWeightType::Intermediate(Ok(Duration::from_millis(50))));
-            obs.record(EdgeWeightType::Capacity(Some(500)));
+            obs.record(EdgeWeightType::Balance(Some(
+                hopr_api::graph::traits::ChannelBalance::from(500u64),
+            )));
         });
         graph.upsert_edge(&hop, &dest, |obs| {
             obs.record(EdgeWeightType::Connected(true));
             obs.record(EdgeWeightType::Intermediate(Ok(Duration::from_millis(50))));
-            obs.record(EdgeWeightType::Capacity(Some(200)));
+            obs.record(EdgeWeightType::Balance(Some(
+                hopr_api::graph::traits::ChannelBalance::from(200u64),
+            )));
         });
         graph.add_edge(&me, &hop).unwrap();
         graph.add_edge(&hop, &dest).unwrap();
@@ -1260,15 +1309,15 @@ mod tests {
         let paths = selector.select_path(me, dest, 1).context("1-hop path")?;
         assert!(!paths.is_empty());
         assert_eq!(
-            paths[0].capacity_floor,
+            paths[0].fundable_tickets_floor,
             Some(200),
             "floor must be the smaller of 500 and 200"
         );
         Ok(())
     }
 
-    // NOTE: a test for capacity_floor=None is omitted intentionally.
-    // The forward cost function requires intermediate capacity on all non-last edges, so
+    // NOTE: a test for fundable_tickets_floor=None is omitted intentionally.
+    // The forward cost function requires a funding balance on all non-last edges, so
     // every path the selector returns has capacity data on at least one edge, making
-    // capacity_floor always Some for reachable paths.
+    // fundable_tickets_floor always Some for reachable paths.
 }

--- a/transport/hopr/src/path/selector.rs
+++ b/transport/hopr/src/path/selector.rs
@@ -76,7 +76,7 @@ struct MetricsValueFn<W: EdgeObservableRead> {
     /// Read once per query rather than stored on any edge: deriving a count at query time is
     /// safe, whereas deriving it at edge-update time is what made a price change stale the
     /// whole graph.
-    ticket_face_value: Option<hopr_api::graph::traits::ChannelBalance>,
+    ticket_face_value: Option<hopr_api::graph::traits::Balance>,
 }
 
 impl<W> ValueFn for MetricsValueFn<W>
@@ -138,13 +138,13 @@ where
             // log ratio, and a base-unit balance would compress every realistic channel into a
             // sliver of its output range.
             let edge_tickets = observed.intermediate_qos().and_then(|m| m.balance()).map(|balance| {
-                let face_value = ticket_face_value.unwrap_or_else(hopr_api::graph::traits::ChannelBalance::one);
+                let face_value = ticket_face_value.unwrap_or_else(hopr_api::graph::traits::Balance::one);
                 let tickets = if face_value.is_zero() {
-                    hopr_api::graph::traits::ChannelBalance::zero()
+                    hopr_api::graph::traits::Balance::zero()
                 } else {
                     balance / face_value
                 };
-                if tickets > hopr_api::graph::traits::ChannelBalance::from(u128::MAX) {
+                if tickets > hopr_api::graph::traits::Balance::from(u128::MAX) {
                     u128::MAX
                 } else {
                     tickets.low_u128()
@@ -574,9 +574,9 @@ mod tests {
             obs.record(EdgeWeightType::Connected(true));
             obs.record(EdgeWeightType::Immediate(Ok(Duration::from_millis(50))));
             obs.record(EdgeWeightType::Intermediate(Ok(Duration::from_millis(50))));
-            obs.record(EdgeWeightType::Balance(Some(
-                hopr_api::graph::traits::ChannelBalance::from(1000u64),
-            )));
+            obs.record(EdgeWeightType::Balance(Some(hopr_api::graph::traits::Balance::from(
+                1000u64,
+            ))));
         });
     }
 
@@ -1249,9 +1249,9 @@ mod tests {
             graph.upsert_edge(src, dst, |obs| {
                 obs.record(EdgeWeightType::Connected(true));
                 obs.record(EdgeWeightType::Immediate(Ok(Duration::from_millis(lat_ms))));
-                obs.record(EdgeWeightType::Balance(Some(
-                    hopr_api::graph::traits::ChannelBalance::from(1000u64),
-                )));
+                obs.record(EdgeWeightType::Balance(Some(hopr_api::graph::traits::Balance::from(
+                    1000u64,
+                ))));
             });
         };
 
@@ -1291,16 +1291,16 @@ mod tests {
         graph.upsert_edge(&me, &hop, |obs| {
             obs.record(EdgeWeightType::Connected(true));
             obs.record(EdgeWeightType::Intermediate(Ok(Duration::from_millis(50))));
-            obs.record(EdgeWeightType::Balance(Some(
-                hopr_api::graph::traits::ChannelBalance::from(500u64),
-            )));
+            obs.record(EdgeWeightType::Balance(Some(hopr_api::graph::traits::Balance::from(
+                500u64,
+            ))));
         });
         graph.upsert_edge(&hop, &dest, |obs| {
             obs.record(EdgeWeightType::Connected(true));
             obs.record(EdgeWeightType::Intermediate(Ok(Duration::from_millis(50))));
-            obs.record(EdgeWeightType::Balance(Some(
-                hopr_api::graph::traits::ChannelBalance::from(200u64),
-            )));
+            obs.record(EdgeWeightType::Balance(Some(hopr_api::graph::traits::Balance::from(
+                200u64,
+            ))));
         });
         graph.add_edge(&me, &hop).unwrap();
         graph.add_edge(&hop, &dest).unwrap();

--- a/transport/hopr/src/path/selector.rs
+++ b/transport/hopr/src/path/selector.rs
@@ -139,19 +139,27 @@ where
             // Expressed in single-hop tickets, not base units: the weighting factor below is a
             // log ratio, and a base-unit balance would compress every realistic channel into a
             // sliver of its output range.
-            let edge_tickets = observed.intermediate_qos().and_then(|m| m.balance()).map(|balance| {
-                let face_value = ticket_face_value.unwrap_or_else(hopr_api::graph::traits::Balance::one);
-                let tickets = if face_value.is_zero() {
-                    hopr_api::graph::traits::Balance::zero()
-                } else {
-                    balance / face_value
-                };
-                if tickets > hopr_api::graph::traits::Balance::from(u128::MAX) {
-                    u128::MAX
-                } else {
-                    tickets.low_u128()
-                }
-            });
+            //
+            // `zip`, not a fallback: an absent face value means the price is unknown, not that it
+            // is one. Dividing a base-unit balance by `1` yields a ticket count that saturates to
+            // `u128::MAX` and reads downstream as unlimited capacity — the opposite of what not
+            // knowing should imply. Contribute nothing to the floor until pricing arrives.
+            let edge_tickets = observed
+                .intermediate_qos()
+                .and_then(|m| m.balance())
+                .zip(ticket_face_value)
+                .map(|(balance, face_value)| {
+                    let tickets = if face_value.is_zero() {
+                        hopr_api::graph::traits::Balance::zero()
+                    } else {
+                        balance / face_value
+                    };
+                    if tickets > hopr_api::graph::traits::Balance::from(u128::MAX) {
+                        u128::MAX
+                    } else {
+                        tickets.low_u128()
+                    }
+                });
             let fundable_tickets_floor = opt_min(prev.fundable_tickets_floor, edge_tickets);
 
             PathCostWithMetrics {
@@ -435,6 +443,11 @@ where
         let length = std::num::NonZeroUsize::new(hops + 1)
             .expect("can never fail, it is physically at least 1 after the addition");
 
+        // One read for the whole query. A concurrent `set_ticket_face_value` between two reads
+        // would let the traversal cost and the fundable-ticket floor come from different snapshots
+        // of the same graph, so `composite_weight` would rank a candidate against itself.
+        let ticket_face_value = self.graph.ticket_face_value();
+
         let paths = if src == self.me {
             // Phase 1: search for full-length forward paths to dest.
             let mut found = compute_paths(
@@ -444,13 +457,8 @@ where
                 length,
                 self.max_paths,
                 MetricsValueFn {
-                    inner: EdgeValueFn::forward(
-                        length,
-                        self.edge_penalty,
-                        self.min_ack_rate,
-                        self.graph.ticket_face_value(),
-                    ),
-                    ticket_face_value: self.graph.ticket_face_value(),
+                    inner: EdgeValueFn::forward(length, self.edge_penalty, self.min_ack_rate, ticket_face_value),
+                    ticket_face_value,
                 },
             );
             tracing::debug!(
@@ -485,13 +493,8 @@ where
                 length,
                 self.max_paths,
                 MetricsValueFn {
-                    inner: EdgeValueFn::returning(
-                        length,
-                        self.edge_penalty,
-                        self.min_ack_rate,
-                        self.graph.ticket_face_value(),
-                    ),
-                    ticket_face_value: self.graph.ticket_face_value(),
+                    inner: EdgeValueFn::returning(length, self.edge_penalty, self.min_ack_rate, ticket_face_value),
+                    ticket_face_value,
                 },
             );
             tracing::debug!(direction, count = found.len(), "[return] candidates");
@@ -529,7 +532,7 @@ mod tests {
     use hex_literal::hex;
     use hopr_api::{
         graph::{
-            NetworkGraphWrite,
+            NetworkGraphUpdate, NetworkGraphWrite,
             traits::{EdgeObservableWrite, EdgeWeightType},
         },
         types::{
@@ -1289,6 +1292,11 @@ mod tests {
         let graph = ChannelGraph::new(me);
         graph.add_node(hop);
         graph.add_node(dest);
+
+        // Stated, not assumed. A face value of one makes the ticket count equal the balance, which
+        // is what keeps the numbers below readable — but it has to be pushed, because without a
+        // price the floor is now `None` rather than silently dividing by one.
+        graph.set_ticket_face_value(hopr_api::graph::traits::Balance::one());
 
         graph.upsert_edge(&me, &hop, |obs| {
             obs.record(EdgeWeightType::Connected(true));

--- a/transport/hopr/src/path/selector.rs
+++ b/transport/hopr/src/path/selector.rs
@@ -1046,7 +1046,7 @@ mod tests {
             total_latency_ms: Some(latency_ms),
             min_probe_success_rate: None,
             min_ack_rate: None,
-            capacity_floor: Some(1000),
+            fundable_tickets_floor: Some(1000),
         }
     }
 

--- a/transport/hopr/src/path/traits.rs
+++ b/transport/hopr/src/path/traits.rs
@@ -26,9 +26,12 @@ pub struct PathWithMetrics {
     /// Worst per-edge acknowledgment rate along the path.
     /// `None` if no edge has sent any messages yet.
     pub min_ack_rate: Option<f64>,
-    /// Smallest known channel capacity along the path.
-    /// `None` if no edge carries channel-capacity data.
-    pub capacity_floor: Option<u128>,
+    /// Smallest number of single-hop tickets any edge along the path can still fund.
+    ///
+    /// Derived per query from each edge's balance and the current ticket face value — never stored
+    /// on an edge, which would stale the graph whenever the price moves.
+    /// `None` if no edge carries balance data.
+    pub fundable_tickets_floor: Option<u128>,
 }
 
 /// Selects multi-hop paths through the network.

--- a/transport/probe/src/probe.rs
+++ b/transport/probe/src/probe.rs
@@ -488,14 +488,10 @@ mod tests {
             None
         }
 
-        fn average_probe_rate(&self) -> f64 {
-            1.0
-        }
-
-        // `has_observations` must agree with `score`: both report a measured, perfect link so the
-        // probe tests see the same edge they did before the trait gained the presence distinction.
-        fn has_observations(&self) -> bool {
-            true
+        // A measured, perfect link — so the probe tests see the same edge they did before the
+        // trait gained the presence distinction. `has_observations` derives from this.
+        fn average_probe_rate(&self) -> Option<f64> {
+            Some(1.0)
         }
 
         fn score(&self) -> Option<f64> {
@@ -504,8 +500,8 @@ mod tests {
     }
 
     impl EdgeNetworkObservableRead for TestEdgeTransportObservations {
-        fn is_connected(&self) -> bool {
-            true
+        fn is_connected(&self) -> Option<bool> {
+            Some(true)
         }
     }
 

--- a/transport/probe/src/probe.rs
+++ b/transport/probe/src/probe.rs
@@ -492,8 +492,14 @@ mod tests {
             1.0
         }
 
-        fn score(&self) -> f64 {
-            1.0
+        // `has_observations` must agree with `score`: both report a measured, perfect link so the
+        // probe tests see the same edge they did before the trait gained the presence distinction.
+        fn has_observations(&self) -> bool {
+            true
+        }
+
+        fn score(&self) -> Option<f64> {
+            Some(1.0)
         }
     }
 
@@ -504,7 +510,7 @@ mod tests {
     }
 
     impl EdgeProtocolObservable for TestEdgeTransportObservations {
-        fn capacity(&self) -> Option<u128> {
+        fn balance(&self) -> Option<hopr_api::graph::traits::Balance> {
             None
         }
     }
@@ -540,8 +546,8 @@ mod tests {
             None
         }
 
-        fn score(&self) -> f64 {
-            1.0
+        fn score(&self) -> Option<f64> {
+            Some(1.0)
         }
     }
 
@@ -583,6 +589,8 @@ mod tests {
         {
             unimplemented!()
         }
+
+        fn set_ticket_face_value(&self, _ticket_face_value: hopr_api::graph::traits::Balance) {}
     }
 
     #[async_trait]
@@ -592,6 +600,10 @@ mod tests {
 
         fn identity(&self) -> &OffchainPublicKey {
             &self.me
+        }
+
+        fn ticket_face_value(&self) -> Option<hopr_api::graph::traits::Balance> {
+            None
         }
 
         fn node_count(&self) -> usize {


### PR DESCRIPTION
The graph edge carried a *ticket count*, derived by dividing the channel balance by a ticket's face value — but face value comes from the ticket price and winning probability, both of which change at runtime, so every price change silently staled that count on every edge in the graph, and correcting it would have meant re-deriving the whole thing. The same expression truncated a `U256` on-chain balance through `low_u128` and fell back to `u128::MAX` when the divisor was zero, which reads downstream as infinite capacity.

Edges now carry the balance verbatim as a `U256`, changing only when the chain says so, while the face value is recomputed whenever the price or probability moves and pushed into the graph once for selection to read back. `capacity_reference` is rescaled to base currency units to match, since the old value was in units of the ticket count and against a base-unit balance would have silently neutralised the capacity term; its dynamic range is genuinely narrower than before, which is documented as a follow-up rather than quietly reweighted here.

## **Stacked on `release/4.0`, with the whole library chain beneath it. Expected red: the git-dependency and publish-dry-run gates clear only on release.**
