### PR TITLE
chore: backmerge 4.0 changes to master

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -16,6 +16,7 @@ ignore = [
   "RUSTSEC-2026-0220", # ruint <1.20.0 pulled transitively by nybbles → alloy-trie → alloy; upgrade blocked on alloy bump
   "RUSTSEC-2026-0249", # `smartstring` unmaintained, requires `opentelemetry-prometheus-text-exporter` > 0.3.0
   "RUSTSEC-2026-0253", # `lru` <0.18.2 use-after-free if a key's `Drop` panics in `pop()`; pinned at 0.16.4 by alloy-provider 2.2.0 (via hopr-bindings -> hopr-types). 0.18.2 is semver-incompatible, so this needs an alloy bump — same blocker as RUSTSEC-2026-0220
+  "RUSTSEC-2026-0258", # `h2` unbounded empty DATA frames, requires new version of `cynic` in `blokli-client`
 ]
 informational_warnings = ["unmaintained"]
 severity_threshold = "low"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.26.2"
+version = "0.26.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4168,7 +4168,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "4.0.2-rc.11"
+version = "4.0.4"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4282,7 +4282,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-session"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4365,7 +4365,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.44.0"
+version = "0.45.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.26.3"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-hopr"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4365,7 +4365,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.45.0"
+version = "0.48.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4411,6 +4411,7 @@ dependencies = [
  "rand_distr",
  "rstest",
  "serde",
+ "serde-saphyr",
  "serial_test",
  "smart-default",
  "strum",
