### PR TITLE
feat(session): gate organic SURB production on the balancer target

### DIFF
--- a/protocols/app/src/v1.rs
+++ b/protocols/app/src/v1.rs
@@ -151,6 +151,9 @@ pub struct IncomingPacketInfo {
     /// surplus was destroyed rather than queued. Under PIX each destroyed SURB also destroys the
     /// partial SSA share it carried, since a share only reaches the reconstructor when its SURB is
     /// used — so this is not a bandwidth statistic but a loss counter.
+    ///
+    /// Reported for observability, and deliberately not fed back into the SURB flow estimator — see
+    /// the note on the field it would correct in `hopr-transport-session`'s `BalancerStateValues`.
     pub num_evicted_surbs: usize,
 }
 

--- a/protocols/app/src/v1.rs
+++ b/protocols/app/src/v1.rs
@@ -144,6 +144,14 @@ pub struct IncomingPacketInfo {
     pub signals_from_sender: PacketSignals,
     /// The number of SURBs the HOPR packet was carrying along with the [`ApplicationData`] instance.
     pub num_saved_surbs: usize,
+    /// How many of those SURBs were discarded on arrival because the SURB buffer for this sender was
+    /// already full.
+    ///
+    /// Non-zero means the sender is producing SURBs faster than this side can hold them, and the
+    /// surplus was destroyed rather than queued. Under PIX each destroyed SURB also destroys the
+    /// partial SSA share it carried, since a share only reaches the reconstructor when its SURB is
+    /// used — so this is not a bandwidth statistic but a loss counter.
+    pub num_evicted_surbs: usize,
 }
 
 /// Holds packet transient information when [`ApplicationData`] is passed to the HOPR protocol layer from the

