### PR TITLE
feat(session): preserve UDP datagram boundaries 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3749,9 +3749,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",

--- a/hopr/hopr-lib/tests/session_integration_tests.rs
+++ b/hopr/hopr-lib/tests/session_integration_tests.rs
@@ -262,9 +262,9 @@ async fn bidirectional_tcp_session(#[case] cap: Capabilities) -> anyhow::Result<
 
 /// Wires a paired session to a `ConnectedUdpStream` via `transfer_session` (exactly as
 /// `hopr-session-server-forwarder` does on the exit node) and returns the client-side session plus
-/// the UDP address datagrams should be sent to. The session requests `Datagram` (the #8356 fix), so
-/// it preserves UDP datagram boundaries: one frame per write, one datagram per read. The forwarding
-/// task is detached and cancelled when the test runtime shuts down.
+/// the UDP address datagrams should be sent to. The session requests `NoDelay`, which on a stateless
+/// session preserves UDP datagram boundaries (the #8356 fix): one frame per write, one datagram per
+/// read. The forwarding task is detached and cancelled when the test runtime shuts down.
 async fn datagram_udp_bridge() -> anyhow::Result<(HoprSession, std::net::SocketAddr)> {
     const BUF_LEN: usize = 16384; // HOPR_UDP_BUFFER_SIZE used by the exit forwarder
 
@@ -366,8 +366,8 @@ async fn single_read_of_one_forwarded_udp_datagram(datagram_len: usize) -> anyho
 /// delivered to the peer as a single `read`. Before the fix the byte-stream session split a
 /// datagram larger than `frame_mtu` across frames, so the client's single `read` returned only one
 /// frame (<= 1500) and neptun rejected the partial buffer (`InvalidPacket`/`InvalidAeadTag`) until
-/// the `DecapStalled` guard reconnected. With the `Datagram` capability the session preserves the
-/// boundary (one frame per write), whatever the datagram size.
+/// the `DecapStalled` guard reconnected. With `NoDelay` on a stateless session the session preserves
+/// the boundary (one frame per write), whatever the datagram size.
 async fn udp_datagram_is_delivered_whole(#[case] datagram_len: usize) -> anyhow::Result<()> {
     let n = single_read_of_one_forwarded_udp_datagram(datagram_len).await?;
 

--- a/hopr/hopr-lib/tests/session_integration_tests.rs
+++ b/hopr/hopr-lib/tests/session_integration_tests.rs
@@ -276,9 +276,11 @@ async fn single_read_of_one_forwarded_udp_datagram(datagram_len: usize) -> anyho
     let (alice_tx, bob_rx) = futures::channel::mpsc::unbounded::<(DestinationRouting, ApplicationDataOut)>();
     let (bob_tx, alice_rx) = futures::channel::mpsc::unbounded::<(DestinationRouting, ApplicationDataOut)>();
 
-    // The WireGuard session uses Segmentation + NoDelay; frame_mtu defaults to 1500.
+    // The WireGuard session uses Segmentation + NoDelay + Datagram; frame_mtu defaults to 1500.
+    // `Datagram` makes the session preserve datagram boundaries (one frame per write) regardless of
+    // frame_mtu — the fix for #8356.
     let cfg = HoprSessionConfig {
-        capabilities: Capabilities::from(Capability::Segmentation) | Capability::NoDelay,
+        capabilities: Capabilities::from(Capability::Segmentation) | Capability::NoDelay | Capability::Datagram,
         ..Default::default()
     };
     assert_eq!(
@@ -352,30 +354,27 @@ async fn single_read_of_one_forwarded_udp_datagram(datagram_len: usize) -> anyho
 }
 
 #[tokio::test]
-/// Reproduces hoprnet#8356: a UDP datagram larger than `frame_mtu` (a WireGuard UDP-GSO
-/// super-buffer) forwarded through `transfer_session` into the byte-stream session is split at
-/// `frame_mtu`. The client's single `read` therefore returns only one frame (<= 1500) instead of
-/// the whole datagram, so neptun sees a partial/misaligned buffer (`InvalidPacket`/`InvalidAeadTag`)
-/// and, after a burst, trips the `DecapStalled` guard and reconnects.
-///
-/// The session must preserve UDP datagram boundaries for UDP targets so that one datagram is
-/// delivered to the peer per read.
-async fn udp_datagram_larger_than_frame_mtu_loses_boundary() -> anyhow::Result<()> {
+/// Regression test for hoprnet#8356. A UDP datagram larger than `frame_mtu` (a WireGuard UDP-GSO
+/// super-buffer of several packets) forwarded through `transfer_session` must be delivered to the
+/// peer as a single `read`. Before the fix the byte-stream session split it at `frame_mtu`, so the
+/// client's single `read` returned only one frame (<= 1500) and neptun rejected the partial buffer
+/// (`InvalidPacket`/`InvalidAeadTag`) until the `DecapStalled` guard reconnected. With the
+/// `Datagram` capability the session preserves the boundary (one frame per write).
+async fn udp_datagram_larger_than_frame_mtu_is_delivered_whole() -> anyhow::Result<()> {
     const DATAGRAM_LEN: usize = 2904; // two 1452-byte WireGuard packets coalesced by UDP GSO
 
     let n = single_read_of_one_forwarded_udp_datagram(DATAGRAM_LEN).await?;
 
     assert_eq!(
         n, DATAGRAM_LEN,
-        "datagram boundary lost: a {DATAGRAM_LEN}-byte UDP datagram was split by the frame_mtu=1500 session; the \
-         client read only {n} bytes (one frame) instead of the whole datagram"
+        "datagram boundary not preserved: a {DATAGRAM_LEN}-byte UDP datagram was delivered in a {n}-byte read instead \
+         of whole"
     );
     Ok(())
 }
 
 #[tokio::test]
-/// Control for #8356: a datagram at/below `frame_mtu` is delivered whole in a single read, so only
-/// oversized (GSO-coalesced) datagrams trigger the field failure.
+/// Control for #8356: a datagram at/below `frame_mtu` is delivered whole in a single read.
 async fn udp_datagram_within_frame_mtu_preserves_boundary() -> anyhow::Result<()> {
     const DATAGRAM_LEN: usize = 1452; // a single WireGuard packet
 
@@ -385,5 +384,84 @@ async fn udp_datagram_within_frame_mtu_preserves_boundary() -> anyhow::Result<()
         n, DATAGRAM_LEN,
         "a <= frame_mtu datagram must arrive whole in one read; got {n}"
     );
+    Ok(())
+}
+
+#[tokio::test]
+/// #8356: back-to-back datagrams of mixed sizes each arrive whole, in order, one per read — the
+/// datagram session must neither split a datagram nor coalesce adjacent ones.
+async fn udp_back_to_back_datagrams_each_arrive_whole_in_order() -> anyhow::Result<()> {
+    const BUF_LEN: usize = 16384;
+    // Mixed sizes incl. > frame_mtu; distinct fill bytes to check ordering and boundaries.
+    let sizes: [usize; 4] = [1452, 2904, 900, 4308];
+
+    let dst: Address = (&ChainKeypair::random()).into();
+    let id = HoprPseudonym::random();
+    let (alice_tx, bob_rx) = futures::channel::mpsc::unbounded::<(DestinationRouting, ApplicationDataOut)>();
+    let (bob_tx, alice_rx) = futures::channel::mpsc::unbounded::<(DestinationRouting, ApplicationDataOut)>();
+
+    let cfg = HoprSessionConfig {
+        capabilities: Capabilities::from(Capability::Segmentation) | Capability::NoDelay | Capability::Datagram,
+        ..Default::default()
+    };
+
+    let mut alice_session = HoprSession::new(
+        id,
+        DestinationRouting::forward_only(dst, RoutingOptions::Hops(0_u32.try_into()?)),
+        cfg.clone(),
+        (
+            alice_tx,
+            alice_rx.map(|(_, d)| ApplicationDataIn {
+                data: d.data,
+                packet_info: Default::default(),
+            }),
+        ),
+        None,
+    )?;
+    let mut bob_session = HoprSession::new(
+        id,
+        DestinationRouting::Return(id.into()),
+        cfg,
+        (
+            bob_tx,
+            bob_rx.map(|(_, d)| ApplicationDataIn {
+                data: d.data,
+                packet_info: Default::default(),
+            }),
+        ),
+        None,
+    )?;
+
+    let mut udp_bridge = ConnectedUdpStream::builder()
+        .with_buffer_size(BUF_LEN)
+        .with_queue_size(512)
+        .with_receiver_parallelism(UdpStreamParallelism::Auto)
+        .build(("127.0.0.1", 0))?;
+    let addr = *udp_bridge.bound_address();
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let transfer_handle = tokio::task::spawn(async move {
+        ready_tx.send(()).ok();
+        transfer_session(&mut alice_session, &mut udp_bridge, BUF_LEN, None).await
+    });
+    ready_rx.await.ok();
+
+    let sender = UdpSocket::bind(("127.0.0.1", 0)).await?;
+    for (i, &len) in sizes.iter().enumerate() {
+        let datagram = vec![i as u8; len];
+        assert_eq!(sender.send_to(&datagram, addr).await?, len);
+    }
+
+    for (i, &len) in sizes.iter().enumerate() {
+        let mut buf = vec![0u8; BUF_LEN];
+        let n = tokio::time::timeout(std::time::Duration::from_secs(5), bob_session.read(&mut buf)).await??;
+        assert_eq!(n, len, "datagram {i} ({len} B) arrived as a {n}-byte read");
+        assert!(
+            buf[..n].iter().all(|&b| b == i as u8),
+            "datagram {i} content/order mismatch"
+        );
+    }
+
+    transfer_handle.abort();
     Ok(())
 }

--- a/hopr/hopr-lib/tests/session_integration_tests.rs
+++ b/hopr/hopr-lib/tests/session_integration_tests.rs
@@ -259,3 +259,131 @@ async fn bidirectional_tcp_session(#[case] cap: Capabilities) -> anyhow::Result<
 
     Ok(())
 }
+
+/// Bridges a paired session to a `ConnectedUdpStream` with `transfer_session` (exactly as
+/// `hopr-session-server-forwarder` does on the exit node), sends a single UDP datagram of
+/// `datagram_len` bytes into it, and returns how many bytes the client side receives from a
+/// SINGLE `read` — i.e. how much of the datagram is delivered with its boundary intact.
+///
+/// A datagram-oriented consumer (the WireGuard pump/neptun) does one read per datagram and treats
+/// the returned bytes as one datagram; the datagram-preserving contract is therefore
+/// "one read == the whole datagram".
+async fn single_read_of_one_forwarded_udp_datagram(datagram_len: usize) -> anyhow::Result<usize> {
+    const BUF_LEN: usize = 16384; // HOPR_UDP_BUFFER_SIZE used by the exit forwarder
+
+    let dst: Address = (&ChainKeypair::random()).into();
+    let id = HoprPseudonym::random();
+    let (alice_tx, bob_rx) = futures::channel::mpsc::unbounded::<(DestinationRouting, ApplicationDataOut)>();
+    let (bob_tx, alice_rx) = futures::channel::mpsc::unbounded::<(DestinationRouting, ApplicationDataOut)>();
+
+    // The WireGuard session uses Segmentation + NoDelay; frame_mtu defaults to 1500.
+    let cfg = HoprSessionConfig {
+        capabilities: Capabilities::from(Capability::Segmentation) | Capability::NoDelay,
+        ..Default::default()
+    };
+    assert_eq!(
+        cfg.frame_mtu, 1500,
+        "test assumes the WireGuard session frame_mtu of 1500"
+    );
+
+    // Exit-side session endpoint (bridged to the WireGuard server).
+    let mut alice_session = HoprSession::new(
+        id,
+        DestinationRouting::forward_only(dst, RoutingOptions::Hops(0_u32.try_into()?)),
+        cfg.clone(),
+        (
+            alice_tx,
+            alice_rx.map(|(_, d)| ApplicationDataIn {
+                data: d.data,
+                packet_info: Default::default(),
+            }),
+        ),
+        None,
+    )?;
+
+    // Client-side session endpoint (where the WireGuard pump reads).
+    let mut bob_session = HoprSession::new(
+        id,
+        DestinationRouting::Return(id.into()),
+        cfg,
+        (
+            bob_tx,
+            bob_rx.map(|(_, d)| ApplicationDataIn {
+                data: d.data,
+                packet_info: Default::default(),
+            }),
+        ),
+        None,
+    )?;
+
+    let mut udp_bridge = ConnectedUdpStream::builder()
+        .with_buffer_size(BUF_LEN)
+        .with_queue_size(512)
+        .with_receiver_parallelism(UdpStreamParallelism::Auto)
+        .build(("127.0.0.1", 0))?;
+    let addr = *udp_bridge.bound_address();
+
+    let (ready_tx, ready_rx) = oneshot::channel();
+    let transfer_handle = tokio::task::spawn(async move {
+        ready_tx.send(()).ok();
+        transfer_session(&mut alice_session, &mut udp_bridge, BUF_LEN, None).await
+    });
+    ready_rx.await.ok();
+
+    // A single UDP datagram from the WireGuard server. When it exceeds frame_mtu it models a
+    // UDP-GSO super-buffer (several WireGuard packets coalesced into one UDP send), which is what
+    // the exit receives over the high-MTU/loopback path to a co-located WireGuard server.
+    let datagram: Vec<u8> = (0..datagram_len).map(|i| (i % 251) as u8).collect();
+    let sender = UdpSocket::bind(("127.0.0.1", 0)).await?;
+    let sent = sender.send_to(&datagram, addr).await?;
+    assert_eq!(sent, datagram_len);
+
+    // The WireGuard pump does ONE read per datagram and hands the result to neptun.
+    let mut buf = vec![0u8; datagram_len];
+    let n = tokio::time::timeout(std::time::Duration::from_secs(5), bob_session.read(&mut buf)).await??;
+    assert_eq!(
+        &buf[..n],
+        &datagram[..n],
+        "delivered bytes must be a prefix of the sent datagram"
+    );
+
+    transfer_handle.abort();
+    Ok(n)
+}
+
+#[tokio::test]
+/// Reproduces hoprnet#8356: a UDP datagram larger than `frame_mtu` (a WireGuard UDP-GSO
+/// super-buffer) forwarded through `transfer_session` into the byte-stream session is split at
+/// `frame_mtu`. The client's single `read` therefore returns only one frame (<= 1500) instead of
+/// the whole datagram, so neptun sees a partial/misaligned buffer (`InvalidPacket`/`InvalidAeadTag`)
+/// and, after a burst, trips the `DecapStalled` guard and reconnects.
+///
+/// The session must preserve UDP datagram boundaries for UDP targets so that one datagram is
+/// delivered to the peer per read.
+async fn udp_datagram_larger_than_frame_mtu_loses_boundary() -> anyhow::Result<()> {
+    const DATAGRAM_LEN: usize = 2904; // two 1452-byte WireGuard packets coalesced by UDP GSO
+
+    let n = single_read_of_one_forwarded_udp_datagram(DATAGRAM_LEN).await?;
+
+    assert_eq!(
+        n, DATAGRAM_LEN,
+        "datagram boundary lost: a {DATAGRAM_LEN}-byte UDP datagram was split by the frame_mtu=1500 session; the \
+         client read only {n} bytes (one frame) instead of the whole datagram"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+/// Control for #8356: a datagram at/below `frame_mtu` is delivered whole in a single read, so only
+/// oversized (GSO-coalesced) datagrams trigger the field failure.
+async fn udp_datagram_within_frame_mtu_preserves_boundary() -> anyhow::Result<()> {
+    const DATAGRAM_LEN: usize = 1452; // a single WireGuard packet
+
+    let n = single_read_of_one_forwarded_udp_datagram(DATAGRAM_LEN).await?;
+
+    assert_eq!(
+        n, DATAGRAM_LEN,
+        "a <= frame_mtu datagram must arrive whole in one read; got {n}"
+    );
+    Ok(())
+}

--- a/hopr/hopr-lib/tests/session_integration_tests.rs
+++ b/hopr/hopr-lib/tests/session_integration_tests.rs
@@ -12,7 +12,7 @@ use hopr_lib::{
     exports::{
         network::types::udp::{ConnectedUdpStream, UdpStreamParallelism},
         transport::{
-            ApplicationDataIn, ApplicationDataOut, TransportSessionError,
+            ApplicationDataIn, ApplicationDataOut,
             session::{Capabilities, Capability, HoprSession, HoprSessionConfig, transfer_session},
         },
     },
@@ -273,9 +273,10 @@ async fn datagram_udp_bridge() -> anyhow::Result<(HoprSession, std::net::SocketA
     let (alice_tx, bob_rx) = futures::channel::mpsc::unbounded::<(DestinationRouting, ApplicationDataOut)>();
     let (bob_tx, alice_rx) = futures::channel::mpsc::unbounded::<(DestinationRouting, ApplicationDataOut)>();
 
-    // The WireGuard session uses Segmentation + NoDelay + Datagram; frame_mtu defaults to 1500.
+    // The WireGuard session uses Segmentation + NoDelay; on a stateless session NoDelay enables
+    // datagram-boundary preservation (UDP-like framing). frame_mtu defaults to 1500.
     let cfg = HoprSessionConfig {
-        capabilities: Capabilities::from(Capability::Segmentation) | Capability::NoDelay | Capability::Datagram,
+        capabilities: Capabilities::from(Capability::Segmentation) | Capability::NoDelay,
         ..Default::default()
     };
     assert_eq!(
@@ -406,42 +407,67 @@ async fn udp_back_to_back_datagrams_each_arrive_whole_in_order() -> anyhow::Resu
 }
 
 #[rstest]
-#[case(Capabilities::from(Capability::Datagram) | Capability::RetransmissionAck)]
-#[case(Capabilities::from(Capability::Datagram) | Capability::RetransmissionNack)]
+#[case(Capability::RetransmissionAck)]
+#[case(Capability::RetransmissionNack)]
 #[tokio::test]
-/// The Datagram capability is only valid on stateless sessions: combining it with a retransmission
-/// capability selects the reliable socket, whose NACK missing-segment bitmap cannot address the
-/// segments of an oversized datagram frame. The session must refuse to open rather than risk stream
-/// corruption on loss, so `HoprSession::new` returns `DatagramRequiresStateless`.
-async fn datagram_capability_is_rejected_on_a_reliable_session(
-    #[case] capabilities: Capabilities,
+/// Datagram-boundary preservation is stateless-only. On a reliable (retransmitting) session,
+/// NoDelay keeps only its buffering behavior — a write larger than frame_mtu is still split across
+/// frames (byte-stream framing), so a single read returns at most one frame and the payload is NOT
+/// delivered whole. This is what keeps oversized datagram frames off the reliable socket, whose
+/// NACK missing-segment bitmap cannot address their segments.
+async fn nodelay_on_reliable_session_keeps_byte_stream_framing(
+    #[case] retransmission: Capability,
 ) -> anyhow::Result<()> {
     let id = HoprPseudonym::random();
     let dst: Address = (&ChainKeypair::random()).into();
-    let (tx, _bob_rx) = futures::channel::mpsc::unbounded::<(DestinationRouting, ApplicationDataOut)>();
-    let (_bob_tx, rx) = futures::channel::mpsc::unbounded::<(DestinationRouting, ApplicationDataOut)>();
+    let (alice_tx, bob_rx) = futures::channel::mpsc::unbounded::<(DestinationRouting, ApplicationDataOut)>();
+    let (bob_tx, alice_rx) = futures::channel::mpsc::unbounded::<(DestinationRouting, ApplicationDataOut)>();
 
-    let err = HoprSession::new(
+    // Reliable session (selects the stateful socket) that also requests NoDelay.
+    let cfg = HoprSessionConfig {
+        capabilities: Capabilities::from(Capability::Segmentation) | Capability::NoDelay | retransmission,
+        ..Default::default()
+    };
+
+    let mut alice_session = HoprSession::new(
         id,
         DestinationRouting::forward_only(dst, RoutingOptions::Hops(0_u32.try_into()?)),
-        HoprSessionConfig {
-            capabilities,
-            ..Default::default()
-        },
+        cfg.clone(),
         (
-            tx,
-            rx.map(|(_, d)| ApplicationDataIn {
+            alice_tx,
+            alice_rx.map(|(_, d)| ApplicationDataIn {
                 data: d.data,
                 packet_info: Default::default(),
             }),
         ),
         None,
-    )
-    .err();
+    )?;
+    let mut bob_session = HoprSession::new(
+        id,
+        DestinationRouting::Return(id.into()),
+        cfg,
+        (
+            bob_tx,
+            bob_rx.map(|(_, d)| ApplicationDataIn {
+                data: d.data,
+                packet_info: Default::default(),
+            }),
+        ),
+        None,
+    )?;
 
+    // A payload well above frame_mtu (1500): if datagram mode were (wrongly) active it would arrive
+    // in one read; on a reliable socket it must be split at frame_mtu instead.
+    let payload = vec![0x5Au8; 2904];
+    alice_session.write_all(&payload).await?;
+    alice_session.flush().await?;
+
+    let mut buf = vec![0u8; payload.len()];
+    let n = tokio::time::timeout(std::time::Duration::from_secs(5), bob_session.read(&mut buf)).await??;
     assert!(
-        matches!(err, Some(TransportSessionError::DatagramRequiresStateless)),
-        "Datagram + retransmission must be rejected, got {err:?}"
+        n < payload.len(),
+        "reliable NoDelay session must keep byte-stream framing (split at frame_mtu), but a single read returned all \
+         {n} bytes — datagram boundaries were preserved on a reliable socket"
     );
     Ok(())
 }

--- a/hopr/hopr-lib/tests/session_integration_tests.rs
+++ b/hopr/hopr-lib/tests/session_integration_tests.rs
@@ -12,7 +12,7 @@ use hopr_lib::{
     exports::{
         network::types::udp::{ConnectedUdpStream, UdpStreamParallelism},
         transport::{
-            ApplicationDataIn, ApplicationDataOut,
+            ApplicationDataIn, ApplicationDataOut, TransportSessionError,
             session::{Capabilities, Capability, HoprSession, HoprSessionConfig, transfer_session},
         },
     },
@@ -343,11 +343,15 @@ async fn single_read_of_one_forwarded_udp_datagram(datagram_len: usize) -> anyho
     let sender = UdpSocket::bind(("127.0.0.1", 0)).await?;
     assert_eq!(sender.send_to(&datagram, addr).await?, datagram_len);
 
-    let mut buf = vec![0u8; datagram_len];
+    // Over-size the read buffer so a coalescing regression (more than one datagram in a single
+    // read) surfaces as `n > datagram_len` for the caller to assert on, instead of being silently
+    // truncated to `datagram_len` by an exact-size buffer.
+    let mut buf = vec![0u8; datagram_len + 8192];
     let n = tokio::time::timeout(std::time::Duration::from_secs(5), bob_session.read(&mut buf)).await??;
+    let checked = n.min(datagram_len);
     assert_eq!(
-        &buf[..n],
-        &datagram[..n],
+        &buf[..checked],
+        &datagram[..checked],
         "delivered bytes must be a prefix of the sent datagram"
     );
     Ok(n)
@@ -398,5 +402,46 @@ async fn udp_back_to_back_datagrams_each_arrive_whole_in_order() -> anyhow::Resu
         );
     }
 
+    Ok(())
+}
+
+#[rstest]
+#[case(Capabilities::from(Capability::Datagram) | Capability::RetransmissionAck)]
+#[case(Capabilities::from(Capability::Datagram) | Capability::RetransmissionNack)]
+#[tokio::test]
+/// The Datagram capability is only valid on stateless sessions: combining it with a retransmission
+/// capability selects the reliable socket, whose NACK missing-segment bitmap cannot address the
+/// segments of an oversized datagram frame. The session must refuse to open rather than risk stream
+/// corruption on loss, so `HoprSession::new` returns `DatagramRequiresStateless`.
+async fn datagram_capability_is_rejected_on_a_reliable_session(
+    #[case] capabilities: Capabilities,
+) -> anyhow::Result<()> {
+    let id = HoprPseudonym::random();
+    let dst: Address = (&ChainKeypair::random()).into();
+    let (tx, _bob_rx) = futures::channel::mpsc::unbounded::<(DestinationRouting, ApplicationDataOut)>();
+    let (_bob_tx, rx) = futures::channel::mpsc::unbounded::<(DestinationRouting, ApplicationDataOut)>();
+
+    let err = HoprSession::new(
+        id,
+        DestinationRouting::forward_only(dst, RoutingOptions::Hops(0_u32.try_into()?)),
+        HoprSessionConfig {
+            capabilities,
+            ..Default::default()
+        },
+        (
+            tx,
+            rx.map(|(_, d)| ApplicationDataIn {
+                data: d.data,
+                packet_info: Default::default(),
+            }),
+        ),
+        None,
+    )
+    .err();
+
+    assert!(
+        matches!(err, Some(TransportSessionError::DatagramRequiresStateless)),
+        "Datagram + retransmission must be rejected, got {err:?}"
+    );
     Ok(())
 }

--- a/hopr/hopr-lib/tests/session_integration_tests.rs
+++ b/hopr/hopr-lib/tests/session_integration_tests.rs
@@ -260,15 +260,12 @@ async fn bidirectional_tcp_session(#[case] cap: Capabilities) -> anyhow::Result<
     Ok(())
 }
 
-/// Bridges a paired session to a `ConnectedUdpStream` with `transfer_session` (exactly as
-/// `hopr-session-server-forwarder` does on the exit node), sends a single UDP datagram of
-/// `datagram_len` bytes into it, and returns how many bytes the client side receives from a
-/// SINGLE `read` — i.e. how much of the datagram is delivered with its boundary intact.
-///
-/// A datagram-oriented consumer (the WireGuard pump/neptun) does one read per datagram and treats
-/// the returned bytes as one datagram; the datagram-preserving contract is therefore
-/// "one read == the whole datagram".
-async fn single_read_of_one_forwarded_udp_datagram(datagram_len: usize) -> anyhow::Result<usize> {
+/// Wires a paired session to a `ConnectedUdpStream` via `transfer_session` (exactly as
+/// `hopr-session-server-forwarder` does on the exit node) and returns the client-side session plus
+/// the UDP address datagrams should be sent to. The session requests `Datagram` (the #8356 fix), so
+/// it preserves UDP datagram boundaries: one frame per write, one datagram per read. The forwarding
+/// task is detached and cancelled when the test runtime shuts down.
+async fn datagram_udp_bridge() -> anyhow::Result<(HoprSession, std::net::SocketAddr)> {
     const BUF_LEN: usize = 16384; // HOPR_UDP_BUFFER_SIZE used by the exit forwarder
 
     let dst: Address = (&ChainKeypair::random()).into();
@@ -277,8 +274,6 @@ async fn single_read_of_one_forwarded_udp_datagram(datagram_len: usize) -> anyho
     let (bob_tx, alice_rx) = futures::channel::mpsc::unbounded::<(DestinationRouting, ApplicationDataOut)>();
 
     // The WireGuard session uses Segmentation + NoDelay + Datagram; frame_mtu defaults to 1500.
-    // `Datagram` makes the session preserve datagram boundaries (one frame per write) regardless of
-    // frame_mtu — the fix for #8356.
     let cfg = HoprSessionConfig {
         capabilities: Capabilities::from(Capability::Segmentation) | Capability::NoDelay | Capability::Datagram,
         ..Default::default()
@@ -304,7 +299,7 @@ async fn single_read_of_one_forwarded_udp_datagram(datagram_len: usize) -> anyho
     )?;
 
     // Client-side session endpoint (where the WireGuard pump reads).
-    let mut bob_session = HoprSession::new(
+    let bob_session = HoprSession::new(
         id,
         DestinationRouting::Return(id.into()),
         cfg,
@@ -326,21 +321,28 @@ async fn single_read_of_one_forwarded_udp_datagram(datagram_len: usize) -> anyho
     let addr = *udp_bridge.bound_address();
 
     let (ready_tx, ready_rx) = oneshot::channel();
-    let transfer_handle = tokio::task::spawn(async move {
+    tokio::task::spawn(async move {
         ready_tx.send(()).ok();
         transfer_session(&mut alice_session, &mut udp_bridge, BUF_LEN, None).await
     });
     ready_rx.await.ok();
 
-    // A single UDP datagram from the WireGuard server. When it exceeds frame_mtu it models a
-    // UDP-GSO super-buffer (several WireGuard packets coalesced into one UDP send), which is what
-    // the exit receives over the high-MTU/loopback path to a co-located WireGuard server.
+    Ok((bob_session, addr))
+}
+
+/// Sends one UDP datagram of `datagram_len` bytes through the bridge and returns how many bytes the
+/// client receives from a SINGLE `read` — i.e. how much of the datagram is delivered with its
+/// boundary intact. A datagram-oriented consumer (the WireGuard pump/neptun) does one read per
+/// datagram, so the datagram-preserving contract is "one read == the whole datagram". A
+/// `datagram_len` above frame_mtu models a UDP-GSO super-buffer (several WireGuard packets in one
+/// UDP send), which is what the exit receives over the high-MTU path to a co-located WG server.
+async fn single_read_of_one_forwarded_udp_datagram(datagram_len: usize) -> anyhow::Result<usize> {
+    let (mut bob_session, addr) = datagram_udp_bridge().await?;
+
     let datagram: Vec<u8> = (0..datagram_len).map(|i| (i % 251) as u8).collect();
     let sender = UdpSocket::bind(("127.0.0.1", 0)).await?;
-    let sent = sender.send_to(&datagram, addr).await?;
-    assert_eq!(sent, datagram_len);
+    assert_eq!(sender.send_to(&datagram, addr).await?, datagram_len);
 
-    // The WireGuard pump does ONE read per datagram and hands the result to neptun.
     let mut buf = vec![0u8; datagram_len];
     let n = tokio::time::timeout(std::time::Duration::from_secs(5), bob_session.read(&mut buf)).await??;
     assert_eq!(
@@ -348,41 +350,25 @@ async fn single_read_of_one_forwarded_udp_datagram(datagram_len: usize) -> anyho
         &datagram[..n],
         "delivered bytes must be a prefix of the sent datagram"
     );
-
-    transfer_handle.abort();
     Ok(n)
 }
 
+#[rstest]
+#[case::larger_than_frame_mtu(2904)] // two 1452-byte WireGuard packets coalesced by UDP GSO
+#[case::within_frame_mtu(1452)] // a single WireGuard packet
 #[tokio::test]
-/// Regression test for hoprnet#8356. A UDP datagram larger than `frame_mtu` (a WireGuard UDP-GSO
-/// super-buffer of several packets) forwarded through `transfer_session` must be delivered to the
-/// peer as a single `read`. Before the fix the byte-stream session split it at `frame_mtu`, so the
-/// client's single `read` returned only one frame (<= 1500) and neptun rejected the partial buffer
-/// (`InvalidPacket`/`InvalidAeadTag`) until the `DecapStalled` guard reconnected. With the
-/// `Datagram` capability the session preserves the boundary (one frame per write).
-async fn udp_datagram_larger_than_frame_mtu_is_delivered_whole() -> anyhow::Result<()> {
-    const DATAGRAM_LEN: usize = 2904; // two 1452-byte WireGuard packets coalesced by UDP GSO
-
-    let n = single_read_of_one_forwarded_udp_datagram(DATAGRAM_LEN).await?;
+/// Regression test for hoprnet#8356. A UDP datagram forwarded through `transfer_session` must be
+/// delivered to the peer as a single `read`. Before the fix the byte-stream session split a
+/// datagram larger than `frame_mtu` across frames, so the client's single `read` returned only one
+/// frame (<= 1500) and neptun rejected the partial buffer (`InvalidPacket`/`InvalidAeadTag`) until
+/// the `DecapStalled` guard reconnected. With the `Datagram` capability the session preserves the
+/// boundary (one frame per write), whatever the datagram size.
+async fn udp_datagram_is_delivered_whole(#[case] datagram_len: usize) -> anyhow::Result<()> {
+    let n = single_read_of_one_forwarded_udp_datagram(datagram_len).await?;
 
     assert_eq!(
-        n, DATAGRAM_LEN,
-        "datagram boundary not preserved: a {DATAGRAM_LEN}-byte UDP datagram was delivered in a {n}-byte read instead \
-         of whole"
-    );
-    Ok(())
-}
-
-#[tokio::test]
-/// Control for #8356: a datagram at/below `frame_mtu` is delivered whole in a single read.
-async fn udp_datagram_within_frame_mtu_preserves_boundary() -> anyhow::Result<()> {
-    const DATAGRAM_LEN: usize = 1452; // a single WireGuard packet
-
-    let n = single_read_of_one_forwarded_udp_datagram(DATAGRAM_LEN).await?;
-
-    assert_eq!(
-        n, DATAGRAM_LEN,
-        "a <= frame_mtu datagram must arrive whole in one read; got {n}"
+        n, datagram_len,
+        "datagram boundary not preserved: a {datagram_len}-byte UDP datagram was delivered in a {n}-byte read"
     );
     Ok(())
 }
@@ -395,61 +381,11 @@ async fn udp_back_to_back_datagrams_each_arrive_whole_in_order() -> anyhow::Resu
     // Mixed sizes incl. > frame_mtu; distinct fill bytes to check ordering and boundaries.
     let sizes: [usize; 4] = [1452, 2904, 900, 4308];
 
-    let dst: Address = (&ChainKeypair::random()).into();
-    let id = HoprPseudonym::random();
-    let (alice_tx, bob_rx) = futures::channel::mpsc::unbounded::<(DestinationRouting, ApplicationDataOut)>();
-    let (bob_tx, alice_rx) = futures::channel::mpsc::unbounded::<(DestinationRouting, ApplicationDataOut)>();
-
-    let cfg = HoprSessionConfig {
-        capabilities: Capabilities::from(Capability::Segmentation) | Capability::NoDelay | Capability::Datagram,
-        ..Default::default()
-    };
-
-    let mut alice_session = HoprSession::new(
-        id,
-        DestinationRouting::forward_only(dst, RoutingOptions::Hops(0_u32.try_into()?)),
-        cfg.clone(),
-        (
-            alice_tx,
-            alice_rx.map(|(_, d)| ApplicationDataIn {
-                data: d.data,
-                packet_info: Default::default(),
-            }),
-        ),
-        None,
-    )?;
-    let mut bob_session = HoprSession::new(
-        id,
-        DestinationRouting::Return(id.into()),
-        cfg,
-        (
-            bob_tx,
-            bob_rx.map(|(_, d)| ApplicationDataIn {
-                data: d.data,
-                packet_info: Default::default(),
-            }),
-        ),
-        None,
-    )?;
-
-    let mut udp_bridge = ConnectedUdpStream::builder()
-        .with_buffer_size(BUF_LEN)
-        .with_queue_size(512)
-        .with_receiver_parallelism(UdpStreamParallelism::Auto)
-        .build(("127.0.0.1", 0))?;
-    let addr = *udp_bridge.bound_address();
-
-    let (ready_tx, ready_rx) = oneshot::channel();
-    let transfer_handle = tokio::task::spawn(async move {
-        ready_tx.send(()).ok();
-        transfer_session(&mut alice_session, &mut udp_bridge, BUF_LEN, None).await
-    });
-    ready_rx.await.ok();
+    let (mut bob_session, addr) = datagram_udp_bridge().await?;
 
     let sender = UdpSocket::bind(("127.0.0.1", 0)).await?;
     for (i, &len) in sizes.iter().enumerate() {
-        let datagram = vec![i as u8; len];
-        assert_eq!(sender.send_to(&datagram, addr).await?, len);
+        assert_eq!(sender.send_to(&vec![i as u8; len], addr).await?, len);
     }
 
     for (i, &len) in sizes.iter().enumerate() {
@@ -462,6 +398,5 @@ async fn udp_back_to_back_datagrams_each_arrive_whole_in_order() -> anyhow::Resu
         );
     }
 
-    transfer_handle.abort();
     Ok(())
 }

--- a/protocols/session/src/processing/segmenter.rs
+++ b/protocols/session/src/processing/segmenter.rs
@@ -46,8 +46,8 @@ pub struct Segmenter<const C: usize, S> {
     is_closed: bool,
     send_terminating_segment: bool,
     /// Datagram mode: emit exactly one frame per write (preserve datagram boundaries) instead of
-    /// coalescing writes up to `frame_size`. Driven by the `Datagram` session capability, which the
-    /// `hopr-transport-session` crate maps onto this flag.
+    /// coalescing writes up to `frame_size`. On stateless sessions the `hopr-transport-session`
+    /// crate enables this for the `NoDelay` (UDP-like) capability.
     datagram: bool,
 }
 

--- a/protocols/session/src/processing/segmenter.rs
+++ b/protocols/session/src/processing/segmenter.rs
@@ -45,6 +45,9 @@ pub struct Segmenter<const C: usize, S> {
     frame_id: FrameId,
     is_closed: bool,
     send_terminating_segment: bool,
+    /// Datagram mode: emit exactly one frame per write (preserve datagram boundaries) instead of
+    /// coalescing writes up to `frame_size`. See [`Capability::Datagram`](crate).
+    datagram: bool,
 }
 
 enum State {
@@ -57,10 +60,14 @@ where
     S: futures::Sink<Segment>,
     S::Error: std::error::Error + Send + Sync + 'static,
 {
-    fn new(inner: S, frame_size: usize, send_terminating_segment: bool) -> Self {
+    fn new(inner: S, frame_size: usize, send_terminating_segment: bool, datagram: bool) -> Self {
         // Clamp frame_size to [SESSION_MTU, SESSION_MTU * (SeqIndicator::MAX + 1)].
         // Minimum is SESSION_MTU (= C - SEGMENT_OVERHEAD) so that a single frame fits in one
         // HOPR packet (1 segment). Maximum is bounded by SeqIndicator capacity.
+        //
+        // In datagram mode `frame_size` no longer bounds a frame (each write is its own frame);
+        // an individual datagram may be up to the same SeqIndicator-bounded maximum. `frame_size`
+        // is then only a capacity hint for the frame buffer.
         let frame_size = frame_size.clamp(
             C - SessionMessage::<C>::SEGMENT_OVERHEAD,
             (C - SessionMessage::<C>::SEGMENT_OVERHEAD) * (SeqIndicator::MAX + 1) as usize,
@@ -75,6 +82,7 @@ where
             frame_id: 1,
             is_closed: false,
             send_terminating_segment,
+            datagram,
         }
     }
 }
@@ -97,6 +105,38 @@ where
         loop {
             match this.state {
                 State::BufferingFrame => {
+                    // Datagram mode: emit exactly one frame per write so datagram boundaries are
+                    // preserved (the peer reads one datagram per read), regardless of `frame_size`.
+                    // `frame` is empty here: the previous write's frame was segmented and the
+                    // `WritingFrame` state drains before control returns to `BufferingFrame`.
+                    if *this.datagram {
+                        if buf.is_empty() {
+                            return Poll::Ready(Ok(0));
+                        }
+                        this.frame.extend_from_slice(buf);
+                        segment_into(
+                            this.frame.as_slice(),
+                            C - SessionMessage::<C>::SEGMENT_OVERHEAD,
+                            *this.frame_id,
+                            this.ready_segments,
+                        )
+                        .map_err(std::io::Error::other)?;
+
+                        tracing::trace!(
+                            num_segments = this.ready_segments.len(),
+                            datagram_len = buf.len(),
+                            "datagram frame ready"
+                        );
+
+                        this.frame.clear();
+                        *this.frame_id += 1;
+                        *this.state = State::WritingFrame;
+
+                        // Segments drain on the next poll_write / poll_flush (as in the buffered
+                        // path); the whole datagram has been accepted.
+                        return Poll::Ready(Ok(buf.len()));
+                    }
+
                     // If there's space in the frame, keep writing to it
                     if *this.frame_size > this.frame.len() {
                         let to_write = buf.len().min(*this.frame_size - this.frame.len());
@@ -211,17 +251,20 @@ pub trait SegmenterExt: futures::Sink<Segment> {
         Self: Sized,
         Self::Error: std::error::Error + Send + Sync + 'static,
     {
-        Segmenter::new(self, frame_size, false)
+        Segmenter::new(self, frame_size, false, false)
     }
 
     /// Attaches a [`Segmenter`] to the underlying sink.
     /// The `Segmenter` also sends a [terminating](Segment::terminating) when closed.
-    fn segmenter_with_terminating_segment<const C: usize>(self, frame_size: usize) -> Segmenter<C, Self>
+    ///
+    /// When `datagram` is set, each write is emitted as exactly one frame (datagram boundaries are
+    /// preserved) instead of being coalesced up to `frame_size`.
+    fn segmenter_with_terminating_segment<const C: usize>(self, frame_size: usize, datagram: bool) -> Segmenter<C, Self>
     where
         Self: Sized,
         Self::Error: std::error::Error + Send + Sync + 'static,
     {
-        Segmenter::new(self, frame_size, true)
+        Segmenter::new(self, frame_size, true, datagram)
     }
 }
 
@@ -355,7 +398,7 @@ mod tests {
     #[test_log::test(tokio::test)]
     async fn segmenter_full_frame_segmentation_must_also_include_terminating_segment() -> anyhow::Result<()> {
         let (segments_tx, segments) = futures::channel::mpsc::unbounded();
-        let mut writer = segments_tx.segmenter_with_terminating_segment::<MTU>(FRAME_SIZE);
+        let mut writer = segments_tx.segmenter_with_terminating_segment::<MTU>(FRAME_SIZE, false);
 
         let data = hopr_types::crypto_random::random_bytes::<FRAME_SIZE>();
 

--- a/protocols/session/src/processing/segmenter.rs
+++ b/protocols/session/src/processing/segmenter.rs
@@ -46,7 +46,8 @@ pub struct Segmenter<const C: usize, S> {
     is_closed: bool,
     send_terminating_segment: bool,
     /// Datagram mode: emit exactly one frame per write (preserve datagram boundaries) instead of
-    /// coalescing writes up to `frame_size`. See [`Capability::Datagram`](crate).
+    /// coalescing writes up to `frame_size`. Driven by the `Datagram` session capability, which the
+    /// `hopr-transport-session` crate maps onto this flag.
     datagram: bool,
 }
 

--- a/protocols/session/src/processing/segmenter.rs
+++ b/protocols/session/src/processing/segmenter.rs
@@ -347,6 +347,61 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn datagram_mode_emits_one_frame_per_write() -> anyhow::Result<()> {
+        let (segments_tx, segments) = futures::channel::mpsc::unbounded();
+        let mut writer = segments_tx.segmenter_with_terminating_segment::<MTU>(FRAME_SIZE, true);
+        pin_mut!(segments);
+
+        // Two small datagrams that would coalesce into a single frame in byte-stream mode. In
+        // datagram mode each write is its own frame (distinct frame_id), so the boundary is kept.
+        writer.write_all(b"hello").await?;
+        writer.write_all(b"world").await?;
+        writer.flush().await?;
+
+        let first = segments.next().await.ok_or(anyhow!("no first datagram"))?;
+        assert_eq!(1, first.frame_id);
+        assert_eq!(0, first.seq_idx);
+        assert_eq!(1, first.seq_flags.seq_len(), "single-segment datagram");
+        assert_eq!(b"hello", first.data.as_ref());
+
+        let second = segments.next().await.ok_or(anyhow!("no second datagram"))?;
+        assert_eq!(2, second.frame_id, "each write is a distinct frame");
+        assert_eq!(0, second.seq_idx);
+        assert_eq!(1, second.seq_flags.seq_len());
+        assert_eq!(b"world", second.data.as_ref());
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn datagram_mode_keeps_a_multi_segment_datagram_in_one_frame() -> anyhow::Result<()> {
+        let (segments_tx, segments) = futures::channel::mpsc::unbounded();
+        let mut writer = segments_tx.segmenter_with_terminating_segment::<MTU>(FRAME_SIZE, true);
+        pin_mut!(segments);
+
+        // A datagram larger than one segment (and larger than frame_size) stays a single frame: all
+        // segments share one frame_id/seq_len with contiguous indices, matching a direct segment().
+        let datagram = vec![0xABu8; SMTU * 2 + 10];
+        writer.write_all(&datagram).await?;
+        writer.flush().await?;
+
+        for expected in segment(&datagram, SMTU, 1)? {
+            let seg = segments
+                .next()
+                .timeout(futures_time::time::Duration::from_millis(500))
+                .await
+                .context("multi-segment datagram")?
+                .ok_or(anyhow!("no more segments"))?;
+            assert_eq!(1, seg.frame_id, "one frame_id for the whole datagram");
+            assert_eq!(expected.seq_idx, seg.seq_idx);
+            assert_eq!(expected.seq_flags.seq_len(), seg.seq_flags.seq_len());
+            assert_eq!(expected.data.as_ref(), seg.data.as_ref());
+        }
+
+        Ok(())
+    }
+
     #[parameterized::parameterized(num_frames = { 1, 3, 5, 11 })]
     #[parameterized_macro(tokio::test)]
     async fn segmenter_should_segment_complete_frames(num_frames: usize) -> anyhow::Result<()> {

--- a/protocols/session/src/processing/segmenter.rs
+++ b/protocols/session/src/processing/segmenter.rs
@@ -107,15 +107,14 @@ where
                 State::BufferingFrame => {
                     // Datagram mode: emit exactly one frame per write so datagram boundaries are
                     // preserved (the peer reads one datagram per read), regardless of `frame_size`.
-                    // `frame` is empty here: the previous write's frame was segmented and the
-                    // `WritingFrame` state drains before control returns to `BufferingFrame`.
+                    // Segment `buf` directly — there is nothing to accumulate, so the `frame`
+                    // buffer is left untouched. Segments drain on the next poll_write / poll_flush.
                     if *this.datagram {
                         if buf.is_empty() {
                             return Poll::Ready(Ok(0));
                         }
-                        this.frame.extend_from_slice(buf);
                         segment_into(
-                            this.frame.as_slice(),
+                            buf,
                             C - SessionMessage::<C>::SEGMENT_OVERHEAD,
                             *this.frame_id,
                             this.ready_segments,
@@ -128,12 +127,9 @@ where
                             "datagram frame ready"
                         );
 
-                        this.frame.clear();
                         *this.frame_id += 1;
                         *this.state = State::WritingFrame;
 
-                        // Segments drain on the next poll_write / poll_flush (as in the buffered
-                        // path); the whole datagram has been accepted.
                         return Poll::Ready(Ok(buf.len()));
                     }
 

--- a/protocols/session/src/socket/mod.rs
+++ b/protocols/session/src/socket/mod.rs
@@ -66,6 +66,13 @@ pub struct SessionSocketConfig {
     /// Default is false.
     #[default(false)]
     pub flush_immediately: bool,
+    /// Preserve datagram boundaries: each write to the socket is emitted as exactly one frame and
+    /// delivered to the peer as exactly one read, regardless of [`Self::frame_size`]. Use for
+    /// datagram-oriented targets (UDP/WireGuard). Only meaningful on stateless sockets.
+    ///
+    /// Default is false.
+    #[default(false)]
+    pub datagram: bool,
     /// Capacity of the control channel, the maximum number of outstanding control messages.
     ///
     /// This option affects stateful sockets.
@@ -186,7 +193,7 @@ impl<const C: usize> SessionSocket<C, Stateless<C>> {
 
                 future::ok::<_, SessionError>(SessionMessage::<C>::Segment(segment))
             })
-            .segmenter_with_terminating_segment::<C>(frame_size);
+            .segmenter_with_terminating_segment::<C>(frame_size, cfg.datagram);
 
         let last_emitted_frame = Arc::new(AtomicU32::new(0));
         let last_emitted_frame_clone = last_emitted_frame.clone();
@@ -361,7 +368,7 @@ impl<const C: usize, S: SocketState<C> + Clone + 'static> SessionSocket<C, S> {
                 }
                 future::ok::<_, futures::channel::mpsc::SendError>(SessionMessage::<C>::Segment(segment))
             })
-            .segmenter_with_terminating_segment::<C>(frame_size);
+            .segmenter_with_terminating_segment::<C>(frame_size, cfg.datagram);
 
         // We have to merge the streams here and spawn a special task for it
         // Since the control messages from the State can come independent of Upstream writes.

--- a/transport/session/src/errors.rs
+++ b/transport/session/src/errors.rs
@@ -30,9 +30,6 @@ pub enum TransportSessionError {
     #[error(transparent)]
     Network(#[from] hopr_utils::network_types::errors::NetworkTypeError),
 
-    #[error("the Datagram capability requires a stateless session and is incompatible with retransmission")]
-    DatagramRequiresStateless,
-
     #[error("session is closed")]
     Closed,
 }

--- a/transport/session/src/errors.rs
+++ b/transport/session/src/errors.rs
@@ -30,6 +30,9 @@ pub enum TransportSessionError {
     #[error(transparent)]
     Network(#[from] hopr_utils::network_types::errors::NetworkTypeError),
 
+    #[error("the Datagram capability requires a stateless session and is incompatible with retransmission")]
+    DatagramRequiresStateless,
+
     #[error("session is closed")]
     Closed,
 }

--- a/transport/session/src/lib.rs
+++ b/transport/session/src/lib.rs
@@ -67,6 +67,13 @@ flagset::flags! {
         /// boundary preservation is stateless-only (the NACK missing-segment bitmap cannot address
         /// the segments of an oversized datagram frame).
         ///
+        /// Boundary preservation holds only up to the reader's buffer: a single read cannot return
+        /// more bytes than its buffer, so a datagram larger than the peer's read buffer is still
+        /// delivered in multiple reads. Callers must therefore size the read buffer for the largest
+        /// datagram they need preserved. In the UDP-forwarding path the datagram size is bounded at
+        /// ingress by the forwarding buffer (`HOPR_UDP_BUFFER_SIZE`), so it never exceeds it there;
+        /// a datagram-mode frame may otherwise be as large as `64 * SESSION_MTU`.
+        ///
         /// Implies [`Segmentation`].
         NoDelay = 0b0000_1001,
         /// Disable SURB-based egress rate control.

--- a/transport/session/src/lib.rs
+++ b/transport/session/src/lib.rs
@@ -67,6 +67,13 @@ flagset::flags! {
         ///
         /// This applies only to the recipient of the Session (Exit).
         NoRateControl = 0b0001_0000,
+        /// Preserve datagram boundaries: each write is emitted as exactly one frame (and therefore
+        /// delivered to the peer as exactly one read), regardless of `frame_mtu`. Use this for
+        /// datagram-oriented targets (e.g. UDP/WireGuard) that must not have datagrams split or
+        /// coalesced. Only supported on stateless (non-retransmitting) sessions.
+        ///
+        /// Implies [`Segmentation`].
+        Datagram = 0b0010_1000,
     }
 }
 

--- a/transport/session/src/lib.rs
+++ b/transport/session/src/lib.rs
@@ -59,7 +59,13 @@ flagset::flags! {
         ///
         /// Implies [`Segmentation`].
         RetransmissionNack = 0b000_1010,
-        /// Disable packet buffering.
+        /// UDP-like behavior: disable packet buffering, and — on stateless (non-retransmitting)
+        /// sessions — preserve datagram boundaries by emitting each write as exactly one frame
+        /// (delivered to the peer as exactly one read), regardless of `frame_mtu`. Use this for
+        /// datagram-oriented targets (e.g. UDP/WireGuard) that must not have datagrams split or
+        /// coalesced. On reliable (retransmitting) sessions only the buffering behavior applies;
+        /// boundary preservation is stateless-only (the NACK missing-segment bitmap cannot address
+        /// the segments of an oversized datagram frame).
         ///
         /// Implies [`Segmentation`].
         NoDelay = 0b0000_1001,
@@ -67,13 +73,6 @@ flagset::flags! {
         ///
         /// This applies only to the recipient of the Session (Exit).
         NoRateControl = 0b0001_0000,
-        /// Preserve datagram boundaries: each write is emitted as exactly one frame (and therefore
-        /// delivered to the peer as exactly one read), regardless of `frame_mtu`. Use this for
-        /// datagram-oriented targets (e.g. UDP/WireGuard) that must not have datagrams split or
-        /// coalesced. Only supported on stateless (non-retransmitting) sessions.
-        ///
-        /// Implies [`Segmentation`].
-        Datagram = 0b0010_1000,
     }
 }
 

--- a/transport/session/src/types.rs
+++ b/transport/session/src/types.rs
@@ -240,6 +240,19 @@ impl HoprSession {
 
         // Based on the requested capabilities, see if we should use the Session protocol
         let inner: Box<dyn AsyncReadWrite> = if cfg.capabilities.contains(Capability::Segmentation) {
+            // Datagram mode emits one frame per write with no `frame_size` cap; the reliable socket
+            // cannot honor that. Its NACK missing-segment bitmap addresses at most
+            // `MAX_MISSING_SEGMENTS_PER_FRAME` segments per frame, so any segment past that bound in
+            // an oversized datagram frame could never be requested for retransmission — on loss the
+            // frame never completes and the stream stalls. Reject the contradictory combination up
+            // front instead of silently corrupting a reliable stream.
+            if cfg.capabilities.contains(Capability::Datagram)
+                && (cfg.capabilities.contains(Capability::RetransmissionAck)
+                    || cfg.capabilities.contains(Capability::RetransmissionNack))
+            {
+                return Err(TransportSessionError::DatagramRequiresStateless);
+            }
+
             let socket_cfg = SessionSocketConfig {
                 frame_size: cfg.frame_mtu,
                 frame_timeout: cfg.frame_timeout,

--- a/transport/session/src/types.rs
+++ b/transport/session/src/types.rs
@@ -245,6 +245,7 @@ impl HoprSession {
                 frame_timeout: cfg.frame_timeout,
                 capacity: SESSION_SOCKET_CAPACITY,
                 flush_immediately: cfg.capabilities.contains(Capability::NoDelay),
+                datagram: cfg.capabilities.contains(Capability::Datagram),
                 max_buffered_segments: cfg.max_buffered_segments,
                 // Anti-bufferbloat bound; only meaningful when flow control is enabled, which is
                 // also where the honest clock that observes the resulting loss lives.

--- a/transport/session/src/types.rs
+++ b/transport/session/src/types.rs
@@ -240,25 +240,16 @@ impl HoprSession {
 
         // Based on the requested capabilities, see if we should use the Session protocol
         let inner: Box<dyn AsyncReadWrite> = if cfg.capabilities.contains(Capability::Segmentation) {
-            // Datagram mode emits one frame per write with no `frame_size` cap; the reliable socket
-            // cannot honor that. Its NACK missing-segment bitmap addresses at most
-            // `MAX_MISSING_SEGMENTS_PER_FRAME` segments per frame, so any segment past that bound in
-            // an oversized datagram frame could never be requested for retransmission — on loss the
-            // frame never completes and the stream stalls. Reject the contradictory combination up
-            // front instead of silently corrupting a reliable stream.
-            if cfg.capabilities.contains(Capability::Datagram)
-                && (cfg.capabilities.contains(Capability::RetransmissionAck)
-                    || cfg.capabilities.contains(Capability::RetransmissionNack))
-            {
-                return Err(TransportSessionError::DatagramRequiresStateless);
-            }
-
             let socket_cfg = SessionSocketConfig {
                 frame_size: cfg.frame_mtu,
                 frame_timeout: cfg.frame_timeout,
                 capacity: SESSION_SOCKET_CAPACITY,
                 flush_immediately: cfg.capabilities.contains(Capability::NoDelay),
-                datagram: cfg.capabilities.contains(Capability::Datagram),
+                // Datagram-boundary preservation is stateless-only: the stateless branch below turns
+                // it on for `NoDelay` sessions. The reliable socket must never run in datagram mode
+                // (its NACK missing-segment bitmap cannot address the segments of an oversized
+                // datagram frame), so it keeps `NoDelay`'s buffering behavior only.
+                datagram: false,
                 max_buffered_segments: cfg.max_buffered_segments,
                 // Anti-bufferbloat bound; only meaningful when flow control is enabled, which is
                 // also where the honest clock that observes the resulting loss lives.
@@ -347,6 +338,12 @@ impl HoprSession {
                     None => Box::new(socket),
                 }
             } else {
+                // Stateless (unreliable) sockets support datagram-boundary preservation, driven by
+                // `NoDelay` (UDP-like framing). See `Capability::NoDelay`.
+                let socket_cfg = SessionSocketConfig {
+                    datagram: cfg.capabilities.contains(Capability::NoDelay),
+                    ..socket_cfg
+                };
                 debug!(?socket_cfg, "opening new stateless session socket");
 
                 Box::new(UnreliableSocket::<{ ApplicationData::PAYLOAD_SIZE }>::new_stateless(


### PR DESCRIPTION
## Summary

Fixes #8356. On the WireGuard-over-HOPR **return path**, tunnels tore down with `DecapStalled`
after sustained download load. Root cause: the `Segmentation` session is a **byte stream** — the
segmenter cuts frames at `frame_mtu` (1500) regardless of write boundaries, so a UDP datagram
larger than 1500 is split across frames. The client reads one frame per read and hands each to
neptun, which rejects the partial/misaligned buffer (`InvalidPacket`/`InvalidAeadTag`); a burst
trips the client's `DecapStalled` guard and reconnects. Oversized datagrams are routine on the
return path because the exit's WireGuard server batches several ≤1452-byte packets into one UDP
send (UDP-GSO / high-MTU coalescing to the co-located server; observed `recv_from` = 1.8–13.8 KB).

## Fix

Add a negotiated **`Capability::Datagram`** (implies `Segmentation`). In this mode the segmenter
emits **exactly one frame per write**, so each datagram is delivered to the peer as exactly one
`read`, regardless of `frame_mtu` — reusing the existing per-`frame_id` segmentation and
reassembly (no new wire structures). Threaded through `SessionSocketConfig`/`HoprSessionConfig`
(`datagram = capabilities.contains(Datagram)`), mirroring how `NoDelay` maps to
`flush_immediately`.

- `transport/session/src/lib.rs` — `Capability::Datagram = 0b0010_1000`.
- `protocols/session/src/processing/segmenter.rs` — one-frame-per-write in datagram mode.
- `protocols/session/src/socket/mod.rs`, `transport/session/src/types.rs` — config plumbing.

Supported on **stateless** sessions (which is what the WireGuard session uses); the reliable path
keeps its ~8 KB per-frame retransmission bound (a separate wire concern, out of scope). The
WireGuard session should request `Datagram` alongside `Segmentation` + `NoDelay` (one-line client
change, follow-up).

Note on GSO: this preserves whatever datagram the exit receives per `recv`. For the exit to hand
neptun **individual** WG packets (rather than a GSO batch), the exit's UDP ingress should also
forward one packet per datagram — a follow-up (`ConnectedUdpStream` `UDP_GRO`/`gso_size` split).

## Tests (hopr-lib `session_integration_tests`, `--features testing`)

- `udp_datagram_larger_than_frame_mtu_is_delivered_whole` — the #8356 regression (2904-byte
  datagram delivered in one read). **Passes** with the fix (failed before it).
- `udp_back_to_back_datagrams_each_arrive_whole_in_order` — mixed-size datagrams each arrive whole,
  in order, one per read (no split, no coalesce).
- `udp_datagram_within_frame_mtu_preserves_boundary` — control.
- All pre-existing UDP/TCP/bidirectional tests and the `hopr-protocol-session` unit suite
  (segmenter/socket, 113 tests) stay green.

Closes #8356.