@@ -4502,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1787,9 +1787,9 @@ dependencies = [
 
 [[package]]
 name = "blokli-client"
-version = "0.30.2"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6da9d0a178246498baf5e4b9f753affb25c14116ea8fbf75552841c6231a429"
+checksum = "1645e71eacbae4cf304636a390a08b5c03cf068a814923dbd1631d5558f7ddeb"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4055,9 +4055,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.22.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25cf2b4ca36321e18c6aa0a28b8d2760f9c272f14f22fbe28cc64b0a35fce91e"
+checksum = "b888d2f2d08002d003db1789f732c812ebe2709375780cc6b12eeba09930452c"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -4093,9 +4093,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.22.1"
+version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8326d358c768a169662397a7cd566a6fc4d4b8e394f285cd7cfcc7a6f6e866"
+checksum = "a053b62b7fb08927b8bc1f271018c122151d8bafbdcd3e0081a09322b13fcdae"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4108,7 +4108,7 @@ dependencies = [
  "futures-concurrency",
  "futures-time",
  "hopr-api",
- "hopr-utilities 0.6.0",
+ "hopr-utilities",
  "moka",
  "parking_lot",
  "petgraph",
@@ -4133,7 +4133,7 @@ dependencies = [
  "flagset",
  "hex-literal",
  "hopr-types",
- "hopr-utilities 0.8.0",
+ "hopr-utilities",
  "lazy_static",
  "mimalloc",
  "parameterized",
@@ -4150,9 +4150,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-ct-full-network"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c670d644ce0535d3fb6beb3b9ade0c67f0a24d6309b888f64f61dd0b9eb51eb3"
+checksum = "d7985d0e77c83e9ae107dcc53012eeb736b83edeb83cf3522a3d1b7ab1e66fa9"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4160,7 +4160,7 @@ dependencies = [
  "futures-time",
  "hopr-api",
  "hopr-network-graph",
- "hopr-utilities 0.6.0",
+ "hopr-utilities",
  "smart-default",
  "tracing",
  "validator",
@@ -4188,7 +4188,7 @@ dependencies = [
  "hopr-ticket-manager",
  "hopr-transport",
  "hopr-transport-p2p",
- "hopr-utilities 0.8.0",
+ "hopr-utilities",
  "humantime-serde",
  "insta",
  "lazy_static",
@@ -4214,15 +4214,15 @@ dependencies = [
 
 [[package]]
 name = "hopr-network-graph"
-version = "0.3.4"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a6a2b0a711541ceaa4a8fd47aec604ae2879d70d20f5b51a1057c0403e64f5d"
+checksum = "1104069d205e792651562e8648e2403f815169c4c822ba00678b82fa1911fa2e"
 dependencies = [
  "anyhow",
  "bimap",
  "futures",
  "hopr-api",
- "hopr-utilities 0.8.0",
+ "hopr-utilities",
  "indexmap 2.14.0",
  "lazy_static",
  "parking_lot",
@@ -4263,7 +4263,7 @@ dependencies = [
  "hopr-chain-connector",
  "hopr-crypto-packet",
  "hopr-ticket-manager",
- "hopr-utilities 0.8.0",
+ "hopr-utilities",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4301,7 +4301,7 @@ dependencies = [
  "hopr-crypto-packet",
  "hopr-protocol-app",
  "hopr-types",
- "hopr-utilities 0.8.0",
+ "hopr-utilities",
  "indexmap 2.14.0",
  "insta",
  "lazy_static",
@@ -4342,9 +4342,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-ticket-manager"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8009dca8550d8803bc730bb89e26a68316df041d4a131287e79b5e4fc9d4a413"
+checksum = "cbedcb10d008c7a1831ceb89c213ab2a0242405e24d99886839553fca725ca89"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4353,7 +4353,7 @@ dependencies = [
  "futures",
  "hashbrown 0.17.1",
  "hopr-api",
- "hopr-utilities 0.6.0",
+ "hopr-utilities",
  "parking_lot",
  "postcard",
  "redb",
@@ -4397,7 +4397,7 @@ dependencies = [
  "hopr-transport-probe",
  "hopr-transport-session",
  "hopr-transport-tag-allocator",
- "hopr-utilities 0.8.0",
+ "hopr-utilities",
  "humantime-serde",
  "insta",
  "lazy_static",
@@ -4448,9 +4448,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-p2p"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e553e6688d8bf422a47cf382673752fbe3086f168e33dde006160481ec317a"
+checksum = "b1e9a987efe3013cf7f3809d5f87aec29d5588a695a6af718dd406f5d0f5806b"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4458,7 +4458,7 @@ dependencies = [
  "dashmap",
  "futures",
  "hopr-api",
- "hopr-utilities 0.6.0",
+ "hopr-utilities",
  "libp2p",
  "libp2p-stream",
  "multiaddr",
@@ -4483,7 +4483,7 @@ dependencies = [
  "hopr-crypto-packet",
  "hopr-protocol-app",
  "hopr-transport-tag-allocator",
- "hopr-utilities 0.8.0",
+ "hopr-utilities",
  "humantime-serde",
  "insta",
  "lazy_static",
@@ -4516,7 +4516,7 @@ dependencies = [
  "hopr-protocol-app",
  "hopr-protocol-session",
  "hopr-protocol-start",
- "hopr-utilities 0.8.0",
+ "hopr-utilities",
  "humantime-serde",
  "insta",
  "lazy_static",
@@ -4618,9 +4618,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-utilities"
-version = "0.6.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c557ecaad14224e4ae1df1be73449c24241f4b34e20129b11b8d0e38062eb6a6"
+checksum = "7de9a46fe251a9aa6ee3ab7e2edd7720ac6f09ad4f01566dd6c056913615cc43"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4633,35 +4633,6 @@ dependencies = [
  "futures-time",
  "hickory-resolver 0.26.1",
  "hopr-api",
- "hopr-types",
- "indexmap 2.14.0",
- "lazy_static",
- "libp2p-identity",
- "multiaddr",
- "pin-project",
- "rand 0.10.2",
- "serde_json",
- "socket2 0.6.5",
- "strum",
- "thiserror 2.0.20",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "hopr-utilities"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4173135d8a520496af92e32148649ab74007239a1082021b491dec6c3905dc87"
-dependencies = [
- "arrayvec",
- "auto_impl",
- "const-hex",
- "crossfire",
- "flume",
- "futures",
- "futures-time",
- "hickory-resolver 0.26.1",
  "hopr-types",
  "indexmap 2.14.0",
  "lazy_static",
@@ -4697,7 +4668,7 @@ dependencies = [
  "hopr-api",
  "hopr-lib",
  "hopr-transport",
- "hopr-utilities 0.8.0",
+ "hopr-utilities",
  "human-bandwidth",
  "lazy_static",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,9 +134,14 @@ tokio-util = { version = "0.7.19", default-features = false, features = [
 tracing = { version = "0.1.44", features = ["release_max_level_debug"] }
 validator = { version = "0.21.0", features = ["derive"] }
 
-hopr-api = "1.22.0"
+# TEMPORARY: pinned to unreleased branches so this change compiles and is tested end to end,
+# and pinned together so a single hopr-api major is in the graph — two majors coexisting makes
+# `hopr_api::chain::DeployedSafe` two distinct types. `version` alongside `git` is the "multiple
+# locations" form: git wins locally, the version requirement survives packaging. Revert to plain
+# versions once hopr-api 2.0.0, hopr-utilities 0.9.0 and the hopr-impls crates are published.
+hopr-api = { version = "2.0.0" }
 hopr-types = { version = "2.2.1", features = ["use-bindings"] }
-hopr-utils = { package = "hopr-utilities", version = "0.8.0", default-features = false }
+hopr-utils = { package = "hopr-utilities", version = "0.9.0", default-features = false }
 hopr-utils-session = { version = "1.2.1", path = "utils-session" }
 
 hopr-crypto-packet = { version = "1.4.0", path = "crypto/packet", default-features = false, features = [
@@ -147,19 +152,19 @@ hopr-protocol-app = { version = "1.0.1", path = "protocols/app", default-feature
 hopr-protocol-hopr = { version = "6.0.0", path = "protocols/hopr", default-features = false }
 hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
 hopr-protocol-start = { version = "1.1.0", path = "protocols/start", default-features = false }
-hopr-ticket-manager = "0.5.1"
+hopr-ticket-manager = { version = "0.5.2" }
 hopr-transport = { version = "0.44.0", path = "transport/hopr" }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
 hopr-transport-session = { version = "0.26.2", path = "transport/session", default-features = false }
 hopr-transport-tag-allocator = { version = "0.1.1", path = "transport/tag-allocator", default-features = false }
-hopr-chain-connector = "0.22.1"
+hopr-chain-connector = { version = "0.22.2" }
 
 # referential implementations (published to crates.io)
-hopr-session-server-forwarder = { version = "0.1.0", default-features = false }
-hopr-transport-p2p = { version = "0.9.4", features = ["transport-quic"] }
-hopr-ct-full-network = { version = "0.3.0", default-features = false }
-hopr-network-graph = { version = "0.3.4", default-features = false }
+hopr-session-server-forwarder = { version = "0.1.1", default-features = false }
+hopr-transport-p2p = { version = "0.9.5", features = ["transport-quic"] }
+hopr-ct-full-network = { version = "0.4.0", default-features = false }
+hopr-network-graph = { version = "0.5.0", default-features = false }
 
 [profile.dev]
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,10 +153,10 @@ hopr-protocol-hopr = { version = "6.0.0", path = "protocols/hopr", default-featu
 hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
 hopr-protocol-start = { version = "1.1.0", path = "protocols/start", default-features = false }
 hopr-ticket-manager = { version = "0.5.2" }
-hopr-transport = { version = "0.44.0", path = "transport/hopr" }
+hopr-transport = { version = "0.45.0", path = "transport/hopr" }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
-hopr-transport-session = { version = "0.26.2", path = "transport/session", default-features = false }
+hopr-transport-session = { version = "0.27.0", path = "transport/session", default-features = false }
 hopr-transport-tag-allocator = { version = "0.1.1", path = "transport/tag-allocator", default-features = false }
 hopr-chain-connector = { version = "0.22.2" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,10 +153,10 @@ hopr-protocol-hopr = { version = "6.0.0", path = "protocols/hopr", default-featu
 hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
 hopr-protocol-start = { version = "1.1.0", path = "protocols/start", default-features = false }
 hopr-ticket-manager = { version = "0.5.2" }
-hopr-transport = { version = "0.45.0", path = "transport/hopr" }
+hopr-transport = { version = "0.48.0", path = "transport/hopr" }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
-hopr-transport-session = { version = "0.27.0", path = "transport/session", default-features = false }
+hopr-transport-session = { version = "0.28.0", path = "transport/session", default-features = false }
 hopr-transport-tag-allocator = { version = "0.1.1", path = "transport/tag-allocator", default-features = false }
 hopr-chain-connector = { version = "0.22.2" }
 

--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-lib"
 description = "HOPR library implementing the HOPR protocol"
-version = "4.0.2-rc.11"
+version = "4.0.4"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/hopr/hopr-lib/src/builder/chain_wiring.rs
+++ b/hopr/hopr-lib/src/builder/chain_wiring.rs
@@ -4,7 +4,7 @@ use futures::{SinkExt, StreamExt, pin_mut};
 use hopr_api::{
     HoprBalance, Multiaddr, OffchainPublicKey, PeerId,
     chain::{ChainKeyOperations, WinningProbability},
-    graph::{EdgeCapacityUpdate, MeasurableEdge, NetworkGraphUpdate},
+    graph::{EdgeBalanceUpdate, MeasurableEdge, NetworkGraphUpdate},
     types::{
         chain::chain_events::ChainEvent,
         internal::prelude::ChannelStatus,
@@ -55,6 +55,12 @@ pub(super) async fn process_chain_events<C, G, S>(
     S: SurbStore + Send + Sync + 'static,
 {
     pin_mut!(events);
+
+    // Seed the face value before the first event. Startup replays on-chain state as channel events,
+    // and a pricing event only follows if the price actually changes — so without this the graph
+    // would record balances while `ticket_face_value()` was still `None`, and selection would price
+    // every path off the fallback until the next price change happened to arrive.
+    push_ticket_face_value(&graph_updater, &ticket_price, &win_probability);
 
     // Tracks the node's currently-open channel IDs per direction so `hopr_channels_count`
     // can be maintained incrementally from channel events. The initial on-chain state is
@@ -131,28 +137,22 @@ pub(super) async fn process_chain_events<C, G, S>(
 
                 match keys {
                     Ok(Some((from, to))) => {
-                        let capacity =
-                            match channel.status {
-                                ChannelStatus::Closed | ChannelStatus::PendingToClose(_) => None,
-                                _ => ticket_price.read().div_f64(win_probability.read().as_f64()).ok().map(
-                                    |ticket_value| {
-                                        channel
-                                            .balance
-                                            .amount()
-                                            .checked_div(ticket_value.amount())
-                                            .map(|v| v.low_u128())
-                                            .unwrap_or(u128::MAX)
-                                    },
-                                ),
-                            };
+                        // Emit the raw balance, not a ticket count. Dividing by the ticket face
+                        // value here would bake a live ticket price and winning probability into
+                        // every edge, so each price change would stale the whole graph at once.
+                        // Consumers apply the face value when they evaluate a path instead.
+                        let balance = match channel.status {
+                            ChannelStatus::Closed | ChannelStatus::PendingToClose(_) => None,
+                            _ => Some(channel.balance.amount()),
+                        };
 
                         tracing::debug!(
-                            %channel, ?capacity,
-                            "recording graph edge for channel capacity"
+                            %channel, ?balance,
+                            "recording graph edge for channel balance"
                         );
-                        graph_updater.record_edge(MeasurableEdge::<NeighborTelemetry, PathTelemetry>::Capacity(
-                            Box::new(EdgeCapacityUpdate {
-                                capacity,
+                        graph_updater.record_edge(MeasurableEdge::<NeighborTelemetry, PathTelemetry>::Balance(
+                            Box::new(EdgeBalanceUpdate {
+                                balance,
                                 src: from,
                                 dest: to,
                             }),
@@ -195,13 +195,46 @@ pub(super) async fn process_chain_events<C, G, S>(
             ChainEvent::WinningProbabilityIncreased(prob) | ChainEvent::WinningProbabilityDecreased(prob) => {
                 tracing::debug!(%prob, "recording winning probability change");
                 *win_probability.write() = prob;
+                push_ticket_face_value(&graph_updater, &ticket_price, &win_probability);
             }
             ChainEvent::TicketPriceChanged(price) => {
                 tracing::debug!(%price, "recording ticket price change");
                 *ticket_price.write() = price;
+                push_ticket_face_value(&graph_updater, &ticket_price, &win_probability);
             }
             _ => {}
         }
+    }
+}
+
+/// Recomputes the single-hop ticket face value and pushes it into the graph.
+///
+/// `price / win_probability` is the amount that makes the expected payout per packet equal the
+/// ticket price, i.e. one ticket's face value. Edges store only a balance, so this is the one place
+/// pricing enters path selection — and a change costs a single write rather than an edge sweep.
+fn push_ticket_face_value<G>(
+    graph: &G,
+    ticket_price: &Arc<RwLock<HoprBalance>>,
+    win_probability: &Arc<RwLock<WinningProbability>>,
+) where
+    G: NetworkGraphUpdate,
+{
+    // Both guards are released before the division: holding one while taking the other is a lock
+    // order this code would then be obliged to honour everywhere else.
+    let price = *ticket_price.read();
+    let probability = win_probability.read().as_f64();
+
+    // The `f64` carries the probability, it does not convert it. `as_f64` packs the 56-bit encoded
+    // value into the mantissa of a number in [1, 2), and `div_f64` strips it straight back out and
+    // divides in `U256` — the balance never becomes a float, and a whole probability short-circuits
+    // to the identity. A hand-rolled integer division here would gain nothing but the guards.
+    match price.div_f64(probability) {
+        Ok(face_value) => {
+            let face_value = face_value.amount();
+            tracing::debug!(%face_value, "recording ticket face value change");
+            graph.set_ticket_face_value(face_value);
+        }
+        Err(error) => tracing::error!(%error, "failed to derive the ticket face value; leaving the previous one"),
     }
 }
 
@@ -217,7 +250,7 @@ mod tests {
     use hopr_api::{
         HoprBalance, OffchainPublicKey,
         chain::{ChainKeyOperations, HoprKeyIdent, KeyIdMapping, WinningProbability},
-        graph::{EdgeCapacityUpdate, MeasurableEdge, MeasurablePath, MeasurablePeer, NetworkGraphUpdate},
+        graph::{EdgeBalanceUpdate, MeasurableEdge, MeasurablePath, MeasurablePeer, NetworkGraphUpdate},
         types::{
             chain::chain_events::ChainEvent,
             crypto::prelude::{ChainKeypair, Keypair, OffchainKeypair},
@@ -292,7 +325,8 @@ mod tests {
     #[derive(Debug, Clone)]
     enum GraphCall {
         Node(OffchainPublicKey),
-        Edge(Box<EdgeCapacityUpdate>),
+        Edge(Box<EdgeBalanceUpdate>),
+        FaceValue(hopr_api::graph::traits::Balance),
     }
 
     #[derive(Debug, Clone, Default)]
@@ -305,10 +339,17 @@ mod tests {
             self.calls.lock().unwrap().clone()
         }
 
-        fn edges(&self) -> Vec<EdgeCapacityUpdate> {
+        fn edges(&self) -> Vec<EdgeBalanceUpdate> {
             self.recorded()
                 .into_iter()
                 .filter_map(|c| if let GraphCall::Edge(e) = c { Some(*e) } else { None })
+                .collect()
+        }
+
+        fn face_values(&self) -> Vec<hopr_api::graph::traits::Balance> {
+            self.recorded()
+                .into_iter()
+                .filter_map(|c| if let GraphCall::FaceValue(v) = c { Some(v) } else { None })
                 .collect()
         }
 
@@ -321,13 +362,17 @@ mod tests {
     }
 
     impl NetworkGraphUpdate for RecordingGraph {
+        fn set_ticket_face_value(&self, ticket_face_value: hopr_api::graph::traits::Balance) {
+            self.calls.lock().unwrap().push(GraphCall::FaceValue(ticket_face_value));
+        }
+
         fn record_edge<N, P>(&self, update: MeasurableEdge<N, P>)
         where
             N: MeasurablePeer + Clone + Send + Sync + 'static,
             P: MeasurablePath + Clone + Send + Sync + 'static,
         {
-            if let MeasurableEdge::Capacity(cap) = update {
-                self.calls.lock().unwrap().push(GraphCall::Edge(cap));
+            if let MeasurableEdge::Balance(balance) = update {
+                self.calls.lock().unwrap().push(GraphCall::Edge(balance));
             }
         }
 
@@ -514,7 +559,7 @@ mod tests {
         let graph = RecordingGraph::default();
         let stub = StubChainKeys::new([(src_addr, *src_offchain.public()), (dst_addr, *dst_offchain.public())]);
 
-        // price=10, win_prob=1.0, balance=100 → capacity = 100/(10/1.0) = 10
+        // The balance is emitted as-is; pricing no longer enters the per-edge value.
         run(
             vec![ChainEvent::ChannelOpened(channel(
                 src_addr,
@@ -533,7 +578,7 @@ mod tests {
 
         let edges = graph.edges();
         assert_eq!(edges.len(), 1);
-        assert_eq!(edges[0].capacity, Some(10));
+        assert_eq!(edges[0].balance, Some(hopr_api::graph::traits::Balance::from(100u64)));
         assert_eq!(edges[0].src, *src_offchain.public());
         assert_eq!(edges[0].dest, *dst_offchain.public());
     }
@@ -548,7 +593,7 @@ mod tests {
         let graph = RecordingGraph::default();
         let stub = StubChainKeys::new([(src_addr, *src_offchain.public()), (dst_addr, *dst_offchain.public())]);
 
-        // price=10, win_prob=1.0, balance=50 after decrease → capacity = 50/10 = 5
+        // The decreased balance is emitted as-is.
         run(
             vec![ChainEvent::ChannelBalanceDecreased(
                 channel(src_addr, dst_addr, 50, ChannelStatus::Open),
@@ -565,7 +610,7 @@ mod tests {
 
         let edges = graph.edges();
         assert_eq!(edges.len(), 1);
-        assert_eq!(edges[0].capacity, Some(5));
+        assert_eq!(edges[0].balance, Some(hopr_api::graph::traits::Balance::from(50u64)));
     }
 
     #[tokio::test]
@@ -596,7 +641,7 @@ mod tests {
 
         let edges = graph.edges();
         assert_eq!(edges.len(), 1);
-        assert_eq!(edges[0].capacity, None);
+        assert_eq!(edges[0].balance, None);
     }
 
     /// Regression test: before the fix, ChannelClosureInitiated was a no-op and the
@@ -631,13 +676,13 @@ mod tests {
         let edges = graph.edges();
         assert_eq!(edges.len(), 1, "closure-initiated must emit a graph update");
         assert_eq!(
-            edges[0].capacity, None,
-            "closure-initiated must zero out the capacity so routing stops using this edge"
+            edges[0].balance, None,
+            "closure-initiated must clear the balance so routing stops using this edge"
         );
     }
 
     #[tokio::test]
-    async fn ticket_price_change_affects_subsequent_capacity() {
+    async fn ticket_price_change_pushes_a_new_face_value() {
         let (src_offchain, src_chain) = make_keypairs();
         let (dst_offchain, dst_chain) = make_keypairs();
         let src_addr = src_chain.public().to_address();
@@ -646,7 +691,7 @@ mod tests {
         let graph = RecordingGraph::default();
         let stub = StubChainKeys::new([(src_addr, *src_offchain.public()), (dst_addr, *dst_offchain.public())]);
 
-        // initial price=10; after price change to 20, balance=200 → 200/(20/1.0) = 10
+        // A price change recomputes the face value: 20 / 1.0 = 20. The balance is untouched.
         run(
             vec![
                 ChainEvent::TicketPriceChanged(HoprBalance::from(20u64)),
@@ -661,13 +706,26 @@ mod tests {
         )
         .await;
 
+        assert_eq!(
+            graph.face_values(),
+            vec![
+                hopr_api::graph::traits::Balance::from(10u64),
+                hopr_api::graph::traits::Balance::from(20u64),
+            ],
+            "the seeded face value, then the one recomputed from the price change"
+        );
+
         let edges = graph.edges();
         assert_eq!(edges.len(), 1);
-        assert_eq!(edges[0].capacity, Some(10));
+        assert_eq!(
+            edges[0].balance,
+            Some(hopr_api::graph::traits::Balance::from(200u64)),
+            "the emitted balance must not depend on the price"
+        );
     }
 
     #[tokio::test]
-    async fn win_probability_change_affects_subsequent_capacity() -> anyhow::Result<()> {
+    async fn win_probability_change_pushes_a_new_face_value() -> anyhow::Result<()> {
         let (src_offchain, src_chain) = make_keypairs();
         let (dst_offchain, dst_chain) = make_keypairs();
         let src_addr = src_chain.public().to_address();
@@ -676,7 +734,7 @@ mod tests {
         let graph = RecordingGraph::default();
         let stub = StubChainKeys::new([(src_addr, *src_offchain.public()), (dst_addr, *dst_offchain.public())]);
 
-        // initial win_prob=1.0; after decrease to 0.5, balance=100, price=10 → 100/(10/0.5) = 5
+        // A winning-probability change recomputes the face value: 10 / 0.5 = 20.
         let new_prob = WinningProbability::try_from_f64(0.5).context("0.5 is a valid winning probability")?;
         run(
             vec![
@@ -692,10 +750,61 @@ mod tests {
         )
         .await;
 
+        assert_eq!(
+            graph.face_values(),
+            vec![
+                hopr_api::graph::traits::Balance::from(10u64),
+                hopr_api::graph::traits::Balance::from(20u64),
+            ],
+            "the seeded face value, then the one recomputed from the probability change"
+        );
+
         let edges = graph.edges();
         assert_eq!(edges.len(), 1);
-        assert_eq!(edges[0].capacity, Some(5));
+        assert_eq!(
+            edges[0].balance,
+            Some(hopr_api::graph::traits::Balance::from(100u64)),
+            "the emitted balance must not depend on the winning probability"
+        );
         Ok(())
+    }
+
+    /// Startup replays on-chain state as channel events, and a pricing event follows only if the
+    /// price actually changed. Without a seed the graph would then hold balances while
+    /// `ticket_face_value()` was still `None`, and selection would price every path off the
+    /// fallback for as long as the price happened to stay put.
+    #[tokio::test]
+    async fn a_face_value_is_seeded_before_any_pricing_event() {
+        let (src_offchain, src_chain) = make_keypairs();
+        let (dst_offchain, dst_chain) = make_keypairs();
+        let src_addr = src_chain.public().to_address();
+        let dst_addr = dst_chain.public().to_address();
+
+        let graph = RecordingGraph::default();
+        let stub = StubChainKeys::new([(src_addr, *src_offchain.public()), (dst_addr, *dst_offchain.public())]);
+
+        // Only a channel event: exactly the startup replay, with no price or probability change.
+        run(
+            vec![ChainEvent::ChannelOpened(channel(
+                src_addr,
+                dst_addr,
+                200,
+                ChannelStatus::Open,
+            ))],
+            stub,
+            graph.clone(),
+            src_addr,
+            *src_offchain.public(),
+            HoprBalance::from(10u64),
+            WinningProbability::ALWAYS,
+        )
+        .await;
+
+        assert_eq!(
+            graph.face_values(),
+            vec![hopr_api::graph::traits::Balance::from(10u64)],
+            "the graph must know the price before it records a balance it will be compared against"
+        );
     }
 
     #[tokio::test]

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -159,6 +159,19 @@ pub struct HoprSessionClientConfig {
     /// the tail-tolerance bundle. Only meaningful on a reliable (`RetransmissionAck`) session.
     #[default(None)]
     pub flow_control: Option<FlowControlConfig>,
+    /// Abandon the frame due next once the sequence has advanced this far past it, instead of
+    /// holding everything already received for the whole frame timeout.
+    ///
+    /// Head-of-line bound for this session's incoming direction. `None` inherits the node's
+    /// setting, `Some(0)` disables it here, `Some(n)` sets it.
+    ///
+    /// Worth setting per session because the right value tracks reordering depth -- throughput x
+    /// latency spread / frame size -- which is a property of the traffic, not of the node: a bulk
+    /// data session and a control session on the same node differ by orders of magnitude.
+    ///
+    /// Has no effect on a session carrying a retransmission capability, where a missing frame can
+    /// still be recovered and waiting for it is productive.
+    pub max_frames_behind_gap: Option<usize>,
 }
 
 /// Session client configuration for explicit intermediate-path routing.
@@ -183,6 +196,8 @@ pub struct HoprSessionClientExplicitPathConfig {
     pub always_max_out_surbs: bool,
     /// Opt-in client-side send-window flow control for this session (`None` = unpaced).
     pub flow_control: Option<FlowControlConfig>,
+    /// As [`HoprSessionClientConfig::max_frames_behind_gap`].
+    pub max_frames_behind_gap: Option<usize>,
 }
 
 #[cfg(all(feature = "session-client", feature = "explicit-path"))]
@@ -197,6 +212,7 @@ impl Default for HoprSessionClientExplicitPathConfig {
             surb_management: Some(SurbBalancerConfig::default()),
             always_max_out_surbs: false,
             flow_control: None,
+            max_frames_behind_gap: None,
         }
     }
 }
@@ -212,6 +228,7 @@ impl From<HoprSessionClientConfig> for hopr_transport::SessionClientConfig {
             surb_management: value.surb_management,
             always_max_out_surbs: value.always_max_out_surbs,
             flow_control: value.flow_control,
+            max_frames_behind_gap: value.max_frames_behind_gap,
         }
     }
 }
@@ -234,6 +251,7 @@ impl TryFrom<HoprSessionClientExplicitPathConfig> for hopr_transport::SessionCli
             surb_management: value.surb_management,
             always_max_out_surbs: value.always_max_out_surbs,
             flow_control: value.flow_control,
+            max_frames_behind_gap: value.max_frames_behind_gap,
         })
     }
 }
@@ -897,9 +915,16 @@ mod tests {
             surb_management: None,
             always_max_out_surbs: false,
             flow_control: None,
+            max_frames_behind_gap: Some(8),
         })
         .context("explicit path config conversion must succeed")?;
 
+        assert_eq!(
+            cfg.max_frames_behind_gap,
+            Some(8),
+            "the session's head-of-line bound has to survive the conversion, or it silently reverts to the node \
+             default"
+        );
         assert!(matches!(
             cfg.forward_path_options,
             hopr_transport::RoutingOptions::IntermediatePath(_)

--- a/hopr/hopr-lib/src/testing/fixtures.rs
+++ b/hopr/hopr-lib/src/testing/fixtures.rs
@@ -203,6 +203,7 @@ impl ClusterGuard {
                     surb_management,
                     always_max_out_surbs: false,
                     flow_control: None,
+                    max_frames_behind_gap: None,
                 },
             )
             .timeout(futures_time::time::Duration::from(timeout))
@@ -251,6 +252,7 @@ impl ClusterGuard {
                     surb_management: Some(SurbBalancerConfig::default()),
                     always_max_out_surbs: false,
                     flow_control: None,
+                    max_frames_behind_gap: None,
                 },
             )
             .timeout(futures_time::time::Duration::from(timeout))

--- a/hopr/hopr-lib/tests/transport_p2p-size3.rs
+++ b/hopr/hopr-lib/tests/transport_p2p-size3.rs
@@ -140,7 +140,10 @@ async fn probe_warmup_should_populate_graph_edges_for_all_peers(cluster: &Cluste
             node.inner()
                 .transport()
                 .network_peer_observations(peer)
-                .and_then(|obs| obs.immediate_qos().map(|imm| imm.average_probe_rate() > 0.0))
+                .and_then(|obs| {
+                    obs.immediate_qos()
+                        .map(|imm| imm.average_probe_rate().is_some_and(|r| r > 0.0))
+                })
                 .unwrap_or(false)
         });
         if scored_all {
@@ -157,7 +160,13 @@ async fn probe_warmup_should_populate_graph_edges_for_all_peers(cluster: &Cluste
             .network_peer_observations(peer)
             .context("peer should have observations in the graph")?;
 
-        assert!(obs.score() > 0.0, "score should be positive for {peer}");
+        // `score` is `Option<f64>` since hopr-api 2.0.0: `None` is unobserved, `Some(0.0)` is
+        // measured and unusable. A probed neighbour must be the former of neither.
+        assert!(
+            obs.score().is_some_and(|score| score > 0.0),
+            "score should be observed and positive for {peer}, got {:?}",
+            obs.score()
+        );
     }
 
     Ok(())
@@ -184,7 +193,11 @@ async fn all_network_peers_should_return_scored_entries(cluster: &ClusterGuard) 
             .all_network_peers(0.0)
             .await
             .context("failed to get all network peers")?;
-        if all_peers.len() >= expected_count && all_peers.iter().all(|(_, obs)| obs.score() > 0.0) {
+        if all_peers.len() >= expected_count
+            && all_peers
+                .iter()
+                .all(|(_, obs)| obs.score().is_some_and(|score| score > 0.0))
+        {
             break;
         }
         sleep(Duration::from_secs(2)).await;
@@ -193,7 +206,11 @@ async fn all_network_peers_should_return_scored_entries(cluster: &ClusterGuard) 
     assert!(!all_peers.is_empty(), "should have at least one peer with score > 0");
 
     for (peer_id, obs) in &all_peers {
-        assert!(obs.score() > 0.0, "peer {peer_id} score should be positive");
+        assert!(
+            obs.score().is_some_and(|score| score > 0.0),
+            "peer {peer_id} score should be observed and positive, got {:?}",
+            obs.score()
+        );
         assert!(
             obs.last_update().as_millis() > 0,
             "peer {peer_id} should have a last_update timestamp"

--- a/hopr/hopr-lib/tests/transport_session-size3.rs
+++ b/hopr/hopr-lib/tests/transport_session-size3.rs
@@ -41,6 +41,7 @@ async fn test_keep_alive_session(cluster: &ClusterGuard) -> anyhow::Result<()> {
                 surb_management: None,
                 always_max_out_surbs: false,
                 flow_control: None,
+                max_frames_behind_gap: None,
             },
         )
         .await?;

--- a/protocols/hopr/Cargo.toml
+++ b/protocols/hopr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-protocol-hopr"
-version = "6.0.0"
+version = "6.1.0"
 description = "Contains implementation of the HOPR protocol as specified in RFC-0004 & RFC-0005"
 edition.workspace = true
 license.workspace = true

--- a/protocols/hopr/src/lib.rs
+++ b/protocols/hopr/src/lib.rs
@@ -10,7 +10,7 @@ pub(crate) mod utils;
 
 pub use codec::{HoprCodecConfig, HoprDecoder, HoprEncoder, MAX_ACKNOWLEDGEMENTS_BATCH_SIZE};
 pub use errors::*;
-pub use surb_store::{MemorySurbStore, SurbPopOrder, SurbStoreConfig};
+pub use surb_store::{MINIMUM_SURB_LIFETIME, MemorySurbStore, SurbPopOrder, SurbStoreConfig};
 pub use tbf::TagBloomFilter;
 pub use ticket_processing::{HoprUnacknowledgedTicketProcessor, HoprUnacknowledgedTicketProcessorConfig};
 pub use traits::*;

--- a/protocols/hopr/src/surb_store.rs
+++ b/protocols/hopr/src/surb_store.rs
@@ -7,7 +7,11 @@ use validator::ValidationError;
 
 use crate::{FoundSurb, traits::SurbStore};
 
-const MINIMUM_SURB_LIFETIME: Duration = Duration::from_secs(30);
+/// Lower bound on [`SurbStoreConfig::pseudonyms_lifetime`], enforced by the config validator.
+///
+/// Public so that callers applying their own override can floor it identically, rather than
+/// reaching a value the config file itself would have been rejected for.
+pub const MINIMUM_SURB_LIFETIME: Duration = Duration::from_secs(30);
 const MINIMUM_OPENER_PSEUDONYMS: usize = 1000;
 const MINIMUM_OPENERS_PER_PSEUDONYM: usize = 1000;
 const MINIMUM_SURBS_PER_PSEUDONYM: usize = 1000;

--- a/protocols/session/Cargo.toml
+++ b/protocols/session/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-protocol-session"
 description = "Contains implementation of Session protocol according to HOPR RFC-0008"
-version = "1.4.0"
+version = "1.5.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/protocols/session/src/processing/mod.rs
+++ b/protocols/session/src/processing/mod.rs
@@ -17,7 +17,7 @@ pub(crate) mod types;
 
 pub(crate) use reassembly::ReassemblerExt;
 pub(crate) use segmenter::SegmenterExt;
-pub(crate) use sequencer::SequencerExt;
+pub(crate) use sequencer::{SequencerConfig, SequencerExt};
 
 #[cfg(test)]
 mod tests {

--- a/protocols/session/src/processing/sequencer.rs
+++ b/protocols/session/src/processing/sequencer.rs
@@ -92,6 +92,9 @@ pub struct Sequencer<S: futures::Stream> {
     /// Anti-bufferbloat bound: items buffered longer than this are dropped, not emitted, so a
     /// stall shows up as loss rather than a latency tail. `None` disables it.
     max_item_age: Option<Duration>,
+    /// Head-of-line bound: abandon the frame due next once the sequence has advanced this far
+    /// past it, rather than holding everything for `max_wait`. `None` disables it.
+    max_frames_behind_gap: Option<usize>,
     state: State,
 }
 
@@ -104,7 +107,13 @@ where
     ///
     /// The `frame_size` value will be clamped into the `[C, (C - SessionMessage::SEGMENT_OVERHEAD) * SeqIndicator::MAX
     /// + 1]` interval.
-    fn new(inner: S, max_wait: Duration, capacity: usize, max_item_age: Option<Duration>) -> Self {
+    fn new(
+        inner: S,
+        max_wait: Duration,
+        capacity: usize,
+        max_item_age: Option<Duration>,
+        max_frames_behind_gap: Option<usize>,
+    ) -> Self {
         assert!(capacity > 0, "capacity should be positive");
         Self {
             inner,
@@ -114,6 +123,10 @@ where
             last_emitted: Instant::now(),
             max_wait,
             max_item_age: max_item_age.filter(|age| !age.is_zero()),
+            // Zero would abandon the frame due next before anything had arrived to justify it,
+            // turning every momentary gap into loss. One later frame is the strictest evidence
+            // that still *is* evidence.
+            max_frames_behind_gap: max_frames_behind_gap.map(|n| n.max(1)),
             state: State::Polling,
         }
     }
@@ -230,6 +243,24 @@ where
                             return Poll::Ready(this.buffer.pop().map(|item| Ok(item.0.item)));
                         } else if this.last_emitted.elapsed() >= *this.max_wait
                             || this.buffer.len() == this.buffer.capacity()
+                            // The sequence has moved far enough past the gap to conclude the
+                            // missing frame was lost rather than reordered. Waiting out `max_wait`
+                            // cannot change that verdict, and on a session with no retransmission
+                            // nothing else can either.
+                            || this.max_frames_behind_gap.is_some_and(|n| {
+                                // Two readings of the same evidence, because each is blind where
+                                // the other sees. The count catches a run of frames arriving
+                                // behind the gap. The distance catches the case that actually
+                                // dominates under loss: the frames in between never completed, so
+                                // they never reach the sequencer and the buffer stays nearly
+                                // empty however far the sender has moved on.
+                                this.buffer.len() >= n
+                                    // Saturating, not `as`: the bound is configuration, and a value past `FrameId`'s
+                                // range would wrap into a small threshold rather than a large one.
+                                || next.gt(&this.next_id.saturating_add(
+                                    FrameId::try_from(n).unwrap_or(FrameId::MAX).saturating_sub(1),
+                                ))
+                            })
                         {
                             let discarded = *this.next_id;
                             *this.next_id = this.next_id.wrapping_add(1);
@@ -280,6 +311,32 @@ where
     }
 }
 
+/// How a [`Sequencer`] decides to stop waiting for a frame that has not arrived.
+///
+/// Grouped rather than passed positionally: the two stopping rules below answer different
+/// questions, and a bare list of `Duration`/`Option<usize>` arguments at the call site gives no
+/// hint which is which.
+#[derive(Clone, Copy, Debug)]
+pub struct SequencerConfig {
+    /// Longest the frame due next is waited for before it is abandoned.
+    pub max_wait: Duration,
+    /// Maximum number of buffered items.
+    pub capacity: usize,
+    /// Discards items buffered longer than this instead of emitting them late; `None` disables.
+    pub max_item_age: Option<Duration>,
+    /// Abandons the frame due next once this many later frames are already waiting behind it.
+    ///
+    /// `None` waits out [`Self::max_wait`] regardless of how much has piled up, which is correct
+    /// only when the missing frame can still be recovered. On a session without retransmission it
+    /// cannot: the wait is for something that is never coming, and everything already received is
+    /// held behind it for the full duration.
+    ///
+    /// Counting later frames rather than watching a clock makes the decision on evidence. One or
+    /// two frames arriving ahead is ordinary reordering across paths of differing latency; a queue
+    /// building up behind a gap is a frame that was lost.
+    pub max_frames_behind_gap: Option<usize>,
+}
+
 /// Stream extensions methods for item sequencing.
 pub trait SequencerExt: futures::Stream {
     /// Attaches a [`Sequencer`] to the underlying stream, given the item `timeout` and `capacity`
@@ -289,7 +346,7 @@ pub trait SequencerExt: futures::Stream {
         Self::Item: Ord + PartialOrd<FrameId>,
         Self: Sized,
     {
-        Sequencer::new(self, timeout, capacity, None)
+        Sequencer::new(self, timeout, capacity, None, None)
     }
 
     /// As [`SequencerExt::sequencer`], but discards items buffered longer than `max_item_age`
@@ -304,7 +361,22 @@ pub trait SequencerExt: futures::Stream {
         Self::Item: Ord + PartialOrd<FrameId>,
         Self: Sized,
     {
-        Sequencer::new(self, timeout, capacity, max_item_age)
+        Sequencer::new(self, timeout, capacity, max_item_age, None)
+    }
+
+    /// As [`SequencerExt::sequencer`], with every stopping rule stated explicitly.
+    fn sequencer_with(self, cfg: SequencerConfig) -> Sequencer<Self>
+    where
+        Self::Item: Ord + PartialOrd<FrameId>,
+        Self: Sized,
+    {
+        Sequencer::new(
+            self,
+            cfg.max_wait,
+            cfg.capacity,
+            cfg.max_item_age,
+            cfg.max_frames_behind_gap,
+        )
     }
 }
 
@@ -423,6 +495,175 @@ mod tests {
         seq_sink.send(3u32).await?;
         assert_eq!(Some(3), seq_stream.try_next().await?);
 
+        Ok(())
+    }
+
+    /// Frames waiting behind a gap must not be held for `max_wait`.
+    ///
+    /// This is the head-of-line stall, measured on a live cluster: with `max_wait` at 3 s a
+    /// session returning 98.5 % of its bytes over the wire delivered 0.60 % of them to the
+    /// application, and the application-side inter-arrival median sat exactly on the timeout. On a
+    /// session with no retransmission the missing frame is never coming, so every second of that
+    /// wait is spent on an outcome that cannot change while the frames already received are held.
+    #[test_log::test(tokio::test)]
+    async fn sequencer_should_abandon_a_gap_once_enough_later_frames_are_waiting() -> anyhow::Result<()> {
+        // Far longer than the test should take, so any reliance on the timer trips the bound below
+        // rather than becoming a matter of tuning margins.
+        let max_wait = Duration::from_secs(5);
+        let (mut seq_sink, seq_stream) = futures::channel::mpsc::unbounded();
+
+        // Frame 1 never arrives.
+        for v in [2u32, 3, 4] {
+            seq_sink.feed(v).await?;
+        }
+        seq_sink.flush().await?;
+
+        let seq_stream = seq_stream.sequencer_with(SequencerConfig {
+            max_wait,
+            capacity: 4096,
+            max_item_age: None,
+            max_frames_behind_gap: Some(2),
+        });
+        pin_mut!(seq_stream);
+
+        // The bound is the assertion: without the rule the sequencer holds everything for the full
+        // `max_wait`, so a regression trips the timeout instead of blocking the suite for 5 s.
+        let released: Vec<u32> = tokio::time::timeout(max_wait / 2, async {
+            assert!(
+                matches!(seq_stream.try_next().await, Err(SessionError::FrameDiscarded(1))),
+                "the gap must be reported as loss, the signal the consumer already handles"
+            );
+            seq_stream.by_ref().take(3).try_collect().await
+        })
+        .await
+        .map_err(|_| anyhow::anyhow!("frames already received waited on a frame that is never coming"))??;
+
+        assert_eq!(vec![2, 3, 4], released, "everything behind the gap must follow it out");
+
+        // Held open deliberately: closing the sink would drain the buffer through `State::Done`,
+        // which has its own emit path and would pass this test without the rule under test.
+        drop(seq_sink);
+        Ok(())
+    }
+
+    /// Under real loss the frames between the gap and the newest arrival mostly never complete, so
+    /// they never reach the sequencer at all and the buffer stays nearly empty. A rule counting
+    /// buffered frames then never fires and the timeout takes over — which is exactly what a
+    /// cluster showed: at an identical setting the scenario delivered 95–97 % on some runs and
+    /// 0.5 % on others, the failing ones with an application-side inter-arrival median sitting
+    /// back on the 3 s timeout.
+    ///
+    /// What is available regardless is how far the sequence has advanced past the gap. One frame
+    /// arriving at id 40 says as much about frame 1 as forty buffered frames would.
+    #[test_log::test(tokio::test)]
+    async fn sequencer_should_abandon_a_gap_when_the_sequence_has_advanced_past_it() -> anyhow::Result<()> {
+        let max_wait = Duration::from_secs(5);
+        let (mut seq_sink, seq_stream) = futures::channel::mpsc::unbounded();
+
+        // Frame 1 is missing and frames 2..=39 never completed, so only one frame is buffered --
+        // far below any count-based threshold, yet the sequence has clearly moved on.
+        seq_sink.feed(40u32).await?;
+        seq_sink.flush().await?;
+
+        let seq_stream = seq_stream.sequencer_with(SequencerConfig {
+            max_wait,
+            capacity: 4096,
+            max_item_age: None,
+            max_frames_behind_gap: Some(4),
+        });
+        pin_mut!(seq_stream);
+
+        // Only the frames that the sequence has genuinely left behind. The last `n - 1` before the
+        // newest arrival are still inside the reordering window -- the sequence has not advanced
+        // far enough past *them* to call them lost -- so they keep the timeout, which is the
+        // conservative half of the same rule.
+        let now = Instant::now();
+        for expected_gap in 1..=36u32 {
+            assert!(
+                matches!(
+                    seq_stream.try_next().await,
+                    Err(SessionError::FrameDiscarded(id)) if id == expected_gap
+                ),
+                "frame {expected_gap} is behind the advanced sequence and must be given up on"
+            );
+        }
+        assert!(
+            now.elapsed() < max_wait / 2,
+            "a single frame far ahead is evidence enough, with no frames buffered behind the gap to count; took {:?}",
+            now.elapsed()
+        );
+
+        drop(seq_sink);
+        Ok(())
+    }
+
+    /// The inverse, so the rule cannot become "never wait". Below the threshold the sequencer must
+    /// still hold the gap open — one frame arriving ahead is ordinary reordering across paths of
+    /// differing latency, not a loss.
+    #[test_log::test(tokio::test)]
+    async fn sequencer_should_keep_waiting_while_fewer_frames_are_behind_the_gap() -> anyhow::Result<()> {
+        let max_wait = Duration::from_millis(300);
+        let (mut seq_sink, seq_stream) = futures::channel::mpsc::unbounded();
+
+        // Frame 1 is missing and only one frame is waiting behind it, under the threshold of 3.
+        seq_sink.feed(2u32).await?;
+        seq_sink.flush().await?;
+
+        let seq_stream = seq_stream.sequencer_with(SequencerConfig {
+            max_wait,
+            capacity: 4096,
+            max_item_age: None,
+            max_frames_behind_gap: Some(3),
+        });
+        pin_mut!(seq_stream);
+
+        let now = Instant::now();
+        assert!(matches!(
+            seq_stream.try_next().await,
+            Err(SessionError::FrameDiscarded(1))
+        ));
+        assert!(
+            now.elapsed() >= max_wait,
+            "under the threshold the timeout still governs; took {:?}",
+            now.elapsed()
+        );
+
+        drop(seq_sink);
+        Ok(())
+    }
+
+    /// A session that *can* recover a missing frame must be unaffected: `None` keeps the timeout
+    /// as the only rule, however much piles up behind the gap.
+    #[test_log::test(tokio::test)]
+    async fn sequencer_without_the_gap_bound_should_still_wait_for_the_timeout() -> anyhow::Result<()> {
+        let max_wait = Duration::from_millis(300);
+        let (mut seq_sink, seq_stream) = futures::channel::mpsc::unbounded();
+
+        for v in [2u32, 3, 4, 5, 6] {
+            seq_sink.feed(v).await?;
+        }
+        seq_sink.flush().await?;
+
+        let seq_stream = seq_stream.sequencer_with(SequencerConfig {
+            max_wait,
+            capacity: 4096,
+            max_item_age: None,
+            max_frames_behind_gap: None,
+        });
+        pin_mut!(seq_stream);
+
+        let now = Instant::now();
+        assert!(matches!(
+            seq_stream.try_next().await,
+            Err(SessionError::FrameDiscarded(1))
+        ));
+        assert!(
+            now.elapsed() >= max_wait,
+            "with no gap bound the timeout is the only rule; took {:?}",
+            now.elapsed()
+        );
+
+        drop(seq_sink);
         Ok(())
     }
 

--- a/protocols/session/src/socket/mod.rs
+++ b/protocols/session/src/socket/mod.rs
@@ -87,6 +87,21 @@ pub struct SessionSocketConfig {
     /// latency tail this bound exists to remove.
     #[default(None)]
     pub max_frame_age: Option<Duration>,
+    /// Abandon the frame due next once this many later frames are already waiting behind it,
+    /// instead of holding them for [`Self::frame_timeout`].
+    ///
+    /// Head-of-line bound. `frame_timeout` waits for a frame that may still arrive; this bounds
+    /// how much already-received data is held hostage while that wait runs. On a session without
+    /// retransmission the missing frame is never coming, so the wait is pure cost: measured on a
+    /// cluster, 98.5% of bytes returned over the wire while 0.60% reached the application and the
+    /// application-side inter-arrival median sat exactly on the timeout.
+    ///
+    /// Counting frames rather than watching a clock decides on evidence -- a queue building up
+    /// behind a gap is a lost frame, where one or two frames ahead is ordinary reordering. The
+    /// right value tracks reordering depth, which is throughput x latency spread, so it is
+    /// deployment-specific and meant to be tuned. `None` (default) keeps the previous behaviour.
+    #[default(None)]
+    pub max_frames_behind_gap: Option<usize>,
 }
 
 enum WriteState {
@@ -234,7 +249,12 @@ impl<const C: usize> SessionSocket<C, Stateless<C>> {
                 })
             })
             // Put the frames into the correct sequence by Frame Ids
-            .sequencer_with_max_age(cfg.frame_timeout, cfg.capacity, cfg.max_frame_age)
+            .sequencer_with(crate::processing::SequencerConfig {
+                max_wait: cfg.frame_timeout,
+                capacity: cfg.capacity,
+                max_item_age: cfg.max_frame_age,
+                max_frames_behind_gap: cfg.max_frames_behind_gap,
+            })
             // Discard frames missing from the sequence
             .filter_map(move |maybe_frame| {
                 let _span = stage3_span.enter();
@@ -440,7 +460,12 @@ impl<const C: usize, S: SocketState<C> + Clone + 'static> SessionSocket<C, S> {
                 })
             })
             // Put the frames into the correct sequence by Frame Ids
-            .sequencer_with_max_age(cfg.frame_timeout, cfg.capacity, cfg.max_frame_age)
+            .sequencer_with(crate::processing::SequencerConfig {
+                max_wait: cfg.frame_timeout,
+                capacity: cfg.capacity,
+                max_item_age: cfg.max_frame_age,
+                max_frames_behind_gap: cfg.max_frames_behind_gap,
+            })
             // Discard frames missing from the sequence and
             // notify the State about emitted or discarded frames
             .filter_map(move |maybe_frame| {
@@ -1124,6 +1149,102 @@ mod tests {
             insta::assert_yaml_snapshot!(bob_tracker);
         }
 
+        Ok(())
+    }
+
+    /// Drives the head-of-line case end to end over the real socket pipeline.
+    ///
+    /// Segment 0 is dropped, so frame 1 can never be completed, and the sender is deliberately
+    /// left **open**: closing it would drain the sequencer through `State::Done`, which discards
+    /// missing frames immediately and would hide the very stall under test. Returns how long the
+    /// surviving frames took to arrive, and asserts they arrived intact.
+    async fn time_delivery_behind_a_lost_frame(max_frames_behind_gap: Option<usize>) -> anyhow::Result<Duration> {
+        // hoprd's production value, chosen to clear the ~2 s SURB KeepAlive.
+        const FRAME_TIMEOUT: Duration = Duration::from_secs(3);
+
+        let (alice, bob) = setup_alice_bob::<MTU>(
+            FaultyNetworkConfig {
+                avg_delay: Duration::from_millis(10),
+                ids_to_drop: HashSet::from_iter([0_usize]),
+                ..Default::default()
+            },
+            None,
+            None,
+        );
+
+        let mut alice_socket = SessionSocket::<MTU, _>::new_stateless(
+            "alice",
+            alice,
+            SessionSocketConfig {
+                frame_size: FRAME_SIZE,
+                ..Default::default()
+            },
+            #[cfg(feature = "telemetry")]
+            TestTelemetryTracker::default(),
+        )?;
+        let mut bob_socket = SessionSocket::<MTU, _>::new_stateless(
+            "bob",
+            bob,
+            SessionSocketConfig {
+                frame_size: FRAME_SIZE,
+                frame_timeout: FRAME_TIMEOUT,
+                max_frames_behind_gap,
+                ..Default::default()
+            },
+            #[cfg(feature = "telemetry")]
+            TestTelemetryTracker::default(),
+        )?;
+
+        let data = hopr_types::crypto_random::random_bytes::<DATA_SIZE>();
+        alice_socket
+            .write_all(&data)
+            .timeout(futures_time::time::Duration::from_secs(2))
+            .await??;
+        alice_socket.flush().await?;
+
+        // Everything except the lost first frame.
+        let mut received = vec![0u8; DATA_SIZE - FRAME_SIZE];
+        let started = std::time::Instant::now();
+        bob_socket
+            .read_exact(&mut received)
+            .timeout(futures_time::time::Duration::from_secs(20))
+            .await??;
+        let elapsed = started.elapsed();
+
+        assert_eq!(
+            &data[FRAME_SIZE..],
+            &received,
+            "the frames that did arrive must be delivered intact, whenever they are released"
+        );
+
+        alice_socket.close().await?;
+        bob_socket.close().await?;
+        Ok(elapsed)
+    }
+
+    /// The fix, at the socket level: frames behind an unfillable gap are released on the evidence
+    /// that later frames are queued, not after the frame timeout has run its course.
+    #[test_log::test(tokio::test)]
+    async fn stateless_socket_should_release_frames_behind_a_gap_without_waiting_for_the_timeout() -> anyhow::Result<()>
+    {
+        let elapsed = time_delivery_behind_a_lost_frame(Some(2)).await?;
+        assert!(
+            elapsed < Duration::from_secs(1),
+            "frames already received must not wait on a frame that cannot arrive; took {elapsed:?}"
+        );
+        Ok(())
+    }
+
+    /// The witness for the test above: with the bound disabled, the same loss on the same pipeline
+    /// stalls for the whole frame timeout. Without this, a fast run could be crediting the fix for
+    /// something the network or the harness was doing anyway.
+    #[test_log::test(tokio::test)]
+    async fn stateless_socket_without_the_gap_bound_should_stall_for_the_whole_frame_timeout() -> anyhow::Result<()> {
+        let elapsed = time_delivery_behind_a_lost_frame(None).await?;
+        assert!(
+            elapsed >= Duration::from_secs(3),
+            "the unbounded path is what the fix removes; it must still be observable here, took {elapsed:?}"
+        );
         Ok(())
     }
 

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport"
 description = "Implements the main HOPR transport interface for the core library"
-version = "0.45.0"
+version = "0.48.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"
@@ -142,6 +142,9 @@ hex-literal = { workspace = true }
 insta = { workspace = true, features = ["yaml"] }
 hopr-utils = { workspace = true, features = ["runtime-tokio"] }
 rstest = { workspace = true }
+# Only for the config round-trip test: the same YAML reader hoprd parses its config file with, so
+# the test exercises the form an operator would actually write.
+serde-saphyr = { workspace = true }
 serial_test = { workspace = true }
 test-log = { workspace = true }
 

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport"
 description = "Implements the main HOPR transport interface for the core library"
-version = "0.44.0"
+version = "0.45.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/hopr/src/config.rs
+++ b/transport/hopr/src/config.rs
@@ -512,6 +512,10 @@ fn default_session_surb_balance_notify_period() -> Option<Duration> {
     Some(Duration::from_secs(15))
 }
 
+fn default_session_max_frames_behind_gap() -> Option<usize> {
+    Some(256)
+}
+
 fn validate_session_idle_timeout(value: &Duration) -> Result<(), ValidationError> {
     if SESSION_IDLE_MIN_TIMEOUT <= *value {
         Ok(())
@@ -635,6 +639,20 @@ pub struct SessionGlobalConfig {
         )
     )]
     pub surb_balance_notify_period: Option<Duration>,
+
+    /// How many later frames may queue behind a missing one before the reassembler gives up on it
+    /// and releases what it already has.
+    ///
+    /// Only applies to Sessions without retransmission, where a missing frame is never coming and
+    /// waiting out the frame timeout cannot change the outcome — it only holds everything behind
+    /// it. The right value tracks reordering depth (throughput × latency spread ÷ frame size), so
+    /// a bulk-data Session and a control Session on the same node differ by orders of magnitude;
+    /// an individual Session may override it.
+    ///
+    /// Default is 256. Set to `null` to disable the bound and wait out the frame timeout instead.
+    #[default(default_session_max_frames_behind_gap())]
+    #[cfg_attr(feature = "serde", serde(default = "default_session_max_frames_behind_gap"))]
+    pub max_frames_behind_gap: Option<usize>,
 
     /// Tag allocator partition configuration.
     #[validate(nested)]

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -59,7 +59,6 @@ use hopr_api::{
     network::{BoxedProcessFn, NetworkStreamControl},
     types::primitive::prelude::*,
 };
-use hopr_crypto_packet::prelude::PacketSignal;
 pub use hopr_protocol_app::prelude::{ApplicationData, ApplicationDataIn, ApplicationDataOut, Tag};
 pub use hopr_protocol_hopr::{MemorySurbStore, SurbStore};
 pub use hopr_transport_probe::{NeighborTelemetry, PathTelemetry, errors::ProbeError, ping::PingQueryReplier};
@@ -88,7 +87,7 @@ use hopr_utils::{
     runtime::AbortableList,
 };
 pub use multiaddr::Protocol;
-use tracing::{Instrument, debug, error, trace, warn};
+use tracing::{debug, warn};
 
 #[cfg(feature = "runtime-tokio")]
 use crate::path::BackgroundPathCacheRefreshable;
@@ -322,11 +321,28 @@ where
         let probing_tag_allocator =
             probing_tag_allocator.ok_or_else(|| HoprTransportError::Api("probing tag allocator missing".into()))?;
 
+        // A pseudonym's SURB ring buffer is dropped once no SURBs have arrived for
+        // `pseudonyms_lifetime` (600 s by default), which is the point at which that pseudonym's
+        // return path becomes permanently unresolvable. Nothing else in the node can be made to
+        // reach that state on a test timescale — the Session slot is evicted for idleness long
+        // before it — so without a way to shorten this timer, the behaviour past it is not
+        // observable end-to-end at all. Floored at the same `MINIMUM_SURB_LIFETIME` the config
+        // validator enforces, so this cannot reach a value the config file could not also express.
+        let surb_store_cfg = hopr_protocol_hopr::SurbStoreConfig {
+            pseudonyms_lifetime: std::env::var("HOPR_INTERNAL_SURB_PSEUDONYM_LIFETIME_MS")
+                .ok()
+                .and_then(|s| s.trim().parse::<u64>().ok())
+                .map(Duration::from_millis)
+                .map(|d| d.max(hopr_protocol_hopr::MINIMUM_SURB_LIFETIME))
+                .unwrap_or(cfg.packet.surb_store.pseudonyms_lifetime),
+            ..cfg.packet.surb_store
+        };
+
         // Built before the session manager so the latter can be handed the seam that lets a
         // session re-plan its return path on sustained loss.
         let path_planner = PathPlanner::new(
             me_offchain,
-            MemorySurbStore::new(cfg.packet.surb_store),
+            MemorySurbStore::new(surb_store_cfg),
             resolver.clone(),
             selector,
             planner_config,
@@ -710,80 +726,16 @@ where
                 .filter(|&n| n > 0)
                 .unwrap_or(avail)
         };
-        let all_resolved_external_msg_rx = merged_unresolved_output_data
-            .map(move |(unresolved, mut data)| {
+        let all_resolved_external_msg_rx = crate::path::resolve::resolve_routing_stage(
+            merged_unresolved_output_data,
+            move |size_hint, max_surbs, unresolved| {
                 let path_planner = path_planner.clone();
-                async move {
-                    // Retry on SURB starvation: the SURB pool on the exit side
-                    // refills asynchronously (target 600, ~300/sec via keep-alive).
-                    // Silently dropping return-path packets when the pool is
-                    // momentarily empty causes irreversible data loss; instead we
-                    // yield briefly so the pool can replenish before retrying.
-                    //
-                    // We use `map().buffered()` (ordered) rather than `then_concurrent`
-                    // (unordered) so that routing resolution preserves the original
-                    // packet sequence.  Out-of-order delivery to the ENTRY reassembler
-                    // causes the sequencer to discard frames that arrive after
-                    // `frame_timeout`.  The retry loop bounds any head-of-line delay
-                    // to ~5 ms per SURB-arrival cycle, which is far below the 3 s
-                    // frame timeout.
-                    loop {
-                        hopr_transport_session::counters::ROUTING_RESOLUTION_ATTEMPTS
-                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        trace!(?unresolved, "resolving routing for packet");
-                        match path_planner
-                            .resolve_routing(
-                                data.data.total_len(),
-                                data.estimate_surbs_with_msg(),
-                                unresolved.clone(),
-                            )
-                            .await
-                        {
-                            Ok((resolved, rem_surbs)) => {
-                                // Set the SURB distress/out-of-SURBs flag if applicable.
-                                // These flags are translated into HOPR protocol packet signals and are
-                                // applicable only on the return path.
-                                let mut signals_to_dst = data
-                                    .packet_info
-                                    .as_ref()
-                                    .map(|info| info.signals_to_destination)
-                                    .unwrap_or_default();
-
-                                if resolved.is_return() {
-                                    signals_to_dst = match rem_surbs {
-                                        Some(rem) if (1..distress_threshold.max(2)).contains(&rem) => {
-                                            signals_to_dst | PacketSignal::SurbDistress
-                                        }
-                                        Some(0) => signals_to_dst | PacketSignal::OutOfSurbs,
-                                        _ => signals_to_dst - (PacketSignal::OutOfSurbs | PacketSignal::SurbDistress),
-                                    };
-                                } else {
-                                    // Unset these flags as they make no sense on the forward path.
-                                    signals_to_dst -= PacketSignal::SurbDistress | PacketSignal::OutOfSurbs;
-                                }
-
-                                data.packet_info.get_or_insert_default().signals_to_destination = signals_to_dst;
-                                trace!(?resolved, "resolved routing for packet");
-                                return Some((resolved, data));
-                            }
-                            Err(error) if error.is_surb() => {
-                                // No SURB available yet (possibly cache-wrapped); yield briefly so the
-                                // pool can refill.
-                                futures_timer::Delay::new(std::time::Duration::from_millis(5)).await;
-                            }
-                            Err(error) => {
-                                hopr_transport_session::counters::ROUTING_RESOLUTION_FAILURES
-                                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                                error!(%error, "failed to resolve routing");
-                                return None;
-                            }
-                        }
-                    }
-                }
-                .in_current_span()
-            })
-            .buffered(routing_concurrency)
-            .filter_map(futures::future::ready);
+                async move { path_planner.resolve_routing(size_hint, max_surbs, unresolved).await }
+            },
+            distress_threshold,
+            routing_concurrency,
+            crate::path::resolve::surb_resolution_wait(self.cfg.packet.pipeline.surb_resolution_wait),
+        );
 
         let channels_dst = self
             .chain_api

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -351,6 +351,7 @@ where
                     .and_then(|s| s.parse::<u64>().ok().map(Duration::from_millis))
                     .unwrap_or_else(|| SessionManagerConfig::default().max_frame_timeout)
                     .max(Duration::from_millis(100)),
+                max_frames_behind_gap: cfg.session.max_frames_behind_gap,
                 max_buffered_segments: std::env::var("HOPR_SESSION_MAX_BUFFERED_SEGMENTS")
                     .ok()
                     .and_then(|s| s.parse::<usize>().ok())

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -1237,7 +1237,8 @@ where
             .filter_map(|peer| {
                 let observation = self.graph.edge(me, &peer);
                 if let Some(info) = observation {
-                    if info.score() >= minimum_score {
+                    // An unobserved edge has no score and cannot clear any threshold.
+                    if info.score().is_some_and(|score| score >= minimum_score) {
                         Some((peer, info))
                     } else {
                         None

--- a/transport/hopr/src/path/mod.rs
+++ b/transport/hopr/src/path/mod.rs
@@ -11,6 +11,7 @@
 
 pub mod errors;
 pub mod planner;
+pub(crate) mod resolve;
 pub mod selector;
 pub mod traits;
 

--- a/transport/hopr/src/path/planner.rs
+++ b/transport/hopr/src/path/planner.rs
@@ -186,7 +186,7 @@ fn capacity_factor(c: u128, reference: u128) -> f64 {
 /// derived from the per-path aggregates.  Factors are neutral (1.0) when the
 /// corresponding aggregate is unavailable to avoid penalising unprobed paths.
 /// For 0-hop routes (`hops == 0`) the capacity factor is always 1.0 — direct
-/// `me -> dest` packets use no payment channel, so `capacity_floor = None` is expected.
+/// `me -> dest` packets use no payment channel, so `fundable_tickets_floor = None` is expected.
 fn composite_weight(pwc: &PathWithMetrics, hops: usize, params: WeightingParams) -> f64 {
     let lat = pwc
         .total_latency_ms
@@ -195,7 +195,7 @@ fn composite_weight(pwc: &PathWithMetrics, hops: usize, params: WeightingParams)
     let cap = if hops == 0 {
         1.0
     } else {
-        pwc.capacity_floor
+        pwc.fundable_tickets_floor
             .map(|c| capacity_factor(c, params.capacity_reference))
             .unwrap_or(1.0)
     };
@@ -310,7 +310,7 @@ where
             total_latency_ms = ?pwm.total_latency_ms,
             min_probe_success_rate = ?pwm.min_probe_success_rate,
             min_ack_rate = ?pwm.min_ack_rate,
-            capacity_floor = ?pwm.capacity_floor,
+            fundable_tickets_floor = ?pwm.fundable_tickets_floor,
             "weighted candidate path",
         );
     }
@@ -1128,7 +1128,9 @@ mod tests {
             obs.record(EdgeWeightType::Connected(true));
             obs.record(EdgeWeightType::Immediate(Ok(std::time::Duration::from_millis(50))));
             obs.record(EdgeWeightType::Intermediate(Ok(std::time::Duration::from_millis(50))));
-            obs.record(EdgeWeightType::Capacity(Some(1000)));
+            obs.record(EdgeWeightType::Balance(Some(hopr_api::graph::traits::Balance::from(
+                1000u64,
+            ))));
         });
     }
 
@@ -1916,14 +1918,14 @@ mod tests {
         }
     }
 
-    fn make_pwm(cost: f64, latency_ms: Option<u32>, capacity_floor: Option<u128>) -> PathWithMetrics {
+    fn make_pwm(cost: f64, latency_ms: Option<u32>, fundable_tickets_floor: Option<u128>) -> PathWithMetrics {
         PathWithMetrics {
             path: vec![],
             cost,
             total_latency_ms: latency_ms,
             min_probe_success_rate: None,
             min_ack_rate: None,
-            capacity_floor,
+            fundable_tickets_floor,
         }
     }
 

--- a/transport/hopr/src/path/resolve.rs
+++ b/transport/hopr/src/path/resolve.rs
@@ -1,0 +1,480 @@
+//! The stage that turns a [`DestinationRouting`] into a [`ResolvedTransportRouting`] for every
+//! packet this node originates.
+//!
+//! It sits between the merged outgoing-data stream and the SPHINX encoder, so **every** packet the
+//! node originates passes through it: session payloads, Start-protocol replies, SURB keep-alives,
+//! probes and cover traffic. Forwarded packets and acknowledgements do not — they are relayed from
+//! inside the ingress pipeline and never reach this stage.
+//!
+//! That asymmetry is why this stage deserves its own tests: a fault here silences origination
+//! node-wide while forwarding, acking and receiving carry on looking perfectly healthy.
+
+use futures::{Stream, StreamExt};
+use hopr_api::types::internal::routing::{DestinationRouting, ResolvedTransportRouting};
+use hopr_crypto_packet::prelude::{HoprSurb, PacketSignal};
+use hopr_protocol_app::prelude::ApplicationDataOut;
+use tracing::{Instrument, error, trace, warn};
+
+use super::errors::Result as PathResult;
+
+/// How often a return route whose SURBs have not arrived is retried.
+const SURB_RETRY_INTERVAL: std::time::Duration = std::time::Duration::from_millis(5);
+
+/// Default for [`PacketPipelineConfig::surb_resolution_wait`][cfg], used when it is unset.
+///
+/// A momentary gap is normal — the SURB pool refills asynchronously, and dropping a return packet
+/// on the first miss loses data on a session that was only waiting. That is why the retry exists.
+///
+/// What it must not do is wait indefinitely. When the counterparty is gone no SURB is ever coming,
+/// and because this stage preserves submission order, one such packet withholds every other packet
+/// the node would originate, for the life of the process.
+///
+/// Six seconds is deliberately generous, because this is a *library* default and the useful ceiling
+/// belongs to the caller. A packet held past the session's frame timeout — 3 s for the sessions
+/// hoprd runs — cannot be used by the receiver anyway, so a deployment that knows its own timeout
+/// should configure something tighter, as hoprd does. What a library default must not do is drop a
+/// packet a slower or reliable session would still have made use of, so it errs long and leaves the
+/// tightening to whoever knows the traffic.
+///
+/// [cfg]: crate::protocol::PacketPipelineConfig::surb_resolution_wait
+pub(crate) const DEFAULT_SURB_RESOLUTION_WAIT: std::time::Duration = std::time::Duration::from_secs(6);
+
+/// The wait a node should use, given what its configuration says.
+///
+/// Unset means the default; zero is honoured as "do not wait", which drops a return packet the
+/// first time its SURBs are missing. Kept as one function so both meanings live in one place
+/// rather than being re-derived at the call site.
+pub(crate) fn surb_resolution_wait(configured: Option<std::time::Duration>) -> std::time::Duration {
+    configured.unwrap_or(DEFAULT_SURB_RESOLUTION_WAIT)
+}
+
+/// Resolves the routing of every outgoing packet, emitting the resolved packets in submission
+/// order.
+///
+/// `resolve` is the resolution step itself — in production
+/// [`PathPlanner::resolve_routing`](super::PathPlanner::resolve_routing), taking the payload size
+/// hint, the maximum number of SURBs the packet can carry, and the unresolved routing.
+///
+/// A packet whose routing cannot be resolved is dropped and counted. A packet whose *return* routing
+/// finds no SURB is retried for up to `surb_wait` before being dropped the same way; see
+/// [`DEFAULT_SURB_RESOLUTION_WAIT`] for why that bound has to exist.
+///
+/// Ordering is deliberate: out-of-order delivery to the entry's reassembler makes the sequencer
+/// discard frames that arrive after `frame_timeout`. It is also why an unbounded wait here is fatal
+/// rather than merely slow — [`buffered`](futures::StreamExt::buffered) withholds completed futures
+/// behind an unfinished one, so the stall is node-wide rather than confined to one packet.
+pub(crate) fn resolve_routing_stage<St, F, Fut>(
+    input: St,
+    resolve: F,
+    distress_threshold: usize,
+    concurrency: usize,
+    surb_wait: std::time::Duration,
+) -> impl Stream<Item = (ResolvedTransportRouting<HoprSurb>, ApplicationDataOut)>
+where
+    St: Stream<Item = (DestinationRouting, ApplicationDataOut)>,
+    F: Fn(usize, usize, DestinationRouting) -> Fut + Clone,
+    Fut: Future<Output = PathResult<(ResolvedTransportRouting<HoprSurb>, Option<usize>)>>,
+{
+    input
+        .map(move |(unresolved, mut data)| {
+            let resolve = resolve.clone();
+            async move {
+                // Retry on SURB starvation: the SURB pool on the exit side refills asynchronously
+                // (target 600, ~300/sec via keep-alive). Silently dropping return-path packets when
+                // the pool is momentarily empty causes irreversible data loss; instead we yield
+                // briefly so the pool can replenish before retrying — but only for `surb_wait`,
+                // after which no SURB is coming and continuing to wait costs the node its egress.
+                let deadline = std::time::Instant::now() + surb_wait;
+                loop {
+                    hopr_transport_session::counters::ROUTING_RESOLUTION_ATTEMPTS
+                        .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                    trace!(?unresolved, "resolving routing for packet");
+                    match resolve(
+                        data.data.total_len(),
+                        data.estimate_surbs_with_msg(),
+                        unresolved.clone(),
+                    )
+                    .await
+                    {
+                        Ok((resolved, rem_surbs)) => {
+                            // Set the SURB distress/out-of-SURBs flag if applicable.
+                            // These flags are translated into HOPR protocol packet signals and are
+                            // applicable only on the return path.
+                            let mut signals_to_dst = data
+                                .packet_info
+                                .as_ref()
+                                .map(|info| info.signals_to_destination)
+                                .unwrap_or_default();
+
+                            if resolved.is_return() {
+                                signals_to_dst = match rem_surbs {
+                                    Some(rem) if (1..distress_threshold.max(2)).contains(&rem) => {
+                                        signals_to_dst | PacketSignal::SurbDistress
+                                    }
+                                    Some(0) => signals_to_dst | PacketSignal::OutOfSurbs,
+                                    _ => signals_to_dst - (PacketSignal::OutOfSurbs | PacketSignal::SurbDistress),
+                                };
+                            } else {
+                                // Unset these flags as they make no sense on the forward path.
+                                signals_to_dst -= PacketSignal::SurbDistress | PacketSignal::OutOfSurbs;
+                            }
+
+                            data.packet_info.get_or_insert_default().signals_to_destination = signals_to_dst;
+                            trace!(?resolved, "resolved routing for packet");
+                            return Some((resolved, data));
+                        }
+                        Err(error) if error.is_surb() && std::time::Instant::now() >= deadline => {
+                            hopr_transport_session::counters::ROUTING_RESOLUTION_SURB_TIMEOUTS
+                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            // Warn rather than trace: this is the only externally visible sign that
+                            // a counterparty has stopped replenishing, and the outage it replaces
+                            // was invisible precisely because nothing on this path said anything.
+                            warn!(
+                                ?unresolved,
+                                ?surb_wait,
+                                %error,
+                                "dropping an outgoing packet: no SURB for its return path within the wait"
+                            );
+                            return None;
+                        }
+                        Err(error) if error.is_surb() => {
+                            // No SURB available yet (possibly cache-wrapped); yield briefly so the
+                            // pool can refill.
+                            futures_timer::Delay::new(SURB_RETRY_INTERVAL).await;
+                        }
+                        Err(error) => {
+                            hopr_transport_session::counters::ROUTING_RESOLUTION_FAILURES
+                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            error!(%error, "failed to resolve routing");
+                            return None;
+                        }
+                    }
+                }
+            }
+            .in_current_span()
+        })
+        .buffered(concurrency)
+        .filter_map(futures::future::ready)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
+    use futures_time::future::FutureExt as _;
+    use hopr_api::types::{
+        crypto::{crypto_traits::Randomizable, prelude::*},
+        internal::{
+            path::ValidatedPath,
+            prelude::HoprPseudonym,
+            routing::{RoutingOptions, SurbMatcher},
+        },
+    };
+    use hopr_protocol_app::prelude::{ApplicationData, Tag};
+
+    use super::*;
+    use crate::path::errors::PathPlannerError;
+
+    /// Bound on every test in this module. The stall under test is unbounded, so a test that hits
+    /// this limit has reproduced it rather than merely run slowly.
+    const TEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+    /// The stage's SURB wait, shortened for the tests.
+    ///
+    /// Well clear of [`SURB_RETRY_INTERVAL`] so a retry-then-succeed case has room, and far enough
+    /// below [`TEST_TIMEOUT`] that "the bound fired" and "the test timed out" cannot be confused.
+    const TEST_SURB_WAIT: std::time::Duration = std::time::Duration::from_millis(200);
+
+    const TEST_TAG: u64 = 1234;
+
+    /// Concurrency of the stage under test. Any value ≥ 2 exhibits the ordering behaviour; a small
+    /// one keeps the failure legible.
+    const TEST_CONCURRENCY: usize = 8;
+
+    const TEST_DISTRESS_THRESHOLD: usize = 2;
+
+    /// The stage under test with the test constants applied, so each test differs only in the two
+    /// things that matter to it: what goes in, and what resolution does.
+    fn stage<St, F, Fut>(
+        input: St,
+        resolve: F,
+    ) -> impl Stream<Item = (ResolvedTransportRouting<HoprSurb>, ApplicationDataOut)>
+    where
+        St: Stream<Item = (DestinationRouting, ApplicationDataOut)>,
+        F: Fn(usize, usize, DestinationRouting) -> Fut + Clone,
+        Fut: Future<Output = PathResult<(ResolvedTransportRouting<HoprSurb>, Option<usize>)>>,
+    {
+        resolve_routing_stage(
+            input,
+            resolve,
+            TEST_DISTRESS_THRESHOLD,
+            TEST_CONCURRENCY,
+            TEST_SURB_WAIT,
+        )
+    }
+
+    /// A resolution result the stage accepts. The variant is a forward one because a
+    /// [`ResolvedTransportRouting::Return`] needs a real `HoprSurb`, and no test here depends on
+    /// which variant came back — only on *whether* the packet was emitted.
+    fn resolved() -> ResolvedTransportRouting<HoprSurb> {
+        ResolvedTransportRouting::Forward {
+            pseudonym: HoprPseudonym::random(),
+            forward_path: ValidatedPath::direct(
+                *OffchainKeypair::random().public(),
+                ChainKeypair::random().public().to_address(),
+            ),
+            return_paths: vec![],
+        }
+    }
+
+    fn forward_routing() -> DestinationRouting {
+        DestinationRouting::forward_only(
+            *OffchainKeypair::random().public(),
+            RoutingOptions::Hops(1.try_into().expect("1 is a valid hop count")),
+        )
+    }
+
+    fn return_routing(pseudonym: HoprPseudonym) -> DestinationRouting {
+        DestinationRouting::Return(SurbMatcher::Pseudonym(pseudonym))
+    }
+
+    /// A packet carrying `marker` as its only payload byte, so emitted packets can be identified.
+    fn packet(marker: u8) -> ApplicationDataOut {
+        ApplicationDataOut::with_no_packet_info(
+            ApplicationData::new(Tag::from(TEST_TAG), &[marker]).expect("a one-byte payload is valid"),
+        )
+    }
+
+    fn marker_of(data: &ApplicationDataOut) -> u8 {
+        data.data.plain_text[0]
+    }
+
+    /// The error the planner raises when the SURB store holds nothing for a pseudonym.
+    ///
+    /// This is a *permanent* condition once the counterparty is gone — it is the same error whether
+    /// the pool is momentarily empty or will never be refilled again, which is precisely what makes
+    /// retrying on it indefinitely unsafe.
+    fn no_surb(routing: &DestinationRouting) -> PathPlannerError {
+        let pseudonym = match routing {
+            DestinationRouting::Return(matcher) => matcher.pseudonym().to_string(),
+            DestinationRouting::Forward { .. } => unreachable!("only return routing can starve for SURBs"),
+        };
+        PathPlannerError::Surb(format!("no surb for pseudonym {pseudonym}"))
+    }
+
+    /// A return packet for a pseudonym whose SURBs will never arrive must not withhold the packets
+    /// queued behind it.
+    ///
+    /// This is the `london-01` outage in miniature. The exit kept a session slot alive after its
+    /// initiator had gone, so its keep-alive stream went on emitting return-routed packets for a
+    /// pseudonym with no SURBs. Resolution for that packet can never succeed, and because the stage
+    /// preserves submission order, every subsequent packet was withheld behind it: the node
+    /// originated nothing for 1h44m while forwarding, acking and receiving carried on normally.
+    ///
+    /// The assertion is that the packets behind the starved one are **emitted** — not merely that
+    /// nothing errored. A stalled origination stage is externally indistinguishable from an idle
+    /// node, which is what made the live outage cost a day to find.
+    #[test_log::test(tokio::test)]
+    async fn a_starved_return_packet_should_not_withhold_the_packets_behind_it() -> anyhow::Result<()> {
+        let starved = HoprPseudonym::random();
+        let dropped_before = hopr_transport_session::counters::routing_resolution_surb_timeout_count();
+
+        let input = futures::stream::iter(vec![
+            (return_routing(starved), packet(0)),
+            (forward_routing(), packet(1)),
+            (forward_routing(), packet(2)),
+        ]);
+
+        let emitted = stage(
+            input,
+            |_size_hint, _max_surbs, routing: DestinationRouting| async move {
+                match routing {
+                    DestinationRouting::Return(_) => Err(no_surb(&routing)),
+                    DestinationRouting::Forward { .. } => Ok((resolved(), None)),
+                }
+            },
+        )
+        .take(2)
+        .collect::<Vec<_>>()
+        .timeout(futures_time::time::Duration::from(TEST_TIMEOUT))
+        .await;
+
+        let emitted = emitted.map_err(|_| {
+            anyhow::anyhow!(
+                "origination stalled: the two forward packets queued behind a return packet whose pseudonym has no \
+                 SURBs were never emitted within {TEST_TIMEOUT:?}. Every packet this node originates passes through \
+                 this stage, so this is a node-wide origination outage."
+            )
+        })?;
+
+        assert_eq!(
+            emitted.iter().map(|(_, data)| marker_of(data)).collect::<Vec<_>>(),
+            vec![1, 2],
+            "the packets behind the starved one must be emitted, in order"
+        );
+
+        // The starved packet is dropped, and that has to be *countable*. A silent drop leaves the
+        // operator with the same nothing the unbounded wait did: traffic missing and no signal
+        // saying why.
+        assert!(
+            hopr_transport_session::counters::routing_resolution_surb_timeout_count() > dropped_before,
+            "the starved packet was dropped without being counted, so the condition stays invisible"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn an_unset_wait_should_fall_back_to_the_default() {
+        assert_eq!(DEFAULT_SURB_RESOLUTION_WAIT, surb_resolution_wait(None));
+    }
+
+    #[test]
+    fn a_configured_wait_should_be_honoured() {
+        let configured = std::time::Duration::from_millis(2_500);
+        assert_eq!(configured, surb_resolution_wait(Some(configured)));
+    }
+
+    /// Zero is honoured rather than treated as "unset".
+    ///
+    /// The sibling concurrency knobs in the same config read `Some(0)` as "use the default", so the
+    /// difference is worth pinning: for a wait, zero has a meaning of its own — do not wait at all.
+    #[test]
+    fn a_zero_wait_should_mean_no_wait_rather_than_the_default() {
+        assert_eq!(
+            std::time::Duration::ZERO,
+            surb_resolution_wait(Some(std::time::Duration::ZERO))
+        );
+    }
+
+    /// With the wait disabled, a starved return packet is dropped on its first miss.
+    ///
+    /// This is the behaviour a zero wait buys, and the reason it is a footgun rather than a
+    /// tuning: any momentary SURB gap becomes loss. Asserting the attempt count is what separates
+    /// "did not wait" from "waited briefly".
+    #[test_log::test(tokio::test)]
+    async fn a_zero_wait_should_drop_a_starved_return_packet_without_retrying() -> anyhow::Result<()> {
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let input = futures::stream::iter(vec![(return_routing(HoprPseudonym::random()), packet(0))]);
+
+        let emitted = {
+            let attempts = attempts.clone();
+            resolve_routing_stage(
+                input,
+                move |_size_hint, _max_surbs, routing: DestinationRouting| {
+                    let attempts = attempts.clone();
+                    async move {
+                        attempts.fetch_add(1, Ordering::Relaxed);
+                        Err(no_surb(&routing))
+                    }
+                },
+                TEST_DISTRESS_THRESHOLD,
+                TEST_CONCURRENCY,
+                surb_resolution_wait(Some(std::time::Duration::ZERO)),
+            )
+            .collect::<Vec<_>>()
+            .timeout(futures_time::time::Duration::from(TEST_TIMEOUT))
+            .await
+            .map_err(|_| anyhow::anyhow!("a zero wait still stalled instead of dropping immediately"))?
+        };
+
+        assert!(emitted.is_empty(), "the starved packet must not be emitted");
+        assert_eq!(
+            1,
+            attempts.load(Ordering::Relaxed),
+            "a zero wait must resolve once and give up, not retry"
+        );
+
+        Ok(())
+    }
+
+    /// A return packet whose SURBs are only momentarily absent must still be emitted once they
+    /// arrive.
+    ///
+    /// This is the behaviour the retry exists for, and it constrains any bound placed on that
+    /// retry: dropping a return packet on the first SURB error would lose data on a session that
+    /// was merely waiting for its pool to refill.
+    #[test_log::test(tokio::test)]
+    async fn a_return_packet_should_be_emitted_once_its_surbs_arrive() -> anyhow::Result<()> {
+        const FAILURES_BEFORE_SUCCESS: usize = 3;
+
+        let attempts = Arc::new(AtomicUsize::new(0));
+        let input = futures::stream::iter(vec![(return_routing(HoprPseudonym::random()), packet(7))]);
+
+        let emitted = {
+            let attempts = attempts.clone();
+            stage(input, move |_size_hint, _max_surbs, routing: DestinationRouting| {
+                let attempts = attempts.clone();
+                async move {
+                    if attempts.fetch_add(1, Ordering::Relaxed) < FAILURES_BEFORE_SUCCESS {
+                        Err(no_surb(&routing))
+                    } else {
+                        Ok((resolved(), Some(0)))
+                    }
+                }
+            })
+            .take(1)
+            .collect::<Vec<_>>()
+            .timeout(futures_time::time::Duration::from(TEST_TIMEOUT))
+            .await
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "a return packet whose SURBs arrived after {FAILURES_BEFORE_SUCCESS} retries was never emitted"
+                )
+            })?
+        };
+
+        assert_eq!(
+            emitted.len(),
+            1,
+            "the return packet must be emitted once its SURBs arrive"
+        );
+        assert_eq!(marker_of(&emitted[0].1), 7);
+        assert!(
+            attempts.load(Ordering::Relaxed) > FAILURES_BEFORE_SUCCESS,
+            "the stage must retry rather than drop on the first SURB error"
+        );
+
+        Ok(())
+    }
+
+    /// A hard (non-SURB) resolution failure drops that packet and lets the rest through.
+    ///
+    /// The contrast with the starvation case is the point: the stage already knows how to drop a
+    /// packet it cannot route and carry on. Only the SURB branch retries without a bound.
+    #[test_log::test(tokio::test)]
+    async fn a_hard_resolution_failure_should_drop_only_its_own_packet() -> anyhow::Result<()> {
+        let input = futures::stream::iter(vec![
+            (forward_routing(), packet(0)),
+            (forward_routing(), packet(1)),
+            (forward_routing(), packet(2)),
+        ]);
+
+        let emitted = stage(
+            input,
+            |_size_hint, _max_surbs, _routing: DestinationRouting| async move {
+                static SEEN: AtomicUsize = AtomicUsize::new(0);
+                if SEEN.fetch_add(1, Ordering::Relaxed) == 0 {
+                    Err(PathPlannerError::Api("no path".into()))
+                } else {
+                    Ok((resolved(), None))
+                }
+            },
+        )
+        .collect::<Vec<_>>()
+        .timeout(futures_time::time::Duration::from(TEST_TIMEOUT))
+        .await
+        .map_err(|_| anyhow::anyhow!("a hard resolution failure stalled the stage instead of dropping its packet"))?;
+
+        assert_eq!(
+            emitted.iter().map(|(_, data)| marker_of(data)).collect::<Vec<_>>(),
+            vec![1, 2],
+            "only the unroutable packet is dropped; the rest keep their order"
+        );
+
+        Ok(())
+    }
+}

--- a/transport/hopr/src/path/selector.rs
+++ b/transport/hopr/src/path/selector.rs
@@ -27,7 +27,7 @@ struct PathCostWithMetrics {
     total_latency_ms: Option<u32>,
     min_probe_success_rate: Option<f64>,
     min_ack_rate: Option<f64>,
-    capacity_floor: Option<u128>,
+    fundable_tickets_floor: Option<u128>,
 }
 
 impl PartialOrd for PathCostWithMetrics {
@@ -50,7 +50,7 @@ impl From<(PathCostWithMetrics, Vec<OffchainPublicKey>)> for PathWithMetrics {
             total_latency_ms: metrics.total_latency_ms,
             min_probe_success_rate: metrics.min_probe_success_rate,
             min_ack_rate: metrics.min_ack_rate,
-            capacity_floor: metrics.capacity_floor,
+            fundable_tickets_floor: metrics.fundable_tickets_floor,
         }
     }
 }
@@ -71,6 +71,12 @@ fn opt_min<T: PartialOrd>(a: Option<T>, b: Option<T>) -> Option<T> {
 /// available during DFS, so no extra graph lookups are needed.
 struct MetricsValueFn<W: EdgeObservableRead> {
     inner: EdgeValueFn<f64, W>,
+    /// Face value used to express each edge's balance as a count of single-hop tickets.
+    ///
+    /// Read once per query rather than stored on any edge: deriving a count at query time is
+    /// safe, whereas deriving it at edge-update time is what made a price change stale the
+    /// whole graph.
+    ticket_face_value: Option<hopr_api::graph::traits::Balance>,
 }
 
 impl<W> ValueFn for MetricsValueFn<W>
@@ -86,7 +92,7 @@ where
             total_latency_ms: Some(0),
             min_probe_success_rate: None,
             min_ack_rate: None,
-            capacity_floor: None,
+            fundable_tickets_floor: None,
         }
     }
 
@@ -96,12 +102,13 @@ where
             total_latency_ms: None,
             min_probe_success_rate: None,
             min_ack_rate: None,
-            capacity_floor: None,
+            fundable_tickets_floor: None,
         })
     }
 
     fn into_value_fn(self) -> BasicValueFn<Self::Value, Self::Weight> {
         let inner = self.inner.into_value_fn();
+        let ticket_face_value = self.ticket_face_value;
         Arc::new(move |prev: PathCostWithMetrics, observed: &W, idx: usize| {
             let cost = inner(prev.cost, observed, idx);
 
@@ -116,26 +123,51 @@ where
 
             // Probe rate: taking the min of immediate and intermediate guards against nodes that
             // look good on direct probes but degrade under multi-hop load.
+            // `and_then`, not `map`: a stream with no observations contributes nothing to the min
+            // rather than contributing a zero it never measured.
             let edge_probe = observed
                 .immediate_qos()
-                .map(|m| m.average_probe_rate())
+                .and_then(|m| m.average_probe_rate())
                 .into_iter()
-                .chain(observed.intermediate_qos().map(|m| m.average_probe_rate()))
+                .chain(observed.intermediate_qos().and_then(|m| m.average_probe_rate()))
                 .reduce(f64::min);
             let min_probe_success_rate = opt_min(prev.min_probe_success_rate, edge_probe);
 
             let edge_ack = observed.immediate_qos().and_then(|m| m.ack_rate());
             let min_ack_rate = opt_min(prev.min_ack_rate, edge_ack);
 
-            let edge_cap = observed.intermediate_qos().and_then(|m| m.capacity());
-            let capacity_floor = opt_min(prev.capacity_floor, edge_cap);
+            // Expressed in single-hop tickets, not base units: the weighting factor below is a
+            // log ratio, and a base-unit balance would compress every realistic channel into a
+            // sliver of its output range.
+            //
+            // `zip`, not a fallback: an absent face value means the price is unknown, not that it
+            // is one. Dividing a base-unit balance by `1` yields a ticket count that saturates to
+            // `u128::MAX` and reads downstream as unlimited capacity — the opposite of what not
+            // knowing should imply. Contribute nothing to the floor until pricing arrives.
+            let edge_tickets = observed
+                .intermediate_qos()
+                .and_then(|m| m.balance())
+                .zip(ticket_face_value)
+                .map(|(balance, face_value)| {
+                    let tickets = if face_value.is_zero() {
+                        hopr_api::graph::traits::Balance::zero()
+                    } else {
+                        balance / face_value
+                    };
+                    if tickets > hopr_api::graph::traits::Balance::from(u128::MAX) {
+                        u128::MAX
+                    } else {
+                        tickets.low_u128()
+                    }
+                });
+            let fundable_tickets_floor = opt_min(prev.fundable_tickets_floor, edge_tickets);
 
             PathCostWithMetrics {
                 cost,
                 total_latency_ms,
                 min_probe_success_rate,
                 min_ack_rate,
-                capacity_floor,
+                fundable_tickets_floor,
             }
         })
     }
@@ -153,7 +185,7 @@ where
 ///
 /// A path is "fully measured" — and therefore preferred over unmeasured alternatives —
 /// when `total_latency_ms` is known AND either `hops == 0` (direct path, no channel
-/// expected) OR `capacity_floor` is also known.  This prevents 0-hop direct paths from
+/// expected) OR `fundable_tickets_floor` is also known.  This prevents 0-hop direct paths from
 /// being demoted simply because they carry no channel-capacity data.
 pub fn prune_for_consistency(candidates: Vec<PathWithMetrics>, floor: usize, hops: usize) -> Vec<PathWithMetrics> {
     // floor == 0 means "no pruning" — caller opts out entirely.
@@ -162,7 +194,7 @@ pub fn prune_for_consistency(candidates: Vec<PathWithMetrics>, floor: usize, hop
     }
 
     let fully_measured =
-        |p: &PathWithMetrics| p.total_latency_ms.is_some() && (hops == 0 || p.capacity_floor.is_some());
+        |p: &PathWithMetrics| p.total_latency_ms.is_some() && (hops == 0 || p.fundable_tickets_floor.is_some());
 
     let (mut populated, unpopulated): (Vec<_>, Vec<_>) = candidates.into_iter().partition(|p| fully_measured(p));
 
@@ -335,9 +367,17 @@ where
         shorter_length: std::num::NonZeroUsize,
         take: usize,
         existing: &[PathWithMetrics],
+        // The caller's snapshot, so both phases of one query cost against the same face value.
+        ticket_face_value: Option<hopr_api::graph::traits::Balance>,
     ) -> Vec<PathWithMetrics> {
         let value_fn = MetricsValueFn {
-            inner: EdgeValueFn::forward_without_self_loopback(self.edge_penalty, self.min_ack_rate),
+            inner: EdgeValueFn::forward_without_self_loopback(
+                shorter_length,
+                self.edge_penalty,
+                self.min_ack_rate,
+                ticket_face_value,
+            ),
+            ticket_face_value,
         };
         let raw = self
             .graph
@@ -404,6 +444,11 @@ where
         let length = std::num::NonZeroUsize::new(hops + 1)
             .expect("can never fail, it is physically at least 1 after the addition");
 
+        // One read for the whole query. A concurrent `set_ticket_face_value` between two reads
+        // would let the traversal cost and the fundable-ticket floor come from different snapshots
+        // of the same graph, so `composite_weight` would rank a candidate against itself.
+        let ticket_face_value = self.graph.ticket_face_value();
+
         let paths = if src == self.me {
             // Phase 1: search for full-length forward paths to dest.
             let mut found = compute_paths(
@@ -413,7 +458,8 @@ where
                 length,
                 self.max_paths,
                 MetricsValueFn {
-                    inner: EdgeValueFn::forward(length, self.edge_penalty, self.min_ack_rate),
+                    inner: EdgeValueFn::forward(length, self.edge_penalty, self.min_ack_rate, ticket_face_value),
+                    ticket_face_value,
                 },
             );
             tracing::debug!(
@@ -429,7 +475,8 @@ where
                 && let Some(shorter) = std::num::NonZeroUsize::new(length.get() - 1)
             {
                 let remaining = self.max_paths - found.len();
-                let extended = self.compute_extended_forward_paths(&src, &dest, shorter, remaining, &found);
+                let extended =
+                    self.compute_extended_forward_paths(&src, &dest, shorter, remaining, &found, ticket_face_value);
                 tracing::debug!(
                     direction,
                     phase = 2,
@@ -448,7 +495,8 @@ where
                 length,
                 self.max_paths,
                 MetricsValueFn {
-                    inner: EdgeValueFn::returning(length, self.edge_penalty, self.min_ack_rate),
+                    inner: EdgeValueFn::returning(length, self.edge_penalty, self.min_ack_rate, ticket_face_value),
+                    ticket_face_value,
                 },
             );
             tracing::debug!(direction, count = found.len(), "[return] candidates");
@@ -486,7 +534,7 @@ mod tests {
     use hex_literal::hex;
     use hopr_api::{
         graph::{
-            NetworkGraphWrite,
+            NetworkGraphUpdate, NetworkGraphWrite,
             traits::{EdgeObservableWrite, EdgeWeightType},
         },
         types::{
@@ -533,7 +581,9 @@ mod tests {
             obs.record(EdgeWeightType::Connected(true));
             obs.record(EdgeWeightType::Immediate(Ok(Duration::from_millis(50))));
             obs.record(EdgeWeightType::Intermediate(Ok(Duration::from_millis(50))));
-            obs.record(EdgeWeightType::Capacity(Some(1000)));
+            obs.record(EdgeWeightType::Balance(Some(hopr_api::graph::traits::Balance::from(
+                1000u64,
+            ))));
         });
     }
 
@@ -977,18 +1027,18 @@ mod tests {
             total_latency_ms: latency_ms,
             min_probe_success_rate: None,
             min_ack_rate: None,
-            capacity_floor: None,
+            fundable_tickets_floor: None,
         }
     }
 
-    fn make_path_with_capacity(latency_ms: Option<u32>, capacity_floor: Option<u128>) -> PathWithMetrics {
+    fn make_path_with_tickets(latency_ms: Option<u32>, fundable_tickets_floor: Option<u128>) -> PathWithMetrics {
         PathWithMetrics {
             path: vec![],
             cost: 1.0,
             total_latency_ms: latency_ms,
             min_probe_success_rate: None,
             min_ack_rate: None,
-            capacity_floor,
+            fundable_tickets_floor,
         }
     }
 
@@ -1003,7 +1053,7 @@ mod tests {
             total_latency_ms: Some(latency_ms),
             min_probe_success_rate: None,
             min_ack_rate: None,
-            capacity_floor: Some(1000),
+            fundable_tickets_floor: Some(1000),
         }
     }
 
@@ -1069,7 +1119,7 @@ mod tests {
     fn prune_drops_high_latency_first() {
         // 30 paths with strictly increasing latency, floor=8 → keep lowest 8
         let candidates: Vec<_> = (0..30u32)
-            .map(|i| make_path_with_capacity(Some(i * 10), Some(1_000_000)))
+            .map(|i| make_path_with_tickets(Some(i * 10), Some(1_000_000)))
             .collect();
         let result = prune_for_consistency(candidates, 8, 1);
         assert_eq!(result.len(), 8);
@@ -1084,9 +1134,9 @@ mod tests {
         // total=9 > floor=8: all 3 populated are kept (populated always preferred),
         // then 5 unpopulated fill the remaining slots.
         let mut candidates: Vec<_> = vec![
-            make_path_with_capacity(Some(10), Some(1_000)),
-            make_path_with_capacity(Some(30), Some(1_000)),
-            make_path_with_capacity(Some(20), Some(1_000)),
+            make_path_with_tickets(Some(10), Some(1_000)),
+            make_path_with_tickets(Some(30), Some(1_000)),
+            make_path_with_tickets(Some(20), Some(1_000)),
         ];
         candidates.extend((0..6).map(|_| make_path_with_latency(None)));
         let result = prune_for_consistency(candidates, 8, 1);
@@ -1113,8 +1163,8 @@ mod tests {
         // Old formula: target_populated = 8.saturating_sub(10) = 0 → both populated dropped.
         // Correct: keep up to 8 populated (only 2 exist), fill 6 remaining with unpopulated.
         let mut candidates: Vec<_> = vec![
-            make_path_with_capacity(Some(10), Some(1_000)),
-            make_path_with_capacity(Some(20), Some(1_000)),
+            make_path_with_tickets(Some(10), Some(1_000)),
+            make_path_with_tickets(Some(20), Some(1_000)),
         ];
         candidates.extend((0..10).map(|_| make_path_with_latency(None)));
         let result = prune_for_consistency(candidates, 8, 1);
@@ -1128,7 +1178,7 @@ mod tests {
     #[test]
     fn prune_exact_floor_is_unchanged() {
         let candidates: Vec<_> = (0..8)
-            .map(|i| make_path_with_capacity(Some(i * 10), Some(1_000)))
+            .map(|i| make_path_with_tickets(Some(i * 10), Some(1_000)))
             .collect();
         let result = prune_for_consistency(candidates, 8, 1);
         assert_eq!(result.len(), 8);
@@ -1136,10 +1186,10 @@ mod tests {
 
     #[test]
     fn prune_0_hop_with_measured_latency_and_no_capacity_is_populated() {
-        // 0-hop: capacity_floor = None is expected; path should be treated as "fully measured"
+        // 0-hop: fundable_tickets_floor = None is expected; path should be treated as "fully measured"
         // if latency is known.
         let mut candidates: Vec<_> = vec![
-            make_path_with_capacity(Some(50), None), // 0-hop: no capacity, latency known
+            make_path_with_tickets(Some(50), None), // 0-hop: no capacity, latency known
         ];
         candidates.extend((0..10).map(|_| make_path_with_latency(None)));
         let result = prune_for_consistency(candidates, 8, 0);
@@ -1150,27 +1200,27 @@ mod tests {
     }
 
     #[test]
-    fn prune_multi_hop_without_capacity_floor_is_unpopulated() {
+    fn prune_multi_hop_without_fundable_tickets_floor_is_unpopulated() {
         // A 1-hop path with measured latency but NO capacity is unmeasured (unpopulated).
         // It should be demoted below paths that have both latency and capacity.
         let candidates: Vec<_> = vec![
-            make_path_with_capacity(Some(50), Some(1_000)), // fully measured
-            make_path_with_capacity(Some(50), Some(1_000)), // fully measured
-            make_path_with_capacity(Some(50), Some(1_000)), // fully measured
-            make_path_with_capacity(Some(50), Some(1_000)), // fully measured
-            make_path_with_capacity(Some(50), Some(1_000)), // fully measured
-            make_path_with_capacity(Some(50), Some(1_000)), // fully measured
-            make_path_with_capacity(Some(50), Some(1_000)), // fully measured
-            make_path_with_capacity(Some(50), Some(1_000)), // fully measured
-            make_path_with_capacity(Some(40), None),        // missing capacity → unpopulated
+            make_path_with_tickets(Some(50), Some(1_000)), // fully measured
+            make_path_with_tickets(Some(50), Some(1_000)), // fully measured
+            make_path_with_tickets(Some(50), Some(1_000)), // fully measured
+            make_path_with_tickets(Some(50), Some(1_000)), // fully measured
+            make_path_with_tickets(Some(50), Some(1_000)), // fully measured
+            make_path_with_tickets(Some(50), Some(1_000)), // fully measured
+            make_path_with_tickets(Some(50), Some(1_000)), // fully measured
+            make_path_with_tickets(Some(50), Some(1_000)), // fully measured
+            make_path_with_tickets(Some(40), None),        // missing capacity → unpopulated
         ];
         let result = prune_for_consistency(candidates, 8, 1);
         assert_eq!(result.len(), 8);
         // The path with missing capacity should not survive when all 8 slots are filled
         // by fully measured paths.
-        let has_missing_cap = result.iter().any(|p| p.capacity_floor.is_none());
+        let has_missing_balance = result.iter().any(|p| p.fundable_tickets_floor.is_none());
         assert!(
-            !has_missing_cap,
+            !has_missing_balance,
             "path without capacity floor must be pruned when fully-measured paths fill the floor"
         );
     }
@@ -1179,9 +1229,9 @@ mod tests {
     fn prune_for_consistency_floor_zero_returns_all() {
         // floor == 0 must be treated as "no pruning" — all candidates survive unchanged.
         let candidates = vec![
-            make_path_with_capacity(Some(10), Some(1_000)),
-            make_path_with_capacity(Some(20), None),
-            make_path_with_capacity(None, None),
+            make_path_with_tickets(Some(10), Some(1_000)),
+            make_path_with_tickets(Some(20), None),
+            make_path_with_tickets(None, None),
         ];
         let result = prune_for_consistency(candidates, 0, 1);
         assert_eq!(result.len(), 3, "floor=0 must return all candidates");
@@ -1206,7 +1256,9 @@ mod tests {
             graph.upsert_edge(src, dst, |obs| {
                 obs.record(EdgeWeightType::Connected(true));
                 obs.record(EdgeWeightType::Immediate(Ok(Duration::from_millis(lat_ms))));
-                obs.record(EdgeWeightType::Capacity(Some(1000)));
+                obs.record(EdgeWeightType::Balance(Some(hopr_api::graph::traits::Balance::from(
+                    1000u64,
+                ))));
             });
         };
 
@@ -1235,7 +1287,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn path_metrics_capacity_floor_is_min() -> anyhow::Result<()> {
+    async fn path_metrics_fundable_tickets_floor_is_min() -> anyhow::Result<()> {
         let me = pubkey(&SECRET_0);
         let hop = pubkey(&SECRET_1);
         let dest = pubkey(&SECRET_2);
@@ -1243,15 +1295,24 @@ mod tests {
         graph.add_node(hop);
         graph.add_node(dest);
 
+        // Stated, not assumed. A face value of one makes the ticket count equal the balance, which
+        // is what keeps the numbers below readable — but it has to be pushed, because without a
+        // price the floor is now `None` rather than silently dividing by one.
+        graph.set_ticket_face_value(hopr_api::graph::traits::Balance::one());
+
         graph.upsert_edge(&me, &hop, |obs| {
             obs.record(EdgeWeightType::Connected(true));
             obs.record(EdgeWeightType::Intermediate(Ok(Duration::from_millis(50))));
-            obs.record(EdgeWeightType::Capacity(Some(500)));
+            obs.record(EdgeWeightType::Balance(Some(hopr_api::graph::traits::Balance::from(
+                500u64,
+            ))));
         });
         graph.upsert_edge(&hop, &dest, |obs| {
             obs.record(EdgeWeightType::Connected(true));
             obs.record(EdgeWeightType::Intermediate(Ok(Duration::from_millis(50))));
-            obs.record(EdgeWeightType::Capacity(Some(200)));
+            obs.record(EdgeWeightType::Balance(Some(hopr_api::graph::traits::Balance::from(
+                200u64,
+            ))));
         });
         graph.add_edge(&me, &hop).unwrap();
         graph.add_edge(&hop, &dest).unwrap();
@@ -1260,15 +1321,15 @@ mod tests {
         let paths = selector.select_path(me, dest, 1).context("1-hop path")?;
         assert!(!paths.is_empty());
         assert_eq!(
-            paths[0].capacity_floor,
+            paths[0].fundable_tickets_floor,
             Some(200),
             "floor must be the smaller of 500 and 200"
         );
         Ok(())
     }
 
-    // NOTE: a test for capacity_floor=None is omitted intentionally.
-    // The forward cost function requires intermediate capacity on all non-last edges, so
+    // NOTE: a test for fundable_tickets_floor=None is omitted intentionally.
+    // The forward cost function requires a funding balance on all non-last edges, so
     // every path the selector returns has capacity data on at least one edge, making
-    // capacity_floor always Some for reachable paths.
+    // fundable_tickets_floor always Some for reachable paths.
 }

--- a/transport/hopr/src/path/traits.rs
+++ b/transport/hopr/src/path/traits.rs
@@ -26,9 +26,12 @@ pub struct PathWithMetrics {
     /// Worst per-edge acknowledgment rate along the path.
     /// `None` if no edge has sent any messages yet.
     pub min_ack_rate: Option<f64>,
-    /// Smallest known channel capacity along the path.
-    /// `None` if no edge carries channel-capacity data.
-    pub capacity_floor: Option<u128>,
+    /// Smallest number of single-hop tickets any edge along the path can still fund.
+    ///
+    /// Derived per query from each edge's balance and the current ticket face value — never stored
+    /// on an edge, which would stale the graph whenever the price moves.
+    /// `None` if no edge carries balance data.
+    pub fundable_tickets_floor: Option<u128>,
 }
 
 /// Selects multi-hop paths through the network.

--- a/transport/hopr/src/protocol/pipeline/config.rs
+++ b/transport/hopr/src/protocol/pipeline/config.rs
@@ -111,7 +111,69 @@ pub struct PacketPipelineConfig {
     /// for outgoing packet encode (SURB generation). Flooding the pool with decode work would
     /// otherwise starve SURB production and collapse download throughput.
     pub input_concurrency: Option<usize>,
+    /// How long routing resolution keeps waiting for a return path's SURBs before giving up on the
+    /// packet.
+    ///
+    /// `None` falls back to the default of 6 s. `Some(0)` disables the wait entirely, dropping a
+    /// return packet the first time its SURBs are missing.
+    ///
+    /// The right value trades two failures against each other. Too short loses data on a session
+    /// whose SURB pool is only momentarily empty, which is why the wait exists at all. Too long
+    /// stalls **every** packet the node originates, not just this one: resolution preserves
+    /// submission order, so an unresolvable packet withholds everything behind it, and a
+    /// counterparty that has gone away never sends another SURB. An unbounded wait here took a
+    /// production exit's entire egress down for 1h44m while it still forwarded and acknowledged
+    /// normally.
+    ///
+    /// **Set this if you know your session's frame timeout.** The default errs long, because a
+    /// library cannot know it; a packet held past that timeout is discarded by the receiver anyway,
+    /// so the wait is pure stall from then on. hoprd, whose sessions time frames out at 3 s,
+    /// configures 1 s.
+    #[cfg_attr(feature = "serde", serde(default, with = "humantime_serde"))]
+    pub surb_resolution_wait: Option<std::time::Duration>,
     /// Configuration of the packet acknowledgement processing
     #[validate(nested)]
     pub ack_config: AcknowledgementPipelineConfig,
+}
+
+#[cfg(all(test, feature = "serde"))]
+mod tests {
+    use super::*;
+
+    /// Everything this struct requires in a document, minus the wait under test.
+    ///
+    /// Only `surb_resolution_wait` carries `serde(default)`, so the surrounding fields have to be
+    /// written out; `deny_unknown_fields` means the document must otherwise be exact.
+    const REQUIRED_FIELDS: &str = "output_concurrency: null\ninput_concurrency: null\nack_config:\n  \
+                                   ack_input_concurrency: null\n  ack_output_concurrency: null\n";
+
+    fn parse(wait: Option<&str>) -> PacketPipelineConfig {
+        let doc = match wait {
+            Some(value) => format!("{REQUIRED_FIELDS}surb_resolution_wait: {value}\n"),
+            None => REQUIRED_FIELDS.to_string(),
+        };
+        serde_saphyr::from_str(&doc).unwrap_or_else(|e| panic!("config must parse:\n{doc}\n{e}"))
+    }
+
+    /// The wait has to survive a config file, in the human-readable form the rest of this config
+    /// uses. `Option<Duration>` through `humantime_serde` is easy to get wrong in a way that only
+    /// shows up when someone's YAML is silently ignored.
+    #[test]
+    fn the_surb_resolution_wait_should_round_trip_through_yaml() {
+        assert_eq!(
+            Some(std::time::Duration::from_secs(2)),
+            parse(Some("2s")).surb_resolution_wait,
+            "a duration string must reach the field"
+        );
+        assert_eq!(
+            None,
+            parse(None).surb_resolution_wait,
+            "an omitted wait must stay unset so the default applies"
+        );
+        assert_eq!(
+            Some(std::time::Duration::ZERO),
+            parse(Some("0s")).surb_resolution_wait,
+            "zero must reach the code as zero, not as unset"
+        );
+    }
 }

--- a/transport/probe/src/probe.rs
+++ b/transport/probe/src/probe.rs
@@ -488,23 +488,25 @@ mod tests {
             None
         }
 
-        fn average_probe_rate(&self) -> f64 {
-            1.0
+        // A measured, perfect link — so the probe tests see the same edge they did before the
+        // trait gained the presence distinction. `has_observations` derives from this.
+        fn average_probe_rate(&self) -> Option<f64> {
+            Some(1.0)
         }
 
-        fn score(&self) -> f64 {
-            1.0
+        fn score(&self) -> Option<f64> {
+            Some(1.0)
         }
     }
 
     impl EdgeNetworkObservableRead for TestEdgeTransportObservations {
-        fn is_connected(&self) -> bool {
-            true
+        fn is_connected(&self) -> Option<bool> {
+            Some(true)
         }
     }
 
     impl EdgeProtocolObservable for TestEdgeTransportObservations {
-        fn capacity(&self) -> Option<u128> {
+        fn balance(&self) -> Option<hopr_api::graph::traits::Balance> {
             None
         }
     }
@@ -540,8 +542,8 @@ mod tests {
             None
         }
 
-        fn score(&self) -> f64 {
-            1.0
+        fn score(&self) -> Option<f64> {
+            Some(1.0)
         }
     }
 
@@ -583,6 +585,8 @@ mod tests {
         {
             unimplemented!()
         }
+
+        fn set_ticket_face_value(&self, _ticket_face_value: hopr_api::graph::traits::Balance) {}
     }
 
     #[async_trait]
@@ -592,6 +596,10 @@ mod tests {
 
         fn identity(&self) -> &OffchainPublicKey {
             &self.me
+        }
+
+        fn ticket_face_value(&self) -> Option<hopr_api::graph::traits::Balance> {
+            None
         }
 
         fn node_count(&self) -> usize {

--- a/transport/session/Cargo.toml
+++ b/transport/session/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport-session"
 description = "Session functionality providing session abstraction over the HOPR transport"
-version = "0.26.2"
+version = "0.26.3"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/session/Cargo.toml
+++ b/transport/session/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport-session"
 description = "Session functionality providing session abstraction over the HOPR transport"
-version = "0.27.0"
+version = "0.28.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/session/Cargo.toml
+++ b/transport/session/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport-session"
 description = "Session functionality providing session abstraction over the HOPR transport"
-version = "0.26.3"
+version = "0.27.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/session/src/balancer/controller.rs
+++ b/transport/session/src/balancer/controller.rs
@@ -219,11 +219,25 @@ impl BalancerStateValues {
             .fetch_max(until, std::sync::atomic::Ordering::Relaxed);
     }
 
-    /// Whether production should currently ignore the counterparty buffer estimate.
+    /// Whether [`buffer_level`](Self::buffer_level) is currently an instruction rather than a
+    /// measurement.
     ///
-    /// Both the opt-in and live evidence are required: without the opt-in this is not our
-    /// behaviour to change, and without evidence there is nothing to distinguish a dead return path
-    /// from an idle one.
+    /// While this holds, the controller deliberately writes `0` into the level to drive production
+    /// to its maximum. That zero says "produce flat out", not "the counterparty holds nothing", so
+    /// anything reading the level as a *supply ceiling* must consult this first or it will read the
+    /// instruction as an order to send nothing.
+    ///
+    /// True only when both the opt-in (`sustain_on_return_path_loss`) and live evidence
+    /// ([`mark_return_path_degraded`](Self::mark_return_path_degraded), within its window) are
+    /// present: without the opt-in this is not our behaviour to change, and without evidence there
+    /// is nothing to tell a dead return path from an idle one.
+    ///
+    /// `pub` because it is not only the controller's business — hence the emphasis above on what
+    /// the flag does *not* mean. It is not a general "the return path is degraded" signal.
+    pub fn return_path_estimate_is_stale(&self) -> bool {
+        self.should_sustain_through_return_path_loss()
+    }
+
     fn should_sustain_through_return_path_loss(&self) -> bool {
         let deadline = self
             .return_path_degraded_until_ms
@@ -442,6 +456,8 @@ where
                 believed = current,
                 "return path degraded; ignoring the counterparty buffer estimate"
             );
+            // Reads as "produce flat out" to the controller below. `SurbSupply` must not read it
+            // as "the buffer is empty, admit nothing" -- see `return_path_estimate_is_stale`.
             current = 0;
         }
 

--- a/transport/session/src/counters.rs
+++ b/transport/session/src/counters.rs
@@ -41,6 +41,21 @@ pub fn session_unrelated_dispatch_count() -> usize {
     SESSION_UNRELATED_DATA_DISPATCHES.load(Ordering::Relaxed)
 }
 
+/// Cumulative count of outgoing packets dropped because their return route still had no SURB
+/// when the resolution wait ran out.
+///
+/// Separate from [`ROUTING_RESOLUTION_FAILURES`] because it means something different and
+/// actionable: a counterparty has stopped replenishing SURBs and is not coming back, rather than a
+/// route that could not be computed. A non-zero and growing value names the condition that used to
+/// stall a node's entire egress indefinitely.
+pub static ROUTING_RESOLUTION_SURB_TIMEOUTS: AtomicUsize = AtomicUsize::new(0);
+
+/// Returns the cumulative count of packets dropped after waiting in vain for a return SURB.
+#[inline]
+pub fn routing_resolution_surb_timeout_count() -> usize {
+    ROUTING_RESOLUTION_SURB_TIMEOUTS.load(Ordering::Relaxed)
+}
+
 /// Cumulative count of packets that failed path/routing resolution before encoding.
 pub static ROUTING_RESOLUTION_FAILURES: AtomicUsize = AtomicUsize::new(0);
 

--- a/transport/session/src/flow_control.rs
+++ b/transport/session/src/flow_control.rs
@@ -59,11 +59,26 @@ impl SupplyConstraint for SurbSupply {
         if self.state.is_disabled() {
             return usize::MAX;
         }
+        // Same reasoning while the return path is degraded. The controller stores `0` there to
+        // drive production to the maximum, not because it measured an empty buffer. Reading that
+        // as a ceiling yields zero admissible bytes -- and the persist probe cannot escape it,
+        // since it is itself capped by the ceiling -- so a session that opted into surviving
+        // return-path loss would instead stop sending for the whole degraded window, which is the
+        // opposite of the intent. Defer to the honest delivery clock, which still sees the missing
+        // acknowledgements and throttles on real evidence.
+        if self.state.return_path_estimate_is_stale() {
+            return usize::MAX;
+        }
         (self.state.buffer_level() as usize).saturating_mul(self.bytes_per_reply_packet)
     }
 
     fn backoff_hint(&self) -> Option<Backoff> {
         if self.state.is_disabled() {
+            return None;
+        }
+        // A degraded-path zero is an instruction to the controller, not an observation, so it is
+        // not evidence of an empty buffer and must not collapse the window to the floor.
+        if self.state.return_path_estimate_is_stale() {
             return None;
         }
         let level = self.state.buffer_level();
@@ -285,6 +300,53 @@ mod tests {
             .buffer_level
             .store(buffer_level, std::sync::atomic::Ordering::Relaxed);
         state
+    }
+
+    /// Regression: the controller stores `0` into `buffer_level` while the return path is
+    /// degraded to drive SURB production to the maximum. That zero is an instruction, not a
+    /// measurement — but `SurbSupply` also reads the same atomic as a supply ceiling, so it used
+    /// to yield zero admissible bytes for the whole degraded window, and the persist probe could
+    /// not escape it because the probe is itself capped by the ceiling.
+    ///
+    /// A session that opted into surviving return-path loss would therefore have stopped sending
+    /// entirely — the opposite of the feature's intent, and indistinguishable from a dead session.
+    #[test]
+    fn a_degraded_return_path_should_not_zero_the_supply_ceiling() {
+        let state = balancer(7_000, 0);
+        // Through the config, as a caller would: the opt-in is a configuration decision, and going
+        // via the atomic would couple this test to a representation it has no business knowing.
+        state.update(&crate::SurbBalancerConfig {
+            sustain_on_return_path_loss: true,
+            ..Default::default()
+        });
+        state.mark_return_path_degraded(Duration::from_secs(30));
+        assert!(
+            state.return_path_estimate_is_stale(),
+            "precondition: the estimate must be marked stale"
+        );
+
+        let supply = SurbSupply::new(state.clone(), 1_000);
+
+        assert_eq!(
+            usize::MAX,
+            supply.max_admissible_inflight(),
+            "a degraded-path zero must not cap the window; the delivery clock governs instead"
+        );
+        assert_eq!(
+            None,
+            supply.backoff_hint(),
+            "a degraded-path zero is not evidence of an empty buffer"
+        );
+    }
+
+    /// The inverse: once the mark expires the level is a measurement again, and a genuinely empty
+    /// buffer must still close the window.
+    #[test]
+    fn an_empty_buffer_should_still_cap_the_window_when_not_degraded() {
+        let supply = SurbSupply::new(balancer(7_000, 0), 1_000);
+
+        assert_eq!(0, supply.max_admissible_inflight());
+        assert_eq!(Some(Backoff::Hard), supply.backoff_hint());
     }
 
     // ---- Persist probe (anti-deadlock at the un-acked tail), configurable ----

--- a/transport/session/src/lib.rs
+++ b/transport/session/src/lib.rs
@@ -113,6 +113,19 @@ pub struct SessionClientConfig {
     /// the client's explicit dial (only meaningful on a reliable / `RetransmissionAck` session).
     #[default(None)]
     pub flow_control: Option<FlowControlConfig>,
+    /// Abandon the frame due next once the sequence has advanced this far past it, instead of
+    /// holding everything already received for the whole frame timeout.
+    ///
+    /// Head-of-line bound for this session's incoming direction. `None` inherits the node's
+    /// setting, `Some(0)` disables it here, `Some(n)` sets it.
+    ///
+    /// Worth setting per session because the right value tracks reordering depth -- throughput x
+    /// latency spread / frame size -- which is a property of the traffic, not of the node: a bulk
+    /// data session and a control session on the same node differ by orders of magnitude.
+    ///
+    /// Has no effect on a session carrying a retransmission capability, where a missing frame can
+    /// still be recovered and waiting for it is productive.
+    pub max_frames_behind_gap: Option<usize>,
 }
 
 #[cfg(test)]

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -2708,6 +2708,155 @@ mod tests {
         Ok(())
     }
 
+    /// Collects everything that arrives on `rx` during `window`, returning once it elapses.
+    async fn originated_during(
+        rx: &mut futures::channel::mpsc::UnboundedReceiver<(DestinationRouting, ApplicationDataOut)>,
+        window: Duration,
+    ) -> Vec<(DestinationRouting, ApplicationDataOut)> {
+        let mut collected = Vec::new();
+        let deadline = tokio::time::Instant::now() + window;
+        while let Ok(Some(item)) = timeout(
+            deadline.saturating_duration_since(tokio::time::Instant::now()),
+            rx.next(),
+        )
+        .await
+        {
+            collected.push(item);
+        }
+        collected
+    }
+
+    /// The manager floors the keep-alive period at [`MIN_SURB_BUFFER_NOTIFICATION_PERIOD`], so this
+    /// is as fast as an Exit keep-alive can be made to run, and it sets the pace of these tests.
+    const KEEP_ALIVE_PERIOD: Duration = MIN_SURB_BUFFER_NOTIFICATION_PERIOD;
+
+    type RecordingManager = SessionManager<UnboundedSender<(DestinationRouting, ApplicationDataOut)>>;
+    type Originated = futures::channel::mpsc::UnboundedReceiver<(DestinationRouting, ApplicationDataOut)>;
+
+    /// Brings up an Exit-side session and returns once its keep-alive stream is observably running.
+    ///
+    /// The "observably running" part is load-bearing for every caller: `nothing was originated` is
+    /// equally true of a stream that stopped and one that never started, so a test that does not
+    /// first establish the stream is alive proves nothing when it later sees silence.
+    async fn exit_session_originating_keep_alives(
+        cfg: SessionManagerConfig,
+    ) -> anyhow::Result<(RecordingManager, Originated, HoprPseudonym)> {
+        let mgr = RecordingManager::new(SessionManagerConfig {
+            surb_balance_notify_period: Some(KEEP_ALIVE_PERIOD),
+            ..cfg
+        });
+
+        let (msg_tx, mut msg_rx) = futures::channel::mpsc::unbounded();
+        // Held, not dropped: dropping it would fail the establishment notification instead.
+        let (new_session_tx, _new_session_rx) = futures::channel::mpsc::channel(4);
+        mgr.start(msg_tx, new_session_tx)?;
+
+        let pseudonym = HoprPseudonym::random();
+        mgr.handle_incoming_session_initiation(
+            pseudonym,
+            StartInitiation {
+                challenge: MIN_CHALLENGE,
+                target: SessionTarget::TcpStream(SealedHost::Plain("127.0.0.1:80".parse()?)),
+                // Empty capabilities keep rate control on, which is what spawns the balancer and
+                // the keep-alive stream. `NoRateControl` would skip both and make this vacuous.
+                capabilities: ByteCapabilities(Capabilities::empty()),
+                additional_data: 0,
+            },
+        )
+        .await?;
+
+        let observed = originated_during(&mut msg_rx, KEEP_ALIVE_PERIOD * 2 + Duration::from_millis(500)).await;
+        let keep_alives = observed
+            .iter()
+            .filter(|(routing, data)| {
+                msg_type(data, StartProtocolDiscriminants::KeepAlive)
+                    && matches!(routing, DestinationRouting::Return(SurbMatcher::Pseudonym(p)) if p == &pseudonym)
+            })
+            .count();
+        anyhow::ensure!(
+            keep_alives > 0,
+            "no return-routed keep-alive was originated, so this test cannot tell a stopped stream from one that \
+             never ran; {} message(s) were observed in total",
+            observed.len()
+        );
+
+        Ok((mgr, msg_rx, pseudonym))
+    }
+
+    /// Asserts `mgr` originates nothing further for `pseudonym`.
+    ///
+    /// Packets already handed to the sender before the closure are in flight rather than newly
+    /// originated, so they are drained first and only what appears afterwards counts.
+    async fn assert_no_further_origination(rx: &mut Originated, closure: &str) {
+        let _in_flight = originated_during(rx, Duration::from_millis(200)).await;
+
+        let window = KEEP_ALIVE_PERIOD * 3;
+        let after = originated_during(rx, window).await;
+        assert!(
+            after.is_empty(),
+            "an Exit session closed by {closure} originated {} further packet(s) over {window:?} — each one is \
+             return-routed to a pseudonym whose SURBs are gone, and one such packet is enough to stall all \
+             origination on the node",
+            after.len()
+        );
+    }
+
+    /// An Exit session must originate nothing once it has been closed explicitly.
+    ///
+    /// The Exit's keep-alive stream is a `repeat_with` on a rate limiter: it produces a
+    /// return-routed packet every period regardless of whether a SURB exists to carry it. That is
+    /// fine while the initiator is present and replenishing, and it is the *supply* side of the
+    /// `london-01` outage once the initiator is gone — every such packet is one the routing
+    /// resolution stage can never resolve, and one unresolvable packet there stalls all origination
+    /// on the node (see `hopr_transport::path::resolve`).
+    ///
+    /// Teardown is therefore the only thing standing between a departed initiator and an unbounded
+    /// supply of unresolvable packets, which is why each closure path has to be shown to stop the
+    /// stream rather than merely drop the slot.
+    #[test_log::test(tokio::test)]
+    async fn an_exit_session_should_originate_nothing_after_an_explicit_close() -> anyhow::Result<()> {
+        // Default idle timeout (180 s), so eviction cannot confound what the explicit close proves.
+        let (mgr, mut msg_rx, pseudonym) = exit_session_originating_keep_alives(Default::default()).await?;
+
+        assert!(mgr.close_session(&pseudonym), "the session must exist to be closed");
+
+        assert_no_further_origination(&mut msg_rx, "an explicit close").await;
+        Ok(())
+    }
+
+    /// An Exit session must originate nothing once it has been evicted for being idle.
+    ///
+    /// This is the path that matters most for a departed initiator: nobody closes that session, so
+    /// idle eviction is what ends it, and eviction runs through a Moka listener rather than the
+    /// explicit close path. A keep-alive stream that survives eviction would go on originating
+    /// unresolvable return packets with no session left to account for them.
+    #[test_log::test(tokio::test)]
+    async fn an_exit_session_should_originate_nothing_after_idle_eviction() -> anyhow::Result<()> {
+        let idle_timeout = KEEP_ALIVE_PERIOD * 3;
+        let (mgr, mut msg_rx, _) = exit_session_originating_keep_alives(SessionManagerConfig {
+            idle_timeout,
+            ..Default::default()
+        })
+        .await?;
+
+        // Moka evicts lazily, so drive its maintenance rather than waiting for the manager's own
+        // (jittered, multi-second) eviction tick: this makes the eviction prompt and deterministic.
+        for _ in 0..50 {
+            mgr.sessions.run_pending_tasks();
+            if mgr.active_sessions().is_empty() {
+                break;
+            }
+            tokio::time::sleep(idle_timeout / 10).await;
+        }
+        assert!(
+            mgr.active_sessions().is_empty(),
+            "the idle session was never evicted, so this test cannot say anything about eviction"
+        );
+
+        assert_no_further_origination(&mut msg_rx, "idle eviction").await;
+        Ok(())
+    }
+
     #[test_log::test(tokio::test)]
     async fn session_manager_should_send_keep_alives_via_surb_balancer() -> anyhow::Result<()> {
         let alice_pseudonym = HoprPseudonym::random();

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -255,6 +255,34 @@ pub struct SessionManagerConfig {
     #[default(0)]
     pub max_buffered_segments: usize,
 
+    /// Abandon the frame due next once this many later frames are waiting behind it, rather than
+    /// holding them for the whole of [`Self::max_frame_timeout`].
+    ///
+    /// The two answer different questions. `max_frame_timeout` is how long a *missing* frame is
+    /// waited for, and is set here to exceed the ~2 s SURB KeepAlive so a starved peer's late echo
+    /// is not discarded. This bounds how much *already received* data is held hostage during that
+    /// wait -- a cost paid once per gap, which compounds as later frames queue up.
+    ///
+    /// Without it, a session that cannot retransmit waits the full timeout for a frame that will
+    /// never arrive. Measured on a 5-node cluster after killing a return relayer: 98.5 % of bytes
+    /// returned over the wire, 0.60 % reached the application, and the application-side
+    /// inter-arrival median sat exactly on the 3 s timeout.
+    ///
+    /// The right value tracks reordering depth -- throughput x latency spread / frame size -- so
+    /// it is deployment-specific. Tune with `SessionConfig::max_frames_behind_gap`; too low converts
+    /// ordinary reordering into loss, too high leaves the stall in place.
+    ///
+    /// Default is 256, which is roughly 3-4x the reordering depth of the cluster it was measured
+    /// on (~0.5 MB/s over paths spread across 10-260 ms, 1500 B frames, so ~70-85 frames in
+    /// flight out of order). The margin is not cosmetic: at 64 -- about one reordering depth --
+    /// a *healthy* baseline dropped from 100 % to 92.2 % arrival, because ordinary reordering was
+    /// being read as loss. At 256 the same baseline returned 100 % while a return relayer killed
+    /// mid-session still recovered 97.1 %, against 0.60 % with the bound absent.
+    ///
+    /// Default is 256.
+    #[default(Some(256))]
+    pub max_frames_behind_gap: Option<usize>,
+
     /// The base timeout for initiation of Session initiation.
     ///
     /// The actual timeout is adjusted according to the number of hops for that Session:
@@ -550,11 +578,43 @@ impl<S> Clone for SessionManager<S> {
 }
 
 fn session_config(cfg: &SessionManagerConfig, capabilities: crate::Capabilities) -> HoprSessionConfig {
+    session_config_with(cfg, capabilities, None)
+}
+
+/// As [`session_config`], with the initiating session's own head-of-line bound.
+///
+/// `None` inherits the node default; `Some(0)` disables the bound for this session; `Some(n)` sets
+/// it. The zero-disables convention matches the node setting, so the per-session
+/// and node-wide knobs cannot mean opposite things by the same value.
+///
+/// Sessions accepted from a peer pass `None`: the bound governs how *we* reassemble what arrives,
+/// so it is ours to choose, not the initiator's to impose on us.
+fn session_config_with(
+    cfg: &SessionManagerConfig,
+    capabilities: crate::Capabilities,
+    max_frames_behind_gap: Option<usize>,
+) -> HoprSessionConfig {
+    // Only a session that cannot recover the missing frame should abandon it early. With
+    // retransmission the gap is a request away, so waiting is productive and cutting it short
+    // would discard data that was on its way back; without it the wait is for something that is
+    // never coming, and every frame behind the gap is held for nothing.
+    let can_retransmit =
+        capabilities.contains(Capability::RetransmissionAck) || capabilities.contains(Capability::RetransmissionNack);
+
+    // The session's own value when it stated one, the node's otherwise. `Some(0)` disables the
+    // bound at either level -- a threshold of zero would abandon every gap before a single frame
+    // arrived behind it, which nobody wants and which the sequencer would silently clamp to one.
+    let bound = match max_frames_behind_gap.or(cfg.max_frames_behind_gap) {
+        Some(0) | None => None,
+        Some(n) => Some(n),
+    };
+
     HoprSessionConfig {
         capabilities,
         frame_mtu: cfg.frame_mtu,
         frame_timeout: cfg.max_frame_timeout,
         max_buffered_segments: cfg.max_buffered_segments,
+        max_frames_behind_gap: (!can_retransmit).then_some(bound).flatten(),
     }
 }
 
@@ -1108,7 +1168,7 @@ where
                     let session = HoprSession::new_with_surb_state(
                         session_id,
                         forward_routing,
-                        session_config(&self.cfg, cfg.capabilities),
+                        session_config_with(&self.cfg, cfg.capabilities, cfg.max_frames_behind_gap),
                         (
                             reduced_surb_scoring_sender,
                             session_rx.inspect(move |_| {
@@ -1183,7 +1243,7 @@ where
                     let session = HoprSession::new(
                         session_id,
                         forward_routing,
-                        session_config(&self.cfg, cfg.capabilities),
+                        session_config_with(&self.cfg, cfg.capabilities, cfg.max_frames_behind_gap),
                         (reduced_surb_sender, session_rx),
                         Some(notifier),
                     )?;
@@ -1878,6 +1938,105 @@ mod tests {
                 segments
             );
         }
+    }
+
+    /// The head-of-line bound must reach a session that cannot recover a missing frame, and must
+    /// not reach one that can.
+    ///
+    /// Both halves matter. Without the first, a session with no retransmission holds every frame
+    /// behind a gap for the full frame timeout, waiting for something that is never coming —
+    /// measured on a cluster as 98.5 % of bytes arriving over the wire and 0.60 % reaching the
+    /// application. Without the second, a session that *would* have retransmitted the gap instead
+    /// abandons it, turning recoverable frames into loss.
+    #[test]
+    fn session_config_should_bound_the_gap_only_without_retransmission() {
+        assert_eq!(
+            SessionManagerConfig::default().max_frames_behind_gap,
+            Some(256),
+            "the default must bound the gap, or the stall stays in place unless opted out of"
+        );
+
+        let cfg = SessionManagerConfig {
+            max_frames_behind_gap: Some(8),
+            ..Default::default()
+        };
+
+        for reliable in [Capability::RetransmissionAck, Capability::RetransmissionNack] {
+            assert_eq!(
+                session_config(&cfg, reliable.into()).max_frames_behind_gap,
+                None,
+                "{reliable:?} can recover the gap, so the wait is productive and must be left alone"
+            );
+        }
+
+        for unreliable in [Capabilities::empty(), Capability::Segmentation.into()] {
+            assert_eq!(
+                session_config(&cfg, unreliable).max_frames_behind_gap,
+                Some(8),
+                "without retransmission the gap must be bounded"
+            );
+        }
+    }
+
+    /// The right value tracks throughput x latency spread, which is a property of the *session*,
+    /// not of the node: a bulk data session and a control session on the same node have entirely
+    /// different reordering depths. A caller that knows its own traffic must be able to say so.
+    #[test]
+    fn a_session_should_be_able_to_override_the_nodes_gap_bound() {
+        let node = SessionManagerConfig {
+            max_frames_behind_gap: Some(256),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            session_config_with(&node, Capabilities::empty(), Some(16)).max_frames_behind_gap,
+            Some(16),
+            "the session's own value must win over the node default"
+        );
+        assert_eq!(
+            session_config_with(&node, Capabilities::empty(), None).max_frames_behind_gap,
+            Some(256),
+            "saying nothing must inherit the node default"
+        );
+        assert_eq!(
+            session_config_with(&node, Capabilities::empty(), Some(0)).max_frames_behind_gap,
+            None,
+            "zero disables the bound for this session, matching the env knob's semantics"
+        );
+    }
+
+    /// A per-session override must not be able to re-enable the bound where waiting is productive.
+    #[test]
+    fn a_session_override_should_not_reach_a_session_that_can_retransmit() {
+        let node = SessionManagerConfig::default();
+        assert_eq!(
+            session_config_with(&node, Capability::RetransmissionAck.into(), Some(4)).max_frames_behind_gap,
+            None,
+            "retransmission can recover the gap, so no caller should be able to cut the wait short"
+        );
+    }
+
+    /// Disabling has to be reachable, since the bound trades reordering tolerance for latency and
+    /// the right value is deployment-specific. `None` restores the previous behaviour exactly.
+    #[test]
+    fn session_config_should_allow_the_gap_bound_to_be_disabled() {
+        let cfg = SessionManagerConfig {
+            max_frames_behind_gap: None,
+            ..Default::default()
+        };
+        assert_eq!(session_config(&cfg, Capabilities::empty()).max_frames_behind_gap, None);
+    }
+
+    #[test]
+    fn a_zero_gap_bound_should_disable_it_at_the_node_level_too() {
+        // `0` means "not for me" wherever it is written. Read literally it would be the strictest
+        // possible bound -- abandon the gap before a single frame arrives behind it -- so the two
+        // levels would mean opposite things by the same value.
+        let cfg = SessionManagerConfig {
+            max_frames_behind_gap: Some(0),
+            ..Default::default()
+        };
+        assert_eq!(session_config(&cfg, Capabilities::empty()).max_frames_behind_gap, None);
     }
 
     #[async_trait::async_trait]

--- a/transport/session/src/snapshots/hopr_transport_session__types__tests__hopr_session_config_default_snapshot.snap
+++ b/transport/session/src/snapshots/hopr_transport_session__types__tests__hopr_session_config_default_snapshot.snap
@@ -1,9 +1,10 @@
 ---
 source: transport/session/src/types.rs
-assertion_line: 487
+assertion_line: 557
 expression: cfg
 ---
 capabilities: 0
 frame_mtu: 1500
 frame_timeout: 800ms
 max_buffered_segments: 0
+max_frames_behind_gap: ~

--- a/transport/session/src/types.rs
+++ b/transport/session/src/types.rs
@@ -139,6 +139,12 @@ pub struct HoprSessionConfig {
     /// Default is 0.
     #[default(0)]
     pub max_buffered_segments: usize,
+    /// Abandon the frame due next once this many later frames are waiting behind it.
+    ///
+    /// Head-of-line bound, distinct from [`Self::frame_timeout`]: that one waits for a frame that
+    /// may still arrive, this bounds how much already-received data is held while it waits. `None`
+    /// keeps the timeout as the only rule.
+    pub max_frames_behind_gap: Option<usize>,
 }
 
 /// Represents the Session protocol socket over HOPR.
@@ -243,6 +249,13 @@ impl HoprSession {
                 // Anti-bufferbloat bound; only meaningful when flow control is enabled, which is
                 // also where the honest clock that observes the resulting loss lives.
                 max_frame_age: flow_control.and_then(|c| c.max_frame_age),
+                // Head-of-line bound, and deliberately *not* gated on flow control the way
+                // `max_frame_age` is. The reasoning there runs backwards for this one: a session
+                // that can retransmit may still recover a missing frame, so waiting is
+                // productive, while a session without retransmission is waiting for something
+                // that is never coming and holds everything already received behind it. The
+                // sessions that need this bound most are exactly the ones flow control excludes.
+                max_frames_behind_gap: cfg.max_frames_behind_gap,
                 ..Default::default()
             };
 


### PR DESCRIPTION
Backmerging 4.0 changes to `master`, so they will be present in 5.0 as well.