### PR TITLE
fix(session): stop ERROR-spam on inbound packets to torn-down sessions

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -16,6 +16,7 @@ ignore = [
   "RUSTSEC-2026-0220", # ruint <1.20.0 pulled transitively by nybbles → alloy-trie → alloy; upgrade blocked on alloy bump
   "RUSTSEC-2026-0249", # `smartstring` unmaintained, requires `opentelemetry-prometheus-text-exporter` > 0.3.0
   "RUSTSEC-2026-0253", # `lru` <0.18.2 use-after-free if a key's `Drop` panics in `pop()`; pinned at 0.16.4 by alloy-provider 2.2.0 (via hopr-bindings -> hopr-types). 0.18.2 is semver-incompatible, so this needs an alloy bump — same blocker as RUSTSEC-2026-0220
+  "RUSTSEC-2026-0258", # `h2` unbounded empty DATA frames, requires new version of `cynic` in `blokli-client`
 ]
 informational_warnings = ["unmaintained"]
 severity_threshold = "low"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4365,7 +4365,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.48.0"
+version = "0.48.1"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,10 +153,10 @@ hopr-protocol-hopr = { version = "6.0.0", path = "protocols/hopr", default-featu
 hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
 hopr-protocol-start = { version = "1.1.0", path = "protocols/start", default-features = false }
 hopr-ticket-manager = { version = "0.5.2" }
-hopr-transport = { version = "0.48.0", path = "transport/hopr" }
+hopr-transport = { version = "0.48.1", path = "transport/hopr" }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
-hopr-transport-session = { version = "0.28.0", path = "transport/session", default-features = false }
+hopr-transport-session = { version = "0.29.0", path = "transport/session", default-features = false }
 hopr-transport-tag-allocator = { version = "0.1.1", path = "transport/tag-allocator", default-features = false }
 hopr-chain-connector = { version = "0.22.2" }
 

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport"
 description = "Implements the main HOPR transport interface for the core library"
-version = "0.48.0"
+version = "0.48.1"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -842,13 +842,20 @@ where
                             // and its silence has by now convinced our balancer that it is well
                             // stocked -- so tell the Sessions routed there to stop believing
                             // that estimate while the evidence says otherwise.
-                            chain
-                                .packet_key_to_chain_key(&destination)
-                                .ok()
-                                .flatten()
-                                .map(hopr_api::types::internal::prelude::NodeId::Chain)
-                                .map(|n| smgr.mark_return_path_degraded(&n, RETURN_PATH_DEGRADED_GRACE))
-                                .unwrap_or(0)
+                            match chain.packet_key_to_chain_key(&destination) {
+                                Ok(Some(address)) => smgr.mark_return_path_degraded(
+                                    &hopr_api::types::internal::prelude::NodeId::Chain(address),
+                                    RETURN_PATH_DEGRADED_GRACE,
+                                ),
+                                // A resolver error is exactly the failure this recovery path exists
+                                // to surface, so it must not be collapsed into "no chain key" — log
+                                // it rather than silently marking zero sessions.
+                                Err(error) => {
+                                    tracing::warn!(%destination, %error, "could not resolve a silent destination's chain key to mark it degraded");
+                                    0
+                                }
+                                Ok(None) => 0,
+                            }
                         },
                     )
                     .await
@@ -965,11 +972,12 @@ where
                                 tracing::trace!("unrelated message dispatch completed");
                                 Some(data)
                             }
