### PR TITLE
feat(session): parameterize PIX admission by Session target

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4099,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "hopr-api"
 version = "4.3.0"
-source = "git+https://github.com/hoprnet/hopr-api?rev=9f2f3c8e63baaa50e669116a30f56d934de21739#9f2f3c8e63baaa50e669116a30f56d934de21739"
+source = "git+https://github.com/hoprnet/hopr-api?rev=8818e6ca00ffa3618b002b97ce004c6deca426a3#8818e6ca00ffa3618b002b97ce004c6deca426a3"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -4921,7 +4921,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -7220,7 +7220,7 @@ dependencies = [
  "quinn-udp 0.5.15",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -7260,7 +7260,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -7273,7 +7273,7 @@ checksum = "76150b617afc75e6e21ac5f39bc196e80b65415ae48d62dbef8e2519d040ce42"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "windows-sys 0.61.2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4098,9 +4098,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f004332014f2739746ff6428b01f6308791528ec0bc5b692e2c4837fa27c87c"
+version = "4.3.0"
+source = "git+https://github.com/hoprnet/hopr-api?branch=lukas%2Fsession-admission-hook#9f2f3c8e63baaa50e669116a30f56d934de21739"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -4922,7 +4921,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -7221,7 +7220,7 @@ dependencies = [
  "quinn-udp 0.5.15",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -7261,7 +7260,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -7274,7 +7273,7 @@ checksum = "76150b617afc75e6e21ac5f39bc196e80b65415ae48d62dbef8e2519d040ce42"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "windows-sys 0.61.2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4099,7 +4099,7 @@ dependencies = [
 [[package]]
 name = "hopr-api"
 version = "4.3.0"
-source = "git+https://github.com/hoprnet/hopr-api?branch=lukas%2Fsession-admission-hook#9f2f3c8e63baaa50e669116a30f56d934de21739"
+source = "git+https://github.com/hoprnet/hopr-api?rev=9f2f3c8e63baaa50e669116a30f56d934de21739#9f2f3c8e63baaa50e669116a30f56d934de21739"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -4921,7 +4921,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -7220,7 +7220,7 @@ dependencies = [
  "quinn-udp 0.5.15",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -7260,7 +7260,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -7273,7 +7273,7 @@ checksum = "76150b617afc75e6e21ac5f39bc196e80b65415ae48d62dbef8e2519d040ce42"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "windows-sys 0.61.2",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4099,7 +4099,8 @@ dependencies = [
 [[package]]
 name = "hopr-api"
 version = "4.3.0"
-source = "git+https://github.com/hoprnet/hopr-api?rev=8818e6ca00ffa3618b002b97ce004c6deca426a3#8818e6ca00ffa3618b002b97ce004c6deca426a3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "750c02e904f0a6156b7da0e7324ed19b59fdbc51656d18bb82ec5e009485aff0"
 dependencies = [
  "async-trait",
  "atomic_enum",
@@ -4921,7 +4922,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -7220,7 +7221,7 @@ dependencies = [
  "quinn-udp 0.5.15",
  "rustc-hash",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.20",
  "tokio",
  "tracing",
@@ -7260,7 +7261,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -7273,7 +7274,7 @@ checksum = "76150b617afc75e6e21ac5f39bc196e80b65415ae48d62dbef8e2519d040ce42"
 dependencies = [
  "cfg_aliases",
  "libc",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "windows-sys 0.61.2",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,4 +238,4 @@ ignored = ["oas3", "hopr-session-server-forwarder", "hopr-utils-session"]
 # do not unify. Pinned by `rev` rather than by branch so the resolved commit cannot move under
 # CI while the PR is open. Reverted once 4.3.0 is on crates.io.
 [patch.crates-io]
-hopr-api = { git = "https://github.com/hoprnet/hopr-api", rev = "9f2f3c8e63baaa50e669116a30f56d934de21739" }
+hopr-api = { git = "https://github.com/hoprnet/hopr-api", rev = "8818e6ca00ffa3618b002b97ce004c6deca426a3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,7 +138,7 @@ tracing = { version = "0.1.44", features = ["release_max_level_debug"] }
 validator = { version = "0.21.0", features = ["derive"] }
 vsss-rs = { version = "6.0.1", default-features = false }
 
-hopr-api = { version = "4.1.0" }
+hopr-api = { version = "4.3.0" }
 hopr-types = { version = "4.0.1", features = ["use-bindings"] }
 hopr-utils = { package = "hopr-utilities", version = "0.13.0", default-features = false }
 hopr-utils-session = { version = "1.2.1", path = "utils-session" }
@@ -165,7 +165,7 @@ hopr-transport-tag-allocator = { version = "0.1.1", path = "transport/tag-alloca
 hopr-chain-connector = { version = "0.26.0" }
 
 # referential implementations (published to crates.io)
-hopr-session-server-forwarder = { version = "0.3.0", default-features = false }
+hopr-session-server-forwarder = { version = "0.4.0", default-features = false }
 hopr-transport-p2p = { version = "0.11.0", features = ["transport-quic"] }
 hopr-ct-full-network = { version = "0.6.0", default-features = false }
 hopr-network-graph = { version = "0.7.0", default-features = false }
@@ -231,11 +231,3 @@ similar.opt-level = 3
 
 [workspace.metadata.cargo-shear]
 ignored = ["oas3", "hopr-session-server-forwarder", "hopr-utils-session"]
-
-# Temporary, for the duration of #8376: `HoprSessionServer::admit` is not published yet. A `[patch]`
-# rather than a git dependency because `hopr-api` also reaches this workspace through several
-# crates.io crates; a git dep would leave two distinct `hopr-api` packages in the graph whose traits
-# do not unify. Pinned by `rev` rather than by branch so the resolved commit cannot move under
-# CI while the PR is open. Reverted once 4.3.0 is on crates.io.
-[patch.crates-io]
-hopr-api = { git = "https://github.com/hoprnet/hopr-api", rev = "8818e6ca00ffa3618b002b97ce004c6deca426a3" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -235,6 +235,7 @@ ignored = ["oas3", "hopr-session-server-forwarder", "hopr-utils-session"]
 # Temporary, for the duration of #8376: `HoprSessionServer::admit` is not published yet. A `[patch]`
 # rather than a git dependency because `hopr-api` also reaches this workspace through several
 # crates.io crates; a git dep would leave two distinct `hopr-api` packages in the graph whose traits
-# do not unify. Reverted once 4.3.0 is on crates.io.
+# do not unify. Pinned by `rev` rather than by branch so the resolved commit cannot move under
+# CI while the PR is open. Reverted once 4.3.0 is on crates.io.
 [patch.crates-io]
-hopr-api = { git = "https://github.com/hoprnet/hopr-api", branch = "lukas/session-admission-hook" }
+hopr-api = { git = "https://github.com/hoprnet/hopr-api", rev = "9f2f3c8e63baaa50e669116a30f56d934de21739" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,3 +231,10 @@ similar.opt-level = 3
 
 [workspace.metadata.cargo-shear]
 ignored = ["oas3", "hopr-session-server-forwarder", "hopr-utils-session"]
+
+# Temporary, for the duration of #8376: `HoprSessionServer::admit` is not published yet. A `[patch]`
+# rather than a git dependency because `hopr-api` also reaches this workspace through several
+# crates.io crates; a git dep would leave two distinct `hopr-api` packages in the graph whose traits
+# do not unify. Reverted once 4.3.0 is on crates.io.
+[patch.crates-io]
+hopr-api = { git = "https://github.com/hoprnet/hopr-api", branch = "lukas/session-admission-hook" }

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -319,7 +319,7 @@ impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
                     }
                 )
                 .inspect(|_| tracing::warn!(
-                    task = %HoprLibProcess::SessionServer,
+                    task = %HoprLibProcess::SessionAdmission,
                     "long-running background task finished"
                 ))
         );

--- a/hopr/hopr-lib/src/builder.rs
+++ b/hopr/hopr-lib/src/builder.rs
@@ -82,6 +82,16 @@ const PEER_DISCOVERY_CHANNEL_CAPACITY: usize = 2048;
 type PeerDiscoveryRx =
     Arc<parking_lot::Mutex<Option<futures::stream::BoxStream<'static, (hopr_api::PeerId, Vec<hopr_api::Multiaddr>)>>>>;
 
+/// What `into_parts` hands to the shared build path: the configured builder, the two channels the
+/// transport is wired to, and the tasks already spawned for them. The admission sink is optional
+/// because a node built without a session server has nobody to ask.
+type BuildParts<Chain, Graph, Net, Ct> = (
+    HoprBuilderConfigured<Chain, Graph, Net, Ct>,
+    futures::channel::mpsc::Sender<IncomingSession>,
+    Option<hopr_transport::SessionAdmissionSink>,
+    AbortableList<HoprLibProcess>,
+);
+
 /// Type-erased factory closure producing `T` from a [`BuildCtx`] reference.
 type Factory<T> = Box<dyn FnOnce(&BuildCtx) -> T + Send>;
 type AsyncFactory<T> = Box<dyn FnOnce(BuildCtx) -> Pin<Box<dyn Future<Output = T> + Send>> + Send>;
@@ -255,17 +265,64 @@ impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
     ///
     /// Eagerly spawns the server task and returns a [`HoprBuilderWithSession`]
     /// that has the `build_edge` / `build_full` methods.
+    ///
+    /// Two tasks are spawned, not one, because the server is consulted at two different points in a
+    /// Session's life. `admit` is asked while the peer's request is still being negotiated and no
+    /// Session exists yet; `process` is handed the established byte-stream. Sharing one channel
+    /// would put a long-lived `process` in front of the admission decisions queued behind it.
     #[cfg(feature = "session-server")]
     pub fn with_session_server(
         self,
+        // `Sync` on top of what `process` alone needed: the server is now driven from two
+        // independent tasks, and `admit` carries a default body, which `async_trait` can only make
+        // `Send` by requiring `&Self` to cross threads.
         server: impl hopr_api::node::HoprSessionServer<Session = IncomingSession, Error: std::fmt::Display>
         + Clone
         + Send
+        + Sync
         + 'static,
     ) -> HoprBuilderWithSession<Chain, Graph, Net, Ct> {
         let incoming_session_capacity = self.ctx.cfg.incoming_session_capacity.max(1);
 
         let (session_tx, session_rx) = futures::channel::mpsc::channel::<IncomingSession>(incoming_session_capacity);
+
+        // Sized like the incoming-session channel: an admission request is in flight only for as
+        // long as one Start negotiation, so this bounds concurrent negotiations rather than live
+        // Sessions. Overflowing refuses the Session as busy rather than queueing its peer.
+        let (admission_tx, admission_rx) = futures::channel::mpsc::channel(incoming_session_capacity);
+
+        let admission_server = server.clone();
+        let admission_diag = hopr_utils::runtime::diagnostics::ConcurrentDiagnostics::new(
+            "session_admission_for_each_concurrent",
+            module_path!(),
+            file!(),
+            line!(),
+        );
+        let admission_handle = hopr_utils::spawn_as_abortable_named!(
+            "hopr_lib_session_admission",
+            admission_rx
+                .for_each_concurrent(
+                    None,
+                    move |(request, reply): (_, hopr_transport::SessionAdmissionReply)| {
+                        let server = admission_server.clone();
+                        let admission_diag = admission_diag.clone();
+                        admission_diag.wrap(|| async move {
+                            // Concurrently rather than in sequence: the transport gives each request its
+                            // own deadline, so one slow decision must not spend another's.
+                            let decision = server.admit(request).await.map_err(|error| error.to_string());
+                            if reply.send(decision).is_err() {
+                                // The transport stopped waiting — its own timeout fired, or the peer
+                                // went away. Nothing to do but note it; it already refused the Session.
+                                tracing::debug!("session admission decided after the transport stopped waiting");
+                            }
+                        })
+                    }
+                )
+                .inspect(|_| tracing::warn!(
+                    task = %HoprLibProcess::SessionServer,
+                    "long-running background task finished"
+                ))
+        );
 
         tracing::debug!(capacity = incoming_session_capacity, "spawning session server");
         let session_diag = hopr_utils::runtime::diagnostics::ConcurrentDiagnostics::new(
@@ -299,7 +356,9 @@ impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
         HoprBuilderWithSession {
             inner: self,
             session_tx,
+            admission_tx,
             session_handle: handle,
+            admission_handle,
         }
     }
 }
@@ -315,7 +374,9 @@ impl<Chain, Graph, Net, Ct> HoprBuilderConfigured<Chain, Graph, Net, Ct> {
 pub struct HoprBuilderWithSession<Chain = (), Graph = (), Net = (), Ct = ()> {
     inner: HoprBuilderConfigured<Chain, Graph, Net, Ct>,
     session_tx: futures::channel::mpsc::Sender<IncomingSession>,
+    admission_tx: hopr_transport::SessionAdmissionSink,
     session_handle: hopr_utils::runtime::AbortHandle,
+    admission_handle: hopr_utils::runtime::AbortHandle,
 }
 
 // ---------------------------------------------------------------------------
@@ -340,6 +401,7 @@ struct PreHopr<Chain, Graph, Net, Ct> {
     ),
     processes: AbortableList<HoprLibProcess>,
     session_tx: futures::channel::mpsc::Sender<IncomingSession>,
+    admission_tx: Option<hopr_transport::SessionAdmissionSink>,
     cover_traffic: Ct,
     network: Net,
     network_process: BoxedProcessFn,
@@ -370,6 +432,7 @@ async fn drain_incoming_data<S: futures::Stream + Unpin>(mut reader: S) {
 async fn pre_build_inner<Chain, Graph, Net, Ct>(
     configured: HoprBuilderConfigured<Chain, Graph, Net, Ct>,
     session_tx: futures::channel::mpsc::Sender<IncomingSession>,
+    admission_tx: Option<hopr_transport::SessionAdmissionSink>,
     mut processes: AbortableList<HoprLibProcess>,
 ) -> Result<PreHopr<Chain, Graph, Net, Ct>, HoprLibError>
 where
@@ -708,6 +771,7 @@ where
         pix_event_subscribers: (ssa_tx, ssa_rx.deactivate()),
         processes,
         session_tx,
+        admission_tx,
         cover_traffic,
         network,
         network_process,
@@ -728,8 +792,8 @@ macro_rules! impl_build_methods {
         where
             TFact: TicketFactory + Clone + Send + Sync + 'static,
         {
-            let (configured, session_tx, processes) = self.into_parts();
-            let pre = pre_build_inner(configured, session_tx, processes).await?;
+            let (configured, session_tx, admission_tx, processes) = self.into_parts();
+            let pre = pre_build_inner(configured, session_tx, admission_tx, processes).await?;
 
             tracing::info!("starting transport for edge (entry) node");
             let (socket, transport_processes) = pre
@@ -787,8 +851,8 @@ macro_rules! impl_build_methods {
         where
             TFact: TicketFactory + Clone + Send + Sync + 'static,
         {
-            let (configured, session_tx, processes) = self.into_parts();
-            let pre = pre_build_inner(configured, session_tx, processes).await?;
+            let (configured, session_tx, admission_tx, processes) = self.into_parts();
+            let pre = pre_build_inner(configured, session_tx, admission_tx, processes).await?;
 
             tracing::info!("starting transport for entry node");
             let (socket, transport_processes) = pre
@@ -846,8 +910,8 @@ macro_rules! impl_build_methods {
         where
             TFact: TicketFactory + Clone + Send + Sync + 'static,
         {
-            let (configured, session_tx, processes) = self.into_parts();
-            let pre = pre_build_inner(configured, session_tx, processes).await?;
+            let (configured, session_tx, admission_tx, processes) = self.into_parts();
+            let pre = pre_build_inner(configured, session_tx, admission_tx, processes).await?;
 
             tracing::info!("starting transport for exit node");
             let (socket, transport_processes) = pre
@@ -859,6 +923,7 @@ macro_rules! impl_build_methods {
                     ticket_factory,
                     Some(BroadcastSenderSink(pre.pix_event_subscribers.0.clone())),
                     pre.session_tx,
+                    pre.admission_tx,
                 )
                 .await?;
 
@@ -905,8 +970,8 @@ macro_rules! impl_build_methods {
             TMgr: TicketManagement + Clone + Send + Sync + 'static,
             TFact: TicketFactory + Clone + Send + Sync + 'static,
         {
-            let (configured, session_tx, processes) = self.into_parts();
-            let pre = pre_build_inner(configured, session_tx, processes).await?;
+            let (configured, session_tx, admission_tx, processes) = self.into_parts();
+            let pre = pre_build_inner(configured, session_tx, admission_tx, processes).await?;
             let mut processes = pre.processes;
 
             tracing::info!("starting ticket events processor");
@@ -1011,6 +1076,7 @@ macro_rules! impl_build_methods {
                     ticket_factory,
                     Some(BroadcastSenderSink(pre.pix_event_subscribers.0.clone())),
                     pre.session_tx,
+                    pre.admission_tx,
                 )
                 .await?;
             // Drain unrelated packets to avoid missing blackhole
@@ -1072,16 +1138,11 @@ where
 {
     impl_build_methods!();
 
-    fn into_parts(
-        self,
-    ) -> (
-        HoprBuilderConfigured<Chain, Graph, Net, Ct>,
-        futures::channel::mpsc::Sender<IncomingSession>,
-        AbortableList<HoprLibProcess>,
-    ) {
+    fn into_parts(self) -> BuildParts<Chain, Graph, Net, Ct> {
         let mut processes = AbortableList::<HoprLibProcess>::default();
         processes.insert(HoprLibProcess::SessionServer, self.session_handle);
-        (self.inner, self.session_tx, processes)
+        processes.insert(HoprLibProcess::SessionAdmission, self.admission_handle);
+        (self.inner, self.session_tx, Some(self.admission_tx), processes)
     }
 }
 
@@ -1099,15 +1160,9 @@ where
 {
     impl_build_methods!();
 
-    fn into_parts(
-        self,
-    ) -> (
-        HoprBuilderConfigured<Chain, Graph, Net, Ct>,
-        futures::channel::mpsc::Sender<IncomingSession>,
-        AbortableList<HoprLibProcess>,
-    ) {
+    fn into_parts(self) -> BuildParts<Chain, Graph, Net, Ct> {
         let (tx, _rx) = futures::channel::mpsc::channel::<IncomingSession>(1);
         let processes = AbortableList::<HoprLibProcess>::default();
-        (self, tx, processes)
+        (self, tx, None, processes)
     }
 }

--- a/hopr/hopr-lib/src/lib.rs
+++ b/hopr/hopr-lib/src/lib.rs
@@ -281,6 +281,9 @@ pub(crate) enum HoprLibProcess {
     #[strum(to_string = "session server providing the exit node session stream functionality")]
     #[allow(dead_code)] // constructed only with feature = "session-server"
     SessionServer,
+    #[strum(to_string = "session server deciding the terms incoming sessions are admitted on")]
+    #[allow(dead_code)] // constructed only with feature = "session-server"
+    SessionAdmission,
     #[strum(to_string = "subscription for on-chain channel updates")]
     ChannelEvents,
     #[strum(to_string = "on received ticket event (winning or rejected)")]

--- a/hopr/hopr-lib/src/testing/wiring.rs
+++ b/hopr/hopr-lib/src/testing/wiring.rs
@@ -96,6 +96,7 @@ pub async fn build_edge_with_chain<
     Srv: hopr_api::node::HoprSessionServer<Session = hopr_transport::IncomingSession, Error: std::fmt::Display>
         + Clone
         + Send
+        + Sync
         + 'static,
 >(
     chain_key: &ChainKeypair,
@@ -135,6 +136,7 @@ pub async fn build_full_with_chain<
     Srv: hopr_api::node::HoprSessionServer<Session = hopr_transport::IncomingSession, Error: std::fmt::Display>
         + Clone
         + Send
+        + Sync
         + 'static,
 >(
     chain_key: &ChainKeypair,
@@ -180,6 +182,7 @@ pub async fn build_entry_with_chain<
     Srv: hopr_api::node::HoprSessionServer<Session = hopr_transport::IncomingSession, Error: std::fmt::Display>
         + Clone
         + Send
+        + Sync
         + 'static,
 >(
     chain_key: &ChainKeypair,
@@ -222,6 +225,7 @@ pub async fn build_exit_with_chain<
     Srv: hopr_api::node::HoprSessionServer<Session = hopr_transport::IncomingSession, Error: std::fmt::Display>
         + Clone
         + Send
+        + Sync
         + 'static,
 >(
     chain_key: &ChainKeypair,

--- a/protocols/start/src/lib.rs
+++ b/protocols/start/src/lib.rs
@@ -807,8 +807,15 @@ where
                     };
                     StartProtocol::SessionError(StartErrorType {
                         identifier,
-                        reason: StartErrorReason::from_repr(body[reason_start])
-                            .ok_or(StartProtocolError::ParseError("err.reason".into()))?,
+                        // An unrecognized reason is read as [`StartErrorReason::Unknown`] rather
+                        // than failing the message, which is the whole purpose of that variant.
+                        // The alternative loses the error entirely: a peer that added a reason this
+                        // build predates would have its `SessionError` rejected as malformed, and
+                        // the Session it was closing would die on a timeout instead of being
+                        // reported. Refusing to parse tells this node *less* than reading the byte
+                        // it does not recognize as "some reason", so a reason may be added without
+                        // a protocol version bump.
+                        reason: StartErrorReason::from_repr(body[reason_start]).unwrap_or(StartErrorReason::Unknown),
                     })
                 }
                 StartProtocolDiscriminants::KeepAlive => {
@@ -1175,6 +1182,41 @@ mod tests {
 
             assert_eq!(sent, received, "round trip of {reason}");
         }
+
+        Ok(())
+    }
+
+    /// A reason byte this build does not know must still decode, as `Unknown`.
+    ///
+    /// Otherwise adding a reason is a protocol break in one direction: the older peer rejects the
+    /// whole `SessionError` as malformed and loses the close it was being told about, so the
+    /// Session dies on a timeout instead. Reading the byte as "some reason" tells it strictly more.
+    #[test]
+    fn a_session_error_reason_this_build_does_not_know_decodes_as_unknown() -> anyhow::Result<()> {
+        let sent =
+            StartProtocol::<i32, String, u8, Box<[u8]>, Box<[u8]>, MinimalDeposit>::SessionError(StartErrorType {
+                identifier: ErrorIdentifier::Challenge(10),
+                reason: StartErrorReason::TargetNotAdmitted,
+            });
+        let (tag, msg) = sent.encode()?;
+
+        // Stand in for a reason added after this build: the last byte is the reason.
+        let mut msg = msg.into_vec();
+        let reason_byte = msg.len() - 1;
+        msg[reason_byte] = u8::MAX;
+
+        let received = StartProtocol::<i32, String, u8, Box<[u8]>, Box<[u8]>, MinimalDeposit>::decode(tag, &msg)?;
+
+        assert!(
+            matches!(
+                received,
+                StartProtocol::SessionError(StartErrorType {
+                    identifier: ErrorIdentifier::Challenge(10),
+                    reason: StartErrorReason::Unknown,
+                })
+            ),
+            "an unknown reason must survive as Unknown, got {received:?}"
+        );
 
         Ok(())
     }

--- a/protocols/start/src/lib.rs
+++ b/protocols/start/src/lib.rs
@@ -41,6 +41,14 @@ pub enum StartErrorReason {
     Busy = 2,
     /// The recipient requires incentivization or the incentivization parameters are not acceptable.
     UnacceptablePixParams = 3,
+    /// The recipient does not serve this Session's target, or does not serve it on the offered
+    /// terms.
+    ///
+    /// Distinct from [`UnacceptablePixParams`](Self::UnacceptablePixParams) because the two call for
+    /// different responses: those parameters could be re-offered differently, whereas this target
+    /// will not be served by this recipient however the request is phrased. Distinct from
+    /// [`Busy`](Self::Busy) because that one is transient and worth retrying.
+    TargetNotAdmitted = 4,
 }
 
 /// Identifies which entity a [`StartErrorType`] refers to.
@@ -1142,6 +1150,31 @@ mod tests {
         let (tag, msg) = msg_3.clone().encode()?;
         let msg_4 = StartProtocol::<i32, String, u8, Box<[u8]>, Box<[u8]>, MinimalDeposit>::decode(tag, &msg)?;
         assert_eq!(msg_3, msg_4);
+
+        Ok(())
+    }
+
+    /// The reason travels as a single byte read back through `from_repr`, so a variant that does not
+    /// survive the round trip is one a peer cannot be told about at all.
+    #[test]
+    fn every_session_error_reason_survives_the_round_trip() -> anyhow::Result<()> {
+        for reason in [
+            StartErrorReason::Unknown,
+            StartErrorReason::NoSlotsAvailable,
+            StartErrorReason::Busy,
+            StartErrorReason::UnacceptablePixParams,
+            StartErrorReason::TargetNotAdmitted,
+        ] {
+            let sent = StartProtocol::SessionError(StartErrorType {
+                identifier: ErrorIdentifier::Challenge(10),
+                reason,
+            });
+
+            let (tag, msg) = sent.clone().encode()?;
+            let received = StartProtocol::<i32, String, u8, Box<[u8]>, Box<[u8]>, MinimalDeposit>::decode(tag, &msg)?;
+
+            assert_eq!(sent, received, "round trip of {reason}");
+        }
 
         Ok(())
     }

--- a/transport/hopr/src/lib.rs
+++ b/transport/hopr/src/lib.rs
@@ -85,7 +85,7 @@ use hopr_transport_session::{
 pub use hopr_transport_session::{
     Capabilities as SessionCapabilities, Capability as SessionCapability, FlowControlConfig, HoprSession,
     IncomingSession, InvalidPixParams, LOCAL_PIX_SUITE, PixParams, SESSION_MTU, SURB_SIZE, ServiceId,
-    SessionClientConfig, SessionId, SessionTarget, SurbBalancerConfig,
+    SessionAdmissionReply, SessionAdmissionSink, SessionClientConfig, SessionId, SessionTarget, SurbBalancerConfig,
     errors::{SessionManagerError, TransportSessionError},
 };
 #[cfg(feature = "telemetry")]
@@ -467,6 +467,7 @@ where
         ticket_factory: TFact,
         exit_ack_share: Option<PixEvt>,
         on_incoming_session: Sender<IncomingSession>,
+        on_session_admission: Option<SessionAdmissionSink>,
     ) -> errors::Result<(
         HoprSocket<
             futures::stream::BoxStream<'static, ApplicationDataIn>,
@@ -491,6 +492,7 @@ where
             ticket_factory,
             exit_ack_share,
             Some(on_incoming_session),
+            on_session_admission,
         )
         .await
     }
@@ -502,6 +504,10 @@ where
     ///
     /// The Exit nodes also work with the PIX protocol, so they process incoming acknowledgements
     /// to decrypt PIX shares.
+    #[allow(
+        clippy::too_many_arguments,
+        reason = "each argument is a distinct wiring point supplied by hopr-lib"
+    )]
     pub async fn run_exit<TFact, Ct, PixEvt>(
         &self,
         cover_traffic: Ct,
@@ -510,6 +516,7 @@ where
         ticket_factory: TFact,
         pix_events: Option<PixEvt>,
         on_incoming_session: Sender<IncomingSession>,
+        on_session_admission: Option<SessionAdmissionSink>,
     ) -> errors::Result<(
         HoprSocket<
             futures::stream::BoxStream<'static, ApplicationDataIn>,
@@ -532,6 +539,7 @@ where
             ticket_factory,
             pix_events,
             Some(on_incoming_session),
+            on_session_admission,
         )
         .await
     }
@@ -570,6 +578,7 @@ where
             ticket_factory,
             pix_events,
             None,
+            None,
         )
         .await
     }
@@ -591,6 +600,7 @@ where
         ticket_factory: TFact,
         exit_ack_share: Option<PixEvt>,
         on_incoming_session: Option<Sender<IncomingSession>>,
+        on_session_admission: Option<SessionAdmissionSink>,
     ) -> errors::Result<(
         HoprSocket<
             futures::stream::BoxStream<'static, ApplicationDataIn>,
@@ -969,10 +979,17 @@ where
                     HoprTransportError::Api("on_incoming_session channel is required for relay/exit nodes".into())
                 })?,
                 pix_toolbox,
+                on_session_admission,
             )
         } else {
-            self.smgr
-                .start(unresolved_routing_msg_tx.clone(), futures::sink::drain(), pix_toolbox)
+            // An Entry establishes Sessions rather than admitting them, so there is nothing to ask
+            // about even if the caller installed a session server.
+            self.smgr.start(
+                unresolved_routing_msg_tx.clone(),
+                futures::sink::drain(),
+                pix_toolbox,
+                None,
+            )
         };
 
         smgr_start_res

--- a/transport/session/benches/dispatch_bench.rs
+++ b/transport/session/benches/dispatch_bench.rs
@@ -160,7 +160,7 @@ fn make_manager_with_session(
 
     runtime.block_on(async {
         manager
-            .start(msg_sender, session_notifier, None)
+            .start(msg_sender, session_notifier, None, None)
             .expect("manager.start() must succeed");
     });
 
@@ -206,7 +206,7 @@ fn make_manager_without_session() -> (
 
     runtime.block_on(async {
         manager
-            .start(msg_sender, session_notifier, None)
+            .start(msg_sender, session_notifier, None, None)
             .expect("manager.start() must succeed");
     });
 

--- a/transport/session/src/lib.rs
+++ b/transport/session/src/lib.rs
@@ -51,7 +51,8 @@ pub use testing::{MsgSender as MockMsgSender, SendMsg, mock_packet_planning, msg
 pub use types::{
     AgreedSsaQuota, ClosureReason, DEFAULT_PIX_POLYS_PER_SSA, DEFAULT_PIX_SHARES_PER_POLY, DEFAULT_PIX_SSA_QUOTA,
     DEFAULT_PIX_SURPLUS_SHARES, HoprSession, HoprSessionCapabilities, HoprSessionConfig, HoprSessionInPixEvent,
-    HoprSessionOutPixEvent, HoprStartProtocol, IncomingSession, LOCAL_PIX_SUITE, ServiceId, SessionId, SessionTarget,
+    HoprSessionOutPixEvent, HoprStartProtocol, IncomingSession, LOCAL_PIX_SUITE, ServiceId, SessionAdmissionReply,
+    SessionAdmissionSink, SessionId, SessionTarget,
 };
 #[cfg(feature = "runtime-tokio")]
 pub use utils::transfer_session;

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -3450,7 +3450,7 @@ where
     /// decision for this Session — rather than against the node's configuration directly, which is
     /// what makes the accepted quota a property of the target as well as of the node.
     ///
-    /// `offered` is what [`decode_pix_offer`](Self::decode_pix_offer) read, so this is only the
+    /// `offered` is what [`decode_pix_offer`] read, so this is only the
     /// policy question; the wire has already been judged.
     ///
     /// Returns the validated parameters and selected SSA batch size, or `None` if the offer cannot

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -1520,7 +1520,13 @@ pub struct SessionManager<S> {
     ///
     /// Unset on a node that runs no session server — an Entry, or a relay — where there is nobody to
     /// ask and every Session is admitted on this node's own terms.
-    admission_tx: Arc<OnceLock<SessionAdmissionSink>>,
+    /// Behind a `Mutex` so every request goes through *one* sender.
+    ///
+    /// `futures::channel::mpsc` gives each cloned `Sender` its own guaranteed slot on top of the
+    /// buffer, so sending through a fresh clone each time would let the queue grow with the number
+    /// of concurrent initiations — the bound would not bound. `try_send` never blocks, so the lock
+    /// is held only for the enqueue itself.
+    admission_tx: Arc<OnceLock<parking_lot::Mutex<SessionAdmissionSink>>>,
 }
 
 impl<S> Clone for SessionManager<S> {
@@ -1817,7 +1823,7 @@ where
 
         if let Some(admission) = admission {
             self.admission_tx
-                .set(admission)
+                .set(parking_lot::Mutex::new(admission))
                 .map_err(|_| SessionManagerError::AlreadyStarted)?;
         }
 
@@ -3339,7 +3345,7 @@ where
         // `try_send` rather than an awaited send: waiting for room in the queue would hold this
         // initiation past the peer's own timeout, and the queue being full is exactly the condition
         // the bound exists to report.
-        if let Err(error) = admission_tx.clone().try_send((request, reply_tx)) {
+        if let Err(error) = admission_tx.lock().try_send((request, reply_tx)) {
             warn!(
                 %session_id,
                 %error,
@@ -6487,6 +6493,225 @@ mod tests {
             lax.effective_for(&SessionAdmissionDecision::default().with_enforce_pix(true))
                 .enforce_pix
         );
+    }
+
+    /// The feature itself: one Exit, one Entry offering the same thing, two targets, two answers.
+    ///
+    /// Every other test here fixes the decision and varies the offer; this one fixes the offer and
+    /// varies the target, which is the only thing #8376 actually asks for.
+    #[test_log::test(tokio::test)]
+    async fn two_targets_on_one_exit_are_admitted_on_different_terms() -> anyhow::Result<()> {
+        let free_target = SessionTarget::TcpStream(SealedHost::Plain("10.0.0.1:80".parse()?));
+        let paid_target = SessionTarget::TcpStream(SealedHost::Plain("10.0.0.2:80".parse()?));
+
+        let free_for = free_target.clone();
+        let (admission, handler) = spawn_admission_handler(move |request| {
+            Ok(if request.target == free_for {
+                SessionAdmissionDecision::default().with_enforce_pix(false)
+            } else {
+                SessionAdmissionDecision::default().with_enforce_pix(true)
+            })
+        });
+
+        // The node demands PIX; only the rule for `free_target` waives it.
+        let (mgr, sender, transport, err_rx, _incoming) =
+            started_manager_admitting_small_params(1..=small_params_quota(), true, Some(admission))?;
+
+        // Same Entry offer both times — no PIX at all.
+        mgr.handle_incoming_session_initiation(
+            HoprPseudonym::random(),
+            StartInitiation {
+                target: free_target,
+                ..no_pix_offer()
+            },
+        )
+        .await?;
+        assert_eq!(mgr.num_active_sessions(), 1, "the waived target must be served");
+
+        mgr.handle_incoming_session_initiation(
+            HoprPseudonym::random(),
+            StartInitiation {
+                target: paid_target,
+                challenge: MIN_CHALLENGE + 1,
+                ..no_pix_offer()
+            },
+        )
+        .await?;
+        assert_eq!(
+            mgr.num_active_sessions(),
+            1,
+            "the second target must be refused, leaving only the first session"
+        );
+
+        let err = err_rx.await.context("send_message was never called")?;
+        assert_eq!(err.reason, StartErrorReason::UnacceptablePixParams);
+        assert_eq!(
+            err.identifier,
+            ErrorIdentifier::Challenge(MIN_CHALLENGE + 1),
+            "the refusal must name the second initiation, not the admitted first"
+        );
+
+        sender.close_channel();
+        transport.await??;
+        handler.abort();
+        Ok(())
+    }
+
+    /// A queue with no reader is the third transient failure, beside the timeout and the dropped
+    /// reply. It is `Busy` for the same reason: nothing about the target was decided.
+    ///
+    /// Reachable only because every request goes through one shared sender — sending through a
+    /// fresh clone would hand each call its own guaranteed slot and the queue would never be full.
+    #[test_log::test(tokio::test)]
+    async fn a_full_admission_queue_refuses_the_session_as_busy() -> anyhow::Result<()> {
+        // No receiver task at all, so nothing is ever drained. `_rx` is held rather than dropped:
+        // a closed channel is a different failure from a full one.
+        let (admission, _rx) =
+            futures::channel::mpsc::channel::<(SessionAdmissionRequest, crate::types::SessionAdmissionReply)>(0);
+
+        let (mgr, sender, transport, err_rx, _incoming) =
+            started_manager_admitting_small_params(1..=small_params_quota(), false, Some(admission))?;
+
+        // The first request takes the sender's guaranteed slot; the second finds the queue full.
+        for challenge in [MIN_CHALLENGE, MIN_CHALLENGE + 1] {
+            mgr.handle_incoming_session_initiation(
+                HoprPseudonym::random(),
+                StartInitiation {
+                    challenge,
+                    ..pix_offer()
+                },
+            )
+            .await?;
+        }
+
+        let err = err_rx.await.context("send_message was never called")?;
+        assert_eq!(err.reason, StartErrorReason::Busy);
+        assert_eq!(mgr.num_active_sessions(), 0);
+
+        sender.close_channel();
+        transport.await??;
+        Ok(())
+    }
+
+    /// The empty-intersection case is a misconfiguration; this is the ordinary one. The narrowed
+    /// window is a real range that simply sits above what the Entry offered, and the refusal must
+    /// look the same.
+    #[test_log::test(tokio::test)]
+    async fn a_narrowed_window_that_excludes_the_offer_refuses_without_being_empty() -> anyhow::Result<()> {
+        let quota = small_params_quota();
+        let (admission, handler) = spawn_admission_handler(move |_| {
+            Ok(SessionAdmissionDecision::default().with_pix_quota_range(quota + 1..=2 * quota))
+        });
+        let (mgr, sender, transport, err_rx, _incoming) =
+            started_manager_admitting_small_params(1..=2 * quota, false, Some(admission))?;
+
+        // The intersection is `quota+1..=2*quota` — non-empty, and above the offer.
+        let effective = mgr
+            .cfg
+            .pix_config
+            .effective_for(&SessionAdmissionDecision::default().with_pix_quota_range(quota + 1..=2 * quota));
+        assert!(!effective.quota_range.is_empty(), "this case must not be the empty one");
+
+        mgr.handle_incoming_session_initiation(HoprPseudonym::random(), pix_offer())
+            .await?;
+
+        let err = err_rx.await.context("send_message was never called")?;
+        assert_eq!(err.reason, StartErrorReason::UnacceptablePixParams);
+        assert_eq!(mgr.num_active_sessions(), 0);
+
+        sender.close_channel();
+        transport.await??;
+        handler.abort();
+        Ok(())
+    }
+
+    /// Narrowing does not only accept or reject — with dynamic batching it moves the batch the Exit
+    /// asks for, which is what the Entry pays per deposit round trip.
+    #[test]
+    fn a_narrowed_window_can_change_the_selected_batch_size() {
+        let cfg = IncomingSessionPixConfig {
+            quota_range: 100..=400,
+            supervision: SupervisorConfig {
+                ssas_per_request: 4,
+                allow_dynamic_ssa_batches: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        // The node's own window accepts a single SSA of 100.
+        assert_eq!(
+            cfg.effective_for(&SessionAdmissionDecision::default())
+                .ssa_batch_size_for_quota(100),
+            Some(1)
+        );
+
+        // Narrowed to a floor of 250, the smallest batch that reaches it is three.
+        assert_eq!(
+            cfg.effective_for(&SessionAdmissionDecision::default().with_pix_quota_range(250..=400))
+                .ssa_batch_size_for_quota(100),
+            Some(3)
+        );
+
+        // Narrowed to a window every multiple of the offer jumps over — three total 300 and four
+        // total 400, with nothing in between — so no batch fits and the Session is refused.
+        assert_eq!(
+            cfg.effective_for(&SessionAdmissionDecision::default().with_pix_quota_range(310..=390))
+                .ssa_batch_size_for_quota(100),
+            None
+        );
+    }
+
+    /// Admission is an Exit-side question. An Entry establishing a Session decided its own target,
+    /// so putting it to the local session server would be asking a node to vet itself.
+    #[test_log::test(tokio::test)]
+    async fn an_outgoing_session_is_never_put_to_the_admission_hook() -> anyhow::Result<()> {
+        let asked = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let asked_by_handler = asked.clone();
+        let (admission, handler) = spawn_admission_handler(move |_| {
+            asked_by_handler.fetch_add(1, Ordering::Relaxed);
+            Ok(SessionAdmissionDecision::default())
+        });
+
+        let mgr = SessionManager::new(SessionManagerConfig {
+            initiation_timeout_base: Duration::from_millis(50),
+            ..Default::default()
+        });
+
+        let mut transport = MockMsgSender::new();
+        transport
+            .expect_send_message()
+            .returning(|_, _| Box::pin(async { Ok(()) }));
+        let (sender, transport_handle) = mock_packet_planning(transport);
+        let (new_session_tx, _new_session_rx) = futures::channel::mpsc::channel(1);
+        mgr.start(sender.clone(), new_session_tx, None, Some(admission))?;
+
+        // No peer answers, so this times out — which is fine: the assertion is about what was asked
+        // before the attempt died, not about it succeeding.
+        let _ = mgr
+            .new_session(
+                (&hopr_api::types::crypto::keypairs::ChainKeypair::random()).into(),
+                SessionTarget::TcpStream(SealedHost::Plain("127.0.0.1:80".parse()?)),
+                SessionClientConfig {
+                    pseudonym: Some(HoprPseudonym::random()),
+                    capabilities: Capability::Segmentation.into(),
+                    surb_management: None,
+                    pix_ssa_quota: None,
+                    ..Default::default()
+                },
+            )
+            .await;
+
+        assert_eq!(
+            asked.load(Ordering::Relaxed),
+            0,
+            "an outgoing session must not consult the admission hook"
+        );
+
+        sender.close_channel();
+        transport_handle.await??;
+        handler.abort();
+        Ok(())
     }
 
     /// The issue's first case: a target served without payment on a node that otherwise demands it.

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -9,7 +9,10 @@ use anyhow::anyhow;
 use futures::{Sink, SinkExt, StreamExt, TryStreamExt, channel::oneshot, future::AbortHandle};
 use futures_time::future::FutureExt as TimeExt;
 use hopr_api::{
-    node::{PixAddressId, PixDepositData, PixDepositDataRequest, SessionAdmissionDecision, SessionAdmissionRequest},
+    node::{
+        OfferedIncentivization, PixAddressId, PixDepositData, PixDepositDataRequest, SessionAdmissionDecision,
+        SessionAdmissionRequest,
+    },
     types::{
         crypto_random::Randomizable,
         internal::{
@@ -905,6 +908,52 @@ impl EffectivePixAdmission {
                 .is_some_and(|batch_quota| self.quota_range.contains(&batch_quota))
         })
     }
+}
+
+/// Decodes the incentivization the Entry offered, before anyone is asked what to do about it.
+///
+/// `Ok(None)` is a peer that offered none. `Err` is one whose offer this node cannot read or
+/// cannot share a curve with, which is refused on its own — no policy could rescue it, and both
+/// questions are cheaper than the round trip to the session server that follows.
+///
+/// Split out from `SessionManager::check_pix_params` so the session server can be
+/// told what was offered: it decides the terms, and terms relative to an offer need the offer.
+fn decode_pix_offer(
+    req: &StartInitiation<SessionTarget, HoprSessionCapabilities>,
+) -> Result<Option<PixParams>, StartErrorReason> {
+    if !req.capabilities.0.contains(Capability::UsePIX) {
+        return Ok(None);
+    }
+
+    // Unpacking is what enforces the protocol ranges on the three dimensions, and what rejects a
+    // suite identifier no curve claims — leaving only "a known curve, but not ours" below.
+    let params = PixParams::try_from_additional_data(req.additional_data).map_err(|error| {
+        debug!(
+            challenge = req.challenge,
+            %error,
+            "client offered PIX parameters outside the protocol ranges"
+        );
+        StartErrorReason::UnacceptablePixParams
+    })?;
+
+    // The Exit decides the curve, and it decides it by refusing anything else: nothing here
+    // is negotiated, because there is nothing to negotiate — the suite is fixed at build
+    // time on both sides. Checked before the quota because it is the cheaper question and
+    // because a suite mismatch makes the dimensions meaningless anyway, and checked at all
+    // because every later PIX field is sized by it. Refusing here means the Exit's own
+    // commitments, the first curve-sized bytes in the exchange, are never sent to a peer
+    // that would read their boundaries in the wrong place.
+    if params.suite() != LOCAL_PIX_SUITE {
+        warn!(
+            challenge = req.challenge,
+            offered = %params.suite(),
+            ours = %LOCAL_PIX_SUITE,
+            "refusing a client offering a PIX curve suite this node was not built for"
+        );
+        return Err(StartErrorReason::UnacceptablePixParams);
+    }
+
+    Ok(Some(params))
 }
 
 /// Validates the incoming-PIX invariants that span quota, supervision and memory settings.
@@ -3333,14 +3382,26 @@ where
     async fn request_admission(
         &self,
         session_id: SessionId,
-        target: &SessionTarget,
+        req: &StartInitiation<SessionTarget, HoprSessionCapabilities>,
+        offered: Option<PixParams>,
     ) -> Result<SessionAdmissionDecision, StartErrorReason> {
         let Some(admission_tx) = self.admission_tx.get() else {
             return Ok(SessionAdmissionDecision::default());
         };
 
         let (reply_tx, reply_rx) = oneshot::channel();
-        let request = SessionAdmissionRequest::new(session_id, target.clone());
+        // The capability bits travel as the peer sent them; the offer travels decoded, since the
+        // wire encoding is this crate's to read and the server has no business unpacking it.
+        let request = SessionAdmissionRequest::new(session_id, req.target.clone(), req.capabilities.0.bits());
+        let request = match offered {
+            Some(params) => request.with_offer(OfferedIncentivization::new(
+                params.polys_per_ssa(),
+                params.shares_per_poly(),
+                params.surplus_shares(),
+                pix_params_to_quota(&params),
+            )),
+            None => request,
+        };
 
         // `try_send` rather than an awaited send: waiting for room in the queue would hold this
         // initiation past the peer's own timeout, and the queue being full is exactly the condition
@@ -3383,55 +3444,29 @@ where
         }
     }
 
-    /// Checks the PIX parameters offered by the Entry during the Session Initiation.
+    /// Checks the offer against the terms this Session was admitted on.
     ///
     /// Judged against `policy` — the node's configuration as narrowed by the session server's
     /// decision for this Session — rather than against the node's configuration directly, which is
     /// what makes the accepted quota a property of the target as well as of the node.
     ///
+    /// `offered` is what [`decode_pix_offer`](Self::decode_pix_offer) read, so this is only the
+    /// policy question; the wire has already been judged.
+    ///
     /// Returns the validated parameters and selected SSA batch size, or `None` if the offer cannot
     /// satisfy that policy.
     fn check_pix_params(
         &self,
-        req: &StartInitiation<SessionTarget, HoprSessionCapabilities>,
+        challenge: StartChallenge,
+        offered: Option<PixParams>,
         policy: &EffectivePixAdmission,
     ) -> Option<(PixParams, usize)> {
-        if req.capabilities.0.contains(Capability::UsePIX) {
-            // Client offered PIX, so validate the offered parameters. Unpacking is what enforces the
-            // protocol ranges on the three dimensions, and what rejects a suite identifier no curve
-            // claims — leaving only "a known curve, but not ours" for the check below.
-            let params = PixParams::try_from_additional_data(req.additional_data)
-                .inspect_err(|error| {
-                    debug!(
-                        challenge = req.challenge,
-                        %error,
-                        "client offered PIX parameters outside the protocol ranges"
-                    )
-                })
-                .ok()?;
-
-            // The Exit decides the curve, and it decides it by refusing anything else: nothing here
-            // is negotiated, because there is nothing to negotiate — the suite is fixed at build
-            // time on both sides. Checked before the quota because it is the cheaper question and
-            // because a suite mismatch makes the dimensions meaningless anyway, and checked at all
-            // because every later PIX field is sized by it. Refusing here means the Exit's own
-            // commitments, the first curve-sized bytes in the exchange, are never sent to a peer
-            // that would read their boundaries in the wrong place.
-            if params.suite() != LOCAL_PIX_SUITE {
-                warn!(
-                    challenge = req.challenge,
-                    offered = %params.suite(),
-                    ours = %LOCAL_PIX_SUITE,
-                    "refusing a client offering a PIX curve suite this node was not built for"
-                );
-                return None;
-            }
-
+        if let Some(params) = offered {
             let quota_per_ssa = pix_params_to_quota(&params);
             let ssas_per_request = policy.ssa_batch_size_for_quota(quota_per_ssa);
             let accepted_quota = ssas_per_request.and_then(|batch_size| quota_per_ssa.checked_mul(batch_size as u64));
             debug!(
-                challenge = req.challenge,
+                challenge,
                 %params,
                 acceptable_range = ?policy.quota_range,
                 node_range = ?self.cfg.pix_config.quota_range,
@@ -3449,7 +3484,7 @@ where
             // Session rather than leaving it to look like a rejected client.
             if ssas_per_request.is_none() && policy.quota_range.is_empty() {
                 warn!(
-                    challenge = req.challenge,
+                    challenge,
                     admitted_range = ?policy.quota_range,
                     node_range = ?self.cfg.pix_config.quota_range,
                     "the admitted quota range for this target is empty, so no offer can be accepted"
@@ -3507,8 +3542,36 @@ where
         // anything is allocated for the Session. This is the only place the target can influence
         // admission: the transport cannot read a sealed target, and by the time the server sees the
         // established Session the terms have already been fixed.
+        // Read the offer before anyone is asked about it: an offer this node cannot read, or whose
+        // curve it does not share, is refused without a round trip to the session server, and the
+        // server is told what was offered rather than having to unpack the wire itself.
+        let offered = match decode_pix_offer(&session_req) {
+            Ok(offered) => offered,
+            Err(reason) => {
+                error!(
+                    challenge = session_req.challenge,
+                    "client offered unacceptable PIX parameters"
+                );
+                let data = HoprStartProtocol::SessionError(StartErrorType {
+                    identifier: ErrorIdentifier::Challenge(session_req.challenge),
+                    reason,
+                });
+                send_via_msg_sender(
+                    &mut msg_sender,
+                    reply_routing,
+                    data,
+                    "session error message due to unacceptable PIX parameters",
+                )
+                .await?;
+
+                #[cfg(all(feature = "telemetry", not(test)))]
+                METRIC_SENT_SESSION_ERRS.increment(&[&reason.to_string()]);
+                return Ok(());
+            }
+        };
+
         let session_id: SessionId = pseudonym;
-        let admission = match self.request_admission(session_id, &session_req.target).await {
+        let admission = match self.request_admission(session_id, &session_req, offered).await {
             Ok(decision) => decision,
             Err(reason) => {
                 let data = HoprStartProtocol::SessionError(StartErrorType {
@@ -3530,8 +3593,10 @@ where
         };
         let pix_policy = self.cfg.pix_config.effective_for(&admission);
 
-        // Verify if the client offered the right parameters for PIX
-        let Some((client_params, ssas_per_request)) = self.check_pix_params(&session_req, &pix_policy) else {
+        // Verify the offer against the terms this Session was admitted on.
+        let Some((client_params, ssas_per_request)) =
+            self.check_pix_params(session_req.challenge, offered, &pix_policy)
+        else {
             error!(
                 challenge = session_req.challenge,
                 "client offered unacceptable PIX parameters"
@@ -6495,6 +6560,128 @@ mod tests {
         );
     }
 
+    /// Runs an initiation through the same two steps admission does — read the offer off the wire,
+    /// then judge it against the node's own terms. `None` is a refusal from either.
+    fn decode_and_check(
+        mgr: &SessionManager<UnboundedSender<(DestinationRouting, ApplicationDataOut)>>,
+        req: &StartInitiation<SessionTarget, HoprSessionCapabilities>,
+    ) -> Option<(PixParams, usize)> {
+        let policy = mgr.cfg.pix_config.effective_for(&SessionAdmissionDecision::default());
+        decode_pix_offer(req)
+            .ok()
+            .and_then(|offered| mgr.check_pix_params(req.challenge, offered, &policy))
+    }
+
+    /// The offer must reach the session server decoded, and the capability bits verbatim.
+    ///
+    /// Without it the server can only price a target blind: it names a window with no idea whether
+    /// the peer is anywhere near it, and cannot hold a *dimension* to a floor, since the quota is
+    /// their product and the same product admits many splits.
+    #[test_log::test(tokio::test)]
+    async fn the_admission_request_carries_the_decoded_offer_and_capability_bits() -> anyhow::Result<()> {
+        let (seen_tx, seen_rx) = oneshot::channel();
+        let seen_tx = Arc::new(std::sync::Mutex::new(Some(seen_tx)));
+        let (admission, handler) = spawn_admission_handler(move |request| {
+            if let Some(tx) = seen_tx.lock().unwrap().take() {
+                let _ = tx.send((request.capabilities, request.offered));
+            }
+            Ok(SessionAdmissionDecision::default())
+        });
+        let (mgr, sender, transport, _err_rx, _incoming) =
+            started_manager_admitting_small_params(1..=small_params_quota(), false, Some(admission))?;
+
+        mgr.handle_incoming_session_initiation(HoprPseudonym::random(), pix_offer())
+            .await?;
+
+        let (capabilities, offered) = seen_rx.await.context("admission was never asked")?;
+        let offered = offered.context("an offer was made, so one must have been reported")?;
+
+        let params = small_pix_params();
+        assert_eq!(offered.parts_per_ssa, params.polys_per_ssa());
+        assert_eq!(offered.shares_per_part, params.shares_per_poly());
+        assert_eq!(
+            offered.surplus_shares,
+            params.surplus_shares(),
+            "the surplus is priced in, so a server judging the quota needs it"
+        );
+        assert_eq!(offered.quota_per_ssa, small_params_quota());
+        assert_eq!(
+            capabilities,
+            pix_offer().capabilities.0.bits(),
+            "the capability bits travel as the peer sent them"
+        );
+
+        sender.close_channel();
+        transport.await??;
+        handler.abort();
+        Ok(())
+    }
+
+    /// A peer offering nothing must be reported as offering nothing, not as offering zero: the two
+    /// are different answers, and only one of them means "this Session is free if you allow it".
+    #[test_log::test(tokio::test)]
+    async fn a_peer_offering_no_incentivization_reports_no_offer() -> anyhow::Result<()> {
+        let (seen_tx, seen_rx) = oneshot::channel();
+        let seen_tx = Arc::new(std::sync::Mutex::new(Some(seen_tx)));
+        let (admission, handler) = spawn_admission_handler(move |request| {
+            if let Some(tx) = seen_tx.lock().unwrap().take() {
+                let _ = tx.send(request.offered);
+            }
+            Ok(SessionAdmissionDecision::default())
+        });
+        let (mgr, sender, transport, _err_rx, _incoming) =
+            started_manager_admitting_small_params(1..=small_params_quota(), false, Some(admission))?;
+
+        mgr.handle_incoming_session_initiation(HoprPseudonym::random(), no_pix_offer())
+            .await?;
+
+        assert!(
+            seen_rx.await.context("admission was never asked")?.is_none(),
+            "no offer must read as no offer"
+        );
+
+        sender.close_channel();
+        transport.await??;
+        handler.abort();
+        Ok(())
+    }
+
+    /// An offer this node cannot read is refused before the session server is troubled with it: no
+    /// decision could rescue it, and the round trip would be spent to reach the same answer.
+    #[test_log::test(tokio::test)]
+    async fn an_unreadable_offer_is_refused_without_asking_the_session_server() -> anyhow::Result<()> {
+        let asked = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let asked_by_handler = asked.clone();
+        let (admission, handler) = spawn_admission_handler(move |_| {
+            asked_by_handler.fetch_add(1, Ordering::Relaxed);
+            Ok(SessionAdmissionDecision::default())
+        });
+        let (mgr, sender, transport, err_rx, _incoming) =
+            started_manager_admitting_small_params(1..=small_params_quota(), false, Some(admission))?;
+
+        // Zero polynomials is outside the protocol range, so unpacking refuses it outright.
+        let unreadable = StartInitiation {
+            additional_data: ((LOCAL_PIX_SUITE as u64) << 62) | (128u64 << 40),
+            ..pix_offer()
+        };
+        mgr.handle_incoming_session_initiation(HoprPseudonym::random(), unreadable)
+            .await?;
+
+        let err = err_rx.await.context("send_message was never called")?;
+        assert_eq!(err.reason, StartErrorReason::UnacceptablePixParams);
+        assert_eq!(
+            asked.load(Ordering::Relaxed),
+            0,
+            "an offer that cannot be read must not cost an admission round trip"
+        );
+        assert_eq!(mgr.num_active_sessions(), 0);
+
+        sender.close_channel();
+        transport.await??;
+        handler.abort();
+        Ok(())
+    }
+
     /// The feature itself: one Exit, one Entry offering the same thing, two targets, two answers.
     ///
     /// Every other test here fixes the decision and varies the offer; this one fixes the offer and
@@ -8463,11 +8650,7 @@ mod tests {
 
         // What makes the missing toolbox the sole remaining cause of the refusal below.
         assert!(
-            mgr.check_pix_params(
-                &req,
-                &mgr.cfg.pix_config.effective_for(&SessionAdmissionDecision::default())
-            )
-            .is_some(),
+            decode_and_check(&mgr, &req).is_some(),
             "the offered dimensions must be acceptable, or the refusal cannot be attributed to the guard"
         );
 
@@ -11010,11 +11193,7 @@ mod tests {
         // polys_per_ssa > MAX_POLYS_PER_SSA (16192), and zero, with a valid quota -> should reject
         for polys in [0, MAX_POLYS_PER_SSA + 1, u16::MAX] {
             assert!(
-                mgr.check_pix_params(
-                    &offer(packed(polys, 128, 0)),
-                    &mgr.cfg.pix_config.effective_for(&SessionAdmissionDecision::default())
-                )
-                .is_none(),
+                decode_and_check(&mgr, &offer(packed(polys, 128, 0))).is_none(),
                 "should reject polys_per_ssa {polys}"
             );
         }
@@ -11024,23 +11203,15 @@ mod tests {
         // cannot be exceeded by anything a peer is able to send.
         for shares in [0, 1] {
             assert!(
-                mgr.check_pix_params(
-                    &offer(packed(8192, shares, 0)),
-                    &mgr.cfg.pix_config.effective_for(&SessionAdmissionDecision::default())
-                )
-                .is_none(),
+                decode_and_check(&mgr, &offer(packed(8192, shares, 0))).is_none(),
                 "should reject shares_per_poly {shares}"
             );
         }
 
         // Valid params should still be accepted, and arrive intact — including the surplus, which
         // no other check looks at and which would therefore be free to go missing.
-        let (accepted, batch_size) = mgr
-            .check_pix_params(
-                &offer(packed(8192, 128, 37)),
-                &mgr.cfg.pix_config.effective_for(&SessionAdmissionDecision::default()),
-            )
-            .context("should accept valid params")?;
+        let (accepted, batch_size) =
+            decode_and_check(&mgr, &offer(packed(8192, 128, 37))).context("should accept valid params")?;
         assert_eq!(PixParams::try_new(8192, 128, 37, LOCAL_PIX_SUITE)?, accepted);
         assert_eq!(1, batch_size);
 
@@ -11048,10 +11219,7 @@ mod tests {
         for surplus in [0, 1, u8::MAX] {
             assert_eq!(
                 Some((PixParams::try_new(8192, 128, surplus, LOCAL_PIX_SUITE)?, 1)),
-                mgr.check_pix_params(
-                    &offer(packed(8192, 128, surplus)),
-                    &mgr.cfg.pix_config.effective_for(&SessionAdmissionDecision::default())
-                )
+                decode_and_check(&mgr, &offer(packed(8192, 128, surplus)))
             );
         }
 
@@ -11093,19 +11261,11 @@ mod tests {
         };
 
         assert!(
-            mgr.check_pix_params(
-                &offer(foreign),
-                &mgr.cfg.pix_config.effective_for(&SessionAdmissionDecision::default())
-            )
-            .is_none(),
+            decode_and_check(&mgr, &offer(foreign)).is_none(),
             "a client offering {foreign} must be refused by a {LOCAL_PIX_SUITE} Exit"
         );
         assert!(
-            mgr.check_pix_params(
-                &offer(LOCAL_PIX_SUITE),
-                &mgr.cfg.pix_config.effective_for(&SessionAdmissionDecision::default())
-            )
-            .is_some(),
+            decode_and_check(&mgr, &offer(LOCAL_PIX_SUITE)).is_some(),
             "and the same dimensions on this build's own curve must still be accepted"
         );
 
@@ -11117,11 +11277,7 @@ mod tests {
             additional_data: (0b11u64 << 62) | (8192u64 << 48) | (128u64 << 40) | (37u64 << 32),
         };
         assert!(
-            mgr.check_pix_params(
-                &unknown,
-                &mgr.cfg.pix_config.effective_for(&SessionAdmissionDecision::default())
-            )
-            .is_none(),
+            decode_and_check(&mgr, &unknown).is_none(),
             "an unknown suite identifier must be refused"
         );
 

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -9,7 +9,7 @@ use anyhow::anyhow;
 use futures::{Sink, SinkExt, StreamExt, TryStreamExt, channel::oneshot, future::AbortHandle};
 use futures_time::future::FutureExt as TimeExt;
 use hopr_api::{
-    node::{PixAddressId, PixDepositData, PixDepositDataRequest},
+    node::{PixAddressId, PixDepositData, PixDepositDataRequest, SessionAdmissionDecision, SessionAdmissionRequest},
     types::{
         crypto_random::Randomizable,
         internal::{
@@ -57,7 +57,8 @@ use crate::{
     types::{
         ClosureReason, DEFAULT_PIX_PARAMS, DEFAULT_PIX_QUOTA_RANGE_SPAN, DEFAULT_PIX_SSA_QUOTA, HoprPixDepositData,
         HoprPixDepositPayload, HoprSessionCapabilities, HoprSessionConfig, HoprSessionInPixEvent, HoprStartProtocol,
-        LOCAL_PIX_SUITE, SESSION_APPLICATION_TAG, SsaQuota, deposit_data_for_batch, pix_params_to_quota,
+        LOCAL_PIX_SUITE, SESSION_APPLICATION_TAG, SessionAdmissionSink, SsaQuota, deposit_data_for_batch,
+        pix_params_to_quota,
     },
     utils,
     utils::{SurbNotificationMode, insert_into_next_slot},
@@ -835,15 +836,66 @@ pub struct IncomingSessionPixConfig {
 }
 
 impl IncomingSessionPixConfig {
+    /// The terms one Session is judged on, once the session server has had its say.
+    ///
+    /// The configured [`quota_range`](Self::quota_range) is an envelope, not a default: it is what
+    /// [`validate_incoming_session_pix_config`] checked the deadlines and memory ceiling against,
+    /// and what [`start_protocol_channel_capacity`] sized a preallocated ring from, both once at
+    /// startup. So a decision's range is *intersected* with it rather than replacing it — a Session
+    /// may be held to less than the node advertises, never to more than it was configured to
+    /// honour. An operator wanting a wider class configures a wider envelope and narrows the rest.
+    ///
+    /// [`enforce_pix`](Self::enforce_pix) carries no such coupling and is simply overridden.
+    fn effective_for(&self, decision: &SessionAdmissionDecision) -> EffectivePixAdmission {
+        let quota_range = match &decision.pix_quota_range {
+            Some(narrowed) => {
+                *self.quota_range.start().max(narrowed.start())..=*self.quota_range.end().min(narrowed.end())
+            }
+            None => self.quota_range.clone(),
+        };
+
+        EffectivePixAdmission {
+            enforce_pix: decision.enforce_pix.unwrap_or(self.enforce_pix),
+            quota_range,
+            allow_dynamic_ssa_batches: self.supervision.allow_dynamic_ssa_batches,
+            ssas_per_request: self.supervision.ssas_per_request,
+        }
+    }
+
+    /// The supervisor configuration for Sessions accepted under these settings.
+    pub fn supervisor_config(&self) -> SupervisorConfig {
+        self.supervision.clone()
+    }
+}
+
+/// The PIX terms a single incoming Session is admitted on.
+///
+/// Lighter than the whole [`IncomingSessionPixConfig`] because only these four fields vary per
+/// Session: everything else the supervisor enforces is validated as a set at startup and stays
+/// node-wide. Narrowing the quota only makes those deadlines more generous, which is why they need
+/// not travel with it.
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct EffectivePixAdmission {
+    /// Whether this Session must offer PIX at all.
+    enforce_pix: bool,
+    /// Quota window this Session's offer must land in, already intersected with the node's envelope.
+    quota_range: std::ops::RangeInclusive<SsaQuota>,
+    /// Whether a batch may be derived from the offer, rather than taken as configured.
+    allow_dynamic_ssa_batches: bool,
+    /// Largest batch the Exit will ask for.
+    ssas_per_request: usize,
+}
+
+impl EffectivePixAdmission {
     /// Selects the batch size with which an Entry's per-SSA quota is acceptable.
     ///
     /// Dynamic mode walks from one upwards so it asks for no more Entry work, deposits or Exit
     /// reconstructor state than necessary. Fixed mode is the legacy rule: validate one SSA against
     /// the range, then request exactly the configured batch size.
     fn ssa_batch_size_for_quota(&self, quota_per_ssa: SsaQuota) -> Option<usize> {
-        let configured_batch = self.supervision.ssas_per_request.clamp(1, MAX_SSA_BATCH_SIZE);
+        let configured_batch = self.ssas_per_request.clamp(1, MAX_SSA_BATCH_SIZE);
 
-        if !self.supervision.allow_dynamic_ssa_batches {
+        if !self.allow_dynamic_ssa_batches {
             return self.quota_range.contains(&quota_per_ssa).then_some(configured_batch);
         }
 
@@ -852,11 +904,6 @@ impl IncomingSessionPixConfig {
                 .checked_mul(*batch_size as u64)
                 .is_some_and(|batch_quota| self.quota_range.contains(&batch_quota))
         })
-    }
-
-    /// The supervisor configuration for Sessions accepted under these settings.
-    pub fn supervisor_config(&self) -> SupervisorConfig {
-        self.supervision.clone()
     }
 }
 
@@ -1079,6 +1126,20 @@ pub struct SessionManagerConfig {
     /// Defaults to [`DEFAULT_MAX_SSAS_PER_SSA_REQUEST`] (2).
     #[default(DEFAULT_MAX_SSAS_PER_SSA_REQUEST)]
     pub max_ssas_per_ssa_request: usize,
+
+    /// How long the Exit waits for the session server to say whether a Session is admitted.
+    ///
+    /// The wait sits inside the peer's own initiation timeout, so it has to be comfortably shorter
+    /// than [`initiation_timeout_base`](Self::initiation_timeout_base): a server slower than the
+    /// peer is patient refuses every Session it is asked about, and does so after the peer has
+    /// already given up. [`SessionManager::new`] rejects a configuration where it is not.
+    ///
+    /// Expiring refuses the Session — the alternative, admitting on the node's own terms, would let
+    /// an overloaded or wedged server silently disable every rule the operator wrote.
+    ///
+    /// Default is 2 seconds.
+    #[default(Duration::from_secs(2))]
+    pub session_admission_timeout: Duration,
 }
 
 // Type-erased sink used by the `SessionManager` to notify about newly incoming sessions.
@@ -1455,6 +1516,11 @@ pub struct SessionManager<S> {
     /// peer offered. Charged in `handle_incoming_session_initiation` and returned by
     /// [`CycleBudgetReservation`]'s `Drop`, so no removal path has to remember to decrement it.
     live_cycle_bytes: Arc<std::sync::atomic::AtomicU64>,
+    /// Where incoming Sessions are put to the session server for an admission decision.
+    ///
+    /// Unset on a node that runs no session server — an Entry, or a relay — where there is nobody to
+    /// ask and every Session is admitted on this node's own terms.
+    admission_tx: Arc<OnceLock<SessionAdmissionSink>>,
 }
 
 impl<S> Clone for SessionManager<S> {
@@ -1471,6 +1537,7 @@ impl<S> Clone for SessionManager<S> {
             pix_toolbox: self.pix_toolbox.clone(),
             slot_allocated: Arc::clone(&self.slot_allocated),
             ssa_request_locks: self.ssa_request_locks.clone(),
+            admission_tx: self.admission_tx.clone(),
         }
     }
 }
@@ -1625,6 +1692,17 @@ where
             sup.max_recovery_idle = sup.max_recovery_idle.min(idle_cap);
         }
 
+        // The admission wait is spent inside the peer's initiation timeout, so a value at or above
+        // it buys nothing: the peer has already given up by the time the wait expires, and the
+        // Session was refused anyway. Clamped to one leg of that budget, leaving the other for the
+        // Start exchange the decision is part of. Clamped rather than rejected because every other
+        // cross-field rule in this constructor normalizes, and because the ceiling is derived from a
+        // field the caller may also have left at its default.
+        cfg.session_admission_timeout = cfg.session_admission_timeout.min(initiation_timeout_max_one_way(
+            cfg.initiation_timeout_base,
+            RoutingOptions::MAX_INTERMEDIATE_HOPS,
+        ));
+
         #[cfg(all(feature = "telemetry", not(test)))]
         METRIC_ACTIVE_SESSIONS.set(0.0);
 
@@ -1674,6 +1752,7 @@ where
             ssa_request_locks: moka::future::Cache::builder()
                 .time_to_idle(Duration::from_secs(1800))
                 .build(),
+            admission_tx: Arc::new(OnceLock::new()),
         }
     }
 
@@ -1683,6 +1762,11 @@ where
     /// Optionally, the PIX processor and event sink can be provided for handling PIX protocol.
     /// If not specified, the `SessionManager` will not handle PIX protocol.
     ///
+    /// `admission` is where incoming Sessions are put to the session server for a per-Session
+    /// decision before they are established. Without it — an Entry, or a relay, or any caller that
+    /// installed no session server — every Session is admitted on this node's own configured terms,
+    /// which is the behaviour of a node that does not distinguish between targets.
+    ///
     /// This method must be called prior to any calls to [`SessionManager::new_session`] or
     /// [`SessionManager::dispatch_message`].
     pub fn start<T>(
@@ -1690,6 +1774,7 @@ where
         msg_sender: S,
         new_session_notifier: T,
         pix: Option<PixToolbox>,
+        admission: Option<SessionAdmissionSink>,
     ) -> errors::Result<Vec<AbortHandle>>
     where
         T: futures::Sink<IncomingSession> + Send + 'static,
@@ -1727,6 +1812,12 @@ where
         if let Some(pix) = pix {
             self.pix_toolbox
                 .set(pix)
+                .map_err(|_| SessionManagerError::AlreadyStarted)?;
+        }
+
+        if let Some(admission) = admission {
+            self.admission_tx
+                .set(admission)
                 .map_err(|_| SessionManagerError::AlreadyStarted)?;
         }
 
@@ -3219,15 +3310,86 @@ where
             })
     }
 
+    /// Asks the session server on what terms this Session may be admitted.
+    ///
+    /// Fails closed. A refusal, a server that does not answer in time, a full request channel and a
+    /// dropped reply all end the Session here rather than falling back to the node's own terms:
+    /// falling back would mean an overloaded or wedged server silently disables every rule the
+    /// operator wrote, and the peer would be served on terms nobody chose.
+    ///
+    /// The two failure kinds are reported differently because they call for different responses. A
+    /// server that answered `Err` has decided, and re-asking will not change the answer, so the peer
+    /// is told [`StartErrorReason::TargetNotAdmitted`]. Everything else is this node being unable to
+    /// ask right now, which is transient, so the peer is told [`StartErrorReason::Busy`] and may
+    /// retry.
+    ///
+    /// A node with no session server has nobody to ask, and admits on its own terms.
+    async fn request_admission(
+        &self,
+        session_id: SessionId,
+        target: &SessionTarget,
+    ) -> Result<SessionAdmissionDecision, StartErrorReason> {
+        let Some(admission_tx) = self.admission_tx.get() else {
+            return Ok(SessionAdmissionDecision::default());
+        };
+
+        let (reply_tx, reply_rx) = oneshot::channel();
+        let request = SessionAdmissionRequest::new(session_id, target.clone());
+
+        // `try_send` rather than an awaited send: waiting for room in the queue would hold this
+        // initiation past the peer's own timeout, and the queue being full is exactly the condition
+        // the bound exists to report.
+        if let Err(error) = admission_tx.clone().try_send((request, reply_tx)) {
+            warn!(
+                %session_id,
+                %error,
+                "cannot ask the session server to admit this session; refusing it as busy"
+            );
+            return Err(StartErrorReason::Busy);
+        }
+
+        match reply_rx
+            .timeout(futures_time::time::Duration::from(self.cfg.session_admission_timeout))
+            .await
+        {
+            Ok(Ok(Ok(decision))) => Ok(decision),
+            Ok(Ok(Err(error))) => {
+                debug!(%session_id, %error, "the session server refused this session's target");
+                Err(StartErrorReason::TargetNotAdmitted)
+            }
+            // The server dropped the reply without answering, which is a bug in it rather than a
+            // decision, so it is reported as transient like the timeout it resembles.
+            Ok(Err(_)) => {
+                error!(
+                    %session_id,
+                    "the session server dropped an admission request without answering it"
+                );
+                Err(StartErrorReason::Busy)
+            }
+            Err(_) => {
+                warn!(
+                    %session_id,
+                    timeout = ?self.cfg.session_admission_timeout,
+                    "the session server did not decide in time; refusing the session as busy"
+                );
+                Err(StartErrorReason::Busy)
+            }
+        }
+    }
+
     /// Checks the PIX parameters offered by the Entry during the Session Initiation.
     ///
+    /// Judged against `policy` — the node's configuration as narrowed by the session server's
+    /// decision for this Session — rather than against the node's configuration directly, which is
+    /// what makes the accepted quota a property of the target as well as of the node.
+    ///
     /// Returns the validated parameters and selected SSA batch size, or `None` if the offer cannot
-    /// satisfy this Exit's PIX policy.
+    /// satisfy that policy.
     fn check_pix_params(
         &self,
         req: &StartInitiation<SessionTarget, HoprSessionCapabilities>,
+        policy: &EffectivePixAdmission,
     ) -> Option<(PixParams, usize)> {
-        // TODO: the Exit may decide to use different quota based on the `target` in the StartInitiation message
         if req.capabilities.0.contains(Capability::UsePIX) {
             // Client offered PIX, so validate the offered parameters. Unpacking is what enforces the
             // protocol ranges on the three dimensions, and what rejects a suite identifier no curve
@@ -3260,22 +3422,36 @@ where
             }
 
             let quota_per_ssa = pix_params_to_quota(&params);
-            let ssas_per_request = self.cfg.pix_config.ssa_batch_size_for_quota(quota_per_ssa);
+            let ssas_per_request = policy.ssa_batch_size_for_quota(quota_per_ssa);
             let accepted_quota = ssas_per_request.and_then(|batch_size| quota_per_ssa.checked_mul(batch_size as u64));
             debug!(
                 challenge = req.challenge,
                 %params,
-                acceptable_range = ?self.cfg.pix_config.quota_range,
-                dynamic_batches = self.cfg.pix_config.supervision.allow_dynamic_ssa_batches,
-                configured_max_ssas_per_request = self.cfg.pix_config.supervision.ssas_per_request,
+                acceptable_range = ?policy.quota_range,
+                node_range = ?self.cfg.pix_config.quota_range,
+                dynamic_batches = policy.allow_dynamic_ssa_batches,
+                configured_max_ssas_per_request = policy.ssas_per_request,
                 selected_ssas_per_request = ?ssas_per_request,
                 offered_quota_mb_per_ssa = quota_per_ssa as f64 / (1024.0 * 1024.0),
                 accepted_quota_mb = ?accepted_quota.map(|quota| quota as f64 / (1024.0 * 1024.0)),
                 "client offered PIX SSA quota"
             );
 
+            // A window narrowed to nothing means the session server's rule and this node's envelope
+            // do not overlap, which is a misconfiguration rather than a peer offering badly: no
+            // offer whatsoever could have been accepted, so it is worth saying out loud once per
+            // Session rather than leaving it to look like a rejected client.
+            if ssas_per_request.is_none() && policy.quota_range.is_empty() {
+                warn!(
+                    challenge = req.challenge,
+                    admitted_range = ?policy.quota_range,
+                    node_range = ?self.cfg.pix_config.quota_range,
+                    "the admitted quota range for this target is empty, so no offer can be accepted"
+                );
+            }
+
             ssas_per_request.map(|batch_size| (params, batch_size))
-        } else if self.cfg.pix_config.enforce_pix {
+        } else if policy.enforce_pix {
             // Client didn't offer PIX, but PIX is enforced
             None
         } else {
@@ -3321,8 +3497,35 @@ where
             return Ok(());
         }
 
+        // Ask whoever runs the session server on what terms this target may be served, before
+        // anything is allocated for the Session. This is the only place the target can influence
+        // admission: the transport cannot read a sealed target, and by the time the server sees the
+        // established Session the terms have already been fixed.
+        let session_id: SessionId = pseudonym;
+        let admission = match self.request_admission(session_id, &session_req.target).await {
+            Ok(decision) => decision,
+            Err(reason) => {
+                let data = HoprStartProtocol::SessionError(StartErrorType {
+                    identifier: ErrorIdentifier::Challenge(session_req.challenge),
+                    reason,
+                });
+                send_via_msg_sender(
+                    &mut msg_sender,
+                    reply_routing,
+                    data,
+                    "session error due to a refused admission",
+                )
+                .await?;
+
+                #[cfg(all(feature = "telemetry", not(test)))]
+                METRIC_SENT_SESSION_ERRS.increment(&[&reason.to_string()]);
+                return Ok(());
+            }
+        };
+        let pix_policy = self.cfg.pix_config.effective_for(&admission);
+
         // Verify if the client offered the right parameters for PIX
-        let Some((client_params, ssas_per_request)) = self.check_pix_params(&session_req) else {
+        let Some((client_params, ssas_per_request)) = self.check_pix_params(&session_req, &pix_policy) else {
             error!(
                 challenge = session_req.challenge,
                 "client offered unacceptable PIX parameters"
@@ -3397,8 +3600,6 @@ where
 
         // Use constant application tag for all sessions
         self.sessions.run_pending_tasks();
-
-        let session_id = pseudonym;
 
         let (session_tx, session_rx) =
             crossfire::mpsc::bounded_blocking_async::<ApplicationDataIn>(self.cfg.session_forward_capacity);
@@ -4863,7 +5064,7 @@ mod tests {
         // Start Alice
         let (new_session_tx_alice, new_session_rx_alice) = futures::channel::mpsc::channel(1024);
         let (alice_sender, alice_handle) = mock_packet_planning(alice_transport);
-        alice_mgr.start(alice_sender.clone(), new_session_tx_alice, None)?;
+        alice_mgr.start(alice_sender.clone(), new_session_tx_alice, None, None)?;
         assert!(alice_mgr.is_started());
 
         let alice_session = alice_mgr
@@ -4936,13 +5137,13 @@ mod tests {
         // Start Alice
         let (new_session_tx_alice, _) = futures::channel::mpsc::channel(1024);
         let (alice_sender, _alice_handle) = mock_packet_planning(alice_transport);
-        alice_mgr.start(alice_sender.clone(), new_session_tx_alice, None)?;
+        alice_mgr.start(alice_sender.clone(), new_session_tx_alice, None, None)?;
         assert!(alice_mgr.is_started());
 
         // Start Bob
         let (new_session_tx_bob, _) = futures::channel::mpsc::channel(1024);
         let (bob_sender, _bob_handle) = mock_packet_planning(bob_transport);
-        bob_mgr.start(bob_sender.clone(), new_session_tx_bob, None)?;
+        bob_mgr.start(bob_sender.clone(), new_session_tx_bob, None, None)?;
         assert!(bob_mgr.is_started());
 
         let result = alice_mgr
@@ -4984,7 +5185,7 @@ mod tests {
         let (new_session_tx, new_session_rx) = futures::channel::mpsc::channel(1);
         drop(new_session_rx);
         let (sender, _handle) = mock_packet_planning(transport);
-        mgr.start(sender.clone(), new_session_tx, None)?;
+        mgr.start(sender.clone(), new_session_tx, None, None)?;
         assert!(mgr.is_started());
 
         let pseudonym = HoprPseudonym::random();
@@ -5036,7 +5237,7 @@ mod tests {
         let (new_session_tx, new_session_rx) = futures::channel::mpsc::channel(1);
         drop(new_session_rx);
         let (sender, handle) = mock_packet_planning(transport);
-        mgr.start(sender.clone(), new_session_tx, None)?;
+        mgr.start(sender.clone(), new_session_tx, None, None)?;
         assert!(mgr.is_started());
 
         let pseudonym = HoprPseudonym::random();
@@ -5112,7 +5313,7 @@ mod tests {
         let (msg_tx, mut msg_rx) = futures::channel::mpsc::unbounded();
         // Held, not dropped: dropping it would fail the establishment notification instead.
         let (new_session_tx, _new_session_rx) = futures::channel::mpsc::channel(4);
-        mgr.start(msg_tx, new_session_tx, None)?;
+        mgr.start(msg_tx, new_session_tx, None, None)?;
 
         let pseudonym = HoprPseudonym::random();
         mgr.handle_incoming_session_initiation(
@@ -5422,13 +5623,13 @@ mod tests {
         // Start Alice
         let (new_session_tx_alice, _) = futures::channel::mpsc::channel(1024);
         let (alice_sender, alice_handle) = mock_packet_planning(alice_transport);
-        ahs.extend(alice_mgr.start(alice_sender.clone(), new_session_tx_alice, None)?);
+        ahs.extend(alice_mgr.start(alice_sender.clone(), new_session_tx_alice, None, None)?);
         assert!(alice_mgr.is_started());
 
         // Start Bob
         let (new_session_tx_bob, new_session_rx_bob) = futures::channel::mpsc::channel(1024);
         let (bob_sender, bob_handle) = mock_packet_planning(bob_transport);
-        ahs.extend(bob_mgr.start(bob_sender.clone(), new_session_tx_bob, None)?);
+        ahs.extend(bob_mgr.start(bob_sender.clone(), new_session_tx_bob, None, None)?);
         assert!(bob_mgr.is_started());
 
         let target = SealedHost::Plain("127.0.0.1:80".parse()?);
@@ -5581,7 +5782,7 @@ mod tests {
             }
         });
         let (sender, _handle) = mock_packet_planning(transport);
-        bob_mgr.start(sender.clone(), new_session_tx, None)?;
+        bob_mgr.start(sender.clone(), new_session_tx, None, None)?;
         assert!(bob_mgr.is_started());
 
         let pseudonym = HoprPseudonym::random();
@@ -5657,7 +5858,7 @@ mod tests {
             while let Some(_session) = new_session_rx.next().await {}
         });
         let (sender, _handle) = mock_packet_planning(transport);
-        mgr.start(sender.clone(), new_session_tx, None)?;
+        mgr.start(sender.clone(), new_session_tx, None, None)?;
         assert!(mgr.is_started());
 
         let fake_session_id = HoprPseudonym::random();
@@ -5695,7 +5896,7 @@ mod tests {
             while let Some(_session) = new_session_rx.next().await {}
         });
         let (sender, _handle) = mock_packet_planning(transport);
-        mgr.start(sender.clone(), new_session_tx, None)?;
+        mgr.start(sender.clone(), new_session_tx, None, None)?;
         assert!(mgr.is_started());
 
         let fake_session_id = HoprPseudonym::random();
@@ -5726,7 +5927,7 @@ mod tests {
             while let Some(_session) = new_session_rx.next().await {}
         });
         let (sender, _handle) = mock_packet_planning(transport);
-        mgr.start(sender.clone(), new_session_tx, None)?;
+        mgr.start(sender.clone(), new_session_tx, None, None)?;
         assert!(mgr.is_started());
 
         let fake_session_id = HoprPseudonym::random();
@@ -5760,7 +5961,7 @@ mod tests {
             while let Some(_session) = new_session_rx.next().await {}
         });
         let (sender, _handle) = mock_packet_planning(transport);
-        mgr.start(sender.clone(), new_session_tx, None)?;
+        mgr.start(sender.clone(), new_session_tx, None, None)?;
         assert!(mgr.is_started());
 
         let fake_session_id = HoprPseudonym::random();
@@ -5798,7 +5999,7 @@ mod tests {
             while let Some(_session) = new_session_rx.next().await {}
         });
         let (sender, _handle) = mock_packet_planning(transport);
-        mgr.start(sender.clone(), new_session_tx, None)?;
+        mgr.start(sender.clone(), new_session_tx, None, None)?;
         assert!(mgr.is_started());
 
         let fake_session_id = HoprPseudonym::random();
@@ -5841,7 +6042,7 @@ mod tests {
             while let Some(_session) = new_session_rx.next().await {}
         });
         let (sender, _handle) = mock_packet_planning(transport);
-        mgr.start(sender.clone(), new_session_tx, None)?;
+        mgr.start(sender.clone(), new_session_tx, None, None)?;
         assert!(mgr.is_started());
 
         // Spawn new_session so it is blocked waiting for the session establishment response.
@@ -5930,7 +6131,7 @@ mod tests {
             while let Some(_session) = new_session_rx.next().await {}
         });
         let (sender, _handle) = mock_packet_planning(transport);
-        mgr.start(sender.clone(), new_session_tx, None)?;
+        mgr.start(sender.clone(), new_session_tx, None, None)?;
         assert!(mgr.is_started());
 
         // First session - should succeed
@@ -6030,7 +6231,7 @@ mod tests {
             pin_mut!(new_session_rx);
             while let Some(_session) = new_session_rx.next().await {}
         });
-        mgr.start(sender.clone(), new_session_tx, Some(pix_toolbox))?;
+        mgr.start(sender.clone(), new_session_tx, Some(pix_toolbox), None)?;
 
         let offer = |pseudonym| {
             (
@@ -6128,19 +6329,433 @@ mod tests {
         Ok(())
     }
 
+    /// Runs an admission handler against `mgr`'s request channel for the duration of one test.
+    ///
+    /// Mirrors what `hopr-lib` spawns beside the session server, minus the concurrency: these tests
+    /// drive one initiation at a time.
+    fn spawn_admission_handler(
+        handler: impl Fn(SessionAdmissionRequest) -> Result<SessionAdmissionDecision, String> + Send + 'static,
+    ) -> (SessionAdmissionSink, tokio::task::JoinHandle<()>) {
+        let (tx, mut rx) =
+            futures::channel::mpsc::channel::<(SessionAdmissionRequest, crate::types::SessionAdmissionReply)>(4);
+        let handle = tokio::task::spawn(async move {
+            while let Some((request, reply)) = rx.next().await {
+                let _ = reply.send(handler(request));
+            }
+        });
+        (tx, handle)
+    }
+
+    /// What [`started_manager_admitting_small_params`] hands back: the manager, its message sender
+    /// and the task draining it, the first `SessionError` it replies with, and the incoming-session
+    /// receiver — which the test must hold, since an admitted Session is published on it and a
+    /// dropped receiver would turn every success into a send failure.
+    type AdmissionFixture = (
+        SessionManager<UnboundedSender<(DestinationRouting, ApplicationDataOut)>>,
+        UnboundedSender<(DestinationRouting, ApplicationDataOut)>,
+        tokio::task::JoinHandle<anyhow::Result<()>>,
+        oneshot::Receiver<StartErrorType<SessionId>>,
+        futures::channel::mpsc::Receiver<IncomingSession>,
+    );
+
+    /// A started manager that accepts an Entry offering [`small_pix_params`], with `admission`
+    /// installed as its session server, so that any refusal is attributable to the decision rather
+    /// than to the dimensions or to a missing toolbox.
+    fn started_manager_admitting_small_params(
+        quota_range: std::ops::RangeInclusive<SsaQuota>,
+        enforce_pix: bool,
+        admission: Option<SessionAdmissionSink>,
+    ) -> anyhow::Result<AdmissionFixture> {
+        use hopr_protocol_pix::{SsaGeneratorConfig, SsaReconstructorConfig};
+
+        let mgr = SessionManager::new(SessionManagerConfig {
+            pix_config: IncomingSessionPixConfig {
+                enforce_pix,
+                quota_range,
+                ..Default::default()
+            },
+            session_admission_timeout: Duration::from_millis(200),
+            ..Default::default()
+        });
+
+        let pix_toolbox = pix_toolbox_with_pool(
+            SsaShareGenerator::new(SsaGeneratorConfig {
+                polynomials_per_ssa: 2,
+                threshold: 2,
+                surplus_shares: TEST_SURPLUS_SHARES,
+            })
+            .into(),
+            SsaReconstructor::new(SsaReconstructorConfig::default()).into(),
+        );
+
+        let mut transport = MockMsgSender::new();
+        let (err_tx, err_rx) = oneshot::channel();
+        let err_tx = Arc::new(std::sync::Mutex::new(Some(err_tx)));
+        transport.expect_send_message().returning(move |_, data| {
+            let err_tx = err_tx.clone();
+            Box::pin(async move {
+                if let Ok(HoprStartProtocol::SessionError(err)) =
+                    HoprStartProtocol::decode(data.data.application_tag, &data.data.plain_text)
+                    && let Some(tx) = err_tx.lock().unwrap().take()
+                {
+                    let _ = tx.send(err);
+                }
+                Ok(())
+            })
+        });
+
+        let (sender, handle) = mock_packet_planning(transport);
+        let (new_session_tx, new_session_rx) = futures::channel::mpsc::channel(1);
+        mgr.start(sender.clone(), new_session_tx, Some(pix_toolbox), admission)?;
+
+        Ok((mgr, sender, handle, err_rx, new_session_rx))
+    }
+
+    /// An Entry offering [`small_pix_params`], i.e. an offer the fixture's node accepts.
+    fn pix_offer() -> StartInitiation<SessionTarget, HoprSessionCapabilities> {
+        StartInitiation {
+            challenge: MIN_CHALLENGE,
+            target: SessionTarget::TcpStream(SealedHost::Plain(
+                "127.0.0.1:80".parse().expect("test target must parse"),
+            )),
+            capabilities: HoprSessionCapabilities(Capability::Segmentation | Capability::UsePIX),
+            additional_data: small_pix_additional_data(),
+        }
+    }
+
+    /// The same target from an Entry that offered no incentivization at all.
+    fn no_pix_offer() -> StartInitiation<SessionTarget, HoprSessionCapabilities> {
+        StartInitiation {
+            capabilities: HoprSessionCapabilities(Capability::Segmentation.into()),
+            additional_data: 0,
+            ..pix_offer()
+        }
+    }
+
+    /// The quota an Entry offering [`small_pix_params`] asks for.
+    fn small_params_quota() -> SsaQuota {
+        pix_params_to_quota(&small_pix_params())
+    }
+
+    /// A node's configured window is an envelope, not a default: a decision may take less of it, but
+    /// asking for more of it than was configured — and validated, and preallocated against — leaves
+    /// the envelope's own bounds in place.
+    #[test]
+    fn an_admission_decision_narrows_the_configured_quota_window_and_never_widens_it() {
+        let cfg = IncomingSessionPixConfig {
+            quota_range: 100..=200,
+            ..Default::default()
+        };
+
+        let narrowed = cfg.effective_for(&SessionAdmissionDecision::default().with_pix_quota_range(120..=180));
+        assert_eq!(narrowed.quota_range, 120..=180);
+
+        let widened = cfg.effective_for(&SessionAdmissionDecision::default().with_pix_quota_range(1..=1000));
+        assert_eq!(widened.quota_range, 100..=200, "neither bound may leave the envelope");
+
+        let one_end = cfg.effective_for(&SessionAdmissionDecision::default().with_pix_quota_range(150..=u64::MAX));
+        assert_eq!(one_end.quota_range, 150..=200, "an open end leaves that bound alone");
+
+        let disjoint = cfg.effective_for(&SessionAdmissionDecision::default().with_pix_quota_range(500..=600));
+        assert!(
+            disjoint.quota_range.is_empty(),
+            "a rule that does not overlap the envelope admits nothing, rather than silently picking one"
+        );
+    }
+
+    /// Unlike the quota window, `enforce_pix` is coupled to nothing validated at startup, so a
+    /// decision simply replaces it — in either direction.
+    #[test]
+    fn an_admission_decision_overrides_enforce_pix_in_both_directions() {
+        let strict = IncomingSessionPixConfig {
+            enforce_pix: true,
+            ..Default::default()
+        };
+        let lax = IncomingSessionPixConfig {
+            enforce_pix: false,
+            ..Default::default()
+        };
+
+        assert!(strict.effective_for(&SessionAdmissionDecision::default()).enforce_pix);
+        assert!(
+            !strict
+                .effective_for(&SessionAdmissionDecision::default().with_enforce_pix(false))
+                .enforce_pix
+        );
+        assert!(!lax.effective_for(&SessionAdmissionDecision::default()).enforce_pix);
+        assert!(
+            lax.effective_for(&SessionAdmissionDecision::default().with_enforce_pix(true))
+                .enforce_pix
+        );
+    }
+
+    /// The issue's first case: a target served without payment on a node that otherwise demands it.
+    #[test_log::test(tokio::test)]
+    async fn a_decision_waiving_pix_admits_a_client_that_offered_none() -> anyhow::Result<()> {
+        let (admission, handler) =
+            spawn_admission_handler(|_| Ok(SessionAdmissionDecision::default().with_enforce_pix(false)));
+        let (mgr, sender, transport, err_rx, _incoming) =
+            started_manager_admitting_small_params(1..=small_params_quota(), true, Some(admission))?;
+
+        mgr.handle_incoming_session_initiation(HoprPseudonym::random(), no_pix_offer())
+            .await?;
+
+        assert_eq!(
+            mgr.num_active_sessions(),
+            1,
+            "a waived target must be admitted even though the node enforces PIX"
+        );
+
+        sender.close_channel();
+        transport.await??;
+        assert!(
+            err_rx.await.is_err(),
+            "no SessionError may be sent for an admitted session"
+        );
+        handler.abort();
+        Ok(())
+    }
+
+    /// And its mirror: a target that must pay on a node that otherwise does not ask.
+    #[test_log::test(tokio::test)]
+    async fn a_decision_demanding_pix_refuses_a_client_that_offered_none() -> anyhow::Result<()> {
+        let (admission, handler) =
+            spawn_admission_handler(|_| Ok(SessionAdmissionDecision::default().with_enforce_pix(true)));
+        let (mgr, sender, transport, err_rx, _incoming) =
+            started_manager_admitting_small_params(1..=small_params_quota(), false, Some(admission))?;
+
+        mgr.handle_incoming_session_initiation(HoprPseudonym::random(), no_pix_offer())
+            .await?;
+
+        let err = err_rx.await.context("send_message was never called")?;
+        assert_eq!(err.reason, StartErrorReason::UnacceptablePixParams);
+        assert_eq!(mgr.num_active_sessions(), 0, "no slot may be created for a refusal");
+
+        sender.close_channel();
+        transport.await??;
+        handler.abort();
+        Ok(())
+    }
+
+    /// A window narrowed past the client's offer refuses it even though the node's own window would
+    /// have accepted it, which is the whole point of parameterizing admission by target.
+    #[test_log::test(tokio::test)]
+    async fn a_decision_narrowing_the_quota_past_the_offer_refuses_it() -> anyhow::Result<()> {
+        let quota = small_params_quota();
+        let (admission, handler) = spawn_admission_handler(move |_| {
+            Ok(SessionAdmissionDecision::default().with_pix_quota_range(quota + 1..=u64::MAX))
+        });
+        let (mgr, sender, transport, err_rx, _incoming) =
+            started_manager_admitting_small_params(1..=quota, false, Some(admission))?;
+
+        mgr.handle_incoming_session_initiation(HoprPseudonym::random(), pix_offer())
+            .await?;
+
+        let err = err_rx.await.context("send_message was never called")?;
+        assert_eq!(err.reason, StartErrorReason::UnacceptablePixParams);
+        assert_eq!(mgr.num_active_sessions(), 0);
+
+        sender.close_channel();
+        transport.await??;
+        handler.abort();
+        Ok(())
+    }
+
+    /// The same offer, and the same node, admitted once the decision leaves the window alone —
+    /// which is what makes the refusal above attributable to the narrowing and nothing else.
+    #[test_log::test(tokio::test)]
+    async fn the_same_offer_is_admitted_when_the_decision_leaves_the_window_alone() -> anyhow::Result<()> {
+        let quota = small_params_quota();
+        let (admission, handler) = spawn_admission_handler(|_| Ok(SessionAdmissionDecision::default()));
+        let (mgr, sender, transport, err_rx, _incoming) =
+            started_manager_admitting_small_params(1..=quota, false, Some(admission))?;
+
+        mgr.handle_incoming_session_initiation(HoprPseudonym::random(), pix_offer())
+            .await?;
+
+        assert_eq!(mgr.num_active_sessions(), 1);
+
+        sender.close_channel();
+        transport.await??;
+        assert!(
+            err_rx.await.is_err(),
+            "no SessionError may be sent for an admitted session"
+        );
+        handler.abort();
+        Ok(())
+    }
+
+    /// A refusal is permanent and says so, so the peer does not retry a target this Exit will not
+    /// serve however the request is phrased.
+    #[test_log::test(tokio::test)]
+    async fn a_refused_admission_is_reported_as_a_target_that_is_not_admitted() -> anyhow::Result<()> {
+        let (admission, handler) = spawn_admission_handler(|_| Err("this exit does not serve that".into()));
+        let (mgr, sender, transport, err_rx, _incoming) =
+            started_manager_admitting_small_params(1..=small_params_quota(), false, Some(admission))?;
+
+        mgr.handle_incoming_session_initiation(HoprPseudonym::random(), pix_offer())
+            .await?;
+
+        let err = err_rx.await.context("send_message was never called")?;
+        assert_eq!(err.reason, StartErrorReason::TargetNotAdmitted);
+        assert_eq!(err.identifier, ErrorIdentifier::Challenge(MIN_CHALLENGE));
+        assert_eq!(mgr.num_active_sessions(), 0, "no slot may be created for a refusal");
+
+        sender.close_channel();
+        transport.await??;
+        handler.abort();
+        Ok(())
+    }
+
+    /// A server that does not answer must not become a server that admits everything: the Session is
+    /// refused, and as `Busy` rather than `TargetNotAdmitted`, since nothing about the target was
+    /// decided and a retry may well succeed.
+    #[test_log::test(tokio::test)]
+    async fn an_admission_that_never_answers_refuses_the_session_as_busy() -> anyhow::Result<()> {
+        // Holds every request without replying, which is what a wedged session server looks like.
+        let (admission, mut rx) =
+            futures::channel::mpsc::channel::<(SessionAdmissionRequest, crate::types::SessionAdmissionReply)>(4);
+        let handler = tokio::task::spawn(async move {
+            let mut held = Vec::new();
+            while let Some(request) = rx.next().await {
+                held.push(request);
+            }
+        });
+
+        let (mgr, sender, transport, err_rx, _incoming) =
+            started_manager_admitting_small_params(1..=small_params_quota(), false, Some(admission))?;
+
+        mgr.handle_incoming_session_initiation(HoprPseudonym::random(), pix_offer())
+            .await?;
+
+        let err = err_rx.await.context("send_message was never called")?;
+        assert_eq!(err.reason, StartErrorReason::Busy);
+        assert_eq!(mgr.num_active_sessions(), 0);
+
+        sender.close_channel();
+        transport.await??;
+        handler.abort();
+        Ok(())
+    }
+
+    /// Same outcome when the server drops the reply instead of answering: a bug in it is still not a
+    /// decision, and must not be read as one.
+    #[test_log::test(tokio::test)]
+    async fn an_admission_whose_reply_is_dropped_refuses_the_session_as_busy() -> anyhow::Result<()> {
+        let (admission, mut rx) =
+            futures::channel::mpsc::channel::<(SessionAdmissionRequest, crate::types::SessionAdmissionReply)>(4);
+        let handler = tokio::task::spawn(async move {
+            while let Some((_request, reply)) = rx.next().await {
+                drop(reply);
+            }
+        });
+
+        let (mgr, sender, transport, err_rx, _incoming) =
+            started_manager_admitting_small_params(1..=small_params_quota(), false, Some(admission))?;
+
+        mgr.handle_incoming_session_initiation(HoprPseudonym::random(), pix_offer())
+            .await?;
+
+        let err = err_rx.await.context("send_message was never called")?;
+        assert_eq!(err.reason, StartErrorReason::Busy);
+        assert_eq!(mgr.num_active_sessions(), 0);
+
+        sender.close_channel();
+        transport.await??;
+        handler.abort();
+        Ok(())
+    }
+
+    /// A node that installed no session server has nobody to ask, so it must behave exactly as it
+    /// did before this hook existed rather than failing closed on an absent decision.
+    #[test_log::test(tokio::test)]
+    async fn a_manager_without_an_admission_sink_admits_on_its_own_terms() -> anyhow::Result<()> {
+        let (mgr, sender, transport, err_rx, _incoming) =
+            started_manager_admitting_small_params(1..=small_params_quota(), false, None)?;
+
+        mgr.handle_incoming_session_initiation(HoprPseudonym::random(), pix_offer())
+            .await?;
+
+        assert_eq!(
+            mgr.num_active_sessions(),
+            1,
+            "an offer the node's own policy accepts must be admitted with no session server present"
+        );
+
+        sender.close_channel();
+        transport.await??;
+        assert!(
+            err_rx.await.is_err(),
+            "no SessionError may be sent for an admitted session"
+        );
+        Ok(())
+    }
+
+    /// The request the session server is handed must name the target it is being asked about, or the
+    /// hook cannot do the one job it exists for.
+    #[test_log::test(tokio::test)]
+    async fn the_admission_request_carries_the_session_target() -> anyhow::Result<()> {
+        let (seen_tx, seen_rx) = oneshot::channel();
+        let seen_tx = Arc::new(std::sync::Mutex::new(Some(seen_tx)));
+        let (admission, handler) = spawn_admission_handler(move |request| {
+            if let Some(tx) = seen_tx.lock().unwrap().take() {
+                let _ = tx.send((request.session_id, request.target.clone()));
+            }
+            Ok(SessionAdmissionDecision::default())
+        });
+        let (mgr, sender, transport, _err_rx, _incoming) =
+            started_manager_admitting_small_params(1..=small_params_quota(), false, Some(admission))?;
+
+        let pseudonym = HoprPseudonym::random();
+        let offer = pix_offer();
+        let expected_target = offer.target.clone();
+        mgr.handle_incoming_session_initiation(pseudonym, offer).await?;
+
+        let (seen_id, seen_target) = seen_rx.await.context("admission was never asked")?;
+        assert_eq!(seen_target, expected_target);
+        assert_eq!(seen_id, pseudonym, "the request must name the session it would become");
+
+        sender.close_channel();
+        transport.await??;
+        handler.abort();
+        Ok(())
+    }
+
+    /// The wait is spent inside the peer's own initiation timeout, so a configuration that outlasts
+    /// it is normalized rather than left to expire after the peer has already given up.
+    #[test]
+    fn the_admission_timeout_is_clamped_below_the_initiation_budget() {
+        let mgr: SessionManager<UnboundedSender<(DestinationRouting, ApplicationDataOut)>> =
+            SessionManager::new(SessionManagerConfig {
+                initiation_timeout_base: Duration::from_millis(100),
+                session_admission_timeout: Duration::from_secs(3600),
+                ..Default::default()
+            });
+
+        assert_eq!(
+            mgr.cfg.session_admission_timeout,
+            initiation_timeout_max_one_way(Duration::from_millis(100), RoutingOptions::MAX_INTERMEDIATE_HOPS)
+        );
+    }
+
     /// Dynamic admission chooses the least expensive batch that brings the Entry's total offer into
     /// the accepted range. A cap is still a cap: it may leave the offer unsatisfiable, and checked
     /// multiplication must make an overflowing candidate a refusal rather than a wrapped match.
     #[test]
     fn dynamic_ssa_batches_choose_the_smallest_satisfying_batch() {
-        let config = |quota_range, ssas_per_request| IncomingSessionPixConfig {
-            quota_range,
-            supervision: SupervisorConfig {
-                ssas_per_request,
-                allow_dynamic_ssa_batches: true,
+        // Through `effective_for` with an empty decision, which is the no-session-server path and
+        // so yields exactly the node's configured policy.
+        let config = |quota_range, ssas_per_request| {
+            IncomingSessionPixConfig {
+                quota_range,
+                supervision: SupervisorConfig {
+                    ssas_per_request,
+                    allow_dynamic_ssa_batches: true,
+                    ..Default::default()
+                },
                 ..Default::default()
-            },
-            ..Default::default()
+            }
+            .effective_for(&SessionAdmissionDecision::default())
         };
 
         assert_eq!(Some(1), config(100..=350, 4).ssa_batch_size_for_quota(100));
@@ -6163,14 +6778,17 @@ mod tests {
     /// is compared with `quota_range`, and an accepted offer uses the configured batch exactly.
     #[test]
     fn disabling_dynamic_ssa_batches_preserves_fixed_batch_admission() {
-        let fixed = |quota_range| IncomingSessionPixConfig {
-            quota_range,
-            supervision: SupervisorConfig {
-                ssas_per_request: 3,
-                allow_dynamic_ssa_batches: false,
+        let fixed = |quota_range| {
+            IncomingSessionPixConfig {
+                quota_range,
+                supervision: SupervisorConfig {
+                    ssas_per_request: 3,
+                    allow_dynamic_ssa_batches: false,
+                    ..Default::default()
+                },
                 ..Default::default()
-            },
-            ..Default::default()
+            }
+            .effective_for(&SessionAdmissionDecision::default())
         };
 
         assert_eq!(
@@ -6245,7 +6863,7 @@ mod tests {
             pin_mut!(new_session_rx);
             while let Some(_session) = new_session_rx.next().await {}
         });
-        mgr.start(sender.clone(), new_session_tx, None)?;
+        mgr.start(sender.clone(), new_session_tx, None, None)?;
 
         mgr.handle_incoming_session_initiation(
             HoprPseudonym::random(),
@@ -6295,7 +6913,7 @@ mod tests {
             while let Some(_session) = new_session_rx.next().await {}
         });
         let (sender, _handle) = mock_packet_planning(transport);
-        mgr.start(sender.clone(), new_session_tx, None)?;
+        mgr.start(sender.clone(), new_session_tx, None, None)?;
         assert!(mgr.is_started());
 
         // Fill the cache with two incoming sessions (Exits).
@@ -6357,7 +6975,7 @@ mod tests {
             pin_mut!(new_session_rx);
             while let Some(_session) = new_session_rx.next().await {}
         });
-        mgr.start(tx, new_session_tx, None)?;
+        mgr.start(tx, new_session_tx, None, None)?;
         assert!(mgr.is_started());
 
         // Verify that sending fails because the receiver is gone.
@@ -6411,12 +7029,12 @@ mod tests {
 
         let (alice_sender, _alice_handle) = mock_packet_planning(alice_transport);
         let (new_session_tx_alice, _) = futures::channel::mpsc::channel(1024);
-        alice_mgr.start(alice_sender.clone(), new_session_tx_alice, None)?;
+        alice_mgr.start(alice_sender.clone(), new_session_tx_alice, None, None)?;
         assert!(alice_mgr.is_started());
 
         let (bob_sender, _bob_handle) = mock_packet_planning(bob_transport);
         let (new_session_tx_bob, _) = futures::channel::mpsc::channel(1024);
-        bob_mgr.start(bob_sender.clone(), new_session_tx_bob, None)?;
+        bob_mgr.start(bob_sender.clone(), new_session_tx_bob, None, None)?;
         assert!(bob_mgr.is_started());
 
         // Record how many entries are in `session_initiations` before the call.
@@ -6577,7 +7195,7 @@ mod tests {
             while let Some(_session) = new_session_rx.next().await {}
         });
         let (sender, _handle) = mock_packet_planning(transport);
-        mgr.start(sender.clone(), new_session_tx, None)?;
+        mgr.start(sender.clone(), new_session_tx, None, None)?;
         assert!(mgr.is_started());
 
         // Create a session
@@ -6642,7 +7260,7 @@ mod tests {
 
         let (new_session_tx, _) = futures::channel::mpsc::channel(1024);
         let (mock_sender, _) = futures::channel::mpsc::unbounded();
-        let _ahs = alice_mgr.start(mock_sender, new_session_tx, None)?;
+        let _ahs = alice_mgr.start(mock_sender, new_session_tx, None, None)?;
         assert!(alice_mgr.is_started());
 
         let (dummy_tx, _) = crossfire::mpsc::bounded_blocking_async::<ApplicationDataIn>(SESSION_FORWARD_CAPACITY);
@@ -6757,7 +7375,7 @@ mod tests {
 
         let (new_session_tx, _) = futures::channel::mpsc::channel(1024);
         let (mock_sender, _) = futures::channel::mpsc::unbounded();
-        let _ahs = alice_mgr.start(mock_sender, new_session_tx, None)?;
+        let _ahs = alice_mgr.start(mock_sender, new_session_tx, None, None)?;
         assert!(alice_mgr.is_started());
 
         let (dummy_tx, _) = crossfire::mpsc::bounded_blocking_async::<ApplicationDataIn>(SESSION_FORWARD_CAPACITY);
@@ -6863,7 +7481,7 @@ mod tests {
             while let Some(_session) = new_session_rx.next().await {}
         });
         let (sender, _handle) = mock_packet_planning(transport);
-        mgr.start(sender.clone(), new_session_tx, None)?;
+        mgr.start(sender.clone(), new_session_tx, None, None)?;
         assert!(mgr.is_started());
 
         // Create first session
@@ -6931,7 +7549,7 @@ mod tests {
             while let Some(_session) = new_session_rx.next().await {}
         });
         let (sender, _handle) = mock_packet_planning(transport);
-        mgr.start(sender.clone(), new_session_tx, None)?;
+        mgr.start(sender.clone(), new_session_tx, None, None)?;
         assert!(mgr.is_started());
 
         // Create first session
@@ -7001,7 +7619,7 @@ mod tests {
 
         let (sender, _handle) = mock_packet_planning(transport);
         let (new_session_tx, _) = futures::channel::mpsc::channel(1);
-        mgr.start(sender.clone(), new_session_tx, None)?;
+        mgr.start(sender.clone(), new_session_tx, None, None)?;
         assert!(mgr.is_started());
 
         let result = mgr
@@ -7075,7 +7693,7 @@ mod tests {
 
         let (sender, _handle) = mock_packet_planning(transport);
         let (new_session_tx, _) = futures::channel::mpsc::channel(1);
-        mgr.start(sender.clone(), new_session_tx, Some(pix_toolbox))?;
+        mgr.start(sender.clone(), new_session_tx, Some(pix_toolbox), None)?;
         assert!(mgr.is_started());
 
         let result = mgr
@@ -7255,7 +7873,7 @@ mod tests {
 
         let (tx, _rx) = futures::channel::mpsc::unbounded();
         let (new_session_tx, _new_session_rx) = futures::channel::mpsc::channel(1);
-        let started = mgr.start(tx, new_session_tx, Some(pix_toolbox));
+        let started = mgr.start(tx, new_session_tx, Some(pix_toolbox), None);
 
         assert!(
             matches!(started, Err(TransportSessionError::InvalidConfig(_))),
@@ -7315,7 +7933,7 @@ mod tests {
             let (tx, _rx) = futures::channel::mpsc::unbounded();
             let (new_session_tx, _new_session_rx) = futures::channel::mpsc::channel(1);
 
-            match mgr.start(tx, new_session_tx, Some(pix_toolbox)) {
+            match mgr.start(tx, new_session_tx, Some(pix_toolbox), None) {
                 Err(TransportSessionError::InvalidConfig(message)) => assert!(
                     message.contains(expected_field),
                     "{case} should identify {expected_field}, got: {message}"
@@ -7364,7 +7982,7 @@ mod tests {
         let (first_tx, _first_rx) = futures::channel::mpsc::unbounded();
         let (first_notifier, _first_notifications) = futures::channel::mpsc::channel(1);
         assert!(matches!(
-            mgr.start(first_tx, first_notifier, Some(invalid_pix)),
+            mgr.start(first_tx, first_notifier, Some(invalid_pix), None),
             Err(TransportSessionError::InvalidConfig(_))
         ));
         assert!(
@@ -7374,7 +7992,7 @@ mod tests {
 
         let (retry_tx, _retry_rx) = futures::channel::mpsc::unbounded();
         let (retry_notifier, _retry_notifications) = futures::channel::mpsc::channel(1);
-        let retry = mgr.start(retry_tx, retry_notifier, None);
+        let retry = mgr.start(retry_tx, retry_notifier, None, None);
         assert!(
             retry.is_ok(),
             "a configuration error must leave the manager retryable, got {retry:?}"
@@ -7470,7 +8088,7 @@ mod tests {
 
         let (bob_sender, bob_handle) = mock_packet_planning(bob_transport);
         let (new_session_tx, _) = futures::channel::mpsc::channel(1);
-        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox))?;
+        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox), None)?;
 
         let alice_pseudonym = HoprPseudonym::random();
 
@@ -7540,7 +8158,7 @@ mod tests {
 
         let (bob_sender, bob_handle) = mock_packet_planning(bob_transport);
         let (new_session_tx, _) = futures::channel::mpsc::channel(1);
-        mgr.start(bob_sender.clone(), new_session_tx, None)?;
+        mgr.start(bob_sender.clone(), new_session_tx, None, None)?;
 
         let alice_pseudonym = HoprPseudonym::random();
 
@@ -7609,7 +8227,7 @@ mod tests {
         let (bob_sender, bob_handle) = mock_packet_planning(bob_transport);
         let (new_session_tx, _) = futures::channel::mpsc::channel(1);
         // No toolbox — the third argument is what a relay that does not participate in PIX gets.
-        mgr.start(bob_sender.clone(), new_session_tx, None)?;
+        mgr.start(bob_sender.clone(), new_session_tx, None, None)?;
 
         let req = StartInitiation {
             challenge: MIN_CHALLENGE,
@@ -7620,7 +8238,11 @@ mod tests {
 
         // What makes the missing toolbox the sole remaining cause of the refusal below.
         assert!(
-            mgr.check_pix_params(&req).is_some(),
+            mgr.check_pix_params(
+                &req,
+                &mgr.cfg.pix_config.effective_for(&SessionAdmissionDecision::default())
+            )
+            .is_some(),
             "the offered dimensions must be acceptable, or the refusal cannot be attributed to the guard"
         );
 
@@ -7689,7 +8311,7 @@ mod tests {
             pin_mut!(new_session_rx);
             while let Some(_session) = new_session_rx.next().await {}
         });
-        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox))?;
+        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox), None)?;
 
         let alice_pseudonym = HoprPseudonym::random();
 
@@ -7780,7 +8402,7 @@ mod tests {
             pin_mut!(new_session_rx);
             while let Some(_session) = new_session_rx.next().await {}
         });
-        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox))?;
+        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox), None)?;
 
         let alice_pseudonym = HoprPseudonym::random();
 
@@ -7905,7 +8527,7 @@ mod tests {
             pin_mut!(new_session_rx);
             while let Some(_session) = new_session_rx.next().await {}
         });
-        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox))?;
+        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox), None)?;
 
         let alice_pseudonym = HoprPseudonym::random();
         mgr.handle_incoming_session_initiation(
@@ -8005,7 +8627,7 @@ mod tests {
             pin_mut!(new_session_rx);
             while let Some(_session) = new_session_rx.next().await {}
         });
-        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox))?;
+        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox), None)?;
 
         let alice_pseudonym = HoprPseudonym::random();
         mgr.handle_incoming_session_initiation(
@@ -8086,7 +8708,7 @@ mod tests {
             pin_mut!(new_session_rx);
             while let Some(_session) = new_session_rx.next().await {}
         });
-        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox))?;
+        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox), None)?;
 
         let alice_pseudonym = HoprPseudonym::random();
         mgr.handle_incoming_session_initiation(
@@ -8185,7 +8807,7 @@ mod tests {
             pin_mut!(new_session_rx);
             while let Some(_session) = new_session_rx.next().await {}
         });
-        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox))?;
+        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox), None)?;
 
         let alice_pseudonym = HoprPseudonym::random();
 
@@ -8348,7 +8970,7 @@ mod tests {
             pin_mut!(new_session_rx);
             while let Some(_session) = new_session_rx.next().await {}
         });
-        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox))?;
+        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox), None)?;
 
         let pseudonym = HoprPseudonym::random();
         mgr.handle_incoming_session_initiation(
@@ -8927,11 +9549,11 @@ mod tests {
 
         let (alice_sender, alice_handle) = mock_packet_planning(alice_transport);
         let (new_session_tx_alice, _alice_rx) = futures::channel::mpsc::channel(1024);
-        alice_mgr.start(alice_sender.clone(), new_session_tx_alice, None)?;
+        alice_mgr.start(alice_sender.clone(), new_session_tx_alice, None, None)?;
 
         let (bob_sender, bob_handle) = mock_packet_planning(bob_transport);
         let (new_session_tx_bob, new_session_rx_bob) = futures::channel::mpsc::channel(1024);
-        bob_mgr.start(bob_sender.clone(), new_session_tx_bob, None)?;
+        bob_mgr.start(bob_sender.clone(), new_session_tx_bob, None, None)?;
         let _bob_notifications = tokio::spawn(async move {
             pin_mut!(new_session_rx_bob);
             while let Some(_session) = new_session_rx_bob.next().await {}
@@ -9062,7 +9684,7 @@ mod tests {
             pin_mut!(new_session_rx);
             while let Some(_session) = new_session_rx.next().await {}
         });
-        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox))?;
+        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox), None)?;
 
         let pseudonym = HoprPseudonym::random();
         mgr.handle_incoming_session_initiation(
@@ -9253,7 +9875,7 @@ mod tests {
             pin_mut!(new_session_rx);
             while let Some(_session) = new_session_rx.next().await {}
         });
-        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox))?;
+        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox), None)?;
 
         let pseudonym = HoprPseudonym::random();
         mgr.handle_incoming_session_initiation(
@@ -9410,7 +10032,7 @@ mod tests {
                 pin_mut!(new_session_rx);
                 while let Some(_session) = new_session_rx.next().await {}
             });
-            mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox))?;
+            mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox), None)?;
 
             let alice_pseudonym = HoprPseudonym::random();
 
@@ -9565,7 +10187,7 @@ mod tests {
             pin_mut!(new_session_rx);
             while let Some(_session) = new_session_rx.next().await {}
         });
-        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox))?;
+        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox), None)?;
 
         let alice_pseudonym = HoprPseudonym::random();
         mgr.handle_incoming_session_initiation(
@@ -9833,7 +10455,7 @@ mod tests {
             pin_mut!(new_session_rx);
             while let Some(_session) = new_session_rx.next().await {}
         });
-        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox.clone()))?;
+        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox.clone()), None)?;
 
         let alice_pseudonym = HoprPseudonym::random();
 
@@ -9994,7 +10616,7 @@ mod tests {
             pin_mut!(new_session_rx);
             while let Some(_session) = new_session_rx.next().await {}
         });
-        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox.clone()))?;
+        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox.clone()), None)?;
 
         let alice_pseudonym = HoprPseudonym::random();
 
