### PR TITLE
feat: carry Curvy scan identities through PIX sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,6 +940,7 @@ checksum = "6bc66f96ebe2a17a499475b4f94791d379817592ef494171586967ffdc6f95db"
 dependencies = [
  "ark-ec 0.6.0",
  "ark-ff 0.6.0",
+ "ark-r1cs-std",
  "ark-std 0.6.0",
 ]
 
@@ -1179,6 +1180,51 @@ dependencies = [
  "educe",
  "fnv",
  "hashbrown 0.17.1",
+]
+
+[[package]]
+name = "ark-r1cs-std"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291f1c6628bfcac79b0dc2adbe401aa9100e2e96daa971645e0b18fc94de9a98"
+dependencies = [
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-relations",
+ "ark-std 0.6.0",
+ "educe",
+ "itertools 0.14.0",
+ "num-bigint 0.4.8",
+ "num-integer",
+ "num-traits",
+ "tracing",
+]
+
+[[package]]
+name = "ark-relations"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe4c11c797a64b8a23e22bf4e77bf582ac27bb21395e3183a9a506ba2561e9f9"
+dependencies = [
+ "ark-ff 0.6.0",
+ "ark-poly 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "foldhash 0.1.5",
+ "indexmap 2.14.0",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "ark-secp256k1"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41b34e9124731f4834db5a8f92ce085a47cd6f006fdb50359ea508d6256341d"
+dependencies = [
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
@@ -1787,9 +1833,8 @@ dependencies = [
 
 [[package]]
 name = "blokli-client"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1645e71eacbae4cf304636a390a08b5c03cf068a814923dbd1631d5558f7ddeb"
+version = "0.31.1"
+source = "git+https://github.com/hoprnet/blokli-client?rev=98a890c7c6609c9467e02072702a743c29e1fa6a#98a890c7c6609c9467e02072702a743c29e1fa6a"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -2585,6 +2630,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "curvy-core"
+version = "0.1.0-rc.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad039edd8eb265c92104aaff6758113893e198c384e0301881f127155bd9ce03"
+dependencies = [
+ "aes 0.9.2",
+ "ark-bn254 0.6.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-secp256k1",
+ "ctr 0.10.1",
+ "getrandom 0.2.17",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
+ "num-bigint 0.5.1",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "zeroize",
 ]
 
 [[package]]
@@ -4098,9 +4165,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b888d2f2d08002d003db1789f732c812ebe2709375780cc6b12eeba09930452c"
+version = "2.0.1"
+source = "git+https://github.com/hoprnet/hopr-api?rev=683c13a710ca6d8ac22455bc104e2dfe876f9d86#683c13a710ca6d8ac22455bc104e2dfe876f9d86"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -4137,8 +4203,7 @@ dependencies = [
 [[package]]
 name = "hopr-chain-connector"
 version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a053b62b7fb08927b8bc1f271018c122151d8bafbdcd3e0081a09322b13fcdae"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=bb32c420b67dfe0d9a68eb8fe931c5f6e2f9d50e#bb32c420b67dfe0d9a68eb8fe931c5f6e2f9d50e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4195,8 +4260,7 @@ dependencies = [
 [[package]]
 name = "hopr-ct-full-network"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7985d0e77c83e9ae107dcc53012eeb736b83edeb83cf3522a3d1b7ab1e66fa9"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=bb32c420b67dfe0d9a68eb8fe931c5f6e2f9d50e#bb32c420b67dfe0d9a68eb8fe931c5f6e2f9d50e"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -4259,8 +4323,7 @@ dependencies = [
 [[package]]
 name = "hopr-network-graph"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1104069d205e792651562e8648e2403f815169c4c822ba00678b82fa1911fa2e"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=bb32c420b67dfe0d9a68eb8fe931c5f6e2f9d50e#bb32c420b67dfe0d9a68eb8fe931c5f6e2f9d50e"
 dependencies = [
  "anyhow",
  "bimap",
@@ -4417,8 +4480,7 @@ dependencies = [
 [[package]]
 name = "hopr-ticket-manager"
 version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbedcb10d008c7a1831ceb89c213ab2a0242405e24d99886839553fca725ca89"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=bb32c420b67dfe0d9a68eb8fe931c5f6e2f9d50e#bb32c420b67dfe0d9a68eb8fe931c5f6e2f9d50e"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4527,8 +4589,7 @@ dependencies = [
 [[package]]
 name = "hopr-transport-p2p"
 version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e9a987efe3013cf7f3809d5f87aec29d5588a695a6af718dd406f5d0f5806b"
+source = "git+https://github.com/hoprnet/hopr-impls?rev=bb32c420b67dfe0d9a68eb8fe931c5f6e2f9d50e#bb32c420b67dfe0d9a68eb8fe931c5f6e2f9d50e"
 dependencies = [
  "async-broadcast",
  "async-trait",
@@ -4586,6 +4647,7 @@ dependencies = [
  "async-trait",
  "criterion",
  "crossfire",
+ "curvy-core",
  "flagset",
  "futures",
  "futures-time",
@@ -4617,6 +4679,7 @@ dependencies = [
  "tikv-jemallocator",
  "tokio",
  "tracing",
+ "zeroize",
 ]
 
 [[package]]
@@ -4635,9 +4698,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19fe24538d5d68590496763119afbb5f8ccb466f88abbf36cda7a8c7d49e1f1"
+version = "2.4.0"
+source = "git+https://github.com/hoprnet/hopr-types?rev=19c6eec0357f75ac544536ae435ffc10da7b222f#19c6eec0357f75ac544536ae435ffc10da7b222f"
 dependencies = [
  "aes 0.9.2",
  "anyhow",
@@ -9078,6 +9140,7 @@ dependencies = [
  "once_cell",
  "regex-automata",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ criterion = { version = "0.8.2", default-features = false, features = [
   "async_tokio",
 ] }
 crossfire = { version = "3.1.19", default-features = false }
+curvy-core = "=0.1.0-rc.3"
 dashmap = { version = "6.2.1", features = ["inline"] }
 elliptic-curve-tools = "0.3.0"
 flagset = "0.4.7"
@@ -137,14 +138,13 @@ tokio-util = { version = "0.7.19", default-features = false, features = [
 tracing = { version = "0.1.44", features = ["release_max_level_debug"] }
 validator = { version = "0.21.0", features = ["derive"] }
 vsss-rs = { version = "6.0.1", default-features = false }
+zeroize = "1.9.0"
 
-# TEMPORARY: pinned to unreleased branches so this change compiles and is tested end to end,
-# and pinned together so a single hopr-api major is in the graph — two majors coexisting makes
-# `hopr_api::chain::DeployedSafe` two distinct types. `version` alongside `git` is the "multiple
-# locations" form: git wins locally, the version requirement survives packaging. Revert to plain
-# versions once hopr-api 2.0.0, hopr-utilities 0.9.0 and the hopr-impls crates are published.
-hopr-api = { version = "2.0.0" }
-hopr-types = { version = "2.2.1", features = ["use-bindings"] }
+# TEMPORARY: version requirements keep these manifests publishable, while the root patch table
+# pins the matching Curvy PIX integration commits. Remove the patches once those commits are
+# released.
+hopr-api = { version = "2.0.1" }
+hopr-types = { version = "2.4.0", features = ["use-bindings"] }
 hopr-utils = { package = "hopr-utilities", version = "0.9.0", default-features = false }
 hopr-utils-session = { version = "1.2.1", path = "utils-session" }
 
@@ -244,3 +244,14 @@ similar.opt-level = 3
 
 [workspace.metadata.cargo-shear]
 ignored = ["oas3", "hopr-session-server-forwarder", "hopr-utils-session"]
+
+# Temporary cross-repository Curvy PIX integration pins.
+[patch.crates-io]
+blokli-client = { git ="https://github.com/hoprnet/blokli-client", rev = "98a890c7c6609c9467e02072702a743c29e1fa6a" }
+hopr-api = { git = "https://github.com/hoprnet/hopr-api", rev = "683c13a710ca6d8ac22455bc104e2dfe876f9d86" }
+hopr-types = { git = "https://github.com/hoprnet/hopr-types", rev = "19c6eec0357f75ac544536ae435ffc10da7b222f" }
+hopr-chain-connector = { git ="https://github.com/hoprnet/hopr-impls", rev = "bb32c420b67dfe0d9a68eb8fe931c5f6e2f9d50e" }
+hopr-ct-full-network = { git ="https://github.com/hoprnet/hopr-impls", rev = "bb32c420b67dfe0d9a68eb8fe931c5f6e2f9d50e" }
+hopr-network-graph = { git ="https://github.com/hoprnet/hopr-impls", rev = "bb32c420b67dfe0d9a68eb8fe931c5f6e2f9d50e" }
+hopr-ticket-manager = { git ="https://github.com/hoprnet/hopr-impls", rev = "bb32c420b67dfe0d9a68eb8fe931c5f6e2f9d50e" }
+hopr-transport-p2p = { git ="https://github.com/hoprnet/hopr-impls", rev = "bb32c420b67dfe0d9a68eb8fe931c5f6e2f9d50e" }

--- a/transport/hopr/src/config.rs
+++ b/transport/hopr/src/config.rs
@@ -428,8 +428,8 @@ pub struct PixGlobalConfig {
     ///
     /// Unlike its neighbours this is not a dimension, so `validate_pix_dimension_product` ignores it.
     ///
-    /// Defaults to 2, minimum 1, maximum 20 (`MAX_SSA_BATCH_SIZE`).
-    #[validate(range(min = 1, max = 20))]
+    /// Defaults to 2, minimum 1, maximum 9 (`MAX_SSA_BATCH_SIZE`).
+    #[validate(range(min = 1, max = 9))]
     #[default(DEFAULT_MAX_SSAS_PER_SSA_REQUEST)]
     pub max_ssas_per_request: usize,
 

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -1389,7 +1389,7 @@ pub(crate) fn recovered_ssa_to_pix_event(
     rec: &RecoveredSsa<SimplePseudonym, <HoprPixSpec as PixSpec>::AddressPrivateKey>,
 ) -> PixEvent {
     PixEvent::PrivateKeyRecovered(PixPrivateKeyRecovered {
-        id: (*rec.ssa_id.pseudonym(), rec.ssa_id.ssa_index()),
+        id: (*rec.ssa_id.pseudonym(), rec.ssa_id.ssa_index()).into(),
         secret: PixDepositSecret(rec.ssa.secret().clone()),
     })
 }
@@ -1407,19 +1407,19 @@ const PIX_EVENT_DISPATCH_CONCURRENCY: usize = 64;
 /// instruction for the funding strategy.
 fn session_pix_event_to_pix_event(event: HoprSessionOutPixEvent) -> PixEvent {
     match event {
-        HoprSessionOutPixEvent::ReadyToDeposit(AgreedSsaQuota {
-            ssa_id,
-            deposit_address,
-            quota_per_ssa,
-        }) => PixEvent::NewDepositAddress(PixNewDepositAddress {
-            id: (*ssa_id.pseudonym(), ssa_id.ssa_index()),
+        HoprSessionOutPixEvent::ReadyToDeposit(
+            AgreedSsaQuota {
+                ssa_id,
+                deposit_address,
+                quota_per_ssa,
+            },
+            scan_key,
+        ) => PixEvent::NewDepositAddress(PixNewDepositAddress {
+            id: (*ssa_id.pseudonym(), ssa_id.ssa_index()).into(),
             address: deposit_address.into(),
             quota: quota_per_ssa,
-            // `None` rather than the handshake's `deposit_data`: that field is carried by the Start
-            // protocol's `SsaRequest` (`hopr-protocol-start`) and is not surfaced through
-            // `AgreedSsaQuota`, so there is nothing here to forward yet. Threading it through is a
-            // change to the Session layer's event types, not to this mapping.
-            additional_data: None,
+            // Entry receives only the public `(K,V)` scan identity.
+            additional_data: scan_key.map(|key| key.as_ref().into()),
         }),
         HoprSessionOutPixEvent::DepositNeeded(
             AgreedSsaQuota {
@@ -1427,14 +1427,14 @@ fn session_pix_event_to_pix_event(event: HoprSessionOutPixEvent) -> PixEvent {
                 deposit_address,
                 quota_per_ssa,
             },
+            scan_secret,
             notifier,
         ) => PixEvent::DepositAddressReceived(PixDepositAddressReceived {
-            id: (*ssa_id.pseudonym(), ssa_id.ssa_index()),
+            id: (*ssa_id.pseudonym(), ssa_id.ssa_index()).into(),
             address: deposit_address.into(),
             quota: quota_per_ssa,
-            // See `NewDepositAddress` above: the handshake's `deposit_data` does not reach
-            // `AgreedSsaQuota`, so there is nothing to forward yet.
-            additional_data: None,
+            // Exit keeps `v` locally and hands the complete scan-only capability to its pool.
+            additional_data: scan_secret.map(|secret| secret.to_bytes().into()),
             deposit_updated: Some(notifier),
         }),
     }
@@ -1760,7 +1760,7 @@ mod pix_recovery_event_tests {
             anyhow::bail!("expected PrivateKeyRecovered");
         };
 
-        assert_eq!(pk.id, (pseudonym, ssa_id.ssa_index()));
+        assert_eq!(pk.id, (pseudonym, ssa_id.ssa_index()).into());
         assert_eq!(pk.secret.0.as_ref(), rec.ssa.secret().as_ref());
 
         Ok(())

--- a/transport/session/Cargo.toml
+++ b/transport/session/Cargo.toml
@@ -62,6 +62,7 @@ allocator-jemalloc = [
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 crossfire = { workspace = true }
+curvy-core = { workspace = true }
 flagset = { workspace = true, features = ["serde"] }
 futures = { workspace = true }
 humantime-serde = { workspace = true }
@@ -78,6 +79,7 @@ smart-default = { workspace = true }
 strum = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+zeroize = { workspace = true }
 tokio = { workspace = true, optional = true }
 mockall = { workspace = true, optional = true }
 

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -9,12 +9,13 @@ use anyhow::anyhow;
 use futures::{FutureExt, Sink, SinkExt, StreamExt, TryStreamExt, channel::oneshot, future::AbortHandle};
 use futures_time::future::FutureExt as TimeExt;
 use hopr_api::types::{
+    crypto::prelude::{CurvyScanPublicKey, CurvyScanSecret, SecretKey},
     crypto_random::Randomizable,
     internal::{
         prelude::HoprPseudonym,
         routing::{DestinationRouting, RoutingOptions},
     },
-    primitive::prelude::Address,
+    primitive::prelude::{Address, U256},
 };
 use hopr_crypto_packet::{
     HoprPixSpec,
@@ -31,6 +32,7 @@ use hopr_protocol_start::{
 };
 use hopr_utils::runtime::AbortableList;
 use tracing::{debug, error, info, trace, warn};
+use zeroize::Zeroizing;
 
 #[cfg(feature = "telemetry")]
 use crate::telemetry::{
@@ -97,6 +99,51 @@ lazy_static::lazy_static! {
 /// `unused_verifier_lifetime`, whereas sweeping every index a session ever used is unbounded work on
 /// the eviction listener, and leaves a tombstone per index behind it.
 const SSA_TEARDOWN_SWEEP_WINDOW: u32 = 64;
+
+/// Generates the scan-only Curvy identity attached to one SSA allocation.
+///
+/// Curvy also generates a temporary secp256k1 spend scalar. PIX deliberately discards it: note
+/// ownership remains the independently derived SSA BabyJubJub key, whose private scalar is only
+/// reconstructed from protocol shares. The Exit retains only `v`; the Entry receives `(K,V)`.
+fn generate_curvy_scan_identity() -> anyhow::Result<(CurvyScanPublicKey, CurvyScanSecret)> {
+    let (spend_secret, view_secret, spend_meta_key, view_public_key) =
+        curvy_core::stealth::new_meta().map_err(|error| anyhow!("failed to generate Curvy scan identity: {error}"))?;
+    let _spend_secret = Zeroizing::new(spend_secret);
+    let view_secret = Zeroizing::new(view_secret);
+
+    let (spend_x, spend_y) = curvy_point_to_bytes(&spend_meta_key, "Curvy spend meta-key K")?;
+    let (view_x, view_y) = curvy_point_to_bytes(&view_public_key, "Curvy view key V")?;
+    let public = CurvyScanPublicKey::from_affine_coordinates((&spend_x, &spend_y), (&view_x, &view_y))
+        .map_err(|error| anyhow!("failed to encode Curvy scan identity: {error}"))?;
+
+    let view_secret = U256::from_str_radix(view_secret.trim_start_matches("0x"), 16)
+        .map_err(|error| anyhow!("invalid Curvy view scalar: {error}"))?;
+    let secret = CurvyScanSecret::new(SecretKey::from(view_secret.to_big_endian()), public);
+    Ok((public, secret))
+}
+
+fn curvy_point_to_bytes(point: &str, field: &str) -> anyhow::Result<([u8; 32], [u8; 32])> {
+    let (x, y) = point
+        .split_once('.')
+        .ok_or_else(|| anyhow!("{field} is not encoded as x.y"))?;
+    let x = U256::from_dec_str(x).map_err(|error| anyhow!("invalid {field} x-coordinate: {error}"))?;
+    let y = U256::from_dec_str(y).map_err(|error| anyhow!("invalid {field} y-coordinate: {error}"))?;
+    Ok((x.to_big_endian(), y.to_big_endian()))
+}
+
+fn validate_curvy_scan_public_key(public: CurvyScanPublicKey) -> anyhow::Result<()> {
+    let (kx, ky) = public
+        .spend_meta_key()
+        .map_err(|error| anyhow!("invalid Curvy spend meta-key K: {error}"))?;
+    let (vx, vy) = public
+        .view_key()
+        .map_err(|error| anyhow!("invalid Curvy view key V: {error}"))?;
+    let spend_meta_key = format!("{}.{}", U256::from_big_endian(&kx), U256::from_big_endian(&ky));
+    let view_public_key = format!("{}.{}", U256::from_big_endian(&vx), U256::from_big_endian(&vy));
+    curvy_core::stealth::send_with_r("1", &spend_meta_key, &view_public_key)
+        .map(|_| ())
+        .map_err(|error| anyhow!("invalid Curvy scan identity: {error}"))
+}
 
 /// Release reconstructor state for the SSA cycles of a session that may still be live.
 ///
@@ -270,20 +317,23 @@ const MAX_ALLOWED_UNVERIFIABLE_PIX_SHARES: usize = 0;
 
 /// Hard ceiling on both SSA batch-size knobs, whatever the configuration says.
 ///
-/// Deliberately far below the wire limit (`StartProtocol::MAX_SSAS_PER_REQUEST`, 27), which only
+/// Deliberately below the generic wire limit (`StartProtocol::MAX_SSAS_PER_REQUEST`), which only
 /// bounds what can be *decoded*. The real cost is paid on both sides of the exchange, and neither is
 /// small at the profiled dimensions:
 ///
 /// * Entry: every entry in the batch is a full `new_ssa_commitment` (hundreds of thousands of EC commitments), its own
 ///   burst of thousands of `SsaCommit` packets, and its own `ReadyToDeposit` — i.e. its own on-chain deposit.
-/// * Exit: every entry is a live reconstructor cycle, ≈49 MiB of peak state, held until that cycle recovers. At this
-///   ceiling that is ≈1 GB per Session.
+/// * Exit: every entry is a live reconstructor cycle, ≈49 MiB of peak state, held until that cycle recovers. Nine
+///   entries are already ≈441 MiB per Session.
+///
+/// Nine also keeps the concrete HOPR `SsaRequest` below the packet budget after adding the 65-byte
+/// Curvy public scan identity and its per-index framing for every commitment.
 ///
 /// Both [`IncomingSessionPixConfig::ssas_per_request`] and
 /// [`SessionManagerConfig::max_ssas_per_ssa_request`] are clamped to `1..=Self` in
 /// [`SessionManager::new`], so a programmatically built config that never calls `validate()` cannot
 /// exceed it.
-pub const MAX_SSA_BATCH_SIZE: usize = 20;
+pub const MAX_SSA_BATCH_SIZE: usize = 9;
 
 /// Default for [`SessionManagerConfig::max_ssas_per_ssa_request`] — how many SSA commitments an Entry
 /// accepts in a single [`SsaServerCommitmentMessage`].
@@ -367,6 +417,9 @@ struct SessionSsaState {
     /// Serializes the three call sites of [`SessionManager::request_next_ssa`] so that
     /// `peek_index` / fallible work / `advance_index` is never interleaved.
     request_lock: Arc<hopr_utils::runtime::prelude::Mutex<()>>,
+    /// Per-SSA private Curvy viewer retained only until it is handed to the Exit-side watcher.
+    /// It contains no BabyJubJub note-spending key.
+    curvy_scan_secrets: Arc<parking_lot::Mutex<HashMap<SsaIndex, CurvyScanSecret>>>,
 }
 
 impl SessionSsaState {
@@ -377,6 +430,7 @@ impl SessionSsaState {
             num_errors: Default::default(),
             params,
             request_lock: Arc::new(hopr_utils::runtime::prelude::Mutex::new(())),
+            curvy_scan_secrets: Default::default(),
         }
     }
 
@@ -410,6 +464,18 @@ impl SessionSsaState {
             .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |i| i.checked_add(n))
             .expect("SSA index overflow after u32::MAX cycles");
         SsaIndex::new(old.checked_add(n).expect("just advanced")).expect("non-zero just advanced")
+    }
+
+    fn insert_curvy_scan_secret(&self, ssa_index: SsaIndex, secret: CurvyScanSecret) {
+        self.curvy_scan_secrets.lock().insert(ssa_index, secret);
+    }
+
+    fn curvy_scan_secret(&self, ssa_index: SsaIndex) -> Option<CurvyScanSecret> {
+        self.curvy_scan_secrets.lock().get(&ssa_index).cloned()
+    }
+
+    fn remove_curvy_scan_secret(&self, ssa_index: SsaIndex) {
+        self.curvy_scan_secrets.lock().remove(&ssa_index);
     }
 
     /// Data quota a single SSA of this Session buys, as per [`pix_params_to_quota`] — the whole
@@ -2077,6 +2143,19 @@ where
             "generated exit commitments for the SSA batch"
         );
 
+        // Generate an independent Curvy viewer per SSA. Only `(K,V)` enters the network payload;
+        // the matching `v` stays in Exit-local session state until the deposit watcher accepts it.
+        // Complete the full batch first so a generation failure cannot install partial state.
+        let mut scan_keys = Vec::with_capacity(exit_commitments.len());
+        let mut scan_secrets = Vec::with_capacity(exit_commitments.len());
+        for (ssa_index, _) in &exit_commitments {
+            let (scan_key, scan_secret) =
+                generate_curvy_scan_identity().map_err(SessionManagerError::other)?;
+            scan_keys.push((*ssa_index, scan_key));
+            scan_secrets.push((*ssa_index, scan_secret));
+        }
+        let deposit_data = HoprPixDepositData::from_scan_keys(scan_keys).map_err(SessionManagerError::other)?;
+
         // Set up the kill switches before sending the SSA request so there is no
         // window where the commitments are in flight but no timeout is installed.
         //
@@ -2129,17 +2208,27 @@ where
             session_id,
             current_ssa_state.params,
             exit_commitments,
-            HoprPixDepositData::default(),
+            deposit_data,
         ));
 
-        send_via_msg_sender(
+        // Install private capabilities before publishing the request so a fast response cannot
+        // reach `handle_ssa_commit` first. Roll them back if the request is not sent.
+        for (ssa_index, scan_secret) in scan_secrets {
+            current_ssa_state.insert_curvy_scan_secret(ssa_index, scan_secret);
+        }
+        if let Err(error) = send_via_msg_sender(
             &mut msg_sender,
             slot.routing_opts.clone(),
             data,
             "session SSA commitment request message",
         )
         .await
-        .map_err(TransportSessionError::packet_sending)?;
+        {
+            for ssa_index in &ssa_indices {
+                current_ssa_state.remove_curvy_scan_secret(*ssa_index);
+            }
+            return Err(TransportSessionError::packet_sending(error));
+        }
 
         // All fallible steps succeeded — commit the index advance past the whole batch, and hand the
         // registrations over to the cycles they now belong to.
@@ -3017,9 +3106,10 @@ where
         };
 
         // See if we haven't received an SSA commitment for a Session that we did not register as PIX-capable
-        let Some(quota_per_ssa) = session_slot.current_ssa_state.get().map(|s| s.quota_per_ssa()) else {
+        let Some(ssa_state) = session_slot.current_ssa_state.get() else {
             return Err(SessionManagerError::Other(anyhow::anyhow!("no SSA state for session {session_id}")).into());
         };
+        let quota_per_ssa = ssa_state.quota_per_ssa();
 
         let ssa_id = SsaId::new(pseudonym, msg.ssa_index);
 
@@ -3058,6 +3148,8 @@ where
         if ssa_client_commitment_state.deposit_address_first_encountered
             && let Some(deposit_address) = ssa_client_commitment_state.ssa_deposit_address
         {
+            let scan_secret = ssa_state.curvy_scan_secret(ssa_id.ssa_index());
+            let allocation_id = (*ssa_id.pseudonym(), ssa_id.ssa_index()).into();
             // Inside the guard on purpose: every other `SsaCommit` of a cycle takes the other branch,
             // so allocating this before the `if` built and dropped a channel per message.
             let (deposit_done_tx, deposit_done_rx) = futures::channel::mpsc::channel(10);
@@ -3076,11 +3168,7 @@ where
                 SessionHandles::DepositAwaiter(ssa_id.ssa_index().get()),
                 hopr_utils::spawn_as_abortable!(async move {
                     let deposit_done_rx_result = deposit_done_rx
-                        .filter(|((evt_pseudonym, evt_index), _)| {
-                            futures::future::ready(
-                                evt_index == &ssa_id.ssa_index() && evt_pseudonym == ssa_id.pseudonym(),
-                            )
-                        })
+                        .filter(move |(event_id, _)| futures::future::ready(event_id == &allocation_id))
                         .next()
                         .delay(futures_time::time::Duration::from_millis(100))
                         .timeout(futures_time::time::Duration::from(max_deposit_wait))
@@ -3117,11 +3205,13 @@ where
                         deposit_address,
                         quota_per_ssa,
                     },
+                    scan_secret,
                     deposit_done_tx,
                 ))
                 .map_err(|_| {
                     SessionManagerError::other(anyhow::anyhow!("failed to send pix event for needed deposit"))
                 })?;
+            ssa_state.remove_curvy_scan_secret(ssa_id.ssa_index());
             info!(%ssa_id, %deposit_address, quota_per_ssa, "retrieved first client SSA commitment and deposit address");
         }
 
@@ -3292,6 +3382,31 @@ where
             return Err(error.into());
         }
 
+        // The deposit data is optional for pools that do not use private discovery. Once present,
+        // it must describe exactly this batch; accepting a partial or extra map could associate a
+        // viewer with the wrong SSA deposit.
+        let mut scan_keys = match msg.deposit_data.scan_keys() {
+            Ok(scan_keys) => scan_keys,
+            Err(error) => {
+                self.refuse_ssa_request(msg.session_id, session_slot.routing_opts.clone())
+                    .await;
+                return Err(SessionManagerError::Unacceptable(format!("invalid PIX deposit data: {error}")).into());
+            }
+        };
+        if !scan_keys.is_empty() {
+            let exact_key_set = scan_keys.len() == msg.commitments.len()
+                && msg.commitments.keys().all(|ssa_index| scan_keys.contains_key(ssa_index));
+            let all_valid = scan_keys.values().copied().all(|key| validate_curvy_scan_public_key(key).is_ok());
+            if !exact_key_set || !all_valid {
+                self.refuse_ssa_request(msg.session_id, session_slot.routing_opts.clone())
+                    .await;
+                return Err(SessionManagerError::Unacceptable(
+                    "PIX deposit data does not contain one valid Curvy scan identity per SSA commitment".into(),
+                )
+                .into());
+            }
+        }
+
         let Some(our_params) = session_slot.current_ssa_state.get().map(|s| s.params) else {
             return Err(
                 SessionManagerError::Other(anyhow::anyhow!("no SSA state for session {}", msg.session_id)).into(),
@@ -3353,6 +3468,7 @@ where
         // by design, since the Exit may advance by more than one SSA at a time.
         for (ssa_index, exit_commitment) in msg.commitments {
             trace!(ssa_index, "received Exit SSA commitment");
+            let scan_key = scan_keys.remove(&ssa_index);
 
             // Use the global `pix_toolbox.share_generator` to generate the client
             // commitment. The generator is shared with the packet pipeline's
@@ -3409,11 +3525,14 @@ where
             // complete commitment to reconstruct the deposit key.
             pix_toolbox
                 .pix_events
-                .try_send(HoprSessionOutPixEvent::ReadyToDeposit(AgreedSsaQuota {
-                    ssa_id: SsaId::new(pseudonym, ssa_index),
-                    deposit_address,
-                    quota_per_ssa,
-                }))
+                .try_send(HoprSessionOutPixEvent::ReadyToDeposit(
+                    AgreedSsaQuota {
+                        ssa_id: SsaId::new(pseudonym, ssa_index),
+                        deposit_address,
+                        quota_per_ssa,
+                    },
+                    scan_key,
+                ))
                 .map_err(|_| SessionManagerError::other(anyhow::anyhow!("failed to notify new deposit ssa")))?;
             info!(%ssa_index, %deposit_address, quota_per_ssa, "generated client SSA commitment and deposit address");
         }
@@ -3467,6 +3586,55 @@ mod tests {
     /// Surplus used by the small test `SsaGeneratorConfig`s below. Non-zero and different from
     /// [`SsaGeneratorConfig::default`], so a value that failed to cross the wire is visible.
     const TEST_SURPLUS_SHARES: u8 = 1;
+
+    #[test]
+    fn curvy_scan_identities_round_trip_in_concrete_hopr_deposit_data() -> anyhow::Result<()> {
+        let mut scan_keys = Vec::new();
+        let mut scan_secrets = Vec::new();
+        let mut commitments = Vec::new();
+        for index in 1..=MAX_SSA_BATCH_SIZE as u32 {
+            let ssa_index = SsaIndex::new(index).ok_or_else(|| anyhow!("non-zero test SSA index"))?;
+            let (scan_key, scan_secret) = generate_curvy_scan_identity()?;
+            assert_eq!(CurvyScanSecret::try_from(scan_secret.to_bytes().as_slice())?.public(), scan_key);
+            scan_keys.push((ssa_index, scan_key));
+            scan_secrets.push((ssa_index, scan_secret));
+            commitments.push((ssa_index, HoprPixGroupElement(Default::default())));
+        }
+
+        let deposit_data = HoprPixDepositData::from_scan_keys(scan_keys.clone())?;
+        let decoded = deposit_data.scan_keys()?;
+        assert_eq!(decoded.len(), MAX_SSA_BATCH_SIZE);
+        for ((ssa_index, scan_key), (_, scan_secret)) in scan_keys.iter().zip(&scan_secrets) {
+            assert_eq!(decoded.get(ssa_index), Some(scan_key));
+            assert_eq!(scan_secret.public(), *scan_key);
+        }
+
+        // The real HOPR instantiation, with the maximum supported batch and full Curvy payload,
+        // must fit the Start protocol packet budget and survive its CBOR round trip.
+        let request = HoprStartProtocol::SsaRequest(SsaServerCommitmentMessage::new(
+            HoprPseudonym::random(),
+            small_pix_params(),
+            commitments,
+            deposit_data.clone(),
+        ));
+        let (tag, encoded) = request.clone().encode()?;
+        let decoded_request = HoprStartProtocol::decode(tag, &encoded)?;
+        assert_eq!(decoded_request, request);
+        Ok(())
+    }
+
+    #[test]
+    fn curvy_deposit_data_rejects_duplicate_indices_and_truncation() -> anyhow::Result<()> {
+        let ssa_index = SsaIndex::MIN;
+        let (scan_key, _) = generate_curvy_scan_identity()?;
+        let duplicate = HoprPixDepositData::from_scan_keys([(ssa_index, scan_key), (ssa_index, scan_key)])?;
+        assert!(duplicate.scan_keys().is_err());
+
+        let mut truncated = HoprPixDepositData::from_scan_keys([(ssa_index, scan_key)])?;
+        truncated.0.pop();
+        assert!(truncated.scan_keys().is_err());
+        Ok(())
+    }
 
     #[test]
     fn session_config_forwards_max_buffered_segments() {
@@ -7578,11 +7746,11 @@ mod tests {
 
         assert!(matches!(
             event,
-            HoprSessionOutPixEvent::DepositNeeded(AgreedSsaQuota { ssa_id: ref received_ssa_id, .. }, _)
+            HoprSessionOutPixEvent::DepositNeeded(AgreedSsaQuota { ssa_id: ref received_ssa_id, .. }, _, _)
             if received_ssa_id == &ssa_id
         ));
 
-        let HoprSessionOutPixEvent::DepositNeeded(quota, _) = event else {
+        let HoprSessionOutPixEvent::DepositNeeded(quota, _, _) = event else {
             unreachable!();
         };
         assert_eq!(quota.quota_per_ssa, pix_params_to_quota(&small_pix_params()));

--- a/transport/session/src/types.rs
+++ b/transport/session/src/types.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::BTreeMap,
     convert::Into,
     fmt::Debug,
     pin::Pin,
@@ -11,7 +12,9 @@ use futures::{SinkExt, StreamExt, TryStreamExt};
 use hopr_api::{
     HoprBalance,
     types::{
+        crypto::prelude::{CURVY_SCAN_PUBLIC_KEY_SIZE, CurvyScanPublicKey, CurvyScanSecret},
         internal::{prelude::HoprPseudonym, routing::DestinationRouting},
+        network::PixAddressId,
         primitive::errors::GeneralError,
     },
 };
@@ -93,12 +96,77 @@ pub type HoprStartProtocol = StartProtocol<
     HoprPixDepositData,
 >;
 
-/// Deposit data placeholder, CBOR-encoded as a byte string.
+/// HOPR-specific PIX deposit data, CBOR-encoded as one compact byte string.
 ///
-/// Currently set to an empty byte string (zero-length Vec). Uses [`serde_bytes`] for compact
-/// CBOR byte-string encoding.
+/// A non-empty payload carries one public Curvy scan identity `(K,V)` for each SSA commitment:
+/// `version || count || (ssa_index || scan_key)*`. The separate Exit-held view scalar `v` is
+/// never serialized into this network type. An empty value remains valid for deposit pools that
+/// do not require private note discovery.
 #[derive(Debug, Clone, PartialEq, Eq, Default, serde::Serialize, serde::Deserialize)]
 pub struct HoprPixDepositData(#[serde(with = "serde_bytes")] pub Vec<u8>);
+
+const CURVY_DEPOSIT_DATA_VERSION: u8 = 1;
+const CURVY_DEPOSIT_DATA_HEADER_SIZE: usize = 2;
+const CURVY_DEPOSIT_DATA_ENTRY_SIZE: usize = size_of::<u32>() + CURVY_SCAN_PUBLIC_KEY_SIZE;
+
+impl HoprPixDepositData {
+    /// Encodes an ordered set of per-SSA public Curvy scan identities.
+    pub fn from_scan_keys(
+        scan_keys: impl IntoIterator<Item = (SsaIndex, CurvyScanPublicKey)>,
+    ) -> Result<Self, GeneralError> {
+        let scan_keys = scan_keys.into_iter().collect::<Vec<_>>();
+        let count = u8::try_from(scan_keys.len())
+            .map_err(|_| GeneralError::ParseError("too many Curvy scan identities".into()))?;
+        if count == 0 {
+            return Ok(Self::default());
+        }
+
+        let mut bytes = Vec::with_capacity(
+            CURVY_DEPOSIT_DATA_HEADER_SIZE + scan_keys.len() * CURVY_DEPOSIT_DATA_ENTRY_SIZE,
+        );
+        bytes.push(CURVY_DEPOSIT_DATA_VERSION);
+        bytes.push(count);
+        for (ssa_index, scan_key) in scan_keys {
+            bytes.extend_from_slice(&ssa_index.get().to_be_bytes());
+            bytes.extend_from_slice(scan_key.as_ref());
+        }
+        Ok(Self(bytes))
+    }
+
+    /// Decodes public scan identities by SSA index.
+    ///
+    /// Every point and index is validated and duplicate indices are rejected. An empty payload
+    /// represents a pool without additional deposit data.
+    pub fn scan_keys(&self) -> Result<BTreeMap<SsaIndex, CurvyScanPublicKey>, GeneralError> {
+        if self.0.is_empty() {
+            return Ok(BTreeMap::new());
+        }
+        if self.0.len() < CURVY_DEPOSIT_DATA_HEADER_SIZE || self.0[0] != CURVY_DEPOSIT_DATA_VERSION {
+            return Err(GeneralError::ParseError("unsupported PIX deposit data".into()));
+        }
+        let count = self.0[1] as usize;
+        let expected_len = CURVY_DEPOSIT_DATA_HEADER_SIZE + count * CURVY_DEPOSIT_DATA_ENTRY_SIZE;
+        if count == 0 || self.0.len() != expected_len {
+            return Err(GeneralError::ParseError("invalid PIX deposit data length".into()));
+        }
+
+        let mut scan_keys = BTreeMap::new();
+        for entry in self.0[CURVY_DEPOSIT_DATA_HEADER_SIZE..].chunks_exact(CURVY_DEPOSIT_DATA_ENTRY_SIZE) {
+            let index = u32::from_be_bytes(
+                entry[..size_of::<u32>()]
+                    .try_into()
+                    .map_err(|_| GeneralError::ParseError("Curvy scan identity SSA index".into()))?,
+            );
+            let ssa_index = SsaIndex::new(index)
+                .ok_or_else(|| GeneralError::ParseError("Curvy scan identity SSA index".into()))?;
+            let scan_key = CurvyScanPublicKey::try_from(&entry[size_of::<u32>()..])?;
+            if scan_keys.insert(ssa_index, scan_key).is_some() {
+                return Err(GeneralError::ParseError("duplicate Curvy scan identity SSA index".into()));
+            }
+        }
+        Ok(scan_keys)
+    }
+}
 
 /// Quota per single SSA in bytes.
 ///
@@ -251,14 +319,15 @@ pub struct AgreedSsaQuota {
 pub enum HoprSessionOutPixEvent {
     /// Event raised by the [`crate::manager::SessionManager`] of an Entry node can deposit funds to an SSA for the
     /// agreed data quota.
-    ReadyToDeposit(AgreedSsaQuota),
+    ReadyToDeposit(AgreedSsaQuota, Option<CurvyScanPublicKey>),
     /// Event raised by the [`crate::manager::SessionManager`] of an Exit node, whenever it knows a new SSA and expects
     /// funds to be deposited.
     ///
     /// The attached sender is used to deliver updates once the deposit is completed.
     DepositNeeded(
         AgreedSsaQuota,
-        futures::channel::mpsc::Sender<((HoprPseudonym, SsaIndex), HoprBalance)>,
+        Option<CurvyScanSecret>,
+        futures::channel::mpsc::Sender<(PixAddressId, HoprBalance)>,
     ),
 }
 

--- a/transport/session/tests/pix.rs
+++ b/transport/session/tests/pix.rs
@@ -307,7 +307,7 @@ async fn session_manager_should_follow_start_protocol_to_establish_new_session_a
         .map_err(|e| anyhow::anyhow!("timeout: {e}"))?
         .ok_or(anyhow::anyhow!("alice must get a pix event"))?;
 
-    let HoprSessionOutPixEvent::ReadyToDeposit(alice_quota) = &alice_session_event else {
+    let HoprSessionOutPixEvent::ReadyToDeposit(alice_quota, Some(alice_scan_key)) = &alice_session_event else {
         panic!("expected ReadyToDeposit, got {alice_session_event:?}");
     };
 
@@ -316,7 +316,7 @@ async fn session_manager_should_follow_start_protocol_to_establish_new_session_a
         .map_err(|e| anyhow::anyhow!("timeout: {e}"))?
         .ok_or(anyhow::anyhow!("bob must get a pix event"))?;
 
-    let HoprSessionOutPixEvent::DepositNeeded(bob_quota, _) = &bob_session_event else {
+    let HoprSessionOutPixEvent::DepositNeeded(bob_quota, Some(bob_scan_secret), _) = &bob_session_event else {
         panic!("expected DepositNeeded, got {bob_session_event:?}");
     };
 
@@ -328,6 +328,11 @@ async fn session_manager_should_follow_start_protocol_to_establish_new_session_a
     assert_eq!(
         alice_quota.quota_per_ssa, bob_quota.quota_per_ssa,
         "Entry and Exit must agree on SSA quota"
+    );
+    assert_eq!(
+        alice_scan_key,
+        &bob_scan_secret.public(),
+        "Entry public scan identity must match the Exit-held private capability"
     );
 
     tokio::time::sleep(Duration::from_millis(100)).await;
@@ -660,7 +665,7 @@ async fn batched_ssa_request_produces_one_deposit_cycle_per_requested_ssa() -> R
             .await
             .map_err(|e| anyhow::anyhow!("timeout awaiting entry cycle {i}: {e}"))?
             .ok_or(anyhow::anyhow!("entry must emit cycle {i}"))?;
-        let HoprSessionOutPixEvent::ReadyToDeposit(quota) = event else {
+        let HoprSessionOutPixEvent::ReadyToDeposit(quota, Some(_)) = event else {
             panic!("expected ReadyToDeposit, got {event:?}");
         };
         entry_cycles.push(quota);
@@ -673,7 +678,7 @@ async fn batched_ssa_request_produces_one_deposit_cycle_per_requested_ssa() -> R
             .await
             .map_err(|e| anyhow::anyhow!("timeout awaiting exit cycle {i}: {e}"))?
             .ok_or(anyhow::anyhow!("exit must emit cycle {i}"))?;
-        let HoprSessionOutPixEvent::DepositNeeded(quota, _) = event else {
+        let HoprSessionOutPixEvent::DepositNeeded(quota, Some(_), _) = event else {
             panic!("expected DepositNeeded, got {event:?}");
         };
         exit_cycles.push(quota);


### PR DESCRIPTION
## Summary

  - generate a Curvy scan identity for each SSA
  - send the public scan identity to the Entry through the PIX handshake
  - retain the private view scalar at the Exit for recovery and withdrawal
  - forward scan data through PIX strategy events using stable `PixAddressId` values


> Reduced MAX_SSA_BATCH_SIZE from 20 to 9 because each SSA now carries a Curvy scan identity alongside its commitment. With 20 SSAs, the encoded SsaRequest can exceed the HOPR packet payload limit. Nine is the largest batch that safely fits within the packet MTU while retaining the required protocol framing and PIX data. The configuration validator and boundary tests now enforce the same limit.

  ## Validation

  - `cargo test --locked -p hopr-transport`
  - `cargo test --locked -p hopr-transport-session --all-features`