-                            // Benign session teardown race (sink closed / inbox full / session
-                            // deregistered). Counted in the session manager; logged quietly here so
-                            // a departing counterparty cannot spam ERROR once per in-flight packet.
+                            // Benign drop: the session's sink has closed, its inbox is momentarily
+                            // full (backpressure), or the session is already deregistered. Counted
+                            // in the session manager and logged quietly here so a departing
+                            // counterparty cannot spam ERROR once per in-flight packet.
                             Ok(DispatchResult::Dropped(reason)) => {
-                                tracing::trace!(?reason, "dropped packet for a torn-down session");
+                                tracing::trace!(?reason, "dropped session packet");
                                 None
                             }
                             Err(error) => {

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -815,52 +815,43 @@ where
                 let mut ticks = futures_time::stream::interval(futures_time::time::Duration::from(surb_flush_interval));
 
                 while ticks.next().await.is_some() {
-                    // Detection before the drain: `degraded_destinations` reads the counts the
-                    // flush is about to reset.
-                    let silent = surb_round_trips.degraded_destinations();
-
-                    // The graph has to see this interval's counts *before* anything re-plans on it,
-                    // otherwise the re-plan that the silence just triggered reads a graph one whole
-                    // tick behind the evidence that triggered it.
-                    protocol::surb_telemetry::flush_into(
-                        &surb_round_trips,
-                        &surb_flush_graph,
-                        hopr_utils::platform::time::native::current_time()
-                            .as_unix_timestamp()
-                            .as_millis(),
-                    );
-
                     // Re-plan first, refill only if re-planning moved traffic. Run the other way
                     // round the refill mints SURBs onto the very route the planner is abandoning --
-                    // see `protocol::return_path_recovery`.
+                    // see `protocol::return_path_recovery`. Detection/flush/tick ordering lives in
+                    // `run_flush_tick`.
                     //
                     // Borrowed rather than cloned per call: the callbacks are `FnMut`, so anything
                     // they capture has to survive being invoked once per silent destination.
                     let (planner, chain, smgr) = (&surb_flush_planner, &surb_flush_chain, &surb_flush_smgr);
-                    for step in episodes
-                        .tick(
-                            silent,
-                            |destination| async move { planner.recompute_paths_from(&destination).await },
-                            |destination| async move {
-                                // Sessions name their destination by its chain address, this
-                                // telemetry by its packet key, and a `NodeId` holding one is never
-                                // equal to a `NodeId` holding the other -- so the match has to be
-                                // made on a resolved form, not on the enum.
-                                //
-                                // The counterparty has to still be receiving SURBs to reply with,
-                                // and its silence has by now convinced our balancer that it is well
-                                // stocked -- so tell the Sessions routed there to stop believing
-                                // that estimate while the evidence says otherwise.
-                                chain
-                                    .packet_key_to_chain_key(&destination)
-                                    .ok()
-                                    .flatten()
-                                    .map(hopr_api::types::internal::prelude::NodeId::Chain)
-                                    .map(|n| smgr.mark_return_path_degraded(&n, RETURN_PATH_DEGRADED_GRACE))
-                                    .unwrap_or(0)
-                            },
-                        )
-                        .await
+                    let now_ms = hopr_utils::platform::time::native::current_time()
+                        .as_unix_timestamp()
+                        .as_millis();
+                    for step in protocol::return_path_recovery::run_flush_tick(
+                        &surb_round_trips,
+                        &surb_flush_graph,
+                        now_ms,
+                        &mut episodes,
+                        |destination| async move { planner.recompute_paths_from(&destination).await },
+                        |destination| async move {
+                            // Sessions name their destination by its chain address, this
+                            // telemetry by its packet key, and a `NodeId` holding one is never
+                            // equal to a `NodeId` holding the other -- so the match has to be
+                            // made on a resolved form, not on the enum.
+                            //
+                            // The counterparty has to still be receiving SURBs to reply with,
+                            // and its silence has by now convinced our balancer that it is well
+                            // stocked -- so tell the Sessions routed there to stop believing
+                            // that estimate while the evidence says otherwise.
+                            chain
+                                .packet_key_to_chain_key(&destination)
+                                .ok()
+                                .flatten()
+                                .map(hopr_api::types::internal::prelude::NodeId::Chain)
+                                .map(|n| smgr.mark_return_path_degraded(&n, RETURN_PATH_DEGRADED_GRACE))
+                                .unwrap_or(0)
+                        },
+                    )
+                    .await
                     {
                         match step {
                             protocol::return_path_recovery::RecoveryStep::Replanned { destination, moved } => {
@@ -973,6 +964,13 @@ where
                             Ok(DispatchResult::Unrelated(data)) => {
                                 tracing::trace!("unrelated message dispatch completed");
                                 Some(data)
+                            }
+                            // Benign session teardown race (sink closed / inbox full / session
+                            // deregistered). Counted in the session manager; logged quietly here so
+                            // a departing counterparty cannot spam ERROR once per in-flight packet.
+                            Ok(DispatchResult::Dropped(reason)) => {
+                                tracing::trace!(?reason, "dropped packet for a torn-down session");
+                                None
                             }
                             Err(error) => {
                                 tracing::error!(%error, "error while dispatching packet in the session manager");

--- a/transport/hopr/src/protocol/return_path_recovery.rs
+++ b/transport/hopr/src/protocol/return_path_recovery.rs
@@ -100,6 +100,39 @@ impl<K: Eq + Hash + Copy> ReturnPathEpisodes<K> {
     }
 }
 
+/// Runs one SURB-flush tick in the exact order the flush task requires: **detect, then flush, then
+/// sequence recovery**.
+///
+/// Extracted from `HoprTransport::run` so the ordering can be exercised deterministically instead of
+/// only inside a live node. Two orderings here are load-bearing and this function is what pins them:
+/// detection must read the per-path counters *before* [`flush_into`](crate::protocol::surb_telemetry::flush_into)
+/// drains them (otherwise every path reads as idle and nothing is ever silent), and the graph must
+/// see this interval's counts *before* any re-plan reads it (otherwise the re-plan the silence just
+/// triggered runs a whole tick behind the evidence). Returns the recovery steps taken, for the
+/// caller to log.
+pub async fn run_flush_tick<G, R, RFut, F, FFut>(
+    surb_round_trips: &crate::protocol::surb_telemetry::SurbRoundTripRegistry,
+    graph: &G,
+    now_ms: u128,
+    episodes: &mut ReturnPathEpisodes<hopr_api::types::crypto::types::OffchainPublicKey>,
+    replan: R,
+    refill: F,
+) -> Vec<RecoveryStep<hopr_api::types::crypto::types::OffchainPublicKey>>
+where
+    G: hopr_api::graph::NetworkGraphUpdate,
+    R: FnMut(hopr_api::types::crypto::types::OffchainPublicKey) -> RFut,
+    RFut: Future<Output = usize>,
+    F: FnMut(hopr_api::types::crypto::types::OffchainPublicKey) -> FFut,
+    FFut: Future<Output = usize>,
+{
+    // Detection before the drain: `degraded_destinations` reads the counts the flush is about to
+    // reset.
+    let silent = surb_round_trips.degraded_destinations();
+    // The graph has to see this interval's counts before anything re-plans on it.
+    crate::protocol::surb_telemetry::flush_into(surb_round_trips, graph, now_ms);
+    episodes.tick(silent, replan, refill).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/transport/hopr/src/protocol/surb_telemetry.rs
+++ b/transport/hopr/src/protocol/surb_telemetry.rs
@@ -979,6 +979,146 @@ mod tests {
         let _ = (graph, me);
     }
 
+    /// End-to-end through the extracted flush tick: a silent return path drives re-plan → refill and
+    /// marks the balancer's estimate stale — **while the balancer's SURB supply reads healthy**.
+    ///
+    /// This is the seam the component tests leave open: detection (`degraded_destinations`),
+    /// sequencing (`ReturnPathEpisodes::tick`) and the balancer's degraded flag are each tested in
+    /// isolation, but nothing wires the real registry through [`run_flush_tick`] into a real
+    /// [`BalancerStateValues`]. It also pins the incident's supply-vs-delivery separation
+    /// (assertion #3): the buffer sits *at target* the whole time, so the signal that fires is a
+    /// return-path *delivery* signal, not SURB-distress.
+    #[tokio::test]
+    async fn a_silent_return_path_drives_replan_then_refill_and_marks_the_balancer_stale() {
+        use hopr_transport_session::{BalancerStateValues, SurbBalancerConfig};
+
+        use crate::protocol::return_path_recovery::{RecoveryStep, ReturnPathEpisodes, run_flush_tick};
+
+        let (graph, _me, peers) = graph_with(1);
+        let destination = peers[0];
+        let registry = registry_at_slot_zero();
+        let paths = legs();
+        let grace = Duration::from_secs(10);
+        let mut episodes = ReturnPathEpisodes::new(grace);
+
+        // A session whose SURB *supply* is healthy: a target is set and the buffer sits at it. If the
+        // return-path signal fires against this, it cannot be a supply/distress signal.
+        let balancer = BalancerStateValues::new(SurbBalancerConfig {
+            target_surb_buffer_size: 1000,
+            sustain_on_return_path_loss: true,
+            ..Default::default()
+        });
+        balancer.buffer_level.store(1000, Ordering::Relaxed);
+        assert!(!balancer.is_disabled(), "precondition: SURB supply is enabled");
+        assert!(
+            !balancer.return_path_estimate_is_stale(),
+            "precondition: nothing has marked the return path yet"
+        );
+
+        let replans = std::cell::Cell::new(0usize);
+        let refills = std::cell::Cell::new(0usize);
+
+        // Establish the pair works; silence only means something against a pair that once delivered.
+        deliver(&registry, paths, destination);
+        let first = run_flush_tick(
+            &registry,
+            &graph,
+            0,
+            &mut episodes,
+            |_d| {
+                replans.set(replans.get() + 1);
+                async { 1usize }
+            },
+            |_d| {
+                refills.set(refills.get() + 1);
+                balancer.mark_return_path_degraded(grace);
+                async { 1usize }
+            },
+        )
+        .await;
+        assert!(first.is_empty(), "a freshly delivering pair is not degraded");
+        assert_eq!((replans.get(), refills.get()), (0, 0), "nothing to recover yet");
+
+        // Then it goes quiet while a sibling keeps answering, until the tick names it and recovers.
+        let mut steps = Vec::new();
+        for _ in 0..SILENT_FLUSHES_BEFORE_DEGRADED {
+            mint_only(&registry, paths, destination);
+            deliver(&registry, heartbeat(), destination);
+            steps = run_flush_tick(
+                &registry,
+                &graph,
+                0,
+                &mut episodes,
+                |_d| {
+                    replans.set(replans.get() + 1);
+                    async { 1usize }
+                },
+                |_d| {
+                    refills.set(refills.get() + 1);
+                    balancer.mark_return_path_degraded(grace);
+                    async { 1usize }
+                },
+            )
+            .await;
+            if !steps.is_empty() {
+                break;
+            }
+        }
+
+        // Re-plan happened first and, because it moved traffic, a refill followed — in that order.
+        assert!(
+            matches!(
+                steps.as_slice(),
+                [
+                    RecoveryStep::Replanned { destination: d1, moved: 1 },
+                    RecoveryStep::Refilled { destination: d2, sessions: 1 },
+                ] if *d1 == destination && *d2 == destination
+            ),
+            "expected re-plan then refill for the silent destination, got {steps:?}"
+        );
+        assert_eq!(refills.get(), 1, "exactly one refill, behind the re-plan");
+
+        // The refill marked the balancer: the estimate is now stale even though supply is healthy.
+        assert!(
+            balancer.return_path_estimate_is_stale(),
+            "the refill must mark the return path degraded"
+        );
+        assert!(
+            !balancer.is_disabled(),
+            "supply-vs-delivery: SURB supply is still healthy…"
+        );
+        assert_eq!(
+            balancer.buffer_level.load(Ordering::Relaxed),
+            1000,
+            "…the buffer never left its target — the signal is delivery, not distress"
+        );
+
+        // Recovery: a reply arrives, so detection stops naming the destination and no further
+        // recovery is driven.
+        deliver(&registry, paths, destination);
+        let recovered = run_flush_tick(
+            &registry,
+            &graph,
+            0,
+            &mut episodes,
+            |_d| {
+                replans.set(replans.get() + 1);
+                async { 1usize }
+            },
+            |_d| {
+                refills.set(refills.get() + 1);
+                balancer.mark_return_path_degraded(grace);
+                async { 1usize }
+            },
+        )
+        .await;
+        assert!(
+            recovered.is_empty(),
+            "once a reply arrives the return path is no longer named silent, got {recovered:?}"
+        );
+        assert_eq!(refills.get(), 1, "no second refill after the path recovered");
+    }
+
     /// Several pairs lead to one destination, but re-planning acts on the destination.
     ///
     /// Regression: silence accrues per pair, so pairs re-armed independently and between them kept

--- a/transport/hopr/src/protocol/surb_telemetry.rs
+++ b/transport/hopr/src/protocol/surb_telemetry.rs
@@ -1025,14 +1025,14 @@ mod tests {
             &graph,
             0,
             &mut episodes,
-            |_d| {
+            |_d| async {
                 replans.set(replans.get() + 1);
-                async { 1usize }
+                1usize
             },
-            |_d| {
+            |_d| async {
                 refills.set(refills.get() + 1);
                 balancer.mark_return_path_degraded(grace);
-                async { 1usize }
+                1usize
             },
         )
         .await;
@@ -1049,14 +1049,14 @@ mod tests {
                 &graph,
                 0,
                 &mut episodes,
-                |_d| {
+                |_d| async {
                     replans.set(replans.get() + 1);
-                    async { 1usize }
+                    1usize
                 },
-                |_d| {
+                |_d| async {
                     refills.set(refills.get() + 1);
                     balancer.mark_return_path_degraded(grace);
-                    async { 1usize }
+                    1usize
                 },
             )
             .await;
@@ -1101,14 +1101,14 @@ mod tests {
             &graph,
             0,
             &mut episodes,
-            |_d| {
+            |_d| async {
                 replans.set(replans.get() + 1);
-                async { 1usize }
+                1usize
             },
-            |_d| {
+            |_d| async {
                 refills.set(refills.get() + 1);
                 balancer.mark_return_path_degraded(grace);
-                async { 1usize }
+                1usize
             },
         )
         .await;

--- a/transport/session/Cargo.toml
+++ b/transport/session/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport-session"
 description = "Session functionality providing session abstraction over the HOPR transport"
-version = "0.28.0"
+version = "0.29.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/session/src/balancer/controller.rs
+++ b/transport/session/src/balancer/controller.rs
@@ -1159,4 +1159,52 @@ mod tests {
             "expected at least one decay step: {levels:?}"
         );
     }
+
+    // --- return-path-degraded deadline primitive (Test C, gap 1) ---------------------------------
+    //
+    // The behavioural loop tests above (sustain / ignore-unless-opted-in / return-to-closed-loop /
+    // refill) already cover how the balancer *reacts* to the signal. What they do not isolate are
+    // three edge cases of the `mark_return_path_degraded` / `return_path_estimate_is_stale`
+    // deadline primitive itself, each guarding a specific correctness invariant.
+
+    /// The zero-guard: never marked is never degraded. `return_path_degraded_until_ms == 0` means
+    /// "never marked", not "marked at the epoch" — without the explicit `deadline > 0` check every
+    /// opted-in session would believe its return path was dead from the first packet.
+    #[test]
+    fn return_path_should_not_be_stale_before_it_is_ever_marked() {
+        let state = BalancerStateValues::new(SurbBalancerConfig {
+            sustain_on_return_path_loss: true,
+            ..Default::default()
+        });
+        assert!(!state.return_path_estimate_is_stale());
+    }
+
+    /// The window expires on its own, independently of any recovery signal. The behavioural tests
+    /// clear the degraded state by resuming replies; this pins the other exit — a marker nobody
+    /// ever withdraws must still lapse, bounding over-production to the grace window. Marking with a
+    /// zero grace sets the deadline to "now"; the monotonic clock only moves forward, so the
+    /// subsequent read is already past it — no sleep, no flake.
+    #[test]
+    fn an_expired_degraded_window_should_no_longer_be_stale() {
+        let state = BalancerStateValues::new(SurbBalancerConfig {
+            sustain_on_return_path_loss: true,
+            ..Default::default()
+        });
+        state.mark_return_path_degraded(Duration::ZERO);
+        assert!(!state.return_path_estimate_is_stale());
+    }
+
+    /// Re-marking extends the window: an already-expired deadline followed by a fresh mark is stale
+    /// again. Guards the `fetch_max` in `mark_return_path_degraded`.
+    #[test]
+    fn re_marking_should_reopen_an_expired_window() {
+        let state = BalancerStateValues::new(SurbBalancerConfig {
+            sustain_on_return_path_loss: true,
+            ..Default::default()
+        });
+        state.mark_return_path_degraded(Duration::ZERO);
+        assert!(!state.return_path_estimate_is_stale());
+        state.mark_return_path_degraded(Duration::from_secs(10));
+        assert!(state.return_path_estimate_is_stale());
+    }
 }

--- a/transport/session/src/counters.rs
+++ b/transport/session/src/counters.rs
@@ -21,6 +21,18 @@ pub fn session_inbox_drop_count() -> usize {
     SESSION_INBOX_DROPS.load(Ordering::Relaxed)
 }
 
+/// Cumulative count of application data packets dropped because the session inbox
+/// channel was closed (`try_send` returned `TrySendError::Disconnected`): the session
+/// data sink was dropped while the slot was still registered — a benign teardown race,
+/// not the backpressure that [`SESSION_INBOX_DROPS`] counts.
+pub static SESSION_INBOX_CLOSED_DROPS: AtomicUsize = AtomicUsize::new(0);
+
+/// Returns the cumulative count of packets dropped because the session inbox was closed.
+#[inline]
+pub fn session_inbox_closed_drop_count() -> usize {
+    SESSION_INBOX_CLOSED_DROPS.load(Ordering::Relaxed)
+}
+
 /// Cumulative count of data packets dropped because no matching session slot was
 /// found in the session manager (`UnknownData` / unestablished-session path).
 pub static SESSION_UNKNOWN_DATA_DROPS: AtomicUsize = AtomicUsize::new(0);

--- a/transport/session/src/lib.rs
+++ b/transport/session/src/lib.rs
@@ -23,7 +23,7 @@ pub use hopr_protocol_session::{AcknowledgementMode, flow_control::FlowControlCo
 pub use hopr_utils::network_types::types::*;
 #[cfg(feature = "benchmark")]
 pub use manager::SESSION_FORWARD_CAPACITY;
-pub use manager::{DispatchResult, MIN_SURB_BUFFER_DURATION, SessionManager, SessionManagerConfig};
+pub use manager::{DispatchResult, DropReason, MIN_SURB_BUFFER_DURATION, SessionManager, SessionManagerConfig};
 #[cfg(feature = "telemetry")]
 pub use telemetry::{SessionAckMode, SessionLifecycleState};
 pub use types::{

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -217,6 +217,27 @@ impl Drop for SessionSlotGuard<'_> {
     }
 }
 
+/// Why an inbound session data packet was dropped without being delivered.
+///
+/// All three are ordinary consequences of a session tearing down or being briefly overwhelmed, not
+/// faults: a departing counterparty leaves packets in flight that arrive after its slot's sink is
+/// gone or after the slot itself is deregistered. They are reported as an [`DispatchResult::Dropped`]
+/// outcome rather than an `Err` precisely so the caller does not log them at `ERROR` — the loud
+/// teardown-race spam this distinction exists to remove.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DropReason {
+    /// The slot is still registered but its data sink (receiver) has been dropped
+    /// (`TrySendError::Disconnected`). The common case when a session is being torn down.
+    SinkClosed,
+    /// The slot's inbox is full (`TrySendError::Full`): genuine backpressure, the reader is not
+    /// keeping up. Distinct from [`SinkClosed`](Self::SinkClosed) because it is transient, not a
+    /// teardown.
+    SinkFull,
+    /// No slot for this session id is registered (formerly the `UnknownData` error): the session
+    /// was fully deregistered before this packet arrived.
+    Unregistered,
+}
+
 /// Indicates the result of processing a message.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum DispatchResult {
@@ -224,6 +245,9 @@ pub enum DispatchResult {
     Processed,
     /// The message was not related to Start or Session protocol.
     Unrelated(ApplicationDataIn),
+    /// The message belonged to a session but could not be delivered and was dropped. Benign — see
+    /// [`DropReason`]. Reported as `Ok` so the caller logs it quietly instead of as an `ERROR`.
+    Dropped(DropReason),
 }
 
 /// Configuration for the [`SessionManager`].
@@ -1437,27 +1461,45 @@ where
         } else if in_data.data.application_tag == SESSION_APPLICATION_TAG {
             let session_id = pseudonym;
 
+            // How often a sustained inbox-full condition is allowed to log. Backpressure can
+            // affect every packet on the hot path, so warning per drop would reproduce exactly
+            // the ERROR spam this dispatch was rewritten to avoid — warn once per interval instead.
+            const SESSION_INBOX_FULL_WARN_INTERVAL: usize = 256;
+
             return if let Some(session_slot) = self.sessions.get(&session_id) {
                 trace!(%session_id, "received data for a registered session");
 
-                Ok(session_slot
-                    .session_tx
-                    .try_send(in_data)
-                    .map(|_| {
+                match session_slot.session_tx.try_send(in_data) {
+                    Ok(_) => {
                         #[cfg(all(feature = "telemetry", not(test)))]
                         METRIC_DISPATCHED_MSGS.increment_by(&["processed"], 1);
 
-                        DispatchResult::Processed
-                    })
-                    .map_err(|error| {
-                        error!(%session_id, %error, "failed to dispatch session data");
-                        crate::counters::SESSION_INBOX_DROPS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                        SessionManagerError::other(error)
-                    })?)
+                        Ok(DispatchResult::Processed)
+                    }
+                    // Benign teardown race: the slot is still registered but its data sink was
+                    // dropped. Quiet on purpose — see [`DropReason`].
+                    Err(crossfire::TrySendError::Disconnected(_)) => {
+                        trace!(%session_id, "dropping data for a session whose sink has closed");
+                        crate::counters::SESSION_INBOX_CLOSED_DROPS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        Ok(DispatchResult::Dropped(DropReason::SinkClosed))
+                    }
+                    // Genuine backpressure: the reader is not keeping up. Rate-limited so a
+                    // sustained overload cannot become per-packet log spam.
+                    Err(crossfire::TrySendError::Full(_)) => {
+                        let prev =
+                            crate::counters::SESSION_INBOX_DROPS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        if prev.is_multiple_of(SESSION_INBOX_FULL_WARN_INTERVAL) {
+                            warn!(%session_id, dropped = prev + 1, "session inbox full, dropping data (backpressure)");
+                        }
+                        Ok(DispatchResult::Dropped(DropReason::SinkFull))
+                    }
+                }
             } else {
-                error!(%session_id, "received data from an unestablished session");
+                // Fully deregistered session: packets still in flight for a torn-down session.
+                // Quiet — see [`DropReason::Unregistered`].
+                trace!(%session_id, "dropping data for an unregistered session");
                 crate::counters::SESSION_UNKNOWN_DATA_DROPS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                Err(TransportSessionError::UnknownData)
+                Ok(DispatchResult::Dropped(DropReason::Unregistered))
             };
         }
 
@@ -1476,8 +1518,8 @@ where
     /// Intended for benchmarks that need a session to exist before calling
     /// [`SessionManager::dispatch_message`].
     ///
-    /// Requires the `"benchmark"` feature.
-    #[cfg(feature = "benchmark")]
+    /// Requires the `"benchmark"` feature (or a test build).
+    #[cfg(any(feature = "benchmark", test))]
     pub fn pre_populate_session(&self, session_id: SessionId, routing_opts: DestinationRouting) {
         let (session_tx, _) =
             crossfire::mpsc::bounded_blocking_async::<ApplicationDataIn>(self.cfg.session_forward_capacity);
@@ -1494,8 +1536,8 @@ where
     /// Like [`pre_populate_session`](SessionManager::pre_populate_session) but also returns the
     /// session channel receiver so the caller can spawn a drain task.
     ///
-    /// Requires the `"benchmark"` feature.
-    #[cfg(feature = "benchmark")]
+    /// Requires the `"benchmark"` feature (or a test build).
+    #[cfg(any(feature = "benchmark", test))]
     pub fn pre_populate_session_with_receiver(
         &self,
         session_id: SessionId,
@@ -3716,38 +3758,105 @@ mod tests {
         Ok(())
     }
 
+    /// Convenience: a session data packet carrying `payload`.
+    #[cfg(test)]
+    fn session_data_packet(payload: &[u8]) -> anyhow::Result<ApplicationDataIn> {
+        Ok(ApplicationDataIn {
+            data: ApplicationData::new(SESSION_APPLICATION_TAG, payload)?,
+            packet_info: Default::default(),
+        })
+    }
+
+    /// The manager sink type used by the dispatch drop tests, which never open a session and so
+    /// never exercise the sink — its concrete type only needs to be nameable.
+    #[cfg(test)]
+    type TestManager =
+        SessionManager<futures::channel::mpsc::UnboundedSender<(DestinationRouting, ApplicationDataOut)>>;
+
+    // Test B (fully deregistered): a data packet for a session id absent from the registry is a
+    // benign, quiet drop counted as UnknownData — NOT an error, and NOT one ERROR log per packet.
+    // Under the old behaviour this returned `Err(UnknownData)` and the caller logged it at ERROR,
+    // which is what produced the per-packet spam during the incident.
     #[test_log::test(tokio::test)]
-    async fn session_manager_should_return_unknown_data_error_when_dispatching_to_unknown_session() -> anyhow::Result<()>
-    {
-        let mgr: SessionManager<futures::channel::mpsc::UnboundedSender<(DestinationRouting, ApplicationDataOut)>> =
-            SessionManager::new(Default::default());
+    async fn dispatching_to_an_unregistered_session_should_be_a_quiet_counted_drop() -> anyhow::Result<()> {
+        let mgr: TestManager = SessionManager::new(Default::default());
 
-        let transport = MockMsgSender::new();
-        let (new_session_tx, new_session_rx) = futures::channel::mpsc::channel(1);
-        let _notifications = tokio::spawn(async move {
-            pin_mut!(new_session_rx);
-            while let Some(_session) = new_session_rx.next().await {}
-        });
-        let (sender, _handle) = mock_packet_planning(transport);
-        mgr.start(sender.clone(), new_session_tx)?;
-        assert!(mgr.is_started());
-
-        // Send data with session application tag but no session exists
         let pseudonym = HoprPseudonym::random();
-        let result = mgr.dispatch_message(
-            pseudonym,
-            ApplicationDataIn {
-                data: ApplicationData::new(SESSION_APPLICATION_TAG, b"test data")?,
-                packet_info: Default::default(),
-            },
+        let before = crate::counters::session_unknown_data_drop_count();
+
+        // N packets → N drops, each an Ok(Dropped(Unregistered)), no panic, no unbounded error.
+        const N: usize = 5;
+        for _ in 0..N {
+            let result = mgr.dispatch_message(pseudonym, session_data_packet(b"test data")?);
+            assert!(
+                matches!(result, Ok(DispatchResult::Dropped(DropReason::Unregistered))),
+                "unregistered-session packet must be a benign Dropped(Unregistered), got {result:?}"
+            );
+        }
+
+        // Counter advanced by at least N (>= rather than == because it is a process-global atomic
+        // other tests in this binary may also touch).
+        assert!(crate::counters::session_unknown_data_drop_count() >= before + N);
+
+        Ok(())
+    }
+
+    // Test A (primary regression): a data packet for a session whose data sink has been dropped
+    // while the slot is still registered must be dropped quietly as SinkClosed — NOT an error.
+    // This is the "sending on a disconnected channel" ERROR from the incident. The bad-behaviour
+    // assertion is the silent-vs-loud distinction: the result is Ok(Dropped(SinkClosed)), not Err,
+    // and specifically not SinkFull (which would misattribute a teardown as backpressure).
+    #[test_log::test(tokio::test)]
+    async fn dispatching_to_a_session_whose_sink_closed_should_be_a_quiet_counted_drop() -> anyhow::Result<()> {
+        let mgr: TestManager = SessionManager::new(Default::default());
+
+        // `pre_populate_session` registers the slot and immediately drops its receiver, so the
+        // sink is closed while the slot is still present — exactly the incident's race.
+        let pseudonym = HoprPseudonym::random();
+        mgr.pre_populate_session(pseudonym, DestinationRouting::Return(pseudonym.into()));
+
+        let before = crate::counters::session_inbox_closed_drop_count();
+        let result = mgr.dispatch_message(pseudonym, session_data_packet(b"after teardown")?);
+
+        assert!(
+            matches!(result, Ok(DispatchResult::Dropped(DropReason::SinkClosed))),
+            "closed-sink packet must be a benign Dropped(SinkClosed), not an error or SinkFull, got {result:?}"
+        );
+        assert!(crate::counters::session_inbox_closed_drop_count() > before);
+
+        Ok(())
+    }
+
+    // Genuine backpressure (inbox full, reader alive but not keeping up) is distinct from a
+    // teardown: it is Dropped(SinkFull) and counted in SESSION_INBOX_DROPS, not the closed counter.
+    #[test_log::test(tokio::test)]
+    async fn dispatching_to_a_full_session_inbox_should_be_a_backpressure_drop() -> anyhow::Result<()> {
+        // Capacity 1 so a single unread packet fills the inbox deterministically.
+        let cfg = SessionManagerConfig {
+            session_forward_capacity: 1,
+            ..Default::default()
+        };
+        let mgr: TestManager = SessionManager::new(cfg);
+
+        // Keep the receiver alive but never read it, so the channel is open but saturates.
+        let pseudonym = HoprPseudonym::random();
+        let _rx = mgr.pre_populate_session_with_receiver(pseudonym, DestinationRouting::Return(pseudonym.into()));
+
+        // First packet fills the single slot and is accepted.
+        let accepted = mgr.dispatch_message(pseudonym, session_data_packet(b"fills the slot")?);
+        assert!(
+            matches!(accepted, Ok(DispatchResult::Processed)),
+            "first packet should be accepted, got {accepted:?}"
         );
 
-        assert!(result.is_err());
-        assert!(matches!(result.unwrap_err(), TransportSessionError::UnknownData));
-
-        // Cleanup: close sender and await handle
-        sender.close_channel();
-        let _ = _handle.await;
+        // Second packet finds the inbox full → backpressure drop.
+        let before = crate::counters::session_inbox_drop_count();
+        let overflow = mgr.dispatch_message(pseudonym, session_data_packet(b"overflows")?);
+        assert!(
+            matches!(overflow, Ok(DispatchResult::Dropped(DropReason::SinkFull))),
+            "overflow packet must be a Dropped(SinkFull) backpressure drop, got {overflow:?}"
+        );
+        assert!(crate::counters::session_inbox_drop_count() > before);
 
         Ok(())
     }

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -221,7 +221,7 @@ impl Drop for SessionSlotGuard<'_> {
 ///
 /// All three are ordinary consequences of a session tearing down or being briefly overwhelmed, not
 /// faults: a departing counterparty leaves packets in flight that arrive after its slot's sink is
-/// gone or after the slot itself is deregistered. They are reported as an [`DispatchResult::Dropped`]
+/// gone or after the slot itself is deregistered. They are reported as a [`DispatchResult::Dropped`]
 /// outcome rather than an `Err` precisely so the caller does not log them at `ERROR` — the loud
 /// teardown-race spam this distinction exists to remove.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -1491,7 +1491,7 @@ where
                         let prev =
                             crate::counters::SESSION_INBOX_DROPS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         if prev.is_multiple_of(SESSION_INBOX_FULL_WARN_INTERVAL) {
-                            warn!(%session_id, dropped = prev + 1, "session inbox full, dropping data (backpressure)");
+                            warn!(%session_id, total_inbox_full_drops = prev + 1, "session inbox full, dropping data (backpressure)");
                         }
                         #[cfg(all(feature = "telemetry", not(test)))]
                         METRIC_DISPATCHED_MSGS.increment_by(&["dropped_sink_full"], 1);

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -1481,6 +1481,8 @@ where
                     Err(crossfire::TrySendError::Disconnected(_)) => {
                         trace!(%session_id, "dropping data for a session whose sink has closed");
                         crate::counters::SESSION_INBOX_CLOSED_DROPS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                        #[cfg(all(feature = "telemetry", not(test)))]
+                        METRIC_DISPATCHED_MSGS.increment_by(&["dropped_sink_closed"], 1);
                         Ok(DispatchResult::Dropped(DropReason::SinkClosed))
                     }
                     // Genuine backpressure: the reader is not keeping up. Rate-limited so a
@@ -1491,6 +1493,8 @@ where
                         if prev.is_multiple_of(SESSION_INBOX_FULL_WARN_INTERVAL) {
                             warn!(%session_id, dropped = prev + 1, "session inbox full, dropping data (backpressure)");
                         }
+                        #[cfg(all(feature = "telemetry", not(test)))]
+                        METRIC_DISPATCHED_MSGS.increment_by(&["dropped_sink_full"], 1);
                         Ok(DispatchResult::Dropped(DropReason::SinkFull))
                     }
                 }
@@ -1499,6 +1503,8 @@ where
                 // Quiet — see [`DropReason::Unregistered`].
                 trace!(%session_id, "dropping data for an unregistered session");
                 crate::counters::SESSION_UNKNOWN_DATA_DROPS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                #[cfg(all(feature = "telemetry", not(test)))]
+                METRIC_DISPATCHED_MSGS.increment_by(&["dropped_unregistered"], 1);
                 Ok(DispatchResult::Dropped(DropReason::Unregistered))
             };
         }


### PR DESCRIPTION
## Summary

Inbound session data addressed to a session whose data sink had been dropped, or whose slot was already deregistered, was logged at `ERROR` **once per packet** — and twice over, because `dispatch_message` returned `Err` and the caller re-logged it. When a counterparty departs it can leave many packets in flight, so a benign teardown race became an `ERROR` storm (the `sending on a disconnected channel` / `received data for an unregistered session` spam observed in the 2026-07-28 return-path incident).

This makes those benign drops a first-class outcome instead of an error:

- `dispatch_message` returns `DispatchResult::Dropped(DropReason)` — `SinkClosed` and `Unregistered` are `trace`-level; `SinkFull` (genuine backpressure) is a **rate-limited** `warn`. The caller logs the outcome quietly rather than at `ERROR`.
- A new `SESSION_INBOX_CLOSED_DROPS` counter separates the torn-down-sink drop from the inbox-full drop it was previously miscounted as (`SESSION_INBOX_DROPS` reverts to meaning "full", as its doc always claimed).

It also makes the return-path recovery loop testable off a live node: the `SurbFlush` per-tick body is extracted into `return_path_recovery::run_flush_tick` (behavior-preserving — `HoprTransport::run` now calls it), which pins the load-bearing detect→flush→recover ordering in one place.

New deterministic coverage: the three dispatch drop reasons; the return-path degraded-deadline primitive (zero-guard, self-expiry, re-mark); and the `surb_telemetry → ReturnPathEpisodes → BalancerStateValues` recovery seam, including the supply-vs-delivery separation (the return-path signal fires while the SURB buffer sits at target — a delivery signal, not SURB distress).

Versions: `hopr-transport-session` 0.28.0 → 0.29.0 (new `DispatchResult` variant is 0.x-breaking); `hopr-transport` 0.48.0 → 0.48.1 (additive `run_flush_tick`).
