### PR TITLE
feat(transport): act on return-path silence from the supply side only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -108,9 +108,9 @@ checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
 
 [[package]]
 name = "alloc-stdlib"
-version = "0.2.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+checksum = "0e76a019e91224d279006ff972f1e984179a6e9feb050adba6ce8274aef23195"
 dependencies = [
  "alloc-no-stdlib",
 ]
@@ -132,9 +132,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9677ab3454c237abe6307805bea17a7912b3a516b606c7b4d3d948b9fede137"
+checksum = "9867f85f660948ddbef071ae484027654c04b62c7decd5b61464a7ed1f8931a0"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -158,20 +158,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.34"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e0378e959aa6a885897522080a990e80eb317f1e9a222a604492ea50e13096"
+checksum = "e5fdcfed8f106be3df944054aaa42bc13ae103a3ac8a9f4b08d4f053e3a743f8"
 dependencies = [
  "alloy-primitives",
  "num_enum",
- "strum 0.27.2",
+ "phf",
 ]
 
 [[package]]
 name = "alloy-consensus"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0f42ee16e9eaffa4df5aa3a17b1df88dd222310d13152ab91357a2551fd054"
+checksum = "12a542fe1e6a48cfd010a9e8eba1235436de58ee0f1415e588c27d5d556e98df"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -186,7 +186,7 @@ dependencies = [
  "either",
  "k256 0.13.4",
  "once_cell",
- "rand 0.8.6",
+ "rand 0.8.7",
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
@@ -196,9 +196,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db388e804269d977d60fa7530ccfefe9184ca48d4055dad3ec7e649a29186a06"
+checksum = "05ac1559726a5e71d6dbab59cbd8ad0988c762105d2ae41ae4f3241a3166262d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -210,9 +210,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69937abc65310c6eb739e540b107688943b61f38e7dcf9fde769367d3608d657"
+checksum = "b86722084d6d07822a6c67e39ae794d437fb9de12fa4127d4f9fd93f89651121"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -228,7 +228,9 @@ dependencies = [
  "futures-util",
  "serde_json",
  "thiserror 2.0.20",
+ "tokio",
  "tracing",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -275,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip2930"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9441120fa82df73e8959ae0e4ab8ade03de2aaae61be313fbf5746277847ce25"
+checksum = "e64579d931b3f8eacc7c9ab0b220e87e9c4816e5c724ede1947b55c2f8e92ae5"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -301,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eip7928"
-version = "0.4.5"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3b12337f74cbfa451cb04dac173974814a6ff463079e1793aa09600ba8813ab"
+checksum = "3fb59cca9e58f5c624becc3cffb32772dc278f31eeae4606844a88592e8d2672"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
@@ -315,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52010e7c255f45b0ef3ca18144cbfbe0c044b055fe53f59323f3df5d95f265b1"
+checksum = "d40246adf7468b430fce87945ece8a54ef27fa760dd9f670f5162a412007bdb2"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -338,9 +340,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-ens"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88c3d803649b2023413a5b84892ed3874977dfa8b8d5481dea05488f20f6f4ef"
+checksum = "be9aa797694e7c55b007aa8f172daef76a83272cbedb8800bdc7038eed3bdb1a"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -352,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60fa6337a6af8bae818de3030448827bf55c1321c90c7d1f6f3b79257ead2a"
+checksum = "4951473e6ff25cdf82eb87b6a1a5fbb4af9c97528398a4a62fbf516198ec5028"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -380,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c36c9d7f9021601b04bfef14a4b64849f6d73116a4e91e071d7fbfe10247901"
+checksum = "6cee30dd4c2f4b23f434fdf675e7bf9681b86768141277266c6f548ef25cba0a"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-type-parser",
@@ -392,9 +394,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d7ff4d7f1503d12edda9b241904a309d6e1d5bcee3f0ffdc4d3d3f16f366b8"
+checksum = "7e5722ea29a9a85ecdba2516c58f50d71e77cd25f8ce7e9f4ee8570ddeee6df1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -407,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44ff1439d901b44f6ff840545f82d65e66830ee33fb33cae495a566d66e0ccc8"
+checksum = "e2e4d278913f00ab611f5367448a3a800fed173ab791c3cc67b7a1b0d7afd305"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -433,9 +435,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb920286c4a71fb0ff3bbb207a640a531a42fceef5b43d4a943f7d5265789876"
+checksum = "e4e52ae56d1acaa6b46e9d7015b8ae6c10f3d1c213a32ae70b17426a03ae6729"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -446,9 +448,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd2d06c4044c3ae7f9b7a70c9a7bb3bde9a08e99f4d9aa91001e17a182b562dc"
+checksum = "cdbb4a1bc03b411a3880d410ccc48d866b72d753ab1080605631890955b9caa2"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -458,7 +460,7 @@ dependencies = [
  "alloy-signer-local",
  "k256 0.13.4",
  "libc",
- "rand 0.8.6",
+ "rand 0.8.7",
  "serde_json",
  "tempfile",
  "thiserror 2.0.20",
@@ -468,15 +470,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4885c1409b6936c4898e646ef58baf6ec54edaf6d8179f79df805a7b85b7cf3e"
+checksum = "f007e257069855bdf21d27762fd3f3705a613f805c9a08309bf353503f081d71"
 dependencies = [
  "alloy-rlp",
  "bytes",
  "cfg-if",
  "const-hex",
  "derive_more",
+ "fixed-cache",
  "foldhash 0.2.0",
  "hashbrown 0.17.1",
  "indexmap 2.14.0",
@@ -485,7 +488,7 @@ dependencies = [
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rapidhash",
  "ruint",
  "rustc-hash",
@@ -496,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "329375f50202cc6b2dcc8c6b1e53b716cbbebbeea54e931befc4f3b628dfc469"
+checksum = "386124639a5c386329b9f2ef2b42969badbf7bba40422b513e3e5739c516dc34"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -537,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
+checksum = "24671b1f62edcf0f9b62994c7bf72cd621a04a4b99f5020ece1a647b40e2f103"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -548,20 +551,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
+checksum = "9d4311c03125e8a18296504560b9de3d75ecbd0dcda7f71e6cf2a196d57e6fba"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52bffef2c5714f578f267bb959b47908b95728f1f3e2073a96d928f4441c148d"
+checksum = "3dfd3ebc1756426a6a9e17979d4467632aff01f359136c50e5320ac6e32d6b8d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -582,9 +585,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64449cae1cf37c4907b10ccca1613b71809f9a1f3ad6e2b4cc14d08e2e4947f"
+checksum = "417dc664965e36fc43a4f9c8eb8b2d14067a29c430e23470d2c923c1c977bac7"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -594,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261411a259d346a69078237e2997a7ce0faba006baf5b1937023316d5ef07bf4"
+checksum = "5a07bb602ee07767e393b5862f719a1d061deca15e617fbb1f7af49cd49576e4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -606,9 +609,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe7fa70c3af4b2de7f670b50d680700e0f979ce3a0ab7725958b51ffc3b16c2"
+checksum = "cd0a6cce3f97e5d9c0048081b5d173e0e406c2056c52c012e578a1d451ff0cdc"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
@@ -621,9 +624,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f60a196df184facc9acbb61bd765a36cfb3c9d27eb6b43d5bd26340df1b96a"
+checksum = "1eb4c87dfdde83cd97e03a8c0c5e986b52e14075e02266e322ac6c7eb02e7399"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -642,9 +645,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07758cbde42596b66da52bb661d77e253c3f7f9b3f553faf07adbadeb6419502"
+checksum = "2ff89f75b8a9d00f659750e9220c31b42d67c69ffc43b2ac8911dfd0506eb4a6"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -653,9 +656,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc43a73bc1bf7044898e1b0dcefaba45d0cfac3e379bb5ca29cc3e3a04c61451"
+checksum = "69e1f6fae3ade809daa4c32bee35a30a439bb307209d7b42f3995988b5cc74b8"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -668,9 +671,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372ff9be2b61c2cd6d33cfcef9bd5865962c0628c932767f5154443aba2c9746"
+checksum = "621cc39c34b85875858ef149598f3d5f9797dff9a3247f3606fcc06f9b20acc8"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -678,7 +681,7 @@ dependencies = [
  "alloy-signer",
  "async-trait",
  "k256 0.13.4",
- "rand 0.8.6",
+ "rand 0.8.7",
  "thiserror 2.0.20",
 ]
 
@@ -693,7 +696,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -711,15 +714,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha3 0.11.0",
- "syn 2.0.117",
+ "syn 2.0.119",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89bf01077f18650876cfa682eb1f949967b5cde03f1a51c955c469d2c9b4aa67"
+checksum = "9762b2ad3e5a0c09886de54fe549ab0056681df843cb082e2df7e1c0eb270d30"
 dependencies = [
  "alloy-json-abi",
  "const-hex",
@@ -729,15 +732,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.117",
+ "syn 2.0.119",
  "syn-solidity",
 ]
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "857b470ecdd2ed38beaf82ad1a38c516a8ff75266750f38b9eeed001d575241b"
+checksum = "da4c7130f0f01f4719678bda3db3bc7267fc2f7f9d0565e3bd964cd2bb45050d"
 dependencies = [
  "serde",
  "winnow",
@@ -757,13 +760,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830c87b05870c80c8d2cfb9245feaff36468893f19fc124c7ff563cabda6386c"
+checksum = "06f4ca8484d6295d5165f67de8fdb00ae630ba585efb606f003171286b56441c"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
- "base64",
+ "base64 0.22.1",
  "derive_more",
  "futures",
  "futures-utils-wasm",
@@ -780,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ecd298fb0e6a31bd90c72efba2728e3d7569f1c89a3719576fb0e4e40b0fc8"
+checksum = "8342aa5a7f8dee6d606307eebbc847d9799a823c7e4f37b9c1e32b08715f73c8"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -812,21 +815,21 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.2.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50185b84799c8b5f016a0c9da74309fe28d1c70fbe590a4e8d9cae6df3eebb0"
+checksum = "1d0626c4f3b2028f7e8db32f53c22d9ecd5939f772317b7c4b6fe5219cb0589a"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -839,9 +842,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "annotate-snippets"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92570a3f9c98e7e84df84b71d0965ac99b1871fcd75a3773a3bd1bad13f64cf7"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
 dependencies = [
  "anstyle",
  "memchr",
@@ -915,7 +918,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1084,7 +1087,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1094,7 +1097,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1479009684adc073dff49a1025d3a7065b317a9ead25aaaca38cdc70058ba8a2"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1132,7 +1135,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1145,7 +1148,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1233,7 +1236,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1244,7 +1247,7 @@ checksum = "4f153690697a2b91e5e1251ff98411ee5371500a111a0fd317a70e588eb300f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1254,7 +1257,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df2c09229cbc5a028b1d70e00fdb2acee28b1055dfb5ca73eea49c5a25c4e7c"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -1264,7 +1267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -1274,7 +1277,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -1284,7 +1287,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "367c9c827ed431bff6868b7aa926e05b16eb46603cc8b6e768e4a5553fa1d155"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.7",
 ]
 
 [[package]]
@@ -1307,9 +1310,9 @@ checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -1329,7 +1332,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -1341,7 +1344,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1381,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "async-compression"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+checksum = "3976abdc8fe7d1133d43d304afd42abdf5bc3e1319d263d223bde07b5efc4be8"
 dependencies = [
  "compression-codecs",
  "compression-core",
@@ -1439,7 +1442,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1491,7 +1494,7 @@ checksum = "99e1aca718ea7b89985790c94aad72d77533063fe00bc497bb79a7c2dae6a661"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1500,7 +1503,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "http",
  "log",
  "url",
@@ -1514,20 +1517,20 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -1535,14 +1538,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.44.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -1631,10 +1635,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "base45"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240e56f4d3c453c36faacb695c535a4d5f8c7d23dac175014f32eb0a71012a03"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -1668,34 +1684,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
-name = "bit-set"
-version = "0.8.0"
+name = "bitcoin-consensus-encoding"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+checksum = "6712f9c6fd6785b3b270884e57c441c403dc5d7e19ca45368c97c7a1de3000ec"
 dependencies = [
- "bit-vec",
+ "bitcoin-internals",
+ "hex-conservative 1.2.0",
+ "serde",
 ]
 
 [[package]]
-name = "bit-vec"
-version = "0.8.0"
+name = "bitcoin-internals"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+checksum = "d573f4cf32996a8dce612e4348cece65a241f1882ed594047c9ba348e8869fa5"
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.4"
+version = "0.1.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+checksum = "bb5de036369d1ac59d3c1819ebc4d850f89466f5401c571a285b6ed564a4cb78"
+dependencies = [
+ "bitcoin-consensus-encoding",
+]
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
 dependencies = [
  "bitcoin-io",
- "hex-conservative",
+ "hex-conservative 0.2.2",
 ]
 
 [[package]]
@@ -1706,9 +1727,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitvec"
@@ -1733,9 +1754,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.5"
+version = "1.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+checksum = "76ae7bad254120e9e4c63bafc385310756f90c484eac0e36b8317cf09cb92a77"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -1757,9 +1778,9 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.12.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
 ]
@@ -1808,9 +1829,9 @@ dependencies = [
 
 [[package]]
 name = "blst"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcdb4c7013139a150f9fc55d123186dbfaba0d912817466282c73ac49e71fb45"
+checksum = "c20659f9bbee16cbbd2f7393e40ab6309f5a98f76a2eb57a995ec508b72387fe"
 dependencies = [
  "cc",
  "glob",
@@ -1820,9 +1841,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+checksum = "a88b7ea17d208c4193f2c1e6de3c35fe71f98c96982d5ced308bdcc749ff6e1f"
 dependencies = [
  "borsh-derive",
  "bytes",
@@ -1831,22 +1852,22 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.6.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+checksum = "d8f347189c62a579b8cd5f80714efa178f52e461dc2e6d701d264f5ff22e566c"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "brotli"
-version = "8.0.2"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+checksum = "5cc91aac060a7a1e25823bdccbfb6af1875b88f17c6daac97894eed8207166b3"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1855,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "5.0.0"
+version = "5.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+checksum = "3a32acac15fe1967bc3986b2a6347dffc965602354ea6f450ad07e8bfd253583"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -1874,9 +1895,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byte-slice-cast"
@@ -1916,18 +1937,18 @@ dependencies = [
 
 [[package]]
 name = "bytesize"
-version = "2.4.2"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7c8918969267b2932ffd5655509bbbea0833823058c378876953217f5fc50e"
+checksum = "7354288c522e7e980fafd2075d63d1285794c3a6a16cdd492f189ea406e5f18b"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "c-kzg"
-version = "2.1.7"
+version = "2.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
+checksum = "38d04308254695569fdb9bfe3bacc1c91837a670d0806605eb82d63748fbd3a6"
 dependencies = [
  "blst",
  "cc",
@@ -1946,9 +1967,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "509591b7bcd67f4ef775afad7662703b4935daaa6ec0e5605cfb1090b32a2b6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1964,9 +1985,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "cfg_eval"
@@ -1976,7 +1997,7 @@ checksum = "45565fc9416b9896014f5732ac776f810ee53a66730c17e4020c3ec064a8f88f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2073,16 +2094,16 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "crypto-common 0.2.2",
  "inout 0.2.2",
 ]
 
 [[package]]
 name = "clap"
-version = "4.6.4"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91e0c145792ef73a6ad36d27c75ac09f1832222a3c209689d90f534685ee5b7"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2090,9 +2111,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2129,9 +2150,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "cobs"
@@ -2189,9 +2210,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -2390,18 +2411,18 @@ checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -2418,9 +2439,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crossfire"
@@ -2462,7 +2483,7 @@ checksum = "1a52aa3fcda4e6302a9f48734f234d35d4721b96f8fe07d073f07ce9df4f0271"
 dependencies = [
  "cpubits",
  "ctutils",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hybrid-array",
  "num-traits",
  "rand_core 0.10.1",
@@ -2487,7 +2508,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hybrid-array",
  "rand_core 0.10.1",
 ]
@@ -2562,14 +2583,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "cynic"
-version = "3.13.2"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2e722e1560ed4e4260cf35ac5fafc422aa7682c919db5a14209e4afad4446c2"
+checksum = "6260314e64d59ff1a962d465573ac6775fbf4624aa67613e220eb61f4a3d9a5c"
 dependencies = [
  "cynic-proc-macros",
  "ref-cast",
@@ -2582,9 +2603,9 @@ dependencies = [
 
 [[package]]
 name = "cynic-codegen"
-version = "3.13.2"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fde92ad70b36e9794eab14cbe915ae33e0ee8013844b7dcacad686830e107a5f"
+checksum = "04e68e191fc65c3b8a5b467368ef8e3d5f610ef770df664d5cca51de573c3010"
 dependencies = [
  "cynic-parser",
  "darling 0.20.11",
@@ -2593,15 +2614,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.10.0",
- "syn 2.0.117",
+ "syn 2.0.119",
  "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "cynic-parser"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4dfae2e0e25c72720197bde791ef9b840562ed6418eab6d8505f1d8fed27e86"
+checksum = "7793e157a59a0bd2142a5723860aeaef3aa459feae1467b597351e5f58251904"
 dependencies = [
  "indexmap 2.14.0",
  "lalrpop-util",
@@ -2610,14 +2631,14 @@ dependencies = [
 
 [[package]]
 name = "cynic-proc-macros"
-version = "3.13.2"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64118c37832e4ff3e2b8ffaf2f3a08d1b646fa049e90ff54826abac01005ae11"
+checksum = "8ca74b7363c9c675b6539aaf151c695cac83d3e7abc80dfbfbfdbfef27e4ec20"
 dependencies = [
  "cynic-codegen",
  "darling 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2651,7 +2672,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2665,7 +2686,7 @@ dependencies = [
  "quote",
  "serde",
  "strsim 0.11.1",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2676,7 +2697,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2687,7 +2708,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2706,15 +2727,15 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3259c913752a86488b501ed8680446a5ed2d5aeac6e596cb23ba3800768ea32c"
+checksum = "c6a127ecbb3c4632e1525380e04c0c3fcf8dcb44d32a79ea290d8a36906edcd8"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -2722,12 +2743,12 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
+checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2737,6 +2758,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2779,7 +2831,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -2824,7 +2875,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.117",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -2855,7 +2906,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
  "ctutils",
@@ -2863,13 +2914,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2989,14 +3040,14 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 dependencies = [
  "serde",
 ]
@@ -3072,9 +3123,9 @@ dependencies = [
 
 [[package]]
 name = "encoding_rs_io"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+checksum = "fba3fe847045ecff794b9c138293a80db914678c453ad63fbf0c6a9eb6e00b22"
 dependencies = [
  "encoding_rs",
 ]
@@ -3088,43 +3139,44 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "enum-ordinalize"
-version = "4.3.2"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1091a7bb1f8f2c4b28f1fe2cef4980ca2d410a3d727d67ecc3178c9b0800f0"
+checksum = "89dd01549b09589510cf0647475075d12071456586d70f5c75c98ae2a5537677"
 dependencies = [
  "enum-ordinalize-derive",
 ]
 
 [[package]]
 name = "enum-ordinalize-derive"
-version = "4.3.2"
+version = "4.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ca9601fb2d62598ee17836250842873a413586e5d7ed88b356e38ddbb0ec631"
+checksum = "a65863d15a4ce2888bd2f0f543cc963d3879c3a022c8ee43f6141d479a3ac815"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "env_filter"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e90c2accc4b07a8456ea0debdc2e7587bdd890680d71173a15d4ae604f6eef"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
+ "regex",
 ]
 
 [[package]]
 name = "env_logger"
-version = "0.11.10"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0621c04f2196ac3f488dd583365b9c09be011a4ab8b9f37248ffcc8f6198b56a"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -3149,7 +3201,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3200,7 +3252,7 @@ version = "0.17.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96df8cfa11d3c8e4e1a48b81c9c600ecbe8c11d1326f41e1524cc4d42f7bf6d9"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures",
  "http",
@@ -3212,10 +3264,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.4.1"
+name = "fastbloom"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash 0.2.0",
+ "libm",
+ "portable-atomic",
+ "siphasher",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fastrlp"
@@ -3273,9 +3337,9 @@ checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "findshlibs"
@@ -3290,13 +3354,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixed-cache"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe63500644ef0269fe6b744e7e5dc5c20b5eebf3d881bc2be53f194636f6583"
+dependencies = [
+ "equivalent",
+ "rapidhash",
+]
+
+[[package]]
 name = "fixed-hash"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rustc-hex",
  "static_assertions",
 ]
@@ -3343,7 +3417,7 @@ checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin 0.9.8",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -3587,25 +3661,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3626,9 +3698,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "gloo-timers"
@@ -3677,9 +3749,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3814,6 +3886,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex-conservative"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35431185f361ccf3ffc58254628af5f1f5d5f28531da2e02e5d6c82bbc282a10"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex-literal"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3859,7 +3940,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.4",
+ "rand 0.9.5",
  "ring",
  "socket2 0.5.10",
  "thiserror 2.0.20",
@@ -3902,7 +3983,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.9.5",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.20",
@@ -3987,7 +4068,7 @@ dependencies = [
  "hopr-types",
  "libp2p-identity",
  "serde",
- "strum 0.28.0",
+ "strum",
  "thiserror 2.0.20",
  "tracing",
 ]
@@ -4059,7 +4140,7 @@ dependencies = [
  "postcard",
  "serde",
  "serde_bytes",
- "strum 0.28.0",
+ "strum",
  "subtle",
  "thiserror 2.0.20",
  "tikv-jemallocator",
@@ -4122,7 +4203,7 @@ dependencies = [
  "serde_with",
  "serial_test",
  "smart-default",
- "strum 0.28.0",
+ "strum",
  "test-log",
  "thiserror 2.0.20",
  "tokio",
@@ -4161,7 +4242,7 @@ dependencies = [
  "hopr-types",
  "serde",
  "serde_bytes",
- "strum 0.28.0",
+ "strum",
  "thiserror 2.0.20",
 ]
 
@@ -4192,7 +4273,7 @@ dependencies = [
  "serde",
  "serde_with",
  "smart-default",
- "strum 0.28.0",
+ "strum",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -4235,7 +4316,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "smart-default",
- "strum 0.28.0",
+ "strum",
  "test-log",
  "thiserror 2.0.20",
  "tikv-jemallocator",
@@ -4255,7 +4336,7 @@ dependencies = [
  "hopr-protocol-app",
  "serde",
  "serde_cbor_2",
- "strum 0.28.0",
+ "strum",
  "thiserror 2.0.20",
 ]
 
@@ -4276,7 +4357,7 @@ dependencies = [
  "parking_lot",
  "postcard",
  "redb",
- "strum 0.28.0",
+ "strum",
  "tempfile",
  "thiserror 2.0.20",
  "tracing",
@@ -4332,7 +4413,7 @@ dependencies = [
  "serde",
  "serial_test",
  "smart-default",
- "strum 0.28.0",
+ "strum",
  "temp-env",
  "test-log",
  "thiserror 2.0.20",
@@ -4412,7 +4493,7 @@ dependencies = [
  "rstest",
  "serde",
  "smart-default",
- "strum 0.28.0",
+ "strum",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -4449,7 +4530,7 @@ dependencies = [
  "serde",
  "serde_repr",
  "smart-default",
- "strum 0.28.0",
+ "strum",
  "test-log",
  "thiserror 2.0.20",
  "tikv-jemallocator",
@@ -4526,7 +4607,7 @@ dependencies = [
  "sha2 0.11.0",
  "sha3 0.12.0",
  "smart-default",
- "strum 0.28.0",
+ "strum",
  "subtle",
  "thiserror 2.0.20",
  "tracing",
@@ -4560,8 +4641,8 @@ dependencies = [
  "pin-project",
  "rand 0.10.2",
  "serde_json",
- "socket2 0.6.4",
- "strum 0.28.0",
+ "socket2 0.6.5",
+ "strum",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -4594,8 +4675,8 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "socket2 0.6.4",
- "strum 0.28.0",
+ "socket2 0.6.5",
+ "strum",
  "thiserror 2.0.20",
  "tokio",
  "tokio-util",
@@ -4608,7 +4689,7 @@ version = "1.2.1"
 dependencies = [
  "anyhow",
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytesize",
  "dashmap",
  "futures",
@@ -4631,9 +4712,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -4641,9 +4722,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
  "http",
@@ -4651,9 +4732,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4680,9 +4761,9 @@ dependencies = [
 
 [[package]]
 name = "humantime"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "humantime-serde"
@@ -4708,9 +4789,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4748,7 +4829,7 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
@@ -4759,7 +4840,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4793,9 +4874,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -4807,9 +4888,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -4820,9 +4901,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -4834,16 +4915,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -4854,15 +4936,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "92a7ed671a6aad807a8651a2e1782a6598fda9ce5185dd8158549e95a91c6428"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -4872,12 +4954,6 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -4954,7 +5030,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand 0.9.4",
+ "rand 0.9.5",
  "tokio",
  "url",
  "xmltree",
@@ -4995,7 +5071,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5098,7 +5174,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "widestring",
  "windows-registry",
  "windows-result",
@@ -5107,20 +5183,10 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
  "serde",
 ]
 
@@ -5175,6 +5241,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5201,7 +5320,7 @@ dependencies = [
  "quote",
  "rustc_version 0.4.1",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5220,28 +5339,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -5278,9 +5396,9 @@ dependencies = [
 
 [[package]]
 name = "keccak"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+checksum = "ffd9697dc4a9a62e2da93389f34400b77a28f0287711263cabb203b3ccb9c0e4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
@@ -5288,9 +5406,9 @@ dependencies = [
 
 [[package]]
 name = "keccak-asm"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa468878266ad91431012b3e5ef1bf9b170eab22883503a318d46857afa4579a"
+checksum = "dd5dc2c0d691cbf7595cde551ced329cca99c2387c2cbc97754c5d0cd045d3ee"
 dependencies = [
  "digest 0.10.7",
  "sha3-asm",
@@ -5339,16 +5457,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -5427,7 +5539,7 @@ dependencies = [
  "libp2p-swarm",
  "quick-protobuf",
  "quick-protobuf-codec",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rand_core 0.6.4",
  "thiserror 2.0.20",
  "tracing",
@@ -5462,7 +5574,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "quick-protobuf",
- "rand 0.8.6",
+ "rand 0.8.7",
  "rw-stream-sink",
  "thiserror 2.0.20",
  "tracing",
@@ -5518,7 +5630,7 @@ dependencies = [
  "hkdf 0.12.4",
  "multihash",
  "prost",
- "rand 0.8.6",
+ "rand 0.8.7",
  "serde",
  "sha2 0.10.9",
  "thiserror 2.0.20",
@@ -5538,7 +5650,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "rand 0.8.6",
+ "rand 0.8.7",
  "smallvec",
  "socket2 0.5.10",
  "tokio",
@@ -5575,7 +5687,7 @@ dependencies = [
  "multiaddr",
  "multihash",
  "quick-protobuf",
- "rand 0.8.6",
+ "rand 0.8.7",
  "snow",
  "static_assertions",
  "thiserror 2.0.20",
@@ -5586,9 +5698,9 @@ dependencies = [
 
 [[package]]
 name = "libp2p-quic"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc448b2de9f4745784e3751fe8bc6c473d01b8317edd5ababcb0dec803d843f"
+checksum = "9dcc597d70bf7f6f30cbe07081802c836184e48416e89e9ce73a0ba2c56a319e"
 dependencies = [
  "futures",
  "futures-timer",
@@ -5597,7 +5709,8 @@ dependencies = [
  "libp2p-identity",
  "libp2p-tls",
  "quinn",
- "rand 0.8.6",
+ "quinn-proto",
+ "rand 0.8.7",
  "ring",
  "rustls",
  "socket2 0.5.10",
@@ -5618,7 +5731,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "rand 0.8.6",
+ "rand 0.8.7",
  "smallvec",
  "tracing",
 ]
@@ -5633,7 +5746,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "rand 0.8.6",
+ "rand 0.8.7",
  "tracing",
 ]
 
@@ -5652,7 +5765,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm-derive",
  "multistream-select",
- "rand 0.8.6",
+ "rand 0.8.7",
  "smallvec",
  "tokio",
  "tracing",
@@ -5667,7 +5780,7 @@ checksum = "dd297cf53f0cb3dee4d2620bb319ae47ef27c702684309f682bdb7e55a18ae9c"
 dependencies = [
  "heck 0.5.0",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5681,7 +5794,7 @@ dependencies = [
  "if-watch",
  "libc",
  "libp2p-core",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "tokio",
  "tracing",
 ]
@@ -5743,9 +5856,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -5758,9 +5871,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "logos"
@@ -5783,7 +5896,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex-syntax 0.8.11",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5797,11 +5910,11 @@ dependencies = [
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -5818,7 +5931,7 @@ checksum = "59a9dbbfc75d2688ed057456ce8a3ee3f48d12eec09229f560f3643b9f275653"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5829,7 +5942,7 @@ checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5843,9 +5956,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memmap2"
@@ -5889,9 +6002,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
 dependencies = [
  "libc",
  "wasi",
@@ -5921,14 +6034,14 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "moka"
-version = "0.12.15"
+version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
 dependencies = [
  "async-lock",
  "crossbeam-channel",
@@ -5971,12 +6084,13 @@ dependencies = [
 
 [[package]]
 name = "multibase"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8694bb4835f452b0e3bb06dbebb1d6fc5385b6ca1caf2e55fd165c042390ec77"
+checksum = "7e0e4a371cbf1dfd666b658ba137763edb23c45beb43cfe369b5593cd6b437b6"
 dependencies = [
  "base-x",
  "base256emoji",
+ "base45",
  "data-encoding",
  "data-encoding-macro",
 ]
@@ -6012,9 +6126,9 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
+checksum = "b897d7bd4f0af82e68d40d0344cf37e97f9c97ddf74a098de3e4da05e96ca395"
 dependencies = [
  "paste",
 ]
@@ -6025,7 +6139,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "libc",
  "log",
  "netlink-packet-core",
@@ -6033,12 +6147,13 @@ dependencies = [
 
 [[package]]
 name = "netlink-proto"
-version = "0.12.0"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
+checksum = "93af8261786086024cd5e96e0a991dd65ced07bbf7c233a487bbc96b971d5539"
 dependencies = [
  "bytes",
- "futures",
+ "futures-channel",
+ "futures-util",
  "log",
  "netlink-packet-core",
  "netlink-sys",
@@ -6075,7 +6190,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -6108,9 +6223,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -6118,9 +6233,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-format"
@@ -6134,9 +6249,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -6180,7 +6295,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6286,7 +6401,7 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "portable-atomic",
- "rand 0.9.4",
+ "rand 0.9.5",
  "thiserror 2.0.20",
  "tokio",
 ]
@@ -6312,7 +6427,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6343,7 +6458,7 @@ dependencies = [
  "indexmap 1.9.3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6371,7 +6486,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6445,7 +6560,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -6457,9 +6572,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.6"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+checksum = "5a07a60cc7a4d00c91f95c685609d1d2f79050e6804b70ebedd7650f0b839bcf"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -6467,9 +6582,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.6"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+checksum = "b3a83744a5c8455b8b3e0dc5031362780a347c878bdd11584d1a8984228cc88d"
 dependencies = [
  "pest",
  "pest_generator",
@@ -6477,25 +6592,24 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.6"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+checksum = "e0cd3451aa3de60d4b9a1e736885e4dea6b31617598026f12256ad566d63304a"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.6"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+checksum = "e04d3a0849e241d7dfce834c83b1c5edc8622009e8dd51a12ba1927c32f05496"
 dependencies = [
  "pest",
- "sha2 0.10.9",
 ]
 
 [[package]]
@@ -6520,6 +6634,24 @@ checksum = "44dc769b75f93afdddd8c7fa12d685292ddeff1e66f7f0f3a234cf1818afe892"
 dependencies = [
  "base64ct",
  "ctutils",
+]
+
+[[package]]
+name = "phf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
+dependencies = [
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -6548,7 +6680,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6585,9 +6717,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "pointers"
@@ -6644,9 +6776,18 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "postcard"
@@ -6662,9 +6803,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -6734,23 +6875,13 @@ dependencies = [
 
 [[package]]
 name = "prefix-trie"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f561214012d3fc240a1f9c817cc4d57f5310910d066069c1b093f766bb5966"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
 dependencies = [
  "either",
  "ipnet",
  "num-traits",
-]
-
-[[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -6800,7 +6931,7 @@ dependencies = [
  "fixed-hash",
  "impl-codec 0.7.1",
  "impl-serde",
- "uint 0.10.0",
+ "uint 0.10.1",
 ]
 
 [[package]]
@@ -6823,6 +6954,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr3"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0084e6206a967a2dad822180626b2f6b07a3b379325e8f1ec0438e33a469ba7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "proc-macro-error2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6831,7 +6972,19 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "proc-macro-error3"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cf066225f2373bc711684792b69bdeac0356019b007e721090c24d92d5d5a50"
+dependencies = [
+ "proc-macro-error-attr3",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -6849,9 +7002,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -6864,7 +7017,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "version_check",
  "yansi",
 ]
@@ -6889,7 +7042,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -6898,16 +7051,12 @@ version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
- "bit-set",
- "bit-vec",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "num-traits",
- "rand 0.9.4",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax 0.8.11",
- "rusty-fork",
- "tempfile",
  "unarray",
 ]
 
@@ -6931,14 +7080,8 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-protobuf"
@@ -6973,19 +7116,19 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
 dependencies = [
  "bytes",
  "cfg_aliases",
  "futures-io",
  "pin-project-lite",
  "quinn-proto",
- "quinn-udp 0.5.14",
+ "quinn-udp 0.5.15",
  "rustc-hash",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -6994,15 +7137,17 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "fastbloom",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -7016,16 +7161,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7036,15 +7181,15 @@ checksum = "76150b617afc75e6e21ac5f39bc196e80b65415ae48d62dbef8e2519d040ce42"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -7069,9 +7214,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -7081,9 +7226,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -7097,7 +7242,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20 0.10.1",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -7157,6 +7302,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7167,9 +7321,9 @@ dependencies = [
 
 [[package]]
 name = "rapidhash"
-version = "4.4.1"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e48930979c155e2f33aa36ab3119b5ee81332beb6482199a8ecd6029b80b59"
+checksum = "5da7e78a036ce858e8d55b7e7dc8ba3a88b78350fd2155d3591bbd966b58589e"
 dependencies = [
  "rustversion",
 ]
@@ -7222,27 +7376,27 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "216e8f773d7923bcba9ceb86a86c93cabb3903a11872fc3f138c49630e50b96d"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -7292,7 +7446,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -7429,7 +7583,7 @@ dependencies = [
  "regex",
  "relative-path",
  "rustc_version 0.4.1",
- "syn 2.0.117",
+ "syn 2.0.119",
  "unicode-ident",
 ]
 
@@ -7471,8 +7625,8 @@ dependencies = [
  "parity-scale-codec",
  "primitive-types 0.12.2",
  "proptest",
- "rand 0.8.6",
- "rand 0.9.4",
+ "rand 0.8.7",
+ "rand 0.9.5",
  "rlp 0.5.2",
  "ruint-macro",
  "serde_core",
@@ -7504,9 +7658,9 @@ checksum = "b74b56ffa8bb2830709a538c2cbcae9aa062db0d2a42563bfb09bdaae44020eb"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc-hex"
@@ -7547,7 +7701,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -7556,9 +7710,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
@@ -7583,9 +7737,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.1"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -7620,9 +7774,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "0527518605e68109d875e248ea259b6758801cf165e4b2c2733ae3b51f12535a"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -7632,21 +7786,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
-dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
-]
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rw-stream-sink"
@@ -7701,9 +7843,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "dyn-clone",
  "ref-cast",
@@ -7767,7 +7909,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.6",
+ "rand 0.8.7",
  "secp256k1-sys 0.10.1",
  "serde",
 ]
@@ -7779,7 +7921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c3c81b43dc2d8877c216a3fccf76677ee1ebccd429566d3e67447290d0c42b2"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.9.4",
+ "rand 0.9.5",
  "secp256k1-sys 0.11.0",
 ]
 
@@ -7807,7 +7949,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -7865,7 +8007,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af2c6921c8ce48fb1b052b457619d008834039d80325992ed3bc55bbe6c155ad"
 dependencies = [
  "annotate-snippets",
- "base64",
+ "base64 0.23.1",
  "encoding_rs_io",
  "granit-parser",
  "nohash-hasher",
@@ -7941,18 +8083,19 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
+checksum = "ee78f1fbe43ac4a0e47aadb3dbd357b69eb0d3793e948624cd03dd2750ab1c0a"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
  "indexmap 2.14.0",
+ "jiff",
  "schemars 0.9.0",
- "schemars 1.2.1",
+ "schemars 1.2.2",
  "serde_core",
  "serde_json",
  "serde_with_macros",
@@ -7961,14 +8104,14 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.21.0"
+version = "3.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
+checksum = "8705578779c2b6bd90d84d66eb2e206b708b1a4d7b9f17641b293545bf1c7e46"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8061,9 +8204,9 @@ dependencies = [
 
 [[package]]
 name = "sha3-asm"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59cbb88c189d6352cc8ae96a39d19c7ecad8f7330b29461187f2587fdc2988d5"
+checksum = "a6287fd675f713484342a89cbf0a386abef5f15919cfad607e5e1f19e1e15331"
 dependencies = [
  "cc",
  "cfg-if",
@@ -8080,9 +8223,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -8116,15 +8259,15 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simd_cesu8"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+checksum = "11031e251abf8611c80f460e19dbdeb54a66db918e49c65a7065b46ac7aec520"
 dependencies = [
  "rustc_version 0.4.1",
  "simdutf8",
@@ -8171,7 +8314,7 @@ checksum = "0eb01866308440fc64d6c44d9e86c5cc17adfe33c4d6eed55da9145044d0ffc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8214,9 +8357,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -8224,9 +8367,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
@@ -8290,7 +8433,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83561175f0a962dea437885589480d216d8741debf853e0d36edd526344fd273"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "byteorder",
  "keccak",
  "subtle",
@@ -8311,32 +8454,11 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros 0.27.2",
-]
-
-[[package]]
-name = "strum"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "strum_macros 0.28.0",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.27.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "strum_macros",
 ]
 
 [[package]]
@@ -8348,7 +8470,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8393,9 +8515,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8415,14 +8537,14 @@ dependencies = [
 
 [[package]]
 name = "syn-solidity"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec005042c7d952febc1a3ef5b0f6674e9054aa836877a31c90b20e25b3d31744"
+checksum = "083be3061e64d362cbe6ef12cfe1307ba3884326d8856448fe8a120fa2c44ebf"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8442,7 +8564,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8451,7 +8573,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -8506,7 +8628,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -8537,7 +8659,7 @@ checksum = "c26ef8b00e4d382e59f6a8ddb3cd790b3a5bb29f21a358a9a69ea2f29f13f27b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8546,7 +8668,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "944ad38adcbb71eaa682c56bceeb079e4ca82b4b3edc2a0fde5cb297b77dac8d"
 dependencies = [
- "syn 2.0.117",
+ "syn 2.0.119",
  "test-log-core",
 ]
 
@@ -8576,7 +8698,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8592,9 +8714,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -8630,12 +8752,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -8645,15 +8766,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -8661,9 +8782,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -8681,9 +8802,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -8705,7 +8826,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.4",
+ "socket2 0.6.5",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -8713,13 +8834,13 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -8770,9 +8891,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.13+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
 dependencies = [
  "indexmap 2.14.0",
  "toml_datetime",
@@ -8782,9 +8903,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
+version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
 dependencies = [
  "winnow",
 ]
@@ -8806,25 +8927,25 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
- "bitflags 2.11.1",
+ "bitflags 2.13.1",
  "bytes",
  "futures-core",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
- "iri-string",
  "pin-project-lite",
  "tokio",
  "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -8845,6 +8966,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -8858,7 +8980,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -8931,9 +9053,9 @@ dependencies = [
 
 [[package]]
 name = "uint"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "909988d098b2f738727b161a106cfc7cab00c539c2687a8836f8e565976fb53e"
+checksum = "6f9227a75a5a540a464c832ad4a4195dbdbecd8787610a56262721fde6f04f90"
 dependencies = [
  "byteorder",
  "crunchy",
@@ -8955,9 +9077,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.2"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
@@ -9040,7 +9162,7 @@ version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
@@ -9063,16 +9185,15 @@ dependencies = [
 
 [[package]]
 name = "validator_derive"
-version = "0.20.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7df16e474ef958526d1205f6dda359fdfab79d9aa6d54bafcb92dcd07673dca"
+checksum = "240e4b81c20a1d6d50d1d7265c658dfbd204e8b9ac4d80f3c931f39462196335"
 dependencies = [
- "darling 0.20.11",
- "once_cell",
- "proc-macro-error2",
+ "darling 0.23.0",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9086,15 +9207,6 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "walkdir"
@@ -9123,27 +9235,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -9154,9 +9257,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.70"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9164,9 +9267,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -9174,46 +9277,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
 ]
 
 [[package]]
@@ -9227,18 +9308,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver 1.0.28",
 ]
 
 [[package]]
@@ -9257,9 +9326,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.97"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -9277,9 +9346,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "b96554aa2acc8ccdb7e1c9a58a7a68dd5d13bccc69cd124cb09406db612a1c9b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -9374,7 +9443,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9385,7 +9454,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -9526,20 +9595,11 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
 ]
 
 [[package]]
@@ -9547,85 +9607,6 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck 0.5.0",
- "indexmap 2.14.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver 1.0.28",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "wnaf"
@@ -9640,9 +9621,9 @@ dependencies = [
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "wyz"
@@ -9684,9 +9665,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.28"
+version = "0.8.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
+checksum = "e450f9b2ed1dff33c94c12589a87338689467b9c4f5d8a5710bd09a847d2c8a7"
 
 [[package]]
 name = "xmltree"
@@ -9708,7 +9689,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot",
  "pin-project",
- "rand 0.8.6",
+ "rand 0.8.7",
  "static_assertions",
 ]
 
@@ -9723,7 +9704,7 @@ dependencies = [
  "nohash-hasher",
  "parking_lot",
  "pin-project",
- "rand 0.9.4",
+ "rand 0.9.5",
  "static_assertions",
  "web-time",
 ]
@@ -9745,9 +9726,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -9762,35 +9743,35 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -9803,7 +9784,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -9824,14 +9805,14 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -9840,9 +9821,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "94b5c6b5976d66c1d703c4fd17d3f5e43c8cedaacf604961b171adc7130896d8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -9851,20 +9832,20 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "47402523226a02bfe5230160dc3ccc089aa6f6f19e7fcbb4e6f824bbb1b4aa62"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zstd"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4284,7 +4284,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4421,7 +4421,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4284,7 +4284,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4421,7 +4421,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4284,7 +4284,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.42.0"
+version = "0.43.0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ hopr-protocol-hopr = { version = "6.0.0", path = "protocols/hopr", default-featu
 hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
 hopr-protocol-start = { version = "1.1.0", path = "protocols/start", default-features = false }
 hopr-ticket-manager = "0.5.1"
-hopr-transport = { version = "0.42.0", path = "transport/hopr" }
+hopr-transport = { version = "0.43.0", path = "transport/hopr" }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
 hopr-transport-session = { version = "0.26.0", path = "transport/session", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,10 +148,10 @@ hopr-protocol-hopr = { version = "6.0.0", path = "protocols/hopr", default-featu
 hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
 hopr-protocol-start = { version = "1.1.0", path = "protocols/start", default-features = false }
 hopr-ticket-manager = "0.5.1"
-hopr-transport = { version = "0.43.0", path = "transport/hopr" }
+hopr-transport = { version = "0.44.0", path = "transport/hopr" }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
-hopr-transport-session = { version = "0.26.0", path = "transport/session", default-features = false }
+hopr-transport-session = { version = "0.26.1", path = "transport/session", default-features = false }
 hopr-transport-tag-allocator = { version = "0.1.1", path = "transport/tag-allocator", default-features = false }
 hopr-chain-connector = "0.22.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,7 +148,7 @@ hopr-protocol-hopr = { version = "6.0.0", path = "protocols/hopr", default-featu
 hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
 hopr-protocol-start = { version = "1.1.0", path = "protocols/start", default-features = false }
 hopr-ticket-manager = "0.5.1"
-hopr-transport = { version = "0.41.0", path = "transport/hopr" }
+hopr-transport = { version = "0.42.0", path = "transport/hopr" }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
 hopr-transport-session = { version = "0.26.0", path = "transport/session", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,7 +151,7 @@ hopr-ticket-manager = "0.5.1"
 hopr-transport = { version = "0.44.0", path = "transport/hopr" }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
-hopr-transport-session = { version = "0.26.1", path = "transport/session", default-features = false }
+hopr-transport-session = { version = "0.26.2", path = "transport/session", default-features = false }
 hopr-transport-tag-allocator = { version = "0.1.1", path = "transport/tag-allocator", default-features = false }
 hopr-chain-connector = "0.22.1"
 

--- a/protocols/session/src/flow_control.rs
+++ b/protocols/session/src/flow_control.rs
@@ -312,6 +312,10 @@ impl FlowControlConfig {
             persist_stall_parks: 8,
             frame_retries: 8,
             max_frame_age: Some(Duration::from_secs(2)),
+            // Detection belongs with the rest of the tail-tolerance bundle. Left unset, the return
+            // path is corrected by probing alone -- EMA-smoothed behind a path cache, so tens of
+            // seconds -- which is the gap this profile exists to close.
+            return_path_replan: Some(ReturnPathReplanConfig::default()),
             ..Self::default()
         }
     }
@@ -730,6 +734,13 @@ mod tests {
     #[test]
     fn robust_profile_should_bound_frame_age() {
         assert_eq!(FlowControlConfig::robust().max_frame_age, Some(Duration::from_secs(2)));
+        // Detection has to be on for the profile to do what it claims: left unset it was never
+        // enabled by anything -- not by a profile, not by hoprd, not by the edge client -- so the
+        // loss clock never ran and no return path was ever re-planned.
+        assert!(
+            FlowControlConfig::robust().return_path_replan.is_some(),
+            "the robust profile must enable return-path re-planning"
+        );
         assert_eq!(FlowControlConfig::default().max_frame_age, None);
     }
 

--- a/protocols/session/src/flow_control.rs
+++ b/protocols/session/src/flow_control.rs
@@ -119,158 +119,6 @@ pub struct FlowControlConfig {
     /// bounds how stale a *present* frame may be. `None` (default) keeps the previous behaviour.
     #[default(None)]
     pub max_frame_age: Option<Duration>,
-
-    /// **Reactive return-path re-planning (opt-in).** When set, sustained loss in the return
-    /// direction triggers a re-plan of the return path instead of waiting for probing to notice.
-    ///
-    /// `None` (the default) leaves the return path to be corrected by probing alone, which is
-    /// EMA-smoothed behind a path cache and therefore takes tens of seconds.
-    #[default(None)]
-    pub return_path_replan: Option<ReturnPathReplanConfig>,
-}
-
-/// Governs when sustained return-direction loss is taken as "this return path is dead".
-///
-/// The signal is the honest delivery clock's `lost_bytes`: a frame retires as lost when its
-/// acknowledgement never came back, which — for a session whose forward path is healthy — means
-/// the *return* path dropped the ack. That is visible within an RTT, whereas probing needs tens of
-/// seconds to move an EMA behind a 60 s path cache.
-#[derive(Clone, Copy, Debug, PartialEq, smart_default::SmartDefault)]
-pub struct ReturnPathReplanConfig {
-    /// Loss ratio (`lost / (acked + lost)`) above which an observation window counts as bad.
-    ///
-    /// Default 0.2, matching the reliable-mode tolerance: below it retransmission already recovers
-    /// the stream, and re-planning would only add churn.
-    #[default(0.2)]
-    pub loss_threshold: f64,
-
-    /// Length of one observation window. Default 1 s — long enough to span a few RTTs, so a single
-    /// unlucky frame cannot make a window look bad.
-    #[default(Duration::from_secs(1))]
-    pub window: Duration,
-
-    /// Consecutive bad windows required before re-planning. Default 3, so a blip has to persist for
-    /// ~3 s to count as sustained.
-    #[default(3)]
-    pub sustained_windows: u32,
-
-    /// Minimum interval between re-plans. Default 5 s, so a return path that stays lossy cannot
-    /// drive continuous re-planning churn.
-    #[default(Duration::from_secs(5))]
-    pub cooldown: Duration,
-}
-
-impl ReturnPathReplanConfig {
-    /// Clamps the parameters so a misconfiguration cannot make the detector fire on every sample.
-    fn normalized(self) -> Self {
-        Self {
-            loss_threshold: if self.loss_threshold.is_finite() {
-                self.loss_threshold.clamp(0.0, 1.0)
-            } else {
-                0.2
-            },
-            window: self.window.max(Duration::from_millis(1)),
-            sustained_windows: self.sustained_windows.max(1),
-            cooldown: self.cooldown,
-        }
-    }
-}
-
-/// Notified when the return direction has been losing for long enough that the current return path
-/// should be abandoned and re-planned.
-///
-/// Implemented on the transport side, where the path planner lives; kept as a one-method trait so
-/// a test can satisfy it without standing up a planner.
-#[cfg_attr(test, mockall::automock)]
-pub trait ReturnPathFeedback: Send + Sync {
-    /// The return path currently in use is degraded; select a different one.
-    fn return_path_degraded(&self);
-}
-
-/// Watches the honest delivery clock for *sustained* return-direction loss.
-///
-/// Deliberately not a simple threshold on a single observation: reliable mode tolerates ~20 % loss
-/// because retransmission recovers it, so only loss that persists across several windows means the
-/// return path itself is gone rather than merely congested.
-pub struct ReturnPathMonitor {
-    feedback: std::sync::Arc<dyn ReturnPathFeedback>,
-    cfg: ReturnPathReplanConfig,
-    window_started: std::time::Instant,
-    acked: u64,
-    lost: u64,
-    /// Consecutive windows whose loss ratio exceeded the threshold.
-    bad_windows: u32,
-    last_replan: Option<std::time::Instant>,
-}
-
-impl ReturnPathMonitor {
-    /// Creates a monitor reporting to `feedback`.
-    pub fn new(feedback: std::sync::Arc<dyn ReturnPathFeedback>, cfg: ReturnPathReplanConfig) -> Self {
-        Self {
-            feedback,
-            cfg: cfg.normalized(),
-            window_started: std::time::Instant::now(),
-            acked: 0,
-            lost: 0,
-            bad_windows: 0,
-            last_replan: None,
-        }
-    }
-
-    /// Folds one delivery observation in, closing the current window if it has elapsed.
-    pub fn observe(&mut self, delivered: Delivered) {
-        self.acked = self.acked.saturating_add(delivered.acked_bytes as u64);
-        self.lost = self.lost.saturating_add(delivered.lost_bytes as u64);
-
-        if self.window_started.elapsed() < self.cfg.window {
-            return;
-        }
-        self.close_window();
-    }
-
-    /// Scores the elapsed window and re-plans if loss has been sustained for long enough.
-    fn close_window(&mut self) {
-        let total = self.acked.saturating_add(self.lost);
-        // An idle window carries no evidence either way, so it neither accuses nor exonerates.
-        if total > 0 {
-            let loss_ratio = self.lost as f64 / total as f64;
-            if loss_ratio > self.cfg.loss_threshold {
-                self.bad_windows = self.bad_windows.saturating_add(1);
-                tracing::debug!(
-                    loss_ratio,
-                    bad_windows = self.bad_windows,
-                    "return-direction loss above threshold"
-                );
-            } else {
-                self.bad_windows = 0;
-            }
-        }
-
-        self.acked = 0;
-        self.lost = 0;
-        self.window_started = std::time::Instant::now();
-
-        if self.bad_windows < self.cfg.sustained_windows {
-            return;
-        }
-
-        let now = std::time::Instant::now();
-        if self
-            .last_replan
-            .is_some_and(|last| now.duration_since(last) < self.cfg.cooldown)
-        {
-            // Still cooling down from the previous re-plan; keep observing rather than churn.
-            return;
-        }
-
-        tracing::info!(
-            bad_windows = self.bad_windows,
-            "sustained return-direction loss; re-planning the return path"
-        );
-        self.feedback.return_path_degraded();
-        self.last_replan = Some(now);
-        self.bad_windows = 0;
-    }
 }
 
 impl FlowControlConfig {
@@ -294,7 +142,6 @@ impl FlowControlConfig {
             // At least one retry: under reliable-mode flow control an abandoned frame leaves a gap
             // (stream corruption), so `frame_retries` must never clamp the retry budget to 0.
             frame_retries: self.frame_retries.max(1),
-            return_path_replan: self.return_path_replan.map(ReturnPathReplanConfig::normalized),
             // A zero bound would drop every frame on sight; treat it as "not set".
             max_frame_age: self.max_frame_age.filter(|age| !age.is_zero()),
         }
@@ -312,10 +159,6 @@ impl FlowControlConfig {
             persist_stall_parks: 8,
             frame_retries: 8,
             max_frame_age: Some(Duration::from_secs(2)),
-            // Detection belongs with the rest of the tail-tolerance bundle. Left unset, the return
-            // path is corrected by probing alone -- EMA-smoothed behind a path cache, so tens of
-            // seconds -- which is the gap this profile exists to close.
-            return_path_replan: Some(ReturnPathReplanConfig::default()),
             ..Self::default()
         }
     }
@@ -634,113 +477,11 @@ impl DeliverySignal for DeliveryClock {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    /// Builds a monitor with a very short window so the tests do not sleep for seconds.
-    fn monitor(feedback: Arc<dyn ReturnPathFeedback>, sustained_windows: u32, cooldown: Duration) -> ReturnPathMonitor {
-        ReturnPathMonitor::new(
-            feedback,
-            ReturnPathReplanConfig {
-                loss_threshold: 0.2,
-                window: Duration::from_millis(10),
-                sustained_windows,
-                cooldown,
-            },
-        )
-    }
-
-    fn delivered(acked: usize, lost: usize) -> Delivered {
-        Delivered {
-            acked_bytes: acked,
-            lost_bytes: lost,
-        }
-    }
-
-    /// Feeds one observation and lets the window elapse, so the next observation closes it.
-    fn close_window(m: &mut ReturnPathMonitor, d: Delivered) {
-        m.observe(d);
-        std::thread::sleep(Duration::from_millis(12));
-        m.observe(delivered(0, 0));
-    }
-
-    #[test]
-    fn return_path_monitor_should_replan_after_sustained_loss() {
-        let mut feedback = MockReturnPathFeedback::new();
-        feedback.expect_return_path_degraded().once().return_const(());
-
-        let mut m = monitor(Arc::new(feedback), 3, Duration::from_secs(60));
-
-        // Three consecutive windows at 50 % loss — well above the 20 % tolerance.
-        for _ in 0..3 {
-            close_window(&mut m, delivered(1_000, 1_000));
-        }
-    }
-
-    #[test]
-    fn return_path_monitor_should_ignore_loss_within_tolerance() {
-        let mut feedback = MockReturnPathFeedback::new();
-        feedback.expect_return_path_degraded().never();
-
-        let mut m = monitor(Arc::new(feedback), 3, Duration::from_secs(60));
-
-        // 10 % loss: retransmission recovers this, so it must not cause churn.
-        for _ in 0..6 {
-            close_window(&mut m, delivered(9_000, 1_000));
-        }
-    }
-
-    #[test]
-    fn return_path_monitor_should_require_loss_to_be_sustained() {
-        let mut feedback = MockReturnPathFeedback::new();
-        feedback.expect_return_path_degraded().never();
-
-        let mut m = monitor(Arc::new(feedback), 3, Duration::from_secs(60));
-
-        // A bad window followed by a good one resets the streak, so it never reaches 3.
-        for _ in 0..4 {
-            close_window(&mut m, delivered(1_000, 1_000));
-            close_window(&mut m, delivered(10_000, 0));
-        }
-    }
-
-    #[test]
-    fn return_path_monitor_should_rate_limit_replans() {
-        let mut feedback = MockReturnPathFeedback::new();
-        // Six bad windows at `sustained_windows = 1` would be six re-plans without the cooldown.
-        feedback.expect_return_path_degraded().once().return_const(());
-
-        let mut m = monitor(Arc::new(feedback), 1, Duration::from_secs(60));
-
-        for _ in 0..6 {
-            close_window(&mut m, delivered(0, 1_000));
-        }
-    }
-
-    #[test]
-    fn return_path_monitor_should_ignore_idle_windows() {
-        let mut feedback = MockReturnPathFeedback::new();
-        feedback.expect_return_path_degraded().never();
-
-        let mut m = monitor(Arc::new(feedback), 1, Duration::from_secs(60));
-
-        // No traffic at all carries no evidence: it must neither accuse nor exonerate.
-        for _ in 0..5 {
-            close_window(&mut m, delivered(0, 0));
-        }
-    }
-
     use super::*;
 
     #[test]
     fn robust_profile_should_bound_frame_age() {
         assert_eq!(FlowControlConfig::robust().max_frame_age, Some(Duration::from_secs(2)));
-        // Detection has to be on for the profile to do what it claims: left unset it was never
-        // enabled by anything -- not by a profile, not by hoprd, not by the edge client -- so the
-        // loss clock never ran and no return path was ever re-planned.
-        assert!(
-            FlowControlConfig::robust().return_path_replan.is_some(),
-            "the robust profile must enable return-path re-planning"
-        );
         assert_eq!(FlowControlConfig::default().max_frame_age, None);
     }
 

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport"
 description = "Implements the main HOPR transport interface for the core library"
-version = "0.43.0"
+version = "0.44.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport"
 description = "Implements the main HOPR transport interface for the core library"
-version = "0.42.0"
+version = "0.43.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport"
 description = "Implements the main HOPR transport interface for the core library"
-version = "0.41.0"
+version = "0.42.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -858,6 +858,7 @@ where
         let surb_flush_interval = self.cfg.surb_flush_interval;
         let surb_flush_planner = self.path_planner.clone();
         let surb_flush_smgr = self.smgr.clone();
+        let surb_flush_chain = self.chain_api.clone();
         processes.insert(
             HoprTransportProcess::SurbFlush,
             hopr_utils::spawn_as_abortable!(async move {
@@ -868,12 +869,24 @@ where
                         for destination in surb_round_trips.degraded_destinations() {
                             let node = hopr_api::types::internal::prelude::NodeId::Offchain(destination);
 
+                            // Sessions name their destination by its chain address, this telemetry
+                            // by its packet key, and a `NodeId` holding one is never equal to a
+                            // `NodeId` holding the other -- so the match has to be made on a
+                            // resolved form, not on the enum.
+                            let as_session_names_it = surb_flush_chain
+                                .packet_key_to_chain_key(&destination)
+                                .ok()
+                                .flatten()
+                                .map(hopr_api::types::internal::prelude::NodeId::Chain);
+
                             // Re-planning only changes which return path the *next* SURBs are minted
                             // on. The counterparty also has to still be receiving SURBs to reply
                             // with, and its silence has by now convinced our balancer that it is
                             // well stocked -- so tell the Sessions routed there to stop believing
                             // that estimate while the evidence says otherwise.
-                            let marked = surb_flush_smgr.mark_return_path_degraded(&node, RETURN_PATH_DEGRADED_GRACE);
+                            let marked = as_session_names_it
+                                .map(|n| surb_flush_smgr.mark_return_path_degraded(&n, RETURN_PATH_DEGRADED_GRACE))
+                                .unwrap_or(0);
 
                             tracing::info!(%destination, sessions = marked, "return path silent; re-planning");
                             surb_flush_planner.degrade_return_path(node);

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -850,9 +850,14 @@ where
 
         // -- periodic SURB round-trip flush
         tracing::info!(?role, "starting surb round-trip flush task");
+        // Long enough to outlast the silence gate that produced the evidence, so a path that stays
+        // dead is re-marked before the previous mark lapses, and short enough that a path which
+        // recovers unnoticed returns to closed-loop control promptly.
+        const RETURN_PATH_DEGRADED_GRACE: std::time::Duration = std::time::Duration::from_secs(10);
         let surb_flush_graph = self.graph.clone();
         let surb_flush_interval = self.cfg.surb_flush_interval;
         let surb_flush_planner = self.path_planner.clone();
+        let surb_flush_smgr = self.smgr.clone();
         processes.insert(
             HoprTransportProcess::SurbFlush,
             hopr_utils::spawn_as_abortable!(async move {
@@ -861,9 +866,17 @@ where
                         // Detection before the drain: `degraded_destinations` reads the counts the
                         // flush is about to reset.
                         for destination in surb_round_trips.degraded_destinations() {
-                            tracing::info!(%destination, "return path silent; re-planning");
-                            surb_flush_planner
-                                .degrade_return_path(hopr_api::types::internal::prelude::NodeId::Offchain(destination));
+                            let node = hopr_api::types::internal::prelude::NodeId::Offchain(destination);
+
+                            // Re-planning only changes which return path the *next* SURBs are minted
+                            // on. The counterparty also has to still be receiving SURBs to reply
+                            // with, and its silence has by now convinced our balancer that it is
+                            // well stocked -- so tell the Sessions routed there to stop believing
+                            // that estimate while the evidence says otherwise.
+                            let marked = surb_flush_smgr.mark_return_path_degraded(&node, RETURN_PATH_DEGRADED_GRACE);
+
+                            tracing::info!(%destination, sessions = marked, "return path silent; re-planning");
+                            surb_flush_planner.degrade_return_path(node);
                         }
 
                         protocol::surb_telemetry::flush_into(

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -852,11 +852,20 @@ where
         tracing::info!(?role, "starting surb round-trip flush task");
         let surb_flush_graph = self.graph.clone();
         let surb_flush_interval = self.cfg.surb_flush_interval;
+        let surb_flush_planner = self.path_planner.clone();
         processes.insert(
             HoprTransportProcess::SurbFlush,
             hopr_utils::spawn_as_abortable!(async move {
                 futures_time::stream::interval(futures_time::time::Duration::from(surb_flush_interval))
                     .for_each(|_| {
+                        // Detection before the drain: `degraded_destinations` reads the counts the
+                        // flush is about to reset.
+                        for destination in surb_round_trips.degraded_destinations() {
+                            tracing::info!(%destination, "return path silent; re-planning");
+                            surb_flush_planner
+                                .degrade_return_path(hopr_api::types::internal::prelude::NodeId::Offchain(destination));
+                        }
+
                         protocol::surb_telemetry::flush_into(
                             &surb_round_trips,
                             &surb_flush_graph,

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -866,19 +866,17 @@ where
                     .for_each(|_| {
                         // Detection before the drain: `degraded_destinations` reads the counts the
                         // flush is about to reset.
-                        // DIAGNOSTIC kill-switch. Re-planning became destructive the moment its
-                        // invalidation started matching real cache entries, and it is not yet
-                        // established whether the damage comes from the invalidation itself or from
-                        // something else in the same change. Toggling this lets one binary produce
-                        // both arms of that comparison, so the two runs differ in nothing else.
+                        // DIAGNOSTIC kill-switch, now gating only the path invalidation.
+                        //
+                        // Measured: with both consumers suppressed a healthy baseline returns
+                        // 100%, and with them live it collapses to 0.14% -- so the invalidation is
+                        // the destructive element, not the key resolution that made it reach the
+                        // cache. What that comparison could not separate is the balancer mark,
+                        // which was suppressed alongside it. Keeping the mark while dropping the
+                        // invalidation isolates the supply fix from the path churn.
                         let replanning_disabled = std::env::var_os("HOPR_DISABLE_RETURN_PATH_REPLAN").is_some();
 
                         for destination in surb_round_trips.degraded_destinations() {
-                            if replanning_disabled {
-                                tracing::info!(%destination, "return path silent; re-planning DISABLED");
-                                continue;
-                            }
-
                             let node = hopr_api::types::internal::prelude::NodeId::Offchain(destination);
 
                             // Sessions name their destination by its chain address, this telemetry
@@ -900,8 +898,16 @@ where
                                 .map(|n| surb_flush_smgr.mark_return_path_degraded(&n, RETURN_PATH_DEGRADED_GRACE))
                                 .unwrap_or(0);
 
-                            tracing::info!(%destination, sessions = marked, "return path silent; re-planning");
-                            surb_flush_planner.degrade_return_path(node);
+                            tracing::info!(
+                                %destination,
+                                sessions = marked,
+                                replanning = !replanning_disabled,
+                                "return path silent"
+                            );
+
+                            if !replanning_disabled {
+                                surb_flush_planner.degrade_return_path(node);
+                            }
                         }
 
                         protocol::surb_telemetry::flush_into(

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -92,7 +92,7 @@ use tracing::{Instrument, debug, error, trace, warn};
 
 #[cfg(feature = "runtime-tokio")]
 use crate::path::BackgroundPathCacheRefreshable;
-pub use crate::{config::HoprProtocolConfig, path::PlannerReturnPathFeedback, protocol::PeerProtocolCounterRegistry};
+pub use crate::{config::HoprProtocolConfig, protocol::PeerProtocolCounterRegistry};
 use crate::{
     constants::SESSION_INITIATION_TIMEOUT_BASE,
     errors::HoprTransportError,
@@ -331,7 +331,6 @@ where
             selector,
             planner_config,
         );
-        let return_path_feedback = Arc::new(PlannerReturnPathFeedback(path_planner.clone()));
 
         Ok(Self {
             packet_key: identity.1.clone(),
@@ -341,41 +340,38 @@ where
             graph,
             path_planner,
             my_multiaddresses,
-            smgr: Arc::new(SessionManager::new(
-                SessionManagerConfig {
-                    frame_mtu: std::env::var("HOPR_SESSION_FRAME_SIZE")
-                        .ok()
-                        .and_then(|s| s.parse::<usize>().ok())
-                        .unwrap_or_else(|| SessionManagerConfig::default().frame_mtu)
-                        .max(SESSION_MTU),
-                    max_frame_timeout: std::env::var("HOPR_SESSION_FRAME_TIMEOUT_MS")
-                        .ok()
-                        .and_then(|s| s.parse::<u64>().ok().map(Duration::from_millis))
-                        .unwrap_or_else(|| SessionManagerConfig::default().max_frame_timeout)
-                        .max(Duration::from_millis(100)),
-                    max_buffered_segments: std::env::var("HOPR_SESSION_MAX_BUFFERED_SEGMENTS")
-                        .ok()
-                        .and_then(|s| s.parse::<usize>().ok())
-                        .unwrap_or_else(|| SessionManagerConfig::default().max_buffered_segments),
-                    initiation_timeout_base: SESSION_INITIATION_TIMEOUT_BASE,
-                    idle_timeout: cfg.session.idle_timeout,
-                    balancer_sampling_interval: cfg.session.balancer_sampling_interval,
-                    initial_return_session_egress_rate: 10,
-                    minimum_surb_buffer_duration: cfg.session.balancer_minimum_surb_buffer_duration,
-                    maximum_surb_buffer_size: cfg.packet.surb_store.rb_capacity,
-                    // The lower bound is enforced once in `SessionManager::new` via
-                    // `MIN_SURB_BUFFER_NOTIFICATION_PERIOD`; don't duplicate that floor as a literal here.
-                    surb_balance_notify_period: std::env::var("HOPR_SESSION_SURB_BALANCE_NOTIFY_PERIOD_MS")
-                        .ok()
-                        .and_then(|s| s.parse::<u64>().ok())
-                        .map(|ms| Some(Duration::from_millis(ms)))
-                        .unwrap_or(cfg.session.surb_balance_notify_period),
-                    surb_target_notify: true,
-                    maximum_sessions: cfg.session.maximum_managed_sessions,
-                    ..Default::default()
-                },
-                Some(return_path_feedback),
-            )),
+            smgr: Arc::new(SessionManager::new(SessionManagerConfig {
+                frame_mtu: std::env::var("HOPR_SESSION_FRAME_SIZE")
+                    .ok()
+                    .and_then(|s| s.parse::<usize>().ok())
+                    .unwrap_or_else(|| SessionManagerConfig::default().frame_mtu)
+                    .max(SESSION_MTU),
+                max_frame_timeout: std::env::var("HOPR_SESSION_FRAME_TIMEOUT_MS")
+                    .ok()
+                    .and_then(|s| s.parse::<u64>().ok().map(Duration::from_millis))
+                    .unwrap_or_else(|| SessionManagerConfig::default().max_frame_timeout)
+                    .max(Duration::from_millis(100)),
+                max_buffered_segments: std::env::var("HOPR_SESSION_MAX_BUFFERED_SEGMENTS")
+                    .ok()
+                    .and_then(|s| s.parse::<usize>().ok())
+                    .unwrap_or_else(|| SessionManagerConfig::default().max_buffered_segments),
+                initiation_timeout_base: SESSION_INITIATION_TIMEOUT_BASE,
+                idle_timeout: cfg.session.idle_timeout,
+                balancer_sampling_interval: cfg.session.balancer_sampling_interval,
+                initial_return_session_egress_rate: 10,
+                minimum_surb_buffer_duration: cfg.session.balancer_minimum_surb_buffer_duration,
+                maximum_surb_buffer_size: cfg.packet.surb_store.rb_capacity,
+                // The lower bound is enforced once in `SessionManager::new` via
+                // `MIN_SURB_BUFFER_NOTIFICATION_PERIOD`; don't duplicate that floor as a literal here.
+                surb_balance_notify_period: std::env::var("HOPR_SESSION_SURB_BALANCE_NOTIFY_PERIOD_MS")
+                    .ok()
+                    .and_then(|s| s.parse::<u64>().ok())
+                    .map(|ms| Some(Duration::from_millis(ms)))
+                    .unwrap_or(cfg.session.surb_balance_notify_period),
+                surb_target_notify: true,
+                maximum_sessions: cfg.session.maximum_managed_sessions,
+                ..Default::default()
+            })),
             chain_api: resolver,
             session_telemetry_tag_allocator,
             probing_tag_allocator,
@@ -856,7 +852,6 @@ where
         const RETURN_PATH_DEGRADED_GRACE: std::time::Duration = std::time::Duration::from_secs(10);
         let surb_flush_graph = self.graph.clone();
         let surb_flush_interval = self.cfg.surb_flush_interval;
-        let surb_flush_planner = self.path_planner.clone();
         let surb_flush_smgr = self.smgr.clone();
         let surb_flush_chain = self.chain_api.clone();
         processes.insert(
@@ -866,19 +861,13 @@ where
                     .for_each(|_| {
                         // Detection before the drain: `degraded_destinations` reads the counts the
                         // flush is about to reset.
-                        // DIAGNOSTIC kill-switch, now gating only the path invalidation.
                         //
-                        // Measured: with both consumers suppressed a healthy baseline returns
-                        // 100%, and with them live it collapses to 0.14% -- so the invalidation is
-                        // the destructive element, not the key resolution that made it reach the
-                        // cache. What that comparison could not separate is the balancer mark,
-                        // which was suppressed alongside it. Keeping the mark while dropping the
-                        // invalidation isolates the supply fix from the path churn.
-                        let replanning_disabled = std::env::var_os("HOPR_DISABLE_RETURN_PATH_REPLAN").is_some();
-
+                        // Silence is acted on by the *supply* side only. Invalidating the cached
+                        // return-path candidates was measured to collapse a healthy session from
+                        // 100% arrival to 0.14%, because re-selection happens faster than a new
+                        // path can be established and judged -- so the planner is deliberately not
+                        // told about this.
                         for destination in surb_round_trips.degraded_destinations() {
-                            let node = hopr_api::types::internal::prelude::NodeId::Offchain(destination);
-
                             // Sessions name their destination by its chain address, this telemetry
                             // by its packet key, and a `NodeId` holding one is never equal to a
                             // `NodeId` holding the other -- so the match has to be made on a
@@ -889,25 +878,15 @@ where
                                 .flatten()
                                 .map(hopr_api::types::internal::prelude::NodeId::Chain);
 
-                            // Re-planning only changes which return path the *next* SURBs are minted
-                            // on. The counterparty also has to still be receiving SURBs to reply
-                            // with, and its silence has by now convinced our balancer that it is
-                            // well stocked -- so tell the Sessions routed there to stop believing
-                            // that estimate while the evidence says otherwise.
+                            // The counterparty has to still be receiving SURBs to reply with, and
+                            // its silence has by now convinced our balancer that it is well
+                            // stocked -- so tell the Sessions routed there to stop believing that
+                            // estimate while the evidence says otherwise.
                             let marked = as_session_names_it
                                 .map(|n| surb_flush_smgr.mark_return_path_degraded(&n, RETURN_PATH_DEGRADED_GRACE))
                                 .unwrap_or(0);
 
-                            tracing::info!(
-                                %destination,
-                                sessions = marked,
-                                replanning = !replanning_disabled,
-                                "return path silent"
-                            );
-
-                            if !replanning_disabled {
-                                surb_flush_planner.degrade_return_path(node);
-                            }
+                            tracing::info!(%destination, sessions = marked, "return path silent");
                         }
 
                         protocol::surb_telemetry::flush_into(

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -866,7 +866,19 @@ where
                     .for_each(|_| {
                         // Detection before the drain: `degraded_destinations` reads the counts the
                         // flush is about to reset.
+                        // DIAGNOSTIC kill-switch. Re-planning became destructive the moment its
+                        // invalidation started matching real cache entries, and it is not yet
+                        // established whether the damage comes from the invalidation itself or from
+                        // something else in the same change. Toggling this lets one binary produce
+                        // both arms of that comparison, so the two runs differ in nothing else.
+                        let replanning_disabled = std::env::var_os("HOPR_DISABLE_RETURN_PATH_REPLAN").is_some();
+
                         for destination in surb_round_trips.degraded_destinations() {
+                            if replanning_disabled {
+                                tracing::info!(%destination, "return path silent; re-planning DISABLED");
+                                continue;
+                            }
+
                             let node = hopr_api::types::internal::prelude::NodeId::Offchain(destination);
 
                             // Sessions name their destination by its chain address, this telemetry

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -854,51 +854,71 @@ where
         let surb_flush_interval = self.cfg.surb_flush_interval;
         let surb_flush_smgr = self.smgr.clone();
         let surb_flush_chain = self.chain_api.clone();
+        let surb_flush_planner = self.path_planner.clone();
         processes.insert(
             HoprTransportProcess::SurbFlush,
             hopr_utils::spawn_as_abortable!(async move {
-                futures_time::stream::interval(futures_time::time::Duration::from(surb_flush_interval))
-                    .for_each(|_| {
-                        // Detection before the drain: `degraded_destinations` reads the counts the
-                        // flush is about to reset.
-                        //
-                        // Silence is acted on by the *supply* side only. Invalidating the cached
-                        // return-path candidates was measured to collapse a healthy session from
-                        // 100% arrival to 0.14%, because re-selection happens faster than a new
-                        // path can be established and judged -- so the planner is deliberately not
-                        // told about this.
-                        for destination in surb_round_trips.degraded_destinations() {
-                            // Sessions name their destination by its chain address, this telemetry
-                            // by its packet key, and a `NodeId` holding one is never equal to a
-                            // `NodeId` holding the other -- so the match has to be made on a
-                            // resolved form, not on the enum.
-                            let as_session_names_it = surb_flush_chain
-                                .packet_key_to_chain_key(&destination)
-                                .ok()
-                                .flatten()
-                                .map(hopr_api::types::internal::prelude::NodeId::Chain);
+                let mut episodes = protocol::return_path_recovery::ReturnPathEpisodes::new(RETURN_PATH_DEGRADED_GRACE);
+                let mut ticks = futures_time::stream::interval(futures_time::time::Duration::from(surb_flush_interval));
 
-                            // The counterparty has to still be receiving SURBs to reply with, and
-                            // its silence has by now convinced our balancer that it is well
-                            // stocked -- so tell the Sessions routed there to stop believing that
-                            // estimate while the evidence says otherwise.
-                            let marked = as_session_names_it
-                                .map(|n| surb_flush_smgr.mark_return_path_degraded(&n, RETURN_PATH_DEGRADED_GRACE))
-                                .unwrap_or(0);
+                while ticks.next().await.is_some() {
+                    // Detection before the drain: `degraded_destinations` reads the counts the
+                    // flush is about to reset.
+                    let silent = surb_round_trips.degraded_destinations();
 
-                            tracing::info!(%destination, sessions = marked, "return path silent");
+                    // The graph has to see this interval's counts *before* anything re-plans on it,
+                    // otherwise the re-plan that the silence just triggered reads a graph one whole
+                    // tick behind the evidence that triggered it.
+                    protocol::surb_telemetry::flush_into(
+                        &surb_round_trips,
+                        &surb_flush_graph,
+                        hopr_utils::platform::time::native::current_time()
+                            .as_unix_timestamp()
+                            .as_millis(),
+                    );
+
+                    // Re-plan first, refill only if re-planning moved traffic. Run the other way
+                    // round the refill mints SURBs onto the very route the planner is abandoning --
+                    // see `protocol::return_path_recovery`.
+                    //
+                    // Borrowed rather than cloned per call: the callbacks are `FnMut`, so anything
+                    // they capture has to survive being invoked once per silent destination.
+                    let (planner, chain, smgr) = (&surb_flush_planner, &surb_flush_chain, &surb_flush_smgr);
+                    for step in episodes
+                        .tick(
+                            silent,
+                            |destination| async move { planner.recompute_paths_from(&destination).await },
+                            |destination| async move {
+                                // Sessions name their destination by its chain address, this
+                                // telemetry by its packet key, and a `NodeId` holding one is never
+                                // equal to a `NodeId` holding the other -- so the match has to be
+                                // made on a resolved form, not on the enum.
+                                //
+                                // The counterparty has to still be receiving SURBs to reply with,
+                                // and its silence has by now convinced our balancer that it is well
+                                // stocked -- so tell the Sessions routed there to stop believing
+                                // that estimate while the evidence says otherwise.
+                                chain
+                                    .packet_key_to_chain_key(&destination)
+                                    .ok()
+                                    .flatten()
+                                    .map(hopr_api::types::internal::prelude::NodeId::Chain)
+                                    .map(|n| smgr.mark_return_path_degraded(&n, RETURN_PATH_DEGRADED_GRACE))
+                                    .unwrap_or(0)
+                            },
+                        )
+                        .await
+                    {
+                        match step {
+                            protocol::return_path_recovery::RecoveryStep::Replanned { destination, moved } => {
+                                tracing::info!(%destination, entries = moved, "return path silent, re-planned")
+                            }
+                            protocol::return_path_recovery::RecoveryStep::Refilled { destination, sessions } => {
+                                tracing::info!(%destination, sessions, "refilling behind the re-plan")
+                            }
                         }
-
-                        protocol::surb_telemetry::flush_into(
-                            &surb_round_trips,
-                            &surb_flush_graph,
-                            hopr_utils::platform::time::native::current_time()
-                                .as_unix_timestamp()
-                                .as_millis(),
-                        );
-                        futures::future::ready(())
-                    })
-                    .await;
+                    }
+                }
             }),
         );
 

--- a/transport/hopr/src/path/mod.rs
+++ b/transport/hopr/src/path/mod.rs
@@ -15,6 +15,6 @@ pub mod selector;
 pub mod traits;
 
 pub use errors::{PathPlannerError, Result};
-pub use planner::{PathPlanner, PathPlannerConfig, PlannerReturnPathFeedback};
+pub use planner::{PathPlanner, PathPlannerConfig};
 pub use selector::HoprGraphPathSelector;
 pub use traits::{BackgroundPathCacheRefreshable, PathSelector, PathWithMetrics};

--- a/transport/hopr/src/path/planner.rs
+++ b/transport/hopr/src/path/planner.rs
@@ -14,7 +14,6 @@ use hopr_api::{
 };
 use hopr_crypto_packet::prelude::*;
 use hopr_protocol_hopr::{FoundSurb, SurbStore};
-use hopr_transport_session::flow_control::{ReturnPathFeedback, ReturnPathFeedbackFactory};
 use tracing::trace;
 use validator::{Validate, ValidationError};
 
@@ -252,9 +251,8 @@ fn temper_weights(weights: &[f64], temper: f64) -> Vec<f64> {
 /// Keyed on resolved offchain keys rather than [`NodeId`], because a `NodeId` naming a node by its
 /// chain address is never equal to one naming the same node by its packet key. Callers hold
 /// whichever form their layer happens to use -- Sessions carry chain addresses, the SURB telemetry
-/// reports packet keys -- so a raw-`NodeId` key silently stores the same route twice and, worse,
-/// makes [`PathPlanner::degrade_return_path`] invalidate an entry that does not exist. Resolving
-/// first makes lookup, insertion and invalidation agree by construction.
+/// reports packet keys -- so a raw-`NodeId` key silently stores the same route twice. Resolving
+/// first makes lookup and insertion agree by construction.
 type PlannerCacheKey = (OffchainPublicKey, OffchainPublicKey, u32);
 type PlannerCacheValue = Arc<hopr_utils::statistics::WeightedCollection<ValidatedPath>>;
 
@@ -615,87 +613,6 @@ where
                 Ok((ResolvedTransportRouting::Return(sender_id, surb), Some(remaining)))
             }
         }
-    }
-
-    /// Drops the cached return-path candidates for `destination`, so the next draw re-runs
-    /// selection against current edge scores instead of a list built before the failure.
-    ///
-    /// Invalidation is the whole action. It deliberately does *not* retire the relayers that were
-    /// in use: an earlier version did, because a batch was believed to span K distinct relayers and
-    /// there was no way to tell which had failed. Neither premise holds —
-    /// `HoprPacket::PAYLOAD_SIZE / HoprSurb::SIZE` is 2, so a batch never spanned more than two,
-    /// and per-edge SURB round-trip telemetry now says which ones are actually delivering.
-    ///
-    /// Return-path cache keys are `(destination, me, hops)` — reversed relative to forward paths,
-    /// because a return path runs *from* the destination back to us.
-    pub fn degrade_return_path(&self, destination: NodeId) {
-        let me = self.me;
-        let cache = self.cache.clone();
-        let resolver = self.resolver.clone();
-
-        // `moka::future::Cache::invalidate` is async and this is called from a poll context (the
-        // session's delivery clock), so it cannot be awaited here.
-        hopr_utils::runtime::prelude::spawn(async move {
-            // Resolve to the key the cache is actually keyed on. Passing the `NodeId` straight
-            // through invalidated nothing whenever the caller and the populating Session named the
-            // node by different forms, which is the normal case.
-            let dest_key = match destination {
-                NodeId::Offchain(key) => Some(key),
-                NodeId::Chain(addr) => ChainPathResolver::from(&*resolver)
-                    .resolve_transport_address(&addr)
-                    .await
-                    .ok()
-                    .flatten(),
-            };
-            let Some(dest_key) = dest_key else {
-                tracing::warn!(%destination, "cannot resolve degraded return path destination; nothing invalidated");
-                return;
-            };
-
-            for hops in 0..=RoutingOptions::MAX_INTERMEDIATE_HOPS as u32 {
-                cache.invalidate(&(dest_key, me, hops)).await;
-            }
-            tracing::debug!(%destination, "dropped cached return-path candidates after sustained loss");
-        });
-    }
-}
-
-/// Adapts a [`PathPlanner`] into the session layer's [`ReturnPathFeedbackFactory`].
-///
-/// The seam exists so the layer that *detects* return-path failure (the session's delivery clock)
-/// does not depend on the layer that *fixes* it (the path planner), nor the reverse.
-#[derive(Clone)]
-pub struct PlannerReturnPathFeedback<Surb, R, S>(pub PathPlanner<Surb, R, S>);
-
-impl<Surb, R, S> ReturnPathFeedbackFactory for PlannerReturnPathFeedback<Surb, R, S>
-where
-    Surb: SurbStore + Clone + Send + Sync + 'static,
-    R: Clone + ChainKeyOperations + ChainReadChannelOperations + Send + Sync + 'static,
-    S: Clone + PathSelector + Send + Sync + 'static,
-{
-    fn for_destination(&self, destination: NodeId) -> Arc<dyn ReturnPathFeedback> {
-        Arc::new(DestinationBoundFeedback {
-            planner: self.0.clone(),
-            destination,
-        })
-    }
-}
-
-/// A [`ReturnPathFeedback`] bound to one destination, since the session knows its counterparty but
-/// the trait method carries no arguments.
-struct DestinationBoundFeedback<Surb, R, S> {
-    planner: PathPlanner<Surb, R, S>,
-    destination: NodeId,
-}
-
-impl<Surb, R, S> ReturnPathFeedback for DestinationBoundFeedback<Surb, R, S>
-where
-    Surb: SurbStore + Send + Sync + 'static,
-    R: ChainKeyOperations + ChainReadChannelOperations + Send + Sync + 'static,
-    S: PathSelector + Send + Sync + 'static,
-{
-    fn return_path_degraded(&self) {
-        self.planner.degrade_return_path(self.destination);
     }
 }
 
@@ -1097,14 +1014,13 @@ mod tests {
 
     // ── test: zero-hop path ───────────────────────────────────────────────────
 
-    /// A Session names its destination by chain address; this telemetry names it by packet key.
+    /// A Session names its destination by chain address; the SURB telemetry names it by packet key.
     ///
-    /// Regression: the cache used to be keyed on the `NodeId` as handed in, so an invalidation
-    /// holding the packet key never matched an entry populated from a chain address. Detection
-    /// fired correctly and dropped nothing -- indistinguishable, from the outside, from a
-    /// re-planning mechanism that simply does not help.
+    /// Regression: the cache used to be keyed on the `NodeId` as handed in, and
+    /// `NodeId::Chain(addr) != NodeId::Offchain(key)` even for the same node -- so the two layers
+    /// stored and looked up the same route under different keys without either noticing.
     #[tokio::test]
-    async fn degrading_a_return_path_should_invalidate_it_whichever_form_names_the_node() {
+    async fn a_return_path_should_cache_under_one_key_whichever_form_names_the_node() {
         let me = pubkey(&SECRET_ME);
         let a = pubkey(&SECRET_A);
         let dest = pubkey(&SECRET_DEST);
@@ -1149,18 +1065,26 @@ mod tests {
             "the return path should be cached after resolution"
         );
 
-        // Degraded the way the SURB telemetry reports it: by packet key.
-        planner.degrade_return_path(NodeId::Offchain(dest));
+        // Asking again the way the SURB telemetry names the node -- by packet key -- must land on
+        // that same entry rather than resolving and caching a second copy.
+        planner.cache.run_pending_tasks().await;
+        assert_eq!(planner.cache.entry_count(), 1, "one resolution, one entry");
 
-        // The invalidation is spawned, so give it a chance to run.
-        for _ in 0..50 {
-            if planner.cache.get(&cache_key).await.is_none() {
-                return;
-            }
-            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-        }
+        let _ = planner
+            .resolve_diverse_return_paths(
+                NodeId::Offchain(dest),
+                RoutingOptions::Hops(1.try_into().expect("valid 1")),
+                1,
+            )
+            .await
+            .expect("return path resolution should succeed");
 
-        panic!("degrading by packet key must invalidate an entry cached by chain address");
+        planner.cache.run_pending_tasks().await;
+        assert_eq!(
+            planner.cache.entry_count(),
+            1,
+            "naming the destination by packet key must hit the entry cached from its chain address"
+        );
     }
 
     #[tokio::test]

--- a/transport/hopr/src/path/planner.rs
+++ b/transport/hopr/src/path/planner.rs
@@ -248,7 +248,14 @@ fn temper_weights(weights: &[f64], temper: f64) -> Vec<f64> {
 ///
 /// Only the `Hops` variant of [`RoutingOptions`] is cached (explicit intermediate
 /// paths bypass the cache), so the key stores the hop count as a plain `u32`.
-type PlannerCacheKey = (NodeId, NodeId, u32);
+///
+/// Keyed on resolved offchain keys rather than [`NodeId`], because a `NodeId` naming a node by its
+/// chain address is never equal to one naming the same node by its packet key. Callers hold
+/// whichever form their layer happens to use -- Sessions carry chain addresses, the SURB telemetry
+/// reports packet keys -- so a raw-`NodeId` key silently stores the same route twice and, worse,
+/// makes [`PathPlanner::degrade_return_path`] invalidate an entry that does not exist. Resolving
+/// first makes lookup, insertion and invalidation agree by construction.
+type PlannerCacheKey = (OffchainPublicKey, OffchainPublicKey, u32);
 type PlannerCacheValue = Arc<hopr_utils::statistics::WeightedCollection<ValidatedPath>>;
 
 /// Path planner that resolves [`DestinationRouting`] to [`ResolvedTransportRouting`].
@@ -403,7 +410,7 @@ where
         let src_key = self.resolve_node_id_to_offchain_key(&source).await?;
         let dest_key = self.resolve_node_id_to_offchain_key(&destination).await?;
 
-        let cache_key: PlannerCacheKey = (source, destination, u32::from(hops));
+        let cache_key: PlannerCacheKey = (src_key, dest_key, u32::from(hops));
 
         let resolver = self.resolver.clone();
         let selector = self.selector.clone();
@@ -622,14 +629,31 @@ where
     /// Return-path cache keys are `(destination, me, hops)` — reversed relative to forward paths,
     /// because a return path runs *from* the destination back to us.
     pub fn degrade_return_path(&self, destination: NodeId) {
-        let me = NodeId::Offchain(self.me);
+        let me = self.me;
         let cache = self.cache.clone();
+        let resolver = self.resolver.clone();
 
         // `moka::future::Cache::invalidate` is async and this is called from a poll context (the
         // session's delivery clock), so it cannot be awaited here.
         hopr_utils::runtime::prelude::spawn(async move {
+            // Resolve to the key the cache is actually keyed on. Passing the `NodeId` straight
+            // through invalidated nothing whenever the caller and the populating Session named the
+            // node by different forms, which is the normal case.
+            let dest_key = match destination {
+                NodeId::Offchain(key) => Some(key),
+                NodeId::Chain(addr) => ChainPathResolver::from(&*resolver)
+                    .resolve_transport_address(&addr)
+                    .await
+                    .ok()
+                    .flatten(),
+            };
+            let Some(dest_key) = dest_key else {
+                tracing::warn!(%destination, "cannot resolve degraded return path destination; nothing invalidated");
+                return;
+            };
+
             for hops in 0..=RoutingOptions::MAX_INTERMEDIATE_HOPS as u32 {
-                cache.invalidate(&(destination, me, hops)).await;
+                cache.invalidate(&(dest_key, me, hops)).await;
             }
             tracing::debug!(%destination, "dropped cached return-path candidates after sustained loss");
         });
@@ -706,7 +730,7 @@ where
 
             async move {
                 for (key, _) in cache.iter() {
-                    let (src, dest, hops_u32) = {
+                    let (src_key, dest_key, hops_u32) = {
                         let k = key.as_ref();
                         (k.0, k.1, k.2)
                     };
@@ -716,24 +740,11 @@ where
                     }
                     let hops_usize = hops_u32 as usize;
 
-                    let resolve_key = |node: NodeId| {
-                        let resolver = resolver.clone();
+                    // The key already holds resolved offchain keys, which is what the selector
+                    // wants -- so nothing has to be resolved again here.
+                    let src = NodeId::Offchain(src_key);
 
-                        async move {
-                            match node {
-                                NodeId::Offchain(k) => Some(k),
-                                NodeId::Chain(addr) => ChainPathResolver::from(&*resolver)
-                                    .resolve_transport_address(&addr)
-                                    .await
-                                    .ok()
-                                    .flatten(),
-                            }
-                        }
-                    };
-
-                    if let (Some(src_key), Some(dest_key)) = (resolve_key(src).await, resolve_key(dest).await)
-                        && let Ok(candidates) = selector.select_path(src_key, dest_key, hops_usize)
-                    {
+                    if let Ok(candidates) = selector.select_path(src_key, dest_key, hops_usize) {
                         let chain_resolver = ChainPathResolver::from(&*resolver);
                         let mut valid_paths: Vec<(ValidatedPath, f64)> = Vec::with_capacity(candidates.len());
                         let mut path_metrics: Vec<PathWithMetrics> = Vec::with_capacity(candidates.len());
@@ -771,7 +782,7 @@ where
                                     "weighted candidate path",
                                 );
                             }
-                            cache.insert((src, dest, hops_u32), Arc::new(weighted)).await;
+                            cache.insert((src_key, dest_key, hops_u32), Arc::new(weighted)).await;
                         }
                     }
                 }
@@ -1086,6 +1097,72 @@ mod tests {
 
     // ── test: zero-hop path ───────────────────────────────────────────────────
 
+    /// A Session names its destination by chain address; this telemetry names it by packet key.
+    ///
+    /// Regression: the cache used to be keyed on the `NodeId` as handed in, so an invalidation
+    /// holding the packet key never matched an entry populated from a chain address. Detection
+    /// fired correctly and dropped nothing -- indistinguishable, from the outside, from a
+    /// re-planning mechanism that simply does not help.
+    #[tokio::test]
+    async fn degrading_a_return_path_should_invalidate_it_whichever_form_names_the_node() {
+        let me = pubkey(&SECRET_ME);
+        let a = pubkey(&SECRET_A);
+        let dest = pubkey(&SECRET_DEST);
+
+        let graph = ChannelGraph::new(me);
+        graph.add_node(a);
+        graph.add_node(dest);
+        // A return path runs from the destination back to us.
+        graph.add_edge(&dest, &a).unwrap();
+        graph.add_edge(&a, &me).unwrap();
+        mark_edge_full(&graph, &dest, &a);
+        mark_edge_full(&graph, &a, &me);
+
+        let cfg = small_config();
+        let selector = HoprGraphPathSelector::new(
+            me,
+            graph,
+            cfg.max_cached_paths,
+            cfg.edge_penalty,
+            cfg.min_ack_rate,
+            cfg.min_paths_anonymity_floor,
+        );
+        let chain_api = TestChainApi::new(me, me_addr(), vec![(a, a_addr()), (dest, dest_addr())])
+            .with_open_channel(dest_addr(), a_addr())
+            .with_open_channel(a_addr(), me_addr());
+        let surb_store = hopr_protocol_hopr::MemorySurbStore::default();
+        let planner = PathPlanner::new(me, surb_store, chain_api, selector, small_config());
+
+        // Populated the way a Session does it: by chain address.
+        let _ = planner
+            .resolve_diverse_return_paths(
+                NodeId::Chain(dest_addr()),
+                RoutingOptions::Hops(1.try_into().expect("valid 1")),
+                1,
+            )
+            .await
+            .expect("return path resolution should succeed");
+
+        let cache_key: PlannerCacheKey = (dest, me, 1);
+        assert!(
+            planner.cache.get(&cache_key).await.is_some(),
+            "the return path should be cached after resolution"
+        );
+
+        // Degraded the way the SURB telemetry reports it: by packet key.
+        planner.degrade_return_path(NodeId::Offchain(dest));
+
+        // The invalidation is spawned, so give it a chance to run.
+        for _ in 0..50 {
+            if planner.cache.get(&cache_key).await.is_none() {
+                return;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        panic!("degrading by packet key must invalidate an entry cached by chain address");
+    }
+
     #[tokio::test]
     async fn zero_hop_path_should_bypass_selector() {
         let me = pubkey(&SECRET_ME);
@@ -1318,7 +1395,12 @@ mod tests {
             .expect("zero return paths is not an error");
         assert!(paths.is_empty());
 
-        let cache_key: PlannerCacheKey = (dest, NodeId::Offchain(pubkey(&SECRET_ME)), 1);
+        // Keyed on resolved offchain keys, so the test names the nodes the same way.
+        let dest_key = match dest {
+            NodeId::Offchain(k) => k,
+            NodeId::Chain(_) => unreachable!("the fixture names the destination by its packet key"),
+        };
+        let cache_key: PlannerCacheKey = (dest_key, pubkey(&SECRET_ME), 1);
         assert!(
             planner.cache.get(&cache_key).await.is_none(),
             "nothing requested must not query the planner"
@@ -1414,7 +1496,7 @@ mod tests {
         let surb_store = hopr_protocol_hopr::MemorySurbStore::default();
         let planner = PathPlanner::new(me, surb_store, chain_api, selector, small_config());
 
-        let cache_key: PlannerCacheKey = (NodeId::Offchain(me), NodeId::Offchain(dest), 1);
+        let cache_key: PlannerCacheKey = (me, dest, 1);
 
         assert!(
             planner.cache.get(&cache_key).await.is_none(),

--- a/transport/hopr/src/path/planner.rs
+++ b/transport/hopr/src/path/planner.rs
@@ -62,10 +62,19 @@ pub struct PathPlannerConfig {
     pub max_cache_capacity: u64,
     /// Time-to-live for a cached path list.  When an entry expires the next
     /// [`PathPlanner::resolve_routing`] call transparently recomputes it (lazy refresh).
-    #[default(Duration::from_secs(60))]
+    ///
+    /// Candidate weights are computed once, when the entry is filled, and frozen in the
+    /// [`hopr_utils::statistics::WeightedCollection`] -- so this bounds how stale the *weights* a
+    /// live session draws from can be, not merely how stale the candidate set is. At the previous
+    /// 60 s a relay that stopped delivering kept its full share of return-path draws for a minute
+    /// after the graph had already scored it down.
+    #[default(Duration::from_secs(10))]
     pub cache_ttl: Duration,
     /// Period between proactive background cache-refresh sweeps.
-    #[default(Duration::from_secs(30))]
+    ///
+    /// Held at half the TTL so a steady-state session is normally served from an entry that was
+    /// re-weighted rather than one that expired under it.
+    #[default(Duration::from_secs(5))]
     pub refresh_period: Duration,
     /// Maximum number of candidate paths the selector may return per query.
     /// All returned candidates are validated and cached.
@@ -904,6 +913,28 @@ mod tests {
         assert!(
             (0..1_000).any(|_| pick_uniform_index(weights.len()) == Some(1)),
             "an exploratory draw must be able to reach it"
+        );
+    }
+
+    /// Cached candidate weights are frozen at fill time, so the TTL bounds how stale the numbers a
+    /// live session draws from can be -- not just how stale the candidate set is.
+    #[test]
+    fn the_path_cache_should_expire_faster_than_a_session_can_be_lost() {
+        let cfg = PathPlannerConfig::default();
+
+        // The SURB round-trip window slices at 5s. A TTL far above that lets a relay keep its full
+        // share of return-path draws long after the graph has scored it down -- measured as a
+        // session that stayed degraded for minutes after the evidence was in.
+        assert!(
+            cfg.cache_ttl <= Duration::from_secs(15),
+            "path cache TTL {:?} outlives the evidence that should displace it",
+            cfg.cache_ttl
+        );
+        assert!(
+            cfg.refresh_period < cfg.cache_ttl,
+            "the background sweep ({:?}) must re-weight entries before they expire ({:?})",
+            cfg.refresh_period,
+            cfg.cache_ttl
         );
     }
 

--- a/transport/hopr/src/path/planner.rs
+++ b/transport/hopr/src/path/planner.rs
@@ -317,6 +317,48 @@ where
     Ok(Some(weighted))
 }
 
+/// Smallest change in a candidate's share of the draws that counts as traffic having moved.
+///
+/// Weights are recomputed from live observations, so they jitter constantly without meaning
+/// anything. One percentage point of a candidate's share is well below the shift a relayer going
+/// silent produces (measured: 33% to near zero) and well above the noise of an idle graph.
+const MIN_SHARE_SHIFT: f64 = 0.01;
+
+/// Each candidate's share of the total weight, keyed by the route it takes.
+fn shares_by_route(paths: &hopr_utils::statistics::WeightedCollection<ValidatedPath>) -> Vec<(String, f64)> {
+    let total: f64 = paths.iter().map(|(_, w)| w.max(0.0)).sum();
+    paths
+        .iter()
+        .map(|(vp, w)| {
+            let share = if total > 0.0 { w.max(0.0) / total } else { 0.0 };
+            (vp.to_string(), share)
+        })
+        .collect()
+}
+
+/// Whether re-weighting would send a materially different share of the draws somewhere else.
+///
+/// Shares rather than raw weights, because the draw normalises over the collection: every weight
+/// halving changes nothing about where traffic goes. Callers use this to decide whether a re-plan
+/// achieved anything, and a re-plan that moved nothing is a reason *not* to act on it -- so
+/// answering "yes" by default would defeat the check it exists for.
+fn weights_moved(
+    before: &hopr_utils::statistics::WeightedCollection<ValidatedPath>,
+    after: &hopr_utils::statistics::WeightedCollection<ValidatedPath>,
+) -> bool {
+    let (before, after) = (shares_by_route(before), shares_by_route(after));
+    if before.len() != after.len() {
+        return true;
+    }
+    before.iter().any(|(route, was)| {
+        // A route that vanished has lost its whole share, which is the largest move there is.
+        after
+            .iter()
+            .find(|(other, _)| other == route)
+            .is_none_or(|(_, now)| (now - was).abs() >= MIN_SHARE_SHIFT)
+    })
+}
+
 /// Cache key for the path planner: `(source, destination, hops)`.
 ///
 /// Only the `Hops` variant of [`RoutingOptions`] is cached (explicit intermediate
@@ -513,7 +555,10 @@ where
     /// already holds. Dropping them was measured to collapse a healthy session from 100 % to
     /// 0.14 %, because a live session draws its next return path from this very entry.
     ///
-    /// Returns how many entries were actually replaced.
+    /// Returns how many entries came back with a materially different **share** of the draws --
+    /// not how many were rebuilt. Callers use this to decide whether the re-plan achieved anything
+    /// worth acting on, and on a healthy graph a rebuild always succeeds, so counting rebuilds
+    /// would answer "something moved" every time.
     pub async fn recompute_paths_from(&self, source: &OffchainPublicKey) -> usize {
         // 0-hop entries name a direct route with nothing to re-weight, exactly as in the sweep.
         let keys = self
@@ -523,7 +568,7 @@ where
             .filter(|(src, _, hops)| src == source && *hops > 0)
             .collect::<Vec<PlannerCacheKey>>();
 
-        let mut replaced = 0usize;
+        let mut moved = 0usize;
         for (src_key, dest_key, hops) in keys {
             if let Ok(Some(weighted)) = rebuild_candidates(
                 &*self.resolver,
@@ -536,13 +581,22 @@ where
             )
             .await
             {
-                self.cache.insert((src_key, dest_key, hops), Arc::new(weighted)).await;
-                replaced += 1;
+                let key = (src_key, dest_key, hops);
+                // A fresh entry counts as moved -- there was no previous distribution to compare
+                // against, so nothing here can say the traffic stayed put.
+                let shifted = match self.cache.get(&key).await {
+                    Some(previous) => weights_moved(&previous, &weighted),
+                    None => true,
+                };
+                self.cache.insert(key, Arc::new(weighted)).await;
+                if shifted {
+                    moved += 1;
+                }
             }
         }
 
-        tracing::debug!(%source, replaced, "recomputed cached paths originating at peer");
-        replaced
+        tracing::debug!(%source, moved, "recomputed cached paths originating at peer");
+        moved
     }
 
     /// Resolves `count` return paths from `destination` back to this node, drawn weighted-random
@@ -1790,12 +1844,48 @@ mod tests {
     ///
     /// Rebuilding every entry on every detection would put the cost of one dead relay onto every
     /// other session the node is carrying.
+    /// A recompute that lands on the same weights has moved no traffic, and the caller uses that
+    /// answer to decide whether refilling is worth anything.
+    ///
+    /// Reporting the number of entries *rebuilt* instead would say "moved" every time, since a
+    /// rebuild always succeeds on a healthy graph -- and refilling behind a re-plan that changed
+    /// nothing just mints more SURBs onto the same route.
+    #[tokio::test]
+    async fn a_recompute_that_lands_on_the_same_weights_should_report_nothing_moved() {
+        let (planner, graph) = two_relayer_return_planner();
+        let dest = pubkey(&SECRET_DEST);
+
+        let _ = fill_return_cache(&planner).await;
+
+        assert_eq!(
+            planner.recompute_paths_from(&dest).await,
+            0,
+            "nothing about the graph changed, so no traffic can have moved"
+        );
+
+        // Vacuity guard: the same call must report movement once the evidence actually shifts.
+        // B has to deliver first -- the rate is read against a peak, so a relayer that never had
+        // one has no rate to fall from and the collapse would be invisible.
+        record_surbs(&graph, &dest, &pubkey(&SECRET_A), 1_000, 1_000);
+        record_surbs(&graph, &dest, &pubkey(&SECRET_B), 1_000, 1_000);
+        record_surbs(&graph, &dest, &pubkey(&SECRET_B), 4_000, 0);
+        assert_eq!(
+            planner.recompute_paths_from(&dest).await,
+            1,
+            "a collapse on one relayer must register as moved"
+        );
+    }
+
     #[tokio::test]
     async fn recomputing_should_rebuild_only_the_entries_originating_at_that_peer() {
-        let (planner, _graph) = two_relayer_return_planner();
+        let (planner, graph) = two_relayer_return_planner();
         let (me, a, dest) = (pubkey(&SECRET_ME), pubkey(&SECRET_A), pubkey(&SECRET_DEST));
 
         let _ = fill_return_cache(&planner).await;
+        // Something has to actually move, or the count below would be zero for the wrong reason.
+        record_surbs(&graph, &dest, &a, 1_000, 1_000);
+        record_surbs(&graph, &dest, &pubkey(&SECRET_B), 1_000, 1_000);
+        record_surbs(&graph, &dest, &pubkey(&SECRET_B), 4_000, 0);
         // A second entry in the other direction, which no `dest` recompute may touch.
         let _ = planner
             .cached_paths(
@@ -1808,7 +1898,7 @@ mod tests {
         assert_eq!(
             planner.recompute_paths_from(&dest).await,
             1,
-            "only the entry whose paths start at the named peer should be rebuilt"
+            "only the entry whose paths start at the named peer should be re-weighted"
         );
         assert_eq!(
             planner.recompute_paths_from(&pubkey(&SECRET_B)).await,

--- a/transport/hopr/src/path/planner.rs
+++ b/transport/hopr/src/path/planner.rs
@@ -252,6 +252,71 @@ fn temper_weights(weights: &[f64], temper: f64) -> Vec<f64> {
     weights.iter().map(|w| w.max(0.0).powf(temper)).collect()
 }
 
+/// Rebuilds the weighted candidate collection for one `(source, destination, hops)` triple from
+/// whatever the graph currently says.
+///
+/// Shared by the lazy cache fill, the background sweep and the on-demand recompute, so all three
+/// necessarily agree: a divergence here would make a session's weights depend on which of the three
+/// happened to run last.
+///
+/// `Ok(None)` means the selector offered nothing, or nothing survived validation. Callers decide
+/// what that means — a fill turns it into `PathNotFound`, a refresh leaves the existing entry
+/// alone. `Err` is reserved for a selector that actually failed.
+async fn rebuild_candidates<R, S>(
+    resolver: &R,
+    selector: &S,
+    weighting: WeightingParams,
+    src_key: OffchainPublicKey,
+    dest_key: OffchainPublicKey,
+    hops: usize,
+    kind: &'static str,
+) -> Result<Option<hopr_utils::statistics::WeightedCollection<ValidatedPath>>>
+where
+    R: ChainKeyOperations + ChainReadChannelOperations + Send + Sync,
+    S: PathSelector,
+{
+    let candidates = selector.select_path(src_key, dest_key, hops)?;
+
+    let chain_resolver = ChainPathResolver::from(resolver);
+    let mut valid_paths: Vec<(ValidatedPath, f64)> = Vec::with_capacity(candidates.len());
+    let mut path_metrics: Vec<PathWithMetrics> = Vec::with_capacity(candidates.len());
+    for mut pwc in candidates {
+        let path_nodes = std::mem::take(&mut pwc.path);
+        let node_ids: Vec<NodeId> = path_nodes.into_iter().map(NodeId::Offchain).collect::<Vec<_>>();
+        match ValidatedPath::new(NodeId::Offchain(src_key), node_ids, &chain_resolver).await {
+            Ok(vp) => {
+                valid_paths.push((vp, composite_weight(&pwc, hops, weighting)));
+                path_metrics.push(pwc);
+            }
+            Err(e) => tracing::debug!(kind, error = %e, "path candidate failed validation"),
+        }
+    }
+
+    if valid_paths.is_empty() {
+        return Ok(None);
+    }
+
+    let weighted = hopr_utils::statistics::WeightedCollection::new(valid_paths);
+    let total_wt = weighted.total_weight();
+    for ((vp, w), pwm) in weighted.iter().zip(path_metrics.iter()) {
+        tracing::debug!(
+            kind,
+            destination = %dest_key,
+            hops,
+            path = %vp,
+            cost = pwm.cost,
+            composite_weight = w,
+            sampling_probability = if total_wt > 0.0 && *w > 0.0 { *w / total_wt } else { 0.0 },
+            total_latency_ms = ?pwm.total_latency_ms,
+            min_probe_success_rate = ?pwm.min_probe_success_rate,
+            min_ack_rate = ?pwm.min_ack_rate,
+            capacity_floor = ?pwm.capacity_floor,
+            "weighted candidate path",
+        );
+    }
+    Ok(Some(weighted))
+}
+
 /// Cache key for the path planner: `(source, destination, hops)`.
 ///
 /// Only the `Hops` variant of [`RoutingOptions`] is cached (explicit intermediate
@@ -426,52 +491,58 @@ where
         self.cache
             .try_get_with(cache_key, async move {
                 trace!(hops = hops_usize, "path cache miss, querying selector");
-                let candidates = selector.select_path(src_key, dest_key, hops_usize)?;
-
-                let chain_resolver = ChainPathResolver::from(&*resolver);
-                let mut valid_paths: Vec<(ValidatedPath, f64)> = Vec::with_capacity(candidates.len());
-                let mut path_metrics: Vec<PathWithMetrics> = Vec::with_capacity(candidates.len());
-                for mut pwc in candidates {
-                    let path_nodes = std::mem::take(&mut pwc.path);
-                    let node_ids: Vec<NodeId> = path_nodes.into_iter().map(NodeId::Offchain).collect::<Vec<_>>();
-                    match ValidatedPath::new(source, node_ids, &chain_resolver).await {
-                        Ok(vp) => {
-                            valid_paths.push((vp, composite_weight(&pwc, hops_usize, weighting)));
-                            path_metrics.push(pwc);
-                        }
-                        Err(e) => tracing::debug!(error = %e, "path candidate failed validation"),
-                    }
-                }
-
-                if valid_paths.is_empty() {
-                    return Err(PathPlannerError::Path(PathError::PathNotFound(
-                        hops_usize,
-                        src_key.to_hex(),
-                        dest_key.to_hex(),
-                    )));
-                }
-
-                let weighted = hopr_utils::statistics::WeightedCollection::new(valid_paths);
-                let total_wt = weighted.total_weight();
-                for ((vp, w), pwm) in weighted.iter().zip(path_metrics.iter()) {
-                    tracing::debug!(
-                        %destination,
-                        hops = hops_usize,
-                        path = %vp,
-                        cost = pwm.cost,
-                        composite_weight = w,
-                        sampling_probability = if total_wt > 0.0 && *w > 0.0 { *w / total_wt } else { 0.0 },
-                        total_latency_ms = ?pwm.total_latency_ms,
-                        min_probe_success_rate = ?pwm.min_probe_success_rate,
-                        min_ack_rate = ?pwm.min_ack_rate,
-                        capacity_floor = ?pwm.capacity_floor,
-                        "weighted candidate path",
-                    );
-                }
-                Ok(Arc::new(weighted))
+                rebuild_candidates(&*resolver, &*selector, weighting, src_key, dest_key, hops_usize, "fill")
+                    .await?
+                    .map(Arc::new)
+                    .ok_or_else(|| {
+                        PathPlannerError::Path(PathError::PathNotFound(hops_usize, src_key.to_hex(), dest_key.to_hex()))
+                    })
             })
             .await
             .map_err(PathPlannerError::CacheError)
+    }
+
+    /// Rebuilds every cached entry whose paths originate at `source`, replacing each in place.
+    ///
+    /// Return paths are cached under `(counterparty, me, hops)`, so this is how a caller that has
+    /// just learned a counterparty's return traffic went silent forces those weights to be rebuilt
+    /// from the current graph, instead of waiting up to
+    /// [`PathPlannerConfig::refresh_period`] for the background sweep to reach them.
+    ///
+    /// Entries are replaced, never dropped: one that rebuilds to nothing keeps serving what it
+    /// already holds. Dropping them was measured to collapse a healthy session from 100 % to
+    /// 0.14 %, because a live session draws its next return path from this very entry.
+    ///
+    /// Returns how many entries were actually replaced.
+    pub async fn recompute_paths_from(&self, source: &OffchainPublicKey) -> usize {
+        // 0-hop entries name a direct route with nothing to re-weight, exactly as in the sweep.
+        let keys = self
+            .cache
+            .iter()
+            .map(|(key, _)| *key.as_ref())
+            .filter(|(src, _, hops)| src == source && *hops > 0)
+            .collect::<Vec<PlannerCacheKey>>();
+
+        let mut replaced = 0usize;
+        for (src_key, dest_key, hops) in keys {
+            if let Ok(Some(weighted)) = rebuild_candidates(
+                &*self.resolver,
+                &*self.selector,
+                self.weighting,
+                src_key,
+                dest_key,
+                hops as usize,
+                "recompute",
+            )
+            .await
+            {
+                self.cache.insert((src_key, dest_key, hops), Arc::new(weighted)).await;
+                replaced += 1;
+            }
+        }
+
+        tracing::debug!(%source, replaced, "recomputed cached paths originating at peer");
+        replaced
     }
 
     /// Resolves `count` return paths from `destination` back to this node, drawn weighted-random
@@ -664,52 +735,21 @@ where
                     if hops_u32 == 0 {
                         continue;
                     }
-                    let hops_usize = hops_u32 as usize;
 
                     // The key already holds resolved offchain keys, which is what the selector
                     // wants -- so nothing has to be resolved again here.
-                    let src = NodeId::Offchain(src_key);
-
-                    if let Ok(candidates) = selector.select_path(src_key, dest_key, hops_usize) {
-                        let chain_resolver = ChainPathResolver::from(&*resolver);
-                        let mut valid_paths: Vec<(ValidatedPath, f64)> = Vec::with_capacity(candidates.len());
-                        let mut path_metrics: Vec<PathWithMetrics> = Vec::with_capacity(candidates.len());
-                        for mut pwc in candidates {
-                            let path_nodes = std::mem::take(&mut pwc.path);
-                            let node_ids: Vec<NodeId> =
-                                path_nodes.into_iter().map(NodeId::Offchain).collect::<Vec<_>>();
-                            match ValidatedPath::new(src, node_ids, &chain_resolver).await {
-                                Ok(vp) => {
-                                    valid_paths.push((vp, composite_weight(&pwc, hops_usize, weighting)));
-                                    path_metrics.push(pwc);
-                                }
-                                Err(e) => {
-                                    tracing::debug!(error = %e, "background refresh: path candidate failed validation")
-                                }
-                            }
-                        }
-
-                        if !valid_paths.is_empty() {
-                            let weighted = hopr_utils::statistics::WeightedCollection::new(valid_paths);
-                            let total_wt = weighted.total_weight();
-                            for ((vp, w), pwm) in weighted.iter().zip(path_metrics.iter()) {
-                                tracing::debug!(
-                                    kind = "background-refresh",
-                                    destination = %dest_key,
-                                    hops = hops_usize,
-                                    path = %vp,
-                                    cost = pwm.cost,
-                                    composite_weight = w,
-                                    sampling_probability = if total_wt > 0.0 && *w > 0.0 { *w / total_wt } else { 0.0 },
-                                    total_latency_ms = ?pwm.total_latency_ms,
-                                    min_probe_success_rate = ?pwm.min_probe_success_rate,
-                                    min_ack_rate = ?pwm.min_ack_rate,
-                                    capacity_floor = ?pwm.capacity_floor,
-                                    "weighted candidate path",
-                                );
-                            }
-                            cache.insert((src_key, dest_key, hops_u32), Arc::new(weighted)).await;
-                        }
+                    if let Ok(Some(weighted)) = rebuild_candidates(
+                        &*resolver,
+                        &*selector,
+                        weighting,
+                        src_key,
+                        dest_key,
+                        hops_u32 as usize,
+                        "background-refresh",
+                    )
+                    .await
+                    {
+                        cache.insert((src_key, dest_key, hops_u32), Arc::new(weighted)).await;
                     }
                 }
             }
@@ -752,6 +792,8 @@ mod tests {
     const SECRET_ME: [u8; 32] = hex!("60741b83b99e36aa0c1331578156e16b8e21166d01834abb6c64b103f885734d");
     const SECRET_A: [u8; 32] = hex!("71bf1f42ebbfcd89c3e197a3fd7cda79b92499e509b6fefa0fe44d02821d146a");
     const SECRET_DEST: [u8; 32] = hex!("c24bd833704dd2abdae3933fcc9962c2ac404f84132224c474147382d4db2299");
+    /// A second relayer, so a return fixture can offer a real alternative to the one that dies.
+    const SECRET_B: [u8; 32] = hex!("3d5f2c8a91b4e07d6a3c1f8e2b95d40c7e6a1938f2c5b8d04e7a1c396b2f8d05");
 
     fn pubkey(secret: &[u8; 32]) -> OffchainPublicKey {
         *OffchainKeypair::from_secret(secret).expect("valid secret").public()
@@ -1020,6 +1062,9 @@ mod tests {
     }
     fn dest_addr() -> Address {
         Address::from_str("0x30004105095c8c10f804109b4d1199a9ac40ed46").expect("valid addr")
+    }
+    fn b_addr() -> Address {
+        Address::from_str("0x40001a7ec3d5b28f9047c6b1e83d5a2f9c71b0e4").expect("valid addr")
     }
 
     // ── graph helpers ──────────────────────────────────────────────────────────
@@ -1547,6 +1592,229 @@ mod tests {
         let planner = PathPlanner::new(me, surb_store, chain_api, selector, small_config());
         // Just ensure it compiles and produces a future.
         let _future = planner.run_background_refresh();
+    }
+
+    // ── recomputing one cache entry in place ──────────────────────────────────
+
+    type TestPlanner =
+        PathPlanner<hopr_protocol_hopr::MemorySurbStore, TestChainApi, HoprGraphPathSelector<ChannelGraph>>;
+
+    /// Return-path fixture with two interchangeable relayers: `dest -> {A, B} -> me`.
+    ///
+    /// Both start fully observed and identically good, so any later divergence in their share of
+    /// the return draws is attributable to what the test recorded and not to the fixture.
+    ///
+    /// The graph is returned alongside the planner because it is the handle a test needs to move
+    /// the evidence *under* an already-populated cache -- which is the whole point of the primitive
+    /// under test.
+    fn two_relayer_return_planner() -> (TestPlanner, ChannelGraph) {
+        let me = pubkey(&SECRET_ME);
+        let a = pubkey(&SECRET_A);
+        let b = pubkey(&SECRET_B);
+        let dest = pubkey(&SECRET_DEST);
+
+        let graph = ChannelGraph::new(me);
+        for node in [a, b, dest] {
+            graph.add_node(node);
+        }
+        for (src, dst) in [(dest, a), (a, me), (dest, b), (b, me)] {
+            graph.add_edge(&src, &dst).expect("edge should be addable");
+            mark_edge_full(&graph, &src, &dst);
+        }
+
+        let cfg = small_config();
+        let selector = HoprGraphPathSelector::new(
+            me,
+            graph.clone(),
+            cfg.max_cached_paths,
+            cfg.edge_penalty,
+            cfg.min_ack_rate,
+            cfg.min_paths_anonymity_floor,
+        );
+        let chain_api = TestChainApi::new(me, me_addr(), vec![(a, a_addr()), (b, b_addr()), (dest, dest_addr())])
+            .with_open_channel(dest_addr(), a_addr())
+            .with_open_channel(a_addr(), me_addr())
+            .with_open_channel(dest_addr(), b_addr())
+            .with_open_channel(b_addr(), me_addr());
+
+        let planner = PathPlanner::new(
+            me,
+            hopr_protocol_hopr::MemorySurbStore::default(),
+            chain_api,
+            selector,
+            cfg,
+        );
+        (planner, graph)
+    }
+
+    /// Populates the return-path cache the way a Session does and hands back the cached entry.
+    async fn fill_return_cache(planner: &TestPlanner) -> PlannerCacheValue {
+        planner
+            .resolve_diverse_return_paths(
+                NodeId::Offchain(pubkey(&SECRET_DEST)),
+                RoutingOptions::Hops(1.try_into().expect("valid 1")),
+                1,
+            )
+            .await
+            .expect("return path resolution should succeed");
+        planner
+            .cache
+            .get(&(pubkey(&SECRET_DEST), pubkey(&SECRET_ME), 1))
+            .await
+            .expect("the return path should be cached after resolution")
+    }
+
+    /// Share of the collection's total weight held by candidates whose first hop is `relayer`.
+    ///
+    /// This -- not the raw weight -- is what decides how much of a session's return stream rides on
+    /// one relay, because the draw normalises over the collection.
+    fn share_of(paths: &PlannerCacheValue, relayer: &OffchainPublicKey) -> f64 {
+        let total: f64 = paths.iter().map(|(_, w)| *w).sum();
+        let held: f64 = paths
+            .iter()
+            .filter(|(vp, _)| vp.first() == Some(relayer))
+            .map(|(_, w)| *w)
+            .sum();
+        if total > 0.0 { held / total } else { 0.0 }
+    }
+
+    /// The candidate paths as stable strings, weights discarded.
+    fn candidate_set(paths: &PlannerCacheValue) -> std::collections::BTreeSet<String> {
+        paths.iter().map(|(vp, _)| vp.to_string()).collect()
+    }
+
+    /// Records `rounds` SURB round-trips on the edge, of which `observed` per round came back.
+    fn record_surbs(
+        graph: &ChannelGraph,
+        src: &OffchainPublicKey,
+        dst: &OffchainPublicKey,
+        expected: u64,
+        observed: u64,
+    ) {
+        use hopr_api::graph::traits::EdgeWeightType;
+        graph.upsert_edge(src, dst, |obs| {
+            obs.record(EdgeWeightType::SurbRoundTrips { expected, observed });
+        });
+    }
+
+    /// A relay that stops delivering must lose its share of the return draws *without* the
+    /// candidate set changing underneath the live session.
+    ///
+    /// Both halves matter and they pull against each other: dropping the candidates is what
+    /// collapsed a healthy session from 100 % to 0.14 % in the cluster, while leaving the weights
+    /// alone is what kept minting SURBs onto a dead relay for a full refresh period.
+    #[tokio::test]
+    async fn recomputing_an_entry_should_reweight_the_candidates_without_changing_the_set() {
+        let (planner, graph) = two_relayer_return_planner();
+        let (me, b, dest) = (pubkey(&SECRET_ME), pubkey(&SECRET_B), pubkey(&SECRET_DEST));
+
+        let before = fill_return_cache(&planner).await;
+        let set_before = candidate_set(&before);
+        let share_before = share_of(&before, &b);
+
+        assert_eq!(
+            set_before.len(),
+            2,
+            "the fixture must offer both relayers as candidates"
+        );
+        assert!(
+            share_before > 0.2,
+            "vacuity guard: B must hold a material share before the collapse, held {share_before}"
+        );
+
+        // A delivers, B stops. Same interval, so the contrast is in the evidence and not in time.
+        record_surbs(&graph, &dest, &pubkey(&SECRET_A), 1_000, 1_000);
+        record_surbs(&graph, &dest, &b, 1_000, 1_000);
+        record_surbs(&graph, &dest, &b, 4_000, 0);
+
+        let replaced = planner.recompute_paths_from(&dest).await;
+        assert_eq!(
+            replaced, 1,
+            "exactly the one cached return entry should have been rebuilt"
+        );
+
+        let after = planner
+            .cache
+            .get(&(dest, me, 1))
+            .await
+            .expect("the entry must still exist after a recompute");
+
+        assert_eq!(
+            candidate_set(&after),
+            set_before,
+            "a recompute must re-weight the candidates, never replace the set"
+        );
+
+        let share_after = share_of(&after, &b);
+        assert!(
+            share_after < share_before,
+            "the relay that stopped delivering must lose share: {share_before} -> {share_after}"
+        );
+    }
+
+    /// A recompute that finds nothing must leave the previous candidates in place.
+    ///
+    /// This is the property that separates recomputation from invalidation. A live session draws
+    /// its next return path from this entry, so an empty result has to mean "no better information"
+    /// rather than "no route".
+    #[tokio::test]
+    async fn recomputing_an_entry_should_keep_the_old_candidates_when_it_finds_none() {
+        let (planner, graph) = two_relayer_return_planner();
+        let (me, dest) = (pubkey(&SECRET_ME), pubkey(&SECRET_DEST));
+
+        let before = fill_return_cache(&planner).await;
+        let set_before = candidate_set(&before);
+
+        // Total blackout: every route out of the destination disappears from the graph, so the
+        // selector can no longer offer any candidate at all.
+        for relay in [pubkey(&SECRET_A), pubkey(&SECRET_B)] {
+            graph.remove_edge(&dest, &relay);
+        }
+
+        let replaced = planner.recompute_paths_from(&dest).await;
+        assert_eq!(replaced, 0, "a recompute that finds nothing must replace nothing");
+
+        let after = planner
+            .cache
+            .get(&(dest, me, 1))
+            .await
+            .expect("an entry must never be dropped by a recompute that found nothing");
+        assert_eq!(
+            candidate_set(&after),
+            set_before,
+            "the previous candidates must survive a fruitless recompute"
+        );
+    }
+
+    /// A recompute is addressed at one counterparty, so it must not sweep the whole cache.
+    ///
+    /// Rebuilding every entry on every detection would put the cost of one dead relay onto every
+    /// other session the node is carrying.
+    #[tokio::test]
+    async fn recomputing_should_rebuild_only_the_entries_originating_at_that_peer() {
+        let (planner, _graph) = two_relayer_return_planner();
+        let (me, a, dest) = (pubkey(&SECRET_ME), pubkey(&SECRET_A), pubkey(&SECRET_DEST));
+
+        let _ = fill_return_cache(&planner).await;
+        // A second entry in the other direction, which no `dest` recompute may touch.
+        let _ = planner
+            .cached_paths(
+                NodeId::Offchain(me),
+                NodeId::Offchain(a),
+                1.try_into().expect("valid 1"),
+            )
+            .await;
+
+        assert_eq!(
+            planner.recompute_paths_from(&dest).await,
+            1,
+            "only the entry whose paths start at the named peer should be rebuilt"
+        );
+        assert_eq!(
+            planner.recompute_paths_from(&pubkey(&SECRET_B)).await,
+            0,
+            "a peer with no cached entries of its own must rebuild nothing"
+        );
     }
 
     // ── composite weight helpers ──────────────────────────────────────────────

--- a/transport/hopr/src/protocol/mod.rs
+++ b/transport/hopr/src/protocol/mod.rs
@@ -27,6 +27,8 @@ mod pipeline;
 /// Stream processing utilities
 pub mod stream;
 
+/// Sequences re-planning ahead of refilling when a return path goes silent.
+pub mod return_path_recovery;
 /// Records SURB round-trips as network graph edge telemetry.
 pub mod surb_telemetry;
 

--- a/transport/hopr/src/protocol/return_path_recovery.rs
+++ b/transport/hopr/src/protocol/return_path_recovery.rs
@@ -1,0 +1,230 @@
+//! Sequences the response to a return path that has gone silent.
+//!
+//! Two mechanisms react to the same evidence and, left unsequenced, work against each other. The
+//! planner learns to route around the relay that stopped delivering, while the SURB balancer floods
+//! the counterparty to refill a buffer it believes is empty. Run in the wrong order the flood mints
+//! its SURBs onto the very route the planner is in the middle of abandoning -- measured at ~38 000
+//! SURBs in 14 s against a 15 000-entry ring buffer, which is 2.5x the counterparty's whole store,
+//! so everything older is evicted and a LIFO reader reaches preferentially for the poisoned ones.
+//!
+//! The rule this module enforces is therefore: **re-plan first, refill only if re-planning actually
+//! moved traffic.** A re-plan that moves nothing means the silent relay sits on every remaining
+//! candidate -- return-path diversity caps at `HoprPacket::PAYLOAD_SIZE / HoprSurb::SIZE` = 2, so
+//! this is an ordinary case, not a corner -- and refilling then only buys more SURBs bound for the
+//! same dead route.
+
+use std::{
+    collections::HashMap,
+    future::Future,
+    hash::Hash,
+    time::{Duration, Instant},
+};
+
+/// One action taken on behalf of one destination, recorded in the order it happened.
+///
+/// Exists so the ordering guarantee is observable: a caller (or a test) can see that no refill was
+/// ever issued for a destination before the re-plan that justified it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryStep<K> {
+    /// The destination's cached return paths were rebuilt; `moved` entries came back re-weighted.
+    Replanned {
+        /// The destination whose paths were rebuilt.
+        destination: K,
+        /// How many cached entries the re-plan actually replaced.
+        moved: usize,
+    },
+    /// The destination's Sessions were told to refill; `sessions` of them were marked.
+    Refilled {
+        /// The destination whose Sessions were marked.
+        destination: K,
+        /// How many Sessions routed there were marked.
+        sessions: usize,
+    },
+}
+
+/// Tracks which destinations already have an open recovery episode.
+///
+/// An episode opens the first tick a destination is reported silent and lapses after `grace`. While
+/// it is open the destination is ignored, which bounds re-planning -- a full path rediscovery per
+/// cached entry -- to once per grace window however long the silence lasts. A destination that is
+/// still silent when the episode lapses simply opens a fresh one, so a re-plan that could not move
+/// traffic the first time is retried later rather than abandoned.
+pub struct ReturnPathEpisodes<K> {
+    open: HashMap<K, Instant>,
+    grace: Duration,
+}
+
+impl<K: Eq + Hash + Copy> ReturnPathEpisodes<K> {
+    /// Creates a tracker whose episodes lapse after `grace`.
+    pub fn new(grace: Duration) -> Self {
+        Self {
+            open: HashMap::new(),
+            grace,
+        }
+    }
+
+    /// Drives one flush tick over the destinations the detector reported silent.
+    ///
+    /// `replan` returns how many cached entries it re-weighted, and `refill` is invoked only when
+    /// that count is non-zero. Both are injected so the sequencing can be exercised without a graph,
+    /// a planner or a cluster.
+    pub async fn tick<S, R, RFut, F, FFut>(&mut self, silent: S, mut replan: R, mut refill: F) -> Vec<RecoveryStep<K>>
+    where
+        S: IntoIterator<Item = K>,
+        R: FnMut(K) -> RFut,
+        RFut: Future<Output = usize>,
+        F: FnMut(K) -> FFut,
+        FFut: Future<Output = usize>,
+    {
+        let now = Instant::now();
+        self.open.retain(|_, lapses_at| *lapses_at > now);
+
+        let mut steps = Vec::new();
+        for destination in silent {
+            if self.open.contains_key(&destination) {
+                continue;
+            }
+            self.open.insert(destination, now + self.grace);
+
+            let moved = replan(destination).await;
+            steps.push(RecoveryStep::Replanned { destination, moved });
+
+            // Nothing moved: the silent relay is on every candidate that remains, so refilling
+            // would only mint more SURBs onto the same route. Wait for the next episode instead.
+            if moved > 0 {
+                let sessions = refill(destination).await;
+                steps.push(RecoveryStep::Refilled { destination, sessions });
+            }
+        }
+        steps
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Counts calls so a test can assert how often each side ran, not merely what it returned.
+    #[derive(Default)]
+    struct Calls {
+        replans: std::cell::Cell<usize>,
+        refills: std::cell::Cell<usize>,
+    }
+
+    /// Refilling before the re-plan is the defect this module exists to prevent: it is what put
+    /// ~38 000 SURBs onto a route the planner was abandoning.
+    #[tokio::test]
+    async fn a_refill_should_never_precede_the_replan_that_justifies_it() {
+        let mut episodes = ReturnPathEpisodes::new(Duration::from_secs(10));
+
+        let steps = episodes.tick([1u32, 2u32], |_| async { 3 }, |_| async { 1 }).await;
+
+        assert_eq!(steps.len(), 4, "each destination should re-plan and then refill");
+        for destination in [1u32, 2u32] {
+            let replanned = steps
+                .iter()
+                .position(|s| matches!(s, RecoveryStep::Replanned { destination: d, .. } if *d == destination))
+                .expect("destination should have been re-planned");
+            let refilled = steps
+                .iter()
+                .position(|s| matches!(s, RecoveryStep::Refilled { destination: d, .. } if *d == destination))
+                .expect("destination should have been refilled");
+            assert!(
+                replanned < refilled,
+                "destination {destination} refilled at step {refilled} before re-planning at {replanned}"
+            );
+        }
+    }
+
+    /// Re-planning rediscovers every path to the destination, so a destination that stays silent
+    /// must not pay that cost on every flush tick.
+    #[tokio::test]
+    async fn an_open_episode_should_replan_once_however_long_the_silence_lasts() {
+        let mut episodes = ReturnPathEpisodes::new(Duration::from_secs(10));
+        let calls = Calls::default();
+
+        for _ in 0..5 {
+            episodes
+                .tick(
+                    [7u32],
+                    |_| {
+                        calls.replans.set(calls.replans.get() + 1);
+                        async { 2 }
+                    },
+                    |_| {
+                        calls.refills.set(calls.refills.get() + 1);
+                        async { 1 }
+                    },
+                )
+                .await;
+        }
+
+        assert_eq!(calls.replans.get(), 1, "one episode must mean one re-plan");
+        assert_eq!(calls.refills.get(), 1, "one episode must mean one refill");
+    }
+
+    /// When the silent relay sits on every remaining candidate, re-planning cannot move traffic —
+    /// and refilling then buys nothing but more SURBs bound for the same dead route.
+    #[tokio::test]
+    async fn a_replan_that_moves_nothing_should_not_refill() {
+        let mut episodes = ReturnPathEpisodes::new(Duration::from_secs(10));
+        let calls = Calls::default();
+
+        let steps = episodes
+            .tick(
+                [7u32],
+                |_| async { 0 },
+                |_| {
+                    calls.refills.set(calls.refills.get() + 1);
+                    async { 1 }
+                },
+            )
+            .await;
+
+        assert_eq!(calls.refills.get(), 0, "a re-plan that moved nothing must not refill");
+        assert_eq!(
+            steps,
+            vec![RecoveryStep::Replanned {
+                destination: 7u32,
+                moved: 0
+            }],
+            "the re-plan itself must still be recorded"
+        );
+
+        // Vacuity guard: the same fixture with a re-plan that *did* move traffic must refill,
+        // otherwise this test would pass against a machine that never refills at all.
+        let mut moved_episodes = ReturnPathEpisodes::new(Duration::from_secs(10));
+        let moved_steps = moved_episodes.tick([7u32], |_| async { 1 }, |_| async { 4 }).await;
+        assert!(
+            moved_steps
+                .iter()
+                .any(|s| matches!(s, RecoveryStep::Refilled { sessions: 4, .. })),
+            "a re-plan that moved traffic must refill: {moved_steps:?}"
+        );
+    }
+
+    /// A destination that is still silent once its episode lapses has to be handled afresh — that
+    /// retry is what lets a re-plan which could not move traffic the first time succeed later.
+    #[tokio::test]
+    async fn a_lapsed_episode_should_be_handled_afresh() {
+        let mut episodes = ReturnPathEpisodes::new(Duration::from_millis(50));
+        let calls = Calls::default();
+
+        let bump = |_| {
+            calls.replans.set(calls.replans.get() + 1);
+            async { 2 }
+        };
+
+        episodes.tick([7u32], bump, |_| async { 1 }).await;
+        assert_eq!(calls.replans.get(), 1, "the first tick opens an episode");
+
+        tokio::time::sleep(Duration::from_millis(80)).await;
+
+        episodes.tick([7u32], bump, |_| async { 1 }).await;
+        assert_eq!(
+            calls.replans.get(),
+            2,
+            "once the grace lapses the same destination must be handled afresh"
+        );
+    }
+}

--- a/transport/hopr/src/protocol/surb_telemetry.rs
+++ b/transport/hopr/src/protocol/surb_telemetry.rs
@@ -89,8 +89,21 @@ pub struct SurbRoundTripRegistry {
     inner: Arc<DashMap<ForwardAndReturnPath, Arc<SurbRoundTripCounters>>>,
     /// Destination each pair of legs leads to, so a collapse can name what to re-plan.
     destinations: Arc<DashMap<ForwardAndReturnPath, OffchainPublicKey>>,
-    /// Consecutive flushes in which a pair minted SURBs and got nothing back.
-    silent: Arc<DashMap<ForwardAndReturnPath, u32>>,
+    /// What each pair's recent flushes say about whether it still works.
+    silence: Arc<DashMap<ForwardAndReturnPath, Silence>>,
+}
+
+/// Per-pair silence bookkeeping, carried between flushes.
+#[derive(Debug, Default, Clone, Copy)]
+struct Silence {
+    /// Consecutive flushes in which the pair minted SURBs and got nothing back.
+    runs: u32,
+    /// Whether a reply has ever come back over this pair.
+    ///
+    /// Load-bearing: it is what turns the signal from "silent" into "stopped working". A pair that
+    /// has never delivered may simply be too young -- a reply is credited to the flush it *arrives*
+    /// in, so the first flushes of a new pair legitimately show mints with no replies yet.
+    delivered: bool,
 }
 
 /// SURBs a pair must have minted in one flush before its silence counts as evidence.
@@ -99,11 +112,13 @@ pub struct SurbRoundTripRegistry {
 /// while returning none. A handful is noise; thousands is not.
 const MIN_EXPECTED_FOR_SILENCE: u64 = 20;
 
-/// Consecutive silent flushes before the return path is called dead.
+/// Consecutive silent flushes before a pair that used to deliver is called dead.
 ///
-/// Flushes are one second apart, so this fires around five seconds after the loss starts --
-/// measured, the dead leg reads exactly zero from t+5s onward while its siblings keep returning.
-const SILENT_FLUSHES_BEFORE_DEGRADED: u32 = 3;
+/// Flushes are one second apart. Three was measured to be too few: it fired six times during
+/// healthy operation, once per flush, because a burst of mints can outrun its replies for a couple
+/// of seconds without anything being wrong. Five keeps detection well inside the fifteen-second
+/// budget -- the dead leg reads exactly zero from t+5s onward while its siblings keep returning.
+const SILENT_FLUSHES_BEFORE_DEGRADED: u32 = 5;
 
 impl SurbRoundTripRegistry {
     fn counters(&self, paths: ForwardAndReturnPath) -> Arc<SurbRoundTripCounters> {
@@ -122,25 +137,46 @@ impl SurbRoundTripRegistry {
     /// separate these cases: measured immediately after a kill, a healthy leg read 0.089 while the
     /// dead one read 0.123, and replies straddling a flush boundary push a healthy leg above 1.
     /// Only sustained silence distinguishes them, and it does so within seconds.
+    ///
+    /// The claim made is narrower than "this pair is silent": it is "this pair **used to deliver**
+    /// and has now stopped". Silence alone was measured to fire during healthy operation, because
+    /// a pair that has not yet returned its first reply is indistinguishable from a dead one.
     pub fn degraded_destinations(&self) -> Vec<OffchainPublicKey> {
         let mut degraded = Vec::new();
 
         for entry in self.inner.iter() {
             let paths = *entry.key();
             let (expected, observed) = entry.value().peek();
+            let mut state = self.silence.entry(paths).or_default();
 
-            if observed > 0 || expected < MIN_EXPECTED_FOR_SILENCE {
-                // Either it is delivering, or too little went out to conclude anything. An idle
-                // pair is not a failing one.
-                self.silent.remove(&paths);
+            if observed > 0 {
+                // Delivering. Note that it ever worked, so future silence is meaningful.
+                state.delivered = true;
+                state.runs = 0;
                 continue;
             }
 
-            let runs = self.silent.entry(paths).and_modify(|r| *r += 1).or_insert(1);
-            if *runs >= SILENT_FLUSHES_BEFORE_DEGRADED
-                && let Some(dest) = self.destinations.get(&paths)
-            {
-                degraded.push(*dest);
+            if expected < MIN_EXPECTED_FOR_SILENCE {
+                // Too little went out to conclude anything. An idle pair is not a failing one.
+                state.runs = 0;
+                continue;
+            }
+
+            if !state.delivered {
+                // Never returned anything yet, so there is no "stopped" to observe -- only a pair
+                // too young to have been measured.
+                continue;
+            }
+
+            state.runs += 1;
+            if state.runs >= SILENT_FLUSHES_BEFORE_DEGRADED {
+                // Re-arm rather than accumulate: re-planning the same destination on every
+                // subsequent flush churns its cached candidates instead of letting the new
+                // selection settle.
+                state.runs = 0;
+                if let Some(dest) = self.destinations.get(&paths) {
+                    degraded.push(*dest);
+                }
             }
         }
 
@@ -701,24 +737,73 @@ mod tests {
         Ok(())
     }
 
+    /// One flush interval, in the order the flush task runs it: detect, then drain.
+    ///
+    /// Draining matters to these tests -- without it a single reply stays visible forever and
+    /// silence can never be observed at all.
+    fn flush(registry: &SurbRoundTripRegistry) -> Vec<OffchainPublicKey> {
+        let degraded = registry.degraded_destinations();
+        registry.drain();
+        degraded
+    }
+
+    /// A pair that mints steadily and returns replies -- the healthy case.
+    fn deliver(registry: &SurbRoundTripRegistry, paths: ForwardAndReturnPath, destination: OffchainPublicKey) {
+        registry.record_expected(paths, MIN_EXPECTED_FOR_SILENCE, destination);
+        registry.record_observed(paths, 1);
+    }
+
+    /// A pair that mints steadily and returns nothing.
+    fn mint_only(registry: &SurbRoundTripRegistry, paths: ForwardAndReturnPath, destination: OffchainPublicKey) {
+        registry.record_expected(paths, MIN_EXPECTED_FOR_SILENCE, destination);
+    }
+
+    fn legs() -> ForwardAndReturnPath {
+        ForwardAndReturnPath {
+            forward: [0, 1, 0, 0, 0],
+            reply: [1, 0, 0, 0, 0],
+        }
+    }
+
     #[test]
     fn sustained_silence_should_name_the_destination_to_replan() {
         let (graph, me, peers) = graph_with(1);
         let destination = peers[0];
         let registry = SurbRoundTripRegistry::default();
-        let paths = ForwardAndReturnPath {
-            forward: [0, 1, 0, 0, 0],
-            reply: [1, 0, 0, 0, 0],
-        };
+        let paths = legs();
 
-        // Enough minted to be evidence, nothing coming back.
-        registry.record_expected(paths, MIN_EXPECTED_FOR_SILENCE, destination);
+        // First establish that the pair works. Silence only means something against that.
+        deliver(&registry, paths, destination);
+        assert!(flush(&registry).is_empty());
 
-        // One quiet interval is not a dead path, which is why the gate counts runs.
+        // Then it goes quiet while still minting. One quiet interval is not a dead path, which is
+        // why the gate counts runs.
         for _ in 1..SILENT_FLUSHES_BEFORE_DEGRADED {
-            assert!(registry.degraded_destinations().is_empty());
+            mint_only(&registry, paths, destination);
+            assert!(flush(&registry).is_empty());
         }
-        assert_eq!(vec![destination], registry.degraded_destinations());
+        mint_only(&registry, paths, destination);
+        assert_eq!(vec![destination], flush(&registry));
+        let _ = (graph, me);
+    }
+
+    #[test]
+    fn a_pair_that_never_delivered_should_never_be_called_degraded() {
+        let (graph, me, peers) = graph_with(1);
+        let destination = peers[0];
+        let registry = SurbRoundTripRegistry::default();
+        let paths = legs();
+
+        // Measured regression: silence alone fired six times during healthy operation, once per
+        // flush, on pairs whose replies had simply not landed yet. Minting hard and returning
+        // nothing *yet* is what a young pair looks like, not what a dead one looks like.
+        for _ in 0..SILENT_FLUSHES_BEFORE_DEGRADED + 3 {
+            registry.record_expected(paths, MIN_EXPECTED_FOR_SILENCE * 10, destination);
+            assert!(
+                flush(&registry).is_empty(),
+                "a pair that has never returned a reply is too young to call dead"
+            );
+        }
         let _ = (graph, me);
     }
 
@@ -727,18 +812,49 @@ mod tests {
         let (graph, me, peers) = graph_with(1);
         let destination = peers[0];
         let registry = SurbRoundTripRegistry::default();
-        let paths = ForwardAndReturnPath {
-            forward: [0, 1, 0, 0, 0],
-            reply: [1, 0, 0, 0, 0],
-        };
+        let paths = legs();
 
-        registry.record_expected(paths, MIN_EXPECTED_FOR_SILENCE, destination);
-        registry.degraded_destinations();
-        registry.degraded_destinations();
+        deliver(&registry, paths, destination);
+        assert!(flush(&registry).is_empty());
 
-        // A path that delivers anything at all is not the failure this looks for.
-        registry.record_observed(paths, 1);
-        assert!(registry.degraded_destinations().is_empty());
+        for _ in 1..SILENT_FLUSHES_BEFORE_DEGRADED {
+            mint_only(&registry, paths, destination);
+            assert!(flush(&registry).is_empty());
+        }
+
+        // A path that delivers anything at all is not the failure this looks for, and the count
+        // starts over rather than resuming where it left off.
+        deliver(&registry, paths, destination);
+        assert!(flush(&registry).is_empty());
+        for _ in 1..SILENT_FLUSHES_BEFORE_DEGRADED {
+            mint_only(&registry, paths, destination);
+            assert!(flush(&registry).is_empty());
+        }
+        let _ = (graph, me);
+    }
+
+    #[test]
+    fn a_degraded_pair_should_not_fire_again_on_the_next_flush() {
+        let (graph, me, peers) = graph_with(1);
+        let destination = peers[0];
+        let registry = SurbRoundTripRegistry::default();
+        let paths = legs();
+
+        deliver(&registry, paths, destination);
+        flush(&registry);
+        for _ in 1..SILENT_FLUSHES_BEFORE_DEGRADED {
+            mint_only(&registry, paths, destination);
+            flush(&registry);
+        }
+        mint_only(&registry, paths, destination);
+        assert_eq!(vec![destination], flush(&registry));
+
+        // Re-planning the same destination every second churns its cached candidates instead of
+        // letting the new selection settle, so the gate re-arms from zero.
+        for _ in 1..SILENT_FLUSHES_BEFORE_DEGRADED {
+            mint_only(&registry, paths, destination);
+            assert!(flush(&registry).is_empty());
+        }
         let _ = (graph, me);
     }
 
@@ -747,16 +863,16 @@ mod tests {
         let (graph, me, peers) = graph_with(1);
         let destination = peers[0];
         let registry = SurbRoundTripRegistry::default();
-        let paths = ForwardAndReturnPath {
-            forward: [0, 1, 0, 0, 0],
-            reply: [1, 0, 0, 0, 0],
-        };
+        let paths = legs();
+
+        deliver(&registry, paths, destination);
+        assert!(flush(&registry).is_empty());
 
         // Below the evidence floor: a trickle that happens not to have returned yet says nothing,
         // and treating it as failure would re-plan healthy paths during quiet periods.
-        registry.record_expected(paths, MIN_EXPECTED_FOR_SILENCE - 1, destination);
         for _ in 0..SILENT_FLUSHES_BEFORE_DEGRADED + 2 {
-            assert!(registry.degraded_destinations().is_empty());
+            registry.record_expected(paths, MIN_EXPECTED_FOR_SILENCE - 1, destination);
+            assert!(flush(&registry).is_empty());
         }
         let _ = (graph, me);
     }

--- a/transport/hopr/src/protocol/surb_telemetry.rs
+++ b/transport/hopr/src/protocol/surb_telemetry.rs
@@ -91,6 +91,8 @@ pub struct SurbRoundTripRegistry {
     destinations: Arc<DashMap<ForwardAndReturnPath, OffchainPublicKey>>,
     /// What each pair's recent flushes say about whether it still works.
     silence: Arc<DashMap<ForwardAndReturnPath, Silence>>,
+    /// Flushes since each destination was last reported, so one is not re-planned repeatedly.
+    replanned: Arc<DashMap<OffchainPublicKey, u32>>,
 }
 
 /// Per-pair silence bookkeeping, carried between flushes.
@@ -120,6 +122,19 @@ const MIN_EXPECTED_FOR_SILENCE: u64 = 20;
 /// budget -- the dead leg reads exactly zero from t+5s onward while its siblings keep returning.
 const SILENT_FLUSHES_BEFORE_DEGRADED: u32 = 5;
 
+/// Flushes a destination must wait before it can be re-planned again.
+///
+/// Silence accrues per pair of legs, but re-planning acts on the *destination*, and a destination
+/// carries several pairs at once. Re-arming each pair individually therefore still allows one
+/// destination to be re-planned every couple of seconds -- faster than a freshly chosen return path
+/// can be established and start delivering, so each re-plan destroys the candidate the previous one
+/// selected. Measured with the invalidation finally reaching the cache: fifteen re-plans during a
+/// thirty-second healthy baseline, which collapsed it from 100% to 0.1% arrival.
+///
+/// Long enough for a new path to prove itself (it needs [`SILENT_FLUSHES_BEFORE_DEGRADED`] flushes
+/// just to be judged), short enough to retry twice inside the recovery budget.
+const FLUSHES_BETWEEN_REPLANS: u32 = 8;
+
 impl SurbRoundTripRegistry {
     fn counters(&self, paths: ForwardAndReturnPath) -> Arc<SurbRoundTripCounters> {
         self.inner.entry(paths).or_default().value().clone()
@@ -143,6 +158,12 @@ impl SurbRoundTripRegistry {
     /// a pair that has not yet returned its first reply is indistinguishable from a dead one.
     pub fn degraded_destinations(&self) -> Vec<OffchainPublicKey> {
         let mut degraded = Vec::new();
+
+        // Age the per-destination cooldowns once per flush, dropping those that have served out.
+        self.replanned.retain(|_, since| {
+            *since += 1;
+            *since < FLUSHES_BETWEEN_REPLANS
+        });
 
         for entry in self.inner.iter() {
             let paths = *entry.key();
@@ -175,14 +196,18 @@ impl SurbRoundTripRegistry {
                 // selection settle.
                 state.runs = 0;
                 if let Some(dest) = self.destinations.get(&paths) {
-                    degraded.push(*dest);
+                    let dest = *dest;
+                    // Only if this destination is not already serving out a cooldown: another of
+                    // its pairs may have reported it moments ago, and re-planning again now would
+                    // discard the candidate that re-plan just chose.
+                    if !self.replanned.contains_key(&dest) {
+                        self.replanned.insert(dest, 0);
+                        degraded.push(dest);
+                    }
                 }
             }
         }
 
-        // `OffchainPublicKey` is not `Ord`, and several pairs of legs can share a destination.
-        let mut seen = std::collections::HashSet::new();
-        degraded.retain(|d: &OffchainPublicKey| seen.insert(*d));
         degraded
     }
 
@@ -787,6 +812,76 @@ mod tests {
         }
         mint_only(&registry, paths, destination);
         assert_eq!(vec![destination], flush(&registry));
+        let _ = (graph, me);
+    }
+
+    /// Several pairs lead to one destination, but re-planning acts on the destination.
+    ///
+    /// Regression: silence accrues per pair, so pairs re-armed independently and between them kept
+    /// re-planning the same destination every couple of seconds. With the invalidation finally
+    /// reaching the path cache, that destroyed each freshly chosen return path before it could
+    /// deliver -- a healthy baseline measured 0.1% arrival with fifteen re-plans inside it.
+    ///
+    /// The two pairs are staggered so they come due on *different* flushes; collapsing duplicates
+    /// within one flush was already handled and is not what failed.
+    #[test]
+    fn one_destination_should_not_be_replanned_again_while_a_new_path_is_settling() {
+        let (graph, me, peers) = graph_with(2);
+        let destination = peers[0];
+        let registry = SurbRoundTripRegistry::default();
+
+        let first = legs();
+        let second = ForwardAndReturnPath {
+            forward: [0, 2, 0, 0, 0],
+            reply: [2, 0, 0, 0, 0],
+        };
+        assert_ne!(
+            first, second,
+            "the two pairs must be distinct for this to test anything"
+        );
+
+        deliver(&registry, first, destination);
+        deliver(&registry, second, destination);
+        assert!(flush(&registry).is_empty());
+
+        // `first` goes quiet immediately; `second` keeps answering for three more flushes, so its
+        // own silence comes due well after the first re-plan.
+        for _ in 1..SILENT_FLUSHES_BEFORE_DEGRADED {
+            mint_only(&registry, first, destination);
+            deliver(&registry, second, destination);
+            assert!(flush(&registry).is_empty());
+        }
+        mint_only(&registry, first, destination);
+        deliver(&registry, second, destination);
+        assert_eq!(
+            vec![destination],
+            flush(&registry),
+            "the first silence must be acted on"
+        );
+
+        // Now both stay silent. Suppression still resets the pair's counter, so it comes due
+        // again and again; what must be bounded is how often the *destination* is acted on.
+        const WINDOW: u32 = 4 * SILENT_FLUSHES_BEFORE_DEGRADED;
+        let mut reports = 0;
+        for _ in 0..WINDOW {
+            mint_only(&registry, first, destination);
+            mint_only(&registry, second, destination);
+            reports += flush(&registry).len();
+        }
+
+        // Two pairs coming due every five flushes would otherwise report roughly eight times in
+        // this window; measured in the cluster, fifteen re-plans in thirty flushes was enough to
+        // hold a healthy session at 0.1% arrival.
+        // An absolute bound, deliberately not derived from `FLUSHES_BETWEEN_REPLANS` -- a limit
+        // computed from the constant under test moves with it and can never fail. Suppression
+        // resets the pair, so it comes due every five flushes; the cooldown lets roughly every
+        // other one through, which over twenty flushes is at most three.
+        assert!(
+            reports <= 3,
+            "a destination must not be re-planned faster than a new path can settle: {reports} re-plans in {WINDOW} \
+             flushes"
+        );
+
         let _ = (graph, me);
     }
 

--- a/transport/hopr/src/protocol/surb_telemetry.rs
+++ b/transport/hopr/src/protocol/surb_telemetry.rs
@@ -346,10 +346,13 @@ where
     }
 
     {
-        // One aggregate line per interval rather than one per pair of legs. At `debug` because
-        // `trace` is compiled out of release builds by `max_level_debug`, which would leave this
-        // mechanism unobservable in exactly the builds where it matters.
-        tracing::debug!(
+        // One aggregate line per interval rather than one per pair of legs.
+        //
+        // DIAGNOSTIC: at `info` while the recovery gap is under investigation. This is the pair of
+        // numbers that separates "the counterparty never got SURBs" from "it got them, replied, and
+        // the replies did not arrive" -- the two explanations left for a return path carrying
+        // packets while the application receives almost nothing. Drop back to `debug` once settled.
+        tracing::info!(
             legs,
             expected = total_expected,
             observed = total_observed,

--- a/transport/hopr/src/protocol/surb_telemetry.rs
+++ b/transport/hopr/src/protocol/surb_telemetry.rs
@@ -84,7 +84,7 @@ impl SurbRoundTripCounters {
 /// Batching is not an optimisation here but a requirement: recording an edge takes a write lock on
 /// the whole graph, a packet carries several SURBs, and a session at 0.5 MB/s moves hundreds of
 /// packets a second -- reporting per event would contend the graph thousands of times a second.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct SurbRoundTripRegistry {
     inner: Arc<DashMap<ForwardAndReturnPath, Arc<SurbRoundTripCounters>>>,
     /// Destination each pair of legs leads to, so a collapse can name what to re-plan.
@@ -97,8 +97,27 @@ pub struct SurbRoundTripRegistry {
     ///
     /// A [`PathId`] is zero-padded with no length, and slot 0 is a legitimate index, so the end of
     /// a leg cannot be found by looking for padding. It can be found by looking for *us*: every
-    /// reply leg terminates here. [`u64::MAX`] means not yet known.
+    /// reply leg terminates here. [`ME_SLOT_UNKNOWN`] means not yet known.
     me_slot: Arc<AtomicU64>,
+}
+
+/// `me_slot` value meaning "this node's slot has not been learned yet".
+///
+/// Cannot collide with a real slot, unlike 0, which is both a legitimate index and what
+/// `AtomicU64::default()` would yield -- a derived `Default` would silently claim we sit in slot 0
+/// and make every reply leg look like it terminates at its padding.
+const ME_SLOT_UNKNOWN: u64 = u64::MAX;
+
+impl Default for SurbRoundTripRegistry {
+    fn default() -> Self {
+        Self {
+            inner: Default::default(),
+            destinations: Default::default(),
+            silence: Default::default(),
+            replanned: Default::default(),
+            me_slot: Arc::new(AtomicU64::new(ME_SLOT_UNKNOWN)),
+        }
+    }
 }
 
 /// Relayers carrying the reply leg: everything between the destination and ourselves.
@@ -201,7 +220,14 @@ impl SurbRoundTripRegistry {
         // correlates with one node is a dead relayer, while silence spread evenly over all of them
         // is a quiet peer. Naming the node is also what lets the blame land on the edges that
         // deserve it instead of on every edge the loop happened to touch.
+        // Without our own slot every leg's relayers are unknowable, and the corroboration step
+        // below is what keeps a quiet peer from being called a dead relay. Guessing here would
+        // trade a missed detection for a false one, so make no claim until the slot is known.
         let me_slot = self.me_slot.load(Ordering::Relaxed);
+        if me_slot == ME_SLOT_UNKNOWN {
+            return degraded;
+        }
+
         let delivering_relayers: std::collections::HashSet<u64> = self
             .inner
             .iter()
@@ -660,7 +686,7 @@ mod tests {
     #[test]
     fn drain_should_take_the_counts_and_leave_the_entry_empty() {
         let (_graph, _me, peers) = graph_with(1);
-        let registry = SurbRoundTripRegistry::default();
+        let registry = registry_at_slot_zero();
         let paths = ForwardAndReturnPath {
             forward: [0, 1, 0, 0, 0],
             reply: [1, 0, 0, 0, 0],
@@ -807,7 +833,7 @@ mod tests {
         // entire observation side. Every other test here drives one instance and cannot see it.
         let (graph, me, peers) = graph_with(1);
         let destination = peers[0];
-        let registry = SurbRoundTripRegistry::default();
+        let registry = registry_at_slot_zero();
         let pending = pending_legs(128);
 
         let minting = SurbTelemetryCodec::new((), me, path_slots_of(graph.clone()), registry.clone(), pending.clone());
@@ -840,6 +866,17 @@ mod tests {
         let degraded = registry.degraded_destinations();
         registry.drain();
         degraded
+    }
+
+    /// A registry that already knows its own slot.
+    ///
+    /// The `legs()`/`heartbeat()` fixtures put us in slot 0, which the live codec would learn from
+    /// the graph on the first mint. Stating it here keeps the fixtures' assumption explicit rather
+    /// than leaning on whatever the field happens to be initialised to.
+    fn registry_at_slot_zero() -> SurbRoundTripRegistry {
+        let registry = SurbRoundTripRegistry::default();
+        registry.note_me_slot(0);
+        registry
     }
 
     /// A pair that mints steadily and returns replies -- the healthy case.
@@ -875,11 +912,54 @@ mod tests {
         }
     }
 
+    /// Every relayer identity in a leg is read relative to our own slot, so until that slot is
+    /// known there is nothing to read them against.
+    ///
+    /// Regression: a derived `Default` initialised `me_slot` to 0, which is a legitimate slot
+    /// rather than a sentinel. A node that is not in slot 0 would then take the zero *padding* at
+    /// the end of every reply leg to be itself, mis-attributing the relayers each leg carries and
+    /// feeding the corroboration gate a set it never observed.
+    #[test]
+    fn silence_should_not_be_attributed_before_our_own_slot_is_known() {
+        let (graph, me, peers) = graph_with(1);
+        let destination = peers[0];
+        let registry = SurbRoundTripRegistry::default();
+        let paths = legs();
+
+        // The exact sequence that names a destination once the slot is known (see the test below),
+        // run for longer than it would take, yields nothing while the slot is unknown.
+        deliver(&registry, paths, destination);
+        assert!(flush(&registry).is_empty());
+        for _ in 0..SILENT_FLUSHES_BEFORE_DEGRADED + 2 {
+            mint_only(&registry, paths, destination);
+            deliver(&registry, heartbeat(), destination);
+            assert!(
+                flush(&registry).is_empty(),
+                "no relayer can be identified without our own slot, so nothing may be blamed"
+            );
+        }
+
+        // Learning the slot makes the same evidence actionable.
+        registry.note_me_slot(0);
+        deliver(&registry, paths, destination);
+        assert!(flush(&registry).is_empty());
+        for _ in 1..SILENT_FLUSHES_BEFORE_DEGRADED {
+            mint_only(&registry, paths, destination);
+            deliver(&registry, heartbeat(), destination);
+            assert!(flush(&registry).is_empty());
+        }
+        mint_only(&registry, paths, destination);
+        deliver(&registry, heartbeat(), destination);
+        assert_eq!(vec![destination], flush(&registry));
+
+        let _ = (graph, me);
+    }
+
     #[test]
     fn sustained_silence_should_name_the_destination_to_replan() {
         let (graph, me, peers) = graph_with(1);
         let destination = peers[0];
-        let registry = SurbRoundTripRegistry::default();
+        let registry = registry_at_slot_zero();
         let paths = legs();
 
         // First establish that the pair works. Silence only means something against that.
@@ -912,7 +992,7 @@ mod tests {
     fn one_destination_should_not_be_replanned_again_while_a_new_path_is_settling() {
         let (graph, me, peers) = graph_with(2);
         let destination = peers[0];
-        let registry = SurbRoundTripRegistry::default();
+        let registry = registry_at_slot_zero();
 
         let first = legs();
         let second = ForwardAndReturnPath {
@@ -979,7 +1059,7 @@ mod tests {
     fn a_relayer_still_delivering_elsewhere_should_not_be_blamed() {
         let (graph, me, peers) = graph_with(3);
         let destination = peers[0];
-        let registry = SurbRoundTripRegistry::default();
+        let registry = registry_at_slot_zero();
 
         // Two distinct pairs sharing return relay 1, differing only in their forward leg.
         let delivering = legs();
@@ -1010,7 +1090,7 @@ mod tests {
     fn silence_on_every_relayer_should_blame_none_of_them() {
         let (graph, me, peers) = graph_with(3);
         let destination = peers[0];
-        let registry = SurbRoundTripRegistry::default();
+        let registry = registry_at_slot_zero();
 
         let first = legs();
         let second = heartbeat();
@@ -1045,7 +1125,7 @@ mod tests {
     fn a_peer_that_goes_quiet_should_not_be_mistaken_for_a_dead_return_path() {
         let (graph, me, peers) = graph_with(2);
         let destination = peers[0];
-        let registry = SurbRoundTripRegistry::default();
+        let registry = registry_at_slot_zero();
 
         let first = legs();
         let second = heartbeat();
@@ -1075,7 +1155,7 @@ mod tests {
     fn a_pair_that_never_delivered_should_never_be_called_degraded() {
         let (graph, me, peers) = graph_with(1);
         let destination = peers[0];
-        let registry = SurbRoundTripRegistry::default();
+        let registry = registry_at_slot_zero();
         let paths = legs();
 
         // Measured regression: silence alone fired six times during healthy operation, once per
@@ -1095,7 +1175,7 @@ mod tests {
     fn a_single_reply_should_clear_the_silence() {
         let (graph, me, peers) = graph_with(1);
         let destination = peers[0];
-        let registry = SurbRoundTripRegistry::default();
+        let registry = registry_at_slot_zero();
         let paths = legs();
 
         deliver(&registry, paths, destination);
@@ -1121,7 +1201,7 @@ mod tests {
     fn a_degraded_pair_should_not_fire_again_on_the_next_flush() {
         let (graph, me, peers) = graph_with(1);
         let destination = peers[0];
-        let registry = SurbRoundTripRegistry::default();
+        let registry = registry_at_slot_zero();
         let paths = legs();
 
         deliver(&registry, paths, destination);
@@ -1149,7 +1229,7 @@ mod tests {
     fn an_idle_path_should_never_be_called_degraded() {
         let (graph, me, peers) = graph_with(1);
         let destination = peers[0];
-        let registry = SurbRoundTripRegistry::default();
+        let registry = registry_at_slot_zero();
         let paths = legs();
 
         deliver(&registry, paths, destination);

--- a/transport/hopr/src/protocol/surb_telemetry.rs
+++ b/transport/hopr/src/protocol/surb_telemetry.rs
@@ -233,7 +233,15 @@ where
         legs += 1;
         total_expected += expected;
         total_observed += observed;
-        tracing::trace!(expected, observed, "flushing surb round-trip counts");
+        // Per pair, at debug: the aggregate cannot answer whether a dead relayer's legs diverge
+        // from healthy ones, which is the property any trigger built on this signal depends on.
+        tracing::debug!(
+            forward = ?paths.forward,
+            reply = ?paths.reply,
+            expected,
+            observed,
+            "surb round-trip pair"
+        );
         graph.record_edge::<NoPeerTelemetry, NoPathTelemetry>(MeasurableEdge::Surb(SurbTelemetry {
             paths,
             timestamp,

--- a/transport/hopr/src/protocol/surb_telemetry.rs
+++ b/transport/hopr/src/protocol/surb_telemetry.rs
@@ -93,6 +93,17 @@ pub struct SurbRoundTripRegistry {
     silence: Arc<DashMap<ForwardAndReturnPath, Silence>>,
     /// Flushes since each destination was last reported, so one is not re-planned repeatedly.
     replanned: Arc<DashMap<OffchainPublicKey, u32>>,
+    /// Slot this node occupies, learned from the first pair recorded.
+    ///
+    /// A [`PathId`] is zero-padded with no length, and slot 0 is a legitimate index, so the end of
+    /// a leg cannot be found by looking for padding. It can be found by looking for *us*: every
+    /// reply leg terminates here. [`u64::MAX`] means not yet known.
+    me_slot: Arc<AtomicU64>,
+}
+
+/// Relayers carrying the reply leg: everything between the destination and ourselves.
+fn return_relayers(reply: &PathId, me_slot: u64) -> impl Iterator<Item = u64> + '_ {
+    reply.iter().skip(1).take_while(move |&&slot| slot != me_slot).copied()
 }
 
 /// Per-pair silence bookkeeping, carried between flushes.
@@ -140,6 +151,11 @@ impl SurbRoundTripRegistry {
         self.inner.entry(paths).or_default().value().clone()
     }
 
+    /// Tells the registry which slot is ours, so a leg's relayers can be told from its padding.
+    pub fn note_me_slot(&self, slot: u64) {
+        self.me_slot.store(slot, Ordering::Relaxed);
+    }
+
     /// Records that `count` SURBs were minted over these legs and are expected back.
     pub fn record_expected(&self, paths: ForwardAndReturnPath, count: u64, destination: OffchainPublicKey) {
         self.destinations.insert(paths, destination);
@@ -179,6 +195,20 @@ impl SurbRoundTripRegistry {
             .filter_map(|entry| self.destinations.get(entry.key()).map(|d| *d))
             .collect();
 
+        // Which relayers are demonstrably still carrying replies.
+        //
+        // A relayer that dies takes down every path through it and nothing else, so silence that
+        // correlates with one node is a dead relayer, while silence spread evenly over all of them
+        // is a quiet peer. Naming the node is also what lets the blame land on the edges that
+        // deserve it instead of on every edge the loop happened to touch.
+        let me_slot = self.me_slot.load(Ordering::Relaxed);
+        let delivering_relayers: std::collections::HashSet<u64> = self
+            .inner
+            .iter()
+            .filter(|entry| entry.value().peek().1 > 0)
+            .flat_map(|entry| return_relayers(&entry.key().reply, me_slot).collect::<Vec<_>>())
+            .collect();
+
         for entry in self.inner.iter() {
             let paths = *entry.key();
             let (expected, observed) = entry.value().peek();
@@ -213,6 +243,14 @@ impl SurbRoundTripRegistry {
             // pair was silent *while the peer was demonstrably answering elsewhere* -- not merely
             // flushes in which it was quiet.
             if !delivering.contains(&dest) {
+                state.runs = 0;
+                continue;
+            }
+
+            // Sharpened: the peer is talking, and this pair carries at least one relayer that is
+            // not carrying replies anywhere else. Silence that every relayer shares is the peer
+            // being selective, not a relay failing.
+            if return_relayers(&paths.reply, me_slot).all(|r| delivering_relayers.contains(&r)) {
                 state.runs = 0;
                 continue;
             }
@@ -474,6 +512,10 @@ impl<C> SurbTelemetryCodec<C> {
         let Some(destination) = forward.last().copied() else {
             return;
         };
+
+        if let Some(slot) = (self.slots)(&self.me) {
+            self.registry.note_me_slot(slot);
+        }
 
         tracing::debug!(
             minted = minted.len(),
@@ -817,15 +859,19 @@ mod tests {
     /// of the silence logic has to keep one pair delivering or nothing can ever fire.
     fn heartbeat() -> ForwardAndReturnPath {
         ForwardAndReturnPath {
-            forward: [0, 3, 0, 0, 0],
-            reply: [3, 0, 0, 0, 0],
+            forward: [0, 3, 2, 0, 0],
+            reply: [2, 3, 0, 0, 0],
         }
     }
 
+    /// me(0) -> relay(1) -> dest(2), and back dest(2) -> relay(1) -> me(0).
+    ///
+    /// The reply leg carries a real intermediate relayer: a zero-hop return has no relay to blame,
+    /// so silence over it can never name one.
     fn legs() -> ForwardAndReturnPath {
         ForwardAndReturnPath {
-            forward: [0, 1, 0, 0, 0],
-            reply: [1, 0, 0, 0, 0],
+            forward: [0, 1, 2, 0, 0],
+            reply: [2, 1, 0, 0, 0],
         }
     }
 
@@ -870,8 +916,8 @@ mod tests {
 
         let first = legs();
         let second = ForwardAndReturnPath {
-            forward: [0, 2, 0, 0, 0],
-            reply: [2, 0, 0, 0, 0],
+            forward: [0, 4, 2, 0, 0],
+            reply: [2, 4, 0, 0, 0],
         };
         assert_ne!(
             first, second,
@@ -920,6 +966,70 @@ mod tests {
             "a destination must not be re-planned faster than a new path can settle: {reports} re-plans in {WINDOW} \
              flushes"
         );
+
+        let _ = (graph, me);
+    }
+
+    /// A relayer still carrying replies elsewhere is not the one at fault.
+    ///
+    /// A dead relayer takes down every path through it and nothing else, so blame belongs to a node
+    /// appearing only in silent legs. One demonstrably delivering on another pair is alive, and the
+    /// silence has some other cause -- selective traffic, or a fault further along the leg.
+    #[test]
+    fn a_relayer_still_delivering_elsewhere_should_not_be_blamed() {
+        let (graph, me, peers) = graph_with(3);
+        let destination = peers[0];
+        let registry = SurbRoundTripRegistry::default();
+
+        // Two distinct pairs sharing return relay 1, differing only in their forward leg.
+        let delivering = legs();
+        let silent = ForwardAndReturnPath {
+            forward: [0, 4, 2, 0, 0],
+            reply: [2, 1, 0, 0, 0],
+        };
+        assert_ne!(delivering, silent, "the pairs must be distinct keys");
+
+        deliver(&registry, silent, destination);
+        assert!(flush(&registry).is_empty());
+
+        // Relay 1 keeps carrying replies on the other pair, so it cannot be what is broken.
+        for _ in 0..(3 * SILENT_FLUSHES_BEFORE_DEGRADED) {
+            mint_only(&registry, silent, destination);
+            deliver(&registry, delivering, destination);
+            assert!(
+                flush(&registry).is_empty(),
+                "a relayer that is delivering elsewhere must not be blamed for this pair's silence"
+            );
+        }
+
+        let _ = (graph, me);
+    }
+
+    /// Silence spread over every relayer is the peer, not a relay.
+    #[test]
+    fn silence_on_every_relayer_should_blame_none_of_them() {
+        let (graph, me, peers) = graph_with(3);
+        let destination = peers[0];
+        let registry = SurbRoundTripRegistry::default();
+
+        let first = legs();
+        let second = heartbeat();
+
+        for _ in 0..5 {
+            deliver(&registry, first, destination);
+            deliver(&registry, second, destination);
+            assert!(flush(&registry).is_empty());
+        }
+
+        // Every relay goes quiet together: that is the counterparty, not a relay failure.
+        for _ in 0..(3 * SILENT_FLUSHES_BEFORE_DEGRADED) {
+            mint_only(&registry, first, destination);
+            mint_only(&registry, second, destination);
+            assert!(
+                flush(&registry).is_empty(),
+                "silence shared by every relayer names none of them"
+            );
+        }
 
         let _ = (graph, me);
     }

--- a/transport/hopr/src/protocol/surb_telemetry.rs
+++ b/transport/hopr/src/protocol/surb_telemetry.rs
@@ -62,6 +62,14 @@ impl SurbRoundTripCounters {
         self.observed.fetch_add(count, Ordering::Relaxed);
     }
 
+    /// Reads both counts without resetting them.
+    fn peek(&self) -> (u64, u64) {
+        (
+            self.expected.load(Ordering::Relaxed),
+            self.observed.load(Ordering::Relaxed),
+        )
+    }
+
     /// Takes both counts, resetting them to zero.
     fn take(&self) -> (u64, u64) {
         (
@@ -79,7 +87,23 @@ impl SurbRoundTripCounters {
 #[derive(Debug, Clone, Default)]
 pub struct SurbRoundTripRegistry {
     inner: Arc<DashMap<ForwardAndReturnPath, Arc<SurbRoundTripCounters>>>,
+    /// Destination each pair of legs leads to, so a collapse can name what to re-plan.
+    destinations: Arc<DashMap<ForwardAndReturnPath, OffchainPublicKey>>,
+    /// Consecutive flushes in which a pair minted SURBs and got nothing back.
+    silent: Arc<DashMap<ForwardAndReturnPath, u32>>,
 }
+
+/// SURBs a pair must have minted in one flush before its silence counts as evidence.
+///
+/// Measured after a relayer was killed: the dead leg minted 2270 SURBs in the 5s that followed
+/// while returning none. A handful is noise; thousands is not.
+const MIN_EXPECTED_FOR_SILENCE: u64 = 20;
+
+/// Consecutive silent flushes before the return path is called dead.
+///
+/// Flushes are one second apart, so this fires around five seconds after the loss starts --
+/// measured, the dead leg reads exactly zero from t+5s onward while its siblings keep returning.
+const SILENT_FLUSHES_BEFORE_DEGRADED: u32 = 3;
 
 impl SurbRoundTripRegistry {
     fn counters(&self, paths: ForwardAndReturnPath) -> Arc<SurbRoundTripCounters> {
@@ -87,8 +111,43 @@ impl SurbRoundTripRegistry {
     }
 
     /// Records that `count` SURBs were minted over these legs and are expected back.
-    pub fn record_expected(&self, paths: ForwardAndReturnPath, count: u64) {
+    pub fn record_expected(&self, paths: ForwardAndReturnPath, count: u64, destination: OffchainPublicKey) {
+        self.destinations.insert(paths, destination);
         self.counters(paths).record_expected(count);
+    }
+
+    /// Destinations whose return path has been silent for long enough to act on.
+    ///
+    /// Deliberately keyed on *no reply at all* rather than on a delivery rate. A rate cannot
+    /// separate these cases: measured immediately after a kill, a healthy leg read 0.089 while the
+    /// dead one read 0.123, and replies straddling a flush boundary push a healthy leg above 1.
+    /// Only sustained silence distinguishes them, and it does so within seconds.
+    pub fn degraded_destinations(&self) -> Vec<OffchainPublicKey> {
+        let mut degraded = Vec::new();
+
+        for entry in self.inner.iter() {
+            let paths = *entry.key();
+            let (expected, observed) = entry.value().peek();
+
+            if observed > 0 || expected < MIN_EXPECTED_FOR_SILENCE {
+                // Either it is delivering, or too little went out to conclude anything. An idle
+                // pair is not a failing one.
+                self.silent.remove(&paths);
+                continue;
+            }
+
+            let runs = self.silent.entry(paths).and_modify(|r| *r += 1).or_insert(1);
+            if *runs >= SILENT_FLUSHES_BEFORE_DEGRADED
+                && let Some(dest) = self.destinations.get(&paths)
+            {
+                degraded.push(*dest);
+            }
+        }
+
+        // `OffchainPublicKey` is not `Ord`, and several pairs of legs can share a destination.
+        let mut seen = std::collections::HashSet::new();
+        degraded.retain(|d: &OffchainPublicKey| seen.insert(*d));
+        degraded
     }
 
     /// Records that `count` replies arrived over these legs.
@@ -323,6 +382,9 @@ impl<C> SurbTelemetryCodec<C> {
         };
 
         let forward: Vec<_> = forward_path.transport_path().iter().copied().collect();
+        let Some(destination) = forward.last().copied() else {
+            return;
+        };
 
         tracing::debug!(
             minted = minted.len(),
@@ -338,7 +400,7 @@ impl<C> SurbTelemetryCodec<C> {
                 continue;
             };
 
-            self.registry.record_expected(paths, 1);
+            self.registry.record_expected(paths, 1, destination);
             self.pending.insert(*surb_id, paths);
         }
     }
@@ -466,13 +528,14 @@ mod tests {
 
     #[test]
     fn drain_should_take_the_counts_and_leave_the_entry_empty() {
+        let (_graph, _me, peers) = graph_with(1);
         let registry = SurbRoundTripRegistry::default();
         let paths = ForwardAndReturnPath {
             forward: [0, 1, 0, 0, 0],
             reply: [1, 0, 0, 0, 0],
         };
 
-        registry.record_expected(paths, 3);
+        registry.record_expected(paths, 3, peers[0]);
         registry.record_observed(paths, 2);
 
         assert_eq!(vec![(paths, 3, 2)], registry.drain());
@@ -636,6 +699,66 @@ mod tests {
             "the reply must reach the legs the mint recorded"
         );
         Ok(())
+    }
+
+    #[test]
+    fn sustained_silence_should_name_the_destination_to_replan() {
+        let (graph, me, peers) = graph_with(1);
+        let destination = peers[0];
+        let registry = SurbRoundTripRegistry::default();
+        let paths = ForwardAndReturnPath {
+            forward: [0, 1, 0, 0, 0],
+            reply: [1, 0, 0, 0, 0],
+        };
+
+        // Enough minted to be evidence, nothing coming back.
+        registry.record_expected(paths, MIN_EXPECTED_FOR_SILENCE, destination);
+
+        // One quiet interval is not a dead path, which is why the gate counts runs.
+        for _ in 1..SILENT_FLUSHES_BEFORE_DEGRADED {
+            assert!(registry.degraded_destinations().is_empty());
+        }
+        assert_eq!(vec![destination], registry.degraded_destinations());
+        let _ = (graph, me);
+    }
+
+    #[test]
+    fn a_single_reply_should_clear_the_silence() {
+        let (graph, me, peers) = graph_with(1);
+        let destination = peers[0];
+        let registry = SurbRoundTripRegistry::default();
+        let paths = ForwardAndReturnPath {
+            forward: [0, 1, 0, 0, 0],
+            reply: [1, 0, 0, 0, 0],
+        };
+
+        registry.record_expected(paths, MIN_EXPECTED_FOR_SILENCE, destination);
+        registry.degraded_destinations();
+        registry.degraded_destinations();
+
+        // A path that delivers anything at all is not the failure this looks for.
+        registry.record_observed(paths, 1);
+        assert!(registry.degraded_destinations().is_empty());
+        let _ = (graph, me);
+    }
+
+    #[test]
+    fn an_idle_path_should_never_be_called_degraded() {
+        let (graph, me, peers) = graph_with(1);
+        let destination = peers[0];
+        let registry = SurbRoundTripRegistry::default();
+        let paths = ForwardAndReturnPath {
+            forward: [0, 1, 0, 0, 0],
+            reply: [1, 0, 0, 0, 0],
+        };
+
+        // Below the evidence floor: a trickle that happens not to have returned yet says nothing,
+        // and treating it as failure would re-plan healthy paths during quiet periods.
+        registry.record_expected(paths, MIN_EXPECTED_FOR_SILENCE - 1, destination);
+        for _ in 0..SILENT_FLUSHES_BEFORE_DEGRADED + 2 {
+            assert!(registry.degraded_destinations().is_empty());
+        }
+        let _ = (graph, me);
     }
 
     #[test]

--- a/transport/hopr/src/protocol/surb_telemetry.rs
+++ b/transport/hopr/src/protocol/surb_telemetry.rs
@@ -165,6 +165,20 @@ impl SurbRoundTripRegistry {
             *since < FLUSHES_BETWEEN_REPLANS
         });
 
+        // Which destinations had *some* pair deliver in this flush.
+        //
+        // This is what makes silence mean anything. On its own, "minted and got nothing back" is
+        // produced identically by a dead relayer and by a peer with nothing to say -- keep-alives
+        // mint either way. Only a sibling pair still delivering to the same destination tells the
+        // two apart, and it does so without a threshold: if the peer had gone quiet, every pair
+        // would be silent together.
+        let delivering: std::collections::HashSet<OffchainPublicKey> = self
+            .inner
+            .iter()
+            .filter(|entry| entry.value().peek().1 > 0)
+            .filter_map(|entry| self.destinations.get(entry.key()).map(|d| *d))
+            .collect();
+
         for entry in self.inner.iter() {
             let paths = *entry.key();
             let (expected, observed) = entry.value().peek();
@@ -189,21 +203,32 @@ impl SurbRoundTripRegistry {
                 continue;
             }
 
+            let Some(dest) = self.destinations.get(&paths).map(|d| *d) else {
+                continue;
+            };
+
+            // Corroboration: some other pair to this destination is still getting replies home, so
+            // the peer is demonstrably talking and this pair's silence is its own fault. The run
+            // resets when nothing corroborates, so `runs` counts consecutive flushes in which this
+            // pair was silent *while the peer was demonstrably answering elsewhere* -- not merely
+            // flushes in which it was quiet.
+            if !delivering.contains(&dest) {
+                state.runs = 0;
+                continue;
+            }
+
             state.runs += 1;
             if state.runs >= SILENT_FLUSHES_BEFORE_DEGRADED {
                 // Re-arm rather than accumulate: re-planning the same destination on every
                 // subsequent flush churns its cached candidates instead of letting the new
                 // selection settle.
                 state.runs = 0;
-                if let Some(dest) = self.destinations.get(&paths) {
-                    let dest = *dest;
-                    // Only if this destination is not already serving out a cooldown: another of
-                    // its pairs may have reported it moments ago, and re-planning again now would
-                    // discard the candidate that re-plan just chose.
-                    if !self.replanned.contains_key(&dest) {
-                        self.replanned.insert(dest, 0);
-                        degraded.push(dest);
-                    }
+                // Only if this destination is not already serving out a cooldown: another of its
+                // pairs may have reported it moments ago, and re-planning again now would discard
+                // the candidate that re-plan just chose.
+                if !self.replanned.contains_key(&dest) {
+                    self.replanned.insert(dest, 0);
+                    degraded.push(dest);
                 }
             }
         }
@@ -786,6 +811,17 @@ mod tests {
         registry.record_expected(paths, MIN_EXPECTED_FOR_SILENCE, destination);
     }
 
+    /// A sibling pair to the same destination that keeps answering.
+    ///
+    /// Silence is only actionable against a peer that is demonstrably still talking, so any test
+    /// of the silence logic has to keep one pair delivering or nothing can ever fire.
+    fn heartbeat() -> ForwardAndReturnPath {
+        ForwardAndReturnPath {
+            forward: [0, 3, 0, 0, 0],
+            reply: [3, 0, 0, 0, 0],
+        }
+    }
+
     fn legs() -> ForwardAndReturnPath {
         ForwardAndReturnPath {
             forward: [0, 1, 0, 0, 0],
@@ -804,13 +840,15 @@ mod tests {
         deliver(&registry, paths, destination);
         assert!(flush(&registry).is_empty());
 
-        // Then it goes quiet while still minting. One quiet interval is not a dead path, which is
-        // why the gate counts runs.
+        // Then it goes quiet while still minting, with a sibling still answering to prove the
+        // peer is talking. One quiet interval is not a dead path, which is why the gate counts runs.
         for _ in 1..SILENT_FLUSHES_BEFORE_DEGRADED {
             mint_only(&registry, paths, destination);
+            deliver(&registry, heartbeat(), destination);
             assert!(flush(&registry).is_empty());
         }
         mint_only(&registry, paths, destination);
+        deliver(&registry, heartbeat(), destination);
         assert_eq!(vec![destination], flush(&registry));
         let _ = (graph, me);
     }
@@ -866,6 +904,7 @@ mod tests {
         for _ in 0..WINDOW {
             mint_only(&registry, first, destination);
             mint_only(&registry, second, destination);
+            deliver(&registry, heartbeat(), destination);
             reports += flush(&registry).len();
         }
 
@@ -881,6 +920,43 @@ mod tests {
             "a destination must not be re-planned faster than a new path can settle: {reports} re-plans in {WINDOW} \
              flushes"
         );
+
+        let _ = (graph, me);
+    }
+
+    /// A peer that simply stops talking must not be mistaken for a dead relayer.
+    ///
+    /// This is the case that killed every absolute gate: after a busy stretch the counters look
+    /// exactly like a failing path -- SURBs still minted by keep-alives, nothing coming back. A
+    /// delivered-ever bool, a recency decay, a volume threshold and a ratio collapse all fire here.
+    /// Corroboration cannot, because when the peer goes quiet it goes quiet on *every* pair, so
+    /// there is never a sibling to corroborate against.
+    #[test]
+    fn a_peer_that_goes_quiet_should_not_be_mistaken_for_a_dead_return_path() {
+        let (graph, me, peers) = graph_with(2);
+        let destination = peers[0];
+        let registry = SurbRoundTripRegistry::default();
+
+        let first = legs();
+        let second = heartbeat();
+
+        // A busy stretch: both pairs carrying real return traffic.
+        for _ in 0..10 {
+            deliver(&registry, first, destination);
+            deliver(&registry, second, destination);
+            assert!(flush(&registry).is_empty());
+        }
+
+        // The application goes idle. Keep-alives keep minting on both pairs; the peer has nothing
+        // to say on either.
+        for _ in 0..(4 * SILENT_FLUSHES_BEFORE_DEGRADED) {
+            mint_only(&registry, first, destination);
+            mint_only(&registry, second, destination);
+            assert!(
+                flush(&registry).is_empty(),
+                "a quiet peer is not a dead return path, however long it stays quiet"
+            );
+        }
 
         let _ = (graph, me);
     }
@@ -942,15 +1018,18 @@ mod tests {
         flush(&registry);
         for _ in 1..SILENT_FLUSHES_BEFORE_DEGRADED {
             mint_only(&registry, paths, destination);
+            deliver(&registry, heartbeat(), destination);
             flush(&registry);
         }
         mint_only(&registry, paths, destination);
+        deliver(&registry, heartbeat(), destination);
         assert_eq!(vec![destination], flush(&registry));
 
         // Re-planning the same destination every second churns its cached candidates instead of
         // letting the new selection settle, so the gate re-arms from zero.
         for _ in 1..SILENT_FLUSHES_BEFORE_DEGRADED {
             mint_only(&registry, paths, destination);
+            deliver(&registry, heartbeat(), destination);
             assert!(flush(&registry).is_empty());
         }
         let _ = (graph, me);

--- a/transport/session/Cargo.toml
+++ b/transport/session/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport-session"
 description = "Session functionality providing session abstraction over the HOPR transport"
-version = "0.26.0"
+version = "0.26.1"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/session/Cargo.toml
+++ b/transport/session/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport-session"
 description = "Session functionality providing session abstraction over the HOPR transport"
-version = "0.26.1"
+version = "0.26.2"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/session/benches/dispatch_bench.rs
+++ b/transport/session/benches/dispatch_bench.rs
@@ -125,7 +125,7 @@ fn make_manager_with_session() -> (
         session_forward_capacity: BENCHMARK_CHANNEL_CAPACITY,
         ..Default::default()
     };
-    let manager = SessionManager::new(cfg, None);
+    let manager = SessionManager::new(cfg);
 
     let (msg_sender, msg_receiver) = futures::channel::mpsc::unbounded();
     let (session_notifier, session_notifier_rx) = futures::channel::mpsc::channel(1);
@@ -172,7 +172,7 @@ fn make_manager_without_session() -> (
         session_forward_capacity: BENCHMARK_CHANNEL_CAPACITY,
         ..Default::default()
     };
-    let manager = SessionManager::new(cfg, None);
+    let manager = SessionManager::new(cfg);
 
     let (msg_sender, msg_receiver) = futures::channel::mpsc::unbounded();
     let (session_notifier, session_notifier_rx) = futures::channel::mpsc::channel(1);

--- a/transport/session/src/balancer/controller.rs
+++ b/transport/session/src/balancer/controller.rs
@@ -139,7 +139,8 @@ pub struct BalancerStateValues {
     /// everything above its capacity was discarded on arrival and was never a real level. Measured
     /// during an outage: 51 917 believed against a 15 000-entry store.
     pub counterparty_buffer_capacity: AtomicU64,
-    /// Milliseconds from [`EPOCH`] until which the return path counts as degraded.
+    /// Milliseconds from the crate-internal `EPOCH` monotonic origin until which the return path
+    /// counts as degraded.
     ///
     /// A deadline rather than a flag: it is set by a layer that observes the return path and read
     /// here, and nothing is guaranteed to come back and clear it. Expiring on its own bounds the
@@ -400,9 +401,15 @@ where
         let believed = current;
         current = self.state.clamp_to_counterparty_capacity(current);
         if current != believed {
+            // Not the configured capacity: the bound applied is `max(capacity, target)`, so name
+            // the clamped level and the capacity separately rather than conflating them.
             tracing::debug!(
                 believed,
-                capacity = current,
+                clamped_to = current,
+                counterparty_capacity = self
+                    .state
+                    .counterparty_buffer_capacity
+                    .load(std::sync::atomic::Ordering::Relaxed),
                 "counterparty SURB estimate exceeded its store; the surplus was never held"
             );
         }
@@ -468,9 +475,13 @@ where
         // Both ends run this same loop -- the Entry with the PID driving production, the Exit with
         // the proportional controller gating egress -- so one line covers both and the session id
         // tells them apart. Rate-limited to one per second so it can run under a full-rate session.
+        //
+        // At `debug` rather than `info`: one line per session per second is fine for a handful of
+        // sessions and is a lot of formatting work for a node carrying many, none of which an
+        // operator needs to see during healthy operation.
         if self.last_report.elapsed() >= Duration::from_secs(1) {
             self.last_report = std::time::Instant::now();
-            tracing::info!(
+            tracing::debug!(
                 session = %self.session_id,
                 level = current,
                 target = self.controller.bounds().target(),

--- a/transport/session/src/balancer/controller.rs
+++ b/transport/session/src/balancer/controller.rs
@@ -131,6 +131,14 @@ pub struct BalancerStateValues {
     pub buffer_level: AtomicU64,
     /// Whether this session opted into sustaining production through return-path loss.
     pub sustain_on_return_path_loss: AtomicBool,
+    /// How many SURBs the counterparty can physically hold, or 0 when unknown.
+    ///
+    /// The estimate is `produced - consumed`, and consumption is only observed once a reply
+    /// arrives -- so a return path that drops replies lets the believed level grow without bound.
+    /// The counterparty's store is a ring buffer that evicts the oldest entry on overflow, so
+    /// everything above its capacity was discarded on arrival and was never a real level. Measured
+    /// during an outage: 51 917 believed against a 15 000-entry store.
+    pub counterparty_buffer_capacity: AtomicU64,
     /// Milliseconds from [`EPOCH`] until which the return path counts as degraded.
     ///
     /// A deadline rather than a flag: it is set by a layer that observes the return path and read
@@ -169,6 +177,34 @@ impl BalancerStateValues {
         );
         self.sustain_on_return_path_loss
             .store(cfg.sustain_on_return_path_loss, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Declares how many SURBs the counterparty's store can hold, bounding the level estimate.
+    ///
+    /// Taken from the session manager's `maximum_surb_buffer_size`, which is the same capacity
+    /// already used to clamp a counterparty's requested target. Zero leaves the estimate unbounded.
+    pub fn set_counterparty_buffer_capacity(&self, capacity: u64) {
+        self.counterparty_buffer_capacity
+            .store(capacity, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Caps `level` at what the counterparty can actually hold.
+    ///
+    /// Never below the configured target: a target above the counterparty's capacity is
+    /// unreachable by construction, and clamping to capacity there would hold the error permanently
+    /// negative and pin production at maximum forever -- a worse failure than the unbounded
+    /// estimate this exists to prevent. In that configuration the capacity figure is simply not
+    /// usable for this session.
+    fn clamp_to_counterparty_capacity(&self, level: u64) -> u64 {
+        match self
+            .counterparty_buffer_capacity
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            0 => level,
+            capacity => {
+                level.min(capacity.max(self.target_surb_buffer_size.load(std::sync::atomic::Ordering::Relaxed)))
+            }
+        }
     }
 
     /// Marks the return path as degraded for the next `grace` period.
@@ -357,6 +393,18 @@ where
             current = current.saturating_sub(num_decayed_surbs);
             self.last_decay = std::time::Instant::now();
             tracing::trace!(num_decayed_surbs, "SURBs were discarded due to automatic decay");
+        }
+
+        // Believing a level the counterparty cannot hold keeps production throttled long after
+        // the surplus was evicted on arrival, so the estimate is bounded by the store it describes.
+        let believed = current;
+        current = self.state.clamp_to_counterparty_capacity(current);
+        if current != believed {
+            tracing::debug!(
+                believed,
+                capacity = current,
+                "counterparty SURB estimate exceeded its store; the surplus was never held"
+            );
         }
 
         let degraded = self.state.should_sustain_through_return_path_loss();
@@ -973,6 +1021,61 @@ mod tests {
         assert!(
             ticks <= 30,
             "refilling must ramp rather than crawl: took {ticks} sampling intervals"
+        );
+    }
+
+    /// The estimate must not claim a level the counterparty's store could never have held.
+    ///
+    /// `produced - consumed` only decreases when a reply arrives, so production that nobody is
+    /// seen to consume accumulates without bound. The counterparty's store is a ring buffer that
+    /// evicts the oldest entry on overflow, so everything above its capacity was discarded on
+    /// arrival. Measured during a live outage: 51 917 believed against a 15 000-entry store, which
+    /// keeps the controller throttling against a buffer that is in fact draining.
+    #[test_log::test]
+    fn surb_balancer_should_not_believe_a_level_the_counterparty_cannot_hold() {
+        const CAPACITY: u64 = 2_000;
+
+        let cfg = sustaining_config(false);
+        let (mut balancer, surb_estimator, state, output) = balancer_with_feedback(cfg);
+        state.set_counterparty_buffer_capacity(CAPACITY);
+
+        for _ in 0..40 {
+            tick(&mut balancer, &surb_estimator, &output, REPLIES_PER_TICK);
+        }
+
+        // Replies stop, while production continues from a source the controller does not drive --
+        // keep-alives mint on their own schedule, which is how the live estimate ran away.
+        for _ in 0..20 {
+            surb_estimator
+                .produced
+                .fetch_add(500, std::sync::atomic::Ordering::Relaxed);
+            tick(&mut balancer, &surb_estimator, &output, 0);
+        }
+
+        let believed = state.buffer_level.load(std::sync::atomic::Ordering::Relaxed);
+        assert!(
+            believed <= CAPACITY,
+            "the estimate must be bounded by the counterparty's store: believed {believed} against a {CAPACITY}-entry \
+             buffer"
+        );
+    }
+
+    /// The bound must not become the setpoint: a store larger than the target changes nothing.
+    #[test_log::test]
+    fn surb_balancer_should_leave_a_healthy_session_untouched_by_the_capacity_bound() {
+        let cfg = sustaining_config(false);
+        let (mut balancer, surb_estimator, state, output) = balancer_with_feedback(cfg);
+        state.set_counterparty_buffer_capacity(cfg.target_surb_buffer_size * 10);
+
+        for _ in 0..40 {
+            tick(&mut balancer, &surb_estimator, &output, REPLIES_PER_TICK);
+        }
+
+        let level = state.buffer_level.load(std::sync::atomic::Ordering::Relaxed);
+        assert!(
+            level >= cfg.target_surb_buffer_size / 2,
+            "a capacity well above the target must not hold the session below its setpoint: level {level}, target {}",
+            cfg.target_surb_buffer_size
         );
     }
 

--- a/transport/session/src/balancer/controller.rs
+++ b/transport/session/src/balancer/controller.rs
@@ -280,6 +280,8 @@ pub struct SurbBalancer<C, E, F> {
     was_below_target: bool,
     /// Whether the previous update ran in open loop, so both edges can be acted on.
     was_degraded: bool,
+    /// DIAGNOSTIC: when the last balancer-state line was emitted, to rate-limit it.
+    last_report: std::time::Instant,
 }
 
 impl<C, E, F> SurbBalancer<C, E, F>
@@ -315,6 +317,7 @@ where
             last_decay: std::time::Instant::now(),
             was_below_target: true,
             was_degraded: false,
+            last_report: std::time::Instant::now(),
         }
     }
 
@@ -413,6 +416,25 @@ where
 
         let output = self.controller.next_control_output(current);
         tracing::trace!(output, "next balancer control output for session");
+
+        // DIAGNOSTIC: both ends run this same loop -- the Entry with the PID driving production,
+        // the Exit with the proportional controller gating egress -- so one report covers both and
+        // the session id tells them apart. At `info` deliberately: the harness filters at info, and
+        // the point is to see supply and spend on both sides during an outage.
+        // Rate-limited to one line per second so it can run under a full-rate session.
+        if self.last_report.elapsed() >= Duration::from_secs(1) {
+            self.last_report = std::time::Instant::now();
+            tracing::info!(
+                session = %self.session_id,
+                level = current,
+                target = self.controller.bounds().target(),
+                output,
+                produced = self.surb_estimator.estimate_surbs_produced(),
+                consumed = self.surb_estimator.estimate_surbs_consumed(),
+                degraded,
+                "surb balancer state"
+            );
+        }
 
         self.flow_control.adjust_surb_flow(output as usize);
 
@@ -903,6 +925,54 @@ mod tests {
             recovered < first_degraded,
             "once replies are arriving again the controller must return to closed loop rather than stay pinned at \
              maximum: degraded={first_degraded}/s, recovered={recovered}/s"
+        );
+    }
+
+    /// After the outage the counterparty must be refilled, not merely un-throttled.
+    ///
+    /// Returning to closed loop is only half the claim: production has to actually climb the curve
+    /// again and restore the buffer. Resetting the controller is what makes that prompt -- the error
+    /// accumulated while the estimate was meaningless would otherwise have to be unwound first.
+    #[test_log::test]
+    fn surb_balancer_should_refill_the_counterparty_after_the_return_path_recovers() {
+        let cfg = sustaining_config(true);
+        let (mut balancer, surb_estimator, state, output) = balancer_with_feedback(cfg);
+
+        for _ in 0..40 {
+            tick(&mut balancer, &surb_estimator, &output, REPLIES_PER_TICK);
+        }
+        // A band, not the setpoint itself: the controller oscillates around its target, so a
+        // sample taken at an arbitrary tick legitimately sits either side of it.
+        let refilled = cfg.target_surb_buffer_size / 2;
+        assert!(
+            state.buffer_level.load(std::sync::atomic::Ordering::Relaxed) >= refilled,
+            "the healthy phase must reach the setpoint band before an outage means anything"
+        );
+
+        // The return path dies: replies stop, and open loop takes over.
+        state.mark_return_path_degraded(Duration::from_millis(400));
+        for _ in 0..8 {
+            tick(&mut balancer, &surb_estimator, &output, 0);
+        }
+
+        // The mark lapses, the counterparty answers again, and the belief restarts from empty.
+        let mut ticks_to_refill = None;
+        for n in 1..=60 {
+            tick(&mut balancer, &surb_estimator, &output, REPLIES_PER_TICK);
+            if state.buffer_level.load(std::sync::atomic::Ordering::Relaxed) >= refilled {
+                ticks_to_refill = Some(n);
+                break;
+            }
+        }
+
+        let ticks = ticks_to_refill.expect("the counterparty must be refilled to the setpoint after recovery");
+        tracing::info!(ticks, "refilled the counterparty after the outage");
+
+        // Each tick is one sampling interval; the balancer samples far more often than this in a
+        // live Session, so a bound in ticks is a bound in sampling intervals, not in wall clock.
+        assert!(
+            ticks <= 30,
+            "refilling must ramp rather than crawl: took {ticks} sampling intervals"
         );
     }
 

--- a/transport/session/src/balancer/controller.rs
+++ b/transport/session/src/balancer/controller.rs
@@ -1,10 +1,17 @@
 use std::{
     sync::{
-        Arc,
-        atomic::{AtomicU8, AtomicU64},
+        Arc, LazyLock,
+        atomic::{AtomicBool, AtomicU8, AtomicU64},
     },
-    time::Duration,
+    time::{Duration, Instant},
 };
+
+/// Monotonic origin for the degraded-return-path deadline.
+///
+/// An `Instant` cannot live in an atomic, and the deadline is written by one layer and read by
+/// another, so it travels as milliseconds elapsed from a fixed point. Monotonic rather than
+/// wall-clock, so a clock adjustment cannot extend or cancel the window.
+static EPOCH: LazyLock<Instant> = LazyLock::new(Instant::now);
 
 use futures::{StreamExt, pin_mut};
 use hopr_utils::runtime::AbortHandle;
@@ -87,6 +94,23 @@ pub struct SurbBalancerConfig {
     /// The default is `(60, 0.05)` (5% of the target buffer size is discarded every 60 seconds).
     #[default(_code = "Some((Duration::from_secs(60), 0.05))")]
     pub surb_decay: Option<(Duration, f64)>,
+
+    /// Keeps producing SURBs while the return path is known to be failing, instead of reading the
+    /// resulting silence as a full counterparty buffer.
+    ///
+    /// The remote buffer is estimated as *produced − consumed*, and consumption is only observed
+    /// when a reply reaches us. A return path that drops every reply therefore looks exactly like a
+    /// counterparty that is well stocked, so production is throttled at the very moment the
+    /// counterparty is in fact draining towards empty and needs more.
+    ///
+    /// Distinguishing that from a peer which simply has nothing to say is impossible from here --
+    /// both show no consumption -- so this only takes effect once an outside observer marks the
+    /// return path degraded, and it expires on its own if no further evidence arrives.
+    ///
+    /// Off by default: sustaining production spends bandwidth on a path that may be genuinely idle,
+    /// which is only worth it for sessions that value recovery latency over that bandwidth.
+    #[default(false)]
+    pub sustain_on_return_path_loss: bool,
 }
 
 impl SurbBalancerConfig {
@@ -105,6 +129,15 @@ pub struct BalancerStateValues {
     pub decay_duration_msec: AtomicU64,
     pub decay_volume_pct: AtomicU8,
     pub buffer_level: AtomicU64,
+    /// Whether this session opted into sustaining production through return-path loss.
+    pub sustain_on_return_path_loss: AtomicBool,
+    /// Milliseconds from [`EPOCH`] until which the return path counts as degraded.
+    ///
+    /// A deadline rather than a flag: it is set by a layer that observes the return path and read
+    /// here, and nothing is guaranteed to come back and clear it. Expiring on its own bounds the
+    /// damage of a marker that is never withdrawn to a short over-production instead of a session
+    /// that mints forever.
+    pub return_path_degraded_until_ms: AtomicU64,
 }
 
 impl BalancerStateValues {
@@ -134,6 +167,38 @@ impl BalancerStateValues {
                 .unwrap_or_default(),
             std::sync::atomic::Ordering::Relaxed,
         );
+        self.sustain_on_return_path_loss
+            .store(cfg.sustain_on_return_path_loss, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Marks the return path as degraded for the next `grace` period.
+    ///
+    /// Called by whichever layer can actually tell a dead return path from a quiet peer -- from
+    /// here the two are indistinguishable, since neither delivers replies. Re-marking simply
+    /// extends the window.
+    pub fn mark_return_path_degraded(&self, grace: Duration) {
+        let until = EPOCH.elapsed().saturating_add(grace).as_millis().min(u64::MAX as u128) as u64;
+        self.return_path_degraded_until_ms
+            .fetch_max(until, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Whether production should currently ignore the counterparty buffer estimate.
+    ///
+    /// Both the opt-in and live evidence are required: without the opt-in this is not our
+    /// behaviour to change, and without evidence there is nothing to distinguish a dead return path
+    /// from an idle one.
+    fn should_sustain_through_return_path_loss(&self) -> bool {
+        let deadline = self
+            .return_path_degraded_until_ms
+            .load(std::sync::atomic::Ordering::Relaxed);
+
+        // Zero is "never marked", not "marked at the epoch" -- otherwise every session that opted
+        // in would start out believing its return path was already dead.
+        deadline > 0
+            && (EPOCH.elapsed().as_millis() as u64) < deadline
+            && self
+                .sustain_on_return_path_loss
+                .load(std::sync::atomic::Ordering::Relaxed)
     }
 
     /// Extracts the [`SurbBalancerConfig`] from the [`BalancerStateValues`].
@@ -142,6 +207,9 @@ impl BalancerStateValues {
             target_surb_buffer_size: self.target_surb_buffer_size.load(std::sync::atomic::Ordering::Relaxed),
             max_surbs_per_sec: self.max_surbs_per_sec.load(std::sync::atomic::Ordering::Relaxed),
             surb_decay: self.surb_decay(),
+            sustain_on_return_path_loss: self
+                .sustain_on_return_path_loss
+                .load(std::sync::atomic::Ordering::Relaxed),
         }
     }
 
@@ -210,6 +278,8 @@ pub struct SurbBalancer<C, E, F> {
     last_update: std::time::Instant,
     last_decay: std::time::Instant,
     was_below_target: bool,
+    /// Whether the previous update ran in open loop, so both edges can be acted on.
+    was_degraded: bool,
 }
 
 impl<C, E, F> SurbBalancer<C, E, F>
@@ -244,6 +314,7 @@ where
             last_update: std::time::Instant::now(),
             last_decay: std::time::Instant::now(),
             was_below_target: true,
+            was_degraded: false,
         }
     }
 
@@ -283,6 +354,37 @@ where
             current = current.saturating_sub(num_decayed_surbs);
             self.last_decay = std::time::Instant::now();
             tracing::trace!(num_decayed_surbs, "SURBs were discarded due to automatic decay");
+        }
+
+        let degraded = self.state.should_sustain_through_return_path_loss();
+        if degraded != self.was_degraded {
+            // The estimate stops meaning what it meant on both edges: entering, it is inflated by
+            // production nobody was seen to consume; leaving, it is a level that was never
+            // observed. Either way the accumulated error belongs to a regime that has ended.
+            self.controller.reset();
+            self.was_degraded = degraded;
+
+            if !degraded {
+                // Coming back, treat the counterparty as freshly started rather than as whatever
+                // the outage left behind. It really did drain while replies were lost, and this is
+                // the estimate that self-corrects: consumption is observable again, so the buffer
+                // level climbs on its own as production outruns it.
+                current = 0;
+                self.last_decay = std::time::Instant::now();
+                tracing::debug!("return path recovered; restarting closed-loop SURB control");
+            }
+        }
+
+        if degraded {
+            // While replies are being lost there is no valid estimate to act on: every SURB the
+            // counterparty spends is invisible from here, so the accumulated `produced - consumed`
+            // reads as a filling buffer precisely when it is emptying. Drop to open loop and assume
+            // the worst, which drives production to the maximum until replies resume.
+            tracing::debug!(
+                believed = current,
+                "return path degraded; ignoring the counterparty buffer estimate"
+            );
+            current = 0;
         }
 
         self.state
@@ -420,6 +522,7 @@ mod tests {
             target_surb_buffer_size: 1000,
             max_surbs_per_sec: 500,
             surb_decay: None,
+            sustain_on_return_path_loss: false,
         };
         let bounds = cfg.as_controller_bounds();
         assert_eq!(bounds.target(), 1000);
@@ -432,6 +535,7 @@ mod tests {
             target_surb_buffer_size: 0,
             max_surbs_per_sec: 0,
             surb_decay: None,
+            sustain_on_return_path_loss: false,
         };
         let state = BalancerStateValues::new(cfg);
         assert!(state.is_disabled());
@@ -450,6 +554,7 @@ mod tests {
             target_surb_buffer_size: 3000,
             max_surbs_per_sec: 1500,
             surb_decay: Some((Duration::from_secs(30), 0.10)),
+            sustain_on_return_path_loss: false,
         };
         state.update(&cfg);
         assert_eq!(state.as_config(), cfg);
@@ -462,6 +567,7 @@ mod tests {
             target_surb_buffer_size: 1000,
             max_surbs_per_sec: 500,
             surb_decay: None,
+            sustain_on_return_path_loss: false,
         };
         let state = BalancerStateValues::new(cfg);
         assert!(state.surb_decay().is_none());
@@ -486,6 +592,7 @@ mod tests {
             target_surb_buffer_size: 5000,
             max_surbs_per_sec: 2500,
             surb_decay: Some((Duration::from_secs(60), 0.05)),
+            sustain_on_return_path_loss: false,
         };
         let state: BalancerStateValues = cfg.into();
         assert_eq!(state.as_config(), cfg);
@@ -556,6 +663,7 @@ mod tests {
                     target_surb_buffer_size: 5_000,
                     max_surbs_per_sec: 2500,
                     surb_decay: None,
+                    sustain_on_return_path_loss: false,
                 }
                 .into(),
             ),
@@ -635,6 +743,180 @@ mod tests {
         }
     }
 
+    /// A balancer whose production follows its own control output, as it does in a live Session.
+    ///
+    /// Returns the balancer, the shared estimator and the latest control output. Production must be
+    /// fed back rather than held constant: with production pinned to consumption the buffer never
+    /// fills, maximum output is the correct answer, and every phase of the test reads the same.
+    #[allow(clippy::type_complexity)]
+    fn balancer_with_feedback(
+        cfg: SurbBalancerConfig,
+    ) -> (
+        SurbBalancer<PidBalancerController, AtomicSurbFlowEstimator, MockSurbFlowController>,
+        AtomicSurbFlowEstimator,
+        Arc<BalancerStateValues>,
+        Arc<AtomicU64>,
+    ) {
+        let output = Arc::new(AtomicU64::new(0));
+        let output_clone = output.clone();
+        let mut controller = MockSurbFlowController::new();
+        controller.expect_adjust_surb_flow().returning(move |r| {
+            output_clone.store(r as u64, std::sync::atomic::Ordering::Relaxed);
+        });
+
+        let surb_estimator = AtomicSurbFlowEstimator::default();
+        let state: Arc<BalancerStateValues> = Arc::new(cfg.into());
+        let balancer = SurbBalancer::new(
+            HoprPseudonym::random(),
+            PidBalancerController::default(),
+            surb_estimator.clone(),
+            controller,
+            state.clone(),
+        );
+
+        (balancer, surb_estimator, state, output)
+    }
+
+    /// One sampling interval: mint at the rate last commanded, and consume `consumed` of them.
+    fn tick(
+        balancer: &mut SurbBalancer<PidBalancerController, AtomicSurbFlowEstimator, MockSurbFlowController>,
+        surb_estimator: &AtomicSurbFlowEstimator,
+        output: &AtomicU64,
+        consumed: u64,
+    ) {
+        let step = Duration::from_millis(50);
+        std::thread::sleep(step);
+
+        let minted = output.load(std::sync::atomic::Ordering::Relaxed) * step.as_millis() as u64 / 1000;
+        surb_estimator
+            .produced
+            .fetch_add(minted, std::sync::atomic::Ordering::Relaxed);
+        surb_estimator
+            .consumed
+            .fetch_add(consumed, std::sync::atomic::Ordering::Relaxed);
+        balancer.update();
+    }
+
+    /// SURBs the counterparty spends per interval while it is answering normally.
+    const REPLIES_PER_TICK: u64 = 40;
+
+    /// Drives a balancer through a healthy stretch, then through one where no reply comes back.
+    ///
+    /// Returns the control output at the end of each stretch. The two phases are deliberately
+    /// indistinguishable from inside the balancer -- consumption simply stops -- which is the whole
+    /// point: only the caller's `sustain` choice separates a dead return path from an idle peer.
+    fn drive_until_replies_stop(cfg: SurbBalancerConfig, mark_degraded: bool) -> (u64, u64) {
+        let (mut balancer, surb_estimator, state, output) = balancer_with_feedback(cfg);
+
+        for _ in 0..40 {
+            tick(&mut balancer, &surb_estimator, &output, REPLIES_PER_TICK);
+        }
+        let healthy = output.load(std::sync::atomic::Ordering::Relaxed);
+
+        if mark_degraded {
+            state.mark_return_path_degraded(Duration::from_secs(30));
+        }
+
+        // Replies stop while production continues.
+        for _ in 0..20 {
+            tick(&mut balancer, &surb_estimator, &output, 0);
+        }
+
+        (healthy, output.load(std::sync::atomic::Ordering::Relaxed))
+    }
+
+    fn sustaining_config(sustain: bool) -> SurbBalancerConfig {
+        SurbBalancerConfig {
+            // Small enough that the healthy phase actually reaches the setpoint and backs off
+            // within the test's tick budget; saturated-at-maximum makes every phase read alike.
+            target_surb_buffer_size: 1_000,
+            max_surbs_per_sec: 2_500,
+            surb_decay: None,
+            sustain_on_return_path_loss: sustain,
+        }
+    }
+
+    /// A peer with nothing to say really is filling up, so throttling it is correct.
+    ///
+    /// This is the case that makes the estimate impossible to fix locally: it is byte-for-byte the
+    /// same observation as a dead return path.
+    #[test_log::test]
+    fn surb_balancer_should_throttle_when_a_quiet_counterparty_stops_consuming() {
+        let (healthy, quiet) = drive_until_replies_stop(sustaining_config(false), false);
+
+        assert!(healthy > 0, "a balanced session must keep minting");
+        assert!(
+            quiet < healthy,
+            "an idle counterparty accumulates SURBs, so production must back off: healthy={healthy}/s, idle={quiet}/s"
+        );
+    }
+
+    /// Once told the return path is dead, the same observation must not be read as a full buffer.
+    ///
+    /// `consumed` advances only when a reply reaches the entry (`manager.rs`, the `session_rx`
+    /// inspect counting "received packets = SURB consumption estimate"). A return path that drops
+    /// every reply therefore looks like a well-stocked counterparty, and production is cut at the
+    /// exact moment the counterparty is draining towards empty -- the feedback signal travels on
+    /// the very path whose failure it is meant to reveal.
+    #[test_log::test]
+    fn surb_balancer_should_sustain_production_through_a_degraded_return_path() {
+        let (healthy, degraded) = drive_until_replies_stop(sustaining_config(true), true);
+
+        assert!(healthy > 0, "a balanced session must keep minting");
+        assert!(
+            degraded >= healthy,
+            "the counterparty is burning SURBs it cannot replace, so production must not be cut: healthy={healthy}/s, \
+             degraded={degraded}/s"
+        );
+    }
+
+    /// Both edges of a degraded window: open loop must engage at once, and let go afterwards.
+    #[test_log::test]
+    fn surb_balancer_should_return_to_closed_loop_when_the_return_path_recovers() {
+        let (mut balancer, surb_estimator, state, output) = balancer_with_feedback(sustaining_config(true));
+
+        for _ in 0..40 {
+            tick(&mut balancer, &surb_estimator, &output, REPLIES_PER_TICK);
+        }
+        let healthy = output.load(std::sync::atomic::Ordering::Relaxed);
+
+        state.mark_return_path_degraded(Duration::from_millis(500));
+        tick(&mut balancer, &surb_estimator, &output, 0);
+        let first_degraded = output.load(std::sync::atomic::Ordering::Relaxed);
+
+        for _ in 0..9 {
+            tick(&mut balancer, &surb_estimator, &output, 0);
+        }
+
+        // The mark lapses and the counterparty starts answering again.
+        for _ in 0..40 {
+            tick(&mut balancer, &surb_estimator, &output, REPLIES_PER_TICK);
+        }
+        let recovered = output.load(std::sync::atomic::Ordering::Relaxed);
+
+        assert!(
+            first_degraded > healthy,
+            "open loop must engage on the first update after the mark, not ramp towards it: healthy={healthy}/s, \
+             first degraded update={first_degraded}/s"
+        );
+        assert!(
+            recovered < first_degraded,
+            "once replies are arriving again the controller must return to closed loop rather than stay pinned at \
+             maximum: degraded={first_degraded}/s, recovered={recovered}/s"
+        );
+    }
+
+    /// The opt-in is what enables it; evidence alone must not change a session's behaviour.
+    #[test_log::test]
+    fn surb_balancer_should_ignore_a_degraded_return_path_unless_configured_to_sustain() {
+        let (healthy, degraded) = drive_until_replies_stop(sustaining_config(false), true);
+
+        assert!(
+            degraded < healthy,
+            "without the opt-in this is not our behaviour to change: healthy={healthy}/s, degraded={degraded}/s"
+        );
+    }
+
     #[test_log::test(tokio::test)]
     async fn surb_balancer_should_start_decrease_level_when_above_target_and_decay_enabled() {
         const NUM_STEPS: usize = 5;
@@ -643,6 +925,7 @@ mod tests {
             target_surb_buffer_size: 5_000,
             max_surbs_per_sec: 2500,
             surb_decay: Some((Duration::from_millis(200), 0.05)),
+            sustain_on_return_path_loss: false,
         };
 
         let mut mock_flow_ctl = MockSurbFlowController::new();

--- a/transport/session/src/balancer/controller.rs
+++ b/transport/session/src/balancer/controller.rs
@@ -470,7 +470,7 @@ where
         // tells them apart. Rate-limited to one per second so it can run under a full-rate session.
         if self.last_report.elapsed() >= Duration::from_secs(1) {
             self.last_report = std::time::Instant::now();
-            tracing::debug!(
+            tracing::info!(
                 session = %self.session_id,
                 level = current,
                 target = self.controller.bounds().target(),

--- a/transport/session/src/balancer/controller.rs
+++ b/transport/session/src/balancer/controller.rs
@@ -465,14 +465,12 @@ where
         let output = self.controller.next_control_output(current);
         tracing::trace!(output, "next balancer control output for session");
 
-        // DIAGNOSTIC: both ends run this same loop -- the Entry with the PID driving production,
-        // the Exit with the proportional controller gating egress -- so one report covers both and
-        // the session id tells them apart. At `info` deliberately: the harness filters at info, and
-        // the point is to see supply and spend on both sides during an outage.
-        // Rate-limited to one line per second so it can run under a full-rate session.
+        // Both ends run this same loop -- the Entry with the PID driving production, the Exit with
+        // the proportional controller gating egress -- so one line covers both and the session id
+        // tells them apart. Rate-limited to one per second so it can run under a full-rate session.
         if self.last_report.elapsed() >= Duration::from_secs(1) {
             self.last_report = std::time::Instant::now();
-            tracing::info!(
+            tracing::debug!(
                 session = %self.session_id,
                 level = current,
                 target = self.controller.bounds().target(),

--- a/transport/session/src/balancer/mod.rs
+++ b/transport/session/src/balancer/mod.rs
@@ -97,6 +97,13 @@ pub trait SurbBalancerController {
     fn set_target_and_limit(&mut self, bounds: BalancerControllerBounds);
     /// Queries the controller for the next control output based on the `current_buffer_level` of SURBs.
     fn next_control_output(&mut self, current_buffer_level: u64) -> u64;
+    /// Discards accumulated history, leaving the bounds intact.
+    ///
+    /// Used when the buffer estimate the controller has been acting on stops meaning what it meant
+    /// -- crossing into or out of a period where the counterparty could not be observed at all.
+    /// Carrying the error accumulated under the old regime into the new one makes the controller
+    /// answer a question nobody asked.
+    fn reset(&mut self);
 }
 
 /// Implementation of [`SurbFlowEstimator`] that tracks the number of produced

--- a/transport/session/src/balancer/pid.rs
+++ b/transport/session/src/balancer/pid.rs
@@ -136,6 +136,85 @@ impl SurbBalancerController for PidBalancerController {
 mod tests {
     use super::*;
 
+    /// A starved buffer must command production. This is the controller's entire purpose, and a
+    /// cluster run showed it returning 0 for an error of -9803 -- maximally starved.
+    #[test]
+    fn pid_should_command_production_when_the_buffer_is_empty() {
+        let mut c = PidBalancerController::from_gains(PidControllerGains::default());
+        c.set_target_and_limit(BalancerControllerBounds::new(7_000, 5_000));
+
+        let out = c.next_control_output(0);
+        assert!(out > 0, "empty buffer against a 7000 target must produce, got {out}");
+    }
+
+    /// The output limit is what every PID term is clamped to. A zero limit silently turns the
+    /// controller into a no-op that reports a huge error and commands nothing -- which is
+    /// indistinguishable, from the outside, from a controller that thinks the buffer is full.
+    #[test]
+    fn pid_with_a_zero_output_limit_commands_nothing_however_starved() {
+        let mut c = PidBalancerController::from_gains(PidControllerGains::default());
+        c.set_target_and_limit(BalancerControllerBounds::new(7_000, 0));
+
+        assert_eq!(0, c.next_control_output(0), "a zero limit clamps every term to zero");
+    }
+
+    /// Reproduces the exact operating point observed on a cluster: target 9803, empty buffer,
+    /// default limit. Production logged `output=0` there, and 15 minutes per observation is too
+    /// slow a loop to debug in -- so pin it here at 80ms instead.
+    #[test]
+    fn pid_should_produce_at_the_operating_point_seen_in_production() {
+        let mut c = PidBalancerController::from_gains(PidControllerGains::default());
+        c.set_target_and_limit(BalancerControllerBounds::new(
+            9_803,
+            crate::SurbBalancerConfig::default().max_surbs_per_sec,
+        ));
+
+        let out = c.next_control_output(0);
+        assert!(out > 0, "target 9803 with an empty buffer produced {out}");
+    }
+
+    /// The very first output after configuration, which is the one that matters on a cold start or
+    /// straight after the estimate is discarded.
+    #[test]
+    fn pid_first_output_after_reconfiguration_should_not_be_zero() {
+        let mut c = PidBalancerController::default();
+        c.set_target_and_limit(BalancerControllerBounds::new(7_000, 5_000));
+
+        assert!(
+            c.next_control_output(0) > 0,
+            "first output after reconfiguration was zero"
+        );
+    }
+
+    /// The exact live bounds, read off a cluster run: target 9803, output limit 1960, empty buffer.
+    /// Production logs `output=0` here while the same controller with a 5000 limit produces.
+    #[test]
+    fn pid_should_produce_at_the_live_bounds() {
+        let mut c = PidBalancerController::from_gains(PidControllerGains::default());
+        c.set_target_and_limit(BalancerControllerBounds::new(9_803, 1_960));
+
+        let out = c.next_control_output(0);
+        assert!(out > 0, "target 9803 / limit 1960 with an empty buffer produced {out}");
+    }
+
+    /// A buffer that was healthy and then drained must be refilled. This is the return-path failure
+    /// exactly: the session runs at target, the return path breaks, the buffer empties -- and
+    /// production commands nothing despite an error of -9803.
+    #[test]
+    fn pid_should_recover_after_a_healthy_buffer_drains() {
+        let mut c = PidBalancerController::from_gains(PidControllerGains::default());
+        c.set_target_and_limit(BalancerControllerBounds::new(9_803, 1_960));
+
+        // Healthy: sitting at target, so the controller has nothing to do for a while.
+        for _ in 0..100 {
+            c.next_control_output(9_803);
+        }
+
+        // The return path breaks and the buffer drains.
+        let out = c.next_control_output(0);
+        assert!(out > 0, "an emptied buffer after a healthy period produced {out}");
+    }
+
     // --- PidControllerGains tests ---
 
     #[test]

--- a/transport/session/src/balancer/pid.rs
+++ b/transport/session/src/balancer/pid.rs
@@ -130,6 +130,12 @@ impl SurbBalancerController for PidBalancerController {
     fn next_control_output(&mut self, current_buffer_level: u64) -> u64 {
         self.0.next_control_output(current_buffer_level as f64).output.max(0.0) as u64
     }
+
+    fn reset(&mut self) {
+        // Only the integral carries history across calls; P and D are derived from the current
+        // sample, so clearing the accumulated error is the whole of "start again".
+        self.0.reset_integral_term();
+    }
 }
 
 #[cfg(test)]

--- a/transport/session/src/balancer/simple.rs
+++ b/transport/session/src/balancer/simple.rs
@@ -2,6 +2,10 @@ use crate::balancer::{BalancerControllerBounds, SurbBalancerController};
 
 /// Controller that uses the simple linear formula `limit * min(current / setpoint, 1.0)` to
 /// compute the control output.
+///
+/// Scaling with the *level* rather than the deficit is deliberate: this drives egress (each sent
+/// packet spends a SURB), so an empty buffer must send nothing. Do not invert it -- that is only
+/// correct for a controller driving production.
 #[derive(Clone, Debug, Default)]
 pub struct SimpleBalancerController {
     bounds: BalancerControllerBounds,

--- a/transport/session/src/balancer/simple.rs
+++ b/transport/session/src/balancer/simple.rs
@@ -24,6 +24,11 @@ impl SurbBalancerController for SimpleBalancerController {
         let ratio = current_buffer_level as f64 / self.bounds.target() as f64;
         (self.bounds.output_limit() as f64 * ratio.clamp(0.0, 1.0)).floor() as u64
     }
+
+    fn reset(&mut self) {
+        // Nothing to discard: the output is a pure function of the level handed in, so this
+        // controller has no history that could outlive the regime it was accumulated under.
+    }
 }
 
 #[cfg(test)]

--- a/transport/session/src/balancer/snapshots/hopr_transport_session__balancer__controller__tests__surb_balancer_config_default_snapshot.snap
+++ b/transport/session/src/balancer/snapshots/hopr_transport_session__balancer__controller__tests__surb_balancer_config_default_snapshot.snap
@@ -11,4 +11,5 @@ SurbBalancerConfig {
             0.05,
         ),
     ),
+    sustain_on_return_path_loss: false,
 }

--- a/transport/session/src/flow_control.rs
+++ b/transport/session/src/flow_control.rs
@@ -17,10 +17,8 @@ use std::{
     time::Duration,
 };
 
-use hopr_api::types::internal::prelude::NodeId;
-pub use hopr_protocol_session::flow_control::ReturnPathFeedback;
 use hopr_protocol_session::flow_control::{
-    Backoff, DeliveryClock, DeliverySignal, FlowControlConfig, ReturnPathMonitor, SupplyConstraint, WindowController,
+    Backoff, DeliveryClock, DeliverySignal, FlowControlConfig, SupplyConstraint, WindowController,
 };
 
 use crate::balancer::BalancerStateValues;
@@ -83,16 +81,6 @@ impl SupplyConstraint for SurbSupply {
     }
 }
 
-/// Builds a [`ReturnPathFeedback`] handle bound to a specific session destination.
-///
-/// The session layer knows *when* a return path has gone bad; only the transport layer knows how
-/// to re-plan one. This factory is the seam between the two, so the session manager can hand each
-/// session a handle without depending on the path planner.
-pub trait ReturnPathFeedbackFactory: Send + Sync {
-    /// Returns a handle that re-plans the return path from `destination` back to this node.
-    fn for_destination(&self, destination: NodeId) -> Arc<dyn ReturnPathFeedback>;
-}
-
 /// Wraps a Session socket, admitting writes only while the [`WindowController`] has room against the
 /// honest delivery clock and the SURB ceiling. Reads are delegated untouched (never gated), so the
 /// duplex socket cannot deadlock; the window always keeps at least `min_window_size` admissible.
@@ -119,9 +107,6 @@ pub struct PacedWriter<S> {
     sent_total: u64,
     /// `refresh_window` call counter, for throttling the diagnostic trace.
     refreshes: u64,
-    /// Opt-in watcher that re-plans the return path on sustained loss. `None` leaves return-path
-    /// correction to probing alone.
-    return_path: Option<ReturnPathMonitor>,
 }
 
 impl<S> PacedWriter<S> {
@@ -139,19 +124,7 @@ impl<S> PacedWriter<S> {
             persist_after: cfg.persist_stall_parks,
             sent_total: 0,
             refreshes: 0,
-            return_path: None,
         }
-    }
-
-    /// Enables reactive return-path re-planning, reporting to `feedback`.
-    ///
-    /// A no-op unless [`FlowControlConfig::return_path_replan`] is set, so the caller can wire the
-    /// handle unconditionally and let configuration decide.
-    pub fn with_return_path_feedback(mut self, cfg: FlowControlConfig, feedback: Arc<dyn ReturnPathFeedback>) -> Self {
-        self.return_path = cfg
-            .return_path_replan
-            .map(|replan_cfg| ReturnPathMonitor::new(feedback, replan_cfg));
-        self
     }
 
     /// Folds the latest honest delivery into the window. `cwnd` moves **only** on the honest delivery
@@ -163,12 +136,6 @@ impl<S> PacedWriter<S> {
         self.window.apply_delivery(delivered);
         if delivered.acked_bytes > 0 || delivered.lost_bytes > 0 {
             self.stalled_parks = 0;
-        }
-
-        // Same observation, different question: the window asks "how fast may I send", the monitor
-        // asks "is the return path still there at all".
-        if let Some(monitor) = self.return_path.as_mut() {
-            monitor.observe(delivered);
         }
 
         self.refreshes = self.refreshes.wrapping_add(1);

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -39,7 +39,6 @@ use crate::{
         simple::SimpleBalancerController,
     },
     errors::{SessionManagerError, TransportSessionError},
-    flow_control::ReturnPathFeedbackFactory,
     types::{ByteCapabilities, ClosureReason, HoprSessionConfig, HoprStartProtocol, SESSION_APPLICATION_TAG},
     utils,
     utils::{SurbNotificationMode, insert_into_next_slot},
@@ -533,9 +532,6 @@ pub struct SessionManager<S> {
     active_sessions: Arc<std::sync::atomic::AtomicUsize>,
     sessions: moka::sync::Cache<SessionId, SessionSlot>,
     msg_sender: Arc<OnceLock<S>>,
-    /// Optional seam to the transport's path planner, used to re-plan a session's return path when
-    /// the loss clock says it has gone bad. `None` leaves return-path correction to probing.
-    return_path_feedback: Option<Arc<dyn ReturnPathFeedbackFactory>>,
     cfg: SessionManagerConfig,
 }
 
@@ -549,7 +545,6 @@ impl<S> Clone for SessionManager<S> {
             sessions: self.sessions.clone(),
             cfg: self.cfg.clone(),
             msg_sender: self.msg_sender.clone(),
-            return_path_feedback: self.return_path_feedback.clone(),
         }
     }
 }
@@ -612,16 +607,7 @@ where
     S::Error: std::error::Error + Send + Sync + Clone + 'static,
 {
     /// Creates a new instance given the [`config`](SessionManagerConfig).
-    ///
-    /// `return_path_feedback` wires the seam that lets a session re-plan its return path on
-    /// sustained loss. With `None` — and without
-    /// [`FlowControlConfig::return_path_replan`](hopr_protocol_session::flow_control::FlowControlConfig::return_path_replan)
-    /// being set — a degraded return path is corrected only once probing notices, which takes tens
-    /// of seconds.
-    pub fn new(
-        mut cfg: SessionManagerConfig,
-        return_path_feedback: Option<Arc<dyn ReturnPathFeedbackFactory>>,
-    ) -> Self {
+    pub fn new(mut cfg: SessionManagerConfig) -> Self {
         let maximum_sessions = cfg.maximum_sessions;
         cfg.surb_balance_notify_period = cfg
             .surb_balance_notify_period
@@ -665,7 +651,6 @@ where
             session_notifiers: Arc::new(OnceLock::new()),
             start_protocol_tx: Arc::new(OnceLock::new()),
             active_sessions,
-            return_path_feedback,
             cfg,
         }
     }
@@ -1137,12 +1122,6 @@ where
                         // anti-grief down-only ceiling, and the client's opt-in flow-control config.
                         Some(surb_mgmt.clone()),
                         cfg.flow_control,
-                        // Only the entry side plans return paths, so only it can re-plan one.
-                        self.return_path_feedback
-                            .as_ref()
-                            // Same conversion the forward routing uses, so the planner's
-                            // per-destination record is keyed identically.
-                            .map(|factory| factory.for_destination(destination.into())),
                     )?;
 
                     #[cfg(feature = "telemetry")]
@@ -1965,8 +1944,8 @@ mod tests {
         let alice_pseudonym = HoprPseudonym::random();
         let bob_peer: Address = (&ChainKeypair::random()).into();
 
-        let alice_mgr = SessionManager::new(Default::default(), None);
-        let bob_mgr = SessionManager::new(Default::default(), None);
+        let alice_mgr = SessionManager::new(Default::default());
+        let bob_mgr = SessionManager::new(Default::default());
 
         let mut sequence = mockall::Sequence::new();
         let mut alice_transport = MockMsgSender::new();
@@ -2154,8 +2133,8 @@ mod tests {
             ..Default::default()
         };
 
-        let alice_mgr = SessionManager::new(cfg, None);
-        let bob_mgr = SessionManager::new(Default::default(), None);
+        let alice_mgr = SessionManager::new(cfg);
+        let bob_mgr = SessionManager::new(Default::default());
 
         let mut sequence = mockall::Sequence::new();
         let mut alice_transport = MockMsgSender::new();
@@ -2291,7 +2270,7 @@ mod tests {
         };
 
         let alice_mgr =
-            SessionManager::<UnboundedSender<(DestinationRouting, ApplicationDataOut)>>::new(Default::default(), None);
+            SessionManager::<UnboundedSender<(DestinationRouting, ApplicationDataOut)>>::new(Default::default());
 
         let (dummy_tx, _) = crossfire::mpsc::bounded_blocking_async::<ApplicationDataIn>(SESSION_FORWARD_CAPACITY);
         alice_mgr.sessions.insert(
@@ -2330,7 +2309,7 @@ mod tests {
         let alice_pseudonym = HoprPseudonym::random();
         let bob_peer: Address = (&ChainKeypair::random()).into();
 
-        let alice_mgr = SessionManager::new(Default::default(), None);
+        let alice_mgr = SessionManager::new(Default::default());
 
         let mut sequence = mockall::Sequence::new();
         let mut alice_transport = MockMsgSender::new();
@@ -2430,8 +2409,8 @@ mod tests {
             ..Default::default()
         };
 
-        let alice_mgr = SessionManager::new(cfg, None);
-        let bob_mgr = SessionManager::new(Default::default(), None);
+        let alice_mgr = SessionManager::new(cfg);
+        let bob_mgr = SessionManager::new(Default::default());
 
         let mut sequence = mockall::Sequence::new();
         let mut alice_transport = MockMsgSender::new();
@@ -2481,7 +2460,7 @@ mod tests {
     #[cfg(feature = "telemetry")]
     #[test_log::test(tokio::test)]
     async fn failed_incoming_session_establishment_does_not_register_telemetry() -> anyhow::Result<()> {
-        let mgr = SessionManager::new(Default::default(), None);
+        let mgr = SessionManager::new(Default::default());
 
         let transport = MockMsgSender::new();
         let (new_session_tx, new_session_rx) = futures::channel::mpsc::channel(1);
@@ -2521,7 +2500,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn session_manager_should_roll_back_slot_when_incoming_session_setup_fails() -> anyhow::Result<()> {
-        let mgr = SessionManager::new(Default::default(), None);
+        let mgr = SessionManager::new(Default::default());
 
         // Drop the receiver so that notifying about the new incoming session fails
         // *after* the session slot has already been inserted into the cache.
@@ -2573,8 +2552,8 @@ mod tests {
             surb_balance_notify_period: Some(Duration::from_millis(500)),
             ..Default::default()
         };
-        let alice_mgr = SessionManager::new(Default::default(), None);
-        let bob_mgr = SessionManager::new(bob_cfg.clone(), None);
+        let alice_mgr = SessionManager::new(Default::default());
+        let bob_mgr = SessionManager::new(bob_cfg.clone());
 
         let mut alice_transport = MockMsgSender::new();
         let mut bob_transport = MockMsgSender::new();
@@ -2881,7 +2860,7 @@ mod tests {
         use hopr_utils::network_types::prelude::SealedHost;
 
         let bob_mgr: SessionManager<futures::channel::mpsc::UnboundedSender<(DestinationRouting, ApplicationDataOut)>> =
-            SessionManager::new(Default::default(), None);
+            SessionManager::new(Default::default());
 
         // Start the manager (required for handling incoming sessions)
         let mut transport = MockMsgSender::new();
@@ -2954,7 +2933,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     async fn session_manager_should_return_error_when_pinging_non_existent_session() -> anyhow::Result<()> {
         let mgr: SessionManager<futures::channel::mpsc::UnboundedSender<(DestinationRouting, ApplicationDataOut)>> =
-            SessionManager::new(Default::default(), None);
+            SessionManager::new(Default::default());
 
         let transport = MockMsgSender::new();
         let (new_session_tx, new_session_rx) = futures::channel::mpsc::channel(1);
@@ -2985,7 +2964,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     async fn session_manager_should_return_false_when_closing_non_existent_session() -> anyhow::Result<()> {
         let mgr: SessionManager<futures::channel::mpsc::UnboundedSender<(DestinationRouting, ApplicationDataOut)>> =
-            SessionManager::new(Default::default(), None);
+            SessionManager::new(Default::default());
 
         let transport = MockMsgSender::new();
         let (new_session_tx, new_session_rx) = futures::channel::mpsc::channel(1);
@@ -3009,7 +2988,7 @@ mod tests {
     async fn session_manager_should_return_error_when_updating_surb_config_for_non_existent_session()
     -> anyhow::Result<()> {
         let mgr: SessionManager<futures::channel::mpsc::UnboundedSender<(DestinationRouting, ApplicationDataOut)>> =
-            SessionManager::new(Default::default(), None);
+            SessionManager::new(Default::default());
 
         let transport = MockMsgSender::new();
         let (new_session_tx, new_session_rx) = futures::channel::mpsc::channel(1);
@@ -3037,7 +3016,7 @@ mod tests {
     async fn session_manager_should_return_error_when_getting_surb_config_for_non_existent_session()
     -> anyhow::Result<()> {
         let mgr: SessionManager<futures::channel::mpsc::UnboundedSender<(DestinationRouting, ApplicationDataOut)>> =
-            SessionManager::new(Default::default(), None);
+            SessionManager::new(Default::default());
 
         let transport = MockMsgSender::new();
         let (new_session_tx, new_session_rx) = futures::channel::mpsc::channel(1);
@@ -3069,7 +3048,7 @@ mod tests {
     async fn session_manager_should_return_error_when_getting_surb_estimates_for_non_existent_session()
     -> anyhow::Result<()> {
         let mgr: SessionManager<futures::channel::mpsc::UnboundedSender<(DestinationRouting, ApplicationDataOut)>> =
-            SessionManager::new(Default::default(), None);
+            SessionManager::new(Default::default());
 
         let transport = MockMsgSender::new();
         let (new_session_tx, new_session_rx) = futures::channel::mpsc::channel(1);
@@ -3106,7 +3085,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     async fn handle_session_error_propagates_peer_rejection_to_pending_new_session() -> anyhow::Result<()> {
         let mgr: SessionManager<UnboundedSender<(DestinationRouting, ApplicationDataOut)>> =
-            SessionManager::new(Default::default(), None);
+            SessionManager::new(Default::default());
 
         let mut transport = MockMsgSender::new();
         // new_session sends StartSession (succeeds), then waits for SessionEstablished.
@@ -3186,7 +3165,7 @@ mod tests {
             ..Default::default()
         };
         let mgr: SessionManager<futures::channel::mpsc::UnboundedSender<(DestinationRouting, ApplicationDataOut)>> =
-            SessionManager::new(cfg, None);
+            SessionManager::new(cfg);
 
         let mut transport = MockMsgSender::new();
         transport
@@ -3259,7 +3238,7 @@ mod tests {
             ..Default::default()
         };
         let mgr: SessionManager<UnboundedSender<(DestinationRouting, ApplicationDataOut)>> =
-            SessionManager::new(cfg, None);
+            SessionManager::new(cfg);
 
         let mut transport = MockMsgSender::new();
         // Two incoming sessions: first sends SessionEstablished, second sends SessionError (no slots).
@@ -3321,7 +3300,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     async fn new_session_removes_challenge_on_send_failure() -> anyhow::Result<()> {
         let mgr: SessionManager<UnboundedSender<(DestinationRouting, ApplicationDataOut)>> =
-            SessionManager::new(Default::default(), None);
+            SessionManager::new(Default::default());
 
         // Create a channel whose receiver is dropped immediately.  When the mock
         // transport tries to `send` over this channel the call will return an error,
@@ -3372,8 +3351,8 @@ mod tests {
             ..Default::default()
         };
 
-        let alice_mgr = SessionManager::new(cfg, None);
-        let bob_mgr = SessionManager::new(Default::default(), None);
+        let alice_mgr = SessionManager::new(cfg);
+        let bob_mgr = SessionManager::new(Default::default());
 
         let bob_peer: Address = (&ChainKeypair::random()).into();
 
@@ -3428,7 +3407,7 @@ mod tests {
     async fn session_manager_should_return_unknown_data_error_when_dispatching_to_unknown_session() -> anyhow::Result<()>
     {
         let mgr: SessionManager<futures::channel::mpsc::UnboundedSender<(DestinationRouting, ApplicationDataOut)>> =
-            SessionManager::new(Default::default(), None);
+            SessionManager::new(Default::default());
 
         let transport = MockMsgSender::new();
         let (new_session_tx, new_session_rx) = futures::channel::mpsc::channel(1);
@@ -3465,7 +3444,7 @@ mod tests {
         use hopr_utils::network_types::prelude::SealedHost;
 
         let mgr: SessionManager<futures::channel::mpsc::UnboundedSender<(DestinationRouting, ApplicationDataOut)>> =
-            SessionManager::new(Default::default(), None);
+            SessionManager::new(Default::default());
 
         let mut transport = MockMsgSender::new();
         transport
@@ -3528,7 +3507,7 @@ mod tests {
         };
 
         let alice_mgr =
-            SessionManager::<UnboundedSender<(DestinationRouting, ApplicationDataOut)>>::new(Default::default(), None);
+            SessionManager::<UnboundedSender<(DestinationRouting, ApplicationDataOut)>>::new(Default::default());
 
         let (new_session_tx, _) = futures::channel::mpsc::channel(1024);
         let (mock_sender, _) = futures::channel::mpsc::unbounded();
@@ -3622,7 +3601,7 @@ mod tests {
         };
 
         let alice_mgr =
-            SessionManager::<UnboundedSender<(DestinationRouting, ApplicationDataOut)>>::new(Default::default(), None);
+            SessionManager::<UnboundedSender<(DestinationRouting, ApplicationDataOut)>>::new(Default::default());
 
         let (new_session_tx, _) = futures::channel::mpsc::channel(1024);
         let (mock_sender, _) = futures::channel::mpsc::unbounded();
@@ -3700,7 +3679,7 @@ mod tests {
             ..Default::default()
         };
         let mgr: SessionManager<futures::channel::mpsc::UnboundedSender<(DestinationRouting, ApplicationDataOut)>> =
-            SessionManager::new(cfg, None);
+            SessionManager::new(cfg);
 
         let mut transport = MockMsgSender::new();
         transport
@@ -3758,7 +3737,7 @@ mod tests {
             ..Default::default()
         };
         let mgr: SessionManager<futures::channel::mpsc::UnboundedSender<(DestinationRouting, ApplicationDataOut)>> =
-            SessionManager::new(cfg, None);
+            SessionManager::new(cfg);
 
         let mut transport = MockMsgSender::new();
         transport

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -3243,8 +3243,7 @@ mod tests {
             idle_timeout: Duration::from_secs(3600),
             ..Default::default()
         };
-        let mgr: SessionManager<UnboundedSender<(DestinationRouting, ApplicationDataOut)>> =
-            SessionManager::new(cfg);
+        let mgr: SessionManager<UnboundedSender<(DestinationRouting, ApplicationDataOut)>> = SessionManager::new(cfg);
 
         let mut transport = MockMsgSender::new();
         // Two incoming sessions: first sends SessionEstablished, second sends SessionError (no slots).

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -1340,6 +1340,28 @@ where
         }
     }
 
+    /// Marks the return path to `destination` as degraded on every Session routed there.
+    ///
+    /// The Session layer cannot tell a dead return path from a peer with nothing to say -- both
+    /// simply stop consuming SURBs -- so the judgement is made where sibling paths can be compared
+    /// and delivered here. Sessions that did not opt in ignore the mark; the rest stop trusting
+    /// their counterparty buffer estimate for `grace`.
+    ///
+    /// Returns how many Sessions were marked, which is zero when nothing currently routes there.
+    pub fn mark_return_path_degraded(
+        &self,
+        destination: &hopr_api::types::internal::NodeId,
+        grace: std::time::Duration,
+    ) -> usize {
+        self.sessions
+            .iter()
+            .filter(|(_, slot)| {
+                matches!(&slot.routing_opts, DestinationRouting::Forward { destination: d, .. } if d.as_ref() == destination)
+            })
+            .map(|(_, slot)| slot.surb_mgmt.mark_return_path_degraded(grace))
+            .count()
+    }
+
     /// The main method to be called whenever data are received.
     ///
     /// It tries to recognize the message and correctly dispatches either
@@ -1587,6 +1609,7 @@ where
                 // No SURB decay at the Exit, since we know almost exactly how many SURBs
                 // were received
                 surb_decay: None,
+                sustain_on_return_path_loss: false,
             };
 
             slot.surb_mgmt.update(&balancer_config);

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -1009,6 +1009,10 @@ where
                     );
 
                     let surb_mgmt = Arc::new(BalancerStateValues::from(balancer_config));
+                    // The counterparty's store is the same bounded ring buffer as ours, so its
+                    // capacity bounds what our `produced - consumed` estimate can legitimately
+                    // claim it is holding.
+                    surb_mgmt.set_counterparty_buffer_capacity(self.cfg.maximum_surb_buffer_size as u64);
 
                     // Spawn the SURB-bearing keep alive stream towards the Exit
                     let (ka_controller, ka_abort_handle) = utils::spawn_keep_alive_stream(
@@ -1592,6 +1596,8 @@ where
             };
 
             slot.surb_mgmt.update(&balancer_config);
+            slot.surb_mgmt
+                .set_counterparty_buffer_capacity(self.cfg.maximum_surb_buffer_size as u64);
 
             // Spawn the SURB balancer only once we know we have registered the
             // abort handle with the pre-allocated Session slot

--- a/transport/session/src/types.rs
+++ b/transport/session/src/types.rs
@@ -25,7 +25,7 @@ use crate::{
     Capabilities, Capability,
     balancer::BalancerStateValues,
     errors::TransportSessionError,
-    flow_control::{PacedWriter, ReturnPathFeedback, SurbSupply},
+    flow_control::{PacedWriter, SurbSupply},
 };
 
 /// Wrapper for [`Capabilities`] that makes conversion to/from `u8` possible.
@@ -178,7 +178,7 @@ impl HoprSession {
         Rx: futures::Stream<Item = ApplicationDataIn> + Send + Unpin + 'static,
         Tx::Error: std::error::Error + Send + Sync,
     {
-        Self::new_with_surb_state(id, routing, cfg, hopr, on_close, None, None, None)
+        Self::new_with_surb_state(id, routing, cfg, hopr, on_close, None, None)
     }
 
     /// Like [`new`](Self::new) but threads the SURB balancer state and the opt-in client-side
@@ -195,7 +195,6 @@ impl HoprSession {
         on_close: Option<Box<dyn FnOnce(SessionId, ClosureReason) + Send + Sync>>,
         surb_mgmt: Option<Arc<BalancerStateValues>>,
         flow_control: Option<FlowControlConfig>,
-        return_path_feedback: Option<Arc<dyn ReturnPathFeedback>>,
     ) -> Result<Self, TransportSessionError>
     where
         Tx: futures::Sink<(DestinationRouting, ApplicationDataOut)> + Send + Unpin + 'static,
@@ -316,11 +315,7 @@ impl HoprSession {
                             .unwrap_or_else(|| Arc::new(BalancerStateValues::default()));
                         let supply = SurbSupply::new(surb_state, cfg.frame_mtu);
                         debug!(?fc_cfg, "wrapping session socket with paced flow-control writer");
-                        let paced = PacedWriter::new(socket, fc_cfg, clock, supply);
-                        Box::new(match return_path_feedback {
-                            Some(feedback) => paced.with_return_path_feedback(fc_cfg, feedback),
-                            None => paced,
-                        })
+                        Box::new(PacedWriter::new(socket, fc_cfg, clock, supply))
                     }
                     None => Box::new(socket),
                 }


### PR DESCRIPTION
Turns the SURB round-trip telemetry from #8341 into a recovery mechanism, and removes the one that measurement disproved.

The system detects dead return paths from real traffic and re-plans routes before refilling buffers. It prioritizes re-planning by rebuilding cached weights on demand and acting on supply rather than routes. The system also bounds buffer estimates, expires cached path weights, and keys the path cache on resolved keys to ensure accurate routing.

## What it removes

The loss-clock re-planner (`ReturnPathMonitor`, `ReturnPathReplanConfig`, `ReturnPathFeedback[Factory]`, the `PacedWriter`/`SessionManager` wiring, `PathPlanner::degrade_return_path`) — closed as #8340.

Invalidating a destination's cached candidates collapses a healthy session from 100% arrival to 0.14%: re-selection happens faster than a new path can be established and judged. No arm with it enabled beat the 43–47% recovery that redistribution alone provides. Removed rather than left behind a switch.

## Depends on

- #8341 (base)
- hoprnet/hopr-utilities#14 — `WindowedRatio::recent_value`
- hoprnet/hopr-impls#7 — recent-vs-window trend discount, 2 s bucket width

All are pinned by git rev in `[patch.crates-io]`; this cannot leave draft until they are published.