@@ -10081,7 +10703,7 @@ mod tests {
             pin_mut!(new_session_rx);
             while let Some(_session) = new_session_rx.next().await {}
         });
-        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox))?;
+        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox), None)?;
 
         let alice_pseudonym = HoprPseudonym::random();
         mgr.handle_incoming_session_initiation(
@@ -10163,7 +10785,11 @@ mod tests {
         // polys_per_ssa > MAX_POLYS_PER_SSA (16192), and zero, with a valid quota -> should reject
         for polys in [0, MAX_POLYS_PER_SSA + 1, u16::MAX] {
             assert!(
-                mgr.check_pix_params(&offer(packed(polys, 128, 0))).is_none(),
+                mgr.check_pix_params(
+                    &offer(packed(polys, 128, 0)),
+                    &mgr.cfg.pix_config.effective_for(&SessionAdmissionDecision::default())
+                )
+                .is_none(),
                 "should reject polys_per_ssa {polys}"
             );
         }
@@ -10173,7 +10799,11 @@ mod tests {
         // cannot be exceeded by anything a peer is able to send.
         for shares in [0, 1] {
             assert!(
-                mgr.check_pix_params(&offer(packed(8192, shares, 0))).is_none(),
+                mgr.check_pix_params(
+                    &offer(packed(8192, shares, 0)),
+                    &mgr.cfg.pix_config.effective_for(&SessionAdmissionDecision::default())
+                )
+                .is_none(),
                 "should reject shares_per_poly {shares}"
             );
         }
@@ -10181,7 +10811,10 @@ mod tests {
         // Valid params should still be accepted, and arrive intact — including the surplus, which
         // no other check looks at and which would therefore be free to go missing.
         let (accepted, batch_size) = mgr
-            .check_pix_params(&offer(packed(8192, 128, 37)))
+            .check_pix_params(
+                &offer(packed(8192, 128, 37)),
+                &mgr.cfg.pix_config.effective_for(&SessionAdmissionDecision::default()),
+            )
             .context("should accept valid params")?;
         assert_eq!(PixParams::try_new(8192, 128, 37, LOCAL_PIX_SUITE)?, accepted);
         assert_eq!(1, batch_size);
@@ -10190,7 +10823,10 @@ mod tests {
         for surplus in [0, 1, u8::MAX] {
             assert_eq!(
                 Some((PixParams::try_new(8192, 128, surplus, LOCAL_PIX_SUITE)?, 1)),
-                mgr.check_pix_params(&offer(packed(8192, 128, surplus)))
+                mgr.check_pix_params(
+                    &offer(packed(8192, 128, surplus)),
+                    &mgr.cfg.pix_config.effective_for(&SessionAdmissionDecision::default())
+                )
             );
         }
 
@@ -10232,11 +10868,19 @@ mod tests {
         };
 
         assert!(
-            mgr.check_pix_params(&offer(foreign)).is_none(),
+            mgr.check_pix_params(
+                &offer(foreign),
+                &mgr.cfg.pix_config.effective_for(&SessionAdmissionDecision::default())
+            )
+            .is_none(),
             "a client offering {foreign} must be refused by a {LOCAL_PIX_SUITE} Exit"
         );
         assert!(
-            mgr.check_pix_params(&offer(LOCAL_PIX_SUITE)).is_some(),
+            mgr.check_pix_params(
+                &offer(LOCAL_PIX_SUITE),
+                &mgr.cfg.pix_config.effective_for(&SessionAdmissionDecision::default())
+            )
+            .is_some(),
             "and the same dimensions on this build's own curve must still be accepted"
         );
 
@@ -10248,7 +10892,11 @@ mod tests {
             additional_data: (0b11u64 << 62) | (8192u64 << 48) | (128u64 << 40) | (37u64 << 32),
         };
         assert!(
-            mgr.check_pix_params(&unknown).is_none(),
+            mgr.check_pix_params(
+                &unknown,
+                &mgr.cfg.pix_config.effective_for(&SessionAdmissionDecision::default())
+            )
+            .is_none(),
             "an unknown suite identifier must be refused"
         );
 
@@ -10299,7 +10947,7 @@ mod tests {
             pin_mut!(new_session_rx);
             while let Some(_session) = new_session_rx.next().await {}
         });
-        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox.clone()))?;
+        mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox.clone()), None)?;
 
         let alice_pseudonym = HoprPseudonym::random();
 

