### PR TITLE
fix(transport): bound the wait for a return SURB so one packet cannot stall a node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4365,7 +4365,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.47.0"
+version = "0.48.0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.27.0"
+version = "0.27.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4365,7 +4365,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.46.0"
+version = "0.47.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4411,6 +4411,7 @@ dependencies = [
  "rand_distr",
  "rstest",
  "serde",
+ "serde-saphyr",
  "serial_test",
  "smart-default",
  "strum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4365,7 +4365,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.45.2"
+version = "0.46.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.27.1"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4365,7 +4365,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.45.0"
+version = "0.45.1"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-hopr"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4365,7 +4365,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.45.1"
+version = "0.45.2"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,10 +153,10 @@ hopr-protocol-hopr = { version = "6.0.0", path = "protocols/hopr", default-featu
 hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
 hopr-protocol-start = { version = "1.1.0", path = "protocols/start", default-features = false }
 hopr-ticket-manager = { version = "0.5.2" }
-hopr-transport = { version = "0.45.0", path = "transport/hopr" }
+hopr-transport = { version = "0.46.0", path = "transport/hopr" }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
-hopr-transport-session = { version = "0.27.0", path = "transport/session", default-features = false }
+hopr-transport-session = { version = "0.28.0", path = "transport/session", default-features = false }
 hopr-transport-tag-allocator = { version = "0.1.1", path = "transport/tag-allocator", default-features = false }
 hopr-chain-connector = { version = "0.22.2" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ hopr-protocol-hopr = { version = "6.0.0", path = "protocols/hopr", default-featu
 hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
 hopr-protocol-start = { version = "1.1.0", path = "protocols/start", default-features = false }
 hopr-ticket-manager = { version = "0.5.2" }
-hopr-transport = { version = "0.47.0", path = "transport/hopr" }
+hopr-transport = { version = "0.48.0", path = "transport/hopr" }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
 hopr-transport-session = { version = "0.28.0", path = "transport/session", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ hopr-protocol-hopr = { version = "6.0.0", path = "protocols/hopr", default-featu
 hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
 hopr-protocol-start = { version = "1.1.0", path = "protocols/start", default-features = false }
 hopr-ticket-manager = { version = "0.5.2" }
-hopr-transport = { version = "0.46.0", path = "transport/hopr" }
+hopr-transport = { version = "0.47.0", path = "transport/hopr" }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
 hopr-transport-session = { version = "0.28.0", path = "transport/session", default-features = false }

--- a/protocols/hopr/Cargo.toml
+++ b/protocols/hopr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-protocol-hopr"
-version = "6.0.0"
+version = "6.1.0"
 description = "Contains implementation of the HOPR protocol as specified in RFC-0004 & RFC-0005"
 edition.workspace = true
 license.workspace = true

--- a/protocols/hopr/src/lib.rs
+++ b/protocols/hopr/src/lib.rs
@@ -10,7 +10,7 @@ pub(crate) mod utils;
 
 pub use codec::{HoprCodecConfig, HoprDecoder, HoprEncoder, MAX_ACKNOWLEDGEMENTS_BATCH_SIZE};
 pub use errors::*;
-pub use surb_store::{MemorySurbStore, SurbPopOrder, SurbStoreConfig};
+pub use surb_store::{MINIMUM_SURB_LIFETIME, MemorySurbStore, SurbPopOrder, SurbStoreConfig};
 pub use tbf::TagBloomFilter;
 pub use ticket_processing::{HoprUnacknowledgedTicketProcessor, HoprUnacknowledgedTicketProcessorConfig};
 pub use traits::*;

--- a/protocols/hopr/src/surb_store.rs
+++ b/protocols/hopr/src/surb_store.rs
@@ -7,7 +7,11 @@ use validator::ValidationError;
 
 use crate::{FoundSurb, traits::SurbStore};
 
-const MINIMUM_SURB_LIFETIME: Duration = Duration::from_secs(30);
+/// Lower bound on [`SurbStoreConfig::pseudonyms_lifetime`], enforced by the config validator.
+///
+/// Public so that callers applying their own override can floor it identically, rather than
+/// reaching a value the config file itself would have been rejected for.
+pub const MINIMUM_SURB_LIFETIME: Duration = Duration::from_secs(30);
 const MINIMUM_OPENER_PSEUDONYMS: usize = 1000;
 const MINIMUM_OPENERS_PER_PSEUDONYM: usize = 1000;
 const MINIMUM_SURBS_PER_PSEUDONYM: usize = 1000;

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport"
 description = "Implements the main HOPR transport interface for the core library"
-version = "0.47.0"
+version = "0.48.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport"
 description = "Implements the main HOPR transport interface for the core library"
-version = "0.45.0"
+version = "0.45.1"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport"
 description = "Implements the main HOPR transport interface for the core library"
-version = "0.45.1"
+version = "0.45.2"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport"
 description = "Implements the main HOPR transport interface for the core library"
-version = "0.45.2"
+version = "0.46.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport"
 description = "Implements the main HOPR transport interface for the core library"
-version = "0.46.0"
+version = "0.47.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"
@@ -142,6 +142,9 @@ hex-literal = { workspace = true }
 insta = { workspace = true, features = ["yaml"] }
 hopr-utils = { workspace = true, features = ["runtime-tokio"] }
 rstest = { workspace = true }
+# Only for the config round-trip test: the same YAML reader hoprd parses its config file with, so
+# the test exercises the form an operator would actually write.
+serde-saphyr = { workspace = true }
 serial_test = { workspace = true }
 test-log = { workspace = true }
 

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -734,7 +734,7 @@ where
             },
             distress_threshold,
             routing_concurrency,
-            crate::path::resolve::SURB_RESOLUTION_WAIT,
+            crate::path::resolve::surb_resolution_wait(self.cfg.packet.pipeline.surb_resolution_wait),
         );
 
         let channels_dst = self

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -59,7 +59,6 @@ use hopr_api::{
     network::{BoxedProcessFn, NetworkStreamControl},
     types::primitive::prelude::*,
 };
-use hopr_crypto_packet::prelude::PacketSignal;
 pub use hopr_protocol_app::prelude::{ApplicationData, ApplicationDataIn, ApplicationDataOut, Tag};
 pub use hopr_protocol_hopr::{MemorySurbStore, SurbStore};
 pub use hopr_transport_probe::{NeighborTelemetry, PathTelemetry, errors::ProbeError, ping::PingQueryReplier};
@@ -88,7 +87,7 @@ use hopr_utils::{
     runtime::AbortableList,
 };
 pub use multiaddr::Protocol;
-use tracing::{Instrument, debug, error, trace, warn};
+use tracing::{debug, warn};
 
 #[cfg(feature = "runtime-tokio")]
 use crate::path::BackgroundPathCacheRefreshable;
@@ -710,80 +709,15 @@ where
                 .filter(|&n| n > 0)
                 .unwrap_or(avail)
         };
-        let all_resolved_external_msg_rx = merged_unresolved_output_data
-            .map(move |(unresolved, mut data)| {
+        let all_resolved_external_msg_rx = crate::path::resolve::resolve_routing_stage(
+            merged_unresolved_output_data,
+            move |size_hint, max_surbs, unresolved| {
                 let path_planner = path_planner.clone();
-                async move {
-                    // Retry on SURB starvation: the SURB pool on the exit side
-                    // refills asynchronously (target 600, ~300/sec via keep-alive).
-                    // Silently dropping return-path packets when the pool is
-                    // momentarily empty causes irreversible data loss; instead we
-                    // yield briefly so the pool can replenish before retrying.
-                    //
-                    // We use `map().buffered()` (ordered) rather than `then_concurrent`
-                    // (unordered) so that routing resolution preserves the original
-                    // packet sequence.  Out-of-order delivery to the ENTRY reassembler
-                    // causes the sequencer to discard frames that arrive after
-                    // `frame_timeout`.  The retry loop bounds any head-of-line delay
-                    // to ~5 ms per SURB-arrival cycle, which is far below the 3 s
-                    // frame timeout.
-                    loop {
-                        hopr_transport_session::counters::ROUTING_RESOLUTION_ATTEMPTS
-                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        trace!(?unresolved, "resolving routing for packet");
-                        match path_planner
-                            .resolve_routing(
-                                data.data.total_len(),
-                                data.estimate_surbs_with_msg(),
-                                unresolved.clone(),
-                            )
-                            .await
-                        {
-                            Ok((resolved, rem_surbs)) => {
-                                // Set the SURB distress/out-of-SURBs flag if applicable.
-                                // These flags are translated into HOPR protocol packet signals and are
-                                // applicable only on the return path.
-                                let mut signals_to_dst = data
-                                    .packet_info
-                                    .as_ref()
-                                    .map(|info| info.signals_to_destination)
-                                    .unwrap_or_default();
-
-                                if resolved.is_return() {
-                                    signals_to_dst = match rem_surbs {
-                                        Some(rem) if (1..distress_threshold.max(2)).contains(&rem) => {
-                                            signals_to_dst | PacketSignal::SurbDistress
-                                        }
-                                        Some(0) => signals_to_dst | PacketSignal::OutOfSurbs,
-                                        _ => signals_to_dst - (PacketSignal::OutOfSurbs | PacketSignal::SurbDistress),
-                                    };
-                                } else {
-                                    // Unset these flags as they make no sense on the forward path.
-                                    signals_to_dst -= PacketSignal::SurbDistress | PacketSignal::OutOfSurbs;
-                                }
-
-                                data.packet_info.get_or_insert_default().signals_to_destination = signals_to_dst;
-                                trace!(?resolved, "resolved routing for packet");
-                                return Some((resolved, data));
-                            }
-                            Err(error) if error.is_surb() => {
-                                // No SURB available yet (possibly cache-wrapped); yield briefly so the
-                                // pool can refill.
-                                futures_timer::Delay::new(std::time::Duration::from_millis(5)).await;
-                            }
-                            Err(error) => {
-                                hopr_transport_session::counters::ROUTING_RESOLUTION_FAILURES
-                                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                error!(%error, "failed to resolve routing");
-                                return None;
-                            }
-                        }
-                    }
-                }
-                .in_current_span()
-            })
-            .buffered(routing_concurrency)
-            .filter_map(futures::future::ready);
+                async move { path_planner.resolve_routing(size_hint, max_surbs, unresolved).await }
+            },
+            distress_threshold,
+            routing_concurrency,
+        );
 
         let channels_dst = self
             .chain_api

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -734,6 +734,7 @@ where
             },
             distress_threshold,
             routing_concurrency,
+            crate::path::resolve::SURB_RESOLUTION_WAIT,
         );
 
         let channels_dst = self

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -321,11 +321,28 @@ where
         let probing_tag_allocator =
             probing_tag_allocator.ok_or_else(|| HoprTransportError::Api("probing tag allocator missing".into()))?;
 
