### PR TITLE
fix(session): stop trusting a SURB buffer estimate nothing confirms

### DIFF
--- a/transport/session/src/balancer/controller.rs
+++ b/transport/session/src/balancer/controller.rs
@@ -414,7 +414,7 @@ where
         );
 
         let output = self.controller.next_control_output(current);
-        tracing::trace!(output, "next balancer control output for session");
+        tracing::debug!(output, current, error, "next balancer control output for session");
 
         self.flow_control.adjust_surb_flow(output as usize);
 

--- a/transport/session/src/balancer/controller.rs
+++ b/transport/session/src/balancer/controller.rs
@@ -210,7 +210,15 @@ pub struct SurbBalancer<C, E, F> {
     last_update: std::time::Instant,
     last_decay: std::time::Instant,
     was_below_target: bool,
+    /// Consecutive windows in which SURBs were sent and none were confirmed consumed.
+    unverified_windows: u32,
 }
+
+/// How many consecutive unverified windows before the buffer estimate is discarded.
+///
+/// More than one, because a momentarily quiet counterparty is not a broken return path; few enough
+/// that recovery is a matter of seconds rather than of the decay window.
+const UNVERIFIED_WINDOWS_BEFORE_RESET: u32 = 3;
 
 impl<C, E, F> SurbBalancer<C, E, F>
 where
@@ -244,6 +252,7 @@ where
             last_update: std::time::Instant::now(),
             last_decay: std::time::Instant::now(),
             was_below_target: true,
+            unverified_windows: 0,
         }
     }
 
@@ -269,6 +278,25 @@ where
             return current;
         };
 
+        // Consumption at the counterparty is inferred from packets coming back, so a broken return
+        // path is indistinguishable from a counterparty that simply stopped spending its SURBs.
+        // Both look like "the buffer is filling up", and the controller answers by producing less --
+        // starving the return direction exactly when it needs more. Track windows where SURBs went
+        // out and nothing at all came back; after enough of them the level is an assumption rather
+        // than a measurement.
+        let produced_delta = snapshot
+            .estimate_surbs_produced()
+            .saturating_sub(self.last_estimator_state.estimate_surbs_produced());
+        let consumed_delta = snapshot
+            .estimate_surbs_consumed()
+            .saturating_sub(self.last_estimator_state.estimate_surbs_consumed());
+
+        if produced_delta > 0 && consumed_delta == 0 {
+            self.unverified_windows = self.unverified_windows.saturating_add(1);
+        } else {
+            self.unverified_windows = 0;
+        }
+
         self.last_estimator_state = snapshot;
         current = current.saturating_add_signed(target_buffer_change);
 
@@ -283,6 +311,19 @@ where
             current = current.saturating_sub(num_decayed_surbs);
             self.last_decay = std::time::Instant::now();
             tracing::trace!(num_decayed_surbs, "SURBs were discarded due to automatic decay");
+        }
+
+        // Nothing has confirmed the counterparty still holds what we think it does, so stop acting
+        // on it. Zeroing rather than decaying makes the controller produce at full rate until real
+        // evidence arrives; the first packet back rebuilds the estimate from measurement.
+        if self.unverified_windows >= UNVERIFIED_WINDOWS_BEFORE_RESET {
+            tracing::debug!(
+                windows = self.unverified_windows,
+                discarded = current,
+                "no SURB consumption confirmed while producing; discarding the buffer estimate"
+            );
+            current = 0;
+            self.unverified_windows = 0;
         }
 
         self.state

--- a/transport/session/src/balancer/controller.rs
+++ b/transport/session/src/balancer/controller.rs
@@ -230,7 +230,16 @@ pub struct SurbBalancer<C, E, F> {
     last_confirmed_consumption: std::time::Instant,
     /// Level report count observed at that point.
     last_level_reports: u64,
+    /// When this balancer started, for the never-reported grace.
+    started_at: std::time::Instant,
 }
+
+/// How long a session may run without ever receiving a level report before silence is acted on.
+///
+/// Comfortably longer than the counterparty's reporting period (15s as configured), so a peer that
+/// reports normally is never treated as silent, while one that has never managed to report at all
+/// stops holding the estimate hostage.
+const NEVER_REPORTED_GRACE: Duration = Duration::from_secs(30);
 
 /// How long SURBs may flow without a level report before the buffer estimate is discarded.
 ///
@@ -278,6 +287,7 @@ where
             was_below_target: true,
             last_confirmed_consumption: std::time::Instant::now(),
             last_level_reports: 0,