--- a/transport/session/src/types.rs
+++ b/transport/session/src/types.rs
@@ -446,6 +446,24 @@ impl<T: futures::AsyncWrite + futures::AsyncRead + Send + Unpin> AsyncReadWrite 
 /// concrete [`HoprSession`] byte-stream.
 pub type IncomingSession = hopr_api::node::IncomingSession<HoprSession>;
 
+/// Where a [`SessionAdmissionRequest`](hopr_api::node::SessionAdmissionRequest)'s answer is delivered.
+///
+/// The error is a string rather than the session server's own type because that type is chosen by
+/// whoever installs the server and is unnameable from here — the same erasure the session-server
+/// wiring already performs when it logs a processing failure. The message is for the Exit's own
+/// operator; the peer is told only [`StartErrorReason::TargetNotAdmitted`].
+///
+/// [`StartErrorReason::TargetNotAdmitted`]: hopr_protocol_start::StartErrorReason::TargetNotAdmitted
+pub type SessionAdmissionReply =
+    futures::channel::oneshot::Sender<Result<hopr_api::node::SessionAdmissionDecision, String>>;
+
+/// How the [`SessionManager`](crate::SessionManager) reaches whoever decides admission.
+///
+/// Bounded, and deliberately so: an unanswered request is a refused Session rather than an
+/// unbounded queue of peers waiting on a session server that has stopped keeping up.
+pub type SessionAdmissionSink =
+    futures::channel::mpsc::Sender<(hopr_api::node::SessionAdmissionRequest, SessionAdmissionReply)>;
+
 /// Configures the Session protocol socket over HOPR.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, smart_default::SmartDefault, serde::Serialize)]
 pub struct HoprSessionConfig {

--- a/transport/session/tests/pix.rs
+++ b/transport/session/tests/pix.rs
@@ -257,13 +257,18 @@ async fn session_manager_should_follow_start_protocol_to_establish_new_session_a
     // Start Alice
     let (new_session_tx_alice, _) = futures::channel::mpsc::channel(1024);
     let (alice_sender, alice_handle) = mock_packet_planning(alice_transport);
-    ahs.extend(alice_mgr.start(alice_sender.clone(), new_session_tx_alice, Some(pix_toolbox_alice))?);
+    ahs.extend(alice_mgr.start(
+        alice_sender.clone(),
+        new_session_tx_alice,
+        Some(pix_toolbox_alice),
+        None,
+    )?);
     assert!(alice_mgr.is_started());
 
     // Start Bob
     let (new_session_tx_bob, new_session_rx_bob) = futures::channel::mpsc::channel(1024);
     let (bob_sender, bob_handle) = mock_packet_planning(bob_transport);
-    ahs.extend(bob_mgr.start(bob_sender.clone(), new_session_tx_bob, Some(pix_toolbox_bob))?);
+    ahs.extend(bob_mgr.start(bob_sender.clone(), new_session_tx_bob, Some(pix_toolbox_bob), None)?);
     assert!(bob_mgr.is_started());
 
     let target = SealedHost::Plain("127.0.0.1:80".parse()?);
@@ -395,7 +400,7 @@ async fn dispatch_pix_event_returns_error_for_unknown_session() -> Result<()> {
         while let Some(_session) = new_session_rx.next().await {}
     });
     let (sender, handle) = mock_packet_planning(transport);
