### PR TITLE
fix(session): capture SURB generation at path resolution, not encode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4214,7 +4214,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-lib"
-version = "5.0.0-rc.1"
+version = "5.0.0-rc.2"
 dependencies = [
  "anyhow",
  "async-broadcast",
@@ -4281,7 +4281,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-app"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "hopr-crypto-packet",
@@ -4294,7 +4294,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-hopr"
-version = "6.2.0"
+version = "6.3.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4441,7 +4441,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport"
-version = "0.49.0"
+version = "0.50.0"
 dependencies = [
  "ahash",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,9 +146,9 @@ hopr-utils-session = { version = "1.2.1", path = "utils-session" }
 hopr-crypto-packet = { version = "2.0.0", path = "crypto/packet", default-features = false, features = [
   "ed25519",
 ] }
-hopr-lib = { version = "5.0.0-rc.1", path = "hopr/hopr-lib" }
-hopr-protocol-app = { version = "1.0.1", path = "protocols/app", default-features = false }
-hopr-protocol-hopr = { version = "6.2.0", path = "protocols/hopr", default-features = false, features = [
+hopr-lib = { version = "5.0.0-rc.2", path = "hopr/hopr-lib" }
+hopr-protocol-app = { version = "1.1.0", path = "protocols/app", default-features = false }
+hopr-protocol-hopr = { version = "6.3.0", path = "protocols/hopr", default-features = false, features = [
   "rayon",
 ] }
 hopr-protocol-pix = { version = "0.2.0", path = "protocols/pix", default-features = false, features = [
@@ -157,7 +157,7 @@ hopr-protocol-pix = { version = "0.2.0", path = "protocols/pix", default-feature
 hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
 hopr-protocol-start = { version = "2.0.0", path = "protocols/start", default-features = false }
 hopr-ticket-manager = { version = "0.7.0" }
-hopr-transport = { version = "0.49.0", path = "transport/hopr" }
+hopr-transport = { version = "0.50.0", path = "transport/hopr" }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
 hopr-transport-session = { version = "0.30.0", path = "transport/session", default-features = false }

--- a/hopr/hopr-lib/Cargo.toml
+++ b/hopr/hopr-lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-lib"
 description = "HOPR library implementing the HOPR protocol"
-version = "5.0.0-rc.1"
+version = "5.0.0-rc.2"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/protocols/app/Cargo.toml
+++ b/protocols/app/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-protocol-app"
 description = "Contains implementation of Application layer for HOPR protocol as specified in RFC-0011"
-version = "1.0.1"
+version = "1.1.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/protocols/app/src/v1.rs
+++ b/protocols/app/src/v1.rs
@@ -157,6 +157,10 @@ pub struct OutgoingPacketInfo {
     pub signals_to_destination: PacketSignals,
     /// The maximum number of SURBs the HOPR packet should be carrying when sent.
     pub max_surbs_in_packet: usize,
+    /// SURB-batch generation to stamp onto the SURBs minted for this packet's return paths,
+    /// captured when those return paths were resolved. `None` when the packet carries no return
+    /// paths, or when the generation is left to the encoder to resolve.
+    pub surb_generation: Option<u8>,
 }
 
 impl Default for OutgoingPacketInfo {
@@ -164,6 +168,7 @@ impl Default for OutgoingPacketInfo {
         Self {
             signals_to_destination: PacketSignals::empty(),
             max_surbs_in_packet: usize::MAX,
+            surb_generation: None,
         }
     }
 }

--- a/protocols/hopr/Cargo.toml
+++ b/protocols/hopr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-protocol-hopr"
-version = "6.2.0"
+version = "6.3.0"
 description = "Contains implementation of the HOPR protocol as specified in RFC-0004 & RFC-0005"
 edition.workspace = true
 license.workspace = true

--- a/protocols/hopr/benches/codec_bench.rs
+++ b/protocols/hopr/benches/codec_bench.rs
@@ -133,7 +133,7 @@ fn hopr_encoder_bench(c: &mut Criterion) {
             |b, routing| {
                 b.iter_batched(
                     || (create_encoder(&sender), data.clone(), routing.clone()),
-                    |(encoder, data, routing)| encoder.encode_packet(data, routing, None).unwrap(),
+                    |(encoder, data, routing)| encoder.encode_packet(data, routing, None, None).unwrap(),
                     BatchSize::PerIteration,
                 )
             },
@@ -198,7 +198,7 @@ fn hopr_decoder_bench(c: &mut Criterion) {
     };
 
     let encoder = create_encoder(&sender);
-    let relay_packet = encoder.encode_packet(data, routing, None).unwrap();
+    let relay_packet = encoder.encode_packet(data, routing, None, None).unwrap();
     let ack_packet = {
         let acks = (0..10)
             .map(|_| VerifiedAcknowledgement::random(&PEERS[0].1))

--- a/protocols/hopr/src/codec/encoder.rs
+++ b/protocols/hopr/src/codec/encoder.rs
@@ -155,6 +155,7 @@ where
         data: D,
         routing: ResolvedTransportRouting<HoprSurb>,
         signals: Sig,
+        generation: Option<u8>,
     ) -> Result<OutgoingPacket, Self::Error> {
         // Get necessary packet routing values
         let (next_peer, num_hops, pseudonym, routing) = match routing {
@@ -169,10 +170,12 @@ where
                 PacketRouting::ForwardPath {
                     forward_path,
                     return_paths,
-                    // Stamp the current SURB-batch generation for this pseudonym so the replying side
-                    // can drop SURBs left over from a superseded return path. Bumped on a re-plan
-                    // via `SurbStore::bump_generation`.
-                    generation: self.surb_store.current_generation(&pseudonym),
+                    // Stamp the SURB-batch generation captured when these return paths were resolved,
+                    // so the replying side drops SURBs left over from a superseded return path. It is
+                    // captured with the plan (not read here) so a concurrent re-plan/bump cannot
+                    // label this already-chosen batch with a newer generation; falling back to the
+                    // store's current value only when a caller did not supply one.
+                    generation: generation.unwrap_or_else(|| self.surb_store.current_generation(&pseudonym)),
                 },
             ),
             ResolvedTransportRouting::Return(sender_id, surb) => {

--- a/protocols/hopr/src/codec/mod.rs
+++ b/protocols/hopr/src/codec/mod.rs
@@ -196,6 +196,7 @@ mod tests {
                 resp,
                 ResolvedTransportRouting::Return(surb.sender_id, surb.surb),
                 None,
+                None,
             )?)
         }
 
@@ -232,6 +233,7 @@ mod tests {
                 return_paths: vec![],
             },
             None,
+            None,
         )?;
 
         let in_packet = decoder.decode(sender.offchain_key.public().into(), out_packet.data)?;
@@ -263,6 +265,7 @@ mod tests {
                         ),
                         return_paths: vec![],
                     },
+                    None,
                     None,
                 )
                 .is_err()
@@ -300,6 +303,7 @@ mod tests {
                 return_paths: vec![],
             },
             None,
+            None,
         )?;
 
         let fwd_packet = relay_decoder.decode(sender.offchain_key.public().into(), out_packet.data)?;
@@ -328,6 +332,7 @@ mod tests {
                 forward_path: f.forward_path.clone(),
                 return_paths: vec![f.return_path.clone()],
             },
+            None,
             None,
         )?;
 
@@ -412,6 +417,7 @@ mod tests {
                     forward_path: f.forward_path.clone(),
                     return_paths: vec![f.return_path.clone()],
                 },
+                None,
                 None,
             )?;
 
@@ -537,6 +543,7 @@ mod tests {
                     forward_path: f.forward_path.clone(),
                     return_paths: vec![f.return_path.clone()],
                 },
+                None,
                 None,
             )?;
 
@@ -738,6 +745,7 @@ mod tests {
                 return_paths: vec![],
             },
             None,
+            None,
         )?;
 
         // First decode should succeed
