### PR TITLE
fix(start): decode keep-alive flags leniently so PIX service still counts

### DIFF
--- a/protocols/start/src/lib.rs
+++ b/protocols/start/src/lib.rs
@@ -824,8 +824,23 @@ where
                     }
 
                     StartProtocol::KeepAlive(KeepAliveMessage {
-                        flags: KeepAliveFlags::new(body[0])
-                            .map_err(|_| StartProtocolError::ParseError("ka.flags".into()))?,
+                        // Unknown bits are dropped rather than failing the message, for the same
+                        // reason [`StartErrorReason::Unknown`] exists above: a peer that sets a flag
+                        // this build predates would otherwise have its whole keep-alive rejected as
+                        // malformed, and a keep-alive is not a message a Session can afford to lose.
+                        // It carries the Exit's SURB level to the Entry's balancer, it is what keeps
+                        // an otherwise silent Session alive, and on a PIX Session it is one packet of
+                        // the service the Entry's successor gate prices — the gate that decides
+                        // whether the next deposit is admitted at all. Refusing to parse tells this
+                        // node *less* than reading the bits it does recognize, so a flag may be added
+                        // without a protocol version bump.
+                        //
+                        // Truncating is safe because the flags only ever *select* a meaning for
+                        // `additional_data`, and every handler tests for the bit it acts on rather
+                        // than matching the set as a whole. An unknown bit therefore selects no
+                        // behaviour, which is what an older node should do with a meaning it has
+                        // never heard of.
+                        flags: KeepAliveFlags::new_truncated(body[0]),
                         additional_data: u64::from_be_bytes(
                             body[1..1 + size_of::<u64>()]
                                 .try_into()
@@ -1571,6 +1586,64 @@ mod tests {
         let msg_2 = StartProtocol::<i32, String, u8, Box<[u8]>, Box<[u8]>, MinimalDeposit>::decode(tag, &msg)?;
 
         assert_eq!(msg_1, msg_2);
+        Ok(())
+    }
+
+    /// A keep-alive carrying a flag this build does not know must still decode.
+    ///
+    /// The flags are the one field of this message that a later protocol version can extend without
+    /// changing its layout, so strict decoding here is a forward-compatibility trap rather than a
+    /// safety property: an Exit that sets a new bit would have every keep-alive rejected by an older
+    /// Entry as malformed. That Entry then loses the SURB level the message reports, the liveness it
+    /// provides on an otherwise silent Session, and — on a PIX Session — the credit for one packet of
+    /// service against its successor gate, which is what decides whether the next deposit is made.
+    ///
+    /// The unknown bit itself must not survive: it selects no behaviour on this node, and letting it
+    /// through would make `flags.contains(..)` answer for a meaning this build cannot implement.
+    #[test]
+    fn a_keep_alive_with_an_unknown_flag_decodes_without_the_unknown_bit() -> anyhow::Result<()> {
+        use anyhow::Context;
+
+        let known: KeepAliveFlags = KeepAliveFlag::BalancerState.into();
+        let msg = StartProtocol::<i32, String, u8, Box<[u8]>, Box<[u8]>, MinimalDeposit>::KeepAlive(KeepAliveMessage {
+            session_id: 10_i32,
+            flags: known,
+            additional_data: 0xffffffff,
+        });
+
+        let (tag, mut encoded) = msg.encode()?;
+
+        // The flag byte is the first byte of the body, which starts after the version, the
+        // discriminant and the two-byte length. `0x80` is the highest bit and no flag this build
+        // knows about, so it stands in for one a later protocol version adds.
+        const FLAGS_AT: usize = 4;
+        assert_eq!(
+            known.bits(),
+            encoded[FLAGS_AT],
+            "the flag byte must be where this test patches it"
+        );
+        encoded[FLAGS_AT] |= 0x80;
+
+        let decoded = StartProtocol::<i32, String, u8, Box<[u8]>, Box<[u8]>, MinimalDeposit>::decode(tag, &encoded)
+            .context("a keep-alive carrying an unknown flag bit must still decode")?;
+
+        match decoded {
+            StartProtocol::KeepAlive(ka) => {
+                assert_eq!(10_i32, ka.session_id);
+                assert_eq!(0xffffffff, ka.additional_data);
+                assert!(
+                    ka.flags.contains(KeepAliveFlag::BalancerState),
+                    "the known flag must survive the unknown one"
+                );
+                assert_eq!(
+                    known.bits(),
+                    ka.flags.bits(),
+                    "the unknown bit must be dropped, not carried into a flag test"
+                );
+            }
+            other => anyhow::bail!("expected KeepAlive, got {other:?}"),
+        }
+
         Ok(())
     }
 

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -608,6 +608,22 @@ pub(crate) struct SessionSlot {
     /// balancer, and it is only wired when `surb_management` is enabled; this one decides whether
     /// money is spent and must be neither. Carrying the increment twice is the cheaper mistake: a
     /// receive path that forgets this counter makes the gate stricter, never laxer.
+    ///
+    /// Credited from exactly two places, and both of them have to stay:
+    ///
+    /// * the `session_rx` inspectors in `new_session`, once per Session data packet handed to the reader — one in each
+    ///   of the balanced and unbalanced branches;
+    /// * the Start-protocol branch of [`dispatch_message`](SessionManager::dispatch_message), which credits every
+    ///   Start-protocol message arriving on an outgoing Session because that traffic bypasses `session_rx` entirely.
+    ///
+    /// The second is what makes the Exit's keep-alives count, and the gate depends on it: an Exit
+    /// whose application has nothing to say can still complete a funded cycle by keep-alive alone, and
+    /// if those packets earned nothing here its successor would be refused as under-served and the
+    /// Session would die on `CommitmentTimeout` with neither side able to name the cause. It is
+    /// credited at the dispatch level rather than inside a per-message handler on purpose — the credit
+    /// is owed for the SURB the packet consumed, which is true whatever the message turns out to be,
+    /// including one this build fails to parse. Adding a second increment inside
+    /// [`handle_keep_alive`](SessionManager::handle_keep_alive) would double-count it.
     returned_packets: Arc<std::sync::atomic::AtomicU64>,
     /// This Session's share of the node's live reconstructor-cycle budget.
     ///
@@ -10028,6 +10044,115 @@ mod tests {
         bob_sender.close_channel();
         let _ = alice_handle.await?;
         let _ = bob_handle.await?;
+        Ok(())
+    }
+
+    /// Re-points the fixture's slot at `Forward` routing, the way a real Entry's slot is built.
+    ///
+    /// [`entry_with_pix_session`] establishes through `handle_incoming_session_initiation` because
+    /// that is the path which installs the PIX state the successor gate needs, and it stores the
+    /// Exit's `Return` reply routing. The gate is an Entry-side rule, and the counter it reads is
+    /// only credited on Sessions this node *initiated* — Start-protocol traffic on an incoming
+    /// Session comes from the Entry over the forward path and must not be paid for. So the routing is
+    /// what decides whether the keep-alives below are read as service arriving or as service being
+    /// asked for, and the fixture has to be put on the side the rule is about.
+    ///
+    /// Re-inserting rather than mutating: the slot lives in a `moka` cache by value, and its routing
+    /// is a plain field rather than a cell, because nothing in production ever changes it.
+    fn make_session_outgoing<S>(mgr: &SessionManager<S>, pseudonym: &HoprPseudonym, destination: Address)
+    where
+        S: futures::Sink<(DestinationRouting, ApplicationDataOut)> + Clone + Send + Sync + Unpin + 'static,
+        S::Error: std::error::Error + Send + Sync + 'static,
+    {
+        let mut slot = mgr.sessions.get(pseudonym).expect("session must exist");
+        slot.routing_opts = DestinationRouting::Forward {
+            destination: Box::new(destination.into()),
+            pseudonym: Some(*pseudonym),
+            forward_options: RoutingOptions::Hops(hopr_api::types::primitive::bounded::BoundedSize::MIN),
+            return_options: RoutingOptions::Hops(hopr_api::types::primitive::bounded::BoundedSize::MIN).into(),
+        };
+        mgr.sessions.insert(*pseudonym, slot);
+    }
+
+    /// A cycle served only by the Exit's keep-alives must still buy its successor.
+    ///
+    /// This is the property that lets the Exit finish a funded cycle whose application has fallen
+    /// silent: it sends its own Exit → Entry keep-alives, each one consuming a return SURB and
+    /// therefore unlocking one share, and the cycle completes on those alone. If they earned nothing
+    /// at this gate the Session would die at exactly the moment it succeeded — the Exit's `RequestSsa`
+    /// for the successor is emitted once and never retried, so a refusal here leaves it in
+    /// `AwaitingCommitment` until `max_ssa_delivery_time` and then closes the Session as
+    /// `CommitmentTimeout`, naming a timer rather than the rule that fired.
+    ///
+    /// Driven through [`dispatch_message`](SessionManager::dispatch_message) with real encoded
+    /// keep-alives rather than by touching the counter, because the credit lives on that path and
+    /// nowhere else: the message never reaches `session_rx`, so the receive-path inspector that
+    /// [`returned_packets_are_counted_on_the_entry_receive_path`] pins cannot cover for it.
+    #[test_log::test(tokio::test)]
+    async fn keep_alives_alone_can_carry_a_cycle_to_its_successor() -> anyhow::Result<()> {
+        let params = wide_pix_params();
+        let (mgr, generator, pseudonym, mut pix_events, bob_sender, bob_handle) =
+            entry_with_pix_session(params, SsaReconstructorConfig::default().early_recovery_threshold).await?;
+
+        mgr.handle_ssa_request(
+            pseudonym,
+            SsaServerCommitmentMessage::new(pseudonym, params, ssa_request_for(1), []),
+        )
+        .await
+        .context("the opening batch must be accepted")?;
+        assert_eq!(1, drain_pix_events(&mut pix_events).await);
+
+        // Emission reaches the boundary, so service is the only thing left for the gate to weigh.
+        for sent in 1..=(params.polys_per_ssa() as u32 * params.emitted_shares_per_poly() as u32) {
+            generator.next_share(&pseudonym, &sent.to_be_bytes())?;
+        }
+
+        make_session_outgoing(&mgr, &pseudonym, (&ChainKeypair::random()).into());
+
+        let counter = mgr
+            .sessions
+            .get(&pseudonym)
+            .expect("session must exist")
+            .returned_packets;
+        assert_eq!(
+            0,
+            counter.load(std::sync::atomic::Ordering::Relaxed),
+            "the fixture must start with nothing served"
+        );
+
+        // Exactly what the gate demands, and every packet of it a keep-alive.
+        let required = required_returned_packets(&params, 1);
+        for level in 0..required {
+            let keep_alive: ApplicationData = HoprStartProtocol::KeepAlive(KeepAliveMessage {
+                session_id: pseudonym,
+                flags: KeepAliveFlag::BalancerState.into(),
+                additional_data: level,
+            })
+            .try_into()?;
+            mgr.dispatch_message(
+                pseudonym,
+                ApplicationDataIn {
+                    data: keep_alive,
+                    packet_info: Default::default(),
+                },
+            )?;
+        }
+        assert_eq!(
+            required,
+            counter.load(std::sync::atomic::Ordering::Relaxed),
+            "every keep-alive consumed a return SURB and must be credited as service"
+        );
+
+        mgr.handle_ssa_request(
+            pseudonym,
+            SsaServerCommitmentMessage::new(pseudonym, params, ssa_request_for(2), []),
+        )
+        .await
+        .context("a cycle served entirely by keep-alives must still buy its successor")?;
+        assert_eq!(1, drain_pix_events(&mut pix_events).await);
+
+        bob_sender.close_channel();
+        bob_handle.await??;
         Ok(())
     }
 


### PR DESCRIPTION
An Exit that has to finish a funded PIX cycle without application traffic does it with its own Exit → Entry keep-alives (follow-up PR). The Entry already credits those packets as service in `dispatch_message`; what was missing is forward compatibility. `KeepAliveFlags::new` rejected any unknown flag bit, so a peer one protocol revision ahead would have every keep-alive dropped at the Entry, losing the SURB level report, the Session liveness, and the service credit.

- Decode keep-alive flags with `new_truncated`: unknown bits are dropped, known ones kept.
- Document the two places `returned_packets` is credited, and why a third inside `handle_keep_alive` would double-count.
- Tests: a keep-alive with an unknown flag decodes; keep-alives alone carry a cycle through the successor gate.

No behaviour change for current peers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