-    mgr.start(sender.clone(), new_session_tx, None)?;
+    mgr.start(sender.clone(), new_session_tx, None, None)?;
     assert!(mgr.is_started());
 
     let unknown_pseudonym = HoprPseudonym::random();
@@ -490,10 +495,10 @@ async fn session_without_pix_establishes_without_an_ssa_exchange() -> Result<()>
     let (bob_sender, bob_handle) = mock_packet_planning(bob_transport);
 
     let (new_session_tx_alice, _) = futures::channel::mpsc::channel(1);
-    alice_mgr.start(alice_sender.clone(), new_session_tx_alice, None)?;
+    alice_mgr.start(alice_sender.clone(), new_session_tx_alice, None, None)?;
 
     let (new_session_tx_bob, new_session_rx_bob) = futures::channel::mpsc::channel(1);
-    bob_mgr.start(bob_sender.clone(), new_session_tx_bob, None)?;
+    bob_mgr.start(bob_sender.clone(), new_session_tx_bob, None, None)?;
 
     let target = SealedHost::Plain("127.0.0.1:80".parse()?);
 
@@ -653,11 +658,16 @@ async fn batched_ssa_request_produces_one_deposit_cycle_per_requested_ssa() -> R
     let mut ahs = Vec::new();
     let (new_session_tx_alice, _) = futures::channel::mpsc::channel(1024);
     let (alice_sender, alice_handle) = mock_packet_planning(alice_transport);