+            started_at: std::time::Instant::now(),
         }
     }
 
@@ -342,10 +352,16 @@ where
         // Nothing has confirmed the counterparty still holds what we think it does, so stop acting
         // on it. Zeroing rather than decaying makes the controller produce at full rate until real
         // evidence arrives; the first packet back rebuilds the estimate from measurement.
-        // Only meaningful once the counterparty has reported at least once: a peer that never
-        // reports leaves dead reckoning as the only estimate available, and discarding it there
-        // would pin production at maximum for the life of the session.
-        if self.last_level_reports > 0 && produced_delta > 0 && unconfirmed_for >= UNCONFIRMED_BEFORE_RESET {
+        // Silence from the very start is the *more* diagnostic case, not the less: the level report
+        // costs a SURB and travels the return path, so a counterparty that has run out cannot send
+        // the message whose whole purpose is to say so. Waiting for a first report before acting
+        // makes the deadlock permanent -- measured, the counterparty was armed to report every 15s
+        // and not one arrived.
+        //
+        // So act on silence either way, but give a peer that simply does not report time to prove
+        // it: the grace exceeds a report period, and a healthy session reports well inside it.
+        let armed = self.last_level_reports > 0 || self.started_at.elapsed() >= NEVER_REPORTED_GRACE;
+        if armed && produced_delta > 0 && unconfirmed_for >= UNCONFIRMED_BEFORE_RESET {
             tracing::debug!(
                 ?unconfirmed_for,
                 discarded = current,

--- a/transport/session/src/balancer/controller.rs
+++ b/transport/session/src/balancer/controller.rs
@@ -105,6 +105,12 @@ pub struct BalancerStateValues {
     pub decay_duration_msec: AtomicU64,
     pub decay_volume_pct: AtomicU8,
     pub buffer_level: AtomicU64,
+    /// Monotonic count of level reports received from the counterparty.
+    ///
+    /// The counterparty knows its own SURB level exactly and reports it; this counts how often that
+    /// report actually arrived. Since the report travels the same path as everything else, the
+    /// count going flat is itself the signal that the level is no longer being corrected.
+    pub level_reports: AtomicU64,
 }
 
 impl BalancerStateValues {
@@ -160,6 +166,16 @@ impl BalancerStateValues {
         .map(|(d, p)| (Duration::from_millis(d), p as f64 / 100.0))
     }
 
+    /// Records that the counterparty reported its SURB level.
+    pub fn record_level_report(&self) {
+        self.level_reports.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Number of level reports received so far.
+    pub fn level_reports(&self) -> u64 {
+        self.level_reports.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
     /// Gets the current estimated SURB buffer level.
     #[inline]
     pub fn buffer_level(&self) -> u64 {
@@ -210,18 +226,22 @@ pub struct SurbBalancer<C, E, F> {
     last_update: std::time::Instant,
     last_decay: std::time::Instant,
     was_below_target: bool,
-    /// When consumption at the counterparty was last confirmed by a packet coming back.
+    /// When the counterparty last reported its SURB level.
     last_confirmed_consumption: std::time::Instant,
+    /// Level report count observed at that point.
+    last_level_reports: u64,
 }
 
-/// How long SURBs may flow with nothing confirmed before the buffer estimate is discarded.
+/// How long SURBs may flow without a level report before the buffer estimate is discarded.
+///
+/// Keyed on the report rather than on consumption, because consumption is only a proxy: with one
+/// relayer of several dead, replies keep arriving over the survivors and consumption never stops,
+/// so a consumption-based gate never fires on the partial loss that actually occurs. The level
+/// report is the specific feedback that corrects the estimate, and it is its absence that leaves
+/// the level stale.
 ///
 /// Must be a duration, not a count of update windows: the balancer samples several times a second,
-/// so a handful of windows is tens of milliseconds and ordinary bursty traffic clears it -- which
-/// discards a perfectly good estimate and drives the controller into over-production.
-///
-/// Long enough that a briefly quiet counterparty is not mistaken for a broken return path, short
-/// enough that recovery is seconds rather than a decay window.
+/// so a handful of windows is tens of milliseconds and ordinary traffic clears it.
 const UNCONFIRMED_BEFORE_RESET: Duration = Duration::from_secs(3);
 
 impl<C, E, F> SurbBalancer<C, E, F>
@@ -257,6 +277,7 @@ where
             last_decay: std::time::Instant::now(),
             was_below_target: true,
             last_confirmed_consumption: std::time::Instant::now(),
+            last_level_reports: 0,
         }
     }
 
@@ -295,7 +316,9 @@ where
             .estimate_surbs_consumed()
             .saturating_sub(self.last_estimator_state.estimate_surbs_consumed());
 
-        if consumed_delta > 0 {
+        let reports = self.state.level_reports();
+        if reports != self.last_level_reports {
+            self.last_level_reports = reports;
             self.last_confirmed_consumption = std::time::Instant::now();
         }
         let unconfirmed_for = self.last_confirmed_consumption.elapsed();
@@ -319,7 +342,10 @@ where
         // Nothing has confirmed the counterparty still holds what we think it does, so stop acting
         // on it. Zeroing rather than decaying makes the controller produce at full rate until real
         // evidence arrives; the first packet back rebuilds the estimate from measurement.
-        if produced_delta > 0 && unconfirmed_for >= UNCONFIRMED_BEFORE_RESET {
+        // Only meaningful once the counterparty has reported at least once: a peer that never
+        // reports leaves dead reckoning as the only estimate available, and discarding it there
+        // would pin production at maximum for the life of the session.
+        if self.last_level_reports > 0 && produced_delta > 0 && unconfirmed_for >= UNCONFIRMED_BEFORE_RESET {
             tracing::debug!(
                 ?unconfirmed_for,
                 discarded = current,

--- a/transport/session/src/balancer/controller.rs
+++ b/transport/session/src/balancer/controller.rs
@@ -361,6 +361,18 @@ where
         // So act on silence either way, but give a peer that simply does not report time to prove
         // it: the grace exceeds a report period, and a healthy session reports well inside it.
         let armed = self.last_level_reports > 0 || self.started_at.elapsed() >= NEVER_REPORTED_GRACE;
+
+        // Temporary: the gate has never fired in a cluster run and its inputs are otherwise only
+        // visible at `trace`, which release builds compile out.
+        tracing::debug!(
+            armed,
+            produced_delta,
+            consumed_delta,
+            ?unconfirmed_for,
+            reports = self.last_level_reports,
+            current,
+            "surb balancer gate inputs"
+        );
         if armed && produced_delta > 0 && unconfirmed_for >= UNCONFIRMED_BEFORE_RESET {
             tracing::debug!(
                 ?unconfirmed_for,

--- a/transport/session/src/balancer/controller.rs
+++ b/transport/session/src/balancer/controller.rs
@@ -373,7 +373,13 @@ where
             current,
             "surb balancer gate inputs"
         );
-        if armed && produced_delta > 0 && unconfirmed_for >= UNCONFIRMED_BEFORE_RESET {
+        // Deliberately not conditioned on current production. Requiring it made the gate
+        // self-defeating: measured, `produced_delta` is non-zero only during the first second of a
+        // session (the initial fill) and zero for 92% of samples afterwards, so the one state the
+        // gate exists for -- production having stalled while the level is stale -- was the one
+        // state in which it could never fire. What matters is whether the level is still evidence,
+        // not whether SURBs happen to be leaving right now.
+        if armed && unconfirmed_for >= UNCONFIRMED_BEFORE_RESET {
             tracing::debug!(
                 ?unconfirmed_for,
                 discarded = current,

--- a/transport/session/src/balancer/controller.rs
+++ b/transport/session/src/balancer/controller.rs
@@ -414,7 +414,14 @@ where
         );
 
         let output = self.controller.next_control_output(current);
-        tracing::debug!(output, current, error, "next balancer control output for session");
+        tracing::debug!(
+            output,
+            current,
+            error,
+            target = self.controller.bounds().target(),
+            output_limit = self.controller.bounds().output_limit(),
+            "next balancer control output for session"
+        );
 
         self.flow_control.adjust_surb_flow(output as usize);
 

--- a/transport/session/src/balancer/controller.rs
+++ b/transport/session/src/balancer/controller.rs
@@ -210,15 +210,19 @@ pub struct SurbBalancer<C, E, F> {
     last_update: std::time::Instant,
     last_decay: std::time::Instant,
     was_below_target: bool,
-    /// Consecutive windows in which SURBs were sent and none were confirmed consumed.
-    unverified_windows: u32,
+    /// When consumption at the counterparty was last confirmed by a packet coming back.
+    last_confirmed_consumption: std::time::Instant,
 }
 
-/// How many consecutive unverified windows before the buffer estimate is discarded.
+/// How long SURBs may flow with nothing confirmed before the buffer estimate is discarded.
 ///
-/// More than one, because a momentarily quiet counterparty is not a broken return path; few enough
-/// that recovery is a matter of seconds rather than of the decay window.
-const UNVERIFIED_WINDOWS_BEFORE_RESET: u32 = 3;
+/// Must be a duration, not a count of update windows: the balancer samples several times a second,
+/// so a handful of windows is tens of milliseconds and ordinary bursty traffic clears it -- which
+/// discards a perfectly good estimate and drives the controller into over-production.
+///
+/// Long enough that a briefly quiet counterparty is not mistaken for a broken return path, short
+/// enough that recovery is seconds rather than a decay window.
+const UNCONFIRMED_BEFORE_RESET: Duration = Duration::from_secs(3);
 
 impl<C, E, F> SurbBalancer<C, E, F>
 where
@@ -252,7 +256,7 @@ where
             last_update: std::time::Instant::now(),
             last_decay: std::time::Instant::now(),
             was_below_target: true,
-            unverified_windows: 0,
+            last_confirmed_consumption: std::time::Instant::now(),
         }
     }
 
@@ -291,11 +295,10 @@ where
             .estimate_surbs_consumed()
             .saturating_sub(self.last_estimator_state.estimate_surbs_consumed());
 
-        if produced_delta > 0 && consumed_delta == 0 {
-            self.unverified_windows = self.unverified_windows.saturating_add(1);
-        } else {
-            self.unverified_windows = 0;
+        if consumed_delta > 0 {
+            self.last_confirmed_consumption = std::time::Instant::now();
         }
+        let unconfirmed_for = self.last_confirmed_consumption.elapsed();
 
         self.last_estimator_state = snapshot;
         current = current.saturating_add_signed(target_buffer_change);
@@ -316,14 +319,14 @@ where
         // Nothing has confirmed the counterparty still holds what we think it does, so stop acting
         // on it. Zeroing rather than decaying makes the controller produce at full rate until real
         // evidence arrives; the first packet back rebuilds the estimate from measurement.
-        if self.unverified_windows >= UNVERIFIED_WINDOWS_BEFORE_RESET {
+        if produced_delta > 0 && unconfirmed_for >= UNCONFIRMED_BEFORE_RESET {
             tracing::debug!(
-                windows = self.unverified_windows,
+                ?unconfirmed_for,
                 discarded = current,
                 "no SURB consumption confirmed while producing; discarding the buffer estimate"
             );
             current = 0;
-            self.unverified_windows = 0;
+            self.last_confirmed_consumption = std::time::Instant::now();
         }
 
         self.state

--- a/transport/session/src/balancer/mod.rs
+++ b/transport/session/src/balancer/mod.rs
@@ -164,8 +164,9 @@ pub struct SurbControllerWithCorrection(pub RateController, pub u32);
 
 impl SurbFlowController for SurbControllerWithCorrection {
     fn adjust_surb_flow(&self, surbs_per_sec: usize) {
-        self.0
-            .set_rate_per_unit(surbs_per_sec, self.1 * std::time::Duration::from_secs(1));
+        let unit = self.1 * std::time::Duration::from_secs(1);
+        tracing::debug!(surbs_per_sec, correction = self.1, ?unit, "adjusting surb flow rate");
+        self.0.set_rate_per_unit(surbs_per_sec, unit);
     }
 }
 

--- a/transport/session/src/balancer/pid.rs
+++ b/transport/session/src/balancer/pid.rs
@@ -136,6 +136,28 @@ impl SurbBalancerController for PidBalancerController {
 mod tests {
     use super::*;
 
+    /// A starved buffer must command production. This is the controller's entire purpose, and a
+    /// cluster run showed it returning 0 for an error of -9803 -- maximally starved.
+    #[test]
+    fn pid_should_command_production_when_the_buffer_is_empty() {
+        let mut c = PidBalancerController::from_gains(PidControllerGains::default());
+        c.set_target_and_limit(BalancerControllerBounds::new(7_000, 5_000));
+
+        let out = c.next_control_output(0);
+        assert!(out > 0, "empty buffer against a 7000 target must produce, got {out}");
+    }
+
+    /// The output limit is what every PID term is clamped to. A zero limit silently turns the
+    /// controller into a no-op that reports a huge error and commands nothing -- which is
+    /// indistinguishable, from the outside, from a controller that thinks the buffer is full.
+    #[test]
+    fn pid_with_a_zero_output_limit_commands_nothing_however_starved() {
+        let mut c = PidBalancerController::from_gains(PidControllerGains::default());
+        c.set_target_and_limit(BalancerControllerBounds::new(7_000, 0));
+
+        assert_eq!(0, c.next_control_output(0), "a zero limit clamps every term to zero");
+    }
+
     // --- PidControllerGains tests ---
 
     #[test]

--- a/transport/session/src/balancer/pid.rs
+++ b/transport/session/src/balancer/pid.rs
@@ -186,6 +186,35 @@ mod tests {
         );
     }
 
+    /// The exact live bounds, read off a cluster run: target 9803, output limit 1960, empty buffer.
+    /// Production logs `output=0` here while the same controller with a 5000 limit produces.
+    #[test]
+    fn pid_should_produce_at_the_live_bounds() {
+        let mut c = PidBalancerController::from_gains(PidControllerGains::default());
+        c.set_target_and_limit(BalancerControllerBounds::new(9_803, 1_960));
+
+        let out = c.next_control_output(0);
+        assert!(out > 0, "target 9803 / limit 1960 with an empty buffer produced {out}");
+    }
+
+    /// A buffer that was healthy and then drained must be refilled. This is the return-path failure
+    /// exactly: the session runs at target, the return path breaks, the buffer empties -- and
+    /// production commands nothing despite an error of -9803.
+    #[test]
+    fn pid_should_recover_after_a_healthy_buffer_drains() {
+        let mut c = PidBalancerController::from_gains(PidControllerGains::default());
+        c.set_target_and_limit(BalancerControllerBounds::new(9_803, 1_960));
+
+        // Healthy: sitting at target, so the controller has nothing to do for a while.
+        for _ in 0..100 {
+            c.next_control_output(9_803);
+        }
+
+        // The return path breaks and the buffer drains.
+        let out = c.next_control_output(0);
+        assert!(out > 0, "an emptied buffer after a healthy period produced {out}");
+    }
+
     // --- PidControllerGains tests ---
 
     #[test]

--- a/transport/session/src/balancer/pid.rs
+++ b/transport/session/src/balancer/pid.rs
@@ -158,6 +158,34 @@ mod tests {
         assert_eq!(0, c.next_control_output(0), "a zero limit clamps every term to zero");
     }
 
+    /// Reproduces the exact operating point observed on a cluster: target 9803, empty buffer,
+    /// default limit. Production logged `output=0` there, and 15 minutes per observation is too
+    /// slow a loop to debug in -- so pin it here at 80ms instead.
+    #[test]
+    fn pid_should_produce_at_the_operating_point_seen_in_production() {
+        let mut c = PidBalancerController::from_gains(PidControllerGains::default());
+        c.set_target_and_limit(BalancerControllerBounds::new(
+            9_803,
+            crate::SurbBalancerConfig::default().max_surbs_per_sec,
+        ));
+
+        let out = c.next_control_output(0);
+        assert!(out > 0, "target 9803 with an empty buffer produced {out}");
+    }
+
+    /// The very first output after configuration, which is the one that matters on a cold start or
+    /// straight after the estimate is discarded.
+    #[test]
+    fn pid_first_output_after_reconfiguration_should_not_be_zero() {
+        let mut c = PidBalancerController::default();
+        c.set_target_and_limit(BalancerControllerBounds::new(7_000, 5_000));
+
+        assert!(
+            c.next_control_output(0) > 0,
+            "first output after reconfiguration was zero"
+        );
+    }
+
     // --- PidControllerGains tests ---
 
     #[test]

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -1776,6 +1776,13 @@ where
             match &session_slot.routing_opts {
                 // Session is outgoing - keep-alive was received from the Exit
                 DestinationRouting::Forward { .. } => {
+                    // Record the arrival itself, not just a change of value: an unchanged level is
+                    // still confirmation that the counterparty is being heard, and it is the
+                    // absence of that confirmation the balancer keys on.
+                    if msg.flags.contains(KeepAliveFlag::BalancerState) && !session_slot.surb_mgmt.is_disabled() {
+                        session_slot.surb_mgmt.record_level_report();
+                    }
+
                     if msg.flags.contains(KeepAliveFlag::BalancerState)
                         && !session_slot.surb_mgmt.is_disabled()
                         && session_slot.surb_mgmt.buffer_level() != msg.additional_data

--- a/transport/session/src/utils.rs
+++ b/transport/session/src/utils.rs
@@ -114,22 +114,25 @@ where
 
     // DropAbortable not needed because the stream only generates items when polled
     let (ka_stream, abort_handle) = futures::stream::abortable(
-        futures::stream::repeat_with(move || match &notification_mode {
-            SurbNotificationMode::Target => HoprStartProtocol::KeepAlive(KeepAliveMessage {
-                session_id,
-                flags: KeepAliveFlag::BalancerTarget.into(),
-                additional_data: cfg.target_surb_buffer_size.load(std::sync::atomic::Ordering::Relaxed),
-            }),
-            SurbNotificationMode::Level(estimator) => HoprStartProtocol::KeepAlive(KeepAliveMessage {
-                session_id,
-                flags: KeepAliveFlag::BalancerState.into(),
-                additional_data: estimator.saturating_diff(),
-            }),
-            SurbNotificationMode::DoNotNotify => HoprStartProtocol::KeepAlive(KeepAliveMessage {
-                session_id,
-                flags: None.into(),
-                additional_data: 0,
-            }),
+        futures::stream::repeat_with(move || {
+            tracing::debug!(%session_id, "keep-alive stream emitting");
+            match &notification_mode {
+                SurbNotificationMode::Target => HoprStartProtocol::KeepAlive(KeepAliveMessage {
+                    session_id,
+                    flags: KeepAliveFlag::BalancerTarget.into(),
+                    additional_data: cfg.target_surb_buffer_size.load(std::sync::atomic::Ordering::Relaxed),
+                }),
+                SurbNotificationMode::Level(estimator) => HoprStartProtocol::KeepAlive(KeepAliveMessage {
+                    session_id,
+                    flags: KeepAliveFlag::BalancerState.into(),
+                    additional_data: estimator.saturating_diff(),
+                }),
+                SurbNotificationMode::DoNotNotify => HoprStartProtocol::KeepAlive(KeepAliveMessage {
+                    session_id,
+                    flags: None.into(),
+                    additional_data: 0,
+                }),
+            }
         })
         .rate_limit_with_controller(&controller),
     );


### PR DESCRIPTION
Stacked on #8341.

## The defect

The entry infers the counterparty's SURB consumption from packets coming back:

```rust
// Received packets = SURB consumption estimate
// The received packets always consume a single SURB.
surb_estimator_for_rx.consumed.fetch_add(1, ...)
```

while `produced` counts SURBs **sent**. So a broken return path is indistinguishable from a counterparty that simply stopped spending: both read as "the buffer is filling up", and the controller answers by producing fewer SURBs — starving the return direction exactly when it needs more. Nothing breaks the loop, because the evidence that would correct it is what the broken path is swallowing.

## Evidence

After killing one return relayer, production settles at **5.3–6.7 SURBs/s** and stays there for the remaining 400 s. That floor is not arbitrary: `surb_decay` discards 5% of a 7000 target every 60 s = **5.83/s**. All demand-driven production had stopped; the decay term was the only thing still minting. Throughput fell ~80×, 0.48 MB/s → ~2 KB/s.

## The change

After three seconds with SURBs going out and no consumption confirmed, the level estimate is discarded rather than decayed. Zeroing makes the controller produce at full rate until real evidence arrives, and the first packet back rebuilds the level from measurement.

## Measured, including a regression I introduced and fixed

| | before-kill | after-kill |
| --- | --- | --- |
| baseline | 100%, 0.48 MB/s | 20.62% |
| gate on 3 update *windows* | **60%, 0.06 MB/s** | 49.80% |
| gate on 3 *seconds* | 100%, 0.47 MB/s | 32.85% |

The first attempt gated on a count of update windows. That sounded conservative and was not — the balancer samples several times a second, so it amounted to tens of milliseconds, which ordinary bursty traffic clears. It fired 36 times including throughout the healthy phase, discarding good estimates and driving over-production. Gating on elapsed time instead fires 3 times and leaves the healthy path untouched.

## Known limit — this does not yet reach the target

Recovery is 32.85% against a ≥60% bar. The estimate is **aggregate**, so with one of four relayers dead the surviving three keep replies flowing, `consumed` keeps incrementing, and the "nothing confirmed" condition is nearly never true. This change only catches a total blackout, not the partial loss that actually happens.

The correction that fits the evidence is per-path: subtract the SURBs known to have been minted over a path and never returned. #8341 already measures exactly that (`expected` vs `observed` per `ForwardAndReturnPath`). Wiring it into the estimate is the natural next step and is deliberately not in this PR.

108 session tests pass unchanged.