### PR TITLE
fix(session): SurbSupply must not read the controller's open-loop zero as a ceiling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/transport/session/Cargo.toml
+++ b/transport/session/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport-session"
 description = "Session functionality providing session abstraction over the HOPR transport"
-version = "0.26.2"
+version = "0.26.3"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/session/src/balancer/controller.rs
+++ b/transport/session/src/balancer/controller.rs
@@ -224,6 +224,16 @@ impl BalancerStateValues {
     /// Both the opt-in and live evidence are required: without the opt-in this is not our
     /// behaviour to change, and without evidence there is nothing to distinguish a dead return path
     /// from an idle one.
+    /// Whether the counterparty buffer estimate is currently meaningless.
+    ///
+    /// `pub` because it is not only the controller's business. While this holds, the controller
+    /// deliberately writes `0` into [`buffer_level`](Self::buffer_level) to drive production to
+    /// the maximum — but that zero is an *instruction to the controller*, not a measurement, and
+    /// anything reading the level as a supply ceiling has to know the difference.
+    pub fn return_path_estimate_is_stale(&self) -> bool {
+        self.should_sustain_through_return_path_loss()
+    }
+
     fn should_sustain_through_return_path_loss(&self) -> bool {
         let deadline = self
             .return_path_degraded_until_ms
@@ -442,6 +452,8 @@ where
                 believed = current,
                 "return path degraded; ignoring the counterparty buffer estimate"
             );
+            // Reads as "produce flat out" to the controller below. `SurbSupply` must not read it
+            // as "the buffer is empty, admit nothing" -- see `return_path_estimate_is_stale`.
             current = 0;
         }
 

--- a/transport/session/src/balancer/controller.rs
+++ b/transport/session/src/balancer/controller.rs
@@ -219,17 +219,21 @@ impl BalancerStateValues {
             .fetch_max(until, std::sync::atomic::Ordering::Relaxed);
     }
 
-    /// Whether production should currently ignore the counterparty buffer estimate.
+    /// Whether [`buffer_level`](Self::buffer_level) is currently an instruction rather than a
+    /// measurement.
     ///
-    /// Both the opt-in and live evidence are required: without the opt-in this is not our
-    /// behaviour to change, and without evidence there is nothing to distinguish a dead return path
-    /// from an idle one.
-    /// Whether the counterparty buffer estimate is currently meaningless.
+    /// While this holds, the controller deliberately writes `0` into the level to drive production
+    /// to its maximum. That zero says "produce flat out", not "the counterparty holds nothing", so
+    /// anything reading the level as a *supply ceiling* must consult this first or it will read the
+    /// instruction as an order to send nothing.
     ///
-    /// `pub` because it is not only the controller's business. While this holds, the controller
-    /// deliberately writes `0` into [`buffer_level`](Self::buffer_level) to drive production to
-    /// the maximum — but that zero is an *instruction to the controller*, not a measurement, and
-    /// anything reading the level as a supply ceiling has to know the difference.
+    /// True only when both the opt-in (`sustain_on_return_path_loss`) and live evidence
+    /// ([`mark_return_path_degraded`](Self::mark_return_path_degraded), within its window) are
+    /// present: without the opt-in this is not our behaviour to change, and without evidence there
+    /// is nothing to tell a dead return path from an idle one.
+    ///
+    /// `pub` because it is not only the controller's business — hence the emphasis above on what
+    /// the flag does *not* mean. It is not a general "the return path is degraded" signal.
     pub fn return_path_estimate_is_stale(&self) -> bool {
         self.should_sustain_through_return_path_loss()
     }