-    ahs.extend(alice_mgr.start(alice_sender.clone(), new_session_tx_alice, Some(pix_toolbox_alice))?);
+    ahs.extend(alice_mgr.start(
+        alice_sender.clone(),
+        new_session_tx_alice,
+        Some(pix_toolbox_alice),
+        None,
+    )?);
 
     let (new_session_tx_bob, new_session_rx_bob) = futures::channel::mpsc::channel(1024);
     let (bob_sender, bob_handle) = mock_packet_planning(bob_transport);
-    ahs.extend(bob_mgr.start(bob_sender.clone(), new_session_tx_bob, Some(pix_toolbox_bob))?);
+    ahs.extend(bob_mgr.start(bob_sender.clone(), new_session_tx_bob, Some(pix_toolbox_bob), None)?);
 
     let target = SealedHost::Plain("127.0.0.1:80".parse()?);
 
@@ -916,11 +926,16 @@ async fn entry_refusing_an_oversized_batch_tears_down_both_halves_promptly() -> 
     let mut ahs = Vec::new();
     let (new_session_tx_alice, _) = futures::channel::mpsc::channel(1024);
     let (alice_sender, alice_handle) = mock_packet_planning(alice_transport);
-    ahs.extend(alice_mgr.start(alice_sender.clone(), new_session_tx_alice, Some(pix_toolbox_alice))?);
+    ahs.extend(alice_mgr.start(
+        alice_sender.clone(),
+        new_session_tx_alice,
+        Some(pix_toolbox_alice),
+        None,
+    )?);
 
     let (new_session_tx_bob, new_session_rx_bob) = futures::channel::mpsc::channel(1024);
     let (bob_sender, bob_handle) = mock_packet_planning(bob_transport);
