### PR TITLE
fix(session): stop holding received frames behind a gap that cannot be filled for unreliable UDP like traffic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4168,7 +4168,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.2-rc.11"
+version = "4.0.2-rc.12"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4168,7 +4168,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.2-rc.12"
+version = "4.0.4"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4282,7 +4282,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-session"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4365,7 +4365,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.26.3"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,10 +153,10 @@ hopr-protocol-hopr = { version = "6.0.0", path = "protocols/hopr", default-featu
 hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
 hopr-protocol-start = { version = "1.1.0", path = "protocols/start", default-features = false }
 hopr-ticket-manager = { version = "0.5.2" }
-hopr-transport = { version = "0.44.0", path = "transport/hopr" }
+hopr-transport = { version = "0.45.0", path = "transport/hopr" }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
-hopr-transport-session = { version = "0.26.2", path = "transport/session", default-features = false }
+hopr-transport-session = { version = "0.27.0", path = "transport/session", default-features = false }
 hopr-transport-tag-allocator = { version = "0.1.1", path = "transport/tag-allocator", default-features = false }
 hopr-chain-connector = { version = "0.22.2" }
 

--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-lib"
 description = "HOPR library implementing the HOPR protocol"
-version = "4.0.2-rc.12"
+version = "4.0.4"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-lib"
 description = "HOPR library implementing the HOPR protocol"
-version = "4.0.2-rc.11"
+version = "4.0.2-rc.12"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -159,6 +159,21 @@ pub struct HoprSessionClientConfig {
     /// the tail-tolerance bundle. Only meaningful on a reliable (`RetransmissionAck`) session.
     #[default(None)]
     pub flow_control: Option<FlowControlConfig>,
+    /// Abandon the frame due next once the sequence has advanced this far past it, instead of
+    /// holding everything already received for the whole frame timeout.
+    ///
+    /// Head-of-line bound for this session's incoming direction. `None` inherits the node's
+    /// setting, `Some(0)` disables it here, `Some(n)` sets it -- the same zero-disables convention
+    /// as `HOPR_SESSION_MAX_FRAMES_BEHIND_GAP`, so the two knobs cannot mean opposite things by
+    /// the same value.
+    ///
+    /// Worth setting per session because the right value tracks reordering depth -- throughput x
+    /// latency spread / frame size -- which is a property of the traffic, not of the node: a bulk
+    /// data session and a control session on the same node differ by orders of magnitude.
+    ///
+    /// Has no effect on a session carrying a retransmission capability, where a missing frame can
+    /// still be recovered and waiting for it is productive.
+    pub max_frames_behind_gap: Option<usize>,
 }
 
 /// Session client configuration for explicit intermediate-path routing.
@@ -183,6 +198,8 @@ pub struct HoprSessionClientExplicitPathConfig {
     pub always_max_out_surbs: bool,
     /// Opt-in client-side send-window flow control for this session (`None` = unpaced).
     pub flow_control: Option<FlowControlConfig>,
+    /// As [`HoprSessionClientConfig::max_frames_behind_gap`].
+    pub max_frames_behind_gap: Option<usize>,
 }
 
 #[cfg(all(feature = "session-client", feature = "explicit-path"))]
@@ -197,6 +214,7 @@ impl Default for HoprSessionClientExplicitPathConfig {
             surb_management: Some(SurbBalancerConfig::default()),
             always_max_out_surbs: false,
             flow_control: None,
+            max_frames_behind_gap: None,
         }
     }
 }
@@ -212,6 +230,7 @@ impl From<HoprSessionClientConfig> for hopr_transport::SessionClientConfig {
             surb_management: value.surb_management,
             always_max_out_surbs: value.always_max_out_surbs,
             flow_control: value.flow_control,
+            max_frames_behind_gap: value.max_frames_behind_gap,
         }
     }
 }
@@ -234,6 +253,7 @@ impl TryFrom<HoprSessionClientExplicitPathConfig> for hopr_transport::SessionCli
             surb_management: value.surb_management,
             always_max_out_surbs: value.always_max_out_surbs,
             flow_control: value.flow_control,
+            max_frames_behind_gap: value.max_frames_behind_gap,
         })
     }
 }
@@ -897,9 +917,16 @@ mod tests {
             surb_management: None,
             always_max_out_surbs: false,
             flow_control: None,
+            max_frames_behind_gap: Some(8),
         })
         .context("explicit path config conversion must succeed")?;
 
+        assert_eq!(
+            cfg.max_frames_behind_gap,
+            Some(8),
+            "the session's head-of-line bound has to survive the conversion, or it silently reverts to the node \
+             default"
+        );
         assert!(matches!(
             cfg.forward_path_options,
             hopr_transport::RoutingOptions::IntermediatePath(_)

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -163,9 +163,7 @@ pub struct HoprSessionClientConfig {
     /// holding everything already received for the whole frame timeout.
     ///
     /// Head-of-line bound for this session's incoming direction. `None` inherits the node's
-    /// setting, `Some(0)` disables it here, `Some(n)` sets it -- the same zero-disables convention
-    /// as `HOPR_SESSION_MAX_FRAMES_BEHIND_GAP`, so the two knobs cannot mean opposite things by
-    /// the same value.
+    /// setting, `Some(0)` disables it here, `Some(n)` sets it.
     ///
     /// Worth setting per session because the right value tracks reordering depth -- throughput x
     /// latency spread / frame size -- which is a property of the traffic, not of the node: a bulk

--- a/hopr/hopr-lib/src/testing/fixtures.rs
+++ b/hopr/hopr-lib/src/testing/fixtures.rs
@@ -203,6 +203,7 @@ impl ClusterGuard {
                     surb_management,
                     always_max_out_surbs: false,
                     flow_control: None,
+                    max_frames_behind_gap: None,
                 },
             )
             .timeout(futures_time::time::Duration::from(timeout))
@@ -251,6 +252,7 @@ impl ClusterGuard {
                     surb_management: Some(SurbBalancerConfig::default()),
                     always_max_out_surbs: false,
                     flow_control: None,
+                    max_frames_behind_gap: None,
                 },
             )
             .timeout(futures_time::time::Duration::from(timeout))

--- a/hopr/hopr-lib/tests/transport_session-size3.rs
+++ b/hopr/hopr-lib/tests/transport_session-size3.rs
@@ -41,6 +41,7 @@ async fn test_keep_alive_session(cluster: &ClusterGuard) -> anyhow::Result<()> {
                 surb_management: None,
                 always_max_out_surbs: false,
                 flow_control: None,
+                max_frames_behind_gap: None,
             },
         )
         .await?;

--- a/protocols/session/Cargo.toml
+++ b/protocols/session/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-protocol-session"
 description = "Contains implementation of Session protocol according to HOPR RFC-0008"
-version = "1.4.0"
+version = "1.5.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/protocols/session/src/processing/mod.rs
+++ b/protocols/session/src/processing/mod.rs
@@ -17,7 +17,7 @@ pub(crate) mod types;
 
 pub(crate) use reassembly::ReassemblerExt;
 pub(crate) use segmenter::SegmenterExt;