+        // A pseudonym's SURB ring buffer is dropped once no SURBs have arrived for
+        // `pseudonyms_lifetime` (600 s by default), which is the point at which that pseudonym's
+        // return path becomes permanently unresolvable. Nothing else in the node can be made to
+        // reach that state on a test timescale — the Session slot is evicted for idleness long
+        // before it — so without a way to shorten this timer, the behaviour past it is not
+        // observable end-to-end at all. Floored at the same `MINIMUM_SURB_LIFETIME` the config
+        // validator enforces, so this cannot reach a value the config file could not also express.
+        let surb_store_cfg = hopr_protocol_hopr::SurbStoreConfig {
+            pseudonyms_lifetime: std::env::var("HOPR_INTERNAL_SURB_PSEUDONYM_LIFETIME_MS")
+                .ok()
+                .and_then(|s| s.trim().parse::<u64>().ok())
+                .map(Duration::from_millis)
+                .map(|d| d.max(hopr_protocol_hopr::MINIMUM_SURB_LIFETIME))
+                .unwrap_or(cfg.packet.surb_store.pseudonyms_lifetime),
+            ..cfg.packet.surb_store
+        };
+
         // Built before the session manager so the latter can be handed the seam that lets a
         // session re-plan its return path on sustained loss.
         let path_planner = PathPlanner::new(
             me_offchain,
-            MemorySurbStore::new(cfg.packet.surb_store),
+            MemorySurbStore::new(surb_store_cfg),
             resolver.clone(),
             selector,
             planner_config,

--- a/transport/hopr/src/path/mod.rs
+++ b/transport/hopr/src/path/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod errors;
 pub mod planner;
+pub(crate) mod resolve;
 pub mod selector;
 pub mod traits;
 

--- a/transport/hopr/src/path/resolve.rs
+++ b/transport/hopr/src/path/resolve.rs
@@ -1,0 +1,343 @@
+//! The stage that turns a [`DestinationRouting`] into a [`ResolvedTransportRouting`] for every
+//! packet this node originates.
+//!
+//! It sits between the merged outgoing-data stream and the SPHINX encoder, so **every** packet the
+//! node originates passes through it: session payloads, Start-protocol replies, SURB keep-alives,
+//! probes and cover traffic. Forwarded packets and acknowledgements do not — they are relayed from
+//! inside the ingress pipeline and never reach this stage.
+//!
+//! That asymmetry is why this stage deserves its own tests: a fault here silences origination
+//! node-wide while forwarding, acking and receiving carry on looking perfectly healthy.
+
+use futures::{Stream, StreamExt};
+use hopr_api::types::internal::routing::{DestinationRouting, ResolvedTransportRouting};
+use hopr_crypto_packet::prelude::{HoprSurb, PacketSignal};
+use hopr_protocol_app::prelude::ApplicationDataOut;
+use tracing::{Instrument, error, trace};
+
+use super::errors::Result as PathResult;
+
+/// Resolves the routing of every outgoing packet, emitting the resolved packets in submission
+/// order.
+///
+/// `resolve` is the resolution step itself — in production
+/// [`PathPlanner::resolve_routing`](super::PathPlanner::resolve_routing), taking the payload size
+/// hint, the maximum number of SURBs the packet can carry, and the unresolved routing.
+///
+/// A packet whose routing cannot be resolved at all is dropped and counted. A packet whose *return*
+/// routing finds no SURB is retried every 5 ms, on the assumption that the counterparty will
+/// deliver more. That assumption does not hold once the counterparty is gone, and the retry has no
+/// bound — see the tests for what that costs.
+///
+/// Ordering is deliberate: out-of-order delivery to the entry's reassembler makes the sequencer
+/// discard frames that arrive after `frame_timeout`. It is also what turns a single unresolvable
+/// packet into a node-wide stall, since [`buffered`](futures::StreamExt::buffered) withholds
+/// completed futures behind an unfinished one.
+pub(crate) fn resolve_routing_stage<St, F, Fut>(
+    input: St,
+    resolve: F,
+    distress_threshold: usize,
+    concurrency: usize,
+) -> impl Stream<Item = (ResolvedTransportRouting<HoprSurb>, ApplicationDataOut)>
+where
+    St: Stream<Item = (DestinationRouting, ApplicationDataOut)>,
+    F: Fn(usize, usize, DestinationRouting) -> Fut + Clone,
+    Fut: Future<Output = PathResult<(ResolvedTransportRouting<HoprSurb>, Option<usize>)>>,
+{
+    input
+        .map(move |(unresolved, mut data)| {
+            let resolve = resolve.clone();
+            async move {
+                // Retry on SURB starvation: the SURB pool on the exit side refills asynchronously
+                // (target 600, ~300/sec via keep-alive). Silently dropping return-path packets when
+                // the pool is momentarily empty causes irreversible data loss; instead we yield
+                // briefly so the pool can replenish before retrying.
+                loop {
+                    hopr_transport_session::counters::ROUTING_RESOLUTION_ATTEMPTS
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    trace!(?unresolved, "resolving routing for packet");
+                    match resolve(
+                        data.data.total_len(),
+                        data.estimate_surbs_with_msg(),
+                        unresolved.clone(),
+                    )
+                    .await
+                    {
+                        Ok((resolved, rem_surbs)) => {
+                            // Set the SURB distress/out-of-SURBs flag if applicable.
+                            // These flags are translated into HOPR protocol packet signals and are
+                            // applicable only on the return path.
+                            let mut signals_to_dst = data
+                                .packet_info
+                                .as_ref()
+                                .map(|info| info.signals_to_destination)
+                                .unwrap_or_default();
+
+                            if resolved.is_return() {
+                                signals_to_dst = match rem_surbs {
+                                    Some(rem) if (1..distress_threshold.max(2)).contains(&rem) => {
+                                        signals_to_dst | PacketSignal::SurbDistress
+                                    }
+                                    Some(0) => signals_to_dst | PacketSignal::OutOfSurbs,
+                                    _ => signals_to_dst - (PacketSignal::OutOfSurbs | PacketSignal::SurbDistress),
+                                };
+                            } else {
+                                // Unset these flags as they make no sense on the forward path.
+                                signals_to_dst -= PacketSignal::SurbDistress | PacketSignal::OutOfSurbs;
+                            }
+
+                            data.packet_info.get_or_insert_default().signals_to_destination = signals_to_dst;
+                            trace!(?resolved, "resolved routing for packet");
+                            return Some((resolved, data));
+                        }
+                        Err(error) if error.is_surb() => {
+                            // No SURB available yet (possibly cache-wrapped); yield briefly so the
+                            // pool can refill.
+                            futures_timer::Delay::new(std::time::Duration::from_millis(5)).await;
+                        }
+                        Err(error) => {
+                            hopr_transport_session::counters::ROUTING_RESOLUTION_FAILURES
+                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            error!(%error, "failed to resolve routing");
+                            return None;
+                        }
+                    }
+                }
+            }
+            .in_current_span()
+        })
+        .buffered(concurrency)
+        .filter_map(futures::future::ready)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use futures_time::future::FutureExt as _;
+    use hopr_api::types::{
+        crypto::{crypto_traits::Randomizable, prelude::*},
+        internal::{
+            path::ValidatedPath,
+            prelude::HoprPseudonym,
+            routing::{RoutingOptions, SurbMatcher},
+        },
+    };
+    use hopr_protocol_app::prelude::{ApplicationData, Tag};
+
+    use super::*;
+    use crate::path::errors::PathPlannerError;
+
+    /// Bound on every test in this module. The stall under test is unbounded, so a test that hits
+    /// this limit has reproduced it rather than merely run slowly.
+    const TEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+    const TEST_TAG: u64 = 1234;
+
+    /// Concurrency of the stage under test. Any value ≥ 2 exhibits the ordering behaviour; a small
+    /// one keeps the failure legible.
+    const TEST_CONCURRENCY: usize = 8;
+
+    const TEST_DISTRESS_THRESHOLD: usize = 2;
+
+    /// A resolution result the stage accepts. The variant is a forward one because a
+    /// [`ResolvedTransportRouting::Return`] needs a real `HoprSurb`, and no test here depends on
+    /// which variant came back — only on *whether* the packet was emitted.
+    fn resolved() -> ResolvedTransportRouting<HoprSurb> {
+        ResolvedTransportRouting::Forward {
+            pseudonym: HoprPseudonym::random(),
+            forward_path: ValidatedPath::direct(
+                *OffchainKeypair::random().public(),
+                ChainKeypair::random().public().to_address(),
+            ),
+            return_paths: vec![],
+        }
+    }
+
+    fn forward_routing() -> DestinationRouting {
+        DestinationRouting::forward_only(
+            *OffchainKeypair::random().public(),
+            RoutingOptions::Hops(1.try_into().expect("1 is a valid hop count")),
+        )
+    }
+
+    fn return_routing(pseudonym: HoprPseudonym) -> DestinationRouting {
+        DestinationRouting::Return(SurbMatcher::Pseudonym(pseudonym))
+    }
+
+    /// A packet carrying `marker` as its only payload byte, so emitted packets can be identified.
+    fn packet(marker: u8) -> ApplicationDataOut {
+        ApplicationDataOut::with_no_packet_info(
+            ApplicationData::new(Tag::from(TEST_TAG), &[marker]).expect("a one-byte payload is valid"),
+        )
+    }
+
+    fn marker_of(data: &ApplicationDataOut) -> u8 {
+        data.data.plain_text[0]
+    }
+
+    /// The error the planner raises when the SURB store holds nothing for a pseudonym.
+    ///
+    /// This is a *permanent* condition once the counterparty is gone — it is the same error whether
+    /// the pool is momentarily empty or will never be refilled again, which is precisely what makes
+    /// retrying on it indefinitely unsafe.
+    fn no_surb(routing: &DestinationRouting) -> PathPlannerError {
+        let pseudonym = match routing {
+            DestinationRouting::Return(matcher) => matcher.pseudonym().to_string(),
+            DestinationRouting::Forward { .. } => unreachable!("only return routing can starve for SURBs"),
+        };
+        PathPlannerError::Surb(format!("no surb for pseudonym {pseudonym}"))
+    }
+
+    /// A return packet for a pseudonym whose SURBs will never arrive must not withhold the packets
+    /// queued behind it.
+    ///
+    /// This is the `london-01` outage in miniature. The exit kept a session slot alive after its
+    /// initiator had gone, so its keep-alive stream went on emitting return-routed packets for a
+    /// pseudonym with no SURBs. Resolution for that packet can never succeed, and because the stage
+    /// preserves submission order, every subsequent packet was withheld behind it: the node
+    /// originated nothing for 1h44m while forwarding, acking and receiving carried on normally.
+    ///
+    /// The assertion is that the packets behind the starved one are **emitted** — not merely that
+    /// nothing errored. A stalled origination stage is externally indistinguishable from an idle
+    /// node, which is what made the live outage cost a day to find.
+    #[test_log::test(tokio::test)]
+    async fn a_starved_return_packet_should_not_withhold_the_packets_behind_it() -> anyhow::Result<()> {
+        let starved = HoprPseudonym::random();
+
+        let input = futures::stream::iter(vec![
+            (return_routing(starved), packet(0)),
+            (forward_routing(), packet(1)),
+            (forward_routing(), packet(2)),
+        ]);
+
+        let emitted = resolve_routing_stage(
+            input,
+            |_size_hint, _max_surbs, routing: DestinationRouting| async move {
+                match routing {
+                    DestinationRouting::Return(_) => Err(no_surb(&routing)),
+                    DestinationRouting::Forward { .. } => Ok((resolved(), None)),
+                }
+            },
+            TEST_DISTRESS_THRESHOLD,
+            TEST_CONCURRENCY,
+        )
+        .take(2)
+        .collect::<Vec<_>>()
+        .timeout(futures_time::time::Duration::from(TEST_TIMEOUT))
+        .await;
+
+        let emitted = emitted.map_err(|_| {
+            anyhow::anyhow!(
+                "origination stalled: the two forward packets queued behind a return packet whose pseudonym has no \
+                 SURBs were never emitted within {TEST_TIMEOUT:?}. Every packet this node originates passes through \
+                 this stage, so this is a node-wide origination outage."
+            )
+        })?;
+
+        assert_eq!(
+            emitted.iter().map(|(_, data)| marker_of(data)).collect::<Vec<_>>(),
+            vec![1, 2],
+            "the packets behind the starved one must be emitted, in order"
+        );
+
+        Ok(())
+    }
+
+    /// A return packet whose SURBs are only momentarily absent must still be emitted once they
+    /// arrive.
+    ///
+    /// This is the behaviour the retry exists for, and it constrains any bound placed on that
+    /// retry: dropping a return packet on the first SURB error would lose data on a session that
+    /// was merely waiting for its pool to refill.
+    #[test_log::test(tokio::test)]
+    async fn a_return_packet_should_be_emitted_once_its_surbs_arrive() -> anyhow::Result<()> {
+        const FAILURES_BEFORE_SUCCESS: usize = 3;
+
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let input = futures::stream::iter(vec![(return_routing(HoprPseudonym::random()), packet(7))]);
+
+        let emitted = {
+            let attempts = attempts.clone();
+            resolve_routing_stage(
+                input,
+                move |_size_hint, _max_surbs, routing: DestinationRouting| {
+                    let attempts = attempts.clone();
+                    async move {
+                        if attempts.fetch_add(1, Ordering::Relaxed) < FAILURES_BEFORE_SUCCESS {
+                            Err(no_surb(&routing))
+                        } else {
+                            Ok((resolved(), Some(0)))
+                        }
+                    }
+                },
+                TEST_DISTRESS_THRESHOLD,
+                TEST_CONCURRENCY,
+            )
+            .take(1)
+            .collect::<Vec<_>>()
+            .timeout(futures_time::time::Duration::from(TEST_TIMEOUT))
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "a return packet whose SURBs arrived after {FAILURES_BEFORE_SUCCESS} retries was never emitted"
+                )
+            })?
+        };
+
+        assert_eq!(
+            emitted.len(),
+            1,
+            "the return packet must be emitted once its SURBs arrive"
+        );
+        assert_eq!(marker_of(&emitted[0].1), 7);
+        assert!(
+            attempts.load(Ordering::Relaxed) > FAILURES_BEFORE_SUCCESS,
+            "the stage must retry rather than drop on the first SURB error"
+        );
+
+        Ok(())
+    }
+
+    /// A hard (non-SURB) resolution failure drops that packet and lets the rest through.
+    ///
+    /// The contrast with the starvation case is the point: the stage already knows how to drop a
+    /// packet it cannot route and carry on. Only the SURB branch retries without a bound.
+    #[test_log::test(tokio::test)]
+    async fn a_hard_resolution_failure_should_drop_only_its_own_packet() -> anyhow::Result<()> {
+        let input = futures::stream::iter(vec![
+            (forward_routing(), packet(0)),
+            (forward_routing(), packet(1)),
+            (forward_routing(), packet(2)),
+        ]);
+
+        let emitted = resolve_routing_stage(
+            input,
+            |_size_hint, _max_surbs, _routing: DestinationRouting| async move {
+                static SEEN: AtomicUsize = AtomicUsize::new(0);
+                if SEEN.fetch_add(1, Ordering::Relaxed) == 0 {
+                    Err(PathPlannerError::Api("no path".into()))
+                } else {
+                    Ok((resolved(), None))
+                }
+            },
+            TEST_DISTRESS_THRESHOLD,
+            TEST_CONCURRENCY,
+        )
+        .collect::<Vec<_>>()
+        .timeout(futures_time::time::Duration::from(TEST_TIMEOUT))
+        .await
+        .map_err(|_| anyhow::anyhow!("a hard resolution failure stalled the stage instead of dropping its packet"))?;
+
+        assert_eq!(
+            emitted.iter().map(|(_, data)| marker_of(data)).collect::<Vec<_>>(),
+            vec![1, 2],
+            "only the unroutable packet is dropped; the rest keep their order"
+        );
+
+        Ok(())
+    }
+}