-    ahs.extend(bob_mgr.start(bob_sender.clone(), new_session_tx_bob, Some(pix_toolbox_bob))?);
+    ahs.extend(bob_mgr.start(bob_sender.clone(), new_session_tx_bob, Some(pix_toolbox_bob), None)?);
 
     let _notifications = tokio::spawn(async move {
         pin_mut!(new_session_rx_bob);

--- a/transport/session/tests/pix.rs
+++ b/transport/session/tests/pix.rs
@@ -1068,9 +1068,14 @@ async fn the_session_target_decides_whether_the_exit_serves_a_session() -> Resul
     let ssa_requests = Arc::new(AtomicUsize::new(0));
 
     // `dispatch_message` needs the pseudonym of the Session a message belongs to, and the relay
-    // closures outlive both Sessions, so the current one is shared rather than captured. The two
-    // Sessions run in sequence, so a single cell is enough.
-    let live_pseudonym = Arc::new(hopr_utils::runtime::prelude::Mutex::new(HoprPseudonym::random()));
+    // closures outlive both Sessions, so the current one is shared rather than captured.
+    //
+    // Read *synchronously, as the message is produced*, not inside the future that delivers it. The
+    // two phases below swap this cell between them, and reading it at delivery time would tag a
+    // first-Session message still in flight with the second Session's pseudonym. Reading at
+    // production time pins each message to the phase that created it, whatever order they arrive
+    // in — a sync mutex, held for the read alone and never across an await.
+    let live_pseudonym = Arc::new(std::sync::Mutex::new(HoprPseudonym::random()));
 
     let bob_mgr_relay = Arc::new(bob_mgr.clone());
     let alice_relay_pseudonym = live_pseudonym.clone();
@@ -1080,9 +1085,8 @@ async fn the_session_target_decides_whether_the_exit_serves_a_session() -> Resul
         .times(1..)
         .returning(move |_, data| {
             let bob_mgr_relay = bob_mgr_relay.clone();
-            let alice_relay_pseudonym = alice_relay_pseudonym.clone();
+            let pseudonym = *alice_relay_pseudonym.lock().expect("relay pseudonym lock");
             Box::pin(async move {
-                let pseudonym = *alice_relay_pseudonym.lock().await;
                 let _ = bob_mgr_relay.dispatch_message(
                     pseudonym,
                     ApplicationDataIn {
@@ -1106,9 +1110,8 @@ async fn the_session_target_decides_whether_the_exit_serves_a_session() -> Resul
                 ssa_requests_seen.fetch_add(1, Ordering::Relaxed);
             }
             let alice_mgr_relay = alice_mgr_relay.clone();
-            let bob_relay_pseudonym = bob_relay_pseudonym.clone();
+            let pseudonym = *bob_relay_pseudonym.lock().expect("relay pseudonym lock");
             Box::pin(async move {
-                let pseudonym = *bob_relay_pseudonym.lock().await;
                 let _ = alice_mgr_relay.dispatch_message(
                     pseudonym,
                     ApplicationDataIn {
@@ -1139,7 +1142,7 @@ async fn the_session_target_decides_whether_the_exit_serves_a_session() -> Resul
 
     // ── 1. The waived target establishes, on an offer carrying no PIX at all ──────────────────
     let free_pseudonym = HoprPseudonym::random();
-    *live_pseudonym.lock().await = free_pseudonym;
+    *live_pseudonym.lock().expect("relay pseudonym lock") = free_pseudonym;
 
     let (alice_session, bob_incoming) = tokio_time::timeout(
         Duration::from_secs(2),
@@ -1161,7 +1164,7 @@ async fn the_session_target_decides_whether_the_exit_serves_a_session() -> Resul
     .await
     .map_err(|e| anyhow::anyhow!("the waived target should have established: {e}"))?;
 
-    let _alice_session = alice_session?;
+    let mut alice_session = alice_session?;
     let bob_incoming = bob_incoming.ok_or_else(|| anyhow::anyhow!("bob must get an incoming session"))?;
     assert_eq!(
         bob_incoming.target, free_target,
@@ -1172,10 +1175,18 @@ async fn the_session_target_decides_whether_the_exit_serves_a_session() -> Resul
         0,
         "a waived session must cost the entry no deposit round trip"
     );
+    let bob_sessions_after_admission = bob_mgr.num_active_sessions();
+    assert_eq!(bob_sessions_after_admission, 1, "the waived target must hold one slot");
+
+    // Closed rather than dropped, as the tests above do, so the first phase leaves nothing sending.
+    // Bob's slot survives its Entry's close and is reclaimed on idle, which is why the refusal below
+    // is judged against the count taken here rather than against zero.
+    alice_session.close().await?;
+    drop(bob_incoming);
 
     // ── 2. The same offer to another target is refused ────────────────────────────────────────
     let paid_pseudonym = HoprPseudonym::random();
-    *live_pseudonym.lock().await = paid_pseudonym;
+    *live_pseudonym.lock().expect("relay pseudonym lock") = paid_pseudonym;
 
     let refusal = tokio_time::timeout(
         Duration::from_secs(2),
@@ -1202,6 +1213,20 @@ async fn the_session_target_decides_whether_the_exit_serves_a_session() -> Resul
             ))
         ),
         "the entry must be told its offer was unacceptable for that target, got {refusal:?}"
+    );
+
+    // The Entry's error alone would also be produced by an Exit that allocated the Session and only
+    // then refused it, which leaks a slot. Both halves of that are checked here.
+    assert!(
+        tokio_time::timeout(Duration::from_millis(200), new_session_rx_bob.next())
+            .await
+            .is_err(),
+        "a refused target must not reach the exit as an incoming session"
+    );
+    assert_eq!(
+        bob_mgr.num_active_sessions(),
+        bob_sessions_after_admission,
+        "the refusal must allocate no slot of its own"
     );
 
     // ── 3. Only the Exit was ever asked ───────────────────────────────────────────────────────

--- a/transport/session/tests/pix.rs
+++ b/transport/session/tests/pix.rs
@@ -996,3 +996,232 @@ async fn entry_refusing_an_oversized_batch_tears_down_both_halves_promptly() -> 
 
     Ok(())
 }
+
+/// End-to-end proof of the feature in #8376: one Exit, one Entry, the same offer both times, and
+/// the **Session target** deciding whether the Session is served.
+///
+/// The unit tests around `handle_incoming_session_initiation` fix the decision and vary the offer.
+/// This runs the whole Start exchange between two managers instead, so it also covers the parts
+/// those cannot reach: that the Exit asks before it replies, that a waived target establishes with
+/// no SSA exchange at all, and that a refused one reaches the *Entry* as a `Rejected` error rather
+/// than as a timeout.
+///
+/// ## Steps
+/// 1. Bob (Exit) enforces PIX node-wide, and installs an admission handler that waives it for one target and leaves the
+///    node's terms in place for every other.
+/// 2. Alice (Entry) opens a Session to the waived target offering no PIX. It establishes, and Bob emits no `SsaRequest`
+///    — a waived Session must cost the Entry no deposit round trip.
+/// 3. Alice opens a second Session, byte-for-byte the same offer, to a different target. Bob refuses it and Alice's
+///    `new_session` returns `Rejected(UnacceptablePixParams)`.
+/// 4. Alice is asked nothing throughout: admission is an Exit-side question, and Alice runs the same handler to prove
+///    her own outgoing Sessions never reach it.
+#[test(tokio::test)]
+async fn the_session_target_decides_whether_the_exit_serves_a_session() -> Result<()> {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use hopr_api::node::{SessionAdmissionDecision, SessionAdmissionRequest};
+    use hopr_transport_session::SessionAdmissionReply;
+
+    let free_target = SessionTarget::TcpStream(SealedHost::Plain("10.0.0.1:80".parse()?));
+    let paid_target = SessionTarget::TcpStream(SealedHost::Plain("10.0.0.2:80".parse()?));
+
+    // Alice enforces nothing and admits nothing — she is the Entry.
+    let alice_mgr = SessionManager::new(SessionManagerConfig::default());
+    let bob_mgr = SessionManager::new(SessionManagerConfig {
+        pix_config: IncomingSessionPixConfig {
+            enforce_pix: true,
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    // One handler, driven by the target alone.
+    let free_for_handler = free_target.clone();
+    let bob_admissions = Arc::new(AtomicUsize::new(0));
+    let bob_admissions_in_handler = bob_admissions.clone();
+    let (bob_admission_tx, mut bob_admission_rx) =
+        futures::channel::mpsc::channel::<(SessionAdmissionRequest, SessionAdmissionReply)>(4);
+    let bob_admission_task = tokio::task::spawn(async move {
+        while let Some((request, reply)) = bob_admission_rx.next().await {
+            bob_admissions_in_handler.fetch_add(1, Ordering::Relaxed);
+            let decision = if request.target == free_for_handler {
+                SessionAdmissionDecision::default().with_enforce_pix(false)
+            } else {
+                SessionAdmissionDecision::default()
+            };
+            let _: Result<_, _> = reply.send(Ok(decision));
+        }
+    });
+
+    // Installed on Alice too, purely to assert it is never consulted for an outgoing Session.
+    let alice_admissions = Arc::new(AtomicUsize::new(0));
+    let alice_admissions_in_handler = alice_admissions.clone();
+    let (alice_admission_tx, mut alice_admission_rx) =
+        futures::channel::mpsc::channel::<(SessionAdmissionRequest, SessionAdmissionReply)>(4);
+    let alice_admission_task = tokio::task::spawn(async move {
+        while let Some((_request, reply)) = alice_admission_rx.next().await {
+            alice_admissions_in_handler.fetch_add(1, Ordering::Relaxed);
+            let _: Result<_, _> = reply.send(Ok(SessionAdmissionDecision::default()));
+        }
+    });
+
+    let ssa_requests = Arc::new(AtomicUsize::new(0));
+
+    // `dispatch_message` needs the pseudonym of the Session a message belongs to, and the relay
+    // closures outlive both Sessions, so the current one is shared rather than captured. The two
+    // Sessions run in sequence, so a single cell is enough.
+    let live_pseudonym = Arc::new(hopr_utils::runtime::prelude::Mutex::new(HoprPseudonym::random()));
+
+    let bob_mgr_relay = Arc::new(bob_mgr.clone());
+    let alice_relay_pseudonym = live_pseudonym.clone();
+    let mut alice_transport = MockMsgSender::new();
+    alice_transport
+        .expect_send_message()
+        .times(1..)
+        .returning(move |_, data| {
+            let bob_mgr_relay = bob_mgr_relay.clone();
+            let alice_relay_pseudonym = alice_relay_pseudonym.clone();
+            Box::pin(async move {
+                let pseudonym = *alice_relay_pseudonym.lock().await;
+                let _ = bob_mgr_relay.dispatch_message(
+                    pseudonym,
+                    ApplicationDataIn {
+                        data: data.data,
+                        packet_info: Default::default(),
+                    },
+                );
+                Ok(())
+            })
+        });
+
+    let alice_mgr_relay = Arc::new(alice_mgr.clone());
+    let ssa_requests_seen = ssa_requests.clone();
+    let bob_relay_pseudonym = live_pseudonym.clone();
+    let mut bob_transport = MockMsgSender::new();
+    bob_transport
+        .expect_send_message()
+        .times(1..)
+        .returning(move |_, data| {
+            if msg_type(&data, StartProtocolDiscriminants::SsaRequest) {
+                ssa_requests_seen.fetch_add(1, Ordering::Relaxed);
+            }
+            let alice_mgr_relay = alice_mgr_relay.clone();
+            let bob_relay_pseudonym = bob_relay_pseudonym.clone();
+            Box::pin(async move {
+                let pseudonym = *bob_relay_pseudonym.lock().await;
+                let _ = alice_mgr_relay.dispatch_message(
+                    pseudonym,
+                    ApplicationDataIn {
+                        data: data.data,
+                        packet_info: Default::default(),
+                    },
+                );
+                Ok(())
+            })
+        });
+
+    let (alice_sender, alice_handle) = mock_packet_planning(alice_transport);
+    let (bob_sender, bob_handle) = mock_packet_planning(bob_transport);
+
+    let (new_session_tx_alice, _alice_incoming) = futures::channel::mpsc::channel(1);
+    alice_mgr.start(
+        alice_sender.clone(),
+        new_session_tx_alice,
+        None,
+        Some(alice_admission_tx),
+    )?;
+
+    let (new_session_tx_bob, new_session_rx_bob) = futures::channel::mpsc::channel(1);
+    bob_mgr.start(bob_sender.clone(), new_session_tx_bob, None, Some(bob_admission_tx))?;
+
+    let bob_peer: Address = (&ChainKeypair::random()).into();
+    pin_mut!(new_session_rx_bob);
+
+    // ── 1. The waived target establishes, on an offer carrying no PIX at all ──────────────────
+    let free_pseudonym = HoprPseudonym::random();
+    *live_pseudonym.lock().await = free_pseudonym;
+
+    let (alice_session, bob_incoming) = tokio_time::timeout(
+        Duration::from_secs(2),
+        futures::future::join(
+            alice_mgr.new_session(
+                bob_peer,
+                free_target.clone(),
+                SessionClientConfig {
+                    pseudonym: free_pseudonym.into(),
+                    capabilities: Capability::Segmentation.into(),
+                    surb_management: None,
+                    pix_ssa_quota: None,
+                    ..Default::default()
+                },
+            ),
+            new_session_rx_bob.next(),
+        ),
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("the waived target should have established: {e}"))?;
+
+    let _alice_session = alice_session?;
+    let bob_incoming = bob_incoming.ok_or_else(|| anyhow::anyhow!("bob must get an incoming session"))?;
+    assert_eq!(
+        bob_incoming.target, free_target,
+        "bob must be handed the target he admitted"
+    );
+    assert_eq!(
+        ssa_requests.load(Ordering::Relaxed),
+        0,
+        "a waived session must cost the entry no deposit round trip"
+    );
+
+    // ── 2. The same offer to another target is refused ────────────────────────────────────────
+    let paid_pseudonym = HoprPseudonym::random();
+    *live_pseudonym.lock().await = paid_pseudonym;
+
+    let refusal = tokio_time::timeout(
+        Duration::from_secs(2),
+        alice_mgr.new_session(
+            bob_peer,
+            paid_target,
+            SessionClientConfig {
+                pseudonym: paid_pseudonym.into(),
+                capabilities: Capability::Segmentation.into(),
+                surb_management: None,
+                pix_ssa_quota: None,
+                ..Default::default()
+            },
+        ),
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("a refusal must reach the entry rather than time out: {e}"))?;
+
+    assert!(
+        matches!(
+            refusal,
+            Err(hopr_transport_session::errors::TransportSessionError::Rejected(
+                hopr_protocol_start::StartErrorReason::UnacceptablePixParams
+            ))
+        ),
+        "the entry must be told its offer was unacceptable for that target, got {refusal:?}"
+    );
+
+    // ── 3. Only the Exit was ever asked ───────────────────────────────────────────────────────
+    assert_eq!(
+        bob_admissions.load(Ordering::Relaxed),
+        2,
+        "the exit must be asked once per incoming session"
+    );
+    assert_eq!(
+        alice_admissions.load(Ordering::Relaxed),
+        0,
+        "an entry must never put its own outgoing session to the hook"
+    );
+
+    alice_sender.close_channel();
+    bob_sender.close_channel();
+    alice_handle.await??;
+    bob_handle.await??;
+    bob_admission_task.abort();
+    alice_admission_task.abort();
+
+    Ok(())
+}

--- a/transport/session/tests/session_lifecycle.rs
+++ b/transport/session/tests/session_lifecycle.rs
@@ -132,13 +132,13 @@ async fn session_manager_should_follow_start_protocol_to_establish_new_session_a
     // Start Alice
     let (new_session_tx_alice, _) = futures::channel::mpsc::channel(1024);
     let (alice_sender, alice_handle) = mock_packet_planning(alice_transport);
-    ahs.extend(alice_mgr.start(alice_sender.clone(), new_session_tx_alice, None)?);
+    ahs.extend(alice_mgr.start(alice_sender.clone(), new_session_tx_alice, None, None)?);
     assert!(alice_mgr.is_started());
 
     // Start Bob
     let (new_session_tx_bob, new_session_rx_bob) = futures::channel::mpsc::channel(1024);
     let (bob_sender, bob_handle) = mock_packet_planning(bob_transport);
-    ahs.extend(bob_mgr.start(bob_sender.clone(), new_session_tx_bob, None)?);
+    ahs.extend(bob_mgr.start(bob_sender.clone(), new_session_tx_bob, None, None)?);
     assert!(bob_mgr.is_started());
 
     let target = SealedHost::Plain("127.0.0.1:80".parse()?);
@@ -300,12 +300,12 @@ async fn session_manager_should_close_idle_session_automatically() -> Result<()>
     // Start Alice
     let (new_session_tx_alice, _) = futures::channel::mpsc::channel(1024);
     let (alice_sender, alice_handle) = mock_packet_planning(alice_transport);
-    ahs.extend(alice_mgr.start(alice_sender.clone(), new_session_tx_alice, None)?);
+    ahs.extend(alice_mgr.start(alice_sender.clone(), new_session_tx_alice, None, None)?);
 
     // Start Bob
     let (new_session_tx_bob, new_session_rx_bob) = futures::channel::mpsc::channel(1024);
     let (bob_sender, bob_handle) = mock_packet_planning(bob_transport);
-    ahs.extend(bob_mgr.start(bob_sender.clone(), new_session_tx_bob, None)?);
+    ahs.extend(bob_mgr.start(bob_sender.clone(), new_session_tx_bob, None, None)?);
     assert!(bob_mgr.is_started());
 
     let target = SealedHost::Plain("127.0.0.1:80".parse()?);
@@ -453,7 +453,7 @@ async fn session_manager_should_not_allow_loopback_sessions() -> Result<()> {
     // Start Alice
     let (new_session_tx_alice, new_session_rx_alice) = futures::channel::mpsc::channel(1024);
     let (alice_sender, alice_handle) = mock_packet_planning(alice_transport);
-    alice_mgr.start(alice_sender.clone(), new_session_tx_alice, None)?;
+    alice_mgr.start(alice_sender.clone(), new_session_tx_alice, None, None)?;
     assert!(alice_mgr.is_started());
 
     let alice_session = alice_mgr
@@ -533,13 +533,13 @@ async fn session_manager_should_timeout_new_session_attempt_when_no_response() -
     // Start Alice
     let (new_session_tx_alice, _) = futures::channel::mpsc::channel(1024);
     let (alice_sender, _alice_handle) = mock_packet_planning(alice_transport);
-    alice_mgr.start(alice_sender.clone(), new_session_tx_alice, None)?;
+    alice_mgr.start(alice_sender.clone(), new_session_tx_alice, None, None)?;
     assert!(alice_mgr.is_started());
 
     // Start Bob
     let (new_session_tx_bob, _) = futures::channel::mpsc::channel(1024);
     let (bob_sender, _bob_handle) = mock_packet_planning(bob_transport);
-    bob_mgr.start(bob_sender.clone(), new_session_tx_bob, None)?;
+    bob_mgr.start(bob_sender.clone(), new_session_tx_bob, None, None)?;
     assert!(bob_mgr.is_started());
 
     let result = alice_mgr
@@ -695,13 +695,13 @@ async fn session_manager_should_send_keep_alive_when_ping_session_is_called() ->
     // Start Alice
     let (new_session_tx_alice, _) = futures::channel::mpsc::channel(1024);
     let (alice_sender, alice_handle) = mock_packet_planning(alice_transport);
-    ahs.extend(alice_mgr.start(alice_sender.clone(), new_session_tx_alice, None)?);
+    ahs.extend(alice_mgr.start(alice_sender.clone(), new_session_tx_alice, None, None)?);
     assert!(alice_mgr.is_started());
 
     // Start Bob
     let (new_session_tx_bob, new_session_rx_bob) = futures::channel::mpsc::channel(1024);
     let (bob_sender, bob_handle) = mock_packet_planning(bob_transport);
-    ahs.extend(bob_mgr.start(bob_sender.clone(), new_session_tx_bob, None)?);
+    ahs.extend(bob_mgr.start(bob_sender.clone(), new_session_tx_bob, None, None)?);
     assert!(bob_mgr.is_started());
 
     let target = SealedHost::Plain("127.0.0.1:80".parse()?);


### PR DESCRIPTION
Closes #8376. Part 3 of 4. Both upstreams have landed — `hopr-api` 4.3.0 and `hopr-session-server-forwarder` 0.4.0 are merged and on crates.io — so this is no longer blocked.

The Exit's incentivization policy was one node-wide setting, but the Start initiation that carries it also carries the Session target — so an Exit could serve some targets for free and demand a narrow quota on others. It could not decide that itself: the target may be sealed to the node's packet key, which belongs to the session server. `check_pix_params` has carried a TODO saying exactly this.

**So it asks.** Before anything is allocated for an incoming Session, the manager puts the target to the session server over a bounded channel and waits on a one-shot for the terms. The mechanism is target-agnostic; PIX parameters are its first payload.

**Fails closed, and distinguishes the two ways it can fail:**

| Outcome | Reported as | Why |
|---|---|---|
| server answered `Err` | `TargetNotAdmitted` *(new)* | decided; re-asking will not change it |
| timeout / full channel / dropped reply | `Busy` | this node cannot ask right now; retryable |

Falling back to the node's own terms was the alternative and is worse — an overloaded server would silently disable every rule the operator wrote.

**Envelope semantics.** `enforce_pix` is overridden outright, in either direction. The quota window is *intersected*, never replaced: the configured range is what `validate_incoming_session_pix_config` checked deadlines and the memory ceiling against, and what `start_protocol_channel_capacity` preallocated a ring from — both once at startup. A Session may be held to less of it, never more, so neither invariant is re-checked per Session.

**Unchanged for everyone else.** A node running no session server has nobody to ask and admits on its own terms, so an Entry, a relay, and any caller that installed no server behave exactly as before.

hopr-lib spawns a second task for `admit` beside the one draining established Sessions — sharing one would put a long-lived `process` in front of the decisions queued behind it. The server bound gains `Sync`, which `async_trait` needs to make a defaulted `&self` method's future `Send`.

**Tests:** 13 new (waive/demand PIX, narrowing refuses and its control, refusal, timeout, dropped reply, no-sink baseline, request contents, timeout clamp) + a wire round-trip over every `StartErrorReason`. 1138 unit and 17 hopr-lib session integration tests pass; clippy clean.

Consumes `hopr-api` 4.3.0 from crates.io; the temporary `[patch.crates-io]` redirect is gone. The declared requirement moves from `4.1.0` to `4.3.0` because `transport/session` now names `SessionAdmissionRequest` and `SessionAdmissionDecision` — 4.3.0 is what this workspace requires, not merely what it tolerates.