-pub(crate) use sequencer::SequencerExt;
+pub(crate) use sequencer::{SequencerConfig, SequencerExt};
 
 #[cfg(test)]
 mod tests {

--- a/protocols/session/src/processing/sequencer.rs
+++ b/protocols/session/src/processing/sequencer.rs
@@ -246,18 +246,14 @@ where
                             // The sequence has moved far enough past the gap to conclude the
                             // missing frame was lost rather than reordered. Waiting out `max_wait`
                             // cannot change that verdict, and on a session with no retransmission
-                            // nothing else can either -- it only holds everything already received
-                            // for the full duration. Measured on a cluster: 98.5% of bytes
-                            // returning over the wire, 0.60% reaching the application.
+                            // nothing else can either.
                             || this.max_frames_behind_gap.is_some_and(|n| {
                                 // Two readings of the same evidence, because each is blind where
                                 // the other sees. The count catches a run of frames arriving
                                 // behind the gap. The distance catches the case that actually
                                 // dominates under loss: the frames in between never completed, so
                                 // they never reach the sequencer and the buffer stays nearly
-                                // empty however far the sender has moved on -- measured on a
-                                // cluster as the same setting delivering 95-97% on some runs and
-                                // 0.5% on others, the failing ones back on the frame timeout.
+                                // empty however far the sender has moved on.
                                 this.buffer.len() >= n
                                     || next.gt(&this.next_id.saturating_add(n as FrameId - 1))
                             })
@@ -507,8 +503,8 @@ mod tests {
     /// wait is spent on an outcome that cannot change while the frames already received are held.
     #[test_log::test(tokio::test)]
     async fn sequencer_should_abandon_a_gap_once_enough_later_frames_are_waiting() -> anyhow::Result<()> {
-        // Far longer than the test should take. Any reliance on the timer is then unmistakable in
-        // the elapsed assertion rather than a matter of tuning margins.
+        // Far longer than the test should take, so any reliance on the timer trips the bound below
+        // rather than becoming a matter of tuning margins.
         let max_wait = Duration::from_secs(5);
         let (mut seq_sink, seq_stream) = futures::channel::mpsc::unbounded();
 
@@ -526,19 +522,19 @@ mod tests {
         });
         pin_mut!(seq_stream);
 
-        let now = Instant::now();
-        assert!(
-            matches!(seq_stream.try_next().await, Err(SessionError::FrameDiscarded(1))),
-            "the gap must be reported as loss, the signal the consumer already handles"
-        );
-        assert_eq!(Some(2), seq_stream.try_next().await?);
-        assert_eq!(Some(3), seq_stream.try_next().await?);
-        assert_eq!(Some(4), seq_stream.try_next().await?);
-        assert!(
-            now.elapsed() < max_wait / 2,
-            "frames already received must not wait on a frame that is never coming; took {:?}",
-            now.elapsed()
-        );
+        // The bound is the assertion: without the rule the sequencer holds everything for the full
+        // `max_wait`, so a regression trips the timeout instead of blocking the suite for 5 s.
+        let released: Vec<u32> = tokio::time::timeout(max_wait / 2, async {
+            assert!(
+                matches!(seq_stream.try_next().await, Err(SessionError::FrameDiscarded(1))),
+                "the gap must be reported as loss, the signal the consumer already handles"
+            );
+            seq_stream.by_ref().take(3).try_collect().await
+        })
+        .await
+        .map_err(|_| anyhow::anyhow!("frames already received waited on a frame that is never coming"))??;
+
+        assert_eq!(vec![2, 3, 4], released, "everything behind the gap must follow it out");
 
         // Held open deliberately: closing the sink would drain the buffer through `State::Done`,
         // which has its own emit path and would pass this test without the rule under test.

--- a/protocols/session/src/processing/sequencer.rs
+++ b/protocols/session/src/processing/sequencer.rs
@@ -92,6 +92,9 @@ pub struct Sequencer<S: futures::Stream> {
     /// Anti-bufferbloat bound: items buffered longer than this are dropped, not emitted, so a
     /// stall shows up as loss rather than a latency tail. `None` disables it.
     max_item_age: Option<Duration>,
+    /// Head-of-line bound: abandon the frame due next once this many later frames are waiting
+    /// behind it, rather than holding them for `max_wait`. `None` disables it.
+    max_frames_behind_gap: Option<usize>,
     state: State,
 }
 
@@ -104,7 +107,13 @@ where
     ///
     /// The `frame_size` value will be clamped into the `[C, (C - SessionMessage::SEGMENT_OVERHEAD) * SeqIndicator::MAX
     /// + 1]` interval.
-    fn new(inner: S, max_wait: Duration, capacity: usize, max_item_age: Option<Duration>) -> Self {
+    fn new(
+        inner: S,
+        max_wait: Duration,
+        capacity: usize,
+        max_item_age: Option<Duration>,
+        max_frames_behind_gap: Option<usize>,
+    ) -> Self {
         assert!(capacity > 0, "capacity should be positive");
         Self {
             inner,
@@ -114,6 +123,10 @@ where
             last_emitted: Instant::now(),
             max_wait,
             max_item_age: max_item_age.filter(|age| !age.is_zero()),
+            // Zero would abandon the frame due next before anything had arrived to justify it,
+            // turning every momentary gap into loss. One later frame is the strictest evidence
+            // that still *is* evidence.
+            max_frames_behind_gap: max_frames_behind_gap.map(|n| n.max(1)),
             state: State::Polling,
         }
     }
@@ -230,6 +243,15 @@ where
                             return Poll::Ready(this.buffer.pop().map(|item| Ok(item.0.item)));
                         } else if this.last_emitted.elapsed() >= *this.max_wait
                             || this.buffer.len() == this.buffer.capacity()
+                            // Enough later frames are queued behind the gap to conclude the
+                            // missing one was lost rather than reordered. Waiting out `max_wait`
+                            // cannot change that verdict, and on a session with no retransmission
+                            // nothing else can either -- it only holds everything already received
+                            // for the full duration. Measured on a cluster: 98.5% of bytes
+                            // returning over the wire, 0.60% reaching the application.
+                            || this
+                                .max_frames_behind_gap
+                                .is_some_and(|n| this.buffer.len() >= n)
                         {
                             let discarded = *this.next_id;
                             *this.next_id = this.next_id.wrapping_add(1);
@@ -280,6 +302,32 @@ where
     }
 }
 
+/// How a [`Sequencer`] decides to stop waiting for a frame that has not arrived.
+///
+/// Grouped rather than passed positionally: the two stopping rules below answer different
+/// questions, and a bare list of `Duration`/`Option<usize>` arguments at the call site gives no
+/// hint which is which.
+#[derive(Clone, Copy, Debug)]
+pub struct SequencerConfig {
+    /// Longest the frame due next is waited for before it is abandoned.
+    pub max_wait: Duration,
+    /// Maximum number of buffered items.
+    pub capacity: usize,
+    /// Discards items buffered longer than this instead of emitting them late; `None` disables.
+    pub max_item_age: Option<Duration>,
+    /// Abandons the frame due next once this many later frames are already waiting behind it.
+    ///
+    /// `None` waits out [`Self::max_wait`] regardless of how much has piled up, which is correct
+    /// only when the missing frame can still be recovered. On a session without retransmission it
+    /// cannot: the wait is for something that is never coming, and everything already received is
+    /// held behind it for the full duration.
+    ///
+    /// Counting later frames rather than watching a clock makes the decision on evidence. One or
+    /// two frames arriving ahead is ordinary reordering across paths of differing latency; a queue
+    /// building up behind a gap is a frame that was lost.
+    pub max_frames_behind_gap: Option<usize>,
+}
+
 /// Stream extensions methods for item sequencing.
 pub trait SequencerExt: futures::Stream {
     /// Attaches a [`Sequencer`] to the underlying stream, given the item `timeout` and `capacity`
@@ -289,7 +337,7 @@ pub trait SequencerExt: futures::Stream {
         Self::Item: Ord + PartialOrd<FrameId>,
         Self: Sized,
     {
-        Sequencer::new(self, timeout, capacity, None)
+        Sequencer::new(self, timeout, capacity, None, None)
     }
 
     /// As [`SequencerExt::sequencer`], but discards items buffered longer than `max_item_age`
@@ -304,7 +352,22 @@ pub trait SequencerExt: futures::Stream {
         Self::Item: Ord + PartialOrd<FrameId>,
         Self: Sized,
     {
-        Sequencer::new(self, timeout, capacity, max_item_age)
+        Sequencer::new(self, timeout, capacity, max_item_age, None)
+    }
+
+    /// As [`SequencerExt::sequencer`], with every stopping rule stated explicitly.
+    fn sequencer_with(self, cfg: SequencerConfig) -> Sequencer<Self>
+    where
+        Self::Item: Ord + PartialOrd<FrameId>,
+        Self: Sized,
+    {
+        Sequencer::new(
+            self,
+            cfg.max_wait,
+            cfg.capacity,
+            cfg.max_item_age,
+            cfg.max_frames_behind_gap,
+        )
     }
 }
 
@@ -423,6 +486,124 @@ mod tests {
         seq_sink.send(3u32).await?;
         assert_eq!(Some(3), seq_stream.try_next().await?);
 
+        Ok(())
+    }
+
+    /// Frames waiting behind a gap must not be held for `max_wait`.
+    ///
+    /// This is the head-of-line stall, measured on a live cluster: with `max_wait` at 3 s a
+    /// session returning 98.5 % of its bytes over the wire delivered 0.60 % of them to the
+    /// application, and the application-side inter-arrival median sat exactly on the timeout. On a
+    /// session with no retransmission the missing frame is never coming, so every second of that
+    /// wait is spent on an outcome that cannot change while the frames already received are held.
+    #[test_log::test(tokio::test)]
+    async fn sequencer_should_abandon_a_gap_once_enough_later_frames_are_waiting() -> anyhow::Result<()> {
+        // Far longer than the test should take. Any reliance on the timer is then unmistakable in
+        // the elapsed assertion rather than a matter of tuning margins.
+        let max_wait = Duration::from_secs(5);
+        let (mut seq_sink, seq_stream) = futures::channel::mpsc::unbounded();
+
+        // Frame 1 never arrives.
+        for v in [2u32, 3, 4] {
+            seq_sink.feed(v).await?;
+        }
+        seq_sink.flush().await?;
+
+        let seq_stream = seq_stream.sequencer_with(SequencerConfig {
+            max_wait,
+            capacity: 4096,
+            max_item_age: None,
+            max_frames_behind_gap: Some(2),
+        });
+        pin_mut!(seq_stream);
+
+        let now = Instant::now();
+        assert!(
+            matches!(seq_stream.try_next().await, Err(SessionError::FrameDiscarded(1))),
+            "the gap must be reported as loss, the signal the consumer already handles"
+        );
+        assert_eq!(Some(2), seq_stream.try_next().await?);
+        assert_eq!(Some(3), seq_stream.try_next().await?);
+        assert_eq!(Some(4), seq_stream.try_next().await?);
+        assert!(
+            now.elapsed() < max_wait / 2,
+            "frames already received must not wait on a frame that is never coming; took {:?}",
+            now.elapsed()
+        );
+
+        // Held open deliberately: closing the sink would drain the buffer through `State::Done`,
+        // which has its own emit path and would pass this test without the rule under test.
+        drop(seq_sink);
+        Ok(())
+    }
+
+    /// The inverse, so the rule cannot become "never wait". Below the threshold the sequencer must
+    /// still hold the gap open — one frame arriving ahead is ordinary reordering across paths of
+    /// differing latency, not a loss.
+    #[test_log::test(tokio::test)]
+    async fn sequencer_should_keep_waiting_while_fewer_frames_are_behind_the_gap() -> anyhow::Result<()> {
+        let max_wait = Duration::from_millis(300);
+        let (mut seq_sink, seq_stream) = futures::channel::mpsc::unbounded();
+
+        // Frame 1 is missing and only one frame is waiting behind it, under the threshold of 3.
+        seq_sink.feed(2u32).await?;
+        seq_sink.flush().await?;
+
+        let seq_stream = seq_stream.sequencer_with(SequencerConfig {
+            max_wait,
+            capacity: 4096,
+            max_item_age: None,
+            max_frames_behind_gap: Some(3),
+        });
+        pin_mut!(seq_stream);
+
+        let now = Instant::now();
+        assert!(matches!(
+            seq_stream.try_next().await,
+            Err(SessionError::FrameDiscarded(1))
+        ));
+        assert!(
+            now.elapsed() >= max_wait,
+            "under the threshold the timeout still governs; took {:?}",
+            now.elapsed()
+        );
+
+        drop(seq_sink);
+        Ok(())
+    }
+
+    /// A session that *can* recover a missing frame must be unaffected: `None` keeps the timeout
+    /// as the only rule, however much piles up behind the gap.
+    #[test_log::test(tokio::test)]
+    async fn sequencer_without_the_gap_bound_should_still_wait_for_the_timeout() -> anyhow::Result<()> {
+        let max_wait = Duration::from_millis(300);
+        let (mut seq_sink, seq_stream) = futures::channel::mpsc::unbounded();
+
+        for v in [2u32, 3, 4, 5, 6] {
+            seq_sink.feed(v).await?;
+        }
+        seq_sink.flush().await?;
+
+        let seq_stream = seq_stream.sequencer_with(SequencerConfig {
+            max_wait,
+            capacity: 4096,
+            max_item_age: None,
+            max_frames_behind_gap: None,
+        });
+        pin_mut!(seq_stream);
+
+        let now = Instant::now();
+        assert!(matches!(
+            seq_stream.try_next().await,
+            Err(SessionError::FrameDiscarded(1))
+        ));
+        assert!(
+            now.elapsed() >= max_wait,
+            "with no gap bound the timeout is the only rule; took {:?}",
+            now.elapsed()
+        );
+
+        drop(seq_sink);
         Ok(())
     }
 

--- a/protocols/session/src/processing/sequencer.rs
+++ b/protocols/session/src/processing/sequencer.rs
@@ -589,8 +589,7 @@ mod tests {
         }
         assert!(
             now.elapsed() < max_wait / 2,
-            "a single frame far ahead is evidence enough, with no frames buffered behind the gap \
-             to count; took {:?}",
+            "a single frame far ahead is evidence enough, with no frames buffered behind the gap to count; took {:?}",
             now.elapsed()
         );
 

--- a/protocols/session/src/processing/sequencer.rs
+++ b/protocols/session/src/processing/sequencer.rs
@@ -92,8 +92,8 @@ pub struct Sequencer<S: futures::Stream> {
     /// Anti-bufferbloat bound: items buffered longer than this are dropped, not emitted, so a
     /// stall shows up as loss rather than a latency tail. `None` disables it.
     max_item_age: Option<Duration>,
-    /// Head-of-line bound: abandon the frame due next once this many later frames are waiting
-    /// behind it, rather than holding them for `max_wait`. `None` disables it.
+    /// Head-of-line bound: abandon the frame due next once the sequence has advanced this far
+    /// past it, rather than holding everything for `max_wait`. `None` disables it.
     max_frames_behind_gap: Option<usize>,
     state: State,
 }
@@ -243,15 +243,24 @@ where
                             return Poll::Ready(this.buffer.pop().map(|item| Ok(item.0.item)));
                         } else if this.last_emitted.elapsed() >= *this.max_wait
                             || this.buffer.len() == this.buffer.capacity()
-                            // Enough later frames are queued behind the gap to conclude the
-                            // missing one was lost rather than reordered. Waiting out `max_wait`
+                            // The sequence has moved far enough past the gap to conclude the
+                            // missing frame was lost rather than reordered. Waiting out `max_wait`
                             // cannot change that verdict, and on a session with no retransmission
                             // nothing else can either -- it only holds everything already received
                             // for the full duration. Measured on a cluster: 98.5% of bytes
                             // returning over the wire, 0.60% reaching the application.
-                            || this
-                                .max_frames_behind_gap
-                                .is_some_and(|n| this.buffer.len() >= n)
+                            || this.max_frames_behind_gap.is_some_and(|n| {
+                                // Two readings of the same evidence, because each is blind where
+                                // the other sees. The count catches a run of frames arriving
+                                // behind the gap. The distance catches the case that actually
+                                // dominates under loss: the frames in between never completed, so
+                                // they never reach the sequencer and the buffer stays nearly
+                                // empty however far the sender has moved on -- measured on a
+                                // cluster as the same setting delivering 95-97% on some runs and
+                                // 0.5% on others, the failing ones back on the frame timeout.
+                                this.buffer.len() >= n
+                                    || next.gt(&this.next_id.saturating_add(n as FrameId - 1))
+                            })
                         {
                             let discarded = *this.next_id;
                             *this.next_id = this.next_id.wrapping_add(1);
@@ -533,6 +542,58 @@ mod tests {
 
         // Held open deliberately: closing the sink would drain the buffer through `State::Done`,
         // which has its own emit path and would pass this test without the rule under test.
+        drop(seq_sink);
+        Ok(())
+    }
+
+    /// Under real loss the frames between the gap and the newest arrival mostly never complete, so
+    /// they never reach the sequencer at all and the buffer stays nearly empty. A rule counting
+    /// buffered frames then never fires and the timeout takes over — which is exactly what a
+    /// cluster showed: at an identical setting the scenario delivered 95–97 % on some runs and
+    /// 0.5 % on others, the failing ones with an application-side inter-arrival median sitting
+    /// back on the 3 s timeout.
+    ///
+    /// What is available regardless is how far the sequence has advanced past the gap. One frame
+    /// arriving at id 40 says as much about frame 1 as forty buffered frames would.
+    #[test_log::test(tokio::test)]
+    async fn sequencer_should_abandon_a_gap_when_the_sequence_has_advanced_past_it() -> anyhow::Result<()> {
+        let max_wait = Duration::from_secs(5);
+        let (mut seq_sink, seq_stream) = futures::channel::mpsc::unbounded();
+
+        // Frame 1 is missing and frames 2..=39 never completed, so only one frame is buffered --
+        // far below any count-based threshold, yet the sequence has clearly moved on.
+        seq_sink.feed(40u32).await?;
+        seq_sink.flush().await?;
+
+        let seq_stream = seq_stream.sequencer_with(SequencerConfig {
+            max_wait,
+            capacity: 4096,
+            max_item_age: None,
+            max_frames_behind_gap: Some(4),
+        });
+        pin_mut!(seq_stream);
+
+        // Only the frames that the sequence has genuinely left behind. The last `n - 1` before the
+        // newest arrival are still inside the reordering window -- the sequence has not advanced
+        // far enough past *them* to call them lost -- so they keep the timeout, which is the
+        // conservative half of the same rule.
+        let now = Instant::now();
+        for expected_gap in 1..=36u32 {
+            assert!(
+                matches!(
+                    seq_stream.try_next().await,
+                    Err(SessionError::FrameDiscarded(id)) if id == expected_gap
+                ),
+                "frame {expected_gap} is behind the advanced sequence and must be given up on"
+            );
+        }
+        assert!(
+            now.elapsed() < max_wait / 2,
+            "a single frame far ahead is evidence enough, with no frames buffered behind the gap \
+             to count; took {:?}",
+            now.elapsed()
+        );
+
         drop(seq_sink);
         Ok(())
     }

--- a/protocols/session/src/processing/sequencer.rs
+++ b/protocols/session/src/processing/sequencer.rs
@@ -255,7 +255,11 @@ where
                                 // they never reach the sequencer and the buffer stays nearly
                                 // empty however far the sender has moved on.
                                 this.buffer.len() >= n
-                                    || next.gt(&this.next_id.saturating_add(n as FrameId - 1))
+                                    // Saturating, not `as`: the bound is configuration, and a value past `FrameId`'s
+                                // range would wrap into a small threshold rather than a large one.
+                                || next.gt(&this.next_id.saturating_add(
+                                    FrameId::try_from(n).unwrap_or(FrameId::MAX).saturating_sub(1),
+                                ))
                             })
                         {
                             let discarded = *this.next_id;

--- a/protocols/session/src/socket/mod.rs
+++ b/protocols/session/src/socket/mod.rs
@@ -87,6 +87,21 @@ pub struct SessionSocketConfig {
     /// latency tail this bound exists to remove.
     #[default(None)]
     pub max_frame_age: Option<Duration>,
+    /// Abandon the frame due next once this many later frames are already waiting behind it,
+    /// instead of holding them for [`Self::frame_timeout`].
+    ///
+    /// Head-of-line bound. `frame_timeout` waits for a frame that may still arrive; this bounds
+    /// how much already-received data is held hostage while that wait runs. On a session without
+    /// retransmission the missing frame is never coming, so the wait is pure cost: measured on a
+    /// cluster, 98.5% of bytes returned over the wire while 0.60% reached the application and the
+    /// application-side inter-arrival median sat exactly on the timeout.
+    ///
+    /// Counting frames rather than watching a clock decides on evidence -- a queue building up
+    /// behind a gap is a lost frame, where one or two frames ahead is ordinary reordering. The
+    /// right value tracks reordering depth, which is throughput x latency spread, so it is
+    /// deployment-specific and meant to be tuned. `None` (default) keeps the previous behaviour.
+    #[default(None)]
+    pub max_frames_behind_gap: Option<usize>,
 }
 
 enum WriteState {
@@ -234,7 +249,12 @@ impl<const C: usize> SessionSocket<C, Stateless<C>> {
                 })
             })
             // Put the frames into the correct sequence by Frame Ids