--- a/transport/hopr/src/path/resolve.rs
+++ b/transport/hopr/src/path/resolve.rs
@@ -182,6 +182,26 @@ mod tests {
 
     const TEST_DISTRESS_THRESHOLD: usize = 2;
 
+    /// The stage under test with the test constants applied, so each test differs only in the two
+    /// things that matter to it: what goes in, and what resolution does.
+    fn stage<St, F, Fut>(
+        input: St,
+        resolve: F,
+    ) -> impl Stream<Item = (ResolvedTransportRouting<HoprSurb>, ApplicationDataOut)>
+    where
+        St: Stream<Item = (DestinationRouting, ApplicationDataOut)>,
+        F: Fn(usize, usize, DestinationRouting) -> Fut + Clone,
+        Fut: Future<Output = PathResult<(ResolvedTransportRouting<HoprSurb>, Option<usize>)>>,
+    {
+        resolve_routing_stage(
+            input,
+            resolve,
+            TEST_DISTRESS_THRESHOLD,
+            TEST_CONCURRENCY,
+            TEST_SURB_WAIT,
+        )
+    }
+
     /// A resolution result the stage accepts. The variant is a forward one because a
     /// [`ResolvedTransportRouting::Return`] needs a real `HoprSurb`, and no test here depends on
     /// which variant came back — only on *whether* the packet was emitted.
@@ -254,7 +274,7 @@ mod tests {
             (forward_routing(), packet(2)),
         ]);
 
