### PR TITLE
feat(pix): make the SSA commitment retransmittable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4330,7 +4330,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-pix"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4401,7 +4401,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-protocol-start"
-version = "1.2.0"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "aquamarine",
@@ -4582,7 +4582,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-transport-session"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -151,16 +151,16 @@ hopr-protocol-app = { version = "1.0.1", path = "protocols/app", default-feature
 hopr-protocol-hopr = { version = "6.0.0", path = "protocols/hopr", default-features = false, features = [
   "rayon",
 ] }
-hopr-protocol-pix = { version = "0.1.0", path = "protocols/pix", default-features = false, features = [
+hopr-protocol-pix = { version = "0.2.0", path = "protocols/pix", default-features = false, features = [
   "rayon",
 ] }
 hopr-protocol-session = { version = "1.2.0", path = "protocols/session", default-features = false }
-hopr-protocol-start = { version = "1.1.0", path = "protocols/start", default-features = false }
+hopr-protocol-start = { version = "2.0.0", path = "protocols/start", default-features = false }
 hopr-ticket-manager = { version = "0.7.0" }
 hopr-transport = { version = "0.48.1", path = "transport/hopr" }
 hopr-transport-mixer = { version = "0.4.1", path = "transport/mixer", default-features = false }
 hopr-transport-probe = { version = "0.8.0", path = "transport/probe", default-features = false }
-hopr-transport-session = { version = "0.29.0", path = "transport/session", default-features = false }
+hopr-transport-session = { version = "0.30.0", path = "transport/session", default-features = false }
 hopr-transport-tag-allocator = { version = "0.1.1", path = "transport/tag-allocator", default-features = false }
 hopr-chain-connector = { version = "0.26.0" }
 

--- a/protocols/pix/Cargo.toml
+++ b/protocols/pix/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-protocol-pix"
-version = "0.1.0"
+version = "0.2.0"
 description = "Protocol for Incentivizing eXit nodes (PIX) as specified in HOPR RFC-0012"
 license = "GPL-3.0-only"
 homepage.workspace = true

--- a/protocols/pix/src/generator.rs
+++ b/protocols/pix/src/generator.rs
@@ -10,8 +10,8 @@ use vsss_rs::{
 
 use crate::{
     CONSTANT_TERM_COEFFICIENT, DEFAULT_POLY_THRESHOLD, DEFAULT_POLYS_PER_SSA, DEFAULT_SURPLUS_SHARES,
-    MAX_POLY_THRESHOLD, MAX_POLYS_PER_SSA, MIN_POLY_THRESHOLD, PixGroup, PixParams, PixScalar, PixSpec,
-    PolynomialIndex, SsaPartCommitment, errors,
+    MAX_COMMITMENT_RETRANSMISSIONS, MAX_POLY_THRESHOLD, MAX_POLYS_PER_SSA, MAX_RETAINED_COMMITMENT_CYCLES,
+    MIN_POLY_THRESHOLD, PixGroup, PixGroupRepr, PixParams, PixScalar, PixSpec, PolynomialIndex, errors,
     errors::PixError,
     traits::EntryShareGenerator,
     types::{
@@ -37,9 +37,47 @@ impl<S: PixSpec> IndexedPolynomial<S> {
     }
 }
 
+/// Everything needed to re-send part of one cycle's commitment, minus the polynomials themselves.
+///
+/// A cycle's commitment ships as hundreds of packets and the peer can only use it once *every* one
+/// has landed, so it must be able to ask for the pieces a lost packet took with it. Answering that
+/// needs the same bytes again, and neither half can be recovered from what
+/// [`SsaShareGenerator`] otherwise keeps: the proof opens the *sum* of the sub-secrets, which is not
+/// retained, and a polynomial exhausted by emission is dropped from the queue along with its
+/// constant term — so an Entry that recomputed would fail exactly when the peer has been waiting
+/// longest.
+///
+/// The cost is the compressed commitments, `polynomials_per_ssa × 33 B` — 270 kB at the deployed
+/// dimensions, against the ~33 MB of polynomial state the same cycle already holds.
+struct RetainedCommitment<S: PixSpec> {
+    ssa_index: SsaIndex,
+    /// Client commitment to the whole SSA, i.e. the sum of every constant term.
+    ssa_commitment: PixGroup<S>,
+    /// The proof of knowledge that opens [`Self::ssa_commitment`].
+    ///
+    /// Kept rather than re-proven, and re-sent verbatim: it is a non-interactive proof of a public
+    /// statement about a public commitment, so a second copy of the same proof discloses nothing a
+    /// fresh one would not, and re-proving would need the sum of the sub-secrets.
+    proof: SsaCommitmentProof<S>,
+    /// Wire-ready constant-term commitments, indexed by polynomial index.
+    constant_terms: Vec<PixGroupRepr<S>>,
+    /// Retransmission requests already answered for this cycle.
+    ///
+    /// Bounded by [`MAX_COMMITMENT_RETRANSMISSIONS`]: one request may name every polynomial, so an
+    /// answer is the whole burst again.
+    attempts_served: u8,
+}
+
 struct SsaPseudonymEntry<S: PixSpec> {
     ssa_index: SsaIndex,
     poly_queue: VecDeque<IndexedPolynomial<S>>,
+    /// Commitment material of the cycles this pseudonym can still serve, oldest first.
+    ///
+    /// Pruned in [`EntryShareGenerator::next_share`] as cycles drain out of `poly_queue`: a cycle
+    /// with no polynomial left can emit no further share, so no retransmission of its commitment
+    /// could make it recoverable. [`MAX_RETAINED_COMMITMENT_CYCLES`] caps it for a pseudonym that
+    /// commits without ever emitting, where nothing has yet drained.
+    retained_commitments: VecDeque<RetainedCommitment<S>>,
     /// Position within the emission window, i.e. into the first
     /// [`SHARE_EMISSION_WINDOW`] entries of `poly_queue`.
     cursor: usize,
@@ -388,6 +426,70 @@ impl<S: PixSpec> SsaShareGenerator<S> {
                 * (self.cfg.threshold as u64 + self.cfg.surplus_shares as u64),
         })
     }
+
+    /// Rebuilds the commitment of an already-committed cycle, restricted to the polynomial indices
+    /// the peer says it never received.
+    ///
+    /// A cycle's commitment ships as hundreds of packets and the peer can use it only once every one
+    /// of them has landed. Nothing else in the protocol repairs a lost packet: the peer cannot
+    /// reconstruct the missing commitment, and this side cannot tell which one went missing — so
+    /// without this a single drop costs a cycle the peer has usually already been told to fund. The
+    /// peer names the gaps, this fills them.
+    ///
+    /// The result is shaped exactly like [`new_ssa_commitment`](EntryShareGenerator::new_ssa_commitment)'s,
+    /// so the caller re-sends it through the same message splitting, carrying the *same* bytes and the
+    /// same proof. It advances no state the peer is charged for: no new index, no new polynomial, and
+    /// no second deposit — the caller must not announce one, since the address is unchanged and was
+    /// announced when the cycle was first committed.
+    ///
+    /// Each run is an inclusive `(first, last)` polynomial-index pair, expected ascending and
+    /// disjoint. Indices this cycle does not have are skipped.
+    ///
+    /// # Errors
+    /// * [`PixError::MissingSsaCommitment`] — nothing retained for `ssa_index`. Either it was never committed, or its
+    ///   last polynomial has been exhausted and the cycle can no longer be served at all, in which case a
+    ///   retransmission could not save it either.
+    /// * [`PixError::InvalidInput`] — [`MAX_COMMITMENT_RETRANSMISSIONS`] answers have already been given for this
+    ///   cycle, or `runs` selects nothing. The cap is what keeps a peer that has already been served from farming whole
+    ///   bursts out of this node; a request that selects nothing still spends an attempt, so malformed scopes are not
+    ///   free either.
+    pub fn recommit(
+        &self,
+        pseudonym: &S::Pseudonym,
+        ssa_index: SsaIndex,
+        runs: impl IntoIterator<Item = (PolynomialIndex, PolynomialIndex)>,
+    ) -> errors::Result<SsaCommitment<S>, S::Pseudonym> {
+        let entry = self.polynomials.get(pseudonym).ok_or(PixError::MissingSsaCommitment)?;
+        let mut entry = entry.lock();
+        let retained = entry
+            .retained_commitments
+            .iter_mut()
+            .find(|retained| retained.ssa_index == ssa_index)
+            .ok_or(PixError::MissingSsaCommitment)?;
+
+        if retained.attempts_served >= MAX_COMMITMENT_RETRANSMISSIONS {
+            return Err(PixError::InvalidInput);
+        }
+        // Spent before the scope is judged, so a peer cannot probe with cheap malformed asks.
+        retained.attempts_served += 1;
+
+        let selected = selected_constant_terms::<S>(&retained.constant_terms, runs);
+        if selected.is_empty() {
+            return Err(PixError::InvalidInput);
+        }
+
+        tracing::debug!(
+            %pseudonym, %ssa_index, count = selected.len(), attempt = retained.attempts_served,
+            "re-sending part of an ssa commitment"
+        );
+
+        Ok(SsaCommitment {
+            ssa_id: SsaId::new(*pseudonym, ssa_index),
+            ssa_commitment: retained.ssa_commitment,
+            commitment_proof: retained.proof,
+            verifiers: transposed_constant_terms::<S>(selected),
+        })
+    }
 }
 
 impl<S: PixSpec> Default for SsaShareGenerator<S> {
@@ -420,6 +522,7 @@ impl<S: PixSpec> EntryShareGenerator<S> for SsaShareGenerator<S> {
         let mut entry = entry.lock();
         let SsaPseudonymEntry {
             poly_queue,
+            retained_commitments,
             cursor,
             highest_emitted,
             front_run,
@@ -446,6 +549,11 @@ impl<S: PixSpec> EntryShareGenerator<S> for SsaShareGenerator<S> {
                 // A new cycle takes the front, so the emission counter restarts with it. This is the
                 // only place it is cleared, which is what keeps it measuring the front cycle alone.
                 *front_emitted = 0;
+                // A cycle behind the new front has no polynomial left, so it can emit no further
+                // share and re-sending its commitment could not make it recoverable. This is the one
+                // place a cycle becomes unservable, so it is where its retained commitment goes.
+                let front_ssa_index = poly_queue[0].spi.as_ref().ssa_index();
+                retained_commitments.retain(|retained| retained.ssa_index >= front_ssa_index);
             }
 
             let window = (*front_run).min(SHARE_EMISSION_WINDOW).min(poly_queue.len()).max(1);
@@ -537,48 +645,61 @@ impl<S: PixSpec> EntryShareGenerator<S> for SsaShareGenerator<S> {
             .into_iter()
             .unzip();
 
-        let mut commitments: Vec<SsaPartCommitment<S>> = Vec::with_capacity(raw_commitments.len());
+        // Compressed exactly once, here. The same bytes go on the wire now and again if the peer
+        // asks for a piece it never received, so the retained copy *is* the wire form rather than
+        // something re-derived from the group elements — compression is the dominant per-commitment
+        // cost, and two derivations of the same bytes are two chances to disagree.
+        let constant_terms: Vec<PixGroupRepr<S>> = raw_commitments.iter().map(|c| c.to_bytes()).collect();
+
+        // Built from the parameters rather than read back off the commitments: every element above
+        // was constructed with exactly this `SsaId`, and indexing would have made the whole function
+        // depend on `polynomials_per_ssa >= 1` holding — which is a validation invariant enforced
+        // three call layers away, not something visible here.
+        let ssa_id = SsaId::new(*pseudonym, ssa_index);
+        let ssa_commitment = PixGroup::<S>::generator() * our_commitment_secret;
+        // Proves we know the sum of the sub-secrets. The recipient adds its own commitment to ours
+        // to get the deposit key, and this is what stops us from having chosen our half so that we —
+        // rather than nobody — know that sum. See `SsaCommitmentProof`.
+        let commitment_proof = SsaCommitmentProof::prove(&ssa_id, &our_commitment_secret, &ssa_commitment)?;
+
+        // Cloned rather than moved: the caller gets these bytes to put on the wire, and the entry
+        // keeps them to answer a request for the pieces that never arrived. 270 kB at the deployed
+        // dimensions — see `RetainedCommitment`.
+        let retained = RetainedCommitment {
+            ssa_index,
+            ssa_commitment,
+            proof: commitment_proof,
+            constant_terms: constant_terms.clone(),
+            attempts_served: 0,
+        };
 
         self.polynomials
             .entry_by_ref(pseudonym)
             .and_try_compute_with(|entry| match entry {
-                None => {
-                    commitments.extend(
-                        raw_commitments
+                None => Ok::<_, PixError<S::Pseudonym>>(moka::ops::compute::Op::Put(std::sync::Arc::new(
+                    parking_lot::Mutex::new(SsaPseudonymEntry {
+                        ssa_index,
+                        cursor: 0,
+                        highest_emitted: None,
+                        // Picked up lazily by `next_share`, like every later cycle's.
+                        front_run: 0,
+                        front_emitted: 0,
+                        retained_commitments: VecDeque::from([retained]),
+                        poly_queue: raw_polynomials
                             .into_iter()
                             .enumerate()
-                            .map(|(poly_index, constant_term)| SsaPartCommitment {
+                            .map(|(poly_index, raw)| IndexedPolynomial {
                                 spi: SsaPolynomialId::new(
                                     SsaId::new(*pseudonym, ssa_index),
                                     poly_index as PolynomialIndex,
                                 ),
-                                constant_term,
-                            }),
-                    );
-                    Ok::<_, PixError<S::Pseudonym>>(moka::ops::compute::Op::Put(std::sync::Arc::new(
-                        parking_lot::Mutex::new(SsaPseudonymEntry {
-                            ssa_index,
-                            cursor: 0,
-                            highest_emitted: None,
-                            // Picked up lazily by `next_share`, like every later cycle's.
-                            front_run: 0,
-                            front_emitted: 0,
-                            poly_queue: raw_polynomials
-                                .into_iter()
-                                .enumerate()
-                                .map(|(poly_index, raw)| IndexedPolynomial {
-                                    spi: SsaPolynomialId::new(
-                                        SsaId::new(*pseudonym, ssa_index),
-                                        poly_index as PolynomialIndex,
-                                    ),
-                                    raw,
-                                    shares_generated: 0,
-                                    t: self.cfg.threshold as usize,
-                                })
-                                .collect(),
-                        }),
-                    )))
-                }
+                                raw,
+                                shares_generated: 0,
+                                t: self.cfg.threshold as usize,
+                            })
+                            .collect(),
+                    }),
+                ))),
                 Some(value) => {
                     let value = value.into_value();
                     {
@@ -588,15 +709,14 @@ impl<S: PixSpec> EntryShareGenerator<S> for SsaShareGenerator<S> {
                         }
                         entry.ssa_index = ssa_index;
 
-                        commitments.extend(raw_commitments.into_iter().enumerate().map(
-                            |(poly_index, constant_term)| SsaPartCommitment {
-                                spi: SsaPolynomialId::new(
-                                    SsaId::new(*pseudonym, ssa_index),
-                                    poly_index as PolynomialIndex,
-                                ),
-                                constant_term,
-                            },
-                        ));
+                        entry.retained_commitments.push_back(retained);
+                        // Only reachable for a pseudonym that keeps committing without emitting, so
+                        // nothing has drained and the pruning in `next_share` has not run. Dropping
+                        // the oldest gives up retransmission for the cycle least likely to still be
+                        // awaited.
+                        while entry.retained_commitments.len() > MAX_RETAINED_COMMITMENT_CYCLES {
+                            entry.retained_commitments.pop_front();
+                        }
 
                         entry
                             .poly_queue
@@ -617,22 +737,39 @@ impl<S: PixSpec> EntryShareGenerator<S> for SsaShareGenerator<S> {
                 }
             })?;
 
-        // Built from the parameters rather than read back off `commitments[0]`: every element above
-        // was constructed with exactly this `SsaId`, and indexing would have made the whole function
-        // depend on `polynomials_per_ssa >= 1` holding — which is a validation invariant enforced
-        // three call layers away, not something visible here.
-        let ssa_id = SsaId::new(*pseudonym, ssa_index);
-        let ssa_commitment = PixGroup::<S>::generator() * our_commitment_secret;
         Ok(SsaCommitment {
             ssa_id,
             ssa_commitment,
-            // Proves we know the sum of the sub-secrets. The recipient adds its own commitment to
-            // ours to get the deposit key, and this is what stops us from having chosen our half so
-            // that we — rather than nobody — know that sum. See `SsaCommitmentProof`.
-            commitment_proof: SsaCommitmentProof::prove(&ssa_id, &our_commitment_secret, &ssa_commitment)?,
-            verifiers: transposed_constant_terms(commitments),
+            commitment_proof,
+            verifiers: transposed_constant_terms::<S>(selected_constant_terms::<S>(
+                &constant_terms,
+                [(0, constant_terms.len().saturating_sub(1) as PolynomialIndex)],
+            )),
         })
     }
+}
+
+/// Picks out the constant-term commitments covered by `runs`, in ascending polynomial-index order.
+///
+/// Each run is an inclusive `(first, last)` polynomial-index pair. Runs are expected ascending and
+/// disjoint — which is what the wire decoder enforces and what the Exit's own scope produces — so
+/// this concatenates rather than deduplicating, and a caller passing overlapping runs merely repeats
+/// entries the peer then discards as re-deliveries.
+///
+/// Indices past the end are skipped rather than refused: a peer naming a polynomial this cycle does
+/// not have is asking for something that cannot exist, and there is nothing to send for it.
+fn selected_constant_terms<S: PixSpec>(
+    constant_terms: &[PixGroupRepr<S>],
+    runs: impl IntoIterator<Item = (PolynomialIndex, PolynomialIndex)>,
+) -> Vec<(PolynomialIndex, PixGroupRepr<S>)> {
+    runs.into_iter()
+        .flat_map(|(first, last)| first..=last)
+        .filter_map(|poly_index| {
+            constant_terms
+                .get(poly_index as usize)
+                .map(|commitment| (poly_index, *commitment))
+        })
+        .collect()
 }
 
 /// Lays the per-polynomial constant-term commitments out in the coefficient-major form the wire
@@ -642,15 +779,11 @@ impl<S: PixSpec> EntryShareGenerator<S> for SsaShareGenerator<S> {
 /// rather than flattened to a plain `Vec` because it is what `SsaClientCommitmentMessage` splits
 /// into packets, and the wire format still admits higher coefficient indices even though PIX no
 /// longer produces any.
-pub(crate) fn transposed_constant_terms<S: PixSpec>(commitments: Vec<SsaPartCommitment<S>>) -> TransposedVerifiers<S> {
+fn transposed_constant_terms<S: PixSpec>(
+    constant_terms: Vec<(PolynomialIndex, PixGroupRepr<S>)>,
+) -> TransposedVerifiers<S> {
     let mut transposed = TransposedVerifiers::<S>::new();
-    transposed.insert(
-        CONSTANT_TERM_COEFFICIENT,
-        commitments
-            .into_iter()
-            .map(|c| (c.spi.poly_index(), c.constant_term.to_bytes()))
-            .collect(),
-    );
+    transposed.insert(CONSTANT_TERM_COEFFICIENT, constant_terms);
     transposed
 }
 
@@ -664,6 +797,144 @@ mod tests {
 
     use super::*;
     use crate::{tests::TestSpec, traits::EntryShareGenerator};
+
+    /// A retransmission answers only what was asked for, only for a cycle that was committed, and
+    /// only a bounded number of times.
+    ///
+    /// The cap is the load-bearing part: one request may name every polynomial of the cycle, so an
+    /// answer is the whole commitment burst again, and a peer that has already been served would
+    /// otherwise be able to farm bursts out of this node indefinitely.
+    #[test]
+    fn recommit_answers_the_named_scope_a_bounded_number_of_times() -> anyhow::Result<()> {
+        const POLYS: u16 = 8;
+        let generator = SsaShareGenerator::<TestSpec>::new(SsaGeneratorConfig {
+            polynomials_per_ssa: POLYS,
+            threshold: 2,
+            surplus_shares: 0,
+        });
+        let pseudonym = SimplePseudonym::random();
+
+        // Nothing is retained for a pseudonym that has never committed, nor for an index it has not.
+        assert!(matches!(
+            generator.recommit(&pseudonym, SsaIndex::MIN, [(0, 0)]),
+            Err(PixError::MissingSsaCommitment)
+        ));
+
+        let original = generator.new_ssa_commitment(&pseudonym, SsaIndex::MIN)?;
+        assert!(matches!(
+            generator.recommit(&pseudonym, 2.try_into()?, [(0, 0)]),
+            Err(PixError::MissingSsaCommitment)
+        ));
+
+        let row_of = |commitment: &SsaCommitment<TestSpec>| {
+            commitment
+                .verifiers
+                .get(&CONSTANT_TERM_COEFFICIENT)
+                .cloned()
+                .unwrap_or_default()
+        };
+        let full = row_of(&original);
+
+        // The scope is honoured exactly, and answered with the bytes that went out the first time.
+        let repair = generator.recommit(&pseudonym, SsaIndex::MIN, [(1, 2), (5, 5)])?;
+        assert_eq!(original.ssa_id, repair.ssa_id);
+        assert_eq!(original.ssa_commitment, repair.ssa_commitment);
+        assert_eq!(
+            original.commitment_proof, repair.commitment_proof,
+            "the proof opens the same public commitment, so the same one is re-sent"
+        );
+        assert_eq!(
+            vec![1, 2, 5],
+            row_of(&repair).iter().map(|(index, _)| *index).collect::<Vec<_>>()
+        );
+        for (poly_index, resent) in row_of(&repair) {
+            assert_eq!(
+                Some(&resent),
+                full.iter().find(|(index, _)| *index == poly_index).map(|(_, o)| o)
+            );
+        }
+
+        // Indices this cycle does not have are skipped; a scope of nothing but those is refused, and
+        // still spends an attempt, so malformed asks are not a free probe.
+        assert_eq!(
+            vec![POLYS as PolynomialIndex - 1],
+            row_of(&generator.recommit(&pseudonym, SsaIndex::MIN, [(POLYS - 1, POLYS + 4)])?)
+                .iter()
+                .map(|(index, _)| *index)
+                .collect::<Vec<_>>()
+        );
+        assert!(matches!(
+            generator.recommit(&pseudonym, SsaIndex::MIN, [(POLYS, POLYS)]),
+            Err(PixError::InvalidInput)
+        ));
+
+        // Three answers spent above, including the refused scope. Spend the rest of the budget, then
+        // find it closed.
+        for attempt in 3..MAX_COMMITMENT_RETRANSMISSIONS {
+            generator
+                .recommit(&pseudonym, SsaIndex::MIN, [(0, 0)])
+                .map_err(|error| anyhow::anyhow!("attempt {attempt} must be answered: {error}"))?;
+        }
+        assert!(
+            matches!(
+                generator.recommit(&pseudonym, SsaIndex::MIN, [(0, 0)]),
+                Err(PixError::InvalidInput)
+            ),
+            "the {MAX_COMMITMENT_RETRANSMISSIONS}-answer budget must be spent"
+        );
+
+        Ok(())
+    }
+
+    /// Retained commitment material is released with the cycle it belongs to.
+    ///
+    /// A cycle whose last polynomial has been exhausted can emit no further share, so re-sending its
+    /// commitment could not make it recoverable — and holding the material past that point would make
+    /// the retention grow with the number of cycles a Session completes.
+    #[test]
+    fn a_drained_cycle_stops_being_retransmittable() -> anyhow::Result<()> {
+        const POLYS: u16 = 2;
+        const THRESHOLD: u8 = 2;
+        let generator = SsaShareGenerator::<TestSpec>::new(SsaGeneratorConfig {
+            polynomials_per_ssa: POLYS,
+            threshold: THRESHOLD,
+            surplus_shares: 0,
+        });
+        let pseudonym = SimplePseudonym::random();
+
+        generator.new_ssa_commitment(&pseudonym, SsaIndex::MIN)?;
+        generator.new_ssa_commitment(&pseudonym, 2.try_into()?)?;
+
+        // Both are retransmittable while both are queued: a successor's commitment can be lost just
+        // as easily as the front's, and it is not being served yet.
+        generator.recommit(&pseudonym, SsaIndex::MIN, [(0, 0)])?;
+        generator.recommit(&pseudonym, 2.try_into()?, [(0, 0)])?;
+
+        // Exhaust the first cycle, then take one more share so the front rotates. Pruning is lazy:
+        // it happens where the new front is picked up, not where the last polynomial is removed.
+        let per_cycle = POLYS as u32 * THRESHOLD as u32;
+        for msg in 0..=per_cycle {
+            let share = generator
+                .next_share(&pseudonym, &msg.to_be_bytes())?
+                .ok_or_else(|| anyhow::anyhow!("share {msg} must be available"))?;
+            if msg == per_cycle {
+                assert_eq!(2, share.id.ssa_index().get(), "the front must have rotated");
+            }
+        }
+
+        assert!(
+            matches!(
+                generator.recommit(&pseudonym, SsaIndex::MIN, [(0, 0)]),
+                Err(PixError::MissingSsaCommitment)
+            ),
+            "a drained cycle must not retain its commitment"
+        );
+        generator
+            .recommit(&pseudonym, 2.try_into()?, [(0, 0)])
+            .map_err(|error| anyhow::anyhow!("the cycle now at the front must stay retransmittable: {error}"))?;
+
+        Ok(())
+    }
 
     /// No share for a cycle may be emitted while any polynomial of an earlier cycle is unexhausted.
     ///

--- a/protocols/pix/src/generator.rs
+++ b/protocols/pix/src/generator.rs
@@ -48,7 +48,8 @@ impl<S: PixSpec> IndexedPolynomial<S> {
 /// longest.
 ///
 /// The cost is the compressed commitments, `polynomials_per_ssa × 33 B` — 270 kB at the deployed
-/// dimensions, against the ~33 MB of polynomial state the same cycle already holds.
+/// dimensions, against the ~33 MB of polynomial state a cycle holds while it is still being served.
+/// [`MAX_RETAINED_COMMITMENT_CYCLES`] bounds how many are held at once.
 struct RetainedCommitment<S: PixSpec> {
     ssa_index: SsaIndex,
     /// Client commitment to the whole SSA, i.e. the sum of every constant term.
@@ -71,12 +72,15 @@ struct RetainedCommitment<S: PixSpec> {
 struct SsaPseudonymEntry<S: PixSpec> {
     ssa_index: SsaIndex,
     poly_queue: VecDeque<IndexedPolynomial<S>>,
-    /// Commitment material of the cycles this pseudonym can still serve, oldest first.
+    /// Commitment material of the cycles most recently committed for this pseudonym, oldest first.
     ///
-    /// Pruned in [`EntryShareGenerator::next_share`] as cycles drain out of `poly_queue`: a cycle
-    /// with no polynomial left can emit no further share, so no retransmission of its commitment
-    /// could make it recoverable. [`MAX_RETAINED_COMMITMENT_CYCLES`] caps it for a pseudonym that
-    /// commits without ever emitting, where nothing has yet drained.
+    /// Bounded by [`MAX_RETAINED_COMMITMENT_CYCLES`] and by nothing else — in particular not by
+    /// emission, which is not a proxy for the peer's need: the peer completes a cycle out of the
+    /// shares it has already buffered and the commitment it is still missing, on its own deadline,
+    /// whether or not the polynomials that produced those shares are still queued here. Releasing on
+    /// drain would take the material away exactly where the repair is worth most, since a fully
+    /// emitted cycle is one whose every share has gone out and whose only missing piece is the one a
+    /// dropped packet took.
     retained_commitments: VecDeque<RetainedCommitment<S>>,
     /// Position within the emission window, i.e. into the first
     /// [`SHARE_EMISSION_WINDOW`] entries of `poly_queue`.
@@ -260,7 +264,7 @@ pub const SHARE_EMISSION_WINDOW: usize = 256;
 ///
 /// Only the constant term is committed to. The higher coefficients still exist — they are what
 /// makes the shares hide the secret — but no commitment to them is published, so the Exit cannot
-/// (and no longer needs to) check an individual share. See [`SsaPartCommitment`].
+/// (and no longer needs to) check an individual share. See [`crate::SsaPartCommitment`].
 ///
 /// This is also why the Entry's per-cycle cost collapsed: committing to every coefficient was
 /// `polys × threshold` fixed-base multiplications against an untabulated generator, over half a
@@ -322,7 +326,7 @@ pub struct SsaGeneratorConfig {
     /// that reach it, so any of the surplus can stand in for one that never arrives. It does not
     /// cover *corrupt* shares — nothing checks a share on arrival any more, so a bad one is only
     /// noticed once it has already poisoned the interpolation. See
-    /// [`SsaPartCommitment`].
+    /// [`crate::SsaPartCommitment`].
     ///
     /// Emitting them is unconditional: a polynomial leaves the queue at `threshold + surplus`
     /// shares, whether or not any were lost, so the Exit serves this many packets per polynomial in
@@ -446,9 +450,10 @@ impl<S: PixSpec> SsaShareGenerator<S> {
     /// disjoint. Indices this cycle does not have are skipped.
     ///
     /// # Errors
-    /// * [`PixError::MissingSsaCommitment`] — nothing retained for `ssa_index`. Either it was never committed, or its
-    ///   last polynomial has been exhausted and the cycle can no longer be served at all, in which case a
-    ///   retransmission could not save it either.
+    /// * [`PixError::MissingSsaCommitment`] — nothing retained for `ssa_index`. Either it was never committed, or
+    ///   [`MAX_RETAINED_COMMITMENT_CYCLES`] newer cycles have pushed it out. Having exhausted a cycle's polynomials
+    ///   does *not* put it here: whether a repair still helps depends on what the peer holds, not on what this side can
+    ///   still emit.
     /// * [`PixError::InvalidInput`] — [`MAX_COMMITMENT_RETRANSMISSIONS`] answers have already been given for this
     ///   cycle, or `runs` selects nothing. The cap is what keeps a peer that has already been served from farming whole
     ///   bursts out of this node; a request that selects nothing still spends an attempt, so malformed scopes are not
@@ -522,7 +527,6 @@ impl<S: PixSpec> EntryShareGenerator<S> for SsaShareGenerator<S> {
         let mut entry = entry.lock();
         let SsaPseudonymEntry {
             poly_queue,
-            retained_commitments,
             cursor,
             highest_emitted,
             front_run,
@@ -549,11 +553,6 @@ impl<S: PixSpec> EntryShareGenerator<S> for SsaShareGenerator<S> {
                 // A new cycle takes the front, so the emission counter restarts with it. This is the
                 // only place it is cleared, which is what keeps it measuring the front cycle alone.
                 *front_emitted = 0;
-                // A cycle behind the new front has no polynomial left, so it can emit no further
-                // share and re-sending its commitment could not make it recoverable. This is the one
-                // place a cycle becomes unservable, so it is where its retained commitment goes.
-                let front_ssa_index = poly_queue[0].spi.as_ref().ssa_index();
-                retained_commitments.retain(|retained| retained.ssa_index >= front_ssa_index);
             }
 
             let window = (*front_run).min(SHARE_EMISSION_WINDOW).min(poly_queue.len()).max(1);
@@ -710,10 +709,10 @@ impl<S: PixSpec> EntryShareGenerator<S> for SsaShareGenerator<S> {
                         entry.ssa_index = ssa_index;
 
                         entry.retained_commitments.push_back(retained);
-                        // Only reachable for a pseudonym that keeps committing without emitting, so
-                        // nothing has drained and the pruning in `next_share` has not run. Dropping
-                        // the oldest gives up retransmission for the cycle least likely to still be
-                        // awaited.
+                        // The only thing that releases retained material, so this runs on the
+                        // ordinary path rather than only for a pathological peer. The index is
+                        // strictly increasing — enforced just above — so the front is the oldest
+                        // cycle, i.e. the one least likely to still be awaited.
                         while entry.retained_commitments.len() > MAX_RETAINED_COMMITMENT_CYCLES {
                             entry.retained_commitments.pop_front();
                         }
@@ -886,13 +885,16 @@ mod tests {
         Ok(())
     }
 
-    /// Retained commitment material is released with the cycle it belongs to.
+    /// A cycle stays retransmittable once its own emission has finished, and is released only by the
+    /// retention cap.
     ///
-    /// A cycle whose last polynomial has been exhausted can emit no further share, so re-sending its
-    /// commitment could not make it recoverable — and holding the material past that point would make
-    /// the retention grow with the number of cycles a Session completes.
+    /// Emission progress says nothing about whether a repair still helps. The peer completes a cycle
+    /// out of the shares it has already buffered plus the commitment it is missing, on its own
+    /// deadline — so a fully emitted cycle is the *likeliest* one to be asked about, every share
+    /// having gone out and the only missing piece being the one a dropped packet took. Releasing the
+    /// material on drain made the repair fail exactly there.
     #[test]
-    fn a_drained_cycle_stops_being_retransmittable() -> anyhow::Result<()> {
+    fn a_drained_cycle_stays_retransmittable_until_the_cap_evicts_it() -> anyhow::Result<()> {
         const POLYS: u16 = 2;
         const THRESHOLD: u8 = 2;
         let generator = SsaShareGenerator::<TestSpec>::new(SsaGeneratorConfig {
@@ -910,8 +912,7 @@ mod tests {
         generator.recommit(&pseudonym, SsaIndex::MIN, [(0, 0)])?;
         generator.recommit(&pseudonym, 2.try_into()?, [(0, 0)])?;
 
-        // Exhaust the first cycle, then take one more share so the front rotates. Pruning is lazy:
-        // it happens where the new front is picked up, not where the last polynomial is removed.
+        // Exhaust the first cycle, then take one more share so the front rotates onto the second.
         let per_cycle = POLYS as u32 * THRESHOLD as u32;
         for msg in 0..=per_cycle {
             let share = generator
@@ -922,16 +923,24 @@ mod tests {
             }
         }
 
+        generator
+            .recommit(&pseudonym, SsaIndex::MIN, [(0, 0)])
+            .map_err(|error| anyhow::anyhow!("a fully emitted cycle must stay retransmittable: {error}"))?;
+
+        // Two are already retained, so committing up to one past the cap is what pushes the first out.
+        for index in 3..=MAX_RETAINED_COMMITMENT_CYCLES as u32 + 1 {
+            generator.new_ssa_commitment(&pseudonym, index.try_into()?)?;
+        }
         assert!(
             matches!(
                 generator.recommit(&pseudonym, SsaIndex::MIN, [(0, 0)]),
                 Err(PixError::MissingSsaCommitment)
             ),
-            "a drained cycle must not retain its commitment"
+            "retention must stay bounded at {MAX_RETAINED_COMMITMENT_CYCLES} cycles"
         );
         generator
             .recommit(&pseudonym, 2.try_into()?, [(0, 0)])
-            .map_err(|error| anyhow::anyhow!("the cycle now at the front must stay retransmittable: {error}"))?;
+            .map_err(|error| anyhow::anyhow!("the oldest cycle still inside the cap must be retained: {error}"))?;
 
         Ok(())
     }

--- a/protocols/pix/src/lib.rs
+++ b/protocols/pix/src/lib.rs
@@ -172,6 +172,32 @@ pub const DEFAULT_SURPLUS_SHARES: u8 = default_surplus_for(DEFAULT_POLY_THRESHOL
 /// Maximum number of polynomials per SSA supported by the [`SsaReconstructor`].
 pub const MAX_POLYS_PER_SSA: u16 = 16192;
 
+/// Retransmission requests the Entry answers for one SSA cycle.
+///
+/// A cycle's commitment ships as hundreds of packets, and a single lost one strands the whole cycle
+/// (see [`SsaShareGenerator::recommit`]), so the Exit must be able to ask again for the pieces it
+/// never received. This bounds how often it may: one request can legally name every polynomial of
+/// the cycle, and an answer is the entire burst again, so an unbounded count is a packet
+/// amplification lever available to a peer that has already been served.
+///
+/// Eight, because the Exit re-asks on an idle timer rather than once. At the shipped Exit settings
+/// — a 3 s re-request interval inside a 20 s commitment deadline — a cycle can produce about six
+/// attempts, and a peer batching several SSAs per request produces proportionally more against a
+/// scaled deadline. The excess is simply refused: an unanswered request costs the Exit one packet
+/// and this node nothing, which is why the two sides are not required to agree on the figure.
+pub const MAX_COMMITMENT_RETRANSMISSIONS: u8 = 8;
+
+/// Cycles per pseudonym whose commitment material the [`SsaShareGenerator`] retains for
+/// retransmission.
+///
+/// The retained material is dropped as soon as a cycle can no longer be served at all — see
+/// [`SsaShareGenerator::recommit`] — so this cap only binds for a pseudonym that commits to cycles
+/// without ever emitting a share of them, where nothing has yet drained. Eighteen is what
+/// `hopr-transport-session` can have live at once, `MAX_OVERLAPPING_BATCHES` (2) generations of
+/// `MAX_SSA_BATCH_SIZE` (9) cycles each; the constants are not visible from here, so the derivation
+/// is written down rather than imported.
+pub const MAX_RETAINED_COMMITMENT_CYCLES: usize = 18;
+
 /// Minimum SSA polynomial threshold.
 ///
 /// A threshold of 1 would make every single share reconstruct its polynomial on its own, so the

--- a/protocols/pix/src/lib.rs
+++ b/protocols/pix/src/lib.rs
@@ -206,13 +206,25 @@ pub const MAX_COMMITMENT_RETRANSMISSIONS: u8 = 8;
 /// asking for far longer than [`MAX_COMMITMENT_RETRANSMISSIONS`] attempts on any sane re-request
 /// interval allow.
 ///
-/// Costs `polynomials_per_ssa × 33 B` per cycle — 4.8 MB per pseudonym with the cap full at the
-/// deployed dimensions, against the ~33 MB a single *undrained* cycle's polynomials occupy. This is
-/// Entry-side state, held per pseudonym and released with the rest of that pseudonym's polynomial
-/// state, by [`SsaShareGenerator::forget`] at teardown or by the cache's own idle eviction. It is
-/// therefore bounded by the Sessions this node has itself opened, and no peer can hold more of it
-/// than the cap allows — which is why it is not charged against an Exit's incoming-Session memory
-/// budget, where nothing else the generator holds is charged either.
+/// Costs `polynomials_per_ssa × 33 B` per cycle — 270 kB at the deployed dimensions, 4.8 MB per
+/// pseudonym with the cap full. Entry-side state, which is why it is not charged against an Exit's
+/// incoming-Session memory budget: that reserves reconstructor state for Sessions this node *serves*,
+/// and nothing else the generator holds is charged there either.
+///
+/// It lives as long as the pseudonym's entry in the generator's cache, which idle eviction alone
+/// releases — closing a Session clears nothing here. So a node holds this for every Entry Session it
+/// closed within that window, and churn accumulates it rather than tracking the live Session count.
+/// What bounds the consequence is that the same entry keeps its polynomial state under exactly the
+/// same rule, and that term is larger by two orders of magnitude: 270 kB here against ~33 MB there,
+/// per cycle. A Session whose cycles are still queued when it closes — the ordinary case, since
+/// draining one takes `polynomials_per_ssa × (threshold + surplus)` shares, 655 k at the deployed
+/// dimensions — leaves both, and this is under 1% of it. Reaching the cap instead means having
+/// drained eighteen cycles, some twelve million shares, by which point the polynomials are gone and
+/// 4.8 MB is the entire residue.
+///
+/// Clearing the entry outright at Session teardown would release both sooner, and is worth doing for
+/// the polynomial term; [`SsaShareGenerator::forget`] exists for it, but no production path calls it
+/// today.
 pub const MAX_RETAINED_COMMITMENT_CYCLES: usize = 18;
 
 /// Minimum SSA polynomial threshold.

--- a/protocols/pix/src/lib.rs
+++ b/protocols/pix/src/lib.rs
@@ -190,8 +190,9 @@ pub const MAX_COMMITMENT_RETRANSMISSIONS: u8 = 8;
 /// Cycles per pseudonym whose commitment material the [`SsaShareGenerator`] retains for
 /// retransmission.
 ///
-/// The newest this many are kept and the oldest is evicted, and that is the *only* thing that
-/// releases them — emission deliberately does not enter into it. Whether a re-sent commitment is
+/// The newest this many are kept and the oldest is evicted, and within a live cache entry that is
+/// the only thing that releases them — emission deliberately does not enter into it. (The entry as a
+/// whole goes on idle eviction, which is a separate lifetime; see below.) Whether a re-sent commitment is
 /// still worth anything is a question about what the peer holds, and none of that is visible from
 /// this side: it completes a cycle out of the shares it has already buffered plus the commitment it
 /// is still missing, on its own delivery deadline. Releasing on drain instead would give up the
@@ -212,8 +213,9 @@ pub const MAX_COMMITMENT_RETRANSMISSIONS: u8 = 8;
 /// and nothing else the generator holds is charged there either.
 ///
 /// It lives as long as the pseudonym's entry in the generator's cache, which idle eviction alone
-/// releases — closing a Session clears nothing here. So a node holds this for every Entry Session it
-/// closed within that window, and churn accumulates it rather than tracking the live Session count.
+/// releases — closing a Session clears nothing here. So a node holds this for every pseudonym it has
+/// committed a cycle for within that window, Sessions long closed included, and churn accumulates it
+/// rather than it tracking the live Session count.
 /// What bounds the consequence is that the same entry keeps its polynomial state under exactly the
 /// same rule, and that term is larger by two orders of magnitude: 270 kB here against ~33 MB there,
 /// per cycle. A Session whose cycles are still queued when it closes — the ordinary case, since

--- a/protocols/pix/src/lib.rs
+++ b/protocols/pix/src/lib.rs
@@ -190,12 +190,24 @@ pub const MAX_COMMITMENT_RETRANSMISSIONS: u8 = 8;
 /// Cycles per pseudonym whose commitment material the [`SsaShareGenerator`] retains for
 /// retransmission.
 ///
-/// The retained material is dropped as soon as a cycle can no longer be served at all — see
-/// [`SsaShareGenerator::recommit`] — so this cap only binds for a pseudonym that commits to cycles
-/// without ever emitting a share of them, where nothing has yet drained. Eighteen is what
-/// `hopr-transport-session` can have live at once, `MAX_OVERLAPPING_BATCHES` (2) generations of
-/// `MAX_SSA_BATCH_SIZE` (9) cycles each; the constants are not visible from here, so the derivation
-/// is written down rather than imported.
+/// The newest this many are kept and the oldest is evicted, and that is the *only* thing that
+/// releases them — emission deliberately does not enter into it. Whether a re-sent commitment is
+/// still worth anything is a question about what the peer holds, and none of that is visible from
+/// this side: it completes a cycle out of the shares it has already buffered plus the commitment it
+/// is still missing, on its own delivery deadline. Releasing on drain instead would give up the
+/// repair exactly where it is worth most, a cycle whose every share has gone out and whose only
+/// missing piece is the one a lost packet took.
+///
+/// Eighteen is `MAX_OVERLAPPING_BATCHES` (2) generations of `MAX_SSA_BATCH_SIZE` (9) cycles, the
+/// figures `hopr-transport-session` is built to; they are not visible from here, so the derivation is
+/// written down rather than imported. It leaves a cycle covered for the whole of its own batch plus
+/// one further generation, and the successor gate makes that second generation expensive — a peer
+/// cannot reach it without draining nearly every cycle of the first, by which point it has been
+/// asking for far longer than [`MAX_COMMITMENT_RETRANSMISSIONS`] attempts on any sane re-request
+/// interval allow.
+///
+/// Costs `polynomials_per_ssa × 33 B` per cycle — 4.8 MB per pseudonym with the cap full at the
+/// deployed dimensions, against the ~33 MB a single *undrained* cycle's polynomials occupy.
 pub const MAX_RETAINED_COMMITMENT_CYCLES: usize = 18;
 
 /// Minimum SSA polynomial threshold.

--- a/protocols/pix/src/lib.rs
+++ b/protocols/pix/src/lib.rs
@@ -207,7 +207,12 @@ pub const MAX_COMMITMENT_RETRANSMISSIONS: u8 = 8;
 /// interval allow.
 ///
 /// Costs `polynomials_per_ssa × 33 B` per cycle — 4.8 MB per pseudonym with the cap full at the
-/// deployed dimensions, against the ~33 MB a single *undrained* cycle's polynomials occupy.
+/// deployed dimensions, against the ~33 MB a single *undrained* cycle's polynomials occupy. This is
+/// Entry-side state, held per pseudonym and released with the rest of that pseudonym's polynomial
+/// state, by [`SsaShareGenerator::forget`] at teardown or by the cache's own idle eviction. It is
+/// therefore bounded by the Sessions this node has itself opened, and no peer can hold more of it
+/// than the cap allows — which is why it is not charged against an Exit's incoming-Session memory
+/// budget, where nothing else the generator holds is charged either.
 pub const MAX_RETAINED_COMMITMENT_CYCLES: usize = 18;
 
 /// Minimum SSA polynomial threshold.

--- a/protocols/pix/src/reconstructor/mod.rs
+++ b/protocols/pix/src/reconstructor/mod.rs
@@ -865,6 +865,34 @@ impl<S: PixSpec + Clone> SsaReconstructor<S> {
         self.ssa_cycles.contains_key(ssa_id) || self.commitment_builder.contains_key(ssa_id)
     }
 
+    /// Polynomial-index runs of `ssa_id` whose constant-term commitment never arrived, so the caller
+    /// can ask the peer to re-send exactly those.
+    ///
+    /// A cycle's commitment ships as hundreds of packets and completes only when every one of them
+    /// has landed, so without this a single lost packet is a lost Session — nothing else in the
+    /// protocol can repair it, since the peer has no way to learn which piece went missing.
+    ///
+    /// * `None` — no registration for `ssa_id`. It was retired, or it went unanswered for longer than
+    ///   [`incomplete_commitment_lifetime`](SsaReconstructorConfig::incomplete_commitment_lifetime), and either way
+    ///   there is nothing left for a retransmission to complete.
+    /// * `Some([])` — the commitment is complete; there is nothing to ask for. This is the *only* thing an empty vector
+    ///   means: a `max_runs` of zero is read as one rather than honoured.
+    /// * `Some(runs)` — at most `max_runs` runs, lowest first. A caller that gets exactly `max_runs` back has not seen
+    ///   the whole shortfall and should ask again once these are answered.
+    // `SsaCommitmentBuilder` is crate-private, so an intra-doc link from this public method trips
+    // `rustdoc::private_intra_doc_links`, which the `nix build .#docs` job builds as an error.
+    /// `max_runs` is the asking message's capacity, which this crate cannot know, so the caller
+    /// supplies it; `SsaCommitmentBuilder::missing_runs` documents how the runs are chosen.
+    pub fn missing_commitment_runs(
+        &self,
+        ssa_id: &SsaId<S::Pseudonym>,
+        max_runs: usize,
+    ) -> Option<Vec<(PolynomialIndex, PolynomialIndex)>> {
+        self.commitment_builder
+            .get(ssa_id)
+            .map(|registration| registration.lock().missing_runs(max_runs))
+    }
+
     /// Removes the heavyweight reconstructor state for a single SSA cycle.
     ///
     /// A successfully recovered cycle's compact accounting tail is owned by the Session retirement
@@ -2522,8 +2550,17 @@ mod tests {
         Ok(())
     }
 
+    /// Commitments arriving after the set is complete are absorbed, and still report the cycle as
+    /// complete.
+    ///
+    /// This is what makes retransmission safe. The peer re-sends parts of the set on request, and a
+    /// re-sent copy travels the same mixed path as the original it repairs — so it can arrive after
+    /// the gap it was asked for was filled by the original showing up late. Refusing those as
+    /// duplicates would turn every successful repair into an error on the next packet. Nothing can
+    /// change at this point anyway: every slot is filled, and the per-slot check cannot even speak
+    /// for these, because the map is drained when the part builders are handed out.
     #[test]
-    fn reconstructor_duplicate_commitments() -> anyhow::Result<()> {
+    fn commitments_arriving_after_completion_are_absorbed() -> anyhow::Result<()> {
         let reconstructor = SsaReconstructor::<TestSpec>::new(Default::default());
 
         let ssa_id = SsaId::new(SimplePseudonym::random(), 1.try_into()?);
@@ -2537,13 +2574,18 @@ mod tests {
         }
         reconstructor.insert_coefficient_commitments(ssa_id, 0, Some(identity_proof(&ssa_id)), poly_map.into_iter())?;
 
-        // Now adding more should fail with DuplicateCommitment
-        let result = reconstructor.insert_coefficient_commitments(ssa_id, 0, None, HashMap::new().into_iter());
-        assert!(matches!(result, Err(PixError::DuplicateCommitment)));
+        // A re-delivery of a slot that is already filled, which is what a repair racing its own
+        // original looks like.
+        let mut resent = HashMap::new();
+        resent.insert(0 as PolynomialIndex, PixGroupRepr::<TestSpec>::default());
+        let absorbed = reconstructor.insert_coefficient_commitments(ssa_id, 0, None, resent.into_iter())?;
+        assert!(
+            absorbed.is_verifiable,
+            "absorbing a re-delivery must not make a completed cycle look incomplete"
+        );
 
-        // A trailing non-constant coefficient, on the other hand, is simply ignored: a peer that
-        // still emits the full Feldman matrix sends the bulk of it *after* the constant-term pass
-        // has completed, and that must not read as a duplicate-commitment attack.
+        // A trailing non-constant coefficient is ignored for its own reason: a peer that still emits
+        // the full Feldman matrix sends the bulk of it *after* the constant-term pass has completed.
         let mut trailing = HashMap::new();
         trailing.insert(0 as PolynomialIndex, PixGroupRepr::<TestSpec>::default());
         let ignored = reconstructor.insert_coefficient_commitments(ssa_id, 1, None, trailing.into_iter())?;
@@ -2555,11 +2597,15 @@ mod tests {
         Ok(())
     }
 
+    /// A slot re-offered the commitment it holds is a no-op; re-offered a *different* one, it is
+    /// still refused.
+    ///
+    /// The single-assignment invariant is the one that matters: a slot that has been decoded and
+    /// accepted can never be rebound, or a peer could displace a commitment the deposit address was
+    /// derived from. Re-delivering the *same* bytes cannot do that, and has to be tolerated because
+    /// retransmission produces exactly that case.
     #[test]
-    fn reconstructor_duplicate_per_polynomial_commitment() -> anyhow::Result<()> {
-        // Regression test for the per-polynomial duplicate check inside add_transposed.
-        // Previously the same polynomial's slot silently overwrote; now it returns
-        // DuplicateCommitment.
+    fn a_slot_tolerates_its_own_commitment_and_refuses_a_different_one() -> anyhow::Result<()> {
         let reconstructor = SsaReconstructor::<TestSpec>::new(Default::default());
 
         let ssa_id = SsaId::new(SimplePseudonym::random(), 1.try_into()?);
@@ -2571,20 +2617,159 @@ mod tests {
         poly_map_1.insert(0 as PolynomialIndex, PixGroupRepr::<TestSpec>::default());
         reconstructor.insert_coefficient_commitments(ssa_id, 0, None, poly_map_1.into_iter())?;
 
-        // Insert the constant term of poly 0 again — must fail
-        let mut poly_map_2 = HashMap::new();
-        poly_map_2.insert(0 as PolynomialIndex, PixGroupRepr::<TestSpec>::default());
-        let result = reconstructor.insert_coefficient_commitments(ssa_id, 0, None, poly_map_2.into_iter());
+        // The same commitment for the same slot: absorbed, and it must not consume the slot twice —
+        // proven below by the set still completing on poly 1 alone.
+        let mut resent = HashMap::new();
+        resent.insert(0 as PolynomialIndex, PixGroupRepr::<TestSpec>::default());
+        let absorbed = reconstructor.insert_coefficient_commitments(ssa_id, 0, None, resent.into_iter())?;
+        assert!(!absorbed.is_verifiable, "poly 1 has still not been committed");
+
+        // A *different* commitment for that slot is a contradiction and must be refused.
+        let mut conflicting = HashMap::new();
+        conflicting.insert(0 as PolynomialIndex, PixGroup::<TestSpec>::generator().to_bytes());
+        let result = reconstructor.insert_coefficient_commitments(ssa_id, 0, None, conflicting.into_iter());
         assert!(matches!(result, Err(PixError::DuplicateCommitment)));
 
-        // Poly 1's constant term is a different slot and must still be accepted
+        // Poly 1's constant term is a different slot and must still complete the set.
         let mut poly_map_3 = HashMap::new();
         poly_map_3.insert(1 as PolynomialIndex, PixGroupRepr::<TestSpec>::default());
+        let completed = reconstructor.insert_coefficient_commitments(
+            ssa_id,
+            0,
+            Some(identity_proof(&ssa_id)),
+            poly_map_3.into_iter(),
+        )?;
         assert!(
-            reconstructor
-                .insert_coefficient_commitments(ssa_id, 0, Some(identity_proof(&ssa_id)), poly_map_3.into_iter())
-                .is_ok()
+            completed.is_verifiable,
+            "the absorbed re-delivery must not have consumed poly 1's slot"
         );
+
+        Ok(())
+    }
+
+    /// The missing-commitment scope is what the Exit puts on the wire to repair a lost packet, so it
+    /// has to name the gaps exactly, compactly, and within one message.
+    #[test]
+    fn missing_commitment_runs_report_the_gaps_and_nothing_else() -> anyhow::Result<()> {
+        const POLYS: u16 = 8;
+        let reconstructor = SsaReconstructor::<TestSpec>::new(Default::default());
+        let ssa_id = SsaId::new(SimplePseudonym::random(), 1.try_into()?);
+
+        // An unregistered cycle is distinguishable from a complete one: there is nothing left for a
+        // retransmission to complete, which the caller has to treat differently from "ask again".
+        assert_eq!(None, reconstructor.missing_commitment_runs(&ssa_id, 8));
+
+        reconstructor.new_exit_commitment(ssa_id, test_params(POLYS, 2))?;
+        assert_eq!(
+            Some(vec![(0, POLYS as PolynomialIndex - 1)]),
+            reconstructor.missing_commitment_runs(&ssa_id, 8),
+            "before anything arrives the whole set is one run"
+        );
+
+        // Two chunk-shaped holes: 2..=3 and 6..=6. Each is what one lost packet leaves behind, since
+        // the sender slices the set into consecutive polynomial indices.
+        let arrived: HashMap<PolynomialIndex, PixGroupRepr<TestSpec>> = [0, 1, 4, 5, 7]
+            .into_iter()
+            .map(|poly| (poly as PolynomialIndex, PixGroupRepr::<TestSpec>::default()))
+            .collect();
+        reconstructor.insert_coefficient_commitments(ssa_id, 0, None, arrived.into_iter())?;
+        assert_eq!(
+            Some(vec![(2, 3), (6, 6)]),
+            reconstructor.missing_commitment_runs(&ssa_id, 8),
+            "consecutive gaps must coalesce into one run each"
+        );
+
+        // A scope larger than the asking message can carry is truncated lowest-first, so successive
+        // asks converge on a prefix instead of interleaving.
+        assert_eq!(
+            Some(vec![(2, 3)]),
+            reconstructor.missing_commitment_runs(&ssa_id, 1),
+            "the run budget must bound the reported scope"
+        );
+
+        // Filling the gaps completes the set, and a complete set has nothing to ask for. Note the map
+        // is *drained* at completion, so reporting emptiness here is not incidental.
+        let repaired: HashMap<PolynomialIndex, PixGroupRepr<TestSpec>> = [2, 3, 6]
+            .into_iter()
+            .map(|poly| (poly as PolynomialIndex, PixGroupRepr::<TestSpec>::default()))
+            .collect();
+        let state = reconstructor.insert_coefficient_commitments(
+            ssa_id,
+            0,
+            Some(identity_proof(&ssa_id)),
+            repaired.into_iter(),
+        )?;
+        assert!(state.is_verifiable);
+        assert_eq!(Some(Vec::new()), reconstructor.missing_commitment_runs(&ssa_id, 8));
+
+        Ok(())
+    }
+
+    /// The whole point of the feature: a commitment burst that lost a slice still completes, because
+    /// the Exit can name the slice and the Entry can re-send exactly it.
+    ///
+    /// Without this a single dropped packet costs the cycle — and by then the Entry has usually
+    /// already been told to fund its deposit address.
+    #[test]
+    fn a_lost_slice_of_a_commitment_is_repaired_by_a_scoped_retransmission() -> anyhow::Result<()> {
+        const POLYS: u16 = 16;
+        let generator = SsaShareGenerator::<TestSpec>::new(SsaGeneratorConfig {
+            polynomials_per_ssa: POLYS,
+            threshold: 2,
+            surplus_shares: 0,
+        });
+        let pseudonym = SimplePseudonym::random();
+        let ssa_id = SsaId::new(pseudonym, SsaIndex::MIN);
+
+        let commitment = generator.new_ssa_commitment(&pseudonym, SsaIndex::MIN)?;
+        let reconstructor = SsaReconstructor::<TestSpec>::new(Default::default());
+        reconstructor.new_exit_commitment(ssa_id, test_params(POLYS, 2))?;
+
+        // Deliver every constant term except one packet's worth, the middle quarter of the set.
+        let full = coefficient_of(&commitment, 0, None)?;
+        let lost: std::collections::HashSet<PolynomialIndex> = (4..8).collect();
+        let delivered: Vec<_> = full
+            .iter()
+            .copied()
+            .filter(|(poly_index, _)| !lost.contains(poly_index))
+            .collect();
+        let partial =
+            reconstructor.insert_coefficient_commitments(ssa_id, 0, proof_of(&commitment, 0), delivered.into_iter())?;
+        assert!(
+            !partial.is_verifiable && partial.ssa_deposit_address.is_none(),
+            "a set one packet short yields no deposit address — this is the failure being repaired"
+        );
+
+        // The Exit names the gap; the Entry answers it from the same bytes it sent the first time.
+        let runs = reconstructor
+            .missing_commitment_runs(&ssa_id, 64)
+            .expect("the registration must still be live");
+        assert_eq!(vec![(4, 7)], runs);
+
+        let repair = generator.recommit(&pseudonym, SsaIndex::MIN, runs)?;
+        let repaired = coefficient_of(&repair, 0, None)?;
+        assert_eq!(
+            lost,
+            repaired.iter().map(|(poly_index, _)| *poly_index).collect(),
+            "the retransmission must carry exactly the missing polynomials"
+        );
+        for (poly_index, resent) in &repaired {
+            assert_eq!(
+                Some(resent),
+                full.iter()
+                    .find(|(index, _)| index == poly_index)
+                    .map(|(_, original)| original),
+                "the retransmission must repeat the original bytes rather than derive new ones"
+            );
+        }
+
+        let completed =
+            reconstructor.insert_coefficient_commitments(ssa_id, 0, proof_of(&repair, 0), repaired.into_iter())?;
+        assert!(
+            completed.is_verifiable && completed.ssa_deposit_address.is_some(),
+            "the repaired set must complete the commitment and yield the deposit address"
+        );
+        assert!(completed.deposit_address_first_encountered);
 
         Ok(())
     }
@@ -3626,21 +3811,24 @@ mod tests {
         Ok(())
     }
 
-    /// **L2 regression.** A polynomial index repeated inside one batch must be rejected, not merely
-    /// one repeated across batches.
+    /// **L2 regression.** A polynomial index repeated inside one batch must not consume its slot
+    /// twice, and a repeat carrying a *different* commitment must be refused.
     ///
     /// The two-phase check tested each entry against `committed_polynomials`, which holds only what
     /// earlier calls inserted, so two entries sharing an index both found the slot vacant. The
     /// second insert then rebound the first — the single-assignment invariant the two phases exist
     /// to enforce — and `total_committed` counted two occupants of one slot. The practical bite:
-    /// a batch carrying every polynomial with a repeat among them can never complete the set, and
-    /// the peer has no way to supply the one it displaced, because every retry is rejected as a
-    /// duplicate against the slots the batch did fill.
+    /// a batch carrying every polynomial with a repeat among them could never complete the set, and
+    /// the peer had no way to supply the one it displaced.
+    ///
+    /// Both halves are checked here because they now take different paths: an identical repeat is
+    /// *absorbed*, since retransmission legitimately produces one, while a conflicting one is still
+    /// an error. Either way the slot is occupied exactly once, which is the invariant.
     ///
     /// The wire decoder rejects intra-message duplicates today. This builder is not meant to depend
     /// on that, which is why the check is here.
     #[test]
-    fn a_polynomial_repeated_within_one_batch_is_rejected() -> anyhow::Result<()> {
+    fn a_polynomial_repeated_within_one_batch_occupies_its_slot_once() -> anyhow::Result<()> {
         let generator = SsaShareGenerator::<TestSpec>::new(SsaGeneratorConfig {
             polynomials_per_ssa: 2,
             threshold: 2,
@@ -3653,27 +3841,39 @@ mod tests {
         let reconstructor = SsaReconstructor::<TestSpec>::new(Default::default());
         reconstructor.new_exit_commitment(ssa_id, test_params(2, 2))?;
 
-        // Polynomial 0 twice, and polynomial 1 not at all — the shape that would otherwise leave the
-        // set permanently one short while reporting two commitments received.
-        let mut batch = coefficient_of(&commitment, 0, Some(0))?;
-        batch.push(batch[0]);
+        // Polynomial 0 twice with conflicting commitments: a contradiction, refused outright.
+        let mut conflicting = coefficient_of(&commitment, 0, Some(0))?;
+        conflicting.push((conflicting[0].0, PixGroup::<TestSpec>::generator().to_bytes()));
         let result =
-            reconstructor.insert_coefficient_commitments(ssa_id, 0, proof_of(&commitment, 0), batch.into_iter());
+            reconstructor.insert_coefficient_commitments(ssa_id, 0, proof_of(&commitment, 0), conflicting.into_iter());
         assert!(
             matches!(&result, Err(crate::errors::PixError::DuplicateCommitment)),
-            "a repeat inside the batch must be rejected, got {result:?}"
+            "a conflicting repeat inside the batch must be rejected, got {result:?}"
         );
 
-        // Rejected transactionally: neither entry was written, so the honest batch still lands.
+        // Rejected transactionally: neither entry was written, so polynomial 0 is still vacant. Now
+        // the same index twice with the *same* commitment — accepted, occupying one slot, which is
+        // the shape that would otherwise leave the set permanently one short while reporting two
+        // commitments received.
+        let mut repeated = coefficient_of(&commitment, 0, Some(0))?;
+        repeated.push(repeated[0]);
+        let partial =
+            reconstructor.insert_coefficient_commitments(ssa_id, 0, proof_of(&commitment, 0), repeated.into_iter())?;
+        assert!(
+            !partial.is_verifiable,
+            "two entries for one polynomial must not stand in for the other one"
+        );
+
+        // ...and the set completes on the polynomial the repeat did not cover.
         let retry = reconstructor.insert_coefficient_commitments(
             ssa_id,
             0,
             proof_of(&commitment, 0),
-            coefficient_of(&commitment, 0, None)?.into_iter(),
+            coefficient_of(&commitment, 0, Some(1))?.into_iter(),
         )?;
         assert!(
             retry.is_verifiable && retry.ssa_deposit_address.is_some(),
-            "the corrected batch must complete the commitment"
+            "the remaining polynomial must complete the commitment"
         );
 
         Ok(())

--- a/protocols/pix/src/reconstructor/mod.rs
+++ b/protocols/pix/src/reconstructor/mod.rs
@@ -2689,6 +2689,16 @@ mod tests {
             "the run budget must bound the reported scope"
         );
 
+        // A budget of zero is read as one rather than honoured, and this is the branch that makes an
+        // empty result mean "complete" and nothing else. Honouring it would report an incomplete
+        // commitment as having nothing to ask for, and the caller — which branches on exactly that —
+        // would stop repairing without a word.
+        assert_eq!(
+            Some(vec![(2, 3)]),
+            reconstructor.missing_commitment_runs(&ssa_id, 0),
+            "a zero run budget must not be mistaken for a complete commitment"
+        );
+
         // Filling the gaps completes the set, and a complete set has nothing to ask for. Note the map
         // is *drained* at completion, so reporting emptiness here is not incidental.
         let repaired: HashMap<PolynomialIndex, PixGroupRepr<TestSpec>> = [2, 3, 6]

--- a/protocols/pix/src/reconstructor/mod.rs
+++ b/protocols/pix/src/reconstructor/mod.rs
@@ -879,10 +879,12 @@ impl<S: PixSpec + Clone> SsaReconstructor<S> {
     ///   means: a `max_runs` of zero is read as one rather than honoured.
     /// * `Some(runs)` — at most `max_runs` runs, lowest first. A caller that gets exactly `max_runs` back has not seen
     ///   the whole shortfall and should ask again once these are answered.
-    // `SsaCommitmentBuilder` is crate-private, so an intra-doc link from this public method trips
-    // `rustdoc::private_intra_doc_links`, which the `nix build .#docs` job builds as an error.
+    ///
     /// `max_runs` is the asking message's capacity, which this crate cannot know, so the caller
     /// supplies it; `SsaCommitmentBuilder::missing_runs` documents how the runs are chosen.
+    // That name is deliberately unlinked: `SsaCommitmentBuilder` is crate-private, so an intra-doc
+    // link from this public method trips `rustdoc::private_intra_doc_links`, which the
+    // `nix build .#docs` job builds as an error.
     pub fn missing_commitment_runs(
         &self,
         ssa_id: &SsaId<S::Pseudonym>,

--- a/protocols/pix/src/reconstructor/utils.rs
+++ b/protocols/pix/src/reconstructor/utils.rs
@@ -794,6 +794,47 @@ impl<S: PixSpec> SsaCommitmentBuilder<S> {
         self.full_ssa_commitment.as_ref().map(|(_, a)| a)
     }
 
+    /// Polynomial-index runs whose constant-term commitment has not arrived, lowest first.
+    ///
+    /// Empty once the set is complete. The runs are what the Exit puts on the wire to ask the peer
+    /// to re-send the pieces a lost packet took with it: loss is chunk-shaped, because the sender
+    /// splits the set into packet-sized slices of *consecutive* polynomial indices, so one lost
+    /// packet is one run of a couple of dozen indices and "nothing arrived at all" is a single run.
+    ///
+    /// Truncated to `max_runs`, which is how many the asking message can carry. Lowest-first rather
+    /// than an arbitrary subset so that successive asks converge on the same prefix instead of
+    /// interleaving, and so the answer to one is never a subset of the answer to the next.
+    ///
+    /// An empty result therefore means the set is *complete*, and nothing else — `max_runs` is raised
+    /// to one rather than honoured at zero, so a caller that branches on emptiness cannot be told
+    /// "nothing is missing" by its own budget.
+    pub fn missing_runs(&self, max_runs: usize) -> Vec<(PolynomialIndex, PolynomialIndex)> {
+        // Not merely an optimisation: the map is drained when the part builders are handed out, so
+        // reading it after completion would report every polynomial as missing.
+        if self.complete {
+            return Vec::new();
+        }
+
+        let max_runs = max_runs.max(1);
+        let mut runs: Vec<(PolynomialIndex, PolynomialIndex)> = Vec::new();
+        for index in 0..self.num_polys as PolynomialIndex {
+            if self.committed_polynomials.contains_key(&index) {
+                continue;
+            }
+            match runs.last_mut() {
+                // Extends the open run rather than starting a new one; `index` only ever grows.
+                Some((_, last)) if *last + 1 == index => *last = index,
+                _ => {
+                    if runs.len() == max_runs {
+                        break;
+                    }
+                    runs.push((index, index));
+                }
+            }
+        }
+        runs
+    }
+
     pub fn add_transposed(
         &mut self,
         coeff_index: CoefficientIndex,
@@ -824,9 +865,20 @@ impl<S: PixSpec> SsaCommitmentBuilder<S> {
             });
         }
 
-        // Cannot add more commitments if we already have all
+        // Every slot is already filled, so nothing this message carries can change the outcome.
+        //
+        // Reported as the completed state rather than as a duplicate: the peer re-sends parts of the
+        // set on request (see `missing_runs`), and a re-sent copy travels the same mixed path as the
+        // original it repairs, so it can arrive after the set completed. The per-slot check below
+        // cannot speak for these — the map is drained at completion — which is the only reason this
+        // guard exists at all.
         if self.complete {
-            return Err(errors::PixError::DuplicateCommitment);
+            tracing::trace!(id = %self.id, "ignoring commitments for an already complete ssa");
+            return Ok(CommitmentProgress {
+                full_commitment: self.full_ssa_commitment.as_ref().map(|(c, _)| *c),
+                fully_committed: true,
+                ..CommitmentProgress::empty()
+            });
         }
 
         // Retain the first proof offered. It cannot be checked yet: the commitment it opens is the
@@ -858,24 +910,44 @@ impl<S: PixSpec> SsaCommitmentBuilder<S> {
             ));
         }
 
-        // Check for duplicate occupancy before any insertion (transactional).
+        // Classify every entry against the slots before any insertion (transactional).
         //
-        // A repeat *within* the batch counts. Testing only against `committed_polynomials` would let
-        // two entries sharing a polynomial index both see a vacant slot: the second insert would
-        // silently rebind the first — the single-assignment invariant this two-phase check exists to
-        // enforce — and `total_committed` would count two occupants of one slot, so a batch of
-        // `num_polys` entries containing a repeat could never complete the set and every retry would
-        // be rejected as a duplicate against the slots it did fill. The wire decoder rejects
-        // intra-message duplicates today, but this builder is not meant to depend on that.
-        let mut seen = std::collections::HashSet::with_capacity(validated.len());
-        for (polynomial_index, _) in &validated {
-            if self.committed_polynomials.contains_key(polynomial_index) || !seen.insert(*polynomial_index) {
-                return Err(errors::PixError::DuplicateCommitment);
+        // A slot re-offered the commitment it already holds is *skipped*, not rejected. The peer
+        // re-sends parts of the set on request (see `missing_runs`), and those travel the same mixed
+        // path as the burst they repair, so a re-sent copy and its original can overtake one another;
+        // refusing the whole message over one such overlap would drop the very entries the ask was
+        // for. Only a *different* commitment for an occupied slot is an error, which is exactly the
+        // single-assignment invariant this two-phase check exists to enforce — a slot that has been
+        // decoded and accepted can never be rebound.
+        //
+        // A repeat *within* the batch is classified the same way, and against `seen` rather than only
+        // against `committed_polynomials`: two entries sharing an index would both see a vacant slot,
+        // the second insert would silently rebind the first, and `total_committed` would count two
+        // occupants of one slot — so a batch of `num_polys` entries containing a repeat could never
+        // complete the set. The wire decoder rejects intra-message duplicates today, but this builder
+        // is not meant to depend on that.
+        let mut seen: std::collections::HashMap<PolynomialIndex, PixGroup<S>> =
+            std::collections::HashMap::with_capacity(validated.len());
+        let mut fresh: Vec<(PolynomialIndex, PixGroup<S>)> = Vec::with_capacity(validated.len());
+        for (polynomial_index, commitment) in validated {
+            let occupant = self
+                .committed_polynomials
+                .get(&polynomial_index)
+                .or_else(|| seen.get(&polynomial_index));
+            match occupant {
+                Some(held) if *held == commitment => {
+                    tracing::trace!(id = %self.id, polynomial_index, "ignoring a re-delivered commitment");
+                }
+                Some(_) => return Err(errors::PixError::DuplicateCommitment),
+                None => {
+                    seen.insert(polynomial_index, commitment);
+                    fresh.push((polynomial_index, commitment));
+                }
             }
         }
 
         // Second phase: insert into confirmed-vacant slots, maintaining the progress counter.
-        for (polynomial_index, polynomial_coeff_commitment) in validated {
+        for (polynomial_index, polynomial_coeff_commitment) in fresh {
             self.committed_polynomials
                 .insert(polynomial_index, polynomial_coeff_commitment);
             self.total_committed += 1;

--- a/protocols/start/Cargo.toml
+++ b/protocols/start/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-protocol-start"
-version = "1.2.0"
+version = "2.0.0"
 description = "Contains implementation of Start protocol for Session initiation according to HOPR RFC-0009"
 edition.workspace = true
 license.workspace = true

--- a/protocols/start/src/lib.rs
+++ b/protocols/start/src/lib.rs
@@ -302,13 +302,29 @@ impl<I: serde::Serialize + Clone, G: Clone, K: Clone> SsaClientCommitmentMessage
     }
 }
 
-/// Sent by the Server to deliver the commitment to possibly multiple new Session Stealth Addresses (SSAs).
+/// Inclusive run of polynomial indices, as carried by
+/// [`SsaServerCommitmentMessage::missing`].
 ///
-/// This message is typically sent for the first time right after the [`StartEstablished`] message
-/// if PIX capabilities are indicated in the [`StartInitiation`] message, and the Server accepts it.
+/// A run rather than a list of indices because commitment loss is chunk-shaped: the sender slices a
+/// cycle's commitment into packet-sized slices of *consecutive* polynomial indices, so one lost
+/// packet is one run of a couple of dozen, and a burst that never arrived at all is a single run.
+pub type PolynomialRun = (hopr_protocol_pix::PolynomialIndex, hopr_protocol_pix::PolynomialIndex);
+
+/// Sent by the Server either to deliver the commitment to new Session Stealth Addresses (SSAs), or
+/// to ask for the parts of an earlier commitment it never received.
 ///
-/// It is then subsequently sent every time the Server needs the next batch of SSAs
-/// (with indices strictly greater than in the last batch) to be committed to.
+/// The first kind is typically sent right after the [`StartEstablished`] message if PIX capabilities
+/// are indicated in the [`StartInitiation`] message and the Server accepts it, and then again every
+/// time the Server needs the next batch of SSAs (with indices strictly greater than in the last
+/// batch) to be committed to.
+///
+/// The second kind exists because the Client's answer to the first is not one message but hundreds,
+/// and the Server can use none of it until every one of them has landed. It names the gaps in
+/// [`missing`](Self::missing) and asks for nothing new; see there.
+///
+/// Exactly one of [`commitments`](Self::commitments) and [`missing`](Self::missing) is populated,
+/// which is what makes the two kinds impossible to confuse — [`Self::new`] and [`Self::recommit`]
+/// each build one of them, and both encoding and decoding refuse a message that is neither.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SsaServerCommitmentMessage<I, G, D> {
     /// Session ID.
@@ -318,9 +334,25 @@ pub struct SsaServerCommitmentMessage<I, G, D> {
     pub params: u32,
     /// Per-SSA deposit/payment data, carried in CBOR as a single map keyed by the same
     /// [`SsaIndex`](hopr_protocol_pix::SsaIndex) as [`commitments`](Self::commitments).
+    ///
+    /// Empty on a retransmission request: it asks for no new SSA, and the deposit data of the cycles
+    /// it names was delivered when they were first requested.
     pub deposit_data: std::collections::HashMap<hopr_protocol_pix::SsaIndex, D>,
     /// Server's serialized commitments to the SSAs, ordered by the SSA index.
+    ///
+    /// Empty on a retransmission request — see the type-level documentation.
     pub commitments: std::collections::BTreeMap<hopr_protocol_pix::SsaIndex, G>,
+    /// Polynomial-index runs whose commitments the Server never received, per SSA.
+    ///
+    /// Empty on a request for new SSAs. Non-empty makes this a *retransmission* request: the Server
+    /// is asking the Client to re-send the commitments it names for cycles it has already committed
+    /// to, and nothing else. Nothing new is requested, no deposit follows, and the Client must not
+    /// announce one — the deposit address of a cycle is fixed when it is first committed.
+    ///
+    /// The runs of one SSA are ascending and disjoint, which the decoder enforces: it makes the scope
+    /// canonical, bounds the indices one request can name at the cycle's polynomial count, and lets
+    /// the answer be assembled without deduplicating.
+    pub missing: std::collections::BTreeMap<hopr_protocol_pix::SsaIndex, Vec<PolynomialRun>>,
 }
 
 impl<I, G, D> SsaServerCommitmentMessage<I, G, D> {
@@ -336,7 +368,38 @@ impl<I, G, D> SsaServerCommitmentMessage<I, G, D> {
             params: params.to_u32(),
             deposit_data: deposit_data.into_iter().collect(),
             commitments: commitments.into_iter().collect(),
+            missing: Default::default(),
         }
+    }
+
+    /// Asks the Client to re-send the commitments of polynomial runs the Server never received.
+    ///
+    /// A constructor of its own rather than a field to fill in, so the two request kinds cannot be
+    /// mixed: this one carries no commitments and no deposit data, which is the invariant the codec
+    /// enforces. `params` is echoed so the recipient can check the request against what was
+    /// negotiated, exactly as it does for a request for new SSAs.
+    ///
+    /// The caller is responsible for keeping the runs of each SSA ascending and disjoint, and for
+    /// naming no more of them than [`StartProtocol::max_missing_runs`] allows.
+    pub fn recommit(
+        session_id: I,
+        params: hopr_protocol_pix::PixParams,
+        missing: impl IntoIterator<Item = (hopr_protocol_pix::SsaIndex, Vec<PolynomialRun>)>,
+    ) -> Self {
+        Self {
+            session_id,
+            params: params.to_u32(),
+            deposit_data: Default::default(),
+            commitments: Default::default(),
+            missing: missing.into_iter().collect(),
+        }
+    }
+
+    /// Total number of polynomial runs this request names, across every SSA.
+    ///
+    /// The wire form is a flat table, so this — not the number of SSAs — is what has to fit a packet.
+    pub fn missing_run_count(&self) -> usize {
+        self.missing.values().map(Vec::len).sum()
     }
 
     /// The PIX dimensions this request was made under, and the curve suite they are dimensions of.
@@ -410,12 +473,17 @@ impl<I, T, C, G, K, D> StartProtocol<I, T, C, G, K, D> {
             + size_of::<u16>()
             + size_of::<hopr_protocol_pix::SsaIndex>()
             + Self::PIX_COEFF_COMMITMENT_REPR_SIZE
+            + size_of::<u16>()
             + 1,
     );
     /// Maximum number of SSAs that can be requested in a single SsaRequest message.
-    pub const MAX_SSAS_PER_REQUEST: u16 = ((ApplicationData::PAYLOAD_SIZE - 11)
+    pub const MAX_SSAS_PER_REQUEST: u16 = ((ApplicationData::PAYLOAD_SIZE - 13)
         / (size_of::<hopr_protocol_pix::SsaIndex>() + Self::PIX_COEFF_COMMITMENT_REPR_SIZE))
         as u16;
+    /// Wire size of one [`missing`](SsaServerCommitmentMessage::missing) table entry: the SSA index
+    /// it belongs to, then the run's inclusive first and last polynomial index.
+    pub const MISSING_RUN_ENTRY_SIZE: usize =
+        size_of::<hopr_protocol_pix::SsaIndex>() + 2 * size_of::<hopr_protocol_pix::PolynomialIndex>();
     /// Size of the PIX coefficient commitment representation in bytes.
     pub const PIX_COEFF_COMMITMENT_REPR_SIZE: usize = size_of::<G>();
     /// Size of the serialized client SSA commitment proof of knowledge in bytes.
@@ -429,7 +497,13 @@ impl<I, T, C, G, K, D> StartProtocol<I, T, C, G, K, D> {
     /// Fixed [`Tag`] of every protocol message.
     pub const START_PROTOCOL_MESSAGE_TAG: Tag = Tag::Reserved(ReservedTag::SessionStart as u64);
     /// Current version of the Start protocol.
-    pub const START_PROTOCOL_VERSION: u8 = 0x03;
+    ///
+    /// Bumped to 4 by the [`missing`](SsaServerCommitmentMessage::missing) run table, which sits
+    /// between an `SsaRequest`'s commitment entries and its trailing CBOR session id. A version-3
+    /// decoder reads that trailer as "everything left", so it would take the run count for part of
+    /// the session id rather than noticing the table at all; the bump turns a silent misparse into an
+    /// [`InvalidVersion`](errors::StartProtocolError::InvalidVersion).
+    pub const START_PROTOCOL_VERSION: u8 = 0x04;
 
     /// How many commitment entries one [`SsaCommit`](StartProtocol::SsaCommit) message can carry,
     /// for each of the two delivery phases.
@@ -472,6 +546,37 @@ impl<I, T, C, G, K, D> StartProtocol<I, T, C, G, K, D> {
             // only phase 1 pays for the proof, costing a handful of extra messages per cycle.
             max_constant_terms_per_message: (budget.saturating_sub(Self::PIX_COMMITMENT_PROOF_SIZE) / per_entry).max(1),
         })
+    }
+
+    /// How many [`missing`](SsaServerCommitmentMessage::missing) runs one retransmission request can
+    /// carry.
+    ///
+    /// Exposed for the same reason as [`ssa_commit_chunking`](Self::ssa_commit_chunking): the caller
+    /// choosing the scope must not restate the encode layout, because a copy that drifts either
+    /// overflows a packet or silently under-reports what is missing. It takes the `session_id`
+    /// itself rather than a length, since the id's CBOR encoding is part of that layout.
+    ///
+    /// Derived against a request built by [`SsaServerCommitmentMessage::recommit`], which carries no
+    /// commitments and an empty `deposit_data` map:
+    ///
+    /// ```text
+    ///   header:    version(1) + disc(1) + data_len(2) = 4
+    ///   fixed:     params(4) + empty CBOR map(1) + num_commitments(2) + num_missing_runs(2) = 9
+    ///   per-entry: MISSING_RUN_ENTRY_SIZE
+    ///   trailer:   CBOR-encoded session_id
+    /// ```
+    ///
+    /// At least one, so a caller can always ask for something: a budget that rounded to zero would
+    /// leave a repairable cycle with no way to be repaired.
+    pub fn max_missing_runs(session_id: &I) -> Result<usize, StartProtocolError>
+    where
+        I: serde::Serialize,
+    {
+        let header_and_fixed: usize = 4 + size_of::<u32>() + 1 + size_of::<u16>() + size_of::<u16>();
+        let cbor_session_id_size = serde_cbor_2::to_vec(session_id)?.len();
+        let budget = ApplicationData::PAYLOAD_SIZE.saturating_sub(header_and_fixed + cbor_session_id_size);
+
+        Ok((budget / Self::MISSING_RUN_ENTRY_SIZE).max(1))
     }
 }
 
@@ -593,6 +698,24 @@ where
                 data.extend(session_id);
             }
             StartProtocol::SsaRequest(req) => {
+                // A request either asks for new SSAs or asks for pieces of ones already committed
+                // to, never both and never neither. Refusing the other two combinations here is what
+                // lets the recipient tell the two kinds apart by looking at one field, and stops a
+                // retransmission request from carrying an index nothing asked for.
+                //
+                // Deposit data goes with SSAs being requested, so a retransmission carries none of
+                // it either. Both rules are enforced on the way out as well as on the way in, so a
+                // message this side is willing to build is one the peer is willing to read.
+                let num_missing_runs = req.missing_run_count();
+                if req.commitments.is_empty() == (num_missing_runs == 0) {
+                    return Err(StartProtocolError::NumberOfCommitments);
+                }
+                if num_missing_runs > 0 && !req.deposit_data.is_empty() {
+                    return Err(StartProtocolError::ParseError(
+                        "deposit_data on a retransmission request".into(),
+                    ));
+                }
+
                 data.extend_from_slice(&req.params.to_be_bytes());
 
                 let deposit_data =
@@ -613,7 +736,9 @@ where
                 let session_id = serde_cbor_2::to_vec(&req.session_id)?;
 
                 let required_size = (size_of::<hopr_protocol_pix::SsaIndex>() + Self::PIX_COEFF_COMMITMENT_REPR_SIZE)
-                    * req.commitments.len();
+                    * req.commitments.len()
+                    + size_of::<u16>()
+                    + Self::MISSING_RUN_ENTRY_SIZE * num_missing_runs;
 
                 // Remaining payload budget: the final `out` buffer contains
                 // version (1) + disc (1) + data_len (2) + data contents = 4 + data.len(),
@@ -623,8 +748,11 @@ where
                 // `data` already holds the serialized deposit data, so a `D` that passed
                 // `MAX_DEPOSIT_DATA_SIZE` above still narrows this budget: past a certain size it
                 // is the commitment count that has to give way, which is what this reports.
+                //
+                // Covers the run table as well, which is also what makes the `as u16` cast below
+                // safe: a count that could not be represented could not have fitted the payload.
                 let avail_space = ApplicationData::PAYLOAD_SIZE.saturating_sub(4 + data.len() + session_id.len());
-                if req.commitments.is_empty() || required_size > avail_space {
+                if required_size > avail_space {
                     return Err(StartProtocolError::NumberOfCommitments);
                 }
 
@@ -636,6 +764,20 @@ where
 
                     data.extend_from_slice(&ssa_index.get().to_be_bytes());
                     data.extend_from_slice(commitment_repr);
+                }
+
+                data.extend_from_slice(&(num_missing_runs as u16).to_be_bytes());
+                for (ssa_index, runs) in req.missing {
+                    for (first, last) in runs {
+                        // Ascending and disjoint is the decoder's rule, and an inverted run names
+                        // nothing at all, so an encoder must not be able to emit one.
+                        if first > last {
+                            return Err(StartProtocolError::ParseError("missing_run_is_inverted".into()));
+                        }
+                        data.extend_from_slice(&ssa_index.get().to_be_bytes());
+                        data.extend_from_slice(&first.to_be_bytes());
+                        data.extend_from_slice(&last.to_be_bytes());
+                    }
                 }
 
                 data.extend(session_id);
@@ -981,7 +1123,7 @@ where
                             .try_into()
                             .map_err(|_| StartProtocolError::ParseError("num_commitments".into()))?,
                     );
-                    if num_commitments == 0 || num_commitments > Self::MAX_SSAS_PER_REQUEST {
+                    if num_commitments > Self::MAX_SSAS_PER_REQUEST {
                         return Err(StartProtocolError::NumberOfCommitments);
                     }
                     next_offset += size_of::<u16>();
@@ -1015,11 +1157,86 @@ where
                         }
                     }
 
+                    if body.len() <= next_offset + size_of::<u16>() {
+                        return Err(StartProtocolError::InvalidLength);
+                    }
+                    let num_missing_runs = u16::from_be_bytes(
+                        body[next_offset..next_offset + size_of::<u16>()]
+                            .try_into()
+                            .map_err(|_| StartProtocolError::ParseError("num_missing_runs".into()))?,
+                    );
+                    next_offset += size_of::<u16>();
+
+                    // A request asks for new SSAs or for pieces of ones already committed to, never
+                    // both and never neither — see [`SsaServerCommitmentMessage`]. Enforced before
+                    // the runs are walked, so a message that is neither is reported as the malformed
+                    // request it is rather than as a length error further in.
+                    if (num_commitments == 0) == (num_missing_runs == 0) {
+                        return Err(StartProtocolError::NumberOfCommitments);
+                    }
+
+                    // The count is the peer's word for what follows, so it is bounded by what the
+                    // body can actually hold before it is used to size anything — reserving at least
+                    // one byte for the trailing CBOR session id, as the table above is.
+                    let max_by_payload = body.len().saturating_sub(next_offset + 1) / Self::MISSING_RUN_ENTRY_SIZE;
+                    if num_missing_runs as usize > max_by_payload {
+                        return Err(StartProtocolError::NumberOfCommitments);
+                    }
+
+                    let mut missing: std::collections::BTreeMap<hopr_protocol_pix::SsaIndex, Vec<PolynomialRun>> =
+                        std::collections::BTreeMap::new();
+                    for _ in 0..num_missing_runs {
+                        let ssa_index: hopr_protocol_pix::SsaIndex = hopr_protocol_pix::RawSsaIndex::from_be_bytes(
+                            body[next_offset..next_offset + size_of::<hopr_protocol_pix::SsaIndex>()]
+                                .try_into()
+                                .map_err(|_| StartProtocolError::ParseError("ssa_index".into()))?,
+                        )
+                        .try_into()
+                        .map_err(|_| StartProtocolError::ParseError("ssa_index is 0".into()))?;
+                        let polynomial_index_at = |offset: usize| {
+                            Ok::<_, StartProtocolError>(hopr_protocol_pix::PolynomialIndex::from_be_bytes(
+                                body[offset..offset + size_of::<hopr_protocol_pix::PolynomialIndex>()]
+                                    .try_into()
+                                    .map_err(|_| StartProtocolError::ParseError("missing_run".into()))?,
+                            ))
+                        };
+                        let run_offset = next_offset + size_of::<hopr_protocol_pix::SsaIndex>();
+                        let first = polynomial_index_at(run_offset)?;
+                        let last = polynomial_index_at(run_offset + size_of::<hopr_protocol_pix::PolynomialIndex>())?;
+                        next_offset += Self::MISSING_RUN_ENTRY_SIZE;
+
+                        // An inverted run names nothing, and one past the largest cycle the protocol
+                        // admits names nothing that can exist.
+                        if first > last || last >= MAX_POLYS_PER_SSA {
+                            return Err(StartProtocolError::ParseError("missing_run_out_of_range".into()));
+                        }
+
+                        // Ascending and disjoint within one SSA. This is what bounds the polynomials
+                        // one request can name by the cycle's own polynomial count rather than by
+                        // `runs × count`, and what lets the answer be assembled without
+                        // deduplicating.
+                        let runs = missing.entry(ssa_index).or_default();
+                        if runs.last().is_some_and(|(_, previous_last)| first <= *previous_last) {
+                            return Err(StartProtocolError::ParseError("missing_runs_not_ascending".into()));
+                        }
+                        runs.push((first, last));
+                    }
+
+                    // Deposit data belongs to SSAs being requested, and a retransmission requests
+                    // none. Checked so that every message which decodes really is exactly one of the
+                    // two kinds, and a recipient branching on `missing` need not re-establish it.
+                    if !missing.is_empty() && !deposit_data.is_empty() {
+                        return Err(StartProtocolError::ParseError(
+                            "deposit_data on a retransmission request".into(),
+                        ));
+                    }
+
                     StartProtocol::SsaRequest(SsaServerCommitmentMessage {
                         session_id: serde_cbor_2::from_slice(&body[next_offset..])?,
                         params,
                         deposit_data,
                         commitments,
+                        missing,
                     })
                 }
             },
@@ -1239,6 +1456,7 @@ mod tests {
             params: 0xfeedbeef,
             deposit_data,
             commitments,
+            missing: Default::default(),
         });
 
         let (tag, msg) = msg_1.clone().encode()?;
@@ -1247,6 +1465,214 @@ mod tests {
 
         let msg_2 = StartProtocol::<u32, String, u8, [u8; 33], [u8; 65], MinimalDeposit>::decode(tag, &msg)?;
         assert_eq!(msg_1, msg_2);
+        Ok(())
+    }
+
+    /// A retransmission request round-trips, and carries the scope rather than any new SSA.
+    #[test]
+    fn start_protocol_ssa_recommit_request_should_encode_and_decode() -> anyhow::Result<()> {
+        type Spec = StartProtocol<u32, String, u8, [u8; 33], [u8; 65], MinimalDeposit>;
+
+        let params = hopr_protocol_pix::PixParams::try_new(8192, 64, 32, hopr_protocol_pix::PixSuite::Secp256k1)?;
+        // Two cycles at once, several runs each: the wire form is a flat table keyed by SSA index, so
+        // one request can scope a whole batch.
+        let msg_1 = Spec::SsaRequest(SsaServerCommitmentMessage::recommit(
+            0xfeedbeef_u32,
+            params,
+            [
+                (1.try_into()?, vec![(0, 25), (104, 129), (8191, 8191)]),
+                (2.try_into()?, vec![(52, 77)]),
+            ],
+        ));
+
+        let (tag, encoded) = msg_1.clone().encode()?;
+        let msg_2 = Spec::decode(tag, &encoded)?;
+        assert_eq!(msg_1, msg_2);
+
+        let Spec::SsaRequest(decoded) = msg_2 else {
+            anyhow::bail!("expected an SsaRequest");
+        };
+        assert_eq!(params, decoded.dimensions()?);
+        assert_eq!(4, decoded.missing_run_count());
+        assert!(
+            decoded.commitments.is_empty() && decoded.deposit_data.is_empty(),
+            "a retransmission request asks for nothing new"
+        );
+        assert!(
+            encoded.len() <= HoprPacket::PAYLOAD_SIZE,
+            "a retransmission request must fit within {}",
+            HoprPacket::PAYLOAD_SIZE
+        );
+
+        Ok(())
+    }
+
+    /// Exactly one of the two tables is populated, so the recipient can tell the two request kinds
+    /// apart by looking at one field — and a retransmission can never smuggle in a new SSA or the
+    /// deposit data that would go with one.
+    #[test]
+    fn start_protocol_ssa_request_must_ask_for_exactly_one_of_the_two_things() -> anyhow::Result<()> {
+        type Spec = StartProtocol<u32, String, u8, [u8; 33], [u8; 65], MinimalDeposit>;
+
+        let neither = Spec::SsaRequest(SsaServerCommitmentMessage {
+            session_id: 0xfeedbeef,
+            params: 0,
+            deposit_data: Default::default(),
+            commitments: Default::default(),
+            missing: Default::default(),
+        });
+        assert!(matches!(neither.encode(), Err(StartProtocolError::NumberOfCommitments)));
+
+        let both = Spec::SsaRequest(SsaServerCommitmentMessage {
+            session_id: 0xfeedbeef,
+            params: 0,
+            deposit_data: Default::default(),
+            commitments: [(SsaIndex::MIN, [0u8; 33])].into_iter().collect(),
+            missing: [(SsaIndex::MIN, vec![(0, 0)])].into_iter().collect(),
+        });
+        assert!(matches!(both.encode(), Err(StartProtocolError::NumberOfCommitments)));
+
+        // Decode refuses both combinations too, so nothing hand-built gets past it either.
+        for (declared_commitments, entries, declared_runs, runs) in [
+            (0u16, &[][..], 0u16, &[][..]),
+            (1, &[(1u32, [0u8; 33])][..], 1, &[(1u32, 0u16, 0u16)][..]),
+        ] {
+            let body = ssa_request_body_with(&[0xa0], declared_commitments, entries, declared_runs, runs);
+            assert!(
+                matches!(
+                    decode_framed(StartProtocolDiscriminants::SsaRequest, &body),
+                    Err(StartProtocolError::NumberOfCommitments)
+                ),
+                "commitments={declared_commitments} runs={declared_runs} must be refused"
+            );
+        }
+
+        // Deposit data belongs to SSAs being requested, and a retransmission requests none. Refused
+        // on the way out as well as on the way in, so `encode` never builds what `decode` rejects.
+        let deposit_data = serde_cbor_2::to_vec(
+            &[(1u32, MinimalDeposit::default())]
+                .into_iter()
+                .collect::<std::collections::BTreeMap<_, _>>(),
+        )?;
+        let body = ssa_request_body_with(&deposit_data, 0, &[], 1, &[(1, 0, 0)]);
+        assert!(
+            matches!(decode_framed(StartProtocolDiscriminants::SsaRequest, &body), Err(ref e) if is_parse_error(e, "deposit_data on a retransmission request")),
+            "deposit data on a retransmission request must be refused: {:?}",
+            decode_framed(StartProtocolDiscriminants::SsaRequest, &body)
+        );
+
+        let with_deposit_data = Spec::SsaRequest(SsaServerCommitmentMessage {
+            session_id: 0xfeedbeef,
+            params: 0,
+            deposit_data: [(SsaIndex::MIN, MinimalDeposit::default())].into_iter().collect(),
+            commitments: Default::default(),
+            missing: [(SsaIndex::MIN, vec![(0, 0)])].into_iter().collect(),
+        });
+        assert!(
+            matches!(with_deposit_data.encode(), Err(ref e) if is_parse_error(e, "deposit_data on a retransmission request")),
+        );
+
+        // An inverted run names nothing, so the encoder must not be able to emit one either.
+        let inverted = Spec::SsaRequest(SsaServerCommitmentMessage::recommit(
+            0xfeedbeef_u32,
+            hopr_protocol_pix::PixParams::try_new(8192, 64, 32, hopr_protocol_pix::PixSuite::Secp256k1)?,
+            [(SsaIndex::MIN, vec![(7, 6)])],
+        ));
+        assert!(matches!(inverted.encode(), Err(ref e) if is_parse_error(e, "missing_run_is_inverted")));
+
+        Ok(())
+    }
+
+    /// The scope has to be canonical: ascending, disjoint and inside the polynomial range. That is
+    /// what bounds the polynomials one request can name by the cycle's own count rather than by
+    /// `runs × count`, and what lets the answer be assembled without deduplicating.
+    #[test]
+    fn start_protocol_decode_should_reject_a_malformed_missing_scope() {
+        let refused = |runs: &[(u32, u16, u16)], what: &str| {
+            let body = ssa_request_body_with(&[0xa0], 0, &[], runs.len() as u16, runs);
+            let decoded = decode_framed(StartProtocolDiscriminants::SsaRequest, &body);
+            assert!(
+                matches!(&decoded, Err(e) if is_parse_error(e, what)),
+                "{runs:?} must be refused as {what}, got {decoded:?}"
+            );
+        };
+
+        refused(&[(1, 7, 6)], "missing_run_out_of_range");
+        refused(&[(1, 0, MAX_POLYS_PER_SSA)], "missing_run_out_of_range");
+        // Overlapping, and merely repeated, both break the disjointness the answer relies on.
+        refused(&[(1, 0, 10), (1, 5, 20)], "missing_runs_not_ascending");
+        refused(&[(1, 0, 10), (1, 0, 10)], "missing_runs_not_ascending");
+        // Descending across two runs of one SSA. Two runs of *different* SSAs are unrelated, which
+        // the accepted case below pins.
+        refused(&[(1, 20, 30), (1, 0, 10)], "missing_runs_not_ascending");
+
+        let interleaved = [(2u32, 20u16, 30u16), (1, 0, 10), (2, 40, 50)];
+        let body = ssa_request_body_with(&[0xa0], 0, &[], interleaved.len() as u16, &interleaved);
+        let decoded = decode_framed(StartProtocolDiscriminants::SsaRequest, &body);
+        assert!(
+            matches!(&decoded, Ok(StartProtocol::SsaRequest(req)) if req.missing_run_count() == 3),
+            "the ordering rule is per SSA, so interleaved SSAs must decode: {decoded:?}"
+        );
+
+        // A count the body cannot possibly satisfy is refused on the count, before it sizes anything.
+        let body = ssa_request_body_with(&[0xa0], 0, &[], u16::MAX, &[(1, 0, 0)]);
+        assert!(matches!(
+            decode_framed(StartProtocolDiscriminants::SsaRequest, &body),
+            Err(StartProtocolError::NumberOfCommitments)
+        ));
+
+        // And a zero SSA index has no representation, in this table as in the other one.
+        let body = ssa_request_body_with(&[0xa0], 0, &[], 1, &[(0, 0, 0)]);
+        assert!(
+            matches!(decode_framed(StartProtocolDiscriminants::SsaRequest, &body), Err(ref e) if is_parse_error(e, "ssa_index is 0")),
+        );
+    }
+
+    /// Pins [`StartProtocol::max_missing_runs`] against the encoder it exists to predict.
+    ///
+    /// The Exit sizes its scope from this and cannot see the layout, so a bound that drifted either
+    /// overflows a packet or silently under-reports what is missing.
+    #[test]
+    fn max_missing_runs_should_match_the_encode_layout() -> anyhow::Result<()> {
+        type Spec = StartProtocol<(), String, u8, [u8; 33], [u8; 65], MinimalDeposit>;
+
+        // PAYLOAD_SIZE(1030) - header(4) - params(4) - empty CBOR map(1) - num_commitments(2)
+        // - num_missing_runs(2) - CBOR null session_id(1), over 8 bytes per run.
+        let max_runs = Spec::max_missing_runs(&())?;
+        assert_eq!(127, max_runs);
+
+        let scope = |runs: usize| {
+            // One run per SSA index, which is the worst case for the flat table: every entry pays
+            // for its own key.
+            (1..=runs as u32)
+                .map(|index| {
+                    (
+                        hopr_protocol_pix::SsaIndex::new(index).expect("index must be non-zero"),
+                        vec![(0u16, 0u16)],
+                    )
+                })
+                .collect::<Vec<_>>()
+        };
+
+        let at_the_bound = Spec::SsaRequest(SsaServerCommitmentMessage::recommit(
+            (),
+            hopr_protocol_pix::PixParams::try_new(8192, 64, 32, hopr_protocol_pix::PixSuite::Secp256k1)?,
+            scope(max_runs),
+        ));
+        let (tag, encoded) = at_the_bound.clone().encode()?;
+        assert!(encoded.len() <= ApplicationData::PAYLOAD_SIZE);
+        assert_eq!(at_the_bound, Spec::decode(tag, &encoded)?);
+
+        let over_the_bound = Spec::SsaRequest(SsaServerCommitmentMessage::recommit(
+            (),
+            hopr_protocol_pix::PixParams::try_new(8192, 64, 32, hopr_protocol_pix::PixSuite::Secp256k1)?,
+            scope(max_runs + 1),
+        ));
+        assert!(
+            matches!(over_the_bound.encode(), Err(StartProtocolError::NumberOfCommitments)),
+            "one run past the bound must not encode"
+        );
+
         Ok(())
     }
 
@@ -1288,6 +1714,7 @@ mod tests {
             params: 0xfeedbeef,
             deposit_data: Default::default(),
             commitments: Default::default(),
+            missing: Default::default(),
         };
         assert!(matches!(msg.dimensions(), Err(StartProtocolError::ParseError(_))));
     }
@@ -1311,6 +1738,7 @@ mod tests {
                 // empty map keeps the deposit data out of that arithmetic entirely.
                 deposit_data: Default::default(),
                 commitments,
+                missing: Default::default(),
             });
 
         assert!(matches!(msg.encode(), Err(StartProtocolError::NumberOfCommitments)));
@@ -1362,6 +1790,7 @@ mod tests {
             commitments: [(SsaIndex::MIN, [0u8; 33]), (2u32.try_into()?, [1u8; 33])]
                 .into_iter()
                 .collect(),
+            missing: Default::default(),
         });
 
         let (tag, encoded) = msg.clone().encode()?;
@@ -1398,6 +1827,7 @@ mod tests {
                 params: 0xfeedbeef,
                 deposit_data,
                 commitments: [(SsaIndex::MIN, [0u8; 33])].into_iter().collect(),
+                missing: Default::default(),
             })
         };
 
@@ -1425,6 +1855,7 @@ mod tests {
             params: 0xfeedbeef,
             deposit_data: deposit_data_of_cbor_size(too_large)?,
             commitments: [(SsaIndex::MIN, [0u8; 33])].into_iter().collect(),
+            missing: Default::default(),
         });
 
         assert!(matches!(
@@ -1446,14 +1877,16 @@ mod tests {
         type Spec = StartProtocol<(), String, u8, [u8; 33], [u8; 65], Vec<u8>>;
 
         // PAYLOAD_SIZE(1030) - header(4) - params(4) - num_commitments(2) - one entry(4 + 33)
-        // - CBOR null session_id(1). Stated as a literal so a layout change has to come through here.
-        assert_eq!(982, Spec::MAX_DEPOSIT_DATA_SIZE);
+        // - num_missing_runs(2) - CBOR null session_id(1). Stated as a literal so a layout change
+        // has to come through here.
+        assert_eq!(980, Spec::MAX_DEPOSIT_DATA_SIZE);
 
         let msg = Spec::SsaRequest(SsaServerCommitmentMessage {
             session_id: (),
             params: 0xfeedbeef,
             deposit_data: deposit_data_of_cbor_size(Spec::MAX_DEPOSIT_DATA_SIZE)?,
             commitments: [(SsaIndex::MIN, [0u8; 33])].into_iter().collect(),
+            missing: Default::default(),
         });
 
         let (tag, encoded) = msg.clone().encode()?;
@@ -1647,6 +2080,7 @@ mod tests {
                     .map(|&ssa_index| (ssa_index, MinimalDeposit::default()))
                     .collect(),
                 commitments,
+                missing: Default::default(),
             },
         );
         assert!(
@@ -1781,6 +2215,18 @@ mod tests {
         declared_commitments: u16,
         entries: &[(u32, [u8; 33])],
     ) -> Vec<u8> {
+        ssa_request_body_with(deposit_data, declared_commitments, entries, 0, &[])
+    }
+
+    /// The most general `SsaRequest` body: both tables written out as the caller asks, counts and
+    /// all, so a count is free to disagree with the entries that follow it.
+    fn ssa_request_body_with(
+        deposit_data: &[u8],
+        declared_commitments: u16,
+        entries: &[(u32, [u8; 33])],
+        declared_runs: u16,
+        runs: &[(u32, u16, u16)],
+    ) -> Vec<u8> {
         let mut body = Vec::new();
         body.extend_from_slice(&0u32.to_be_bytes());
         body.extend_from_slice(deposit_data);
@@ -1788,6 +2234,12 @@ mod tests {
         for (ssa_index, commitment) in entries {
             body.extend_from_slice(&ssa_index.to_be_bytes());
             body.extend_from_slice(commitment);
+        }
+        body.extend_from_slice(&declared_runs.to_be_bytes());
+        for (ssa_index, first, last) in runs {
+            body.extend_from_slice(&ssa_index.to_be_bytes());
+            body.extend_from_slice(&first.to_be_bytes());
+            body.extend_from_slice(&last.to_be_bytes());
         }
         body.extend(serde_cbor_2::to_vec(&MALFORMED_SESSION_ID).expect("session id must serialize"));
         body
@@ -1900,6 +2352,7 @@ mod tests {
                 params: 0,
                 deposit_data: [(SsaIndex::MIN, MinimalDeposit::default())].into_iter().collect(),
                 commitments: [(SsaIndex::MIN, VarLenBytes(vec![0u8; 7]))].into_iter().collect(),
+                missing: Default::default(),
             },
         );
         assert!(

--- a/protocols/start/src/lib.rs
+++ b/protocols/start/src/lib.rs
@@ -497,13 +497,7 @@ impl<I, T, C, G, K, D> StartProtocol<I, T, C, G, K, D> {
     /// Fixed [`Tag`] of every protocol message.
     pub const START_PROTOCOL_MESSAGE_TAG: Tag = Tag::Reserved(ReservedTag::SessionStart as u64);
     /// Current version of the Start protocol.
-    ///
-    /// Bumped to 4 by the [`missing`](SsaServerCommitmentMessage::missing) run table, which sits
-    /// between an `SsaRequest`'s commitment entries and its trailing CBOR session id. A version-3
-    /// decoder reads that trailer as "everything left", so it would take the run count for part of
-    /// the session id rather than noticing the table at all; the bump turns a silent misparse into an
-    /// [`InvalidVersion`](errors::StartProtocolError::InvalidVersion).
-    pub const START_PROTOCOL_VERSION: u8 = 0x04;
+    pub const START_PROTOCOL_VERSION: u8 = 0x03;
 
     /// How many commitment entries one [`SsaCommit`](StartProtocol::SsaCommit) message can carry,
     /// for each of the two delivery phases.

--- a/transport/session/Cargo.toml
+++ b/transport/session/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hopr-transport-session"
 description = "Session functionality providing session abstraction over the HOPR transport"
-version = "0.29.0"
+version = "0.30.0"
 edition.workspace = true
 license.workspace = true
 readme = "README.md"

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -1460,6 +1460,22 @@ impl PixToolbox {
 /// emits a [`HoprSessionOutPixEvent::ReadyToDeposit`] to the upper layer, signaling that
 /// funds can be deposited at the computed address.
 ///
+/// "One or more" is hundreds at the deployed dimensions — one commitment per polynomial, chunked to
+/// packet size — and the Exit can use *none* of it until every message has landed, since the SSA
+/// commitment is the sum of them all. A single lost packet therefore used to cost the whole Session
+/// on `max_ssa_delivery_time`, typically after the Entry had already been told to fund the address.
+///
+/// So a partially delivered commitment is repaired rather than waited out. Each arriving message
+/// reports `SessionPixEvent::CommitmentProgress`, which arms (and re-arms) the supervisor's
+/// [`commitment_recommit_interval`](crate::SupervisorConfig::commitment_recommit_interval); if
+/// delivery then goes quiet with the set incomplete, `RequestCommitmentRetransmission` has
+/// `send_commitment_retransmission_request` ask the Entry — via an `SsaRequest` whose
+/// [`missing`](hopr_protocol_start::SsaServerCommitmentMessage::missing) scope names the polynomial
+/// runs the reconstructor never received — to re-send exactly those. The Entry answers in
+/// `handle_ssa_recommit` from the bytes it sent the first time, advancing nothing and announcing no
+/// second deposit. A cycle for which *nothing* arrived never asks: it has no scope to name, and the
+/// delivery deadline remains what ends it.
+///
 /// ### 4. Deposit Awaiting (Exit Side)
 ///
 /// The Exit receives the client commitment messages in `handle_ssa_commit`, inserts the
@@ -2768,6 +2784,19 @@ where
                             }
                         }
                     }
+                    SessionPixAction::RequestCommitmentRetransmission { ssa_id, params } => {
+                        // Failure is logged and dropped rather than reported back. Unlike
+                        // `RequestSsa` this action is not a step the Session depends on: it repeats
+                        // on its own interval, and the commitment deadline is still the backstop, so
+                        // a dropped ask costs one interval rather than the Session.
+                        if let Some(slot) = myself.sessions.get(&session_id)
+                            && let Err(error) = myself
+                                .send_commitment_retransmission_request(session_id, &slot, ssa_id, params)
+                                .await
+                        {
+                            error!(%session_id, %ssa_id, %error, "failed to re-request ssa commitment parts");
+                        }
+                    }
                     SessionPixAction::ReleaseService => {
                         #[cfg(feature = "telemetry")]
                         crate::telemetry::set_pix_gate_mode(&session_id, true);
@@ -2993,6 +3022,74 @@ where
         .map_err(TransportSessionError::packet_sending)?;
 
         Ok(guards)
+    }
+
+    /// Asks the Entry to re-send the parts of one SSA's commitment that never arrived.
+    ///
+    /// The Entry's answer to an `SsaRequest` is hundreds of packets and the reconstructor can use
+    /// none of it until every one has landed, so a single drop used to cost the Session on
+    /// `max_ssa_delivery_time` — after the Entry had already been told to fund the cycle. This is the
+    /// repair: the reconstructor says which polynomial runs are missing, and the Entry re-sends
+    /// exactly those.
+    ///
+    /// Deliberately *not* built on [`send_ssa_request`](Self::send_ssa_request), whose every step is
+    /// wrong here. It registers no Exit commitment — the cycle already has one, and registering a
+    /// second for the same index is refused as a duplicate — allocates no index, and asks the deposit
+    /// pool for nothing, since the deposit data of this cycle travelled with the request that created
+    /// it. Nothing it does can earn the Entry a deposit, which is what makes it safe to repeat.
+    ///
+    /// The scope is read here rather than carried in the action: what is missing changes as the burst
+    /// continues to arrive, and the freshest answer is both smaller and the one that converges.
+    async fn send_commitment_retransmission_request(
+        &self,
+        session_id: SessionId,
+        slot: &SessionSlot,
+        ssa_id: SsaId<HoprPseudonym>,
+        params: PixParams,
+    ) -> errors::Result<()> {
+        let pix_toolbox = self.pix_toolbox.get().cloned().ok_or(SessionManagerError::NotStarted)?;
+        let mut msg_sender = self.msg_sender.get().cloned().ok_or(SessionManagerError::NotStarted)?;
+
+        // Asked of the encoder, so the scope cannot be sized against a restated layout — see
+        // `StartProtocol::max_missing_runs`.
+        let max_runs = HoprStartProtocol::max_missing_runs(&session_id).map_err(SessionManagerError::other)?;
+
+        let Some(runs) = pix_toolbox.share_processor.missing_commitment_runs(&ssa_id, max_runs) else {
+            // The registration is gone — retired, or expired after
+            // `incomplete_commitment_lifetime` — so there is nothing left for a retransmission to
+            // complete. The commitment deadline is what ends the Session; saying so here is the only
+            // way an operator learns which of the two it was.
+            warn!(%session_id, %ssa_id, "cannot re-request commitment parts for a cycle the reconstructor no longer holds");
+            return Ok(());
+        };
+
+        if runs.is_empty() {
+            // The commitment completed between the timer firing and this running. Its
+            // `CommitmentVerified` is already on its way to the supervisor, which clears the timer.
+            debug!(%session_id, %ssa_id, "commitment completed before its parts could be re-requested");
+            return Ok(());
+        }
+
+        let missing_polynomials: u32 = runs.iter().map(|(first, last)| (last - first) as u32 + 1).sum();
+        info!(
+            %session_id, %ssa_id, runs = runs.len(), missing_polynomials,
+            "re-requesting the SSA commitment parts that did not arrive"
+        );
+
+        send_via_msg_sender(
+            &mut msg_sender,
+            slot.routing_opts.clone(),
+            HoprStartProtocol::SsaRequest(SsaServerCommitmentMessage::recommit(
+                session_id,
+                params,
+                [(ssa_id.ssa_index(), runs)],
+            )),
+            "ssa commitment retransmission request",
+        )
+        .await
+        .map_err(TransportSessionError::packet_sending)?;
+
+        Ok(())
     }
 
     /// Returns the current number of active sessions.
@@ -4170,14 +4267,21 @@ where
 
         // A verifiable commitment is what starts the deposit clock, so tell the supervisor before
         // the observer below can report anything against it.
-        if ssa_client_commitment_state.is_verifiable
-            && let Some(supervisor) = session_slot.pix_supervisor.get()
-            && supervisor
-                .send_event(SessionPixEvent::CommitmentVerified(ssa_id))
-                .await
-                .is_err()
-        {
-            error!(%session_id, %ssa_id, "pix supervisor is no longer accepting events");
+        //
+        // An *incomplete* one is reported too, and per message: that is what arms the supervisor's
+        // re-request timer and keeps pushing it out while the burst is still arriving, so it fires
+        // only once delivery has actually stalled. It is also the only evidence that the Entry
+        // answered at all, which is what separates a cycle worth re-asking for from one where
+        // nothing was ever delivered and there is no scope to name.
+        if let Some(supervisor) = session_slot.pix_supervisor.get() {
+            let event = if ssa_client_commitment_state.is_verifiable {
+                SessionPixEvent::CommitmentVerified(ssa_id)
+            } else {
+                SessionPixEvent::CommitmentProgress(ssa_id)
+            };
+            if supervisor.send_event(event).await.is_err() {
+                error!(%session_id, %ssa_id, "pix supervisor is no longer accepting events");
+            }
         }
 
         if ssa_client_commitment_state.deposit_address_first_encountered
@@ -4280,6 +4384,66 @@ where
         if self.close_session(&session_id) {
             error!(%session_id, "closed session after refusing the Exit's SSA request");
         }
+    }
+
+    /// Handled by the Entry, when the Exit says it never received parts of a commitment this node
+    /// already published.
+    ///
+    /// Re-sends the named polynomial commitments and nothing else. Emits no
+    /// [`ReadyToDeposit`](HoprSessionOutPixEvent::ReadyToDeposit): the deposit address of a cycle is
+    /// fixed when it is first committed, and the caller was told it then, so announcing it again
+    /// would invite a second deposit against one quota.
+    ///
+    /// A failure here is reported to the caller of the Start-message dispatcher and otherwise
+    /// dropped. It is deliberately not [`refuse_ssa_request`](Self::refuse_ssa_request), which closes
+    /// the Session: an Exit that asks for a cycle this node cannot serve is asking for something
+    /// already lost, and its own commitment deadline ends the Session either way — whereas closing on
+    /// a request that merely raced our own state would throw away a Session that was about to work.
+    ///
+    /// The generator bounds how often it answers per cycle
+    /// ([`MAX_COMMITMENT_RETRANSMISSIONS`](hopr_protocol_pix::MAX_COMMITMENT_RETRANSMISSIONS)), which
+    /// is what keeps this from being a packet-amplification lever: one request may name a whole
+    /// cycle's polynomials, and the answer to that is the entire commitment burst again.
+    async fn handle_ssa_recommit(
+        &self,
+        pseudonym: HoprPseudonym,
+        session_slot: &SessionSlot,
+        msg: SsaServerCommitmentMessage<SessionId, HoprPixGroupElement, HoprPixDepositPayload>,
+    ) -> errors::Result<()> {
+        let pix_toolbox = self.pix_toolbox.get().cloned().ok_or(SessionManagerError::NotStarted)?;
+        let mut msg_sender = self.msg_sender.get().cloned().ok_or(SessionManagerError::NotStarted)?;
+        let session_id = msg.session_id;
+
+        for (ssa_index, runs) in msg.missing {
+            // Rebuilt from the bytes that went out the first time, so the peer's already-filled slots
+            // see a re-delivery rather than a contradiction.
+            let pix_toolbox_clone = pix_toolbox.clone();
+            let commitment = hopr_utils::parallelize::cpu::spawn_blocking(
+                move || pix_toolbox_clone.share_generator.recommit(&pseudonym, ssa_index, runs),
+                "client_ssa_recommitment",
+            )
+            .await
+            .map_err(SessionManagerError::other)?
+            .map_err(SessionManagerError::PixError)?;
+
+            let commitment_msgs =
+                SsaClientCommitmentMessage::new_multiple(session_id, commitment).map_err(SessionManagerError::other)?;
+            let num_messages = commitment_msgs.len();
+
+            for commitment_msg in commitment_msgs {
+                send_via_msg_sender(
+                    &mut msg_sender,
+                    session_slot.routing_opts.clone(),
+                    HoprStartProtocol::SsaCommit(commitment_msg),
+                    "re-sent client SSA commitment message",
+                )
+                .await?;
+            }
+
+            info!(%session_id, %ssa_index, num_messages, "re-sent the requested SSA commitment parts");
+        }
+
+        Ok(())
     }
 
     /// Handled by the Entry, when the Exit sends PIX initiation request
@@ -4432,6 +4596,19 @@ where
                 .await;
             return Err(error.into());
         }
+        // A request naming missing commitment parts asks for nothing new — see
+        // `SsaServerCommitmentMessage` — and none of what follows may run for it.
+        //
+        // That placement is the whole safety argument for reusing this message. The successor gate
+        // below would refuse an index that is *already* being served, which is every index a
+        // retransmission can name; the served-packet gate prices service against a batch nobody is
+        // asking for; and `new_ssa_commitment` rejects an index at or below the watermark, which
+        // again is every index this can name. Above this line is what a retransmission does need:
+        // the pseudonym check, the session slot, and the parameter comparison.
+        if !msg.missing.is_empty() {
+            return self.handle_ssa_recommit(pseudonym, &session_slot, msg).await;
+        }
+
         let quota_per_ssa = pix_params_to_quota(&our_params);
 
         // Everything from here to the end of the batch is serialised per pseudonym. Start messages run
@@ -11000,6 +11177,10 @@ mod tests {
                 supervision: SupervisorConfig {
                     // Short, so the deadline under test fires quickly.
                     max_ssa_delivery_time: Duration::from_millis(50),
+                    // Scaled with it, since it has to stay under the delivery deadline. Nothing arms
+                    // it here — the Entry sends no commitment at all, so there is no scope to
+                    // re-request and the deadline under test is the only one that can fire.
+                    commitment_recommit_interval: Duration::from_millis(10),
                     // Far out of reach, so it cannot be what closes the Session.
                     max_deposit_wait: Duration::from_secs(3600),
                     ..Default::default()

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -344,6 +344,18 @@ const MIN_FRAME_TIMEOUT: Duration = Duration::from_millis(10);
 /// so a programmatically built config that never calls `validate()` cannot exceed it.
 pub const MAX_SSA_BATCH_SIZE: usize = 9;
 
+// The Entry's retention of commitment material has to outlast the batch that material belongs to.
+// `hopr-protocol-pix` cannot see this figure, so it derives its cap from it in prose; this is the
+// half of that derivation which has to hold. A cycle must stay retransmittable at least until its
+// own batch has finished being committed, or a commitment packet lost early in a large batch becomes
+// unrepairable while the rest of the batch is still arriving. Slack beyond one batch is a judgement
+// call, which is why this is an inequality and not the equality the two figures satisfy today.
+const _: () = assert!(
+    hopr_protocol_pix::MAX_RETAINED_COMMITMENT_CYCLES >= MAX_SSA_BATCH_SIZE,
+    "MAX_SSA_BATCH_SIZE exceeds MAX_RETAINED_COMMITMENT_CYCLES, so a cycle can be evicted from the Entry's retention \
+     before its own batch is fully committed and its commitment stops being repairable"
+);
+
 /// How long an Exit waits for the deposit pool to answer a
 /// [`DepositDataRequest`](HoprSessionOutPixEvent::DepositDataRequest) before sending the batch
 /// without what has not arrived.
@@ -4400,16 +4412,39 @@ where
     /// already lost, and its own commitment deadline ends the Session either way — whereas closing on
     /// a request that merely raced our own state would throw away a Session that was about to work.
     ///
-    /// The generator bounds how often it answers per cycle
-    /// ([`MAX_COMMITMENT_RETRANSMISSIONS`](hopr_protocol_pix::MAX_COMMITMENT_RETRANSMISSIONS)), which
-    /// is what keeps this from being a packet-amplification lever: one request may name a whole
-    /// cycle's polynomials, and the answer to that is the entire commitment burst again.
+    /// Two separate bounds keep this from being a packet-amplification lever, because one request may
+    /// name a whole cycle's polynomials and the answer to that is the entire commitment burst again.
+    /// The generator bounds how often it answers for *one* cycle
+    /// ([`MAX_COMMITMENT_RETRANSMISSIONS`](hopr_protocol_pix::MAX_COMMITMENT_RETRANSMISSIONS)); this
+    /// function bounds how many cycles one request may set going. Neither stands in for the other —
+    /// the first bounds repeats, the second bounds breadth.
     async fn handle_ssa_recommit(
         &self,
         pseudonym: HoprPseudonym,
         session_slot: &SessionSlot,
         msg: SsaServerCommitmentMessage<SessionId, HoprPixGroupElement, HoprPixDepositPayload>,
     ) -> errors::Result<()> {
+        // The wire bounds the *runs* a request carries, not the number of cycles they are spread
+        // over — one run of 8 bytes can name a whole cycle — so without this a single packet names
+        // every retained cycle and is answered with a full commitment burst for each. The generator's
+        // per-cycle attempt cap does not bound that: it bounds repeats of one cycle, not breadth
+        // across cycles.
+        //
+        // The same cap as the new-SSA path, so repairing a batch can never cost more than committing
+        // to it did, and the Exit's own requests name a single cycle. Dropped rather than refused
+        // with `refuse_ssa_request`: the peer is already inside its own commitment deadline and
+        // learns nothing from a refusal it does not learn from that, and replying at all would hand
+        // back some of the amplification the request was reaching for.
+        let max_ssas_per_request = self.cfg.max_ssas_per_ssa_request;
+        if msg.missing.len() > max_ssas_per_request {
+            return Err(SessionManagerError::Unacceptable(format!(
+                "Exit asked for retransmissions across {} SSA cycles in a single request, at most \
+                 {max_ssas_per_request} allowed",
+                msg.missing.len()
+            ))
+            .into());
+        }
+
         let pix_toolbox = self.pix_toolbox.get().cloned().ok_or(SessionManagerError::NotStarted)?;
         let mut msg_sender = self.msg_sender.get().cloned().ok_or(SessionManagerError::NotStarted)?;
         let session_id = msg.session_id;
@@ -10708,6 +10743,156 @@ mod tests {
         assert!(
             accepted.session_alive,
             "an accepted batch must leave the Session running"
+        );
+
+        Ok(())
+    }
+
+    /// A retransmission request must be capped on the *cycles* it names, not only on the runs the
+    /// wire can carry.
+    ///
+    /// One 8-byte run names a whole cycle, so a request naming every retained cycle is answered with
+    /// a full commitment burst for each — thousands of packets out of a single packet in. The
+    /// generator's per-cycle attempt cap does not bound that: it bounds repeats of one cycle, and
+    /// each cycle here is being asked for the first time.
+    #[test_log::test(tokio::test)]
+    async fn entry_rejects_a_retransmission_request_naming_too_many_cycles() -> anyhow::Result<()> {
+        use std::collections::BTreeMap;
+
+        use hopr_crypto_packet::prelude::HoprPixGroupElement;
+        use hopr_protocol_pix::{PixGroup, SsaGeneratorConfig, SsaReconstructorConfig};
+        use hopr_protocol_start::StartInitiation;
+
+        /// Commits `cap` cycles to an Entry capped at `cap`, then asks it to retransmit `cycles` of
+        /// them, and reports what `handle_ssa_request` made of the second request together with every
+        /// `SsaCommit` the Entry sent across both — one per cycle at these dimensions, so the
+        /// commitment alone accounts for `cap` of them.
+        ///
+        /// Committing first is what gives the assertions their teeth: an uncapped handler answers
+        /// every *retained* index it is named before it trips over the first one it does not hold, so
+        /// the packet count — not the error — is what separates a gate from an accident. The count is
+        /// read only after the send channel has drained, since the bursts are queued rather than sent
+        /// inline and a running total would race them.
+        async fn ask_for_cycles(cap: usize, cycles: u32) -> anyhow::Result<(errors::Result<()>, usize)> {
+            let (pix_toolbox, _pix_events) = PixToolbox::new(
+                SsaShareGenerator::new(SsaGeneratorConfig {
+                    polynomials_per_ssa: 2,
+                    threshold: 2,
+                    surplus_shares: 1,
+                })
+                .into(),
+                SsaReconstructor::new(SsaReconstructorConfig::default()).into(),
+            );
+
+            let mgr = SessionManager::new(SessionManagerConfig {
+                pix_config: IncomingSessionPixConfig {
+                    quota_range: 0..=1024 * 1024 * 1024,
+                    ..Default::default()
+                },
+                max_ssas_per_ssa_request: cap,
+                ..Default::default()
+            });
+
+            // The amplification is the thing being bounded, so count what actually goes out.
+            let commits = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+            let commits_tx = commits.clone();
+            let mut bob_transport = MockMsgSender::new();
+            bob_transport
+                .expect_send_message()
+                .times(1..)
+                .returning(move |_, data| {
+                    if crate::testing::msg_type(&data, StartProtocolDiscriminants::SsaCommit) {
+                        commits_tx.fetch_add(1, Ordering::Relaxed);
+                    }
+                    Box::pin(async { Ok(()) })
+                });
+
+            let (bob_sender, bob_handle) = mock_packet_planning(bob_transport);
+            let (new_session_tx, new_session_rx) = futures::channel::mpsc::channel(1);
+            let _notifications = tokio::spawn(async move {
+                pin_mut!(new_session_rx);
+                while let Some(_session) = new_session_rx.next().await {}
+            });
+            mgr.start(bob_sender.clone(), new_session_tx, Some(pix_toolbox), None)?;
+
+            let alice_pseudonym = HoprPseudonym::random();
+            mgr.handle_incoming_session_initiation(
+                alice_pseudonym,
+                StartInitiation {
+                    challenge: MIN_CHALLENGE,
+                    target: SessionTarget::TcpStream(SealedHost::Plain("127.0.0.1:80".parse()?)),
+                    capabilities: HoprSessionCapabilities(Capability::UsePIX.into()),
+                    additional_data: small_pix_additional_data(),
+                },
+            )
+            .await?;
+
+            let params = PixParams::try_new(2, 2, TEST_SURPLUS_SHARES, LOCAL_PIX_SUITE)?;
+            let identity = HoprPixGroupElement::try_from(PixGroup::<HoprPixSpec>::default().to_bytes().as_ref())
+                .expect("identity element must be valid");
+
+            // Commit a full batch first, so there is real material for the retransmission to name.
+            let commitments: BTreeMap<_, _> = (100..100 + cap as u32)
+                .map(|i| (SsaIndex::new(i).expect("non-zero"), identity))
+                .collect();
+            mgr.handle_ssa_request(
+                alice_pseudonym,
+                SsaServerCommitmentMessage::new(alice_pseudonym, params, commitments, []),
+            )
+            .await?;
+
+            // One run apiece, each covering its whole cycle: the cheapest request to send and the
+            // most expensive to answer.
+            let missing = (100..100 + cycles).map(|i| (SsaIndex::new(i).expect("non-zero"), vec![(0u16, 1u16)]));
+
+            let result = mgr
+                .handle_ssa_request(
+                    alice_pseudonym,
+                    SsaServerCommitmentMessage::recommit(alice_pseudonym, params, missing),
+                )
+                .await;
+
+            bob_sender.close_channel();
+            bob_handle.await??;
+
+            Ok((result, commits.load(Ordering::Relaxed)))
+        }
+
+        // One cycle over the cap is refused whole, and — the part that matters — answered with
+        // nothing at all, rather than with a burst for each retained cycle it managed to name first.
+        let (over_cap, over_cap_commits) = ask_for_cycles(
+            DEFAULT_MAX_SSAS_PER_SSA_REQUEST,
+            DEFAULT_MAX_SSAS_PER_SSA_REQUEST as u32 + 1,
+        )
+        .await?;
+        assert!(
+            matches!(
+                over_cap,
+                Err(TransportSessionError::Manager(SessionManagerError::Unacceptable(_)))
+            ),
+            "a retransmission request over the cycle cap must be refused, got {over_cap:?}"
+        );
+        assert_eq!(
+            DEFAULT_MAX_SSAS_PER_SSA_REQUEST, over_cap_commits,
+            "a refused request must add nothing to the {DEFAULT_MAX_SSAS_PER_SSA_REQUEST} messages the commitment \
+             itself cost"
+        );
+
+        // ...and the very same cycles are repaired once they fit the cap, so the refusal above is the
+        // cap talking and not some other validation the request also trips.
+        let (at_cap, at_cap_commits) = ask_for_cycles(
+            DEFAULT_MAX_SSAS_PER_SSA_REQUEST,
+            DEFAULT_MAX_SSAS_PER_SSA_REQUEST as u32,
+        )
+        .await?;
+        assert!(
+            at_cap.is_ok(),
+            "a request at the cycle cap must be answered, got {at_cap:?}"
+        );
+        assert_eq!(
+            2 * DEFAULT_MAX_SSAS_PER_SSA_REQUEST,
+            at_cap_commits,
+            "every named cycle must be re-sent, one message each on top of the commitment's own"
         );
 
         Ok(())

--- a/transport/session/src/supervision/mod.rs
+++ b/transport/session/src/supervision/mod.rs
@@ -43,6 +43,8 @@
 //!
 //! ```text
 //! RequestSsa  ──►  SsaRequestSent  ──►  AwaitingCommitment
+//!                                          ├── (CommitmentProgress arms/re-arms the re-request timer)
+//!                                          ├── (its expiry → RequestCommitmentRetransmission, bounded)
 //!                                          │
 //!                                     CommitmentVerified
 //!                                          │
@@ -64,6 +66,12 @@
 //! **Key deadlines** (all configurable via [`SupervisorConfig`]):
 //!
 //! * **Commitment timeout** — time from `SsaRequestSent` to `CommitmentVerified`.
+//! * **Commitment re-request** — time a *partially* delivered commitment may go quiet before the missing parts are
+//!   asked for again. The one deadline here that is not a deadline: it emits a repair and re-arms, never a close, and
+//!   the commitment timeout above remains the bound. It is armed only by `CommitmentProgress`, so a commitment nothing
+//!   was ever delivered for never asks — there is no scope for it to name. Bounded by count, at
+//!   [`MAX_COMMITMENT_RETRANSMISSIONS`](hopr_protocol_pix::MAX_COMMITMENT_RETRANSMISSIONS), which is what the Entry
+//!   will answer.
 //! * **Deposit timeout** — time from `CommitmentVerified` to a sufficient deposit.
 //! * **Recovery idle** — time without *any share arriving* while service is being consumed. **Service-gated**: if no
 //!   packets were served since the last progress snapshot, the timer re-arms instead of closing (prevents a
@@ -193,9 +201,9 @@
 //! blocking or failing the worker. The gate has already consumed the notification locally, and the
 //! next forwarded notification replaces it for observers.
 //!
-//! All other actions (`RequestSsa`, `ReleaseService`, `WithholdService`, `RetireSsa`, `Close`)
-//! are non-coalescible — if they cannot be delivered, the channel is
-//! genuinely wedged and the worker fails the session.
+//! All other actions (`RequestSsa`, `RequestCommitmentRetransmission`, `ReleaseService`,
+//! `WithholdService`, `RetireSsa`, `Close`) are non-coalescible — if they cannot be delivered, the
+//! channel is genuinely wedged and the worker fails the session.
 //!
 //! ## Integration with [`SessionManager`]
 //!
@@ -216,6 +224,7 @@
 //!    | Action | Behaviour |
 //!    |---|---|
 //!    | `RequestSsa` | Calls `send_ssa_request`, feeds back result to supervisor. Tracks each SSA in `SsaCommitmentGuard` for Drop-safe cleanup. |
+//!    | `RequestCommitmentRetransmission` | Calls `send_commitment_retransmission_request`, which reads the missing scope from the reconstructor and asks the Entry for it. Registers nothing and reports nothing back: it repeats on its own interval and the commitment deadline is the backstop. |
 //!    | `ReleaseService` | Worker calls `gate.release_service()`; driver records funded telemetry. |
 //!    | `WithholdService` | Worker calls `gate.withhold_service()`; driver records unfunded telemetry. |
 //!    | `ProgressNotification` | Worker calls `gate.notify_progress()`; no driver I/O. |
@@ -281,6 +290,7 @@
 //! | `allow_dynamic_ssa_batches` | true | Lets a sub-range per-SSA offer satisfy `quota_range` by committing to the smallest batch whose total quota enters the range. Disable it to retain the fixed-batch, per-SSA admission rule. |
 //! | `max_failed_cycles` | 1 | An Entry losing one cycle per batch indefinitely while a single funded sibling holds the Session open. One loss is survivable, the second closes the Session. Only reachable above a batch of one, where the failing cycle is not always the last one standing. |
 //! | `max_ssa_delivery_time` | 20 s | An Entry that accepts a request and never delivers the commitment set, holding a session slot and a reconstructor cycle that can never be funded. |
+//! | `commitment_recommit_interval` | 3 s | A *single lost packet* costing the whole Session. A commitment set ships as hundreds of messages and is unusable until every one lands, so without this a drop stranded the cycle on the deadline above — after the Entry had already been told to fund it. The one parameter here that buys liveness rather than bounding an attack; it bounds nothing itself. |
 //! | `max_deposit_wait` | 60 s | An Entry that commits but never deposits — typically after it has already drawn the predeposit budget. |
 //! | `max_recovery_idle` | 60 s | An Entry, or a colluding first return relayer, consuming service while returning no shares. Service-gated, so a Session that is merely quiet is never punished. |
 //! | `max_recovery_time` | 2 h | A cycle that dribbles just enough progress to refresh the idle timer forever. A resource backstop for the slot and the reconstructor state, *not* the anti-drip rule. It must clear a whole cycle at the widest dimensions the node accepts — 655 360 packets of *full emission*, ~61 min, at the defaults — or it closes honest Sessions instead. That is the quantity `quota_range` prices and `validate_incoming_session_pix_config` enforces; the *last useful share* lands earlier, at 651 264, which is the figure the "why two hours" argument on [`SupervisorConfig::max_recovery_time`] uses. |
@@ -330,7 +340,8 @@
 //!
 //! [`validate_pix_supervision`] enforces, at config-load time and against the reconstructor config
 //! actually in use: `max_recovery_idle >= max_ack_await_time`; `tombstone_retention_window >=
-//! max_ack_await_time`; `max_recovery_idle < unused_verifier_lifetime`; `ssas_per_request` in
+//! max_ack_await_time`; `max_recovery_idle < unused_verifier_lifetime`;
+//! `commitment_recommit_interval < max_ssa_delivery_time`; `ssas_per_request` in
 //! `1..=MAX_SSA_BATCH_SIZE`; both scaled deadlines under 24 h; non-zero durations; a share fraction in
 //! `0.0..=1.0`; and non-zero `max_served_without_progress`, `min_share_order_sample` and
 //! `max_failed_cycles`.
@@ -526,6 +537,33 @@ pub struct SupervisorConfig {
     #[default(Duration::from_secs(20))]
     #[serde(with = "humantime_serde")]
     pub max_ssa_delivery_time: Duration,
+
+    /// How long a *partially* delivered commitment may go quiet before the missing parts are
+    /// re-requested.
+    ///
+    /// The Entry's answer to an `SsaRequest` is not one message but hundreds of them, and the Exit
+    /// can use none of it until every one has landed — so a single lost packet used to cost the whole
+    /// Session on [`max_ssa_delivery_time`](Self::max_ssa_delivery_time), typically after the Entry
+    /// had already been told to fund the cycle's deposit address. This is the timer that repairs it:
+    /// on expiry the Exit asks the Entry to re-send the polynomial commitments it never received.
+    ///
+    /// An *idle* timer, armed and re-armed by each arriving commitment message, so it measures
+    /// silence rather than elapsed time and the first ask cannot land in the middle of the burst.
+    /// It is only ever armed once something has arrived: a commitment nothing was delivered for has
+    /// no scope to name, and there is nothing the Exit could ask for.
+    ///
+    /// It bounds nothing on its own — `max_ssa_delivery_time` remains the absolute deadline, so the
+    /// unincentivized exposure of a cycle is unchanged however often this fires. How many asks a
+    /// cycle makes is bounded by count rather than by this interval:
+    /// [`MAX_COMMITMENT_RETRANSMISSIONS`](hopr_protocol_pix::MAX_COMMITMENT_RETRANSMISSIONS), which
+    /// is also exactly how many the Entry will answer, so shortening this buys promptness and never
+    /// a flood of wasted packets.
+    ///
+    /// Default: 3 s — well clear of the time a full burst takes to arrive, and short enough that a
+    /// repair completes several times over inside the delivery deadline.
+    #[default(Duration::from_secs(3))]
+    #[serde(with = "humantime_serde")]
+    pub commitment_recommit_interval: Duration,
 
     /// Maximum time to wait for a deposit after the commitment is verifiable.
     ///
@@ -763,6 +801,13 @@ pub use hopr_protocol_pix::PixParams;
 pub enum SessionPixEvent {
     /// The initial or next SSA request was successfully sent on the wire.
     SsaRequestSent(SsaId<HoprPseudonym>),
+    /// Part of an SSA commitment arrived, but the set is still incomplete.
+    ///
+    /// Reported per message, which is what makes the re-request timer an *idle* timer: the burst
+    /// keeps pushing it out, and it only expires once delivery has actually stalled. It is also the
+    /// only evidence that the Entry answered at all, which is what distinguishes a cycle worth
+    /// re-asking for from one where nothing was ever delivered and there is no scope to name.
+    CommitmentProgress(SsaId<HoprPseudonym>),
     /// A verifiable commitment was installed in the reconstructor.
     CommitmentVerified(SsaId<HoprPseudonym>),
     /// The Exit's deposit pool reported a sufficient deposit for this SSA.
@@ -805,6 +850,20 @@ pub enum SessionPixAction {
     /// registration it made.
     RequestSsa {
         ssa_ids: Vec<SsaId<HoprPseudonym>>,
+        params: PixParams,
+    },
+    /// Ask the Entry to re-send the parts of one SSA's commitment that never arrived.
+    ///
+    /// Emitted when a partially delivered commitment has been quiet for
+    /// [`SupervisorConfig::commitment_recommit_interval`], and repeated on that interval until the
+    /// commitment verifies or the absolute delivery deadline closes the Session. The scope is not
+    /// carried here: what is missing is the reconstructor's to say, and it can change between this
+    /// action being emitted and being carried out, so the carrier reads it at the point of sending.
+    ///
+    /// Unlike [`RequestSsa`](Self::RequestSsa) this asks for nothing new and its failure is not
+    /// terminal — the delivery deadline remains the backstop, so a dropped ask costs one interval.
+    RequestCommitmentRetransmission {
+        ssa_id: SsaId<HoprPseudonym>,
         params: PixParams,
     },
     /// Put the service gate in funded mode for the front cycle, or rebaseline a funded successor.
@@ -913,6 +972,23 @@ pub fn validate_pix_supervision(
         return Err(TransportSessionError::InvalidConfig(
             "max_ssa_delivery_time must be non-zero".into(),
         ));
+    }
+    // Both halves are dead config rather than merely odd. A zero interval fires the re-request timer
+    // on the same instant it is armed, so every arriving commitment message answers itself with an
+    // ask; an interval at or above the delivery deadline never fires before the deadline closes the
+    // Session, which is exactly the failure the timer exists to prevent — and neither is visible to
+    // the operator anywhere but here.
+    if cfg.commitment_recommit_interval.is_zero() {
+        return Err(TransportSessionError::InvalidConfig(
+            "commitment_recommit_interval must be non-zero".into(),
+        ));
+    }
+    if cfg.commitment_recommit_interval >= cfg.max_ssa_delivery_time {
+        return Err(TransportSessionError::InvalidConfig(format!(
+            "commitment_recommit_interval ({:?}) must be shorter than max_ssa_delivery_time ({:?}), or a partially \
+             delivered commitment is never re-requested before the Session closes",
+            cfg.commitment_recommit_interval, cfg.max_ssa_delivery_time
+        )));
     }
     if cfg.max_deposit_wait.is_zero() {
         return Err(TransportSessionError::InvalidConfig(
@@ -1116,6 +1192,7 @@ mod tests {
             allow_dynamic_ssa_batches: true,
             max_failed_cycles: 1,
             max_ssa_delivery_time: Duration::from_secs(20),
+            commitment_recommit_interval: Duration::from_secs(3),
             max_deposit_wait: Duration::from_secs(60),
             max_recovery_idle: Duration::from_secs(60),
             max_recovery_time: Duration::from_secs(3600),
@@ -1157,6 +1234,36 @@ mod tests {
         let mut cfg = valid_cfg();
         cfg.max_deposit_wait = Duration::ZERO;
         assert!(validate_pix_supervision(&cfg, &valid_rcn_cfg()).is_err());
+    }
+
+    /// Both ends of the re-request interval are dead config, and invisible anywhere but here.
+    ///
+    /// Asserts on the messages: a zero interval also trips nothing else, but an interval at or above
+    /// the delivery deadline would stay green under `is_err()` if the branch naming it were deleted,
+    /// since a lone `is_err()` cannot see which guard fired.
+    #[test]
+    fn validation_rejects_a_recommit_interval_that_cannot_fire() {
+        let message_of = |cfg: &SupervisorConfig| match validate_pix_supervision(cfg, &valid_rcn_cfg()) {
+            Err(TransportSessionError::InvalidConfig(message)) => message,
+            other => panic!("expected an invalid-config error, got {other:?}"),
+        };
+
+        let mut zero = valid_cfg();
+        zero.commitment_recommit_interval = Duration::ZERO;
+        assert!(
+            message_of(&zero).contains("commitment_recommit_interval must be non-zero"),
+            "a zero interval fires on the instant it is armed, so every arriving part answers itself"
+        );
+
+        let mut too_long = valid_cfg();
+        too_long.commitment_recommit_interval = too_long.max_ssa_delivery_time;
+        assert!(
+            message_of(&too_long).contains("must be shorter than max_ssa_delivery_time"),
+            "an interval at the deadline never fires before the Session closes"
+        );
+
+        // And the shipping default satisfies it, which is what makes the rule safe to enforce.
+        assert!(validate_pix_supervision(&SupervisorConfig::default(), &SsaReconstructorConfig::default()).is_ok());
     }
 
     /// Unlike its siblings, this one has to assert on the message.

--- a/transport/session/src/supervision/supervisor.rs
+++ b/transport/session/src/supervision/supervisor.rs
@@ -44,6 +44,23 @@ struct PerSsaState {
 
     // Deadlines (None means not set for this phase).
     commitment_deadline: Option<Instant>,
+    /// When to re-request the parts of this commitment that have not arrived, or `None` while there
+    /// is nothing to ask for.
+    ///
+    /// Set only once *some* of the commitment has arrived, and pushed out by every further part, so
+    /// it measures silence in the delivery rather than elapsed time. A cycle for which nothing was
+    /// ever delivered leaves it unset and dies on `commitment_deadline`, which is all the Exit can
+    /// do about one: it has no scope to name.
+    recommit_deadline: Option<Instant>,
+    /// Re-requests already made for this cycle, capped at
+    /// [`MAX_COMMITMENT_RETRANSMISSIONS`](hopr_protocol_pix::MAX_COMMITMENT_RETRANSMISSIONS).
+    ///
+    /// The cap is a count and not a duration on purpose. `commitment_deadline` bounds the asks in
+    /// *time*, which is what protects the Entry, but the packets they cost are this node's own: at a
+    /// misconfigured millisecond interval inside a 20-second deadline the time bound alone permits
+    /// twenty thousand of them. Matching the figure the Entry will answer means none of the asks is
+    /// wasted either.
+    recommit_attempts: u8,
     deposit_deadline: Option<Instant>,
     recovery_idle_deadline: Option<Instant>,
     recovery_hard_deadline: Option<Instant>,
@@ -93,6 +110,8 @@ impl PerSsaState {
             batch_id,
             phase: SsaPhase::AwaitingCommitment,
             commitment_deadline: None,
+            recommit_deadline: None,
+            recommit_attempts: 0,
             deposit_deadline: None,
             recovery_idle_deadline: None,
             recovery_hard_deadline: None,
@@ -237,6 +256,7 @@ impl SessionPixSupervisor {
 
         let actions = match ev {
             SessionPixEvent::SsaRequestSent(ssa_id) => self.on_ssa_request_sent(ssa_id, now),
+            SessionPixEvent::CommitmentProgress(ssa_id) => self.on_commitment_progress(ssa_id, now),
             SessionPixEvent::CommitmentVerified(ssa_id) => self.on_commitment_verified(ssa_id, now),
             SessionPixEvent::DepositConfirmed { ssa_id, amount } => {
                 self.on_deposit_confirmed(ssa_id, *amount, now, served_total)
@@ -508,6 +528,32 @@ impl SessionPixSupervisor {
                 ssa.check_deadlines(now)
             };
 
+            // A stalled commitment is re-requested rather than given up on, and the timer re-arms so
+            // a repair that is itself lost is asked for again. This yields no close reason and is
+            // bounded by nothing of its own: the absolute `commitment_deadline` still ends the cycle,
+            // which is why it can repeat freely — and why it is skipped once that deadline has gone,
+            // rather than putting an ask on the wire for a Session about to close.
+            if expired.is_none()
+                && self.ssas[i].phase == SsaPhase::AwaitingCommitment
+                && self.ssas[i].recommit_deadline.is_some_and(|deadline| now >= deadline)
+            {
+                let ssa = &mut self.ssas[i];
+                ssa.recommit_attempts += 1;
+                // Disarmed rather than re-armed at the cap, so the worker stops waking for a timer
+                // that would produce nothing. Further arriving parts cannot re-arm it either.
+                ssa.recommit_deadline = (ssa.recommit_attempts < hopr_protocol_pix::MAX_COMMITMENT_RETRANSMISSIONS)
+                    .then(|| now.checked_add(self.cfg.commitment_recommit_interval))
+                    .flatten();
+                tracing::debug!(
+                    ssa_id = %ssa.ssa_id, attempt = ssa.recommit_attempts,
+                    "commitment delivery stalled — re-requesting the parts that did not arrive"
+                );
+                actions.push(SessionPixAction::RequestCommitmentRetransmission {
+                    ssa_id: ssa.ssa_id,
+                    params: self.dims,
+                });
+            }
+
             if let Some(reason) = expired {
                 // Service-gated idle: if no service consumed since last progress,
                 // re-arm instead of closing.
@@ -594,9 +640,13 @@ impl SessionPixSupervisor {
                     }
                     return None;
                 }
-                // Return the earliest set deadline.
+                // Return the earliest set deadline. The re-request timer belongs here like the rest:
+                // it is shorter than every other deadline of the phase it runs in, so leaving it out
+                // would mean the worker slept past it and only re-requested when something else woke
+                // it up.
                 ssa.commitment_deadline
                     .into_iter()
+                    .chain(ssa.recommit_deadline)
                     .chain(ssa.deposit_deadline)
                     .chain(ssa.recovery_idle_deadline)
                     .chain(ssa.recovery_hard_deadline)
@@ -675,6 +725,27 @@ impl SessionPixSupervisor {
         Vec::new()
     }
 
+    /// Arms — or re-arms — the re-request timer on a commitment that is under way but not complete.
+    ///
+    /// This is where the issue's rule lives: a cycle that received *nothing* never reaches here, so
+    /// it never asks, which is correct because there is no scope for it to name. And because every
+    /// arriving part pushes the timer out, the first ask cannot land in the middle of the burst —
+    /// what the timer measures is a stall in delivery.
+    ///
+    /// Unscaled by the batch size, unlike the two absolute deadlines: this is a per-cycle stall
+    /// detector, and a batch's commitment sets do not queue behind one another in a way that would
+    /// make one cycle's silence expected.
+    fn on_commitment_progress(&mut self, ssa_id: &SsaId<HoprPseudonym>, now: Instant) -> Vec<SessionPixAction> {
+        if let Some(idx) = self.find_ssa_idx(ssa_id)
+            && self.ssas[idx].phase == SsaPhase::AwaitingCommitment
+            && self.ssas[idx].recommit_attempts < hopr_protocol_pix::MAX_COMMITMENT_RETRANSMISSIONS
+        {
+            self.ssas[idx].recommit_deadline = now.checked_add(self.cfg.commitment_recommit_interval);
+        }
+
+        Vec::new()
+    }
+
     fn on_commitment_verified(&mut self, ssa_id: &SsaId<HoprPseudonym>, now: Instant) -> Vec<SessionPixAction> {
         let idx = match self.find_ssa_idx(ssa_id) {
             Some(i) => i,
@@ -692,6 +763,8 @@ impl SessionPixSupervisor {
         ssa.phase = SsaPhase::AwaitingDeposit;
         ssa.deposit_deadline = deposit_deadline;
         ssa.commitment_deadline = None;
+        // Nothing is missing any more, so nothing is to be asked for.
+        ssa.recommit_deadline = None;
 
         Vec::new()
     }
@@ -1481,6 +1554,7 @@ mod tests {
             allow_dynamic_ssa_batches: true,
             max_failed_cycles: 1,
             max_ssa_delivery_time: Duration::from_secs(20),
+            commitment_recommit_interval: Duration::from_secs(3),
             max_deposit_wait: Duration::from_secs(60),
             max_recovery_idle: Duration::from_secs(60),
             max_recovery_time: Duration::from_secs(3600),
@@ -2380,6 +2454,174 @@ mod tests {
             actions[0],
             SessionPixAction::Close(SessionPixCloseReason::CommitmentTimeout)
         ));
+    }
+
+    /// A commitment that is under way but has gone quiet is re-requested, repeatedly, without ever
+    /// being closed for it — and the absolute deadline is still what ends the cycle.
+    #[test]
+    fn a_stalled_commitment_is_re_requested_until_the_delivery_deadline() {
+        let p = pseudonym();
+        let cfg = default_cfg();
+        let (mut sup, _) = SessionPixSupervisor::new(cfg.clone(), dims(10, 5), p, Instant::now());
+        let start = Instant::now();
+        let id = ssa_id(p, 1);
+
+        sup.handle_event(&SessionPixEvent::SsaRequestSent(id), start, 0);
+
+        // Nothing has arrived, so there is no scope to ask for and no timer to expire.
+        assert!(
+            sup.handle_deadline(start + cfg.commitment_recommit_interval * 3, 0)
+                .is_empty(),
+            "a commitment nothing was delivered for must not be re-requested"
+        );
+
+        // The first part arrives; the timer is armed from *that* instant.
+        let first_part = start + Duration::from_secs(1);
+        sup.handle_event(&SessionPixEvent::CommitmentProgress(id), first_part, 0);
+        assert!(
+            sup.handle_deadline(first_part + cfg.commitment_recommit_interval / 2, 0)
+                .is_empty(),
+            "the interval must be measured from the last part that arrived"
+        );
+
+        // More of the burst lands, pushing the timer out again: the first ask must not land in the
+        // middle of delivery.
+        let last_part = first_part + cfg.commitment_recommit_interval;
+        sup.handle_event(&SessionPixEvent::CommitmentProgress(id), last_part, 0);
+        assert!(
+            sup.handle_deadline(last_part + cfg.commitment_recommit_interval / 2, 0)
+                .is_empty(),
+            "an arriving part must re-arm the timer"
+        );
+
+        // Delivery stalls. Every interval from here produces one ask, and no close, for as long as
+        // the delivery deadline has room — at the shipped 3 s inside 20 s that is five of them, so
+        // the count cap is not what binds at the defaults.
+        let delivery_deadline =
+            start + crate::supervision::scaled_deadline(cfg.max_ssa_delivery_time, cfg.ssas_per_request);
+        let mut now = last_part;
+        let mut asks = 0;
+        while now + cfg.commitment_recommit_interval < delivery_deadline {
+            now += cfg.commitment_recommit_interval;
+            let actions = sup.handle_deadline(now, 0);
+            assert!(
+                matches!(
+                    actions.as_slice(),
+                    [SessionPixAction::RequestCommitmentRetransmission { ssa_id, params }]
+                        if *ssa_id == id && *params == dims(10, 5)
+                ),
+                "ask {} must name the missing parts, got {actions:?}",
+                asks + 1
+            );
+            asks += 1;
+        }
+        assert!(asks > 1, "the interval must fit several asks inside the deadline");
+
+        // The delivery deadline is untouched by any of it, and remains the only thing that ends the
+        // cycle.
+        let actions = sup.handle_deadline(delivery_deadline, 0);
+        assert!(matches!(
+            actions.as_slice(),
+            [SessionPixAction::Close(SessionPixCloseReason::CommitmentTimeout)]
+        ));
+    }
+
+    /// Asks stop at [`MAX_COMMITMENT_RETRANSMISSIONS`], which is what the Entry will answer.
+    ///
+    /// The delivery deadline bounds the asks in *time*, and that is what protects the Entry — but the
+    /// packets they cost are the Exit's own, and a short interval inside a long deadline leaves time
+    /// for far more of them than any Entry answers. Hence a count.
+    #[test]
+    fn asks_for_a_stalled_commitment_are_capped_by_count() {
+        let p = pseudonym();
+        // Short enough that the whole budget is spent well inside the delivery deadline, so it is the
+        // count and not the clock that stops it.
+        let cfg = SupervisorConfig {
+            commitment_recommit_interval: Duration::from_secs(1),
+            ..default_cfg()
+        };
+        let (mut sup, _) = SessionPixSupervisor::new(cfg.clone(), dims(10, 5), p, Instant::now());
+        let start = Instant::now();
+        let id = ssa_id(p, 1);
+
+        sup.handle_event(&SessionPixEvent::SsaRequestSent(id), start, 0);
+        sup.handle_event(&SessionPixEvent::CommitmentProgress(id), start, 0);
+
+        let mut now = start;
+        for attempt in 1..=hopr_protocol_pix::MAX_COMMITMENT_RETRANSMISSIONS {
+            now += cfg.commitment_recommit_interval;
+            let actions = sup.handle_deadline(now, 0);
+            assert!(
+                matches!(
+                    actions.as_slice(),
+                    [SessionPixAction::RequestCommitmentRetransmission { ssa_id, .. }] if *ssa_id == id
+                ),
+                "attempt {attempt} must ask for the missing parts, got {actions:?}"
+            );
+        }
+
+        now += cfg.commitment_recommit_interval;
+        assert!(
+            sup.handle_deadline(now, 0).is_empty(),
+            "the ask budget must be spent, with the delivery deadline still far off"
+        );
+        assert_eq!(
+            Some(start + crate::supervision::scaled_deadline(cfg.max_ssa_delivery_time, cfg.ssas_per_request)),
+            sup.next_deadline(),
+            "a spent budget must leave no timer for the worker to wake on"
+        );
+
+        // Further parts of the burst cannot buy more asks either.
+        sup.handle_event(&SessionPixEvent::CommitmentProgress(id), now, 0);
+        assert!(
+            sup.handle_deadline(now + cfg.commitment_recommit_interval * 2, 0)
+                .is_empty(),
+            "an arriving part must not re-open a spent budget"
+        );
+    }
+
+    /// The re-request timer is the earliest deadline of the phase it runs in, so the worker has to be
+    /// woken by it — and it must stop existing the moment the commitment completes.
+    #[test]
+    fn the_re_request_timer_leads_the_deadlines_and_ends_with_the_commitment() {
+        let p = pseudonym();
+        let cfg = default_cfg();
+        let (mut sup, _) = SessionPixSupervisor::new(cfg.clone(), dims(10, 5), p, Instant::now());
+        let start = Instant::now();
+        let id = ssa_id(p, 1);
+
+        sup.handle_event(&SessionPixEvent::SsaRequestSent(id), start, 0);
+        sup.handle_event(&SessionPixEvent::CommitmentProgress(id), start, 0);
+        assert_eq!(
+            Some(start + cfg.commitment_recommit_interval),
+            sup.next_deadline(),
+            "the worker must wake for the re-request before the delivery deadline"
+        );
+
+        sup.handle_event(&SessionPixEvent::CommitmentVerified(id), start, 0);
+        assert_eq!(
+            Some(start + crate::supervision::scaled_deadline(cfg.max_deposit_wait, cfg.ssas_per_request)),
+            sup.next_deadline(),
+            "a completed commitment leaves only the deposit clock"
+        );
+        assert!(
+            sup.handle_deadline(start + cfg.commitment_recommit_interval, 0)
+                .is_empty(),
+            "nothing may be re-requested once the commitment verified"
+        );
+
+        // A straggling part of the burst arrives after completion — which retransmission makes
+        // routine — and must not resurrect the timer.
+        sup.handle_event(
+            &SessionPixEvent::CommitmentProgress(id),
+            start + cfg.commitment_recommit_interval,
+            0,
+        );
+        assert!(
+            sup.handle_deadline(start + cfg.commitment_recommit_interval * 3, 0)
+                .is_empty(),
+            "a late part must not re-arm a timer the phase has left"
+        );
     }
 
     #[test]

--- a/transport/session/src/supervision/worker.rs
+++ b/transport/session/src/supervision/worker.rs
@@ -357,6 +357,7 @@ mod tests {
             allow_dynamic_ssa_batches: true,
             max_failed_cycles: 1,
             max_ssa_delivery_time: Duration::from_secs(20),
+            commitment_recommit_interval: Duration::from_secs(3),
             max_deposit_wait: Duration::from_secs(60),
             max_recovery_idle: Duration::from_secs(10),
             max_recovery_time: Duration::from_secs(3600),

--- a/transport/session/tests/pix.rs
+++ b/transport/session/tests/pix.rs
@@ -380,6 +380,279 @@ async fn session_manager_should_follow_start_protocol_to_establish_new_session_a
     Ok(())
 }
 
+/// Verifies that a commitment burst which loses a message still completes, because the Exit asks for
+/// the missing polynomials and the Entry re-sends exactly those.
+///
+/// This is the failure the retransmission exists for. A cycle's commitment ships as several
+/// `SsaCommit` messages and the Exit can use none of it until every one lands, so before this a
+/// single dropped packet stranded the cycle until `max_ssa_delivery_time` closed the Session — by
+/// which point the Entry had already emitted `ReadyToDeposit` and been told to fund an address that
+/// could never pay out.
+///
+/// ## Steps
+/// 1. Alice and Bob are set up as in the lifecycle test above, but Bob's supervisor gets a 200 ms
+///    `commitment_recommit_interval` so the repair happens inside the test's patience.
+/// 2. Alice's mock transport **drops** her first `SsaCommit` instead of delivering it, and records the polynomial
+///    indices it carried. Everything else is relayed.
+/// 3. Bob's reconstructor is left one chunk short, so it derives no deposit address and reports no verifiable
+///    commitment. Each message that *did* arrive re-armed his re-request timer.
+/// 4. On the timer, Bob sends a second `SsaRequest` whose `missing` scope names the dropped run.
+/// 5. Alice answers it from the bytes she sent the first time, and only for the indices asked for.
+/// 6. Bob completes the commitment and emits `DepositNeeded`; Alice emits `ReadyToDeposit` exactly once, since the
+///    repair must not invite a second deposit against one quota.
+#[test(tokio::test)]
+async fn a_dropped_ssa_commit_is_repaired_by_a_scoped_retransmission() -> Result<()> {
+    use std::sync::Mutex;
+
+    let alice_pseudonym = HoprPseudonym::random();
+    let bob_peer: Address = (&ChainKeypair::random()).into();
+
+    let ssa_gen_config = SsaGeneratorConfig {
+        polynomials_per_ssa: 64,
+        threshold: 64,
+        surplus_shares: 16,
+    };
+    let params = PixParams::try_from_config::<HoprPixSpec>(&ssa_gen_config)?;
+
+    // More than one message, or there is no "one of them" to drop.
+    let expected_ssa_commits = (ssa_gen_config.polynomials_per_ssa as usize)
+        .div_ceil(HoprStartProtocol::ssa_commit_chunking(&alice_pseudonym)?.max_constant_terms_per_message);
+    assert!(
+        expected_ssa_commits > 1,
+        "the commitment must span several messages for this test to mean anything"
+    );
+
+    let alice_mgr = SessionManager::new(Default::default());
+    let bob_mgr = SessionManager::new(SessionManagerConfig {
+        pix_config: IncomingSessionPixConfig {
+            quota_range: 0..=cycle_quota(&params),
+            supervision: SupervisorConfig {
+                // Short, so the stall is noticed and repaired within the test's timeouts. Everything
+                // else is left at its shipping value, including the delivery deadline this races.
+                commitment_recommit_interval: Duration::from_millis(200),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    });
+
+    /// Polynomial indices one `SsaCommit` carries, sorted, or `None` for any other message.
+    fn committed_polynomials(data: &ApplicationData) -> Option<Vec<u16>> {
+        match HoprStartProtocol::try_from(data.clone()) {
+            Ok(HoprStartProtocol::SsaCommit(commit)) => {
+                let mut indices: Vec<u16> = commit.coefficient_commitments.into_keys().collect();
+                indices.sort_unstable();
+                Some(indices)
+            }
+            _ => None,
+        }
+    }
+
+    // Every `SsaCommit` Alice sends, in order, and the one the transport swallowed.
+    let sent_commits: Arc<Mutex<Vec<Vec<u16>>>> = Arc::new(Mutex::new(Vec::new()));
+    let dropped_commit: Arc<Mutex<Option<Vec<u16>>>> = Arc::new(Mutex::new(None));
+    // The scope of every retransmission request Bob sends, flattened to plain polynomial indices.
+    type RequestedScopes = Arc<Mutex<Vec<(SsaIndex, Vec<u16>)>>>;
+    let requested_scopes: RequestedScopes = Arc::new(Mutex::new(Vec::new()));
+
+    let mut alice_transport = MockMsgSender::new();
+    let mut bob_transport = MockMsgSender::new();
+
+    let bob_mgr_relay = Arc::new(bob_mgr.clone());
+    let sent_commits_relay = sent_commits.clone();
+    let dropped_commit_relay = dropped_commit.clone();
+    // A single catch-all expectation rather than one per message kind: the repair is a *second*
+    // exchange over the same channel, so the message counts are not known in advance — which is what
+    // the assertions below establish instead.
+    alice_transport
+        .expect_send_message()
+        .times(1..)
+        .returning(move |_, data| {
+            let bob_mgr = bob_mgr_relay.clone();
+            let sent_commits = sent_commits_relay.clone();
+            let dropped_commit = dropped_commit_relay.clone();
+            Box::pin(async move {
+                if let Some(indices) = committed_polynomials(&data.data) {
+                    sent_commits.lock().unwrap().push(indices.clone());
+                    let mut dropped = dropped_commit.lock().unwrap();
+                    if dropped.is_none() {
+                        // The loss this test is about: the first chunk never reaches Bob.
+                        tracing::info!(?indices, "dropping alice's first SsaCommit");
+                        *dropped = Some(indices);
+                        return Ok(());
+                    }
+                }
+                bob_mgr.dispatch_message(
+                    alice_pseudonym,
+                    ApplicationDataIn {
+                        data: data.data,
+                        packet_info: Default::default(),
+                    },
+                )?;
+                Ok(())
+            })
+        });
+
+    let alice_mgr_relay = Arc::new(alice_mgr.clone());
+    let requested_scopes_relay = requested_scopes.clone();
+    bob_transport
+        .expect_send_message()
+        .times(1..)
+        .returning(move |_, data| {
+            let alice_mgr = alice_mgr_relay.clone();
+            let requested_scopes = requested_scopes_relay.clone();
+            Box::pin(async move {
+                if let Ok(HoprStartProtocol::SsaRequest(req)) = HoprStartProtocol::try_from(data.data.clone()) {
+                    for (ssa_index, runs) in req.missing {
+                        let indices = runs.into_iter().flat_map(|(first, last)| first..=last).collect();
+                        tracing::info!(%ssa_index, ?indices, "bob asks for the missing commitment parts");
+                        requested_scopes.lock().unwrap().push((ssa_index, indices));
+                    }
+                }
+                alice_mgr.dispatch_message(
+                    alice_pseudonym,
+                    ApplicationDataIn {
+                        data: data.data,
+                        packet_info: Default::default(),
+                    },
+                )?;
+                Ok(())
+            })
+        });
+
+    let ssa_rec_config = SsaReconstructorConfig::default();
+    let (pix_toolbox_alice, pix_alice_rx) = PixToolbox::new(
+        SsaShareGenerator::new(ssa_gen_config).into(),
+        SsaReconstructor::new(ssa_rec_config).into(),
+    );
+    let (pix_toolbox_bob, pix_bob_rx) = PixToolbox::new(
+        SsaShareGenerator::new(ssa_gen_config).into(),
+        SsaReconstructor::new(ssa_rec_config).into(),
+    );
+    let pix_bob_rx = answering_deposit_pool(pix_bob_rx, |_| Vec::new());
+
+    let mut ahs = Vec::new();
+
+    let (new_session_tx_alice, _) = futures::channel::mpsc::channel(1024);
+    let (alice_sender, alice_handle) = mock_packet_planning(alice_transport);
+    ahs.extend(alice_mgr.start(
+        alice_sender.clone(),
+        new_session_tx_alice,
+        Some(pix_toolbox_alice),
+        None,
+    )?);
+
+    let (new_session_tx_bob, new_session_rx_bob) = futures::channel::mpsc::channel(1024);
+    let (bob_sender, bob_handle) = mock_packet_planning(bob_transport);
+    ahs.extend(bob_mgr.start(bob_sender.clone(), new_session_tx_bob, Some(pix_toolbox_bob), None)?);
+
+    let target = SealedHost::Plain("127.0.0.1:80".parse()?);
+    pin_mut!(new_session_rx_bob);
+    let (alice_session, bob_session) = tokio_time::timeout(
+        Duration::from_secs(5),
+        futures::future::join(
+            alice_mgr.new_session(
+                bob_peer,
+                SessionTarget::TcpStream(target.clone()),
+                SessionClientConfig {
+                    pseudonym: alice_pseudonym.into(),
+                    capabilities: Capability::NoRateControl | Capability::Segmentation | Capability::UsePIX,
+                    surb_management: None,
+                    pix_ssa_quota: Some(params),
+                    return_path_options: RoutingOptions::Hops(1.try_into()?),
+                    ..Default::default()
+                },
+            ),
+            new_session_rx_bob.next(),
+        ),
+    )
+    .await
+    .map_err(|e| anyhow::anyhow!("timeout establishing the session: {e}"))?;
+
+    let mut alice_session = alice_session?;
+    let _bob_session = bob_session.ok_or(anyhow::anyhow!("bob must get an incoming session"))?;
+
+    pin_mut!(pix_alice_rx);
+    pin_mut!(pix_bob_rx);
+
+    // Alice announces her deposit as soon as the burst is *sent*, so this does not wait on the repair
+    // — it is what makes the loss expensive and the repair worth having.
+    let alice_event = tokio_time::timeout(Duration::from_secs(5), pix_alice_rx.next())
+        .await
+        .map_err(|e| anyhow::anyhow!("timeout waiting for alice's ReadyToDeposit: {e}"))?
+        .ok_or(anyhow::anyhow!("alice must get a pix event"))?;
+    let HoprSessionOutPixEvent::ReadyToDeposit(alice_quota) = &alice_event else {
+        panic!("expected ReadyToDeposit, got {alice_event:?}");
+    };
+
+    // Bob's, on the other hand, can only arrive once the missing chunk has been asked for and
+    // answered. Before the retransmission this timed out and the Session died on the delivery
+    // deadline.
+    let bob_event = tokio_time::timeout(Duration::from_secs(5), pix_bob_rx.next())
+        .await
+        .map_err(|e| anyhow::anyhow!("timeout waiting for bob's DepositNeeded — the repair did not complete: {e}"))?
+        .ok_or(anyhow::anyhow!("bob must get a pix event"))?;
+    let HoprSessionOutPixEvent::DepositNeeded(bob_quota, _) = &bob_event else {
+        panic!("expected DepositNeeded, got {bob_event:?}");
+    };
+    assert_eq!(
+        alice_quota.ssa_id, bob_quota.ssa_id,
+        "the repaired cycle must be the one Alice committed to"
+    );
+    assert_eq!(alice_quota.deposit_address, bob_quota.deposit_address);
+
+    let dropped = dropped_commit
+        .lock()
+        .unwrap()
+        .clone()
+        .ok_or(anyhow::anyhow!("the test must have dropped an SsaCommit"))?;
+
+    // Bob asked for exactly what went missing, and asked at all — the scope is derived from what his
+    // reconstructor holds, so this pins the whole detection path.
+    let scopes = requested_scopes.lock().unwrap().clone();
+    assert_eq!(
+        vec![(alice_quota.ssa_id.ssa_index(), dropped.clone())],
+        scopes,
+        "bob must ask once, for the dropped run and nothing else"
+    );
+
+    // And Alice answered with exactly those, rather than re-sending the whole burst.
+    let commits = sent_commits.lock().unwrap().clone();
+    assert_eq!(
+        expected_ssa_commits + 1,
+        commits.len(),
+        "the burst plus one repair message, got {commits:?}"
+    );
+    assert_eq!(
+        Some(&dropped),
+        commits.last(),
+        "the repair must carry the dropped indices and no others"
+    );
+
+    // Exactly one deposit for the cycle: the address is fixed when it is first committed, so a repair
+    // that announced it again would invite a second deposit against one quota.
+    assert!(
+        tokio_time::timeout(Duration::from_millis(300), pix_alice_rx.next())
+            .await
+            .is_err(),
+        "the repair must not make Alice announce a second deposit"
+    );
+
+    alice_session.close().await?;
+    tokio_time::sleep(Duration::from_millis(100)).await;
+
+    for ah in ahs {
+        ah.abort();
+    }
+    alice_sender.close_channel();
+    bob_sender.close_channel();
+    alice_handle.await??;
+    bob_handle.await??;
+
+    Ok(())
+}
+
 /// Verifies that dispatching a PIX event to a session that does not exist returns a
 /// `NonExistingSession` error.
 ///

--- a/transport/session/tests/pix.rs
+++ b/transport/session/tests/pix.rs
@@ -610,25 +610,36 @@ async fn a_dropped_ssa_commit_is_repaired_by_a_scoped_retransmission() -> Result
 
     // Bob asked for exactly what went missing, and asked at all — the scope is derived from what his
     // reconstructor holds, so this pins the whole detection path.
+    //
+    // How *many* times he asked is deliberately not pinned. The idle timer re-arms before the repair
+    // it triggered has been relayed, reconstructed and verified, so a slow enough round trip earns a
+    // second ask — which is correct here rather than a defect, since re-delivery is idempotent and
+    // the attempt cap bounds it. What must hold is that every ask names the gap and nothing else;
+    // the cadence and the cap are the supervisor's contract and are pinned by its own tests.
     let scopes = requested_scopes.lock().unwrap().clone();
-    assert_eq!(
-        vec![(alice_quota.ssa_id.ssa_index(), dropped.clone())],
-        scopes,
-        "bob must ask once, for the dropped run and nothing else"
-    );
+    assert!(!scopes.is_empty(), "bob must ask for the missing commitment parts");
+    for scope in &scopes {
+        assert_eq!(
+            &(alice_quota.ssa_id.ssa_index(), dropped.clone()),
+            scope,
+            "every ask must name the dropped run and nothing else, got {scopes:?}"
+        );
+    }
 
-    // And Alice answered with exactly those, rather than re-sending the whole burst.
+    // And Alice answered with exactly those, rather than re-sending the whole burst. The burst is
+    // recorded before the transport decides to swallow one of it, so it occupies the first
+    // `expected_ssa_commits` slots and everything after them is a repair.
     let commits = sent_commits.lock().unwrap().clone();
-    assert_eq!(
-        expected_ssa_commits + 1,
-        commits.len(),
-        "the burst plus one repair message, got {commits:?}"
+    assert!(
+        commits.len() > expected_ssa_commits,
+        "the burst plus at least one repair message, got {commits:?}"
     );
-    assert_eq!(
-        Some(&dropped),
-        commits.last(),
-        "the repair must carry the dropped indices and no others"
-    );
+    for repair in &commits[expected_ssa_commits..] {
+        assert_eq!(
+            &dropped, repair,
+            "every repair must carry the dropped indices and no others, got {commits:?}"
+        );
+    }
 
     // Exactly one deposit for the cycle: the address is fixed when it is first committed, so a repair
     // that announced it again would invite a second deposit against one quota.


### PR DESCRIPTION
Closes #8318.

A cycle's SSA commitment is one constant-term commitment per polynomial — ~315 `SsaCommit` packets at the deployed 8192 polynomials — the Exit can use **none** of it until every one has been received, since the commitment is their sum. So a single lost packet stranded the whole cycle until `max_ssa_delivery_time` closed the Session, typically *after* the Entry had emitted `ReadyToDeposit` and been told to fund an address that could never pay out. At 1 % per-packet loss that is a ~96 % chance of losing the Session at every cycle boundary.

## The Change

**The Exit asks for what it is missing.** Each arriving `SsaCommit` reports `CommitmentProgress`, which arms (or re-arms) a new `commitment_recommit_interval` (3 s). It is an *idle* timer, so the first ask cannot land in the middle of the burst. On expiry the Exit sends an `SsaRequest` whose new `missing` table names the polynomial-index runs its reconstructor never received, and the Entry re-sends exactly those — from the bytes it sent the first time, advancing no index and announcing no second deposit.

Runs rather than a list of indices, because loss is chunk-shaped: the sender slices the set into packet-sized slices of *consecutive* indices, so one lost packet is one run of a couple of dozen — and a burst that never arrived at all is a single run.

**A cycle for which nothing arrived never asks.** It has no scope to name, which is the issue's own rule and comes for free from arming on progress. `max_ssa_delivery_time` is untouched, so the unincentivized exposure of a cycle does not grow however often this fires.

**Both sides are bounded, because a request may name a whole cycle and its answer is the entire burst again:**

| Bound | Value | Why |
|---|---|---|
| Exit asks per cycle | `MAX_COMMITMENT_RETRANSMISSIONS` (8) | the deadline bounds asks in *time*, but the packets are the Exit's own — a millisecond interval inside a 20 s deadline permits 20 000 of them |
| Entry answers per cycle | same 8 | so no ask is wasted, and a peer already served cannot farm bursts out of the Entry |
| Entry retention | ~270 kB/cycle, `MAX_RETAINED_COMMITMENT_CYCLES` (18) cycles | oldest evicted first, and nothing else releases it — emission is not a proxy for whether a repair still helps, since the Exit completes a cycle out of the shares it has already buffered. 4.8 MB per pseudonym with the cap full, against the 33 MB a single *undrained* cycle's polynomials occupy |

The Entry retains the wire-ready commitments rather than recomputing them: the proof opens the *sum* of the sub-secrets, which is not kept, and a polynomial exhausted by emission is dropped along with its constant term — so a recomputing Entry would fail exactly when the Exit had waited longest.

**Re-delivery is idempotent.** A slot re-offered the commitment it already holds is absorbed, and a message arriving after completion reports the completed cycle; only a *different* commitment for an occupied slot is still an error, which is the single-assignment invariant that matters. Without this every successful repair would fail on the next packet, since a repair and its own original can overtake one another on the mixed path.

**Placement is the safety argument for reusing `SsaRequest`.** The branch sits after the pseudonym check, the session slot and the parameter comparison, and before everything else: the successor gate would refuse an index already being served, the served-packet gate prices service against a batch nobody asked for, and `new_ssa_commitment` rejects an index at or below the watermark — all of which is every index a retransmission can name. Encoding and decoding enforce that exactly one of `commitments` and `missing` is populated, so the two request kinds cannot be confused.

**BREAKING:** `START_PROTOCOL_VERSION` goes to 4. The `missing` run table sits between an `SsaRequest`'s commitment entries and its trailing CBOR session id, which a version-3 decoder reads as "everything left"; the bump turns a silent misparse into `InvalidVersion`. RFC-0012 needs the matching update.

**Versions.** `hopr-protocol-start` goes to **2.0.0** rather than 1.3.0: every field of `SsaServerCommitmentMessage` is public, so the added `missing` table breaks any struct literal, and the wire version changes on top of that. The other two are pre-1.0, where the minor is the breaking slot, and both changes are breaking.

| Crate | | Breaking because |
|---|---|---|
| `hopr-protocol-start` | 1.2.0 → **2.0.0** | public field added to `SsaServerCommitmentMessage` |
| `hopr-protocol-pix` | 0.1.0 → **0.2.0** | `add_transposed` now absorbs a re-delivered commitment instead of erroring |
| `hopr-transport-session` | 0.29.0 → **0.30.0** | field added to `SupervisorConfig`; a variant to each of `SessionPixEvent` and `SessionPixAction` |