-            .sequencer_with_max_age(cfg.frame_timeout, cfg.capacity, cfg.max_frame_age)
+            .sequencer_with(crate::processing::SequencerConfig {
+                max_wait: cfg.frame_timeout,
+                capacity: cfg.capacity,
+                max_item_age: cfg.max_frame_age,
+                max_frames_behind_gap: cfg.max_frames_behind_gap,
+            })
             // Discard frames missing from the sequence
             .filter_map(move |maybe_frame| {
                 let _span = stage3_span.enter();
@@ -440,7 +460,12 @@ impl<const C: usize, S: SocketState<C> + Clone + 'static> SessionSocket<C, S> {
                 })
             })
             // Put the frames into the correct sequence by Frame Ids
-            .sequencer_with_max_age(cfg.frame_timeout, cfg.capacity, cfg.max_frame_age)
+            .sequencer_with(crate::processing::SequencerConfig {
+                max_wait: cfg.frame_timeout,
+                capacity: cfg.capacity,
+                max_item_age: cfg.max_frame_age,
+                max_frames_behind_gap: cfg.max_frames_behind_gap,
+            })
             // Discard frames missing from the sequence and
             // notify the State about emitted or discarded frames
             .filter_map(move |maybe_frame| {

--- a/protocols/session/src/socket/mod.rs
+++ b/protocols/session/src/socket/mod.rs
@@ -1152,6 +1152,102 @@ mod tests {
         Ok(())
     }
 
+    /// Drives the head-of-line case end to end over the real socket pipeline.
+    ///
+    /// Segment 0 is dropped, so frame 1 can never be completed, and the sender is deliberately
+    /// left **open**: closing it would drain the sequencer through `State::Done`, which discards
+    /// missing frames immediately and would hide the very stall under test. Returns how long the
+    /// surviving frames took to arrive, and asserts they arrived intact.
+    async fn time_delivery_behind_a_lost_frame(max_frames_behind_gap: Option<usize>) -> anyhow::Result<Duration> {
+        // hoprd's production value, chosen to clear the ~2 s SURB KeepAlive.
+        const FRAME_TIMEOUT: Duration = Duration::from_secs(3);
+
+        let (alice, bob) = setup_alice_bob::<MTU>(
+            FaultyNetworkConfig {
+                avg_delay: Duration::from_millis(10),
+                ids_to_drop: HashSet::from_iter([0_usize]),
+                ..Default::default()
+            },
+            None,
+            None,
+        );
+
+        let mut alice_socket = SessionSocket::<MTU, _>::new_stateless(
+            "alice",
+            alice,
+            SessionSocketConfig {
+                frame_size: FRAME_SIZE,
+                ..Default::default()
+            },
+            #[cfg(feature = "telemetry")]
+            TestTelemetryTracker::default(),
+        )?;
+        let mut bob_socket = SessionSocket::<MTU, _>::new_stateless(
+            "bob",
+            bob,
+            SessionSocketConfig {
+                frame_size: FRAME_SIZE,
+                frame_timeout: FRAME_TIMEOUT,
+                max_frames_behind_gap,
+                ..Default::default()
+            },
+            #[cfg(feature = "telemetry")]
+            TestTelemetryTracker::default(),
+        )?;
+
+        let data = hopr_types::crypto_random::random_bytes::<DATA_SIZE>();
+        alice_socket
+            .write_all(&data)
+            .timeout(futures_time::time::Duration::from_secs(2))
+            .await??;
+        alice_socket.flush().await?;
+
+        // Everything except the lost first frame.
+        let mut received = vec![0u8; DATA_SIZE - FRAME_SIZE];
+        let started = std::time::Instant::now();
+        bob_socket
+            .read_exact(&mut received)
+            .timeout(futures_time::time::Duration::from_secs(20))
+            .await??;
+        let elapsed = started.elapsed();
+
+        assert_eq!(
+            &data[FRAME_SIZE..],
+            &received,
+            "the frames that did arrive must be delivered intact, whenever they are released"
+        );
+
+        alice_socket.close().await?;
+        bob_socket.close().await?;
+        Ok(elapsed)
+    }
+
+    /// The fix, at the socket level: frames behind an unfillable gap are released on the evidence
+    /// that later frames are queued, not after the frame timeout has run its course.
+    #[test_log::test(tokio::test)]
+    async fn stateless_socket_should_release_frames_behind_a_gap_without_waiting_for_the_timeout() -> anyhow::Result<()>
+    {
+        let elapsed = time_delivery_behind_a_lost_frame(Some(2)).await?;
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "frames already received must not wait on a frame that cannot arrive; took {elapsed:?}"
+        );
+        Ok(())
+    }
+
+    /// The witness for the test above: with the bound disabled, the same loss on the same pipeline
+    /// stalls for the whole frame timeout. Without this, a fast run could be crediting the fix for
+    /// something the network or the harness was doing anyway.
+    #[test_log::test(tokio::test)]
+    async fn stateless_socket_without_the_gap_bound_should_stall_for_the_whole_frame_timeout() -> anyhow::Result<()> {
+        let elapsed = time_delivery_behind_a_lost_frame(None).await?;
+        assert!(
+            elapsed >= Duration::from_secs(3),
+            "the unbounded path is what the fix removes; it must still be observable here, took {elapsed:?}"
+        );
+        Ok(())
+    }
+
     #[test_log::test(tokio::test)]
     async fn stateful_socket_unidirectional_should_should_not_skip_missing_frames() -> anyhow::Result<()> {
         let (alice, bob) = setup_alice_bob::<MTU>(

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport"
 description = "Implements the main HOPR transport interface for the core library"
-version = "0.44.0"
+version = "0.45.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/hopr/src/config.rs
+++ b/transport/hopr/src/config.rs
@@ -512,6 +512,10 @@ fn default_session_surb_balance_notify_period() -> Option<Duration> {
     Some(Duration::from_secs(15))
 }
 
+fn default_session_max_frames_behind_gap() -> Option<usize> {
+    Some(256)
+}
+
 fn validate_session_idle_timeout(value: &Duration) -> Result<(), ValidationError> {
     if SESSION_IDLE_MIN_TIMEOUT <= *value {
         Ok(())
@@ -635,6 +639,20 @@ pub struct SessionGlobalConfig {
         )
     )]
     pub surb_balance_notify_period: Option<Duration>,
+
+    /// How many later frames may queue behind a missing one before the reassembler gives up on it
+    /// and releases what it already has.
+    ///
+    /// Only applies to Sessions without retransmission, where a missing frame is never coming and
+    /// waiting out the frame timeout cannot change the outcome — it only holds everything behind
+    /// it. The right value tracks reordering depth (throughput × latency spread ÷ frame size), so
+    /// a bulk-data Session and a control Session on the same node differ by orders of magnitude;
+    /// an individual Session may override it.
+    ///
+    /// Default is 256. Set to `null` to disable the bound and wait out the frame timeout instead.
+    #[default(default_session_max_frames_behind_gap())]
+    #[cfg_attr(feature = "serde", serde(default = "default_session_max_frames_behind_gap"))]
+    pub max_frames_behind_gap: Option<usize>,
 
     /// Tag allocator partition configuration.
     #[validate(nested)]

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -351,6 +351,13 @@ where
                     .and_then(|s| s.parse::<u64>().ok().map(Duration::from_millis))
                     .unwrap_or_else(|| SessionManagerConfig::default().max_frame_timeout)
                     .max(Duration::from_millis(100)),
+                // `0` disables the bound, so a run can compare against the old
+                // hold-for-the-whole-timeout behaviour without rebuilding.
+                max_frames_behind_gap: std::env::var("HOPR_SESSION_MAX_FRAMES_BEHIND_GAP")
+                    .ok()
+                    .and_then(|s| s.parse::<usize>().ok())
+                    .map(|n| (n > 0).then_some(n))
+                    .unwrap_or_else(|| SessionManagerConfig::default().max_frames_behind_gap),
                 max_buffered_segments: std::env::var("HOPR_SESSION_MAX_BUFFERED_SEGMENTS")
                     .ok()
                     .and_then(|s| s.parse::<usize>().ok())

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -351,13 +351,7 @@ where
                     .and_then(|s| s.parse::<u64>().ok().map(Duration::from_millis))
                     .unwrap_or_else(|| SessionManagerConfig::default().max_frame_timeout)
                     .max(Duration::from_millis(100)),
-                // `0` disables the bound, so a run can compare against the old
-                // hold-for-the-whole-timeout behaviour without rebuilding.
-                max_frames_behind_gap: std::env::var("HOPR_SESSION_MAX_FRAMES_BEHIND_GAP")
-                    .ok()
-                    .and_then(|s| s.parse::<usize>().ok())
-                    .map(|n| (n > 0).then_some(n))
-                    .unwrap_or_else(|| SessionManagerConfig::default().max_frames_behind_gap),
+                max_frames_behind_gap: cfg.session.max_frames_behind_gap,
                 max_buffered_segments: std::env::var("HOPR_SESSION_MAX_BUFFERED_SEGMENTS")
                     .ok()
                     .and_then(|s| s.parse::<usize>().ok())

--- a/transport/session/Cargo.toml
+++ b/transport/session/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport-session"
 description = "Session functionality providing session abstraction over the HOPR transport"
-version = "0.26.3"
+version = "0.27.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/session/src/lib.rs
+++ b/transport/session/src/lib.rs
@@ -117,9 +117,7 @@ pub struct SessionClientConfig {
     /// holding everything already received for the whole frame timeout.
     ///
     /// Head-of-line bound for this session's incoming direction. `None` inherits the node's
-    /// setting, `Some(0)` disables it here, `Some(n)` sets it -- the same zero-disables convention
-    /// as `HOPR_SESSION_MAX_FRAMES_BEHIND_GAP`, so the two knobs cannot mean opposite things by
-    /// the same value.
+    /// setting, `Some(0)` disables it here, `Some(n)` sets it.
     ///
     /// Worth setting per session because the right value tracks reordering depth -- throughput x
     /// latency spread / frame size -- which is a property of the traffic, not of the node: a bulk

--- a/transport/session/src/lib.rs
+++ b/transport/session/src/lib.rs
@@ -113,6 +113,21 @@ pub struct SessionClientConfig {
     /// the client's explicit dial (only meaningful on a reliable / `RetransmissionAck` session).
     #[default(None)]
     pub flow_control: Option<FlowControlConfig>,
+    /// Abandon the frame due next once the sequence has advanced this far past it, instead of
+    /// holding everything already received for the whole frame timeout.
+    ///
+    /// Head-of-line bound for this session's incoming direction. `None` inherits the node's
+    /// setting, `Some(0)` disables it here, `Some(n)` sets it -- the same zero-disables convention
+    /// as `HOPR_SESSION_MAX_FRAMES_BEHIND_GAP`, so the two knobs cannot mean opposite things by
+    /// the same value.
+    ///
+    /// Worth setting per session because the right value tracks reordering depth -- throughput x
+    /// latency spread / frame size -- which is a property of the traffic, not of the node: a bulk
+    /// data session and a control session on the same node differ by orders of magnitude.
+    ///
+    /// Has no effect on a session carrying a retransmission capability, where a missing frame can
+    /// still be recovered and waiting for it is productive.
+    pub max_frames_behind_gap: Option<usize>,
 }
 
 #[cfg(test)]

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -269,7 +269,7 @@ pub struct SessionManagerConfig {
     /// inter-arrival median sat exactly on the 3 s timeout.
     ///
     /// The right value tracks reordering depth -- throughput x latency spread / frame size -- so
-    /// it is deployment-specific. Tune with `HOPR_SESSION_MAX_FRAMES_BEHIND_GAP`; too low converts
+    /// it is deployment-specific. Tune with `SessionConfig::max_frames_behind_gap`; too low converts
     /// ordinary reordering into loss, too high leaves the stall in place.
     ///
     /// Default is 256, which is roughly 3-4x the reordering depth of the cluster it was measured
@@ -584,7 +584,7 @@ fn session_config(cfg: &SessionManagerConfig, capabilities: crate::Capabilities)
 /// As [`session_config`], with the initiating session's own head-of-line bound.
 ///
 /// `None` inherits the node default; `Some(0)` disables the bound for this session; `Some(n)` sets
-/// it. The zero-disables convention matches `HOPR_SESSION_MAX_FRAMES_BEHIND_GAP`, so the per-session
+/// it. The zero-disables convention matches the node setting, so the per-session
 /// and node-wide knobs cannot mean opposite things by the same value.
 ///
 /// Sessions accepted from a peer pass `None`: the bound governs how *we* reassemble what arrives,

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -578,6 +578,22 @@ impl<S> Clone for SessionManager<S> {
 }
 
 fn session_config(cfg: &SessionManagerConfig, capabilities: crate::Capabilities) -> HoprSessionConfig {
+    session_config_with(cfg, capabilities, None)
+}
+
+/// As [`session_config`], with the initiating session's own head-of-line bound.
+///
+/// `None` inherits the node default; `Some(0)` disables the bound for this session; `Some(n)` sets
+/// it. The zero-disables convention matches `HOPR_SESSION_MAX_FRAMES_BEHIND_GAP`, so the per-session
+/// and node-wide knobs cannot mean opposite things by the same value.
+///
+/// Sessions accepted from a peer pass `None`: the bound governs how *we* reassemble what arrives,
+/// so it is ours to choose, not the initiator's to impose on us.
+fn session_config_with(
+    cfg: &SessionManagerConfig,
+    capabilities: crate::Capabilities,
+    max_frames_behind_gap: Option<usize>,
+) -> HoprSessionConfig {
     // Only a session that cannot recover the missing frame should abandon it early. With
     // retransmission the gap is a request away, so waiting is productive and cutting it short
     // would discard data that was on its way back; without it the wait is for something that is
@@ -585,12 +601,20 @@ fn session_config(cfg: &SessionManagerConfig, capabilities: crate::Capabilities)
     let can_retransmit =
         capabilities.contains(Capability::RetransmissionAck) || capabilities.contains(Capability::RetransmissionNack);
 
+    // The session's own value when it stated one, the node's otherwise; `Some(0)` is a session
+    // saying "not for me" rather than a threshold of zero.
+    let bound = match max_frames_behind_gap {
+        Some(0) => None,
+        Some(n) => Some(n),
+        None => cfg.max_frames_behind_gap,
+    };
+
     HoprSessionConfig {
         capabilities,
         frame_mtu: cfg.frame_mtu,
         frame_timeout: cfg.max_frame_timeout,
         max_buffered_segments: cfg.max_buffered_segments,
-        max_frames_behind_gap: (!can_retransmit).then_some(cfg.max_frames_behind_gap).flatten(),
+        max_frames_behind_gap: (!can_retransmit).then_some(bound).flatten(),
     }
 }
 
@@ -1144,7 +1168,7 @@ where
                     let session = HoprSession::new_with_surb_state(
                         session_id,
                         forward_routing,
-                        session_config(&self.cfg, cfg.capabilities),
+                        session_config_with(&self.cfg, cfg.capabilities, cfg.max_frames_behind_gap),
                         (
                             reduced_surb_scoring_sender,
                             session_rx.inspect(move |_| {
@@ -1219,7 +1243,7 @@ where
                     let session = HoprSession::new(
                         session_id,
                         forward_routing,
-                        session_config(&self.cfg, cfg.capabilities),
+                        session_config_with(&self.cfg, cfg.capabilities, cfg.max_frames_behind_gap),
                         (reduced_surb_sender, session_rx),
                         Some(notifier),
                     )?;
@@ -1952,6 +1976,44 @@ mod tests {
                 "without retransmission the gap must be bounded"
             );
         }
+    }
+
+    /// The right value tracks throughput x latency spread, which is a property of the *session*,
+    /// not of the node: a bulk data session and a control session on the same node have entirely
+    /// different reordering depths. A caller that knows its own traffic must be able to say so.
+    #[test]
+    fn a_session_should_be_able_to_override_the_nodes_gap_bound() {
+        let node = SessionManagerConfig {
+            max_frames_behind_gap: Some(256),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            session_config_with(&node, Capabilities::empty(), Some(16)).max_frames_behind_gap,
+            Some(16),
+            "the session's own value must win over the node default"
+        );
+        assert_eq!(
+            session_config_with(&node, Capabilities::empty(), None).max_frames_behind_gap,
+            Some(256),
+            "saying nothing must inherit the node default"
+        );
+        assert_eq!(
+            session_config_with(&node, Capabilities::empty(), Some(0)).max_frames_behind_gap,
+            None,
+            "zero disables the bound for this session, matching the env knob's semantics"
+        );
+    }
+
+    /// A per-session override must not be able to re-enable the bound where waiting is productive.
+    #[test]
+    fn a_session_override_should_not_reach_a_session_that_can_retransmit() {
+        let node = SessionManagerConfig::default();
+        assert_eq!(
+            session_config_with(&node, Capability::RetransmissionAck.into(), Some(4)).max_frames_behind_gap,
+            None,
+            "retransmission can recover the gap, so no caller should be able to cut the wait short"
+        );
     }
 
     /// Disabling has to be reachable, since the bound trades reordering tolerance for latency and

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -255,6 +255,27 @@ pub struct SessionManagerConfig {
     #[default(0)]
     pub max_buffered_segments: usize,
 
+    /// Abandon the frame due next once this many later frames are waiting behind it, rather than
+    /// holding them for the whole of [`Self::max_frame_timeout`].
+    ///
+    /// The two answer different questions. `max_frame_timeout` is how long a *missing* frame is
+    /// waited for, and is set here to exceed the ~2 s SURB KeepAlive so a starved peer's late echo
+    /// is not discarded. This bounds how much *already received* data is held hostage during that
+    /// wait -- a cost paid once per gap, which compounds as later frames queue up.
+    ///
+    /// Without it, a session that cannot retransmit waits the full timeout for a frame that will
+    /// never arrive. Measured on a 5-node cluster after killing a return relayer: 98.5 % of bytes
+    /// returned over the wire, 0.60 % reached the application, and the application-side
+    /// inter-arrival median sat exactly on the 3 s timeout.
+    ///
+    /// The right value tracks reordering depth -- throughput x latency spread -- so it is
+    /// deployment-specific. Tune with `HOPR_SESSION_MAX_FRAMES_BEHIND_GAP`; too low converts
+    /// ordinary reordering into loss, too high leaves the stall in place.
+    ///
+    /// Default is 64.
+    #[default(Some(64))]
+    pub max_frames_behind_gap: Option<usize>,
+
     /// The base timeout for initiation of Session initiation.
     ///
     /// The actual timeout is adjusted according to the number of hops for that Session:
@@ -550,11 +571,19 @@ impl<S> Clone for SessionManager<S> {
 }
 
 fn session_config(cfg: &SessionManagerConfig, capabilities: crate::Capabilities) -> HoprSessionConfig {
+    // Only a session that cannot recover the missing frame should abandon it early. With
+    // retransmission the gap is a request away, so waiting is productive and cutting it short
+    // would discard data that was on its way back; without it the wait is for something that is
+    // never coming, and every frame behind the gap is held for nothing.
+    let can_retransmit =
+        capabilities.contains(Capability::RetransmissionAck) || capabilities.contains(Capability::RetransmissionNack);
+
     HoprSessionConfig {
         capabilities,
         frame_mtu: cfg.frame_mtu,
         frame_timeout: cfg.max_frame_timeout,
         max_buffered_segments: cfg.max_buffered_segments,
+        max_frames_behind_gap: (!can_retransmit).then_some(cfg.max_frames_behind_gap).flatten(),
     }
 }
 
@@ -1878,6 +1907,55 @@ mod tests {
                 segments
             );
         }
+    }
+
+    /// The head-of-line bound must reach a session that cannot recover a missing frame, and must
+    /// not reach one that can.
+    ///
+    /// Both halves matter. Without the first, a session with no retransmission holds every frame
+    /// behind a gap for the full frame timeout, waiting for something that is never coming —
+    /// measured on a cluster as 98.5 % of bytes arriving over the wire and 0.60 % reaching the
+    /// application. Without the second, a session that *would* have retransmitted the gap instead
+    /// abandons it, turning recoverable frames into loss.
+    #[test]
+    fn session_config_should_bound_the_gap_only_without_retransmission() {
+        assert_eq!(
+            SessionManagerConfig::default().max_frames_behind_gap,
+            Some(64),
+            "the default must bound the gap, or the stall stays in place unless opted out of"
+        );
+
+        let cfg = SessionManagerConfig {
+            max_frames_behind_gap: Some(8),
+            ..Default::default()
+        };
+
+        for reliable in [Capability::RetransmissionAck, Capability::RetransmissionNack] {
+            assert_eq!(
+                session_config(&cfg, reliable.into()).max_frames_behind_gap,
+                None,
+                "{reliable:?} can recover the gap, so the wait is productive and must be left alone"
+            );
+        }
+
+        for unreliable in [Capabilities::empty(), Capability::Segmentation.into()] {
+            assert_eq!(
+                session_config(&cfg, unreliable).max_frames_behind_gap,
+                Some(8),
+                "without retransmission the gap must be bounded"
+            );
+        }
+    }
+
+    /// Disabling has to be reachable, since the bound trades reordering tolerance for latency and
+    /// the right value is deployment-specific. `None` restores the previous behaviour exactly.
+    #[test]
+    fn session_config_should_allow_the_gap_bound_to_be_disabled() {
+        let cfg = SessionManagerConfig {
+            max_frames_behind_gap: None,
+            ..Default::default()
+        };
+        assert_eq!(session_config(&cfg, Capabilities::empty()).max_frames_behind_gap, None);
     }
 
     #[async_trait::async_trait]

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -601,12 +601,12 @@ fn session_config_with(
     let can_retransmit =
         capabilities.contains(Capability::RetransmissionAck) || capabilities.contains(Capability::RetransmissionNack);
 
-    // The session's own value when it stated one, the node's otherwise; `Some(0)` is a session
-    // saying "not for me" rather than a threshold of zero.
-    let bound = match max_frames_behind_gap {
-        Some(0) => None,
+    // The session's own value when it stated one, the node's otherwise. `Some(0)` disables the
+    // bound at either level -- a threshold of zero would abandon every gap before a single frame
+    // arrived behind it, which nobody wants and which the sequencer would silently clamp to one.
+    let bound = match max_frames_behind_gap.or(cfg.max_frames_behind_gap) {
+        Some(0) | None => None,
         Some(n) => Some(n),
-        None => cfg.max_frames_behind_gap,
     };
 
     HoprSessionConfig {
@@ -2022,6 +2022,18 @@ mod tests {
     fn session_config_should_allow_the_gap_bound_to_be_disabled() {
         let cfg = SessionManagerConfig {
             max_frames_behind_gap: None,
+            ..Default::default()
+        };
+        assert_eq!(session_config(&cfg, Capabilities::empty()).max_frames_behind_gap, None);
+    }
+
+    #[test]
+    fn a_zero_gap_bound_should_disable_it_at_the_node_level_too() {
+        // `0` means "not for me" wherever it is written. Read literally it would be the strictest
+        // possible bound -- abandon the gap before a single frame arrives behind it -- so the two
+        // levels would mean opposite things by the same value.
+        let cfg = SessionManagerConfig {
+            max_frames_behind_gap: Some(0),
             ..Default::default()
         };
         assert_eq!(session_config(&cfg, Capabilities::empty()).max_frames_behind_gap, None);

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -268,12 +268,19 @@ pub struct SessionManagerConfig {
     /// returned over the wire, 0.60 % reached the application, and the application-side
     /// inter-arrival median sat exactly on the 3 s timeout.
     ///
-    /// The right value tracks reordering depth -- throughput x latency spread -- so it is
-    /// deployment-specific. Tune with `HOPR_SESSION_MAX_FRAMES_BEHIND_GAP`; too low converts
+    /// The right value tracks reordering depth -- throughput x latency spread / frame size -- so
+    /// it is deployment-specific. Tune with `HOPR_SESSION_MAX_FRAMES_BEHIND_GAP`; too low converts
     /// ordinary reordering into loss, too high leaves the stall in place.
     ///
-    /// Default is 64.
-    #[default(Some(64))]
+    /// Default is 256, which is roughly 3-4x the reordering depth of the cluster it was measured
+    /// on (~0.5 MB/s over paths spread across 10-260 ms, 1500 B frames, so ~70-85 frames in
+    /// flight out of order). The margin is not cosmetic: at 64 -- about one reordering depth --
+    /// a *healthy* baseline dropped from 100 % to 92.2 % arrival, because ordinary reordering was
+    /// being read as loss. At 256 the same baseline returned 100 % while a return relayer killed
+    /// mid-session still recovered 97.1 %, against 0.60 % with the bound absent.
+    ///
+    /// Default is 256.
+    #[default(Some(256))]
     pub max_frames_behind_gap: Option<usize>,
 
     /// The base timeout for initiation of Session initiation.
@@ -1921,7 +1928,7 @@ mod tests {
     fn session_config_should_bound_the_gap_only_without_retransmission() {
         assert_eq!(
             SessionManagerConfig::default().max_frames_behind_gap,
-            Some(64),
+            Some(256),
             "the default must bound the gap, or the stall stays in place unless opted out of"
         );
 

--- a/transport/session/src/snapshots/hopr_transport_session__types__tests__hopr_session_config_default_snapshot.snap
+++ b/transport/session/src/snapshots/hopr_transport_session__types__tests__hopr_session_config_default_snapshot.snap
@@ -1,9 +1,10 @@
 ---
 source: transport/session/src/types.rs
-assertion_line: 487
+assertion_line: 557
 expression: cfg
 ---
 capabilities: 0
 frame_mtu: 1500
 frame_timeout: 800ms
 max_buffered_segments: 0
+max_frames_behind_gap: ~

--- a/transport/session/src/types.rs
+++ b/transport/session/src/types.rs
@@ -139,6 +139,12 @@ pub struct HoprSessionConfig {
     /// Default is 0.
     #[default(0)]
     pub max_buffered_segments: usize,
+    /// Abandon the frame due next once this many later frames are waiting behind it.
+    ///
+    /// Head-of-line bound, distinct from [`Self::frame_timeout`]: that one waits for a frame that
+    /// may still arrive, this bounds how much already-received data is held while it waits. `None`
+    /// keeps the timeout as the only rule.
+    pub max_frames_behind_gap: Option<usize>,
 }
 
 /// Represents the Session protocol socket over HOPR.
@@ -243,6 +249,13 @@ impl HoprSession {
                 // Anti-bufferbloat bound; only meaningful when flow control is enabled, which is
                 // also where the honest clock that observes the resulting loss lives.
                 max_frame_age: flow_control.and_then(|c| c.max_frame_age),
+                // Head-of-line bound, and deliberately *not* gated on flow control the way
+                // `max_frame_age` is. The reasoning there runs backwards for this one: a session
+                // that can retransmit may still recover a missing frame, so waiting is
+                // productive, while a session without retransmission is waiting for something
+                // that is never coming and holds everything already received behind it. The
+                // sessions that need this bound most are exactly the ones flow control excludes.
+                max_frames_behind_gap: cfg.max_frames_behind_gap,
                 ..Default::default()
             };
 


### PR DESCRIPTION
The sequencer abandons the frame due next only when `max_wait` elapses or the buffer reaches capacity, and hoprd sets that timeout to 3 s. On a session with no retransmission the missing frame is never coming, so the wait cannot change the outcome — it only holds everything already received hostage behind the gap. Measured on a five-node cluster with the busiest return relayer killed mid-session: 98.5 % of offered bytes reached the wire while 0.60 % reached the application, and the application-side median inter-arrival sat exactly on the timeout. Halving the timeout moved arrival to 24 % without moving bytes on the wire, so the network was never the constraint.

The fix adds a second stopping rule, abandoning the gap once enough later frames are queued behind it. Counting frames decides on evidence rather than on a clock: one or two arriving ahead is ordinary reordering across paths of differing latency, whereas a queue building up behind a gap means the frame was lost. It applies only where waiting is unproductive, gated on the absence of retransmission so a session that could still recover the gap is left alone, and is tunable per session, per node and at runtime. Post-kill arrival goes from 0.60 % to 97 %.

## **Stacked. Expected red: the git-dependency and publish-dry-run gates clear only on release.**