--- a/protocols/hopr/src/codec/decoder.rs
+++ b/protocols/hopr/src/codec/decoder.rs
@@ -241,15 +241,30 @@ where
         match packet {
             HoprPacket::Final(incoming) => {
                 // Extract additional information from the packet that will be passed upwards
-                let info = AuxiliaryPacketInfo {
+                let mut info = AuxiliaryPacketInfo {
                     packet_signals: incoming.signals,
                     num_surbs: incoming.surbs.len(),
+                    num_evicted_surbs: 0,
                 };
 
                 // Store all incoming SURBs if any
                 if !incoming.surbs.is_empty() {
-                    self.surb_store.insert_surbs(incoming.sender, incoming.surbs);
-                    tracing::trace!(pseudonym = %incoming.sender, num_surbs = info.num_surbs, packet_type = "final", "stored incoming surbs for pseudonym");
+                    let outcome = self.surb_store.insert_surbs(incoming.sender, incoming.surbs);
+                    info.num_evicted_surbs = outcome.evicted;
+                    tracing::trace!(pseudonym = %incoming.sender, num_surbs = info.num_surbs, retained = outcome.retained, packet_type = "final", "stored incoming surbs for pseudonym");
+
+                    // Warn rather than trace: an overflow is silent everywhere else, and it is not a
+                    // wasted SURB but a destroyed PIX share. Without this line the only way to learn
+                    // that a buffer is overflowing is to infer it from a balancer estimate that
+                    // outgrew the store it describes, which is how it was found the first time.
+                    if outcome.evicted > 0 {
+                        tracing::warn!(
+                            pseudonym = %incoming.sender,
+                            evicted = outcome.evicted,
+                            retained = outcome.retained,
+                            "SURB buffer full; dropped the oldest SURBs and the PIX shares they carried"
+                        );
+                    }
                 }
 
                 let result = match incoming.ack_key {

--- a/protocols/hopr/src/surb_store.rs
+++ b/protocols/hopr/src/surb_store.rs
@@ -5,7 +5,7 @@ use hopr_crypto_packet::prelude::*;
 use moka::notification::RemovalCause;
 use validator::ValidationError;
 
-use crate::{FoundSurb, traits::SurbStore};
+use crate::{FoundSurb, SurbInsertOutcome, traits::SurbStore};
 
 /// Lower bound on [`SurbStoreConfig::pseudonyms_lifetime`], enforced by the config validator.
 ///
@@ -315,7 +315,7 @@ impl SurbStore for MemorySurbStore {
     }
 
     #[tracing::instrument(skip_all, level = "trace", fields(%pseudonym, num_surbs = surbs.len()))]
-    fn insert_surbs(&self, pseudonym: HoprPseudonym, surbs: Vec<(HoprSurbId, HoprSurb)>) -> usize {
+    fn insert_surbs(&self, pseudonym: HoprPseudonym, surbs: Vec<(HoprSurbId, HoprSurb)>) -> SurbInsertOutcome {
         self.surbs_per_pseudonym
             .entry_by_ref(&pseudonym)
             .or_insert_with(|| SurbRingBuffer::new(self.cfg.rb_capacity.max(MIN_SURB_RB_CAPACITY), self.cfg.pop_order))
@@ -432,18 +432,24 @@ impl<S> SurbRingBuffer<S> {
     /// Once at capacity, each push evicts the oldest SURB. Under PIX that is a lost SSA share, not
     /// merely a lost SURB — see [`SurbStoreConfig::rb_capacity`].
     ///
-    /// Returns the number of elements held after the push.
-    pub fn push<I: IntoIterator<Item = (HoprSurbId, S)>>(&self, surbs: I) -> usize {
+    /// Returns what the push did; the eviction count is what lets a caller notice the overflow at
+    /// all, since dropping the oldest entry is otherwise indistinguishable from a clean insert.
+    pub fn push<I: IntoIterator<Item = (HoprSurbId, S)>>(&self, surbs: I) -> SurbInsertOutcome {
         let mut rb = self.surbs.lock();
+        let mut evicted = 0;
         for surb in surbs {
             // Evict before inserting, so the length never exceeds the ceiling and the backing
             // allocation stops growing once the high-water mark is reached.
             if rb.len() >= self.capacity {
                 rb.pop_front();
+                evicted += 1;
             }
             rb.push_back(surb);
         }
-        rb.len()
+        SurbInsertOutcome {
+            retained: rb.len(),
+            evicted,
+        }
     }
 
     /// Pops the next SURB that `is_valid` accepts, in the buffer's [`SurbPopOrder`].
@@ -680,10 +686,10 @@ mod tests {
     fn surb_ring_buffer_should_pop_fifo_by_default() -> anyhow::Result<()> {
         let rb = SurbRingBuffer::new(5, SurbPopOrder::default());
 
-        let len = rb.push([([1u8; 8], 0)]);
+        let len = rb.push([([1u8; 8], 0)]).retained;
         assert_eq!(1, len);
 
-        let len = rb.push([([2u8; 8], 0)]);
+        let len = rb.push([([2u8; 8], 0)]).retained;
         assert_eq!(2, len);
 
         let popped = rb.pop_any().ok_or(anyhow::anyhow!("expected pop"))?;
@@ -694,7 +700,7 @@ mod tests {
         assert_eq!([2u8; 8], popped.id);
         assert_eq!(0, popped.remaining);
 
-        let len = rb.push([([1u8; 8], 0), ([2u8; 8], 0)]);
+        let len = rb.push([([1u8; 8], 0), ([2u8; 8], 0)]).retained;
         assert_eq!(2, len);
 
         assert_eq!([1u8; 8], rb.pop_any().ok_or(anyhow::anyhow!("expected pop"))?.id);
@@ -707,10 +713,10 @@ mod tests {
     fn surb_ring_buffer_should_pop_lifo_when_configured() -> anyhow::Result<()> {
         let rb = SurbRingBuffer::new(5, SurbPopOrder::Lifo);
 
-        let len = rb.push([([1u8; 8], 0)]);
+        let len = rb.push([([1u8; 8], 0)]).retained;
         assert_eq!(1, len);
 
-        let len = rb.push([([2u8; 8], 0)]);
+        let len = rb.push([([2u8; 8], 0)]).retained;
         assert_eq!(2, len);
 
         let popped = rb.pop_any().ok_or(anyhow::anyhow!("expected pop"))?;
@@ -721,7 +727,7 @@ mod tests {
         assert_eq!([1u8; 8], popped.id);
         assert_eq!(0, popped.remaining);
 
-        let len = rb.push([([1u8; 8], 0), ([2u8; 8], 0)]);
+        let len = rb.push([([1u8; 8], 0), ([2u8; 8], 0)]).retained;
         assert_eq!(2, len);
 
         assert_eq!([2u8; 8], rb.pop_any().ok_or(anyhow::anyhow!("expected pop"))?.id);
@@ -760,6 +766,82 @@ mod tests {
         assert!(rb.pop_any().is_none());
 
         Ok(())
+    }
+
+    #[rstest]
+    #[case::fifo(SurbPopOrder::Fifo)]
+    #[case::lifo(SurbPopOrder::Lifo)]
+    fn surb_ring_buffer_should_report_no_eviction_below_capacity(#[case] order: SurbPopOrder) {
+        let rb = SurbRingBuffer::new(4, order);
+
+        assert_eq!(
+            SurbInsertOutcome {
+                retained: 2,
+                evicted: 0
+            },
+            rb.push([([1u8; 8], 0), ([2u8; 8], 0)])
+        );
+        assert_eq!(
+            SurbInsertOutcome {
+                retained: 4,
+                evicted: 0
+            },
+            rb.push([([3u8; 8], 0), ([4u8; 8], 0)])
+        );
+    }
+
+    /// Overflow is otherwise entirely silent — the buffer drops its oldest entry and the caller sees
+    /// only a successful push. The count is what lets the layers above notice that SURBs (and the
+    /// PIX shares riding on them) are being destroyed on arrival, so it has to be exact.
+    #[rstest]
+    #[case::fifo(SurbPopOrder::Fifo)]
+    #[case::lifo(SurbPopOrder::Lifo)]
+    fn surb_ring_buffer_should_count_evictions_past_capacity(#[case] order: SurbPopOrder) -> anyhow::Result<()> {
+        let rb = SurbRingBuffer::new(2, order);
+
+        let outcome = rb.push([([1u8; 8], 0), ([2u8; 8], 0), ([3u8; 8], 0)]);
+        assert_eq!(
+            SurbInsertOutcome {
+                retained: 2,
+                evicted: 1
+            },
+            outcome,
+            "a 3-element push into a 2-slot buffer drops exactly one"
+        );
+
+        // The *oldest* is the one gone, in either pop order.
+        let ids: Vec<_> = std::iter::from_fn(|| rb.pop_any().map(|p| p.id)).collect();
+        assert!(
+            !ids.contains(&[1u8; 8]),
+            "the oldest entry must be the evicted one, got {ids:?}"
+        );
+
+        Ok(())
+    }
+
+    /// A buffer already at capacity evicts one per element pushed, however the pushes are grouped —
+    /// the steady-state overflow that a counterparty producing faster than this side drains creates.
+    #[rstest]
+    #[case::fifo(SurbPopOrder::Fifo)]
+    #[case::lifo(SurbPopOrder::Lifo)]
+    fn surb_ring_buffer_should_count_evictions_across_separate_pushes(#[case] order: SurbPopOrder) {
+        let rb = SurbRingBuffer::new(2, order);
+        assert_eq!(0, rb.push([([1u8; 8], 0), ([2u8; 8], 0)]).evicted, "precondition: full");
+
+        assert_eq!(
+            SurbInsertOutcome {
+                retained: 2,
+                evicted: 1
+            },
+            rb.push([([3u8; 8], 0)])
+        );
+        assert_eq!(
+            SurbInsertOutcome {
+                retained: 2,
+                evicted: 2
+            },
+            rb.push([([4u8; 8], 0), ([5u8; 8], 0)])
+        );
     }
 
     /// The buffer grows with occupancy, so it does reallocate on the way up to its ceiling — that

--- a/protocols/hopr/src/traits.rs
+++ b/protocols/hopr/src/traits.rs
@@ -4,7 +4,7 @@ use hopr_crypto_packet::prelude::*;
 
 pub use crate::{
     errors::IncomingPacketError,
-    types::{FoundSurb, IncomingPacket, OutgoingPacket, ResolvedAcknowledgement},
+    types::{FoundSurb, IncomingPacket, OutgoingPacket, ResolvedAcknowledgement, SurbInsertOutcome},
 };
 
 /// A trait defining the operations required to store and retrieve SURBs (Single Use Reply Blocks) and their reply
@@ -25,9 +25,11 @@ pub trait SurbStore {
     /// This is used by the replying side when it receives packets containing SURBs from the sender
     /// with the given `pseudonym`.
     ///
-    /// Returns the total number of SURBs available for that `pseudonym`, including the newly inserted
-    /// ones.
-    fn insert_surbs(&self, pseudonym: HoprPseudonym, surbs: Vec<(HoprSurbId, HoprSurb)>) -> usize;
+    /// Returns the total number of SURBs available for that `pseudonym` including the newly inserted
+    /// ones, along with how many had to be dropped to make room. The eviction count must not be
+    /// discarded lightly: it is the only evidence that the sender is over-producing, and each
+    /// evicted SURB takes an undelivered PIX share with it.
+    fn insert_surbs(&self, pseudonym: HoprPseudonym, surbs: Vec<(HoprSurbId, HoprSurb)>) -> SurbInsertOutcome;
 
     /// Stores the given [`opener`](ReplyOpener) for the given [`sender_id`](HoprSenderId).
     ///

--- a/protocols/hopr/src/types.rs
+++ b/protocols/hopr/src/types.rs
@@ -40,6 +40,18 @@ pub struct AuxiliaryPacketInfo {
     pub packet_signals: PacketSignals,
     /// Number of SURBs that the packet carried.
     pub num_surbs: usize,
+    /// How many of those SURBs the store dropped on arrival because the per-pseudonym buffer was
+    /// already full.
+    ///
+    /// This is the only point at which an overflow is visible, and the cost is higher than a wasted
+    /// SURB: each one carries a partial SSA share that reaches the reconstructor only when the SURB
+    /// is *used*, so an eviction destroys the share. The redundancy budget that absorbs those losses
+    /// is a fixed surplus per polynomial, and emission is windowed, so on deployed dimensions a
+    /// burst of roughly `surplus × SHARE_EMISSION_WINDOW` evictions is enough to put polynomials
+    /// below their threshold — and a cycle short of recovery is worth nothing at all. See
+    /// [`SurbStoreConfig::rb_capacity`](crate::SurbStoreConfig::rb_capacity) and
+    /// `hopr_protocol_pix::SHARE_EMISSION_WINDOW`.
+    pub num_evicted_surbs: usize,
 }
 
 /// An incoming packet with a payload intended for us.
@@ -167,6 +179,21 @@ pub struct FoundSurb {
     pub surb: HoprSurb,
     /// Number of SURBs remaining in the ring buffer with the same pseudonym.
     pub remaining: usize,
+}
+
+/// What storing SURBs via `SurbStore::insert_surbs` did to the ring buffer.
+///
+/// The `evicted` count exists because an overflow is otherwise entirely silent: the buffer drops its
+/// oldest entry and the caller sees only that the insert "succeeded". That count is the only local
+/// evidence that the sender is producing faster than this side can hold, and under PIX it is also a
+/// tally of destroyed SSA shares — a share reaches the reconstructor only when its SURB is *used*,
+/// so an evicted SURB takes its share with it permanently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct SurbInsertOutcome {
+    /// Number of SURBs held for the pseudonym after the insert.
+    pub retained: usize,
+    /// Number of SURBs dropped to make room during this insert, oldest first.
+    pub evicted: usize,
 }
 
 /// Determines the result of how an acknowledgement was resolved.

--- a/protocols/hopr/src/types.rs
+++ b/protocols/hopr/src/types.rs
@@ -51,6 +51,10 @@ pub struct AuxiliaryPacketInfo {
     /// below their threshold — and a cycle short of recovery is worth nothing at all. See
     /// [`SurbStoreConfig::rb_capacity`](crate::SurbStoreConfig::rb_capacity) and
     /// `hopr_protocol_pix::SHARE_EMISSION_WINDOW`.
+    ///
+    /// Carried for observability. Sessions deliberately do not subtract it from their SURB level
+    /// estimate, because the imprecise estimate is the one that fails safe — see
+    /// `counterparty_buffer_capacity` in `hopr-transport-session`.
     pub num_evicted_surbs: usize,
 }
 

--- a/transport/hopr/src/protocol/pipeline/mod.rs
+++ b/transport/hopr/src/protocol/pipeline/mod.rs
@@ -502,6 +502,7 @@ async fn start_incoming_packet_pipeline<WIn, WOut, D, T, TEvt, AckIn, AckOut, Ap
                         packet_info: IncomingPacketInfo {
                             signals_from_sender: aux_info.packet_signals,
                             num_saved_surbs: aux_info.num_surbs,
+                            num_evicted_surbs: aux_info.num_evicted_surbs,
                         }
                     })))
         ))

--- a/transport/session/src/balancer/controller.rs
+++ b/transport/session/src/balancer/controller.rs
@@ -819,6 +819,15 @@ mod tests {
         assert_eq!(1, state.organic_surbs_per_packet());
     }
 
+    /// Sessions opened without SURB management hold a default state and route their outgoing packets
+    /// through the same policy as balanced ones, relying on it to answer 1. A `Default` that ever
+    /// gained a non-zero target would silently stop those sessions producing organic SURBs, with
+    /// nothing at the call site to show why.
+    #[test]
+    fn a_default_state_should_keep_producing_organic_surbs() {
+        assert_eq!(1, BalancerStateValues::default().organic_surbs_per_packet());
+    }
+
     /// Mirror image of `a_degraded_return_path_should_not_zero_the_supply_ceiling` in `flow_control`:
     /// there, the degraded-path `0` must be suppressed because it would read as "admit no bytes";
     /// here it must be honoured, because it reads as "below target, keep producing" — which is

--- a/transport/session/src/balancer/controller.rs
+++ b/transport/session/src/balancer/controller.rs
@@ -139,6 +139,18 @@ pub struct BalancerStateValues {
     /// The counterparty's store is a ring buffer that evicts the oldest entry on overflow, so
     /// everything above its capacity was discarded on arrival and was never a real level. Measured
     /// during an outage: 51 917 believed against a 15 000-entry store.
+    ///
+    /// ## Why evictions are not subtracted from the level
+    ///
+    /// The counterparty reports its evictions (`num_evicted_surbs` on the incoming packet), so the
+    /// level could be corrected to the exact truth instead of merely bounded here. It deliberately
+    /// is not, because the clamp below is `max(capacity, target)` rather than `capacity`: a level
+    /// inflated past a full buffer still climbs to the target and shuts organic production off,
+    /// whereas an accurate level pins at the counterparty's real capacity. If that capacity is below
+    /// the target -- which nothing prevents, since this figure is the *local* store size and the
+    /// counterparty may be smaller -- the accurate level never reaches the target, production never
+    /// stops, and the buffer evicts forever. The imprecise estimate fails safe and the precise one
+    /// does not, so the eviction count stays an observability signal.
     pub counterparty_buffer_capacity: AtomicU64,
     /// Milliseconds from the crate-internal `EPOCH` monotonic origin until which the return path
     /// counts as degraded.

--- a/transport/session/src/balancer/controller.rs
+++ b/transport/session/src/balancer/controller.rs
@@ -14,6 +14,7 @@ use std::{
 static EPOCH: LazyLock<Instant> = LazyLock::new(Instant::now);
 
 use futures::{StreamExt, pin_mut};
+use hopr_crypto_packet::prelude::{PacketSignal, PacketSignals};
 use hopr_utils::runtime::AbortHandle;
 use tracing::{Instrument, instrument};
 
@@ -147,6 +148,18 @@ pub struct BalancerStateValues {
     /// damage of a marker that is never withdrawn to a short over-production instead of a session
     /// that mints forever.
     pub return_path_degraded_until_ms: AtomicU64,
+    /// Whether the counterparty's last packet said it was running low on SURBs of its own.
+    ///
+    /// A plain flag with no deadline, unlike `return_path_degraded_until_ms` above, because the two
+    /// fail in opposite directions: a degraded-path marker that is never withdrawn makes this side
+    /// mint forever, whereas a distress flag that is never withdrawn merely keeps organic production
+    /// at one SURB per packet — the behaviour that predates the gate. A flag whose stuck state is
+    /// the old behaviour does not need to expire.
+    ///
+    /// It clears on its own in the normal case: the counterparty recomputes both SURB signals on
+    /// every return packet and strips them once its pool recovers, so the next healthy packet
+    /// resets this.
+    pub counterparty_in_surb_distress: AtomicBool,
 }
 
 impl BalancerStateValues {
@@ -205,6 +218,56 @@ impl BalancerStateValues {
             capacity => {
                 level.min(capacity.max(self.target_surb_buffer_size.load(std::sync::atomic::Ordering::Relaxed)))
             }
+        }
+    }
+
+    /// Records what the counterparty's latest packet said about *its own* SURB supply.
+    ///
+    /// Takes the whole signal set rather than a `bool` so the containment rule lives here: `OutOfSurbs`
+    /// is a superset of `SurbDistress` on the wire, so `contains` catches both, whereas an equality
+    /// match against `SurbDistress` would silently ignore the more severe of the two.
+    pub fn observe_counterparty_signals(&self, signals: PacketSignals) {
+        self.counterparty_in_surb_distress.store(
+            signals.contains(PacketSignal::SurbDistress),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+    }
+
+    /// How many SURBs an outgoing Session data packet should carry along with its payload.
+    ///
+    /// Entry-side only. [`BalancerStateValues`] is shared by both ends of a Session, but only the
+    /// initiator mints SURBs for its counterparty, so on the Exit this answer is meaningless.
+    ///
+    /// Returning `0` is the point: a SURB delivered to a counterparty that is already at its target
+    /// evicts the oldest one it holds, and under PIX that destroys an SSA share rather than merely
+    /// wasting a SURB. Production resumes at one per packet as soon as the estimate falls back below
+    /// target, or immediately if the counterparty signals it is running low.
+    ///
+    /// Note this reads the raw buffer level and deliberately does *not* consult
+    /// [`return_path_estimate_is_stale`](Self::return_path_estimate_is_stale), which the otherwise
+    /// analogous `SurbSupply` ceiling must consult. The polarity is inverted between the two: there,
+    /// a degraded-path `0` would read as "admit no bytes" and has to be suppressed; here it reads as
+    /// "below target, keep producing", which is exactly what the `sustain_on_return_path_loss` opt-in
+    /// asks for.
+    pub fn organic_surbs_per_packet(&self) -> usize {
+        // Not defensive boilerplate: nothing rejects a `SurbBalancerConfig` with a zero target, and
+        // without this branch `level >= 0` would hold forever and shut organic production off
+        // permanently — while a PID with a zero output limit produces nothing either.
+        if self.is_disabled() {
+            return 1;
+        }
+
+        if self
+            .counterparty_in_surb_distress
+            .load(std::sync::atomic::Ordering::Relaxed)
+        {
+            return 1;
+        }
+
+        if self.buffer_level() >= self.target_surb_buffer_size.load(std::sync::atomic::Ordering::Relaxed) {
+            0
+        } else {
+            1
         }
     }
 
@@ -505,6 +568,10 @@ where
                 produced = self.surb_estimator.estimate_surbs_produced(),
                 consumed = self.surb_estimator.estimate_surbs_consumed(),
                 degraded,
+                distress = self
+                    .state
+                    .counterparty_in_surb_distress
+                    .load(std::sync::atomic::Ordering::Relaxed),
                 "surb balancer state"
             );
         }
@@ -679,6 +746,97 @@ mod tests {
         let state = BalancerStateValues::default();
         state.buffer_level.store(42, std::sync::atomic::Ordering::Relaxed);
         assert_eq!(state.buffer_level(), 42);
+    }
+
+    /// State with a given target sitting at a given level, for the organic-gate tests below.
+    fn gate_state(target: u64, buffer_level: u64) -> BalancerStateValues {
+        let state = BalancerStateValues::new(SurbBalancerConfig {
+            target_surb_buffer_size: target,
+            max_surbs_per_sec: 5_000,
+            ..Default::default()
+        });
+        state
+            .buffer_level
+            .store(buffer_level, std::sync::atomic::Ordering::Relaxed);
+        state
+    }
+
+    #[test]
+    fn organic_surbs_should_be_produced_while_the_counterparty_is_below_target() {
+        assert_eq!(1, gate_state(100, 99).organic_surbs_per_packet());
+        assert_eq!(1, gate_state(100, 0).organic_surbs_per_packet());
+    }
+
+    /// The `>=` boundary: at target is already too many, because the next SURB is the one that
+    /// evicts. Pinned at exactly the target and well past it.
+    #[test]
+    fn organic_surbs_should_stop_once_the_counterparty_reaches_its_target() {
+        assert_eq!(0, gate_state(100, 100).organic_surbs_per_packet());
+        assert_eq!(0, gate_state(100, 200).organic_surbs_per_packet());
+    }
+
+    /// The safety valve. Our level estimate counts SURBs as delivered when they are *sent*, so
+    /// forward-path loss inflates it — the counterparty's own word about its supply has to win over
+    /// an estimate that can be wrong in exactly that direction.
+    #[test]
+    fn organic_surbs_should_resume_at_one_when_the_counterparty_signals_distress() {
+        let state = gate_state(100, 200);
+        assert_eq!(0, state.organic_surbs_per_packet(), "precondition: gate is closed");
+
+        state.observe_counterparty_signals(PacketSignal::SurbDistress.into());
+        assert_eq!(1, state.organic_surbs_per_packet());
+    }
+
+    /// `OutOfSurbs` is `0b11` and `SurbDistress` is `0b01`, so the former *contains* the latter.
+    /// Matching on equality instead of containment would ignore the more severe of the two signals
+    /// and leave production shut off for a counterparty that has nothing left to reply with.
+    #[test]
+    fn out_of_surbs_should_count_as_distress() {
+        let state = gate_state(100, 200);
+        state.observe_counterparty_signals(PacketSignal::OutOfSurbs.into());
+        assert_eq!(1, state.organic_surbs_per_packet());
+    }
+
+    /// Distress is not sticky once the counterparty recovers: it recomputes both signals per return
+    /// packet and strips them when its pool is healthy, so the next such packet re-arms the gate.
+    #[test]
+    fn a_recovered_counterparty_should_clear_distress() {
+        let state = gate_state(100, 200);
+        state.observe_counterparty_signals(PacketSignal::OutOfSurbs.into());
+        assert_eq!(1, state.organic_surbs_per_packet(), "precondition: distress is set");
+
+        state.observe_counterparty_signals(PacketSignals::default());
+        assert_eq!(0, state.organic_surbs_per_packet());
+    }
+
+    /// A zero target means "no balancing", not "the target is already met". Nothing rejects such a
+    /// config, so without the explicit branch `level >= 0` would hold forever and starve the session
+    /// of organic SURBs permanently — while a PID with a zero output limit produces none either.
+    #[test]
+    fn a_disabled_balancer_should_keep_producing_organic_surbs() {
+        let state = gate_state(0, 0);
+        assert!(state.is_disabled(), "precondition: a zero target disables balancing");
+        assert_eq!(1, state.organic_surbs_per_packet());
+    }
+
+    /// Mirror image of `a_degraded_return_path_should_not_zero_the_supply_ceiling` in `flow_control`:
+    /// there, the degraded-path `0` must be suppressed because it would read as "admit no bytes";
+    /// here it must be honoured, because it reads as "below target, keep producing" — which is
+    /// exactly what opting into `sustain_on_return_path_loss` asks for. Same stored value, opposite
+    /// polarity, so this must *not* grow the guard its counterpart needs.
+    #[test]
+    fn a_degraded_return_path_should_not_stop_organic_surb_production() {
+        let state = BalancerStateValues::new(SurbBalancerConfig {
+            target_surb_buffer_size: 100,
+            sustain_on_return_path_loss: true,
+            ..Default::default()
+        });
+        state.mark_return_path_degraded(Duration::from_secs(30));
+        // What the control loop writes while it drives production flat out.
+        state.buffer_level.store(0, std::sync::atomic::Ordering::Relaxed);
+
+        assert!(state.return_path_estimate_is_stale(), "precondition: open loop");
+        assert_eq!(1, state.organic_surbs_per_packet());
     }
 
     #[test]

--- a/transport/session/src/lib.rs
+++ b/transport/session/src/lib.rs
@@ -130,6 +130,12 @@ pub struct SessionClientConfig {
     /// carry the maximum number of SURBs possible. Setting this to `true` will put additional CPU
     /// pressure on the local node as it will generate the maximum number of SURBs for each data packet.
     ///
+    /// It also opts out of the SURB balancer's control over organic production entirely. With the
+    /// default `false`, a data packet carries *at most* one SURB and none at all while the
+    /// counterparty is estimated to be at its target buffer size — which is what stops SURBs (and
+    /// the PIX shares they carry) being delivered into a full buffer that discards them. Setting
+    /// this to `true` keeps producing regardless of that estimate.
+    ///
     /// Set this to `true` only when the underlying traffic is highly asymmetric.
     ///
     /// Default is `false`.

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -2424,25 +2424,16 @@ where
                     METRIC_NUM_INITIATED_SESSIONS.increment();
 
                     let surb_estimator_for_rx = surb_estimator.clone();
-                    let surb_mgmt_for_rx = surb_mgmt.clone();
                     let session = HoprSession::new_with_surb_state(
                         session_id,
                         forward_routing,
                         session_config_with(&self.cfg, cfg.capabilities, cfg.max_frames_behind_gap),
                         (
                             reduced_surb_scoring_sender,
-                            session_rx.inspect(move |data| {
-                                // What the Exit says about its own SURB supply overrides our estimate
-                                // of it, and is the safety valve on the organic SURB gate: our
-                                // estimate counts SURBs as delivered when they are sent, so loss on
-                                // the forward path inflates it, and this is the one input that is not
-                                // downstream of that error.
-                                //
-                                // Only Session data carries it. The Exit's keep-alives are stripped
-                                // of their packet signals before `handle_keep_alive` sees them, so a
-                                // Session that is quiet apart from keep-alives relies on the level
-                                // those keep-alives report instead.
-                                surb_mgmt_for_rx.observe_counterparty_signals(data.packet_info.signals_from_sender);
+                            session_rx.inspect(move |_| {
+                                // The Exit's SURB signals are recorded in `dispatch_message`, upstream
+                                // of this: they override the organic SURB gate, and a packet dropped
+                                // before it reaches here would take the override with it.
 
                                 // Received packets = SURB consumption estimate
                                 // The received packets always consume a single SURB.
@@ -3220,33 +3211,6 @@ where
         pseudonym: HoprPseudonym,
         in_data: ApplicationDataIn,
     ) -> errors::Result<DispatchResult> {
-        // An evicted SURB and a spent SURB are the same event to the balancer: both leave the buffer,
-        // and `produced - consumed` nets out identically either way. Crediting the eviction is what
-        // keeps the level honest — without it the estimate counts SURBs that were destroyed on
-        // arrival, so this side believes it is stocked while it is running dry, and the level it
-        // reports to the Entry inherits the same error.
-        //
-        // Done here rather than at either counting site because this is the only place both classes
-        // of SURB-bearing traffic are still seen with their packet info attached: the Entry's
-        // keep-alives are the dominant SURB source, and the conversion below discards it.
-        if in_data.packet_info.num_evicted_surbs > 0
-            && let Some(session_slot) = self.sessions.get(&pseudonym)
-            && matches!(&session_slot.routing_opts, DestinationRouting::Return(_))
-        {
-            // Only the replying side accumulates received SURBs, so only it can evict them.
-            //
-            // `consumed` moves here while the matching `produced` is credited further downstream, so
-            // the difference can under-report for a single sampling window. That direction is the
-            // safe one: it asks the counterparty for more SURBs, never fewer.
-            session_slot.surb_estimator.consumed.fetch_add(
-                in_data.packet_info.num_evicted_surbs as u64,
-                std::sync::atomic::Ordering::Relaxed,
-            );
-
-            #[cfg(feature = "telemetry")]
-            telemetry::record_session_surb_consumed(&pseudonym, in_data.packet_info.num_evicted_surbs as u64);
-        }
-
         if in_data.data.application_tag == HoprStartProtocol::START_PROTOCOL_MESSAGE_TAG {
             // Start-protocol traffic bypasses `session_rx`, but an Exit → Entry message still
             // consumed one return SURB and unlocked one PIX share. Count it on outgoing Sessions
@@ -3258,6 +3222,14 @@ where
                 session_slot
                     .returned_packets
                     .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
+                // The only place the Exit's SURB supply can be heard from a quiet Session. The
+                // conversion below takes `in_data.data` and drops the packet info with it, so by the
+                // time `handle_keep_alive` runs the signals are gone -- and keep-alives are all a
+                // Session that has stopped exchanging data still sends.
+                session_slot
+                    .surb_mgmt
+                    .observe_counterparty_signals(in_data.packet_info.signals_from_sender);
             }
 
             // This is a Start protocol message, so we send it to the handler
@@ -3288,6 +3260,17 @@ where
 
             return if let Some(session_slot) = self.sessions.get(&session_id) {
                 trace!(%session_id, "received data for a registered session");
+
+                // Recorded here rather than once the Session reads the packet, because the send
+                // below can drop it for local backpressure and the reader would never see it. What
+                // the counterparty says about its own SURB supply is the override on the organic
+                // SURB gate, so losing it to a full inbox would leave production shut off on an
+                // estimate the counterparty has just contradicted.
+                if matches!(&session_slot.routing_opts, DestinationRouting::Forward { .. }) {
+                    session_slot
+                        .surb_mgmt
+                        .observe_counterparty_signals(in_data.packet_info.signals_from_sender);
+                }
 
                 match session_slot.session_tx.try_send(in_data) {
                     Ok(_) => {
@@ -4839,11 +4822,7 @@ mod tests {
     use tokio::time::timeout;
 
     use super::*;
-    use crate::{
-        Capabilities,
-        balancer::{SurbBalancerConfig, SurbFlowEstimator},
-        types::SessionTarget,
-    };
+    use crate::{Capabilities, balancer::SurbBalancerConfig, types::SessionTarget};
 
     /// A [`PixToolbox`] whose deposit-data requests are answered, for tests that do not read the
     /// PIX event stream themselves.
@@ -7773,52 +7752,13 @@ mod tests {
     }
 
     /// A packet reporting that some of the SURBs it carried were dropped on arrival.
-    fn packet_evicting(num_evicted_surbs: usize) -> anyhow::Result<ApplicationDataIn> {
-        let mut data = session_data_packet(b"carried surbs")?;
-        data.packet_info.num_evicted_surbs = num_evicted_surbs;
-        Ok(data)
-    }
-
-    /// An evicted SURB never entered the buffer, so counting it as consumed is what keeps
-    /// `produced - consumed` describing what this side actually holds. Without it the estimate
-    /// credits SURBs that were destroyed on arrival, and both this side's own egress balancer and
-    /// the level it reports back to the Entry inherit that error.
-    #[test_log::test(tokio::test)]
-    async fn dispatching_a_packet_with_evicted_surbs_should_count_them_as_consumed() -> anyhow::Result<()> {
-        let mgr: TestManager = SessionManager::new(Default::default());
-
-        // A Return-routed slot is the replying (Exit) side — the only one that accumulates received
-        // SURBs, and therefore the only one that can evict them.
-        let pseudonym = HoprPseudonym::random();
-        let _rx = mgr.pre_populate_session_with_receiver(pseudonym, DestinationRouting::Return(pseudonym.into()));
-
-        let estimator = mgr
-            .sessions
-            .get(&pseudonym)
-            .ok_or_else(|| anyhow::anyhow!("slot must exist"))?
-            .surb_estimator
-            .clone();
-        assert_eq!(0, estimator.estimate_surbs_consumed(), "precondition");
-
-        mgr.dispatch_message(pseudonym, packet_evicting(3)?)?;
-        assert_eq!(3, estimator.estimate_surbs_consumed());
-
-        // Cumulative across packets, not a high-water mark.
-        mgr.dispatch_message(pseudonym, packet_evicting(2)?)?;
-        assert_eq!(5, estimator.estimate_surbs_consumed());
-
-        Ok(())
-    }
-
-    /// On an outgoing (Entry) Session the estimator tracks what the *counterparty* holds, so a local
-    /// eviction says nothing about it. Crediting it there would make the Entry believe the Exit had
-    /// spent SURBs it never received, and mint replacements for them.
-    #[test_log::test(tokio::test)]
-    async fn dispatching_evicted_surbs_on_an_outgoing_session_should_not_be_counted() -> anyhow::Result<()> {
-        let mgr: TestManager = SessionManager::new(Default::default());
-
-        let pseudonym = HoprPseudonym::random();
-        let _rx = mgr.pre_populate_session_with_receiver(
+    /// An Entry-side slot whose organic SURB gate is closed: a target of 100 against a believed
+    /// level of 200. Anything that reopens it in the tests below did so on the counterparty's word.
+    fn entry_slot_with_closed_gate(
+        mgr: &TestManager,
+        pseudonym: HoprPseudonym,
+    ) -> anyhow::Result<crossfire::AsyncRx<crossfire::mpsc::Array<ApplicationDataIn>>> {
+        let rx = mgr.pre_populate_session_with_receiver(
             pseudonym,
             DestinationRouting::Forward {
                 destination: Box::new(Address::from(&ChainKeypair::random()).into()),
@@ -7828,18 +7768,152 @@ mod tests {
             },
         );
 
-        let estimator = mgr
+        let slot = mgr
             .sessions
             .get(&pseudonym)
-            .ok_or_else(|| anyhow::anyhow!("slot must exist"))?
-            .surb_estimator
-            .clone();
+            .ok_or_else(|| anyhow::anyhow!("slot must exist"))?;
+        slot.surb_mgmt.update(&SurbBalancerConfig {
+            target_surb_buffer_size: 100,
+            ..Default::default()
+        });
+        slot.surb_mgmt
+            .buffer_level
+            .store(200, std::sync::atomic::Ordering::Relaxed);
+        anyhow::ensure!(
+            0 == slot.surb_mgmt.organic_surbs_per_packet(),
+            "precondition: the gate must start closed"
+        );
 
-        mgr.dispatch_message(pseudonym, packet_evicting(3)?)?;
+        Ok(rx)
+    }
+
+    /// The organic SURB cap the slot's gate currently answers.
+    fn organic_surbs(mgr: &TestManager, pseudonym: HoprPseudonym) -> Option<usize> {
+        mgr.sessions
+            .get(&pseudonym)
+            .map(|slot| slot.surb_mgmt.organic_surbs_per_packet())
+    }
+
+    fn session_packet_signalling(signals: PacketSignals) -> anyhow::Result<ApplicationDataIn> {
+        let mut data = session_data_packet(b"reply")?;
+        data.packet_info.signals_from_sender = signals;
+        Ok(data)
+    }
+
+    fn keep_alive_packet_signalling(
+        session_id: SessionId,
+        signals: PacketSignals,
+    ) -> anyhow::Result<ApplicationDataIn> {
+        Ok(ApplicationDataIn {
+            data: ApplicationData::try_from(HoprStartProtocol::KeepAlive(KeepAliveMessage {
+                session_id,
+                flags: KeepAliveFlag::BalancerState.into(),
+                additional_data: 0,
+            }))?,
+            packet_info: IncomingPacketInfo {
+                signals_from_sender: signals,
+                ..Default::default()
+            },
+        })
+    }
+
+    /// The regression: a packet dropped for local backpressure still carries what the counterparty
+    /// said about its own SURB supply. Recorded only once the Session reads the packet, that word is
+    /// lost exactly when the inbox is saturated — leaving organic production shut off on an estimate
+    /// the counterparty has just contradicted, and with nothing else able to reopen it.
+    #[test_log::test(tokio::test)]
+    async fn distress_should_be_recorded_even_when_the_packet_is_dropped() -> anyhow::Result<()> {
+        // Capacity 1, so the second packet deterministically finds the inbox full.
+        let mgr: TestManager = SessionManager::new(SessionManagerConfig {
+            session_forward_capacity: 1,
+            ..Default::default()
+        });
+        let pseudonym = HoprPseudonym::random();
+        let _rx = entry_slot_with_closed_gate(&mgr, pseudonym)?;
+
+        // Fill the single slot; nothing reads it.
+        mgr.dispatch_message(pseudonym, session_packet_signalling(PacketSignals::default())?)?;
+
+        let dropped = mgr.dispatch_message(pseudonym, session_packet_signalling(PacketSignal::SurbDistress.into())?)?;
+        assert!(
+            matches!(dropped, DispatchResult::Dropped(DropReason::SinkFull)),
+            "the fixture must actually drop this packet, got {dropped:?}"
+        );
         assert_eq!(
-            0,
-            estimator.estimate_surbs_consumed(),
-            "the Entry's estimator tracks the Exit's buffer, not its own"
+            Some(1),
+            organic_surbs(&mgr, pseudonym),
+            "a dropped packet still spoke for the counterparty"
+        );
+
+        Ok(())
+    }
+
+    /// Keep-alives are all a Session that has stopped exchanging data still sends, and they reach
+    /// `handle_keep_alive` stripped of their packet info — so before this was recorded at dispatch,
+    /// a quiet counterparty could not report distress at all.
+    #[test_log::test(tokio::test)]
+    async fn distress_should_be_recorded_from_a_keep_alive() -> anyhow::Result<()> {
+        let mgr: TestManager = SessionManager::new(Default::default());
+        let pseudonym = HoprPseudonym::random();
+        let _rx = entry_slot_with_closed_gate(&mgr, pseudonym)?;
+
+        // The manager is not started, so the Start-protocol worker rejects this after the signal has
+        // been taken from it. That is the property under test: the record does not depend on
+        // anything downstream succeeding.
+        let _ = mgr.dispatch_message(
+            pseudonym,
+            keep_alive_packet_signalling(pseudonym, PacketSignal::OutOfSurbs.into())?,
+        );
+
+        assert_eq!(Some(1), organic_surbs(&mgr, pseudonym));
+
+        Ok(())
+    }
+
+    /// Distress is a running state, not a latch: the counterparty recomputes it per packet and stops
+    /// setting it once its pool recovers, so a clean packet has to close the gate again.
+    #[test_log::test(tokio::test)]
+    async fn a_clean_packet_should_clear_distress() -> anyhow::Result<()> {
+        let mgr: TestManager = SessionManager::new(Default::default());
+        let pseudonym = HoprPseudonym::random();
+        let _rx = entry_slot_with_closed_gate(&mgr, pseudonym)?;
+
+        mgr.dispatch_message(pseudonym, session_packet_signalling(PacketSignal::SurbDistress.into())?)?;
+        assert_eq!(Some(1), organic_surbs(&mgr, pseudonym), "precondition: distress is set");
+
+        mgr.dispatch_message(pseudonym, session_packet_signalling(PacketSignals::default())?)?;
+        assert_eq!(Some(0), organic_surbs(&mgr, pseudonym));
+
+        Ok(())
+    }
+
+    /// The gate governs SURBs this side mints *for* its counterparty, which only the initiator does.
+    /// On an incoming Session the same signal describes our own supply coming back to us, and acting
+    /// on it would let a peer talk this side into minting for a buffer it does not keep.
+    #[test_log::test(tokio::test)]
+    async fn distress_should_be_ignored_on_an_incoming_session() -> anyhow::Result<()> {
+        let mgr: TestManager = SessionManager::new(Default::default());
+        let pseudonym = HoprPseudonym::random();
+        let _rx = mgr.pre_populate_session_with_receiver(pseudonym, DestinationRouting::Return(pseudonym.into()));
+
+        let slot = mgr
+            .sessions
+            .get(&pseudonym)
+            .ok_or_else(|| anyhow::anyhow!("slot must exist"))?;
+        slot.surb_mgmt.update(&SurbBalancerConfig {
+            target_surb_buffer_size: 100,
+            ..Default::default()
+        });
+        slot.surb_mgmt
+            .buffer_level
+            .store(200, std::sync::atomic::Ordering::Relaxed);
+
+        mgr.dispatch_message(pseudonym, session_packet_signalling(PacketSignal::OutOfSurbs.into())?)?;
+
+        assert_eq!(
+            Some(0),
+            organic_surbs(&mgr, pseudonym),
+            "an incoming Session must not take the signal as licence to mint"
         );
 
         Ok(())

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -1267,7 +1267,8 @@ impl PixToolbox {
 /// avoid the depletion of SURBs but slows it down in the hope that the initiating party can deliver
 /// more SURBs over time. This might happen either organically by sending effective payloads that
 /// allow non-zero number of SURBs in the packet, or non-organically by delivering KeepAlive messages
-/// via *remote SURB balancing*.
+/// via *remote SURB balancing*. Both are governed by the initiator's estimate of our buffer, so
+/// signalling SURB distress is what tells it to keep the organic ones coming.
 ///
 /// The egress shaping is done automatically, unless the Session initiator sets the [`Capability::NoRateControl`]
 /// flag during Session initiation.
@@ -1283,6 +1284,14 @@ impl PixToolbox {
 ///
 /// In other words, the Session initiator tries to compensate for the usage of SURBs by the counterparty by
 /// sending new ones via the keep-alive messages.
+///
+/// The same estimate also governs *organic* production: once the counterparty is estimated to be at
+/// its target, outgoing Session data packets carry no SURBs at all, and they return to one per packet
+/// as soon as the estimate falls back below target. Without that, a balancer could correctly silence
+/// its keep-alives while organic SURBs kept pouring into a full buffer — where each one evicts an
+/// older SURB and destroys the PIX share it was carrying. A `SurbDistress` or `OutOfSurbs` signal
+/// from the counterparty overrides the estimate and restores production immediately, which is what
+/// makes it safe to act on an estimate that forward-path loss can inflate.
 ///
 /// This mechanism is configurable via the `surb_management` field in [`SessionClientConfig`].
 ///
@@ -1650,6 +1659,28 @@ fn initialize_session_telemetry(
     set_session_state(&session_id, SessionLifecycleState::Active);
     if let (Some(estimator), Some(mgmt)) = (surb_estimator, surb_mgmt) {
         set_session_balancer_data(&session_id, estimator.clone(), mgmt.clone());
+    }
+}
+
+/// Caps how many SURBs an outgoing Session data packet may carry, per the SURB balancer.
+///
+/// `max_out` is the client's `always_max_out_surbs` opt-in, which wins outright: a client that has
+/// asked for the maximum has said something about its own traffic that the balancer's estimate
+/// cannot contradict.
+///
+/// Otherwise the cap comes from [`BalancerStateValues::organic_surbs_per_packet`], which yields `0`
+/// once the counterparty is estimated to be at its target. That zero is the whole point of the
+/// function: without it, the balancer can silence its keep-alives and still have organic SURBs
+/// pouring into a full buffer, where each one evicts an older SURB and destroys the PIX share it
+/// carried.
+///
+/// Nothing else has to change to keep the SURB accounting straight. This runs in front of the
+/// counting sink, so `estimate_surbs_with_msg` reports the capped figure; and the PIX share for a
+/// SURB is drawn per SURB while it is built, so a cap of `0` draws no share at all and leaves it
+/// queued for a packet that can actually deliver it.
+fn cap_organic_surbs(data: &mut ApplicationDataOut, max_out: bool, surb_mgmt: &BalancerStateValues) {
+    if !max_out {
+        data.packet_info.get_or_insert_default().max_surbs_in_packet = surb_mgmt.organic_surbs_per_packet();
     }
 }
 
@@ -2271,32 +2302,25 @@ where
                             futures::future::ok::<_, S::Error>((routing, data))
                         });
 
-                    // For standard Session data we first reduce the number of SURBs we want to produce,
-                    // unless requested to always max them out
-                    let max_out_organic_surbs = cfg.always_max_out_surbs;
-                    let reduced_surb_scoring_sender = full_surb_scoring_sender.clone().with(
-                        // NOTE: this is put in-front of the `full_surb_scoring_sender`,
-                        // so that its estimate of SURBs gets automatically updated based on
-                        // the `max_surbs_in_packets` set here.
-                        move |(routing, mut data): (DestinationRouting, ApplicationDataOut)| {
-                            if !max_out_organic_surbs {
-                                // TODO: make this dynamic to honor the balancer target (#7439)
-                                data.packet_info
-                                    .get_or_insert_with(|| OutgoingPacketInfo {
-                                        max_surbs_in_packet: 1,
-                                        ..Default::default()
-                                    })
-                                    .max_surbs_in_packet = 1;
-                            }
-                            futures::future::ok::<_, S::Error>((routing, data))
-                        },
-                    );
-
                     let surb_mgmt = Arc::new(BalancerStateValues::from(balancer_config));
                     // The counterparty's store is the same bounded ring buffer as ours, so its
                     // capacity bounds what our `produced - consumed` estimate can legitimately
                     // claim it is holding.
                     surb_mgmt.set_counterparty_buffer_capacity(self.cfg.maximum_surb_buffer_size as u64);
+
+                    // For standard Session data we first reduce the number of SURBs we want to produce,
+                    // unless requested to always max them out
+                    let max_out_organic_surbs = cfg.always_max_out_surbs;
+                    let surb_mgmt_for_tx = surb_mgmt.clone();
+                    let reduced_surb_scoring_sender = full_surb_scoring_sender.clone().with(
+                        // NOTE: this is put in-front of the `full_surb_scoring_sender`,
+                        // so that its estimate of SURBs gets automatically updated based on
+                        // the `max_surbs_in_packets` set here.
+                        move |(routing, mut data): (DestinationRouting, ApplicationDataOut)| {
+                            cap_organic_surbs(&mut data, max_out_organic_surbs, &surb_mgmt_for_tx);
+                            futures::future::ok::<_, S::Error>((routing, data))
+                        },
+                    );
 
                     // Spawn the SURB-bearing keep alive stream towards the Exit
                     let (ka_controller, ka_abort_handle) = utils::spawn_keep_alive_stream(
@@ -2400,13 +2424,26 @@ where
                     METRIC_NUM_INITIATED_SESSIONS.increment();
 
                     let surb_estimator_for_rx = surb_estimator.clone();
+                    let surb_mgmt_for_rx = surb_mgmt.clone();
                     let session = HoprSession::new_with_surb_state(
                         session_id,
                         forward_routing,
                         session_config_with(&self.cfg, cfg.capabilities, cfg.max_frames_behind_gap),
                         (
                             reduced_surb_scoring_sender,
-                            session_rx.inspect(move |_| {
+                            session_rx.inspect(move |data| {
+                                // What the Exit says about its own SURB supply overrides our estimate
+                                // of it, and is the safety valve on the organic SURB gate: our
+                                // estimate counts SURBs as delivered when they are sent, so loss on
+                                // the forward path inflates it, and this is the one input that is not
+                                // downstream of that error.
+                                //
+                                // Only Session data carries it. The Exit's keep-alives are stripped
+                                // of their packet signals before `handle_keep_alive` sees them, so a
+                                // Session that is quiet apart from keep-alives relies on the level
+                                // those keep-alives report instead.
+                                surb_mgmt_for_rx.observe_counterparty_signals(data.packet_info.signals_from_sender);
+
                                 // Received packets = SURB consumption estimate
                                 // The received packets always consume a single SURB.
                                 surb_estimator_for_rx
@@ -3183,6 +3220,33 @@ where
         pseudonym: HoprPseudonym,
         in_data: ApplicationDataIn,
     ) -> errors::Result<DispatchResult> {
+        // An evicted SURB and a spent SURB are the same event to the balancer: both leave the buffer,
+        // and `produced - consumed` nets out identically either way. Crediting the eviction is what
+        // keeps the level honest — without it the estimate counts SURBs that were destroyed on
+        // arrival, so this side believes it is stocked while it is running dry, and the level it
+        // reports to the Entry inherits the same error.
+        //
+        // Done here rather than at either counting site because this is the only place both classes
+        // of SURB-bearing traffic are still seen with their packet info attached: the Entry's
+        // keep-alives are the dominant SURB source, and the conversion below discards it.
+        if in_data.packet_info.num_evicted_surbs > 0
+            && let Some(session_slot) = self.sessions.get(&pseudonym)
+            && matches!(&session_slot.routing_opts, DestinationRouting::Return(_))
+        {
+            // Only the replying side accumulates received SURBs, so only it can evict them.
+            //
+            // `consumed` moves here while the matching `produced` is credited further downstream, so
+            // the difference can under-report for a single sampling window. That direction is the
+            // safe one: it asks the counterparty for more SURBs, never fewer.
+            session_slot.surb_estimator.consumed.fetch_add(
+                in_data.packet_info.num_evicted_surbs as u64,
+                std::sync::atomic::Ordering::Relaxed,
+            );
+
+            #[cfg(feature = "telemetry")]
+            telemetry::record_session_surb_consumed(&pseudonym, in_data.packet_info.num_evicted_surbs as u64);
+        }
+
         if in_data.data.application_tag == HoprStartProtocol::START_PROTOCOL_MESSAGE_TAG {
             // Start-protocol traffic bypasses `session_rx`, but an Exit → Entry message still
             // consumed one return SURB and unlocked one PIX share. Count it on outgoing Sessions
@@ -4767,6 +4831,7 @@ mod tests {
         internal::routing::SurbMatcher,
         primitive::prelude::Address,
     };
+    use hopr_crypto_packet::prelude::{PacketSignal, PacketSignals};
     use hopr_protocol_pix::{SsaGeneratorConfig, SsaIndex, SsaReconstructorConfig};
     use hopr_protocol_start::{StartProtocol, StartProtocolDiscriminants};
     use hopr_utils::network_types::prelude::SealedHost;
@@ -4774,7 +4839,11 @@ mod tests {
     use tokio::time::timeout;
 
     use super::*;
-    use crate::{Capabilities, balancer::SurbBalancerConfig, types::SessionTarget};
+    use crate::{
+        Capabilities,
+        balancer::{SurbBalancerConfig, SurbFlowEstimator},
+        types::SessionTarget,
+    };
 
     /// A [`PixToolbox`] whose deposit-data requests are answered, for tests that do not read the
     /// PIX event stream themselves.
@@ -4935,6 +5004,88 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(session_config(&cfg, Capabilities::empty()).max_frames_behind_gap, None);
+    }
+
+    /// Balancer state with the given target sitting at the given level.
+    fn gate_state(target: u64, buffer_level: u64) -> BalancerStateValues {
+        let state = BalancerStateValues::new(SurbBalancerConfig {
+            target_surb_buffer_size: target,
+            ..Default::default()
+        });
+        state
+            .buffer_level
+            .store(buffer_level, std::sync::atomic::Ordering::Relaxed);
+        state
+    }
+
+    /// A packet short enough to have room for a SURB. `max_surbs_with_message` is
+    /// `(PAYLOAD_SIZE - len) / SURB_SIZE`, so anything past roughly half the payload already caps
+    /// itself at zero and would make the assertions below pass for the wrong reason.
+    fn small_outgoing_packet() -> anyhow::Result<ApplicationDataOut> {
+        let data = ApplicationDataOut::with_no_packet_info(ApplicationData::new(SESSION_APPLICATION_TAG, b"short")?);
+        anyhow::ensure!(
+            data.estimate_surbs_with_msg() >= 1,
+            "fixture must have room for a SURB, otherwise the cap is not what is being measured"
+        );
+        Ok(data)
+    }
+
+    #[test]
+    fn cap_organic_surbs_should_zero_the_packet_once_the_counterparty_is_at_target() -> anyhow::Result<()> {
+        let mut data = small_outgoing_packet()?;
+        cap_organic_surbs(&mut data, false, &gate_state(100, 200));
+
+        assert_eq!(Some(0), data.packet_info.map(|i| i.max_surbs_in_packet));
+        assert_eq!(
+            0,
+            data.estimate_surbs_with_msg(),
+            "the cap must reach the SURB accounting, not just the packet info"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn cap_organic_surbs_should_allow_one_while_the_counterparty_is_below_target() -> anyhow::Result<()> {
+        let mut data = small_outgoing_packet()?;
+        cap_organic_surbs(&mut data, false, &gate_state(100, 10));
+
+        assert_eq!(Some(1), data.packet_info.map(|i| i.max_surbs_in_packet));
+        assert_eq!(1, data.estimate_surbs_with_msg());
+        Ok(())
+    }
+
+    /// The cap writes into a field it may have to create, so it must not take the rest of the packet
+    /// info with it — the routing stage sets the outgoing signals on this same struct.
+    #[test]
+    fn cap_organic_surbs_should_not_clobber_existing_packet_info() -> anyhow::Result<()> {
+        let mut data = small_outgoing_packet()?;
+        data.packet_info = Some(OutgoingPacketInfo {
+            signals_to_destination: PacketSignal::SurbDistress.into(),
+            max_surbs_in_packet: usize::MAX,
+        });
+
+        cap_organic_surbs(&mut data, false, &gate_state(100, 200));
+
+        let info = data.packet_info.expect("packet info must survive");
+        assert_eq!(0, info.max_surbs_in_packet);
+        assert_eq!(
+            PacketSignals::from(PacketSignal::SurbDistress),
+            info.signals_to_destination
+        );
+        Ok(())
+    }
+
+    /// `always_max_out_surbs` is an explicit statement by the client about its own traffic, so it
+    /// wins over the balancer's estimate — and must leave the packet entirely untouched rather than
+    /// writing some larger cap.
+    #[test]
+    fn maxing_out_surbs_should_bypass_the_balancer_gate() -> anyhow::Result<()> {
+        let mut data = small_outgoing_packet()?;
+        cap_organic_surbs(&mut data, true, &gate_state(100, 200));
+
+        assert_eq!(None, data.packet_info, "the opt-in must not touch the packet at all");
+        assert!(data.estimate_surbs_with_msg() >= 1);
+        Ok(())
     }
 
     #[async_trait::async_trait]
@@ -5739,6 +5890,46 @@ mod tests {
             Some(balancer_cfg),
             alice_mgr.get_surb_balancer_config(alice_session.id())?
         );
+
+        // The organic SURB gate, on the real slot rather than a hand-built state. Two things it must
+        // get right, both of which would deadlock a Session if inverted.
+        {
+            let alice_slot = alice_mgr
+                .sessions
+                .get(alice_session.id())
+                .ok_or(anyhow!("alice must hold the session slot"))?;
+
+            // At cold start the gate must be open: readiness only waits for half the target, so a
+            // gate that closed at or below that would stop the very production it is waiting on.
+            assert_eq!(
+                1,
+                alice_slot.surb_mgmt.organic_surbs_per_packet(),
+                "a freshly opened session must still produce organic SURBs"
+            );
+
+            // And it must stay open on the counterparty's word, whatever the local estimate says.
+            alice_slot
+                .surb_mgmt
+                .observe_counterparty_signals(PacketSignal::OutOfSurbs.into());
+            alice_slot
+                .surb_mgmt
+                .buffer_level
+                .store(u64::MAX, std::sync::atomic::Ordering::Relaxed);
+            assert_eq!(
+                1,
+                alice_slot.surb_mgmt.organic_surbs_per_packet(),
+                "a counterparty out of SURBs must override any local estimate"
+            );
+
+            // Leave the slot as it was found; the balancer loop keeps running below.
+            alice_slot
+                .surb_mgmt
+                .observe_counterparty_signals(PacketSignals::default());
+            alice_slot
+                .surb_mgmt
+                .buffer_level
+                .store(0, std::sync::atomic::Ordering::Relaxed);
+        }
 
         let remote_cfg = bob_mgr
             .get_surb_balancer_config(bob_session.session.id())?
@@ -7577,6 +7768,79 @@ mod tests {
             "overflow packet must be a Dropped(SinkFull) backpressure drop, got {overflow:?}"
         );
         assert!(crate::counters::session_inbox_drop_count() > before);
+
+        Ok(())
+    }
+
+    /// A packet reporting that some of the SURBs it carried were dropped on arrival.
+    fn packet_evicting(num_evicted_surbs: usize) -> anyhow::Result<ApplicationDataIn> {
+        let mut data = session_data_packet(b"carried surbs")?;
+        data.packet_info.num_evicted_surbs = num_evicted_surbs;
+        Ok(data)
+    }
+
+    /// An evicted SURB never entered the buffer, so counting it as consumed is what keeps
+    /// `produced - consumed` describing what this side actually holds. Without it the estimate
+    /// credits SURBs that were destroyed on arrival, and both this side's own egress balancer and
+    /// the level it reports back to the Entry inherit that error.
+    #[test_log::test(tokio::test)]
+    async fn dispatching_a_packet_with_evicted_surbs_should_count_them_as_consumed() -> anyhow::Result<()> {
+        let mgr: TestManager = SessionManager::new(Default::default());
+
+        // A Return-routed slot is the replying (Exit) side — the only one that accumulates received
+        // SURBs, and therefore the only one that can evict them.
+        let pseudonym = HoprPseudonym::random();
+        let _rx = mgr.pre_populate_session_with_receiver(pseudonym, DestinationRouting::Return(pseudonym.into()));
+
+        let estimator = mgr
+            .sessions
+            .get(&pseudonym)
+            .ok_or_else(|| anyhow::anyhow!("slot must exist"))?
+            .surb_estimator
+            .clone();
+        assert_eq!(0, estimator.estimate_surbs_consumed(), "precondition");
+
+        mgr.dispatch_message(pseudonym, packet_evicting(3)?)?;
+        assert_eq!(3, estimator.estimate_surbs_consumed());
+
+        // Cumulative across packets, not a high-water mark.
+        mgr.dispatch_message(pseudonym, packet_evicting(2)?)?;
+        assert_eq!(5, estimator.estimate_surbs_consumed());
+
+        Ok(())
+    }
+
+    /// On an outgoing (Entry) Session the estimator tracks what the *counterparty* holds, so a local
+    /// eviction says nothing about it. Crediting it there would make the Entry believe the Exit had
+    /// spent SURBs it never received, and mint replacements for them.
+    #[test_log::test(tokio::test)]
+    async fn dispatching_evicted_surbs_on_an_outgoing_session_should_not_be_counted() -> anyhow::Result<()> {
+        let mgr: TestManager = SessionManager::new(Default::default());
+
+        let pseudonym = HoprPseudonym::random();
+        let _rx = mgr.pre_populate_session_with_receiver(
+            pseudonym,
+            DestinationRouting::Forward {
+                destination: Box::new(Address::from(&ChainKeypair::random()).into()),
+                pseudonym: Some(pseudonym),
+                forward_options: RoutingOptions::Hops(1.try_into()?),
+                return_options: None,
+            },
+        );
+
+        let estimator = mgr
+            .sessions
+            .get(&pseudonym)
+            .ok_or_else(|| anyhow::anyhow!("slot must exist"))?
+            .surb_estimator
+            .clone();
+
+        mgr.dispatch_message(pseudonym, packet_evicting(3)?)?;
+        assert_eq!(
+            0,
+            estimator.estimate_surbs_consumed(),
+            "the Entry's estimator tracks the Exit's buffer, not its own"
+        );
 
         Ok(())
     }

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -2482,6 +2482,12 @@ where
                     let returned_packets = Arc::new(std::sync::atomic::AtomicU64::new(0));
                     let returned_packets_for_rx = returned_packets.clone();
 
+                    // Disabled SURB management: a default state has a zero target, which reads as
+                    // `is_disabled()` and so caps organic SURBs at one per packet — this branch's
+                    // behaviour, expressed through the same policy the balancing branch uses rather
+                    // than restated as a literal below.
+                    let surb_mgmt: Arc<BalancerStateValues> = Default::default();
+
                     // Insert the slot and obtain a guard that rolls it back if any
                     // subsequent setup step fails.
                     let mut slot_guard = self
@@ -2491,7 +2497,7 @@ where
                                 session_tx,
                                 routing_opts: forward_routing.clone(),
                                 abort_handles: Arc::new(parking_lot::Mutex::new(abort_handles)),
-                                surb_mgmt: Default::default(), // Disabled SURB management
+                                surb_mgmt: surb_mgmt.clone(),
                                 surb_estimator: Default::default(), // No SURB estimator needed
                                 current_ssa_state,
                                 // Entry side: the Exit is authoritative for the PIX lifecycle.
@@ -2515,16 +2521,10 @@ where
                     // For standard Session data we first reduce the number of SURBs we want to produce,
                     // unless requested to always max them out
                     let max_out_organic_surbs = cfg.always_max_out_surbs;
+                    let surb_mgmt_for_tx = surb_mgmt.clone();
                     let reduced_surb_sender =
                         msg_sender.with(move |(routing, mut data): (DestinationRouting, ApplicationDataOut)| {
-                            if !max_out_organic_surbs {
-                                data.packet_info
-                                    .get_or_insert_with(|| OutgoingPacketInfo {
-                                        max_surbs_in_packet: 1,
-                                        ..Default::default()
-                                    })
-                                    .max_surbs_in_packet = 1;
-                            }
+                            cap_organic_surbs(&mut data, max_out_organic_surbs, &surb_mgmt_for_tx);
                             futures::future::ok::<_, S::Error>((routing, data))
                         });
 


### PR DESCRIPTION
Closes #7439.

A Session's Entry produces SURBs for the Exit two ways, and only one of them was under control. Keep-alives stop as soon as the estimated counterparty buffer reaches target; *organic* SURBs — the ones riding along in the spare payload of ordinary data packets — were pinned at one per packet unconditionally, with a TODO pointing at this issue.

So an Entry could correctly silence its keep-alives and still pour SURBs into a buffer that was already full, where each one evicts the oldest entry.

**Under PIX that destroys SSAs.** A partial SSA share is minted *into* a SURB and only reaches the Exit's reconstructor when that SURB is used, so an evicted SURB is a permanently destroyed share. The budget this eats is small and fixed — 16 surplus shares per polynomial, emitted in lockstep across a 256-polynomial window — so on the order of 4 100 evictions is enough to push polynomials below their threshold. An SSA is the sum of *every* polynomial's constant term, so one unrecoverable polynomial makes the whole cycle worth nothing. For scale, the overshoot already recorded in `BalancerStateValues` (51 917 SURBs believed against a 15 000-entry store) is roughly nine times past that line, and it spends the same surplus that exists to absorb ordinary network loss.

## What changed

**Organic production now follows the same estimate as the keep-alives** — zero SURBs per packet once the counterparty is at target, one otherwise. This is safe by construction: a PIX share is drawn per SURB while the SURB is built, so a cap of zero draws no share at all and leaves it queued for a packet that can actually deliver it.

**The counterparty's distress signal overrides the gate.** The estimate counts SURBs as delivered when they are *sent*, so forward-path loss inflates it. `SurbDistress`/`OutOfSurbs` is the one input that isn't downstream of that error, and it restores production immediately. (Incidentally the first reader of `signals_from_sender`, which until now was populated and never consumed.)

**Evictions are no longer silent.** The ring buffer already computed the true occupancy and the decoder threw it away, so an overflow was invisible everywhere — the only way to learn a buffer was overflowing was to infer it from a balancer estimate that had outgrown the store it described. The count is now carried up on the packet and there's a `warn!` at the point of loss.

It is deliberately *not* fed back into the SURB level estimate, and the reasoning is on `counterparty_buffer_capacity` next to the clamp it depends on. The level is clamped to `max(capacity, target)`, so an estimate inflated past a full buffer still climbs to the target and shuts organic production off — whereas an accurate estimate pins at the counterparty's real capacity, and where that sits below the target the gate never closes and the buffer evicts forever. The imprecise estimate fails safe; the precise one does not.

`always_max_out_surbs: true` bypasses the gate entirely — an explicit client opt-in wins over the estimate.

## Follow-ups (not in this PR)

- `SurbSupply::backoff_hint` infers `Backoff::Hard` from `level == 0`; the real distress signal is now available to it.
- `StartSession` and `SsaCommit` SURBs are never credited to the Exit's `produced` — a pre-existing accounting gap found while reviewing this, worth its own issue.
- The Entry uses its own `maximum_surb_buffer_size` as the counterparty's capacity. Pre-existing (verbatim in the base commit), but the clamp reasoning above is exactly why it matters.
- Both PIX cluster tests run `surb_management: None`, so nothing in CI exercises this gate under PIX.

