### PR TITLE
fix(audit): stop cargo-audit cloning the advisory DB into the repo

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -22,18 +22,6 @@ informational_warnings = ["unmaintained"]
 severity_threshold = "low"
 
 [database]
-# No `path` key on purpose. cargo-audit does not expand `~` read from this file: it takes the value
-# literally, relative to the working directory, so `path = "~/.cargo/advisory-db"` made `cargo audit`
-# clone ~40 MB into a directory actually named `~` in the repo root, once per checkout.
-#
-# `.gitignore` used to carry two entries spelled `~/.cargo/advisory-db`, which git reads as
-# repository-relative — so they matched that clone and kept it out of `git status` entirely. The copy
-# was invisible rather than merely untracked, and only `git status --ignored` showed it. Those two
-# entries are removed with this change: they described the bug rather than anything intended, and the
-# directory they were hiding is no longer created.
-#
-# The `--db` default is already `~/.cargo/advisory-db` and *is* expanded correctly, so naming it here
-# only broke the thing it was restating.
 url = "https://github.com/RustSec/advisory-db.git"
 fetch = true
 stale = false

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -24,9 +24,16 @@ severity_threshold = "low"
 [database]
 # No `path` key on purpose. cargo-audit does not expand `~` read from this file: it takes the value
 # literally, relative to the working directory, so `path = "~/.cargo/advisory-db"` made `cargo audit`
-# clone ~40 MB into a directory actually named `~` in the repo root — untracked, ungitignored, and
-# re-cloned per repo. The `--db` default is already `~/.cargo/advisory-db` and *is* expanded
-# correctly, so naming it here only broke the thing it was restating.
+# clone ~40 MB into a directory actually named `~` in the repo root, once per checkout.
+#
+# `.gitignore` used to carry two entries spelled `~/.cargo/advisory-db`, which git reads as
+# repository-relative — so they matched that clone and kept it out of `git status` entirely. The copy
+# was invisible rather than merely untracked, and only `git status --ignored` showed it. Those two
+# entries are removed with this change: they described the bug rather than anything intended, and the
+# directory they were hiding is no longer created.
+#
+# The `--db` default is already `~/.cargo/advisory-db` and *is* expanded correctly, so naming it here
+# only broke the thing it was restating.
 url = "https://github.com/RustSec/advisory-db.git"
 fetch = true
 stale = false

--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -22,7 +22,11 @@ informational_warnings = ["unmaintained"]
 severity_threshold = "low"
 
 [database]
-path = "~/.cargo/advisory-db"
+# No `path` key on purpose. cargo-audit does not expand `~` read from this file: it takes the value
+# literally, relative to the working directory, so `path = "~/.cargo/advisory-db"` made `cargo audit`
+# clone ~40 MB into a directory actually named `~` in the repo root — untracked, ungitignored, and
+# re-cloned per repo. The `--db` default is already `~/.cargo/advisory-db` and *is* expanded
+# correctly, so naming it here only broke the thing it was restating.
 url = "https://github.com/RustSec/advisory-db.git"
 fetch = true
 stale = false

--- a/.gitignore
+++ b/.gitignore
@@ -227,6 +227,4 @@ deploy/nfpm/*.1.gz
 
 # pcap packet capture files
 **/*.pcap
-~/.cargo/advisory-db
-~/.cargo/advisory-db..lock
 jeprof-pull-*/


### PR DESCRIPTION
`[database].path` was `~/.cargo/advisory-db`, and cargo-audit does not expand `~` read from this file — it takes the value literally, relative to the working directory. With `fetch = true`, `nix run .#audit` therefore cloned the advisory database into a directory actually named `~` in the repo root: 42 MB, untracked, not gitignored, and a separate copy in every repo carrying this same line.

The key is simply removed. cargo-audit's `--db` default is already `~/.cargo/advisory-db` and that one *is* expanded properly, so the line was restating the default and breaking it in the process.

Confirmed against cargo-audit 0.22.0. With `path = "~/probe-advisory-db"` in a throwaway crate it fails with ``failed to read directory `~/probe-advisory-db/crates` `` — the tilde unexpanded. With the key absent it reports `Loaded 1217 security advisories` from the real `$HOME/.cargo/advisory-db` and exits 0.

A comment marks the omission as deliberate, because a `[database]` section with no `path` looks like something to helpfully fill in.