### PR TITLE
chore(deps): unify on hopr-chain-connector 0.26.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1787,9 +1787,9 @@ dependencies = [
 
 [[package]]
 name = "blokli-client"
-version = "0.32.1"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2eed63aec778288cd2fa8aaf9537687e0b5a7d2eae53f7b0360e05fc02134db"
+checksum = "b841703b39a44da4578c39433f770631f6405a89dfd33451ff041b16cf096ea4"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4137,9 +4137,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-chain-connector"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5ccf6e1918b73b93a3e56fc1181490b21f2e3b5a18d87fde363103af7adbc36"
+checksum = "3b46905f969c4ea754093e14eca3d7619dd390d6a37816ceb4320c5cac6314f0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4153,7 +4153,7 @@ dependencies = [
  "futures-concurrency",
  "futures-time",
  "hopr-api",
- "hopr-utilities",
+ "hopr-utilities 0.13.0",
  "moka",
  "parking_lot",
  "petgraph",
@@ -4179,7 +4179,7 @@ dependencies = [
  "hex-literal",
  "hopr-protocol-pix",
  "hopr-types",
- "hopr-utilities",
+ "hopr-utilities 0.13.0",
  "lazy_static",
  "mimalloc",
  "parameterized",
@@ -4206,7 +4206,7 @@ dependencies = [
  "futures-time",
  "hopr-api",
  "hopr-network-graph",
- "hopr-utilities",
+ "hopr-utilities 0.12.0",
  "smart-default",
  "tracing",
  "validator",
@@ -4234,7 +4234,7 @@ dependencies = [
  "hopr-ticket-manager",
  "hopr-transport",
  "hopr-transport-p2p",
- "hopr-utilities",
+ "hopr-utilities 0.13.0",
  "humantime-serde",
  "insta",
  "lazy_static",
@@ -4268,7 +4268,7 @@ dependencies = [
  "bimap",
  "futures",
  "hopr-api",
- "hopr-utilities",
+ "hopr-utilities 0.12.0",
  "indexmap 2.14.0",
  "lazy_static",
  "parking_lot",
@@ -4310,7 +4310,7 @@ dependencies = [
  "hopr-crypto-packet",
  "hopr-protocol-pix",
  "hopr-ticket-manager",
- "hopr-utilities",
+ "hopr-utilities 0.13.0",
  "humantime-serde",
  "lazy_static",
  "moka",
@@ -4339,7 +4339,7 @@ dependencies = [
  "criterion",
  "elliptic-curve-tools",
  "hopr-types",
- "hopr-utilities",
+ "hopr-utilities 0.13.0",
  "moka",
  "parking_lot",
  "rand 0.10.2",
@@ -4375,7 +4375,7 @@ dependencies = [
  "hopr-crypto-packet",
  "hopr-protocol-app",
  "hopr-types",
- "hopr-utilities",
+ "hopr-utilities 0.13.0",
  "indexmap 2.14.0",
  "insta",
  "lazy_static",
@@ -4429,7 +4429,7 @@ dependencies = [
  "futures",
  "hashbrown 0.17.1",
  "hopr-api",
- "hopr-utilities",
+ "hopr-utilities 0.12.0",
  "parking_lot",
  "postcard",
  "redb",
@@ -4474,7 +4474,7 @@ dependencies = [
  "hopr-transport-probe",
  "hopr-transport-session",
  "hopr-transport-tag-allocator",
- "hopr-utilities",
+ "hopr-utilities 0.13.0",
  "humantime-serde",
  "insta",
  "lazy_static",
@@ -4538,7 +4538,7 @@ dependencies = [
  "dashmap",
  "futures",
  "hopr-api",
- "hopr-utilities",
+ "hopr-utilities 0.12.0",
  "libp2p",
  "libp2p-stream",
  "multiaddr",
@@ -4563,7 +4563,7 @@ dependencies = [
  "hopr-crypto-packet",
  "hopr-protocol-app",
  "hopr-transport-tag-allocator",
- "hopr-utilities",
+ "hopr-utilities 0.13.0",
  "humantime-serde",
  "insta",
  "lazy_static",
@@ -4598,7 +4598,7 @@ dependencies = [
  "hopr-protocol-session",
  "hopr-protocol-start",
  "hopr-transport-session",
- "hopr-utilities",
+ "hopr-utilities 0.13.0",
  "humantime-serde",
  "insta",
  "lazy_static",
@@ -4637,9 +4637,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "4.0.0"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1998a31a5fec199e2e51cb6c79804934a49d72a10c54714208ce17fa42e73af0"
+checksum = "c46c3109d786f2688fa712240720a0ada428d99382eb2b76a996ee7ea33ba188"
 dependencies = [
  "aes 0.9.2",
  "anyhow",
@@ -4705,6 +4705,34 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c14c15d3f0945752daaf2a0b5c5b0a9e11821d012eff7c48195e89dc1454695d"
 dependencies = [
+ "arrayvec",
+ "auto_impl",
+ "const-hex",
+ "crossfire",
+ "flume",
+ "futures",
+ "futures-time",
+ "hickory-resolver 0.26.1",
+ "hopr-types",
+ "indexmap 2.14.0",
+ "lazy_static",
+ "libp2p-identity",
+ "multiaddr",
+ "pin-project",
+ "rand 0.10.2",
+ "serde_json",
+ "socket2 0.6.5",
+ "strum",
+ "thiserror 2.0.20",
+ "tracing",
+]
+
+[[package]]
+name = "hopr-utilities"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "752062e541c6d679acec0bf94af8099bca83a225d0ce8b933aaf464ad7396877"
+dependencies = [
  "anyhow",
  "arrayvec",
  "auto_impl",
@@ -4751,7 +4779,7 @@ dependencies = [
  "hopr-api",
  "hopr-lib",
  "hopr-transport",
- "hopr-utilities",
+ "hopr-utilities 0.13.0",
  "human-bandwidth",
  "lazy_static",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,9 +139,6 @@ validator = { version = "0.21.0", features = ["derive"] }
 vsss-rs = { version = "6.0.1", default-features = false }
 
 hopr-api = { version = "4.1.0" }
-# These two and `hopr-chain-connector` below move together: 4.0.1 added the `Payer` to the
-# `Withdraw*` actions, `hopr-utils` 0.13.0 is the blokli emulator that reads it, and the connector
-# is what requires that `hopr-utils`.
 hopr-types = { version = "4.0.1", features = ["use-bindings"] }
 hopr-utils = { package = "hopr-utilities", version = "0.13.0", default-features = false }
 hopr-utils-session = { version = "1.2.1", path = "utils-session" }
@@ -165,9 +162,6 @@ hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-fe
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
 hopr-transport-session = { version = "0.29.0", path = "transport/session", default-features = false }
 hopr-transport-tag-allocator = { version = "0.1.1", path = "transport/tag-allocator", default-features = false }
-# Kept at whatever `hopr-strategy` requires, which is 0.26.0. A consumer linking both gets two
-# connector copies otherwise, and with them a `hopr-utils` 0.12.0 whose emulator no longer compiles
-# against the `hopr-types` the rest of the graph resolves.
 hopr-chain-connector = { version = "0.26.0" }
 
 # referential implementations (published to crates.io)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,8 +139,11 @@ validator = { version = "0.21.0", features = ["derive"] }
 vsss-rs = { version = "6.0.1", default-features = false }
 
 hopr-api = { version = "4.1.0" }
-hopr-types = { version = "4.0.0", features = ["use-bindings"] }
-hopr-utils = { package = "hopr-utilities", version = "0.12.0", default-features = false }
+# These two and `hopr-chain-connector` below move together: 4.0.1 added the `Payer` to the
+# `Withdraw*` actions, `hopr-utils` 0.13.0 is the blokli emulator that reads it, and the connector
+# is what requires that `hopr-utils`.
+hopr-types = { version = "4.0.1", features = ["use-bindings"] }
+hopr-utils = { package = "hopr-utilities", version = "0.13.0", default-features = false }
 hopr-utils-session = { version = "1.2.1", path = "utils-session" }
 
 hopr-crypto-packet = { version = "1.4.0", path = "crypto/packet", default-features = false, features = [
@@ -162,7 +165,10 @@ hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-fe
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
 hopr-transport-session = { version = "0.29.0", path = "transport/session", default-features = false }
 hopr-transport-tag-allocator = { version = "0.1.1", path = "transport/tag-allocator", default-features = false }
-hopr-chain-connector = { version = "0.25.0" }
+# Kept at whatever `hopr-strategy` requires, which is 0.26.0. A consumer linking both gets two
+# connector copies otherwise, and with them a `hopr-utils` 0.12.0 whose emulator no longer compiles
+# against the `hopr-types` the rest of the graph resolves.
+hopr-chain-connector = { version = "0.26.0" }
 
 # referential implementations (published to crates.io)
 hopr-session-server-forwarder = { version = "0.3.0", default-features = false }

--- a/hopr/hopr-lib/tests/chain_operations-size3.rs
+++ b/hopr/hopr-lib/tests/chain_operations-size3.rs
@@ -217,10 +217,14 @@ async fn test_withdraw_native(cluster: &ClusterGuard) -> anyhow::Result<()> {
 
     // Exactly the withdrawn amount: the Safe pays the value and none of the gas.
     assert_eq!(final_safe_balance, initial_safe_balance - withdrawn_amount);
-    // The signer is out only the fee. Bounded on both sides rather than stated exactly, because
-    // the fee is not fixed — but it has to stay strictly under the value moved, or the node paid
-    // for the withdrawal after all and the assertion above passed for the wrong reason.
-    assert!(final_balance_src <= initial_balance_src);
+    // The signer is out the fee and nothing else, so it is bounded on both sides rather than
+    // stated exactly — the fee is not fixed, but neither bound may be slack:
+    //
+    // - strictly below, because the signer always pays the fee. `<=` would also admit a node that paid nothing at all,
+    //   which is what a broken fee accounting looks like.
+    // - strictly above `initial - withdrawn`, because it must not have paid the value. Without this, a node debited for
+    //   the whole withdrawal satisfies the bound above just as well.
+    assert!(final_balance_src < initial_balance_src);
     assert!(final_balance_src > initial_balance_src - withdrawn_amount);
     Ok(())
 }

--- a/hopr/hopr-lib/tests/chain_operations-size3.rs
+++ b/hopr/hopr-lib/tests/chain_operations-size3.rs
@@ -154,7 +154,16 @@ async fn test_channel_retrieval(cluster: &ClusterGuard) -> anyhow::Result<()> {
 #[test_log::test(tokio::test)]
 #[timeout(TEST_GLOBAL_TIMEOUT)]
 /// Exercises the native withdrawal path by sending xDai from one node to a fixed address
-/// and asserting that the recipient balance increases while the sender balance decreases.
+/// and asserting that the recipient balance increases while the paying **Safe** decreases.
+///
+/// The Safe and not the node's own account: the fixture builds each node on a Safe-bound
+/// connector, so `withdraw` goes out as an `execTransactionFromModule` and the Safe holds the
+/// value being moved. The node key only signs, and pays the gas.
+///
+/// This asserted against the node's own balance until `hopr-utils` 0.13.0, whose blokli emulator
+/// began settling a withdrawal against the payer the parsed action names rather than always
+/// against the signer. The old assertion passed because the emulator debited the wrong account,
+/// not because the node paid.
 async fn test_withdraw_native(cluster: &ClusterGuard) -> anyhow::Result<()> {
     let [src] = cluster.sample_nodes::<1>();
 
@@ -170,6 +179,11 @@ async fn test_withdraw_native(cluster: &ClusterGuard) -> anyhow::Result<()> {
         .unwrap_or("0 wxHOPR".into());
     assert_eq!("0 wxHOPR", &balance);
 
+    let initial_safe_balance = src
+        .inner()
+        .get_safe_balance::<XDai>()
+        .await
+        .context("should get safe xdai balance")?;
     let initial_balance_src = src
         .inner()
         .get_balance::<XDai>()
@@ -182,6 +196,11 @@ async fn test_withdraw_native(cluster: &ClusterGuard) -> anyhow::Result<()> {
         .await
         .context("failed to withdraw native")?;
 
+    let final_safe_balance = src
+        .inner()
+        .get_safe_balance::<XDai>()
+        .await
+        .context("should get safe xdai balance")?;
     let final_balance_src = src
         .inner()
         .get_balance::<XDai>()
@@ -196,6 +215,12 @@ async fn test_withdraw_native(cluster: &ClusterGuard) -> anyhow::Result<()> {
         .unwrap_or("0 wxHOPR".into());
     assert_eq!(balance, withdrawn_amount.to_string());
 
-    assert!(final_balance_src < initial_balance_src - withdrawn_amount); // account for gas
+    // Exactly the withdrawn amount: the Safe pays the value and none of the gas.
+    assert_eq!(final_safe_balance, initial_safe_balance - withdrawn_amount);
+    // The signer is out only the fee. Bounded on both sides rather than stated exactly, because
+    // the fee is not fixed — but it has to stay strictly under the value moved, or the node paid
+    // for the withdrawal after all and the assertion above passed for the wrong reason.
+    assert!(final_balance_src <= initial_balance_src);
+    assert!(final_balance_src > initial_balance_src - withdrawn_amount);
     Ok(())
 }


### PR DESCRIPTION
- update hopr-types to 4.0.1
- update hopr-chain-connector to 0.26.0

Update the tests to fix the Connector's new tests semantics.