-        let emitted = resolve_routing_stage(
+        let emitted = stage(
             input,
             |_size_hint, _max_surbs, routing: DestinationRouting| async move {
                 match routing {
@@ -262,9 +282,6 @@ mod tests {
                     DestinationRouting::Forward { .. } => Ok((resolved(), None)),
                 }
             },
-            TEST_DISTRESS_THRESHOLD,
-            TEST_CONCURRENCY,
-            TEST_SURB_WAIT,
         )
         .take(2)
         .collect::<Vec<_>>()
@@ -311,22 +328,16 @@ mod tests {
 
         let emitted = {
             let attempts = attempts.clone();
-            resolve_routing_stage(
-                input,
-                move |_size_hint, _max_surbs, routing: DestinationRouting| {
-                    let attempts = attempts.clone();
-                    async move {
-                        if attempts.fetch_add(1, Ordering::Relaxed) < FAILURES_BEFORE_SUCCESS {
-                            Err(no_surb(&routing))
-                        } else {
-                            Ok((resolved(), Some(0)))
-                        }
+            stage(input, move |_size_hint, _max_surbs, routing: DestinationRouting| {
+                let attempts = attempts.clone();
+                async move {
+                    if attempts.fetch_add(1, Ordering::Relaxed) < FAILURES_BEFORE_SUCCESS {
+                        Err(no_surb(&routing))
+                    } else {
+                        Ok((resolved(), Some(0)))
                     }
-                },
-                TEST_DISTRESS_THRESHOLD,
-                TEST_CONCURRENCY,
-                TEST_SURB_WAIT,
-            )
+                }
+            })
             .take(1)
             .collect::<Vec<_>>()
             .timeout(futures_time::time::Duration::from(TEST_TIMEOUT))
@@ -364,7 +375,7 @@ mod tests {
             (forward_routing(), packet(2)),
         ]);
 
-        let emitted = resolve_routing_stage(
+        let emitted = stage(
             input,
             |_size_hint, _max_surbs, _routing: DestinationRouting| async move {
                 static SEEN: AtomicUsize = AtomicUsize::new(0);
@@ -374,9 +385,6 @@ mod tests {
                     Ok((resolved(), None))
                 }
             },
-            TEST_DISTRESS_THRESHOLD,
-            TEST_CONCURRENCY,
-            TEST_SURB_WAIT,
         )
         .collect::<Vec<_>>()
         .timeout(futures_time::time::Duration::from(TEST_TIMEOUT))

--- a/transport/hopr/src/path/resolve.rs
+++ b/transport/hopr/src/path/resolve.rs
@@ -29,12 +29,15 @@ const SURB_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_milli
 /// and because this stage preserves submission order, one such packet withholds every other packet
 /// the node would originate, for the life of the process.
 ///
-/// One second is ~200 retry cycles, far longer than a refill needs, and inside the session's 3 s
-/// frame timeout — a packet held past that is discarded by the receiver anyway, so waiting longer
-/// cannot save it and can only cost the node its egress.
+/// Six seconds is deliberately generous, because this is a *library* default and the useful ceiling
+/// belongs to the caller. A packet held past the session's frame timeout — 3 s for the sessions
+/// hoprd runs — cannot be used by the receiver anyway, so a deployment that knows its own timeout
+/// should configure something tighter, as hoprd does. What a library default must not do is drop a
+/// packet a slower or reliable session would still have made use of, so it errs long and leaves the
+/// tightening to whoever knows the traffic.
 ///
 /// [cfg]: crate::protocol::PacketPipelineConfig::surb_resolution_wait
-pub(crate) const DEFAULT_SURB_RESOLUTION_WAIT: std::time::Duration = std::time::Duration::from_secs(1);
+pub(crate) const DEFAULT_SURB_RESOLUTION_WAIT: std::time::Duration = std::time::Duration::from_secs(6);
 
 /// The wait a node should use, given what its configuration says.
 ///

--- a/transport/hopr/src/path/resolve.rs
+++ b/transport/hopr/src/path/resolve.rs
@@ -20,7 +20,7 @@ use super::errors::Result as PathResult;
 /// How often a return route whose SURBs have not arrived is retried.
 const SURB_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(5);
 
-/// How long the stage keeps retrying a return route whose SURBs have not arrived.
+/// Default for [`PacketPipelineConfig::surb_resolution_wait`][cfg], used when it is unset.
 ///
 /// A momentary gap is normal — the SURB pool refills asynchronously, and dropping a return packet
 /// on the first miss loses data on a session that was only waiting. That is why the retry exists.
@@ -32,7 +32,18 @@ const SURB_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_milli
 /// One second is ~200 retry cycles, far longer than a refill needs, and inside the session's 3 s
 /// frame timeout — a packet held past that is discarded by the receiver anyway, so waiting longer
 /// cannot save it and can only cost the node its egress.
-pub(crate) const SURB_RESOLUTION_WAIT: std::time::Duration = std::time::Duration::from_secs(1);
+///
+/// [cfg]: crate::protocol::PacketPipelineConfig::surb_resolution_wait
+pub(crate) const DEFAULT_SURB_RESOLUTION_WAIT: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// The wait a node should use, given what its configuration says.
+///
+/// Unset means the default; zero is honoured as "do not wait", which drops a return packet the
+/// first time its SURBs are missing. Kept as one function so both meanings live in one place
+/// rather than being re-derived at the call site.
+pub(crate) fn surb_resolution_wait(configured: Option<std::time::Duration>) -> std::time::Duration {
+    configured.unwrap_or(DEFAULT_SURB_RESOLUTION_WAIT)
+}
 
 /// Resolves the routing of every outgoing packet, emitting the resolved packets in submission
 /// order.
@@ -43,7 +54,7 @@ pub(crate) const SURB_RESOLUTION_WAIT: std::time::Duration = std::time::Duration
 ///
 /// A packet whose routing cannot be resolved is dropped and counted. A packet whose *return* routing
 /// finds no SURB is retried for up to `surb_wait` before being dropped the same way; see
-/// [`SURB_RESOLUTION_WAIT`] for why that bound has to exist.
+/// [`DEFAULT_SURB_RESOLUTION_WAIT`] for why that bound has to exist.
 ///
 /// Ordering is deliberate: out-of-order delivery to the entry's reassembler makes the sequencer
 /// discard frames that arrive after `frame_timeout`. It is also why an unbounded wait here is fatal
@@ -308,6 +319,70 @@ mod tests {
         assert!(
             hopr_transport_session::counters::routing_resolution_surb_timeout_count() > dropped_before,
             "the starved packet was dropped without being counted, so the condition stays invisible"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn an_unset_wait_should_fall_back_to_the_default() {
+        assert_eq!(DEFAULT_SURB_RESOLUTION_WAIT, surb_resolution_wait(None));
+    }
+
+    #[test]
+    fn a_configured_wait_should_be_honoured() {
+        let configured = std::time::Duration::from_millis(2_500);
+        assert_eq!(configured, surb_resolution_wait(Some(configured)));
+    }
+
+    /// Zero is honoured rather than treated as "unset".
+    ///
+    /// The sibling concurrency knobs in the same config read `Some(0)` as "use the default", so the
+    /// difference is worth pinning: for a wait, zero has a meaning of its own — do not wait at all.
+    #[test]
+    fn a_zero_wait_should_mean_no_wait_rather_than_the_default() {
+        assert_eq!(
+            std::time::Duration::ZERO,
+            surb_resolution_wait(Some(std::time::Duration::ZERO))
+        );
+    }
+
+    /// With the wait disabled, a starved return packet is dropped on its first miss.
+    ///
+    /// This is the behaviour a zero wait buys, and the reason it is a footgun rather than a
+    /// tuning: any momentary SURB gap becomes loss. Asserting the attempt count is what separates
+    /// "did not wait" from "waited briefly".
+    #[test_log::test(tokio::test)]
+    async fn a_zero_wait_should_drop_a_starved_return_packet_without_retrying() -> anyhow::Result<()> {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let input = futures::stream::iter(vec![(return_routing(HoprPseudonym::random()), packet(0))]);
+
+        let emitted = {
+            let attempts = attempts.clone();
+            resolve_routing_stage(
+                input,
+                move |_size_hint, _max_surbs, routing: DestinationRouting| {
+                    let attempts = attempts.clone();
+                    async move {
+                        attempts.fetch_add(1, Ordering::Relaxed);
+                        Err(no_surb(&routing))
+                    }
+                },
+                TEST_DISTRESS_THRESHOLD,
+                TEST_CONCURRENCY,
+                surb_resolution_wait(Some(std::time::Duration::ZERO)),
+            )
+            .collect::<Vec<_>>()
+            .timeout(futures_time::time::Duration::from(TEST_TIMEOUT))
+            .await
+            .map_err(|_| anyhow::anyhow!("a zero wait still stalled instead of dropping immediately"))?
+        };
+
+        assert!(emitted.is_empty(), "the starved packet must not be emitted");
+        assert_eq!(
+            1,
+            attempts.load(Ordering::Relaxed),
+            "a zero wait must resolve once and give up, not retry"
         );
 
         Ok(())

--- a/transport/hopr/src/path/resolve.rs
+++ b/transport/hopr/src/path/resolve.rs
@@ -13,9 +13,26 @@ use futures::{Stream, StreamExt};
 use hopr_api::types::internal::routing::{DestinationRouting, ResolvedTransportRouting};
 use hopr_crypto_packet::prelude::{HoprSurb, PacketSignal};
 use hopr_protocol_app::prelude::ApplicationDataOut;
-use tracing::{Instrument, error, trace};
+use tracing::{Instrument, error, trace, warn};
 
 use super::errors::Result as PathResult;
+
+/// How often a return route whose SURBs have not arrived is retried.
+const SURB_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(5);
+
+/// How long the stage keeps retrying a return route whose SURBs have not arrived.
+///
+/// A momentary gap is normal — the SURB pool refills asynchronously, and dropping a return packet
+/// on the first miss loses data on a session that was only waiting. That is why the retry exists.
+///
+/// What it must not do is wait indefinitely. When the counterparty is gone no SURB is ever coming,
+/// and because this stage preserves submission order, one such packet withholds every other packet
+/// the node would originate, for the life of the process.
+///
+/// One second is ~200 retry cycles, far longer than a refill needs, and inside the session's 3 s
+/// frame timeout — a packet held past that is discarded by the receiver anyway, so waiting longer
+/// cannot save it and can only cost the node its egress.
+pub(crate) const SURB_RESOLUTION_WAIT: std::time::Duration = std::time::Duration::from_secs(1);
 
 /// Resolves the routing of every outgoing packet, emitting the resolved packets in submission
 /// order.
@@ -24,20 +41,20 @@ use super::errors::Result as PathResult;
 /// [`PathPlanner::resolve_routing`](super::PathPlanner::resolve_routing), taking the payload size
 /// hint, the maximum number of SURBs the packet can carry, and the unresolved routing.
 ///
-/// A packet whose routing cannot be resolved at all is dropped and counted. A packet whose *return*
-/// routing finds no SURB is retried every 5 ms, on the assumption that the counterparty will
-/// deliver more. That assumption does not hold once the counterparty is gone, and the retry has no
-/// bound — see the tests for what that costs.
+/// A packet whose routing cannot be resolved is dropped and counted. A packet whose *return* routing
+/// finds no SURB is retried for up to `surb_wait` before being dropped the same way; see
+/// [`SURB_RESOLUTION_WAIT`] for why that bound has to exist.
 ///
 /// Ordering is deliberate: out-of-order delivery to the entry's reassembler makes the sequencer
-/// discard frames that arrive after `frame_timeout`. It is also what turns a single unresolvable
-/// packet into a node-wide stall, since [`buffered`](futures::StreamExt::buffered) withholds
-/// completed futures behind an unfinished one.
+/// discard frames that arrive after `frame_timeout`. It is also why an unbounded wait here is fatal
+/// rather than merely slow — [`buffered`](futures::StreamExt::buffered) withholds completed futures
+/// behind an unfinished one, so the stall is node-wide rather than confined to one packet.
 pub(crate) fn resolve_routing_stage<St, F, Fut>(
     input: St,
     resolve: F,
     distress_threshold: usize,
     concurrency: usize,
+    surb_wait: std::time::Duration,
 ) -> impl Stream<Item = (ResolvedTransportRouting<HoprSurb>, ApplicationDataOut)>
 where
     St: Stream<Item = (DestinationRouting, ApplicationDataOut)>,
@@ -51,7 +68,9 @@ where
                 // Retry on SURB starvation: the SURB pool on the exit side refills asynchronously
                 // (target 600, ~300/sec via keep-alive). Silently dropping return-path packets when
                 // the pool is momentarily empty causes irreversible data loss; instead we yield
-                // briefly so the pool can replenish before retrying.
+                // briefly so the pool can replenish before retrying — but only for `surb_wait`,
+                // after which no SURB is coming and continuing to wait costs the node its egress.
+                let deadline = std::time::Instant::now() + surb_wait;
                 loop {
                     hopr_transport_session::counters::ROUTING_RESOLUTION_ATTEMPTS
                         .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -90,10 +109,24 @@ where
                             trace!(?resolved, "resolved routing for packet");
                             return Some((resolved, data));
                         }
+                        Err(error) if error.is_surb() && std::time::Instant::now() >= deadline => {
+                            hopr_transport_session::counters::ROUTING_RESOLUTION_SURB_TIMEOUTS
+                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            // Warn rather than trace: this is the only externally visible sign that
+                            // a counterparty has stopped replenishing, and the outage it replaces
+                            // was invisible precisely because nothing on this path said anything.
+                            warn!(
+                                ?unresolved,
+                                ?surb_wait,
+                                %error,
+                                "dropping an outgoing packet: no SURB for its return path within the wait"
+                            );
+                            return None;
+                        }
                         Err(error) if error.is_surb() => {
                             // No SURB available yet (possibly cache-wrapped); yield briefly so the
                             // pool can refill.
-                            futures_timer::Delay::new(std::time::Duration::from_millis(5)).await;
+                            futures_timer::Delay::new(SURB_RETRY_INTERVAL).await;
                         }
                         Err(error) => {
                             hopr_transport_session::counters::ROUTING_RESOLUTION_FAILURES
@@ -134,6 +167,12 @@ mod tests {
     /// Bound on every test in this module. The stall under test is unbounded, so a test that hits
     /// this limit has reproduced it rather than merely run slowly.
     const TEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+    /// The stage's SURB wait, shortened for the tests.
+    ///
+    /// Well clear of [`SURB_RETRY_INTERVAL`] so a retry-then-succeed case has room, and far enough
+    /// below [`TEST_TIMEOUT`] that "the bound fired" and "the test timed out" cannot be confused.
+    const TEST_SURB_WAIT: std::time::Duration = std::time::Duration::from_millis(200);
 
     const TEST_TAG: u64 = 1234;
 
@@ -207,6 +246,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     async fn a_starved_return_packet_should_not_withhold_the_packets_behind_it() -> anyhow::Result<()> {
         let starved = HoprPseudonym::random();
+        let dropped_before = hopr_transport_session::counters::routing_resolution_surb_timeout_count();
 
         let input = futures::stream::iter(vec![
             (return_routing(starved), packet(0)),
@@ -224,6 +264,7 @@ mod tests {
             },
             TEST_DISTRESS_THRESHOLD,
             TEST_CONCURRENCY,
+            TEST_SURB_WAIT,
         )
         .take(2)
         .collect::<Vec<_>>()
@@ -242,6 +283,14 @@ mod tests {
             emitted.iter().map(|(_, data)| marker_of(data)).collect::<Vec<_>>(),
             vec![1, 2],
             "the packets behind the starved one must be emitted, in order"
+        );
+
+        // The starved packet is dropped, and that has to be *countable*. A silent drop leaves the
+        // operator with the same nothing the unbounded wait did: traffic missing and no signal
+        // saying why.
+        assert!(
+            hopr_transport_session::counters::routing_resolution_surb_timeout_count() > dropped_before,
+            "the starved packet was dropped without being counted, so the condition stays invisible"
         );
 
         Ok(())
@@ -276,6 +325,7 @@ mod tests {
                 },
                 TEST_DISTRESS_THRESHOLD,
                 TEST_CONCURRENCY,
+                TEST_SURB_WAIT,
             )
             .take(1)
             .collect::<Vec<_>>()
@@ -326,6 +376,7 @@ mod tests {
             },
             TEST_DISTRESS_THRESHOLD,
             TEST_CONCURRENCY,
+            TEST_SURB_WAIT,
         )
         .collect::<Vec<_>>()
         .timeout(futures_time::time::Duration::from(TEST_TIMEOUT))

--- a/transport/hopr/src/protocol/pipeline/config.rs
+++ b/transport/hopr/src/protocol/pipeline/config.rs
@@ -111,7 +111,68 @@ pub struct PacketPipelineConfig {
     /// for outgoing packet encode (SURB generation). Flooding the pool with decode work would
     /// otherwise starve SURB production and collapse download throughput.
     pub input_concurrency: Option<usize>,
+    /// How long routing resolution keeps waiting for a return path's SURBs before giving up on the
+    /// packet.
+    ///
+    /// `None` falls back to the default of 1 s. `Some(0)` disables the wait entirely, dropping a
+    /// return packet the first time its SURBs are missing.
+    ///
+    /// The right value trades two failures against each other. Too short loses data on a session
+    /// whose SURB pool is only momentarily empty, which is why the wait exists at all. Too long
+    /// stalls **every** packet the node originates, not just this one: resolution preserves
+    /// submission order, so an unresolvable packet withholds everything behind it, and a
+    /// counterparty that has gone away never sends another SURB. An unbounded wait here took a
+    /// production exit's entire egress down for 1h44m while it still forwarded and acknowledged
+    /// normally.
+    ///
+    /// The default is ~200 retry cycles, far longer than a refill needs, and stays inside the
+    /// session's 3 s frame timeout — a packet held past that is discarded by the receiver anyway.
+    /// Raising it much beyond the frame timeout buys nothing and reopens the stall.
+    #[cfg_attr(feature = "serde", serde(default, with = "humantime_serde"))]
+    pub surb_resolution_wait: Option<std::time::Duration>,
     /// Configuration of the packet acknowledgement processing
     #[validate(nested)]
     pub ack_config: AcknowledgementPipelineConfig,
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests {
+    use super::*;
+
+    /// Everything this struct requires in a document, minus the wait under test.
+    ///
+    /// Only `surb_resolution_wait` carries `serde(default)`, so the surrounding fields have to be
+    /// written out; `deny_unknown_fields` means the document must otherwise be exact.
+    const REQUIRED_FIELDS: &str = "output_concurrency: null\ninput_concurrency: null\nack_config:\n  \
+                                   ack_input_concurrency: null\n  ack_output_concurrency: null\n";
+
+    fn parse(wait: Option<&str>) -> PacketPipelineConfig {
+        let doc = match wait {
+            Some(value) => format!("{REQUIRED_FIELDS}surb_resolution_wait: {value}\n"),
+            None => REQUIRED_FIELDS.to_string(),
+        };
+        serde_saphyr::from_str(&doc).unwrap_or_else(|e| panic!("config must parse:\n{doc}\n{e}"))
+    }
+
+    /// The wait has to survive a config file, in the human-readable form the rest of this config
+    /// uses. `Option<Duration>` through `humantime_serde` is easy to get wrong in a way that only
+    /// shows up when someone's YAML is silently ignored.
+    #[test]
+    fn the_surb_resolution_wait_should_round_trip_through_yaml() {
+        assert_eq!(
+            Some(std::time::Duration::from_secs(2)),
+            parse(Some("2s")).surb_resolution_wait,
+            "a duration string must reach the field"
+        );
+        assert_eq!(
+            None,
+            parse(None).surb_resolution_wait,
+            "an omitted wait must stay unset so the default applies"
+        );
+        assert_eq!(
+            Some(std::time::Duration::ZERO),
+            parse(Some("0s")).surb_resolution_wait,
+            "zero must reach the code as zero, not as unset"
+        );
+    }
 }

--- a/transport/hopr/src/protocol/pipeline/config.rs
+++ b/transport/hopr/src/protocol/pipeline/config.rs
@@ -114,7 +114,7 @@ pub struct PacketPipelineConfig {
     /// How long routing resolution keeps waiting for a return path's SURBs before giving up on the
     /// packet.
     ///
-    /// `None` falls back to the default of 1 s. `Some(0)` disables the wait entirely, dropping a
+    /// `None` falls back to the default of 6 s. `Some(0)` disables the wait entirely, dropping a
     /// return packet the first time its SURBs are missing.
     ///
     /// The right value trades two failures against each other. Too short loses data on a session
@@ -125,9 +125,10 @@ pub struct PacketPipelineConfig {
     /// production exit's entire egress down for 1h44m while it still forwarded and acknowledged
     /// normally.
     ///
-    /// The default is ~200 retry cycles, far longer than a refill needs, and stays inside the
-    /// session's 3 s frame timeout — a packet held past that is discarded by the receiver anyway.
-    /// Raising it much beyond the frame timeout buys nothing and reopens the stall.
+    /// **Set this if you know your session's frame timeout.** The default errs long, because a
+    /// library cannot know it; a packet held past that timeout is discarded by the receiver anyway,
+    /// so the wait is pure stall from then on. hoprd, whose sessions time frames out at 3 s,
+    /// configures 1 s.
     #[cfg_attr(feature = "serde", serde(default, with = "humantime_serde"))]
     pub surb_resolution_wait: Option<std::time::Duration>,
     /// Configuration of the packet acknowledgement processing

--- a/transport/session/Cargo.toml
+++ b/transport/session/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport-session"
 description = "Session functionality providing session abstraction over the HOPR transport"
-version = "0.27.0"
+version = "0.27.1"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/session/Cargo.toml
+++ b/transport/session/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport-session"
 description = "Session functionality providing session abstraction over the HOPR transport"
-version = "0.27.1"
+version = "0.28.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/session/src/counters.rs
+++ b/transport/session/src/counters.rs
@@ -41,6 +41,21 @@ pub fn session_unrelated_dispatch_count() -> usize {
     SESSION_UNRELATED_DATA_DISPATCHES.load(Ordering::Relaxed)
 }
 
+/// Cumulative count of outgoing packets dropped because their return route still had no SURB
+/// when the resolution wait ran out.
+///
+/// Separate from [`ROUTING_RESOLUTION_FAILURES`] because it means something different and
+/// actionable: a counterparty has stopped replenishing SURBs and is not coming back, rather than a
+/// route that could not be computed. A non-zero and growing value names the condition that used to
+/// stall a node's entire egress indefinitely.
+pub static ROUTING_RESOLUTION_SURB_TIMEOUTS: AtomicUsize = AtomicUsize::new(0);
+
+/// Returns the cumulative count of packets dropped after waiting in vain for a return SURB.
+#[inline]
+pub fn routing_resolution_surb_timeout_count() -> usize {
+    ROUTING_RESOLUTION_SURB_TIMEOUTS.load(Ordering::Relaxed)
+}
+
 /// Cumulative count of packets that failed path/routing resolution before encoding.
 pub static ROUTING_RESOLUTION_FAILURES: AtomicUsize = AtomicUsize::new(0);
 

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -2708,6 +2708,155 @@ mod tests {
         Ok(())
     }
 
+    /// Collects everything that arrives on `rx` during `window`, returning once it elapses.
+    async fn originated_during(
+        rx: &mut futures::channel::mpsc::UnboundedReceiver<(DestinationRouting, ApplicationDataOut)>,
+        window: Duration,
+    ) -> Vec<(DestinationRouting, ApplicationDataOut)> {
+        let mut collected = Vec::new();
+        let deadline = tokio::time::Instant::now() + window;
+        while let Ok(Some(item)) = timeout(
+            deadline.saturating_duration_since(tokio::time::Instant::now()),
+            rx.next(),
+        )
+        .await
+        {
+            collected.push(item);
+        }
+        collected
+    }
+
+    /// The manager floors the keep-alive period at [`MIN_SURB_BUFFER_NOTIFICATION_PERIOD`], so this
+    /// is as fast as an Exit keep-alive can be made to run, and it sets the pace of these tests.
+    const KEEP_ALIVE_PERIOD: Duration = MIN_SURB_BUFFER_NOTIFICATION_PERIOD;
+
+    type RecordingManager = SessionManager<UnboundedSender<(DestinationRouting, ApplicationDataOut)>>;
+    type Originated = futures::channel::mpsc::UnboundedReceiver<(DestinationRouting, ApplicationDataOut)>;
+
+    /// Brings up an Exit-side session and returns once its keep-alive stream is observably running.
+    ///
+    /// The "observably running" part is load-bearing for every caller: `nothing was originated` is
+    /// equally true of a stream that stopped and one that never started, so a test that does not
+    /// first establish the stream is alive proves nothing when it later sees silence.
+    async fn exit_session_originating_keep_alives(
+        cfg: SessionManagerConfig,
+    ) -> anyhow::Result<(RecordingManager, Originated, HoprPseudonym)> {
+        let mgr = RecordingManager::new(SessionManagerConfig {
+            surb_balance_notify_period: Some(KEEP_ALIVE_PERIOD),
+            ..cfg
+        });
+
+        let (msg_tx, mut msg_rx) = futures::channel::mpsc::unbounded();
+        // Held, not dropped: dropping it would fail the establishment notification instead.
+        let (new_session_tx, _new_session_rx) = futures::channel::mpsc::channel(4);
+        mgr.start(msg_tx, new_session_tx)?;
+
+        let pseudonym = HoprPseudonym::random();
+        mgr.handle_incoming_session_initiation(
+            pseudonym,
+            StartInitiation {
+                challenge: MIN_CHALLENGE,
+                target: SessionTarget::TcpStream(SealedHost::Plain("127.0.0.1:80".parse()?)),
+                // Empty capabilities keep rate control on, which is what spawns the balancer and
+                // the keep-alive stream. `NoRateControl` would skip both and make this vacuous.
+                capabilities: ByteCapabilities(Capabilities::empty()),
+                additional_data: 0,
+            },
+        )
+        .await?;
+
+        let observed = originated_during(&mut msg_rx, KEEP_ALIVE_PERIOD * 2 + Duration::from_millis(500)).await;
+        let keep_alives = observed
+            .iter()
+            .filter(|(routing, data)| {
+                msg_type(data, StartProtocolDiscriminants::KeepAlive)
+                    && matches!(routing, DestinationRouting::Return(SurbMatcher::Pseudonym(p)) if p == &pseudonym)
+            })
+            .count();
+        anyhow::ensure!(
+            keep_alives > 0,
+            "no return-routed keep-alive was originated, so this test cannot tell a stopped stream from one that \
+             never ran; {} message(s) were observed in total",
+            observed.len()
+        );
+
+        Ok((mgr, msg_rx, pseudonym))
+    }
+
+    /// Asserts `mgr` originates nothing further for `pseudonym`.
+    ///
+    /// Packets already handed to the sender before the closure are in flight rather than newly
+    /// originated, so they are drained first and only what appears afterwards counts.
+    async fn assert_no_further_origination(rx: &mut Originated, closure: &str) {
+        let _in_flight = originated_during(rx, Duration::from_millis(200)).await;
+
+        let window = KEEP_ALIVE_PERIOD * 3;
+        let after = originated_during(rx, window).await;
+        assert!(
+            after.is_empty(),
+            "an Exit session closed by {closure} originated {} further packet(s) over {window:?} — each one is \
+             return-routed to a pseudonym whose SURBs are gone, and one such packet is enough to stall all \
+             origination on the node",
+            after.len()
+        );
+    }
+
+    /// An Exit session must originate nothing once it has been closed explicitly.
+    ///
+    /// The Exit's keep-alive stream is a `repeat_with` on a rate limiter: it produces a
+    /// return-routed packet every period regardless of whether a SURB exists to carry it. That is
+    /// fine while the initiator is present and replenishing, and it is the *supply* side of the
+    /// `london-01` outage once the initiator is gone — every such packet is one the routing
+    /// resolution stage can never resolve, and one unresolvable packet there stalls all origination
+    /// on the node (see `hopr_transport::path::resolve`).
+    ///
+    /// Teardown is therefore the only thing standing between a departed initiator and an unbounded
+    /// supply of unresolvable packets, which is why each closure path has to be shown to stop the
+    /// stream rather than merely drop the slot.
+    #[test_log::test(tokio::test)]
+    async fn an_exit_session_should_originate_nothing_after_an_explicit_close() -> anyhow::Result<()> {
+        // Default idle timeout (180 s), so eviction cannot confound what the explicit close proves.
+        let (mgr, mut msg_rx, pseudonym) = exit_session_originating_keep_alives(Default::default()).await?;
+
+        assert!(mgr.close_session(&pseudonym), "the session must exist to be closed");
+
+        assert_no_further_origination(&mut msg_rx, "an explicit close").await;
+        Ok(())
+    }
+
+    /// An Exit session must originate nothing once it has been evicted for being idle.
+    ///
+    /// This is the path that matters most for a departed initiator: nobody closes that session, so
+    /// idle eviction is what ends it, and eviction runs through a Moka listener rather than the
+    /// explicit close path. A keep-alive stream that survives eviction would go on originating
+    /// unresolvable return packets with no session left to account for them.
+    #[test_log::test(tokio::test)]
+    async fn an_exit_session_should_originate_nothing_after_idle_eviction() -> anyhow::Result<()> {
+        let idle_timeout = KEEP_ALIVE_PERIOD * 3;
+        let (mgr, mut msg_rx, _) = exit_session_originating_keep_alives(SessionManagerConfig {
+            idle_timeout,
+            ..Default::default()
+        })
+        .await?;
+
+        // Moka evicts lazily, so drive its maintenance rather than waiting for the manager's own
+        // (jittered, multi-second) eviction tick: this makes the eviction prompt and deterministic.
+        for _ in 0..50 {
+            mgr.sessions.run_pending_tasks();
+            if mgr.active_sessions().is_empty() {
+                break;
+            }
+            tokio::time::sleep(idle_timeout / 10).await;
+        }
+        assert!(
+            mgr.active_sessions().is_empty(),
+            "the idle session was never evicted, so this test cannot say anything about eviction"
+        );
+
+        assert_no_further_origination(&mut msg_rx, "idle eviction").await;
+        Ok(())
+    }
+
     #[test_log::test(tokio::test)]
     async fn session_manager_should_send_keep_alives_via_surb_balancer() -> anyhow::Result<()> {
         let alice_pseudonym = HoprPseudonym::random();


### PR DESCRIPTION
A node loses **all** origination when a single return packet has no SURB.

Routing resolution retried `PathPlannerError::Surb` every 5 ms with no bound, on the assumption that the counterparty would deliver more SURBs. Once that counterparty is gone the assumption never holds again, and the stage preserves submission order via `.buffered()` — which withholds completed futures behind an unfinished one. One packet that can never resolve therefore withholds every packet the node would originate, for the life of the process.

Forwarding and acknowledgement run on the ingress path and never touch this stage, which is why nothing looks wrong: `hopr_packets_count{type="sent"}` and rayon `packet_encode` freeze at the same value while `forwarded`, `received` and `ack_sent` keep climbing, with no panic, no error line, and a green healthcheck. A `gnosis_vpn` exit lost origination entirely for 1h44m this way on 2026-08-16.

## The change

- The retry is bounded by `PacketPipelineConfig::surb_resolution_wait`, after which the packet is dropped like any other unroutable one.
- The drop is counted (`ROUTING_RESOLUTION_SURB_TIMEOUTS`) and logged at `warn`. The outage was invisible precisely because nothing on this path said anything, so a silent drop would trade one unobservable failure for another.
- The stage moves out of `HoprTransport::run()` into `path::resolve`, which is what makes it testable at all: it sits upstream of `HoprPacketPipelineBuilder`, so the existing `pipeline_stage_isolation` tests — which take already-resolved routing — never covered it.
- Exit-side teardown coverage for the emitter that supplies such packets: a Session slot's keep-alive stream emits return-routed packets on a timer, blind to SURB availability, so teardown is what stands between a departed initiator and an unbounded supply of them. Both the explicit close and idle eviction paths are covered.

## Choosing the wait

The value trades data loss against a node-wide stall, and the useful ceiling is the session's frame timeout: a packet held past it is discarded by the receiver anyway, so from then on the wait is pure stall.

A library cannot know that timeout, so the **default errs long at 6 s** — it never drops a packet a slower or reliable session would still have used — and the deployment that does know configures something tighter. hoprd, whose sessions time frames out at 3 s, sets **1 s** (hoprnet/hoprd#130).

`surb_resolution_wait` sits beside `output_concurrency`, the sibling knob passed to the same stage. Unset takes the default; zero disables the wait, dropping a return packet on its first miss. Zero is honoured rather than folded into the default — the concurrency fields next to it read `Some(0)` as "use the default" — and a test pins the difference.

## Verification
Exercised by: hoprnet/hoprd-test#19. Consumed by: hoprnet/hoprd#130.