--- a/transport/session/src/flow_control.rs
+++ b/transport/session/src/flow_control.rs
@@ -59,11 +59,26 @@ impl SupplyConstraint for SurbSupply {
         if self.state.is_disabled() {
             return usize::MAX;
         }
+        // Same reasoning while the return path is degraded. The controller stores `0` there to
+        // drive production to the maximum, not because it measured an empty buffer. Reading that
+        // as a ceiling yields zero admissible bytes -- and the persist probe cannot escape it,
+        // since it is itself capped by the ceiling -- so a session that opted into surviving
+        // return-path loss would instead stop sending for the whole degraded window, which is the
+        // opposite of the intent. Defer to the honest delivery clock, which still sees the missing
+        // acknowledgements and throttles on real evidence.
+        if self.state.return_path_estimate_is_stale() {
+            return usize::MAX;
+        }
         (self.state.buffer_level() as usize).saturating_mul(self.bytes_per_reply_packet)
     }
 
     fn backoff_hint(&self) -> Option<Backoff> {
         if self.state.is_disabled() {
+            return None;
+        }
+        // A degraded-path zero is an instruction to the controller, not an observation, so it is
+        // not evidence of an empty buffer and must not collapse the window to the floor.
+        if self.state.return_path_estimate_is_stale() {
             return None;
         }
         let level = self.state.buffer_level();
@@ -285,6 +300,50 @@ mod tests {
             .buffer_level
             .store(buffer_level, std::sync::atomic::Ordering::Relaxed);
         state
+    }
+
+    /// Regression: the controller stores `0` into `buffer_level` while the return path is
+    /// degraded to drive SURB production to the maximum. That zero is an instruction, not a
+    /// measurement — but `SurbSupply` also reads the same atomic as a supply ceiling, so it used
+    /// to yield zero admissible bytes for the whole degraded window, and the persist probe could
+    /// not escape it because the probe is itself capped by the ceiling.
+    ///
+    /// A session that opted into surviving return-path loss would therefore have stopped sending
+    /// entirely — the opposite of the feature's intent, and indistinguishable from a dead session.
+    #[test]
+    fn a_degraded_return_path_should_not_zero_the_supply_ceiling() {
+        let state = balancer(7_000, 0);
+        state
+            .sustain_on_return_path_loss
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        state.mark_return_path_degraded(Duration::from_secs(30));
+        assert!(
+            state.return_path_estimate_is_stale(),
+            "precondition: the estimate must be marked stale"
+        );
+
+        let supply = SurbSupply::new(state.clone(), 1_000);
+
+        assert_eq!(
+            usize::MAX,
+            supply.max_admissible_inflight(),
+            "a degraded-path zero must not cap the window; the delivery clock governs instead"
+        );
+        assert_eq!(
+            None,
+            supply.backoff_hint(),
+            "a degraded-path zero is not evidence of an empty buffer"
+        );
+    }
+
+    /// The inverse: once the mark expires the level is a measurement again, and a genuinely empty
+    /// buffer must still close the window.
+    #[test]
+    fn an_empty_buffer_should_still_cap_the_window_when_not_degraded() {
+        let supply = SurbSupply::new(balancer(7_000, 0), 1_000);
+
+        assert_eq!(0, supply.max_admissible_inflight());
+        assert_eq!(Some(Backoff::Hard), supply.backoff_hint());
     }
 
     // ---- Persist probe (anti-deadlock at the un-acked tail), configurable ----

--- a/transport/session/src/flow_control.rs
+++ b/transport/session/src/flow_control.rs
@@ -313,9 +313,12 @@ mod tests {
     #[test]
     fn a_degraded_return_path_should_not_zero_the_supply_ceiling() {
         let state = balancer(7_000, 0);
-        state
-            .sustain_on_return_path_loss
-            .store(true, std::sync::atomic::Ordering::Relaxed);
+        // Through the config, as a caller would: the opt-in is a configuration decision, and going
+        // via the atomic would couple this test to a representation it has no business knowing.
+        state.update(&crate::SurbBalancerConfig {
+            sustain_on_return_path_loss: true,
+            ..Default::default()
+        });
         state.mark_return_path_degraded(Duration::from_secs(30));
         assert!(
             state.return_path_estimate_is_stale(),


### PR DESCRIPTION
`BalancerStateValues::buffer_level` is a single atomic read by two consumers that interpret it oppositely. While the return path is degraded the controller deliberately stores `0`, and that is correct for the controller — every SURB the counterparty spends is invisible from here, so the zero saturates production, which is the point of the feature. But `SurbSupply` reads the same field as a supply ceiling, so zero admits zero application bytes for the entire degraded window. A session that explicitly opted into surviving return-path loss would instead go silent and present as dead rather than throttled.

The zero is an instruction to the controller, not a measurement, so `SurbSupply` now defers to the honest delivery clock while the estimate is stale — the precedent already set by `is_disabled()`. That is not permissive: the delivery clock measures real acknowledgements, so it still throttles, just on evidence rather than on a number the controller deliberately falsified.

## **This does not fix the return-path survival failure. The PR was opened believing it did; that failure has since been measured and is in a different direction at a different layer. What remains is a genuine latent defect, kept on its own merits.**