@@ -772,6 +780,7 @@ mod tests {
                 ),
                 return_paths: vec![],
             },
+            None,
             None,
         )?;
 

--- a/protocols/hopr/src/traits.rs
+++ b/protocols/hopr/src/traits.rs
@@ -96,11 +96,19 @@ pub trait PacketEncoder {
     ///
     /// The `data` MUST be already correctly sized for HOPR packets, otherwise the operation
     /// must fail.
+    ///
+    /// `generation` is the SURB-batch generation to stamp onto SURBs minted for a forward packet's
+    /// return paths, captured when those return paths were resolved (see
+    /// [`PathPlanner::resolve_routing`](../../../hopr_transport/path/planner)). It must be captured
+    /// with the plan rather than read here, so a concurrent return-path re-plan cannot label an
+    /// already-chosen batch with a newer generation. `None` (no return path, or a non-forward
+    /// packet) falls back to the store's current generation.
     fn encode_packet<T: AsRef<[u8]> + Send + 'static, S: Into<PacketSignals> + Send + 'static>(
         &self,
         data: T,
         routing: ResolvedTransportRouting<HoprSurb>,
         signals: S,
+        generation: Option<u8>,
     ) -> Result<OutgoingPacket, Self::Error>;
 
     /// Encodes the given vector of [`VerifiedAcknowledgements`](VerifiedAcknowledgement) as an outgoing packet to be

--- a/transport/hopr/Cargo.toml
+++ b/transport/hopr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport"
 description = "Implements the main HOPR transport interface for the core library"
-version = "0.49.0"
+version = "0.50.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/hopr/src/capture.rs
+++ b/transport/hopr/src/capture.rs
@@ -387,12 +387,13 @@ impl<C: PacketEncoder + Send + Sync> PacketEncoder for CapturePacketCodec<C> {
         data: T,
         routing: ResolvedTransportRouting<HoprSurb>,
         signals: S,
+        generation: Option<u8>,
     ) -> Result<OutgoingPacket, Self::Error> {
         let data_clone = data.as_ref().to_vec();
         let signals = signals.into();
         let num_surbs = routing.count_return_paths() as u8;
 
-        let packet = self.inner.encode_packet(data, routing, signals)?;
+        let packet = self.inner.encode_packet(data, routing, signals, generation)?;
 
         if let Err(error) = self.sender.try_send(
             PacketBeforeTransit::OutgoingPacket {

--- a/transport/hopr/src/path/planner.rs
+++ b/transport/hopr/src/path/planner.rs
@@ -685,7 +685,7 @@ where
         size_hint: usize,
         max_surbs: usize,
         routing: DestinationRouting,
-    ) -> Result<(ResolvedTransportRouting<HoprSurb>, Option<usize>)> {
+    ) -> Result<(ResolvedTransportRouting<HoprSurb>, Option<usize>, Option<u8>)> {
         match routing {
             DestinationRouting::Forward {
                 destination,
@@ -725,13 +725,26 @@ where
 
                 trace!(%destination, num_surbs = return_paths.len(), data_len = size_hint, "resolved packet");
 
+                let resolved_pseudonym = pseudonym.unwrap_or_else(HoprPseudonym::random);
+                // Capture the SURB-batch generation here, adjacent to return-path resolution, rather
+                // than at encode time. The replying side supersedes SURBs by generation, so a batch's
+                // generation must match the return-path plan it was minted for. Reading it here — with
+                // no `await` between choosing the return paths and this read — means a concurrent
+                // `bump_generation` (return-path re-plan, on the flush-loop task) cannot re-stamp an
+                // already-chosen plan; the window it could slip into is a couple of instructions
+                // instead of the whole resolve->encode pipeline hop. `None` when there is no return
+                // path (no SURBs are minted).
+                let generation =
+                    (!return_paths.is_empty()).then(|| self.surb_store.current_generation(&resolved_pseudonym));
+
                 Ok((
                     ResolvedTransportRouting::Forward {
-                        pseudonym: pseudonym.unwrap_or_else(HoprPseudonym::random),
+                        pseudonym: resolved_pseudonym,
                         forward_path,
                         return_paths,
                     },
                     None,
+                    generation,
                 ))
             }
 
@@ -744,7 +757,7 @@ where
                     .surb_store
                     .find_surb(matcher)
                     .ok_or_else(|| PathPlannerError::Surb(format!("no surb for pseudonym {}", matcher.pseudonym())))?;
-                Ok((ResolvedTransportRouting::Return(sender_id, surb), Some(remaining)))
+                Ok((ResolvedTransportRouting::Return(sender_id, surb), Some(remaining), None))
             }
         }
     }
@@ -1251,7 +1264,7 @@ mod tests {
         let result = planner.resolve_routing(100, 0, routing).await;
         assert!(result.is_ok(), "zero-hop should succeed: {:?}", result.err());
 
-        let (resolved, rem) = result.unwrap();
+        let (resolved, rem, _) = result.unwrap();
         assert!(rem.is_none());
         if let ResolvedTransportRouting::Forward { forward_path, .. } = resolved {
             assert_eq!(
@@ -1307,7 +1320,7 @@ mod tests {
         let result = planner.resolve_routing(100, 0, routing).await;
         assert!(result.is_ok(), "1-hop routing should succeed: {:?}", result.err());
 
-        let (resolved, _) = result.unwrap();
+        let (resolved, ..) = result.unwrap();
         if let ResolvedTransportRouting::Forward { forward_path, .. } = resolved {
             assert_eq!(
                 forward_path.num_hops(),
@@ -1357,7 +1370,7 @@ mod tests {
         let result = planner.resolve_routing(100, 0, routing).await;
         assert!(result.is_ok(), "explicit path should succeed: {:?}", result.err());
 
-        let (resolved, _) = result.unwrap();
+        let (resolved, ..) = result.unwrap();
         if let ResolvedTransportRouting::Forward { forward_path, .. } = resolved {
             assert_eq!(forward_path.num_hops(), 2, "one intermediate + destination = 2 hops");
         } else {
@@ -1612,8 +1625,8 @@ mod tests {
             return_options: None,
         };
 
-        let (r1, _) = planner.resolve_routing(100, 0, make_routing()).await.expect("call 1");
-        let (r2, _) = planner.resolve_routing(100, 0, make_routing()).await.expect("call 2");
+        let (r1, ..) = planner.resolve_routing(100, 0, make_routing()).await.expect("call 1");
+        let (r2, ..) = planner.resolve_routing(100, 0, make_routing()).await.expect("call 2");
 
         let hops1 = if let ResolvedTransportRouting::Forward { forward_path, .. } = r1 {
             forward_path.num_hops()
@@ -1627,6 +1640,69 @@ mod tests {
         };
         assert_eq!(hops1, 2);
         assert_eq!(hops2, 2);
+    }
+
+    /// `resolve_routing` must capture the sending-side SURB generation for the packet's pseudonym at
+    /// resolution time (adjacent to choosing the return paths), so the batch is later stamped with
+    /// the generation of the plan it was minted for rather than one re-read at encode time.
+    #[tokio::test]
+    async fn resolve_routing_should_capture_the_current_surb_generation() {
+        let me = pubkey(&SECRET_ME);
+        let a = pubkey(&SECRET_A);
+        let dest = pubkey(&SECRET_DEST);
+
+        let graph = ChannelGraph::new(me);
+        graph.add_node(a);
+        graph.add_node(dest);
+        // Forward path me -> a -> dest, and a return path dest -> a -> me.
+        graph.add_edge(&me, &a).unwrap();
+        graph.add_edge(&a, &dest).unwrap();
+        graph.add_edge(&dest, &a).unwrap();
+        graph.add_edge(&a, &me).unwrap();
+        mark_edge_full(&graph, &me, &a);
+        mark_edge_full(&graph, &a, &dest);
+        mark_edge_full(&graph, &dest, &a);
+        mark_edge_full(&graph, &a, &me);
+
+        let cfg = small_config();
+        let selector = HoprGraphPathSelector::new(
+            me,
+            graph,
+            cfg.max_cached_paths,
+            cfg.edge_penalty,
+            cfg.min_ack_rate,
+            cfg.min_paths_anonymity_floor,
+        );
+        let chain_api = TestChainApi::new(me, me_addr(), vec![(a, a_addr()), (dest, dest_addr())])
+            .with_open_channel(me_addr(), a_addr())
+            .with_open_channel(a_addr(), dest_addr())
+            .with_open_channel(dest_addr(), a_addr())
+            .with_open_channel(a_addr(), me_addr());
+        let surb_store = hopr_protocol_hopr::MemorySurbStore::default();
+        let planner = PathPlanner::new(me, surb_store, chain_api, selector, small_config());
+
+        let pseudonym = HoprPseudonym::random();
+        // Advance the sending-side generation, as return-path re-plans would.
+        planner.surb_store.bump_generation(&pseudonym);
+        let expected = planner.surb_store.bump_generation(&pseudonym);
+
+        let routing = DestinationRouting::Forward {
+            destination: Box::new(NodeId::Offchain(dest)),
+            pseudonym: Some(pseudonym),
+            forward_options: RoutingOptions::Hops(1.try_into().expect("valid 1")),
+            return_options: Some(RoutingOptions::Hops(1.try_into().expect("valid 1"))),
+        };
+
+        let (_resolved, _rem, generation) = planner
+            .resolve_routing(100, 1, routing)
+            .await
+            .expect("resolution should succeed");
+
+        assert_eq!(
+            generation,
+            Some(expected),
+            "resolve_routing must capture the store's current generation for the pseudonym"
+        );
     }
 
     #[tokio::test]

--- a/transport/hopr/src/path/planner.rs
+++ b/transport/hopr/src/path/planner.rs
@@ -700,7 +700,26 @@ where
                     .await?;
                 tracing::debug!(direction = "forward", %destination, path = %forward_path, "resolved path");
 
-                let return_paths = if let Some(return_options) = return_options {
+                let resolved_pseudonym = pseudonym.unwrap_or_else(HoprPseudonym::random);
+
+                // Capture the SURB-batch generation here — with the return-path plan, not at encode
+                // time — because the replying side supersedes SURBs by generation, so a batch's
+                // generation must match the plan it was minted for.
+                //
+                // Crucially, read it *before* resolving the return paths, not after. The flush loop
+                // recomputes paths and only *then* bumps the generation (`recompute_paths_from` then
+                // `bump_generation` in `HoprTransport`'s SURB-flush task), so a bump racing this
+                // resolution has, by the time it happens, already moved the planner to the new route.
+                // Reading first therefore makes any residual mislabel *under*-label — a fresh route
+                // stamped with the previous generation, which the peer merely appends and then clears
+                // on the next batch (a few wasted SURBs) — and never *over*-label — a stale route
+                // stamped with the newer generation, which would make the peer drop live SURBs and
+                // hand out dead ones. Reading after the resolve is what would allow the harmful
+                // over-label (choose old route, bump, read new generation), so the order matters and a
+                // lock on the per-packet hot path is not needed.
+                let (return_paths, generation) = if let Some(return_options) = return_options {
+                    let generation = self.surb_store.current_generation(&resolved_pseudonym);
+
                     let num_possible_surbs = HoprPacket::max_surbs_with_message(size_hint).min(max_surbs);
                     trace!(
                         %destination,
@@ -710,7 +729,8 @@ where
                         "resolving packet return paths"
                     );
 
-                    self.resolve_diverse_return_paths(*destination, return_options, num_possible_surbs)
+                    let return_paths: Vec<_> = self
+                        .resolve_diverse_return_paths(*destination, return_options, num_possible_surbs)
                         .await?
                         .into_iter()
                         .enumerate()
@@ -718,24 +738,16 @@ where
                             tracing::debug!(direction = "return", %destination, index = i, path = %rp, "resolved return path");
                         })
                         .map(|(_, rp)| rp)
-                        .collect()
+                        .collect();
+
+                    // Only stamp a generation if return paths (hence SURBs) were actually produced.
+                    let generation = (!return_paths.is_empty()).then_some(generation);
+                    (return_paths, generation)
                 } else {
-                    vec![]
+                    (vec![], None)
                 };
 
                 trace!(%destination, num_surbs = return_paths.len(), data_len = size_hint, "resolved packet");
-
-                let resolved_pseudonym = pseudonym.unwrap_or_else(HoprPseudonym::random);
-                // Capture the SURB-batch generation here, adjacent to return-path resolution, rather
-                // than at encode time. The replying side supersedes SURBs by generation, so a batch's
-                // generation must match the return-path plan it was minted for. Reading it here — with
-                // no `await` between choosing the return paths and this read — means a concurrent
-                // `bump_generation` (return-path re-plan, on the flush-loop task) cannot re-stamp an
-                // already-chosen plan; the window it could slip into is a couple of instructions
-                // instead of the whole resolve->encode pipeline hop. `None` when there is no return
-                // path (no SURBs are minted).
-                let generation =
-                    (!return_paths.is_empty()).then(|| self.surb_store.current_generation(&resolved_pseudonym));
 
                 Ok((
                     ResolvedTransportRouting::Forward {

--- a/transport/hopr/src/path/resolve.rs
+++ b/transport/hopr/src/path/resolve.rs
@@ -73,7 +73,7 @@ pub(crate) fn resolve_routing_stage<St, F, Fut>(
 where
     St: Stream<Item = (DestinationRouting, ApplicationDataOut)>,
     F: Fn(usize, usize, DestinationRouting) -> Fut + Clone,
-    Fut: Future<Output = PathResult<(ResolvedTransportRouting<HoprSurb>, Option<usize>)>>,
+    Fut: Future<Output = PathResult<(ResolvedTransportRouting<HoprSurb>, Option<usize>, Option<u8>)>>,
 {
     input
         .map(move |(unresolved, mut data)| {
@@ -96,7 +96,7 @@ where
                     )
                     .await
                     {
-                        Ok((resolved, rem_surbs)) => {
+                        Ok((resolved, rem_surbs, generation)) => {
                             // Set the SURB distress/out-of-SURBs flag if applicable.
                             // These flags are translated into HOPR protocol packet signals and are
                             // applicable only on the return path.
@@ -119,7 +119,12 @@ where
                                 signals_to_dst -= PacketSignal::SurbDistress | PacketSignal::OutOfSurbs;
                             }
 
-                            data.packet_info.get_or_insert_default().signals_to_destination = signals_to_dst;
+                            let info = data.packet_info.get_or_insert_default();
+                            info.signals_to_destination = signals_to_dst;
+                            // Carry the generation captured with the return-path plan alongside the
+                            // packet, so the encode stage stamps the plan's generation rather than
+                            // re-reading a possibly-newer one after a concurrent re-plan.
+                            info.surb_generation = generation;
                             trace!(?resolved, "resolved routing for packet");
                             return Some((resolved, data));
                         }
@@ -205,7 +210,7 @@ mod tests {
     where
         St: Stream<Item = (DestinationRouting, ApplicationDataOut)>,
         F: Fn(usize, usize, DestinationRouting) -> Fut + Clone,
-        Fut: Future<Output = PathResult<(ResolvedTransportRouting<HoprSurb>, Option<usize>)>>,
+        Fut: Future<Output = PathResult<(ResolvedTransportRouting<HoprSurb>, Option<usize>, Option<u8>)>>,
     {
         resolve_routing_stage(
             input,
@@ -293,7 +298,7 @@ mod tests {
             |_size_hint, _max_surbs, routing: DestinationRouting| async move {
                 match routing {
                     DestinationRouting::Return(_) => Err(no_surb(&routing)),
-                    DestinationRouting::Forward { .. } => Ok((resolved(), None)),
+                    DestinationRouting::Forward { .. } => Ok((resolved(), None, None)),
                 }
             },
         )
@@ -412,7 +417,7 @@ mod tests {
                     if attempts.fetch_add(1, Ordering::Relaxed) < FAILURES_BEFORE_SUCCESS {
                         Err(no_surb(&routing))
                     } else {
-                        Ok((resolved(), Some(0)))
+                        Ok((resolved(), Some(0), None))
                     }
                 }
             })
@@ -460,7 +465,7 @@ mod tests {
                 if SEEN.fetch_add(1, Ordering::Relaxed) == 0 {
                     Err(PathPlannerError::Api("no path".into()))
                 } else {
-                    Ok((resolved(), None))
+                    Ok((resolved(), None, None))
                 }
             },
         )
@@ -473,6 +478,37 @@ mod tests {
             emitted.iter().map(|(_, data)| marker_of(data)).collect::<Vec<_>>(),
             vec![1, 2],
             "only the unroutable packet is dropped; the rest keep their order"
+        );
+
+        Ok(())
+    }
+
+    /// The SURB-batch generation captured with the return-path plan (the third element of the
+    /// resolve result) must ride on the emitted packet's `packet_info`, so the encode stage stamps
+    /// that value instead of re-reading a possibly-newer one after a concurrent re-plan.
+    #[test_log::test(tokio::test)]
+    async fn resolved_packet_should_carry_the_captured_surb_generation() -> anyhow::Result<()> {
+        const CAPTURED: u8 = 7;
+
+        let input = futures::stream::iter(vec![(forward_routing(), packet(0))]);
+
+        let emitted = stage(input, |_size_hint, _max_surbs, _routing| async move {
+            Ok((resolved(), None, Some(CAPTURED)))
+        })
+        .take(1)
+        .collect::<Vec<_>>()
+        .timeout(futures_time::time::Duration::from(TEST_TIMEOUT))
+        .await
+        .map_err(|_| anyhow::anyhow!("the stage did not emit the packet within {TEST_TIMEOUT:?}"))?;
+
+        let (_, data) = emitted
+            .into_iter()
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("no packet emitted"))?;
+        assert_eq!(
+            data.packet_info.and_then(|info| info.surb_generation),
+            Some(CAPTURED),
+            "the generation captured at resolution must ride on packet_info to the encode stage"
         );
 
         Ok(())

--- a/transport/hopr/src/protocol/pipeline/mod.rs
+++ b/transport/hopr/src/protocol/pipeline/mod.rs
@@ -151,6 +151,9 @@ async fn start_outgoing_packet_pipeline<AppOut, A, E, WOut, WOutErr>(
             async move {
                 hopr_transport_session::counters::ENCODE_STAGE_ENTRIES
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                // The SURB-batch generation was captured with the return-path plan and carried on
+                // `packet_info`; stamp that, not a value re-read at encode time.
+                let generation = data.packet_info.and_then(|info| info.surb_generation);
                 match hopr_utils::parallelize::cpu::spawn_encode_blocking(
                     move || {
                         encoder.encode_packet(
@@ -159,6 +162,7 @@ async fn start_outgoing_packet_pipeline<AppOut, A, E, WOut, WOutErr>(
                             data.packet_info
                                 .map(|data| data.signals_to_destination)
                                 .unwrap_or_default(),
+                            generation,
                         )
                     },
                     "packet_encode",

--- a/transport/hopr/src/protocol/surb_telemetry.rs
+++ b/transport/hopr/src/protocol/surb_telemetry.rs
@@ -583,8 +583,9 @@ where
         data: T,
         routing: ResolvedTransportRouting<HoprSurb>,
         signals: S,
+        generation: Option<u8>,
     ) -> Result<OutgoingPacket, <Self as PacketEncoder>::Error> {
-        let packet = self.inner.encode_packet(data, routing.clone(), signals)?;
+        let packet = self.inner.encode_packet(data, routing.clone(), signals, generation)?;
         self.on_minted(&routing, &packet.minted_surbs);
         Ok(packet)
     }


### PR DESCRIPTION
The replying side supersedes SURBs by generation, so a batch's generation must match the return-path plan it was minted for. The generation was read in the encoder — a separate pipeline stage from where the return paths are chosen — which left a window in which a concurrent return-path re-plan could stamp an already-chosen plan with a newer generation. The harmful case is a stale route labelled with the newer generation: the peer clears its buffer, accepts the now-dead SURBs, and appends the genuinely fresh SURBs at the same generation with no further clear until the next re-plan, so it can hand out dead SURBs in between.

This captures the generation in the path planner, where the return paths are chosen, and carries it on the outgoing packet metadata to the encoder, which stamps that value instead of re-reading a current one. It is read before the return paths are resolved rather than after: because the flush loop recomputes paths and only then bumps the generation, a racing bump has by then already moved the planner to the new route, so reading first makes any residual mislabel a benign under-label (a fresh route with the previous generation, cleared on the next batch) and never the harmful over-label. This keeps the per-packet hot path lock-free while closing the race.
