### PR TITLE
feat(session): drain buffered SURBs after an Exit-side close when they cover the funded cycle

### DIFF
--- a/hopr/hopr-lib/src/testing/fixtures.rs
+++ b/hopr/hopr-lib/src/testing/fixtures.rs
@@ -926,6 +926,29 @@ pub async fn build_role_cluster(
     relay_cfgs: Vec<TestNodeConfig>,
     exit_cfg: TestNodeConfig,
 ) -> anyhow::Result<RoleClusterGuard> {
+    build_role_cluster_with_exit_server(entry_cfg, relay_cfgs, exit_cfg, EchoServer::new()).await
+}
+
+/// [`build_role_cluster`] with the Exit's session server under the caller's control.
+///
+/// Only the Exit's server is swappable, because the Entry and the relays never receive an incoming
+/// Session in these clusters — the Entry opens them and the relays only forward. A test that needs to
+/// *hold* the Exit-side `IncomingSession` rather than have it echoed passes
+/// [`SessionCaptureServer`](super::dummies::SessionCaptureServer) here, which is what makes the Exit
+/// side of a Session closable from the test.
+pub async fn build_role_cluster_with_exit_server<Srv>(
+    entry_cfg: TestNodeConfig,
+    relay_cfgs: Vec<TestNodeConfig>,
+    exit_cfg: TestNodeConfig,
+    exit_server: Srv,
+) -> anyhow::Result<RoleClusterGuard>
+where
+    Srv: hopr_api::node::HoprSessionServer<Session = hopr_transport::IncomingSession, Error: std::fmt::Display>
+        + Clone
+        + Send
+        + Sync
+        + 'static,
+{
     let total_size = 1 + relay_cfgs.len() + 1;
     if !(3..=SWARM_N).contains(&total_size) {
         anyhow::bail!("total cluster size {total_size} must be between 3 and {SWARM_N}");
@@ -969,6 +992,10 @@ pub async fn build_role_cluster(
                 .with_mutator(FullStateEmulator::new(safes[i].module_address));
             let is_entry = i == 0;
             let is_exit = i == total_size - 1;
+            // Cloned per thread rather than moved: only the Exit's branch reads it, but each thread's
+            // closure must own something, and the server is `Clone` precisely so a captured session
+            // handle can be shared back out to the test.
+            let exit_server = exit_server.clone();
 
             std::thread::spawn(move || {
                 let runtime = tokio::runtime::Builder::new_multi_thread()
@@ -1036,7 +1063,7 @@ pub async fn build_role_cluster(
                             config,
                             prober,
                             connector.clone(),
-                            EchoServer::new(),
+                            exit_server,
                         )
                         .await?;
                         Ok(RawRoleNode::Exit(instance, connector))

--- a/hopr/hopr-lib/tests/transport_session_pix.rs
+++ b/hopr/hopr-lib/tests/transport_session_pix.rs
@@ -10,7 +10,8 @@
 //!   4. [Exit]  `PrivateKeyRecovered` — quota exhausted, key recovered → SessionManager requests next SSA → goto 1
 
 use hopr_lib::testing::fixtures::{
-    MINIMUM_INCOMING_WIN_PROB, TEST_GLOBAL_TIMEOUT, TestNodeConfig, build_role_cluster, chain_propagation_delay,
+    MINIMUM_INCOMING_WIN_PROB, TEST_GLOBAL_TIMEOUT, TestNodeConfig, build_role_cluster,
+    build_role_cluster_with_exit_server, chain_propagation_delay,
 };
 #[cfg(feature = "session-client")]
 use {
@@ -114,7 +115,62 @@ async fn build_pix_cluster_with_entry_cap(
     idle_timeout: Duration,
     entry_max_ssas_per_request: usize,
 ) -> anyhow::Result<hopr_lib::testing::fixtures::RoleClusterGuard> {
-    let cluster = build_role_cluster(
+    build_pix_cluster_with(
+        hops,
+        exit_pix,
+        idle_timeout,
+        entry_max_ssas_per_request,
+        hopr_lib::testing::dummies::EchoServer::new(),
+    )
+    .await
+}
+
+/// As [`build_pix_cluster`], but with the Exit's session server under the caller's control.
+///
+/// Only [`a_closed_exit_session_drains_its_surbs_into_the_funded_cycle`] needs this. An
+/// [`EchoServer`](hopr_lib::testing::dummies::EchoServer) owns the Exit-side Session for its whole
+/// life and never hands it back, so there is no way to *close* one from a test; a
+/// [`SessionCaptureServer`](hopr_lib::testing::dummies::SessionCaptureServer) parks instead and hands
+/// the `IncomingSession` out, which is what makes the Exit-side close reachable at all.
+#[cfg(feature = "session-client")]
+async fn build_pix_cluster_with_exit_server<Srv>(
+    hops: usize,
+    exit_pix: IncomingSessionPixConfig,
+    idle_timeout: Duration,
+    exit_server: Srv,
+) -> anyhow::Result<hopr_lib::testing::fixtures::RoleClusterGuard>
+where
+    Srv: hopr_api::node::HoprSessionServer<
+            Session = hopr_lib::exports::transport::IncomingSession,
+            Error: std::fmt::Display,
+        > + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    let default_cap = hopr_lib::exports::transport::config::PixGlobalConfig::default().max_ssas_per_request;
+    build_pix_cluster_with(hops, exit_pix, idle_timeout, default_cap, exit_server).await
+}
+
+/// The cluster the three builders above are all a special case of.
+#[cfg(feature = "session-client")]
+async fn build_pix_cluster_with<Srv>(
+    hops: usize,
+    exit_pix: IncomingSessionPixConfig,
+    idle_timeout: Duration,
+    entry_max_ssas_per_request: usize,
+    exit_server: Srv,
+) -> anyhow::Result<hopr_lib::testing::fixtures::RoleClusterGuard>
+where
+    Srv: hopr_api::node::HoprSessionServer<
+            Session = hopr_lib::exports::transport::IncomingSession,
+            Error: std::fmt::Display,
+        > + Clone
+        + Send
+        + Sync
+        + 'static,
+{
+    let cluster = build_role_cluster_with_exit_server(
         TestNodeConfig {
             win_prob: 1.0,
             pix_global_config: Some(hopr_lib::exports::transport::config::PixGlobalConfig {
@@ -134,6 +190,7 @@ async fn build_pix_cluster_with_entry_cap(
             idle_timeout_ms: idle_timeout.as_millis() as u64,
             ..Default::default()
         },
+        exit_server,
     )
     .await?;
 
@@ -1291,6 +1348,139 @@ async fn idle_session_is_completed_by_exit_fill(#[case] hops: usize, #[case] rat
     driver.abort();
 
     tracing::info!(hops, rate_control, "idle PIX fill test PASSED");
+    Ok(())
+}
+
+/// A Session closed at the Exit still finishes the cycle its deposit has already paid for.
+///
+/// The close here is the real one rather than a simulated one: the Exit's session server hands the
+/// `IncomingSession` back to the test, which closes its write half — the same `WriteClosed` route a
+/// session server takes when its downstream connection ends. Before this, that tore the Exit's
+/// Session down at once, taking the reconstructor state with it; the deposit the Entry had already
+/// paid for the cycle in flight was stranded, since the address derives from both nodes' commitments
+/// and nothing refunds it.
+///
+/// The two cases are the property and its control, and they differ in one config flag:
+///
+/// * with `drain_after_close` on, a `Recovered` milestone arrives **after** the close instant, which can only mean the
+///   Exit went on spending its buffered SURBs on the cycle with no Session left to serve;
+/// * with it off, none does, because the close is the immediate teardown it has always been.
+///
+/// Two guards keep the comparison honest. The cycle must not have recovered *before* the close — at
+/// [`PIX_PARAMS`]' 32-packet cycle against the 45 s aim point, fill alone needs about forty seconds,
+/// so closing a few seconds in leaves most of the cycle outstanding — and no successor may be funded
+/// after the close, since a drained Session has no quota left to serve one with.
+#[cfg(feature = "session-client")]
+#[rstest]
+#[case(1, true)]
+#[case(1, false)]
+#[serial]
+#[test_log::test(tokio::test)]
+#[timeout(TEST_GLOBAL_TIMEOUT)]
+async fn a_closed_exit_session_drains_its_surbs_into_the_funded_cycle(
+    #[case] hops: usize,
+    #[case] drain_after_close: bool,
+) -> anyhow::Result<()> {
+    /// Long enough for the Entry's balancer to reach its 64-SURB target, short enough that fill has
+    /// spent only a handful of the cycle's 32 packets by the time the close lands.
+    const SETTLE: Duration = Duration::from_secs(8);
+    /// What the drain gets, and what the control case waits out in full. Above the 30 s
+    /// `max_recovery_idle`, which is no longer service-gated while draining and is therefore the
+    /// deadline a drain that stops making progress actually dies on.
+    const DRAIN_BUDGET: Duration = Duration::from_secs(35);
+
+    let exit_pix = fill_pix_config(hopr_lib::exports::transport::session::PixFillConfig {
+        drain_after_close,
+        ..Default::default()
+    });
+    let aim_point = exit_pix
+        .supervision
+        .max_recovery_time
+        .mul_f64(exit_pix.supervision.fill.finish_fraction);
+
+    let (exit_server, captured) = hopr_lib::testing::dummies::SessionCaptureServer::new();
+    let cluster = build_pix_cluster_with_exit_server(hops, exit_pix, Duration::from_secs(120), exit_server).await?;
+
+    // Before the Session exists, as in every fill test here: the Exit's first SSA request blocks on
+    // the deposit pool with a budget shorter than `connect_to` takes to return.
+    let (driver, mut milestones) = spawn_exit_pix_driver(&cluster);
+    // The rate-controlled branch, because it is the only one on which the Entry announces its SURB
+    // buffer target — and that target is what the drain's reserve, and so its own admission
+    // threshold, is derived from.
+    let _session = establish_pix_session_with(&cluster, hops, Some(idle_surb_balancer()), true).await?;
+
+    let funded = await_milestones(&mut milestones, aim_point, |seen| {
+        seen.iter()
+            .any(|(milestone, _)| matches!(milestone, PixMilestone::Funded(_)))
+    })
+    .await;
+    anyhow::ensure!(
+        funded
+            .iter()
+            .any(|(milestone, _)| matches!(milestone, PixMilestone::Funded(_))),
+        "no cycle was funded within {aim_point:?}, so there was never a deposit at stake: {funded:?}"
+    );
+
+    // Doubles as the settle window and as a drain of the milestone channel, so that everything
+    // observed after the close really did arrive after it.
+    let before_close = await_milestones(&mut milestones, SETTLE, |_| false).await;
+    anyhow::ensure!(
+        !before_close
+            .iter()
+            .any(|(milestone, _)| matches!(milestone, PixMilestone::Recovered(_))),
+        "the funded cycle recovered before the Session was closed, so this test cannot tell a drain from ordinary \
+         fill: {before_close:?}"
+    );
+
+    let mut exit_session = captured
+        .lock()
+        .map_err(|_| anyhow::anyhow!("the captured-session mutex was poisoned"))?
+        .take()
+        .context("the Exit's session server must have captured the incoming session")?;
+    let closed_at = std::time::Instant::now();
+    tokio::time::timeout(Duration::from_secs(30), exit_session.session.close())
+        .await
+        .context("closing the exit-side session timed out")?
+        .context("closing the exit-side session failed")?;
+    tracing::info!(drain_after_close, "exit-side session closed");
+
+    let after_close = await_milestones(&mut milestones, DRAIN_BUDGET, |seen| {
+        seen.iter()
+            .any(|(milestone, at)| matches!(milestone, PixMilestone::Recovered(_)) && *at >= closed_at)
+    })
+    .await;
+    let drained = after_close
+        .iter()
+        .find(|(milestone, at)| matches!(milestone, PixMilestone::Recovered(_)) && *at >= closed_at);
+
+    if drain_after_close {
+        let (_, recovered_at) = drained.with_context(|| {
+            format!(
+                "the Exit held enough SURBs to finish its funded cycle but stopped working for it when the Session \
+                 closed, so the deposit is stranded; nothing recovered within {DRAIN_BUDGET:?}: {after_close:?}"
+            )
+        })?;
+        tracing::info!(drained_after = ?recovered_at.duration_since(closed_at), "post-close drain completed");
+
+        assert!(
+            !after_close
+                .iter()
+                .any(|(milestone, at)| matches!(milestone, PixMilestone::Funded(_)) && *at >= closed_at),
+            "a drained Session has no quota left to serve, so it must never order a successor cycle the Entry would \
+             have to deposit for: {after_close:?}"
+        );
+    } else {
+        assert!(
+            drained.is_none(),
+            "with draining disabled an Exit-side close must tear the Session down at once, but a cycle recovered {:?} \
+             after it: {after_close:?}",
+            drained.map(|(_, at)| at.duration_since(closed_at))
+        );
+    }
+
+    driver.abort();
+
+    tracing::info!(hops, drain_after_close, "post-close SURB drain test PASSED");
     Ok(())
 }
 

--- a/hopr/hopr-lib/tests/transport_session_pix.rs
+++ b/hopr/hopr-lib/tests/transport_session_pix.rs
@@ -1453,6 +1453,16 @@ async fn a_closed_exit_session_drains_its_surbs_into_the_funded_cycle(
         .iter()
         .find(|(milestone, at)| matches!(milestone, PixMilestone::Recovered(_)) && *at >= closed_at);
 
+    // The observation path has to have outlived the budget, or "nothing recovered after the close"
+    // would be a statement about this test rather than about the Exit. Checked for both cases: it is
+    // what gives the control branch's negative assertion any force, and in the drain branch it turns
+    // a dead event driver into a diagnosis rather than an accusation of a stranded deposit.
+    anyhow::ensure!(
+        !driver.is_finished(),
+        "the Exit PIX event driver stopped before the {DRAIN_BUDGET:?} drain budget elapsed, so nothing observed \
+         after the close proves anything either way"
+    );
+
     if drain_after_close {
         let (_, recovered_at) = drained.with_context(|| {
             format!(

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -769,8 +769,9 @@ impl PixFillControl {
     ///
     /// The notification is the single packet [`admit_at`](Self::admit_at) exempts from the SURB
     /// reserve, and the exemption exists for one reason: it is the message that asks the Entry for
-    /// more SURBs. A drained Session has no Entry left to ask, so leaving it on would originate below
-    /// the reserve into a buffer nothing is refilling — which is the one failure mode
+    /// more SURBs. It asks on behalf of a Session that a drain has already lost — the Entry itself
+    /// may well still be there, but nothing is left to act on the request — so leaving it on would
+    /// originate below the reserve into a buffer nothing is refilling, which is the one failure mode
     /// [`PixFillConfig::min_surb_reserve`](crate::supervision::PixFillConfig::min_surb_reserve)
     /// exists to prevent, since a return packet with no SURB holds up every packet this node
     /// originates. With it off, `notification_due` is always false and the reserve is the only gate.
@@ -3263,12 +3264,12 @@ where
             // Tell the Entry, so it can drop its side rather than wait out its own timeout. The
             // Session is closed either way, so a send failure here changes nothing.
             //
-            // Except after a drain, where there is no peer left to tell and the report is
-            // return-routed: sending it would spend a SURB out of a buffer that may already be
-            // empty, which is precisely the origination this whole path exists to avoid. It would
-            // also be new behaviour rather than preserved behaviour, since an Exit-side close sends
-            // the Entry nothing today — and `draining` is set before the supervisor's verdict, so
-            // this covers a refused drain as well as a completed one.
+            // Except after a drain, where the Session the report would be about is already gone and
+            // the report is return-routed: sending it would spend a SURB out of a buffer that may
+            // already be empty, which is precisely the origination this whole path exists to avoid.
+            // It would also be new behaviour rather than preserved behaviour, since an Exit-side
+            // close sends the Entry nothing today — and `draining` is set before the supervisor's
+            // verdict, so this covers a refused drain as well as a completed one.
             if !draining {
                 myself.notify_pix_failure(session_id, reply_routing).await;
             }
@@ -3683,6 +3684,14 @@ where
     /// This avoids waiting for the idle timeout (`time_to_idle`) or the LRU
     /// capacity bound to evict the entry, which is the desired behaviour when
     /// the caller (e.g. REST `DELETE /session`) knows the session is finished.
+    ///
+    /// One case departs from that: an Exit-side PIX Session with
+    /// [`fill.drain_after_close`](crate::PixFillConfig::drain_after_close) on and spendable SURBs
+    /// left starts a SURB drain instead of being torn down (see `begin_surb_drain`). The data path
+    /// still ends at once, but the session slot and the keep-alive stream stay in place until the
+    /// supervisor closes the Session — whether because the funded cycle recovered or because the
+    /// drain was refused — and `true` then means "found, and now draining" rather than "found and
+    /// closed".
     pub fn close_session(&self, id: &SessionId) -> bool {
         self.close_session_with_reason(id, ClosureReason::Eviction)
     }
@@ -6836,7 +6845,7 @@ mod tests {
     /// the close to the supervisor, and not enough for the supervisor to take it. That is the
     /// arithmetic under test — draining on a buffer that runs out partway is strictly worse than not
     /// draining at all, since the SURBs are spent down to the reserve, the cycle recovers nothing,
-    /// and every packet past the last useful one is return-routed to an Entry that has gone.
+    /// and every packet past the last useful one is return-routed on behalf of a Session that is gone.
     #[test_log::test(tokio::test)]
     async fn a_closed_pix_session_without_enough_surbs_originates_nothing() -> anyhow::Result<()> {
         let (mgr, mut msg_rx, pseudonym) = recovering_exit_pix_session(
@@ -6909,9 +6918,9 @@ mod tests {
     /// Closing a draining Session a second time forces the teardown.
     ///
     /// The drain is the Exit's decision, taken on the operator's behalf, and this is the operator's
-    /// way to overrule it: a second `DELETE /session` — or a peer `SessionError`, which arrives on
-    /// the same path — stops the origination immediately rather than waiting out a cycle. The
-    /// end-of-stream a close of our own ingress produces is deliberately *not* on this path; it
+    /// way to overrule it: a second `SessionManager::close_session` — or a peer `SessionError`, which
+    /// arrives on the same path — stops the origination immediately rather than waiting out a cycle.
+    /// The end-of-stream a close of our own ingress produces is deliberately *not* on this path; it
     /// carries `WriteClosed`/`EmptyRead` and is absorbed.
     #[test_log::test(tokio::test)]
     async fn a_second_close_of_a_draining_session_tears_it_down() -> anyhow::Result<()> {

--- a/transport/session/src/manager.rs
+++ b/transport/session/src/manager.rs
@@ -717,6 +717,11 @@ struct PixFillState {
     /// This is what makes the distinction: one packet per notification period is the notification and
     /// is exempt from the SURB reserve, and everything above that rate is fill and is not.
     last_notify_at: Option<Instant>,
+    /// Whether this stream is draining the SURB buffer of a Session that has already been closed.
+    ///
+    /// Set once, by [`PixFillControl::enter_drain`], and never cleared: a drain ends with the
+    /// Session, and the stream with it.
+    draining: bool,
 }
 
 impl PixFillControl {
@@ -741,15 +746,54 @@ impl PixFillControl {
                 notify_started: false,
                 fill: FillRate::ZERO,
                 last_notify_at: None,
+                draining: false,
             }),
         }
     }
 
     /// Turns the SURB-level notification on, after its initial delay.
+    ///
+    /// A no-op once the Session is draining, for the reason [`enter_drain`](Self::enter_drain)
+    /// gives — and it has to be checked here rather than only there, because the one-shot delay task
+    /// holds a clone of this control and nothing bounds how long an operator may make its period.
     pub(crate) fn start_notify(&self) {
         let mut state = self.state.lock();
+        if state.draining {
+            return;
+        }
         state.notify_started = true;
         self.apply(&state);
+    }
+
+    /// Puts the stream into post-close drain mode, silencing the SURB-level notification.
+    ///
+    /// The notification is the single packet [`admit_at`](Self::admit_at) exempts from the SURB
+    /// reserve, and the exemption exists for one reason: it is the message that asks the Entry for
+    /// more SURBs. A drained Session has no Entry left to ask, so leaving it on would originate below
+    /// the reserve into a buffer nothing is refilling — which is the one failure mode
+    /// [`PixFillConfig::min_surb_reserve`](crate::supervision::PixFillConfig::min_surb_reserve)
+    /// exists to prevent, since a return packet with no SURB holds up every packet this node
+    /// originates. With it off, `notification_due` is always false and the reserve is the only gate.
+    pub(crate) fn enter_drain(&self) {
+        let mut state = self.state.lock();
+        state.draining = true;
+        state.notify_started = false;
+        self.apply(&state);
+    }
+
+    /// Whether this Session is draining its SURB buffer after having been closed.
+    pub(crate) fn is_draining(&self) -> bool {
+        self.state.lock().draining
+    }
+
+    /// The SURBs this Session could still spend on a drain, net of the reserve it must leave behind.
+    ///
+    /// An estimate and an upper bound at that — ring-buffer overwrites, store eviction and
+    /// invalidated relayers are all unobserved — which is why the supervisor weighs it against a
+    /// cycle's whole remaining emission rather than a discounted one. The reserve subtracted is the
+    /// *effective* one already derived for this Session, not the configured ceiling.
+    pub(crate) fn drainable_surbs(&self) -> u64 {
+        self.estimator.saturating_diff().saturating_sub(self.min_surb_reserve)
     }
 
     /// Applies a rate planned by the PIX supervisor.
@@ -2268,12 +2312,12 @@ where
                         // These notifications come from the Sessions themselves once
                         // an empty read is encountered, which means the closure was done by the
                         // other party.
-                        if let Some(session_data) = myself.sessions.remove(&session_id) {
-                            // Reconstructor state is released by `close_session` aborting the PIX
-                            // action driver, whose commitment guards retire on drop.
-                            myself.active_sessions.fetch_sub(1, Ordering::Relaxed);
-                            close_session(session_id, session_data, closure_reason);
-                        } else {
+                        //
+                        // Routed through `close_session_with_reason` rather than removing the slot
+                        // here, so that this path — the one an Exit-side session server actually
+                        // closes on — can answer with a SURB drain like every other. Identical
+                        // behaviour when it does not.
+                        if !myself.close_session_with_reason(&session_id, closure_reason) {
                             // Do not treat this as an error
                             debug!(
                                 ?session_id,
@@ -3190,7 +3234,20 @@ where
             };
 
             let Some(reason) = close_reason else { return };
-            error!(%session_id, %reason, "pix supervisor closed the session");
+
+            // Read before `stop_pix_fill`, which silences the stream either way. Keyed on the drain
+            // rather than on the reason, which is a strict superset of it: a *stalled* drain closes
+            // with `RecoveryIdle` or `RecoveryDeadline`, and that is likewise the ordinary end of a
+            // Session an operator has already closed rather than something to page anyone about.
+            let draining = myself
+                .sessions
+                .get(&session_id)
+                .is_some_and(|slot| slot.pix_fill.get().is_some_and(|fill| fill.is_draining()));
+            if draining {
+                info!(%session_id, %reason, "pix supervisor ended the post-close SURB drain");
+            } else {
+                error!(%session_id, %reason, "pix supervisor closed the session");
+            }
 
             // Unblock anything parked on the gate before tearing down: the supervisor that would
             // have woken it is the thing that just stopped. Fill is silenced alongside it, and for a
@@ -3205,7 +3262,16 @@ where
 
             // Tell the Entry, so it can drop its side rather than wait out its own timeout. The
             // Session is closed either way, so a send failure here changes nothing.
-            myself.notify_pix_failure(session_id, reply_routing).await;
+            //
+            // Except after a drain, where there is no peer left to tell and the report is
+            // return-routed: sending it would spend a SURB out of a buffer that may already be
+            // empty, which is precisely the origination this whole path exists to avoid. It would
+            // also be new behaviour rather than preserved behaviour, since an Exit-side close sends
+            // the Entry nothing today — and `draining` is set before the supervisor's verdict, so
+            // this covers a refused drain as well as a completed one.
+            if !draining {
+                myself.notify_pix_failure(session_id, reply_routing).await;
+            }
 
             if let Some(slot) = myself.sessions.remove(&session_id) {
                 myself.active_sessions.fetch_sub(1, Ordering::Relaxed);
@@ -3621,11 +3687,115 @@ where
         self.close_session_with_reason(id, ClosureReason::Eviction)
     }
 
+    /// Answers an Exit-side close by draining the Session's buffered SURBs, when that is worth doing.
+    ///
+    /// A PIX Session can end long before the cycle it was funded for does. The deposit that cycle was
+    /// paid is released only once its whole emission has ridden back to the Entry, and the address it
+    /// sits at derives from both nodes' commitments — so tearing the Session down mid-cycle strands
+    /// money both sides have already parted with. When the Exit still holds enough SURBs to finish,
+    /// it keeps the keep-alive stream running instead, and the Session's slot with it, until the
+    /// supervisor closes the Session for good.
+    ///
+    /// Returns `None` when this close was **not** answered here, which is every case the caller must
+    /// handle exactly as it always has; `Some(v)` is the value
+    /// [`close_session_with_reason`](Self::close_session_with_reason) should return. `Some` currently
+    /// always carries `true` — a drain is only ever started for a Session that was found — but the
+    /// value is returned rather than assumed so that the two outcomes stay distinguishable if a
+    /// future refusal path wants to report one.
+    ///
+    /// The order of the checks is load-bearing:
+    ///
+    /// 1. the configuration, so that with `drain_after_close` (or `fill.enabled`) off nothing below runs and every
+    ///    close path is byte-for-byte what it was;
+    /// 2. the slot, by `get` rather than `remove` — the lookup also refreshes the idle timer the drain lives on;
+    /// 3. an Exit-side PIX Session, so an Entry-side or non-PIX Session falls straight through;
+    /// 4. an already-draining Session: a `WriteClosed`/`EmptyRead` is the end-of-stream our own ingress abort produces
+    ///    and is absorbed, while anything else — a second operator close, or a peer `SessionError` — forces the hard
+    ///    teardown, which is the operator's way to overrule a drain;
+    /// 5. a PIX failure already tearing the Session down, which nothing here should interfere with;
+    /// 6. the SURB estimate, which is the one half of the predicate this layer can answer — see the comment on it for
+    ///    why answering it here rather than leaving it all to the supervisor matters;
+    /// 7. and only then the stream is put into drain mode, **before** the supervisor is told, so that no packet can be
+    ///    classified as the reserve-exempt notification in the window between the supervisor deciding and the stream
+    ///    learning.
+    ///
+    /// What it does *not* do is decrement `active_sessions` or remove the slot: the supervisor's own
+    /// `Close` teardown does both, whether the drain completes or is refused a channel hop later.
+    /// `Balancer`, `KeepAlive`, `SurbNotifyDelay`, `PixActionDriver` and the deposit observers are
+    /// all left running; only the ingress is aborted, so the session server sees its end of the
+    /// stream as promptly as it would have.
+    fn begin_surb_drain(&self, id: &SessionId, reason: ClosureReason) -> Option<bool> {
+        let fill_cfg = &self.cfg.pix_config.supervision.fill;
+        if !(fill_cfg.enabled && fill_cfg.drain_after_close) {
+            return None;
+        }
+
+        let slot = self.sessions.get(id)?;
+        let supervisor = slot.pix_supervisor.get()?;
+        let fill = slot.pix_fill.get()?;
+
+        if fill.is_draining() {
+            return match reason {
+                ClosureReason::WriteClosed | ClosureReason::EmptyRead => Some(true),
+                _ => None,
+            };
+        }
+
+        if matches!(reason, ClosureReason::PixFailure | ClosureReason::MissingDepositData) {
+            return None;
+        }
+
+        // Nothing to drain *with* is decidable here, and cheaply, unlike whether there is anything
+        // worth draining *for* — which needs the cycle state only the supervisor holds. Asking it
+        // anyway would defer the teardown of every PIX Session by however long the action driver
+        // takes to reach the answer, and a driver mid-`send_ssa_request` can be seconds away from
+        // that. So a Session whose estimate is already at or below its reserve is torn down here and
+        // now, exactly as it always was: no rate the supervisor could plan would put a packet on the
+        // wire against a buffer that shallow.
+        let drainable_surbs = fill.drainable_surbs();
+        if drainable_surbs == 0 {
+            return None;
+        }
+
+        fill.enter_drain();
+        if !supervisor.try_send_event(SessionPixEvent::SessionClosed { drainable_surbs }) {
+            return None;
+        }
+
+        // The data path ends here regardless of what the supervisor decides: a writer parked on the
+        // egress gate is waiting for a Session that has gone, and the reader's end-of-stream is what
+        // the session server is waiting for.
+        if let Some(gate) = slot.pix_egress_gate.get() {
+            gate.poison();
+        }
+        slot.abort_handles.lock().abort_one(&SessionHandles::Ingress);
+
+        #[cfg(feature = "telemetry")]
+        set_session_state(id, SessionLifecycleState::Closing);
+
+        info!(
+            session_id = %id,
+            ?reason,
+            drainable_surbs,
+            "session closed at the exit — draining its buffered SURBs into the funded cycle"
+        );
+        Some(true)
+    }
+
     /// [`close_session`](Self::close_session) with the reason spelled out.
     ///
     /// The reason is what the operator reads when a PIX Session stops, and the failures are hard to
     /// tell apart from the outside, so a caller that knows which one it is says so.
+    ///
+    /// `true` means the Session was found and dealt with. Since
+    /// [`begin_surb_drain`](Self::begin_surb_drain), "dealt with" also covers "found, and now
+    /// draining its remaining SURBs into a funded cycle" — in which case the slot is deliberately
+    /// left in place until the supervisor's own teardown removes it.
     fn close_session_with_reason(&self, id: &SessionId, reason: ClosureReason) -> bool {
+        if let Some(handled) = self.begin_surb_drain(id, reason) {
+            return handled;
+        }
+
         if let Some(slot) = self.sessions.remove(id) {
             self.active_sessions.fetch_sub(1, Ordering::Relaxed);
             // Reconstructor state is released by `close_session` aborting the PIX action driver,
@@ -6431,7 +6601,7 @@ mod tests {
     async fn recovering_exit_pix_session(
         capabilities: Capabilities,
         notify_period: Option<Duration>,
-        min_surb_reserve: u64,
+        fill: crate::supervision::PixFillConfig,
     ) -> anyhow::Result<(RecordingManager, Originated, HoprPseudonym)> {
         let params = fill_pix_params();
         let mgr = RecordingManager::new(SessionManagerConfig {
@@ -6445,10 +6615,7 @@ mod tests {
                     // about eleven packets a second — observable inside a test-length window.
                     max_recovery_idle: Duration::from_secs(31),
                     max_recovery_time: Duration::from_secs(40),
-                    fill: crate::supervision::PixFillConfig {
-                        min_surb_reserve,
-                        ..Default::default()
-                    },
+                    fill,
                     ..Default::default()
                 },
                 ..Default::default()
@@ -6531,7 +6698,18 @@ mod tests {
     #[test_log::test(tokio::test)]
     async fn a_funded_idle_pix_session_is_filled_by_the_exit() -> anyhow::Result<()> {
         let notify = Duration::from_secs(1);
-        let (mgr, mut msg_rx, pseudonym) = recovering_exit_pix_session(Capabilities::empty(), Some(notify), 1).await?;
+        let (mgr, mut msg_rx, pseudonym) = recovering_exit_pix_session(
+            Capabilities::empty(),
+            Some(notify),
+            // Draining off, so the trailing close below still means "the stream stopped at once".
+            // What a drain does instead is the subject of the tests further down.
+            crate::supervision::PixFillConfig {
+                min_surb_reserve: 1,
+                drain_after_close: false,
+                ..Default::default()
+            },
+        )
+        .await?;
 
         // SURBs to spend, so the reserve is not what this test is measuring.
         mgr.sessions
@@ -6565,6 +6743,195 @@ mod tests {
         Ok(())
     }
 
+    // ---------------------------------------------------------------
+    // Draining a closed PIX Session
+    // ---------------------------------------------------------------
+
+    /// A funded, filling Exit PIX Session whose SURB estimate covers the rest of its cycle.
+    ///
+    /// The 100 000 is not decoration: it is the estimate `begin_surb_drain` nets the reserve out of
+    /// and hands the supervisor, and against [`fill_pix_params`]' 300-packet cycle it is what makes a
+    /// drain admissible at all. The ramp is waited out for the reason
+    /// [`exit_session_originating_keep_alives`] gives — silence after a close says nothing unless the
+    /// stream was observably running before it.
+    async fn drainable_exit_pix_session(
+        notify_period: Duration,
+    ) -> anyhow::Result<(RecordingManager, Originated, HoprPseudonym)> {
+        let (mgr, mut msg_rx, pseudonym) = recovering_exit_pix_session(
+            Capabilities::empty(),
+            Some(notify_period),
+            crate::supervision::PixFillConfig {
+                min_surb_reserve: 1,
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        mgr.sessions
+            .get(&pseudonym)
+            .context("the session slot must exist")?
+            .surb_estimator
+            .produced
+            .fetch_add(100_000, std::sync::atomic::Ordering::Relaxed);
+
+        let observed = keep_alives_during(&mut msg_rx, pseudonym, Duration::from_millis(1500)).await;
+        anyhow::ensure!(
+            observed > 0,
+            "the fixture's keep-alive stream never ran, so nothing below can tell a drain from a Session that was \
+             silent all along"
+        );
+        Ok((mgr, msg_rx, pseudonym))
+    }
+
+    /// A closed PIX Session goes on originating until the cycle it was paid for recovers.
+    ///
+    /// The deposit is stranded rather than refunded if the cycle does not complete, so a close that
+    /// tore the stream down while the Exit still held enough SURBs to finish would throw away money
+    /// both sides have already paid. What must *not* happen is the mirror image of that: origination
+    /// continuing past the point it is buying anything. So the recovery is delivered and the slot has
+    /// to be gone, and the stream silent, on the other side of it.
+    #[test_log::test(tokio::test)]
+    async fn a_closed_pix_session_keeps_originating_until_its_cycle_recovers() -> anyhow::Result<()> {
+        let notify = Duration::from_secs(1);
+        let (mgr, mut msg_rx, pseudonym) = drainable_exit_pix_session(notify).await?;
+
+        assert!(
+            mgr.close_session(&pseudonym),
+            "a close that starts a drain is still a close that was handled"
+        );
+        assert!(
+            mgr.active_sessions().contains(&pseudonym),
+            "the slot must survive the close — the drain runs out of it, and the supervisor's own teardown is what \
+             removes it"
+        );
+
+        // The SURB-level notification is switched off for the whole drain, so every packet counted
+        // here is fill. The bar is nevertheless the notification-only figure, which keeps this
+        // comparable with `a_funded_idle_pix_session_is_filled_by_the_exit` above.
+        let window = Duration::from_millis(1500);
+        let observed = keep_alives_during(&mut msg_rx, pseudonym, window).await;
+        let promote_every = notify - MAX_WAIT_CHUNK.min(notify / 2);
+        let notify_only = (window.as_secs_f64() / promote_every.as_secs_f64()).ceil() as usize;
+        assert!(
+            observed > notify_only,
+            "a closed session with a full SURB buffer originated {observed} keep-alive(s) over {window:?}, which is \
+             no more than the {notify_only} its (now silenced) notification would have accounted for"
+        );
+
+        // Recovery is the end of the drain: there is nothing left to work for, so the Session must go.
+        let ssa_id = SsaId::new(pseudonym, SsaIndex::new(1).expect("index one is non-zero"));
+        mgr.dispatch_pix_event(HoprSessionInPixEvent::SsaRecovered(ssa_id))
+            .await?;
+        assert!(
+            wait_for_no_active_sessions(&mgr).await,
+            "a recovered cycle must end the drain and tear the Session down"
+        );
+        assert_no_further_origination(&mut msg_rx, "a completed SURB drain").await;
+        Ok(())
+    }
+
+    /// A closed PIX Session with too few SURBs to finish is torn down as it always was.
+    ///
+    /// A hundred SURBs against [`fill_pix_params`]' 300-packet cycle: enough for the manager to offer
+    /// the close to the supervisor, and not enough for the supervisor to take it. That is the
+    /// arithmetic under test — draining on a buffer that runs out partway is strictly worse than not
+    /// draining at all, since the SURBs are spent down to the reserve, the cycle recovers nothing,
+    /// and every packet past the last useful one is return-routed to an Entry that has gone.
+    #[test_log::test(tokio::test)]
+    async fn a_closed_pix_session_without_enough_surbs_originates_nothing() -> anyhow::Result<()> {
+        let (mgr, mut msg_rx, pseudonym) = recovering_exit_pix_session(
+            Capabilities::empty(),
+            Some(MIN_SURB_BUFFER_NOTIFICATION_PERIOD),
+            crate::supervision::PixFillConfig {
+                min_surb_reserve: 1,
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        mgr.sessions
+            .get(&pseudonym)
+            .context("the session slot must exist")?
+            .surb_estimator
+            .produced
+            .fetch_add(100, std::sync::atomic::Ordering::Relaxed);
+        anyhow::ensure!(
+            keep_alives_during(&mut msg_rx, pseudonym, Duration::from_millis(1500)).await > 0,
+            "the stream must be running before the close for its absence afterwards to mean anything"
+        );
+
+        assert!(mgr.close_session(&pseudonym), "the session must exist to be closed");
+        assert!(
+            wait_for_no_active_sessions(&mgr).await,
+            "a drain the supervisor refuses must still tear the Session down"
+        );
+        assert_no_further_origination(&mut msg_rx, "a close with too few SURBs to drain").await;
+        Ok(())
+    }
+
+    /// With `drain_after_close` off, every close path is what it was before draining existed.
+    ///
+    /// Including the part an operator would notice first: the slot is gone by the time
+    /// `close_session` returns, rather than one channel hop later once the supervisor has answered.
+    #[test_log::test(tokio::test)]
+    async fn a_closed_pix_session_with_draining_disabled_originates_nothing() -> anyhow::Result<()> {
+        let (mgr, mut msg_rx, pseudonym) = recovering_exit_pix_session(
+            Capabilities::empty(),
+            Some(Duration::from_secs(1)),
+            crate::supervision::PixFillConfig {
+                min_surb_reserve: 1,
+                drain_after_close: false,
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        mgr.sessions
+            .get(&pseudonym)
+            .context("the session slot must exist")?
+            .surb_estimator
+            .produced
+            .fetch_add(100_000, std::sync::atomic::Ordering::Relaxed);
+        anyhow::ensure!(
+            keep_alives_during(&mut msg_rx, pseudonym, Duration::from_millis(1500)).await > 0,
+            "the fixture's keep-alive stream never ran"
+        );
+
+        assert!(mgr.close_session(&pseudonym), "the session must exist to be closed");
+        assert!(
+            mgr.active_sessions().is_empty(),
+            "with draining disabled the slot must be gone by the time the close returns"
+        );
+        assert_no_further_origination(&mut msg_rx, "an explicit close with draining disabled").await;
+        Ok(())
+    }
+
+    /// Closing a draining Session a second time forces the teardown.
+    ///
+    /// The drain is the Exit's decision, taken on the operator's behalf, and this is the operator's
+    /// way to overrule it: a second `DELETE /session` — or a peer `SessionError`, which arrives on
+    /// the same path — stops the origination immediately rather than waiting out a cycle. The
+    /// end-of-stream a close of our own ingress produces is deliberately *not* on this path; it
+    /// carries `WriteClosed`/`EmptyRead` and is absorbed.
+    #[test_log::test(tokio::test)]
+    async fn a_second_close_of_a_draining_session_tears_it_down() -> anyhow::Result<()> {
+        let (mgr, mut msg_rx, pseudonym) = drainable_exit_pix_session(Duration::from_secs(1)).await?;
+
+        assert!(mgr.close_session(&pseudonym), "the first close starts the drain");
+        assert!(
+            mgr.active_sessions().contains(&pseudonym),
+            "the drain must be running for the second close to have anything to overrule"
+        );
+
+        assert!(mgr.close_session(&pseudonym), "the second close must find the session");
+        assert!(
+            mgr.active_sessions().is_empty(),
+            "a second explicit close must remove the slot rather than let the drain run on"
+        );
+        assert_no_further_origination(&mut msg_rx, "a second explicit close of a draining session").await;
+        Ok(())
+    }
+
     /// The same Session, with no SURBs to spend, must fall back to its SURB-level notification.
     ///
     /// A Session whose Entry has stopped supplying SURBs is the one case where filling harder is
@@ -6577,8 +6944,15 @@ mod tests {
         // applies. A shorter value would be raised to this one anyway, and the bound below would then
         // be computed from a period that is not the one in effect.
         let notify = MIN_SURB_BUFFER_NOTIFICATION_PERIOD;
-        let (mgr, mut msg_rx, pseudonym) =
-            recovering_exit_pix_session(Capabilities::empty(), Some(notify), 500).await?;
+        let (mgr, mut msg_rx, pseudonym) = recovering_exit_pix_session(
+            Capabilities::empty(),
+            Some(notify),
+            crate::supervision::PixFillConfig {
+                min_surb_reserve: 500,
+                ..Default::default()
+            },
+        )
+        .await?;
         assert_eq!(
             Some(notify),
             mgr.cfg.surb_balance_notify_period,
@@ -6617,8 +6991,15 @@ mod tests {
     /// fastest, so it is the one where getting it wrong costs most.
     #[test_log::test(tokio::test)]
     async fn a_no_rate_control_pix_session_still_estimates_its_surb_level() -> anyhow::Result<()> {
-        let (mgr, mut msg_rx, pseudonym) =
-            recovering_exit_pix_session(Capability::NoRateControl.into(), Some(Duration::from_secs(1)), 1).await?;
+        let (mgr, mut msg_rx, pseudonym) = recovering_exit_pix_session(
+            Capability::NoRateControl.into(),
+            Some(Duration::from_secs(1)),
+            crate::supervision::PixFillConfig {
+                min_surb_reserve: 1,
+                ..Default::default()
+            },
+        )
+        .await?;
 
         let slot = mgr.sessions.get(&pseudonym).context("the session slot must exist")?;
         slot.surb_estimator

--- a/transport/session/src/supervision/fill.rs
+++ b/transport/session/src/supervision/fill.rs
@@ -191,7 +191,19 @@ impl FillPlanner {
         self.observe_target(now, &target);
 
         let required = self.required_rate(now, &target);
-        let wanted = (required - self.organic_pps).max(0.0);
+        // Organic egress is subtracted because the application is expected to keep contributing it.
+        // A drained Session's will not: the egress gate is poisoned, the ingress is aborted, and
+        // `served_total` can never move again, so the average above is a memory of traffic that
+        // cannot recur. Subtracting it would credit the drain with a contribution nothing is left to
+        // make — and it bites hardest in the case the drain exists for. A client that hangs up on a
+        // cycle it has all but paid off leaves a small remainder and a high average, so `required`
+        // lands *below* what the Session was doing a moment earlier, the drain is suppressed to its
+        // heartbeat for the whole of the averaging window, and the deadline arrives first.
+        let wanted = if target.drain {
+            required
+        } else {
+            (required - self.organic_pps).max(0.0)
+        };
         let rate = self.bound(now, wanted);
 
         self.should_emit(rate).then(|| {
@@ -285,6 +297,15 @@ impl FillPlanner {
     /// up still emits one packet per period: it refreshes the Entry's idle eviction, it carries the
     /// SURB level the Entry's balancer acts on, and it is what distinguishes a planner that decided
     /// on nothing from one that has stopped planning.
+    ///
+    /// The stall rule applies to a [drain](FillTarget::drain) exactly as it does to ordinary fill,
+    /// and deliberately so. It is the only thing standing between a *doomed* drain — a failed
+    /// polynomial, or a SURB supply carrying no shares — and `max_rate` sustained until a deadline
+    /// fires, which at the shipped ceiling is fifteen thousand SURBs spent for nothing. It costs a
+    /// healthy drain nothing, because a cycle that is progressing refreshes
+    /// [`target_progress_at`](Self::target_progress_at) on every tick that sees it move. And it is
+    /// not made redundant by `max_recovery_idle` no longer being service-gated while draining: that
+    /// deadline ends the drain, this bounds what the drain spends up to the moment it does.
     fn bound(&mut self, now: Instant, wanted: f64) -> FillRate {
         let heartbeat = FillRate::once_per(self.cfg.heartbeat);
         let heartbeat_pps = heartbeat.as_packets_per_sec();
@@ -578,5 +599,62 @@ mod tests {
         // And above it, the ceiling binds — the drain is loud, not unbounded.
         let mut capped = FillPlanner::new(&cfg(Duration::from_secs(60), 100, idle), &dims(), now);
         assert_eq!(FillRate::per_second(100), capped.bound(now, drained));
+    }
+
+    /// A drain plans its own remainder, not the traffic the Session used to carry.
+    ///
+    /// Organic egress is subtracted from the requirement because the application is expected to go
+    /// on providing it. After a close it cannot: the gate is poisoned and `served_total` is frozen,
+    /// so the average is a memory. Left in, it suppresses precisely the case the drain exists for —
+    /// a client that hangs up on a cycle it has all but paid off, where the remainder is small and
+    /// the average is still high, so the requirement lands *below* it and the drain falls to its
+    /// heartbeat until the average decays. At the shipped ten-second window that is most of a
+    /// `max_recovery_idle`, and the deadline gets there first.
+    #[test]
+    fn a_drain_is_not_suppressed_by_the_traffic_that_preceded_it() {
+        const REMAINING: u64 = 2;
+
+        let idle = Duration::from_secs(30);
+        let t0 = Instant::now();
+        let mut planner = FillPlanner::new(&cfg(Duration::from_secs(60), 250, idle), &dims(), t0);
+
+        // One tick of a busy Session, to put a real average on the books. The cycle is all but done,
+        // which is what puts the requirement below it.
+        let nearly_done = FillTarget {
+            largest_shares_seen: planner.cycle_shares - REMAINING,
+            ..target(t0)
+        };
+        let busy = planner.plan(t0 + SAMPLING_INTERVAL, 600, Some(nearly_done));
+        assert_eq!(
+            Some(FillRate::once_per(Duration::from_secs(60))),
+            busy,
+            "a live Session this far ahead of its deadline is held at the heartbeat, which is what makes the drain \
+             below observable"
+        );
+        assert!(
+            planner.organic_pps > 0.0,
+            "the average must be non-zero to be subtracted"
+        );
+
+        // Now the same cycle, drained. `served_total` does not move again, ever.
+        let rate = planner
+            .plan(
+                t0 + 2 * SAMPLING_INTERVAL,
+                600,
+                Some(FillTarget {
+                    drain: true,
+                    ..nearly_done
+                }),
+            )
+            .expect("a drain that has to finish a remainder must plan a rate for it");
+
+        let expected = (REMAINING as f64 * (1.0 + planner.cfg.loss_margin) / SAMPLING_INTERVAL.as_secs_f64()).ceil();
+        assert_eq!(
+            FillRate::per_second(expected as u32),
+            rate,
+            "the drain must ask for its {REMAINING}-share remainder, not for what is left of it after {} packets/s of \
+             traffic that can never return",
+            planner.organic_pps
+        );
     }
 }

--- a/transport/session/src/supervision/fill.rs
+++ b/transport/session/src/supervision/fill.rs
@@ -58,6 +58,14 @@ pub(crate) struct FillTarget {
     pub largest_shares_seen: u64,
     /// The immutable per-cycle recovery deadline this cycle must finish before.
     pub hard_deadline: Instant,
+    /// Whether this target is a post-close drain, so the whole remainder is wanted at once.
+    ///
+    /// A live Session is filled at the pace its deadline needs, because it will still be there when
+    /// the deadline arrives. A drained one will not be: it is closed, the buffer it is spending is
+    /// finite and nothing is refilling it, so the only sensible rate is as fast as
+    /// [`PixFillConfig::max_rate`] allows. See "Draining a closed Session" in the module
+    /// documentation of `supervision`.
+    pub drain: bool,
 }
 
 /// The pure rate law. See the module documentation for what it computes and why.
@@ -248,16 +256,26 @@ impl FillPlanner {
     /// already in the past collapses to one sampling interval, which asks for the whole remainder at
     /// once and is then bounded by `max_rate` — the correct behaviour for a cycle that is out of time,
     /// since there is no rate at which it can still be saved and no reason to stop trying.
+    ///
+    /// A [drain](FillTarget::drain) collapses the horizon the same way for a different reason: pacing
+    /// a cycle to its deadline only makes sense while the Session is still there to be paced, and a
+    /// drained one is spending a buffer nothing will refill. The ceiling in
+    /// [`bound`](Self::bound) then becomes the only thing setting the rate, which is the intent
+    /// rather than a side effect.
     fn required_rate(&self, now: Instant, target: &FillTarget) -> f64 {
         let remaining =
             self.cycle_shares.saturating_sub(target.largest_shares_seen) as f64 * (1.0 + self.cfg.loss_margin);
-        let slack = self.max_recovery_time.mul_f64(1.0 - self.cfg.finish_fraction);
-        let horizon = target
-            .hard_deadline
-            .checked_sub(slack)
-            .map(|finish_by| finish_by.saturating_duration_since(now))
-            .unwrap_or(SAMPLING_INTERVAL)
-            .max(SAMPLING_INTERVAL);
+        let horizon = if target.drain {
+            SAMPLING_INTERVAL
+        } else {
+            let slack = self.max_recovery_time.mul_f64(1.0 - self.cfg.finish_fraction);
+            target
+                .hard_deadline
+                .checked_sub(slack)
+                .map(|finish_by| finish_by.saturating_duration_since(now))
+                .unwrap_or(SAMPLING_INTERVAL)
+                .max(SAMPLING_INTERVAL)
+        };
         remaining / horizon.as_secs_f64()
     }
 
@@ -390,6 +408,7 @@ mod tests {
             ),
             largest_shares_seen: 0,
             hard_deadline: now + Duration::from_secs(3600),
+            drain: false,
         }
     }
 
@@ -516,5 +535,48 @@ mod tests {
             stalled.as_packets_per_sec() <= 5.0,
             "the stall fallback must never exceed the ceiling either"
         );
+    }
+
+    /// A post-close drain wants its whole remainder at once, and `max_rate` is what paces it.
+    ///
+    /// The ordinary rate law spreads the remainder over the aim point, which is the right answer for
+    /// a Session that will still be there in an hour. A drained Session will not be: it is closed,
+    /// the buffer it is spending is finite and nothing is refilling it, and every SURB in it that is
+    /// not spent on a share is one the deposit being recovered has already paid for. So the horizon
+    /// collapses to a single sampling interval and the ceiling becomes the only thing setting the
+    /// pace — which is the intended reading of "drain", not an accident of the arithmetic.
+    #[test]
+    fn a_draining_target_asks_for_its_whole_remainder_at_once() {
+        let idle = Duration::from_secs(30);
+        let now = Instant::now();
+        let mut planner = FillPlanner::new(&cfg(Duration::from_secs(60), 250, idle), &dims(), now);
+
+        // An hour of runway on both, so the only difference between them is the flag.
+        let patient = target(now);
+        let draining = FillTarget { drain: true, ..patient };
+
+        let whole_remainder = planner.cycle_shares as f64 * (1.0 + planner.cfg.loss_margin);
+        let drained = planner.required_rate(now, &draining);
+        assert!(
+            (drained - whole_remainder / SAMPLING_INTERVAL.as_secs_f64()).abs() < 1e-9,
+            "a drain must ask for its whole remainder inside one sampling interval, got {drained} against a remainder \
+             of {whole_remainder}"
+        );
+
+        let patient_rate = planner.required_rate(now, &patient);
+        assert!(
+            patient_rate < 1.0 && patient_rate * 1_000.0 < drained,
+            "the same target with an hour of runway must still be spread over that hour, got {patient_rate}"
+        );
+
+        // Below the ceiling the drain is the remainder itself, rounded up as every rate is.
+        assert_eq!(
+            FillRate::per_second(whole_remainder.ceil() as u32),
+            planner.bound(now, drained)
+        );
+
+        // And above it, the ceiling binds — the drain is loud, not unbounded.
+        let mut capped = FillPlanner::new(&cfg(Duration::from_secs(60), 100, idle), &dims(), now);
+        assert_eq!(FillRate::per_second(100), capped.bound(now, drained));
     }
 }

--- a/transport/session/src/supervision/mod.rs
+++ b/transport/session/src/supervision/mod.rs
@@ -259,7 +259,7 @@
 //!
 //! A PIX Session can end at the Exit long before its funded cycle does, by three routes that all
 //! arrive at the same place: the session server closes the `HoprSession` (`WriteClosed`/`EmptyRead`),
-//! the operator calls `close_session` over the REST API, or the peer sends a `SessionError`. Until
+//! the operator calls `SessionManager::close_session`, or the peer sends a `SessionError`. Until
 //! now each of those tore the Session down at once, taking the action driver's commitment guards and
 //! the reconstructor state with it. If the Exit was already holding enough SURBs to finish the cycle,
 //! the deposit both sides paid for was stranded — the address derives from the two commitments
@@ -285,8 +285,9 @@
 //! in force for the whole drain, because the failure it prevents is worse than a lost deposit: a
 //! return-routed packet that finds no SURB holds *every* packet this node originates for
 //! `surb_resolution_wait`. And the SURB-level notification — the one packet the reserve exempts — is
-//! switched **off** for the duration, since the reason for the exemption is that it asks the Entry
-//! for more SURBs, and the Entry it would ask has gone.
+//! switched **off** for the duration, since the reason for the exemption is that it asks for more
+//! SURBs on behalf of a Session that is gone: the Entry itself very likely still exists, but nothing
+//! is left there to act on the request, so no refill ever answers it.
 //!
 //! What a drain does not do is carry the Session on in any other respect. It retires every sibling
 //! cycle immediately (they are queued behind the target and can receive nothing while it drains) and
@@ -367,7 +368,7 @@
 //!    | `ProgressNotification` | Worker calls `gate.notify_progress()`; no driver I/O. |
 //!    | `RetireSsa` | Calls `share_processor.retire_ssa`, aborts the deposit observer task. |
 //!    | `SetFillRate` | Applies the rate to the Session's shared keep-alive controller and records the gauge. |
-//!    | `Close` | Silences fill, poisons gate, retires all SSAs, publishes close metric, removes session slot. A close that ends a *drain* is an ordinary outcome rather than a failure: it is logged as information and the Entry is sent no failure notice, since the notice is return-routed and the peer it would name has already gone. |
+//!    | `Close` | Silences fill, poisons gate, retires all SSAs, publishes close metric, removes session slot. A close that ends a *drain* is an ordinary outcome rather than a failure: it is logged as information and the Entry is sent no failure notice, since the notice is return-routed and the Session it would report on is already gone — sending it would only spend a SURB out of a buffer that may be empty. |
 //!
 //! 7. PIX protocol events from the packet pipeline arrive via `dispatch_pix_event` and are forwarded to the supervisor
 //!    as `SessionPixEvent::RecoveryProgress`, `UnverifiableShares`, `AlmostRecovered`, or `Recovered`.
@@ -1080,12 +1081,12 @@ pub struct PixFillConfig {
     /// Whether a Session closed at this Exit keeps draining its buffered SURBs into the funded cycle.
     ///
     /// A Session can end at the Exit long before its funded cycle does: the session server closes it,
-    /// the operator calls `close_session`, or the peer reports a `SessionError`. The deposit that
-    /// cycle was paid is only released once its whole emission has ridden back to the Entry, and the
-    /// address it sits at derives from both nodes' commitments — so a cycle abandoned midway strands
-    /// money both sides have already parted with rather than refunding it. With this on, the Exit
-    /// answers such a close by keeping the keep-alive stream running until the cycle recovers,
-    /// spending SURBs it is already holding on shares it has already been paid for.
+    /// the operator calls `SessionManager::close_session`, or the peer reports a `SessionError`. The
+    /// deposit that cycle was paid is only released once its whole emission has ridden back to the
+    /// Entry, and the address it sits at derives from both nodes' commitments — so a cycle abandoned
+    /// midway strands money both sides have already parted with rather than refunding it. With this
+    /// on, the Exit answers such a close by keeping the keep-alive stream running until the cycle
+    /// recovers, spending SURBs it is already holding on shares it has already been paid for.
     ///
     /// Deliberately narrow, and inert unless [`enabled`](Self::enabled) is set — a drain is fill,
     /// planned by the same rate law and carried by the same stream, so a disabled planner emits no
@@ -1095,8 +1096,9 @@ pub struct PixFillConfig {
     ///   [`min_surb_reserve`](Self::min_surb_reserve), covers the cycle's whole remaining emission — a drain that runs
     ///   out partway spends the reserve and recovers nothing, which is worse than not starting;
     /// * [`max_rate`](Self::max_rate) and that same reserve bound it exactly as they bound ordinary fill, and the
-    ///   SURB-level notification — fill's one reserve-exempt packet — is switched off for the duration, since the peer
-    ///   it asks for more SURBs has gone;
+    ///   SURB-level notification — fill's one reserve-exempt packet — is switched off for the duration, since it asks
+    ///   for more SURBs on behalf of a Session that is gone: the Entry itself may well still be there, but nothing is
+    ///   left to act on the request, so no refill answers it;
     /// * [`max_recovery_idle`](SupervisorConfig::max_recovery_idle) and
     ///   [`max_recovery_time`](SupervisorConfig::max_recovery_time) end it whether or not it succeeds.
     ///

--- a/transport/session/src/supervision/mod.rs
+++ b/transport/session/src/supervision/mod.rs
@@ -215,6 +215,9 @@
 //! fill       = clamp(required − organic, heartbeat, max_rate)
 //! ```
 //!
+//! Both of the middle two lines change for a *drain*, which is the same law over a Session that has
+//! already been closed — see "Draining a closed Session" below.
+//!
 //! The tail wins over the successor whenever it exists, for two reasons that point the same way: its
 //! SURBs sit ahead of the successor's in the Exit's own buffer, so packets sent now carry *its*
 //! shares; and it holds the binding deadline, since the successor's clocks are deliberately not armed
@@ -288,6 +291,23 @@
 //! switched **off** for the duration, since the reason for the exemption is that it asks for more
 //! SURBs on behalf of a Session that is gone: the Entry itself very likely still exists, but nothing
 //! is left there to act on the request, so no refill ever answers it.
+//!
+//! The rate law is the same one, with the two terms that assume a live Session taken out:
+//!
+//! ```text
+//! required = remaining × (1 + loss_margin) / SAMPLING_INTERVAL   -- no aim point; nothing to pace for
+//! fill     = clamp(required, heartbeat, max_rate)                -- no organic; nothing left to contribute
+//! ```
+//!
+//! Pacing a cycle to its aim point only makes sense while the Session is there to be paced, and
+//! subtracting organic egress only makes sense while an application is there to provide it. After the
+//! close neither is true — `served_total` is frozen for good — so a drain asks for its whole remainder
+//! at once and `max_rate` is what actually sets the pace. Leaving the subtraction in would have been
+//! worse than untidy: a client that hangs up on a cycle it has all but paid off leaves a small
+//! remainder against a still-high average, which suppresses the drain to its heartbeat for the whole
+//! of the averaging window — the one case the drain is most clearly worth doing. The stall rule is the
+//! one bound that does **not** step aside: it costs a progressing drain nothing and it is all that
+//! stands between a doomed one and `max_rate` sustained until a deadline fires.
 //!
 //! What a drain does not do is carry the Session on in any other respect. It retires every sibling
 //! cycle immediately (they are queued behind the target and can receive nothing while it drains) and

--- a/transport/session/src/supervision/mod.rs
+++ b/transport/session/src/supervision/mod.rs
@@ -253,6 +253,61 @@
 //! the required rate. The client accepts that as the price of a Session whose cycles complete, and
 //! funds successors as it would have.
 //!
+//! ### Draining a closed Session
+//!
+//! Fill answers a Session that has nothing to say. This answers one that is no longer there.
+//!
+//! A PIX Session can end at the Exit long before its funded cycle does, by three routes that all
+//! arrive at the same place: the session server closes the `HoprSession` (`WriteClosed`/`EmptyRead`),
+//! the operator calls `close_session` over the REST API, or the peer sends a `SessionError`. Until
+//! now each of those tore the Session down at once, taking the action driver's commitment guards and
+//! the reconstructor state with it. If the Exit was already holding enough SURBs to finish the cycle,
+//! the deposit both sides paid for was stranded — the address derives from the two commitments
+//! together, so nothing refunds it.
+//!
+//! So the Exit keeps draining, under [`fill.drain_after_close`](PixFillConfig::drain_after_close),
+//! and only when the arithmetic says the drain can finish:
+//!
+//! ```text
+//! remaining = E − largest_shares_seen(target)
+//! drain iff estimated_surbs − min_surb_reserve ≥ remaining
+//! ```
+//!
+//! The target is the earliest live cycle, and only if it is both funded and clocked — the same cycle
+//! fill would have been working for. A Session with no funded cycle, or one whose front has already
+//! recovered and left a paid FIFO tail behind, has nothing a drain could buy and closes at once with
+//! `SessionPixCloseReason::SessionClosed`.
+//!
+//! Three things about that predicate are deliberate. The estimate is an **upper** bound — ring-buffer
+//! overwrites, store eviction and invalidated relayers are all unobserved — so `remaining` carries no
+//! loss margin to go with it; in-flight packets are already subtracted from the estimate, and full
+//! recovery needs fewer than `E` shares, so both errors point the conservative way. The reserve stays
+//! in force for the whole drain, because the failure it prevents is worse than a lost deposit: a
+//! return-routed packet that finds no SURB holds *every* packet this node originates for
+//! `surb_resolution_wait`. And the SURB-level notification — the one packet the reserve exempts — is
+//! switched **off** for the duration, since the reason for the exemption is that it asks the Entry
+//! for more SURBs, and the Entry it would ask has gone.
+//!
+//! What a drain does not do is carry the Session on in any other respect. It retires every sibling
+//! cycle immediately (they are queued behind the target and can receive nothing while it drains) and
+//! it never asks for a successor, on any route into the request — there is no Session left to serve a
+//! successor's quota, so ordering one would commit the Entry to a deposit against a cycle that could
+//! never be served. It ends with `SessionPixCloseReason::Drained` when the cycle recovers, and with
+//! `RecoveryIdle` or `RecoveryDeadline` when it does not: `max_recovery_idle` stops being
+//! service-gated while draining, because a drained Session consumes no gated service ever again and
+//! the re-arm would otherwise never fire. The Session slot survives on its `time_to_idle`, which
+//! every progress event refreshes, so a productive drain keeps its slot and a stalled one is closed
+//! by the idle deadline long before the 180 s eviction — which remains the backstop.
+//!
+//! Two cases are deliberately excluded. **Idle eviction** does not drain — it reaches the cache's own
+//! listener rather than any of the close paths above — and that is the right answer rather than an
+//! omission: a filling Session's slot is refreshed by every progress event, so reaching the eviction
+//! at all means the cycle was already starved or stalled. A second explicit close of a *draining*
+//! Session forces the teardown for a different reason: it is the operator's way to overrule the
+//! drain. And a funded successor that has not yet reached the front, or a recovered predecessor's
+//! paid tail, is never drained for: a production SURB buffer is at most ten thousand deep and a cycle
+//! is 160 000–330 000 packets, so it could not cover a second one.
+//!
 //! ## The Worker — bridging pure logic to async
 //!
 //! `spawn_supervisor_worker` creates the `SessionPixSupervisor`,
@@ -312,12 +367,15 @@
 //!    | `ProgressNotification` | Worker calls `gate.notify_progress()`; no driver I/O. |
 //!    | `RetireSsa` | Calls `share_processor.retire_ssa`, aborts the deposit observer task. |
 //!    | `SetFillRate` | Applies the rate to the Session's shared keep-alive controller and records the gauge. |
-//!    | `Close` | Silences fill, poisons gate, retires all SSAs, publishes close metric, removes session slot. |
+//!    | `Close` | Silences fill, poisons gate, retires all SSAs, publishes close metric, removes session slot. A close that ends a *drain* is an ordinary outcome rather than a failure: it is logged as information and the Entry is sent no failure notice, since the notice is return-routed and the peer it would name has already gone. |
 //!
 //! 7. PIX protocol events from the packet pipeline arrive via `dispatch_pix_event` and are forwarded to the supervisor
 //!    as `SessionPixEvent::RecoveryProgress`, `UnverifiableShares`, `AlmostRecovered`, or `Recovered`.
 //! 8. When a commitment becomes verifiable, a `PixDepositObserver` task loops on deposit confirmations, forwarding each
 //!    as `DepositConfirmed` to the supervisor.
+//! 9. `SessionPixEvent::SessionClosed` is the one event that does not come from `dispatch_pix_event`. The manager's own
+//!    close paths raise it, from `begin_surb_drain`, and the supervisor answers by either draining the funded cycle or
+//!    closing at once — see "Draining a closed Session" above.
 //!
 //! ### Entry side (outgoing sessions)
 //!
@@ -383,6 +441,7 @@
 //! | `max_served_without_progress` | 2048 | Packets served with no share of *any* kind coming back — in *packets*, so unlike the idle timer the bound does not move with the Session's rate. Counts `shares_seen`, so a conforming Entry's surplus resets it; see below. |
 //! | `tombstone_retention_window` | 30 s | Bounds how long recovered-cycle diagnostics and observer ownership remain; the separately bounded FIFO-tail receipt may outlive it. |
 //! | `fill` | on | The one rule here that *sends* rather than stops: a funded cycle only recovers once its whole emission has ridden back to the Entry, so an idle Session strands the deposit it has already been paid. See [`PixFillConfig`]. |
+//! | `fill.drain_after_close` | on | A Session closed at the Exit mid-cycle stranding a deposit both sides have already paid for, while the Exit still holds the SURBs that would have completed it. Entered only when the estimated buffer covers the whole remainder, and bounded by everything `fill` is bounded by. |
 //!
 //! ## What is *not* here: the price of a cycle
 //!
@@ -506,6 +565,7 @@
 //! | `fill.max_rate` | 250 | An idle cycle here needs 163 840 x 1.05 / 5400 s = **32 packets/s**, so this is ~8x the requirement — headroom for a Session that fell behind, at a ceiling of ~2 Mbps. `validate_incoming_session_pix_config` enforces the floor against the *widest accepted quota*, which at the default `quota_range` is 128 packets/s |
 //! | `fill.heartbeat` | 60 s | The floor while organic egress covers the need. Not zero: the Entry's own idle eviction is refreshed by this traffic, and its balancer has no SURB-level report without it |
 //! | `fill.min_surb_reserve` | 500 | `SurbStoreConfig::distress_threshold`. A *ceiling*: the effective reserve is `min(500, announced_target / 4)`, floored at one, because the buffer it is measured against is sized by the Entry rather than here. At the 7 000-SURB balancer target below a quarter is 1 750, so 500 is what binds — leaving fill 93 % of the buffer and keeping the last 7 % for the application, which is the side that has something waiting on it. The derivation engages only on a Session whose Entry asked for under 2 000 SURBs, which without it could never be filled at all |
+//! | `fill.drain_after_close` | true | Shipped value, and inert at this profile's buffer depth: 7 000 SURBs less the 500 reserve is 4 % of a 163 840-packet cycle, so a Session closed at any point before the last 6 500 shares simply closes. What it does buy is the endgame — a client that hangs up in the final seconds of a cycle it has all but paid off no longer strands the whole deposit, and the drain then finishes in about 26 s at `max_rate` |
 //!
 //! What one cycle costs is not in this table, because it is not in this configuration: the 162.2 MiB
 //! quota is priced by the deposit pool, which is also what decides that a deposit has cleared it.
@@ -1016,6 +1076,35 @@ pub struct PixFillConfig {
     /// and the derivation only engages on a Session whose Entry asked for less than four times it.
     #[default(500)]
     pub min_surb_reserve: u64,
+
+    /// Whether a Session closed at this Exit keeps draining its buffered SURBs into the funded cycle.
+    ///
+    /// A Session can end at the Exit long before its funded cycle does: the session server closes it,
+    /// the operator calls `close_session`, or the peer reports a `SessionError`. The deposit that
+    /// cycle was paid is only released once its whole emission has ridden back to the Entry, and the
+    /// address it sits at derives from both nodes' commitments — so a cycle abandoned midway strands
+    /// money both sides have already parted with rather than refunding it. With this on, the Exit
+    /// answers such a close by keeping the keep-alive stream running until the cycle recovers,
+    /// spending SURBs it is already holding on shares it has already been paid for.
+    ///
+    /// Deliberately narrow, and inert unless [`enabled`](Self::enabled) is set — a drain is fill,
+    /// planned by the same rate law and carried by the same stream, so a disabled planner emits no
+    /// rate to drain at. Three further conditions bound what it can cost:
+    ///
+    /// * it is entered only when the Exit's *estimated* SURB buffer, net of
+    ///   [`min_surb_reserve`](Self::min_surb_reserve), covers the cycle's whole remaining emission — a drain that runs
+    ///   out partway spends the reserve and recovers nothing, which is worse than not starting;
+    /// * [`max_rate`](Self::max_rate) and that same reserve bound it exactly as they bound ordinary fill, and the
+    ///   SURB-level notification — fill's one reserve-exempt packet — is switched off for the duration, since the peer
+    ///   it asks for more SURBs has gone;
+    /// * [`max_recovery_idle`](SupervisorConfig::max_recovery_idle) and
+    ///   [`max_recovery_time`](SupervisorConfig::max_recovery_time) end it whether or not it succeeds.
+    ///
+    /// Setting it to `false` restores the immediate teardown on every close path, byte for byte.
+    ///
+    /// Default: `true`.
+    #[default(true)]
+    pub drain_after_close: bool,
 }
 
 /// A rate at which the Exit originates PIX fill keep-alives.
@@ -1135,6 +1224,18 @@ pub enum SessionPixEvent {
         ssa_id: SsaId<HoprPseudonym>,
         observed_total: u64,
     },
+    /// The session layer closed this Session at the Exit.
+    ///
+    /// The one event here that does not come from the packet pipeline: it is raised by the manager's
+    /// own close paths — the session server's `WriteClosed`/`EmptyRead`, an operator's
+    /// `close_session`, or a peer `SessionError` — rather than by an observation about a cycle.
+    ///
+    /// `drainable_surbs` is the Exit's *estimate* of the SURBs it may still spend, already net of the
+    /// fill reserve. An estimate, and an upper bound at that: ring-buffer overwrites, store eviction
+    /// and invalidated relayers are all unobserved. That is why the supervisor compares it against
+    /// the whole remaining emission rather than a discounted one, and why the deadlines remain the
+    /// backstop for a drain admitted on a figure that turns out to have been optimistic.
+    SessionClosed { drainable_surbs: u64 },
 }
 
 // ---------------------------------------------------------------------------
@@ -1234,6 +1335,19 @@ pub enum SessionPixCloseReason {
     NoSsaRemaining,
     /// The supervisor action driver failed or was dropped.
     SupervisorUnavailable,
+    /// The Session was closed at the Exit with nothing left worth draining.
+    ///
+    /// Not a fault: it is the ordinary end of a Session whose funded cycle the Exit cannot finish out
+    /// of the SURBs it holds — or which had no funded cycle at all. What it reports is that the
+    /// Session ended because it was closed, rather than because one of the deadlines above expired.
+    SessionClosed,
+    /// The funded cycle recovered after the Session had already been closed at the Exit.
+    ///
+    /// The good outcome of a drain, and the reason the drain exists: the deposit the Entry paid for
+    /// that cycle is released rather than stranded. A drain that instead runs out of SURBs or of
+    /// shares closes with [`RecoveryIdle`](Self::RecoveryIdle) or
+    /// [`RecoveryDeadline`](Self::RecoveryDeadline), which is why there is no third reason here.
+    Drained,
 }
 
 // ---------------------------------------------------------------------------
@@ -2070,6 +2184,8 @@ mod tests {
             SessionPixCloseReason::InvalidTransition,
             SessionPixCloseReason::NoSsaRemaining,
             SessionPixCloseReason::SupervisorUnavailable,
+            SessionPixCloseReason::SessionClosed,
+            SessionPixCloseReason::Drained,
         ];
 
         for reason in reasons {
@@ -2084,7 +2200,9 @@ mod tests {
                 | SessionPixCloseReason::CounterRegression
                 | SessionPixCloseReason::InvalidTransition
                 | SessionPixCloseReason::NoSsaRemaining
-                | SessionPixCloseReason::SupervisorUnavailable => {}
+                | SessionPixCloseReason::SupervisorUnavailable
+                | SessionPixCloseReason::SessionClosed
+                | SessionPixCloseReason::Drained => {}
             }
         }
 

--- a/transport/session/src/supervision/snapshots/hopr_transport_session__supervision__tests__pix_close_reason_display_values_are_stable.snap
+++ b/transport/session/src/supervision/snapshots/hopr_transport_session__supervision__tests__pix_close_reason_display_values_are_stable.snap
@@ -14,4 +14,6 @@ expression: labels
     "InvalidTransition",
     "NoSsaRemaining",
     "SupervisorUnavailable",
+    "SessionClosed",
+    "Drained",
 ]

--- a/transport/session/src/supervision/supervisor.rs
+++ b/transport/session/src/supervision/supervisor.rs
@@ -161,6 +161,14 @@ pub struct SessionPixSupervisor {
     pub(crate) dims: PixParams,
     pub(crate) pseudonym: HoprPseudonym,
     pub(crate) closed: bool,
+    /// The Session is gone and only its funded front cycle is still being worked for.
+    ///
+    /// Set by [`on_session_closed`](Self::on_session_closed) and never cleared: a drain ends by
+    /// closing, one way or another. While it is set the supervisor asks for no successor, plans fill
+    /// at the ceiling, and stops service-gating the recovery idle deadline — see "Draining a closed
+    /// Session" in this module's documentation for why each of those follows from the Session having
+    /// left rather than being separate policy.
+    pub(crate) draining: bool,
     next_ssa_index: u32,
     /// The cycle the two share-order counters below are measured against — the earliest unrecovered
     /// cycle, i.e. the one the Entry should currently be serving. `None` before the first batch exists.
@@ -242,6 +250,7 @@ impl SessionPixSupervisor {
             front_useful: 0,
             off_front_useful: 0,
             closed: false,
+            draining: false,
             service_open: false,
             service_front: None,
             paid_front_handoff: false,
@@ -278,6 +287,7 @@ impl SessionPixSupervisor {
             SessionPixEvent::UnverifiableShares { ssa_id, observed_total } => {
                 self.on_unverifiable_shares(ssa_id, *observed_total, now)
             }
+            SessionPixEvent::SessionClosed { drainable_surbs } => self.on_session_closed(*drainable_surbs, now),
         };
 
         let mut lifecycle_actions = actions;
@@ -575,7 +585,15 @@ impl SessionPixSupervisor {
             if let Some(reason) = expired {
                 // Service-gated idle: if no service consumed since last progress,
                 // re-arm instead of closing.
+                //
+                // Not while draining, though. The re-arm asks "was any *gated* service consumed",
+                // and a drained Session has no application left to consume any — `served_total` is
+                // frozen for good, so the re-arm would fire for ever and the one bound on a drain
+                // admitted against an over-estimated buffer would be gone with it. A *productive*
+                // drain is unaffected: its own progress still refreshes `recovery_idle_deadline`
+                // through `on_recovery_progress`.
                 if reason == SessionPixCloseReason::RecoveryIdle
+                    && !self.draining
                     && served_total <= self.ssas[i].served_total_at_last_progress
                 {
                     self.ssas[i].recovery_idle_deadline = now.checked_add(max_recovery_idle);
@@ -721,6 +739,7 @@ impl SessionPixSupervisor {
                 ssa_id: tail.ssa_id,
                 largest_shares_seen: tail.largest_shares_seen,
                 hard_deadline,
+                drain: self.draining,
             });
         }
 
@@ -732,6 +751,7 @@ impl SessionPixSupervisor {
                 ssa_id: ssa.ssa_id,
                 largest_shares_seen: ssa.largest_shares_seen,
                 hard_deadline,
+                drain: self.draining,
             })
     }
 
@@ -1301,6 +1321,20 @@ impl SessionPixSupervisor {
     /// `on_deposit_confirmed`/`on_commitment_verified` when `recovered_pending`
     /// was set earlier.
     fn perform_recovered_transition(&mut self, idx: usize, now: Instant, served_total: u64) -> Vec<SessionPixAction> {
+        // The end of a drain, and the outcome it exists for: the deposit this cycle was paid is
+        // released rather than stranded. None of the bookkeeping below is worth doing — the tail
+        // receipt, the tombstone and the gate notification all serve a Session that is about to be
+        // torn down, and `closed` gates every entry point from here on. Returning before the tail is
+        // created also guarantees a drain can never leave one behind.
+        if self.draining {
+            tracing::info!(
+                ssa_id = %self.ssas[idx].ssa_id,
+                "the funded cycle of a closed session recovered — the SURB drain is complete"
+            );
+            self.closed = true;
+            return self.with_fill_stopped(vec![SessionPixAction::Close(SessionPixCloseReason::Drained)]);
+        }
+
         let next_requested = self.ssas[idx].next_requested;
         let was_front = self.earliest_live_idx() == Some(idx);
 
@@ -1424,6 +1458,91 @@ impl SessionPixSupervisor {
         );
 
         self.with_fill_stopped(vec![SessionPixAction::Close(SessionPixCloseReason::UnverifiableShares)])
+    }
+
+    /// Decides whether a Session closed at the Exit is worth draining its buffered SURBs into.
+    ///
+    /// `available` is the manager's estimate of the SURBs still spendable, already net of the fill
+    /// reserve. The cycle it is measured against is the earliest live one, and only when it is both
+    /// funded and clocked — i.e. exactly the cycle fill would have been working for. Two shapes have
+    /// nothing a drain could buy and close at once: an unfunded front, where no deposit is at stake;
+    /// and a recovered predecessor's paid FIFO tail, whose key is already recovered and behind which
+    /// the successor is queued without clocks of its own.
+    ///
+    /// The comparison is against the *whole* remaining emission, with no loss margin. That is
+    /// conservative in both directions on purpose: the estimate is an upper bound (see
+    /// [`SessionPixEvent::SessionClosed`]), while in-flight packets are already subtracted from it
+    /// and full recovery in practice needs fewer than `E` shares. A drain that runs out partway has
+    /// spent the Session's SURBs down to the reserve and recovered nothing, which is strictly worse
+    /// than never starting.
+    ///
+    /// Siblings are retired directly rather than through
+    /// [`close_ssa_and_collect`](Self::close_ssa_and_collect), which would be wrong twice over: it
+    /// charges [`failed_cycles`](Self::failed_cycles), and these cycles were retired by an operator
+    /// closing a Session rather than lost by an Entry; and its `ssas.len() == 1` branch would close
+    /// the Session outright. Recovered tombstones are left alone — they hold no reconstructor state
+    /// and expire on their own timer with an idempotent `RetireSsa`.
+    ///
+    /// `_now` is taken for symmetry with every other handler; nothing here is timed. A drain inherits
+    /// the target's existing clocks rather than starting any of its own, which is the point — the
+    /// resource bound on the cycle must not be extended by the Session ending.
+    fn on_session_closed(&mut self, available: u64, _now: Instant) -> Vec<SessionPixAction> {
+        let target = self
+            .paid_recovery_tail
+            .is_none()
+            .then(|| self.earliest_live_idx())
+            .flatten()
+            .filter(|&idx| {
+                self.ssas[idx].phase == SsaPhase::Recovering && self.ssas[idx].recovery_hard_deadline.is_some()
+            });
+
+        let cycle_shares = self.dims.polys_per_ssa() as u64 * self.dims.emitted_shares_per_poly() as u64;
+        let remaining = target.map(|idx| cycle_shares.saturating_sub(self.ssas[idx].largest_shares_seen));
+
+        let Some((idx, remaining)) = target.zip(remaining).filter(|&(_, remaining)| available >= remaining) else {
+            tracing::info!(
+                available,
+                ?remaining,
+                target = ?target.map(|idx| self.ssas[idx].ssa_id),
+                "closing PIX session: the exit-side close left nothing worth draining for"
+            );
+            self.closed = true;
+            return self.with_fill_stopped(vec![SessionPixAction::Close(SessionPixCloseReason::SessionClosed)]);
+        };
+
+        let target_id = self.ssas[idx].ssa_id;
+        tracing::info!(
+            %target_id,
+            available,
+            remaining,
+            "draining buffered SURBs into the funded cycle of a session closed at the exit"
+        );
+
+        self.draining = true;
+        // A deferred request can never be retried now, and leaving the flag set would have
+        // `retry_deferred_successor_request` call into the (now silent) request path every event.
+        self.successor_request_deferred = false;
+
+        // Every sibling is behind the target in index order — the target *is* `earliest_live_idx` —
+        // so removing them cannot move the front, and the tail of `handle_event` re-derives the same
+        // gate state and share-order front it already had.
+        let mut retired = Vec::new();
+        self.ssas.retain(|ssa| {
+            if ssa.ssa_id == target_id || ssa.is_terminal() {
+                true
+            } else {
+                retired.push(ssa.ssa_id);
+                false
+            }
+        });
+
+        retired
+            .into_iter()
+            .map(|ssa_id| {
+                self.note_retired_index(ssa_id.ssa_index());
+                SessionPixAction::RetireSsa(ssa_id)
+            })
+            .collect()
     }
 
     // ------------------------------------------------------------------
@@ -1553,6 +1672,14 @@ impl SessionPixSupervisor {
     /// once, so the ceiling is `ssas_per_request` SSA quotas rather than one. That is the trade the
     /// knob exists to make, and it is why both deadlines are scaled by the same factor.
     fn emit_request_next_ssa(&mut self, now: Instant) -> Vec<SessionPixAction> {
+        // A drain has no Session left to serve a successor's quota, so asking for one would commit
+        // the Entry to a deposit against a cycle that could never be served. Guarded here rather than
+        // at each of the four call sites — the early signal, the recovered transition, the deferred
+        // retry and the deposit replay — so no route into a request can be missed.
+        if self.draining {
+            return Vec::new();
+        }
+
         let batch = self.cfg.ssas_per_request.clamp(1, crate::MAX_SSA_BATCH_SIZE);
         let live_cycles = self.live_cycle_count();
         let live_batches = self.live_batch_count();
@@ -5352,6 +5479,309 @@ mod tests {
         assert!(
             matches!(actions.first(), Some(SessionPixAction::SetFillRate(rate)) if rate.is_zero()),
             "the zero must lead the close, got {actions:?}"
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Draining a closed Session
+    // ---------------------------------------------------------------
+
+    /// A closed Session whose buffer covers the rest of the cycle keeps working for it.
+    ///
+    /// This is the whole feature in one test: the deposit both sides have already paid for is
+    /// recoverable, the SURBs to recover it are already held, and the only thing that had been
+    /// spending them was a Session that has now gone. Nothing about the close makes the cycle
+    /// un-completable, so the supervisor neither closes nor asks for a successor it could never
+    /// serve — it plans the remainder at the ceiling and works it off.
+    #[test]
+    fn a_closed_session_with_enough_surbs_drains_its_funded_cycle() {
+        let cfg = default_cfg();
+        let t0 = Instant::now();
+        let (mut sup, _) = funded_at_front(cfg.clone(), fill_dims(), t0);
+
+        let actions = sup.handle_event(
+            &SessionPixEvent::SessionClosed {
+                drainable_surbs: max_cycle_shares(&sup),
+            },
+            t0 + Duration::from_secs(1),
+            0,
+        );
+
+        assert!(!sup.closed, "a drain leaves the state machine running");
+        assert!(sup.draining);
+        assert!(
+            !actions
+                .iter()
+                .any(|action| matches!(action, SessionPixAction::Close(_) | SessionPixAction::RequestSsa { .. })),
+            "a drain neither closes the Session nor asks for a successor, got {actions:?}"
+        );
+
+        // The next tick asks for the whole remainder, which the ceiling then paces.
+        let rate =
+            planned_rate(&sup.handle_timers(t0 + Duration::from_secs(2), 0)).expect("a draining cycle must be filled");
+        assert_eq!(FillRate::per_second(cfg.fill.max_rate), rate);
+    }
+
+    /// A buffer one SURB short of the remainder is not worth draining.
+    ///
+    /// The estimate is an upper bound and the comparison is against the *whole* remaining emission,
+    /// because a drain that runs out partway has spent the Session's SURBs down to the reserve and
+    /// recovered nothing — strictly worse than closing at once, which is what it must do instead.
+    #[test]
+    fn a_closed_session_without_enough_surbs_closes_instead_of_draining() {
+        let t0 = Instant::now();
+        let (mut sup, p) = funded_at_front(default_cfg(), fill_dims(), t0);
+        let id = ssa_id(p, 1);
+
+        // Filling before the close, so the refusal has a stream to silence.
+        assert!(planned_rate(&sup.handle_timers(t0 + SAMPLING_INTERVAL, 0)).is_some());
+
+        let seen = max_cycle_shares(&sup) / 2;
+        feed_seen(&mut sup, id, seen, t0 + Duration::from_secs(2), 0);
+        let one_short = max_cycle_shares(&sup) - seen - 1;
+
+        let actions = sup.handle_event(
+            &SessionPixEvent::SessionClosed {
+                drainable_surbs: one_short,
+            },
+            t0 + Duration::from_secs(3),
+            0,
+        );
+
+        assert!(sup.closed);
+        assert!(!sup.draining);
+        assert!(
+            matches!(actions.first(), Some(SessionPixAction::SetFillRate(rate)) if rate.is_zero()),
+            "the zero must lead the close, got {actions:?}"
+        );
+        assert!(
+            actions
+                .iter()
+                .any(|action| matches!(action, SessionPixAction::Close(SessionPixCloseReason::SessionClosed))),
+            "got {actions:?}"
+        );
+    }
+
+    /// With no funded cycle to work for, a close is just a close.
+    ///
+    /// Two ways to have none. An unfunded front has nothing at stake — no deposit has been paid, so
+    /// there is nothing to strand. A paid recovery tail means the front's key is *already* recovered,
+    /// so draining it would buy nothing either; and its successor is queued behind the tail with no
+    /// clocks of its own, which is precisely the state fill refuses to plan against.
+    #[test]
+    fn a_closed_session_with_no_funded_cycle_closes_instead_of_draining() {
+        let plenty = u64::MAX;
+
+        let t0 = Instant::now();
+        let p = pseudonym();
+        let (mut sup, _) = SessionPixSupervisor::new(default_cfg(), fill_dims(), p, t0);
+        commit_unfunded(&mut sup, p, 1..=1, t0);
+
+        let actions = sup.handle_event(
+            &SessionPixEvent::SessionClosed {
+                drainable_surbs: plenty,
+            },
+            t0 + Duration::from_secs(1),
+            0,
+        );
+        assert!(
+            sup.closed && !sup.draining,
+            "an unfunded front has nothing to drain for"
+        );
+        assert!(
+            actions
+                .iter()
+                .any(|action| matches!(action, SessionPixAction::Close(SessionPixCloseReason::SessionClosed))),
+            "got {actions:?}"
+        );
+
+        // And the same with a recovered predecessor's paid tail in front.
+        let t0 = Instant::now();
+        let (mut sup, p) = funded_at_front(default_cfg(), fill_dims(), t0);
+        let first = ssa_id(p, 1);
+        let half = max_cycle_shares(&sup) / 2;
+        feed_seen(&mut sup, first, half, t0 + Duration::from_secs(1), 0);
+        sup.handle_event(&SessionPixEvent::Recovered(first), t0 + Duration::from_secs(1), 0);
+        assert!(
+            sup.paid_recovery_tail.is_some(),
+            "the fixture must leave a paid tail behind for this half to mean anything"
+        );
+
+        let actions = sup.handle_event(
+            &SessionPixEvent::SessionClosed {
+                drainable_surbs: plenty,
+            },
+            t0 + Duration::from_secs(2),
+            0,
+        );
+        assert!(sup.closed && !sup.draining, "a recovered key is not worth draining for");
+        assert!(
+            actions
+                .iter()
+                .any(|action| matches!(action, SessionPixAction::Close(SessionPixCloseReason::SessionClosed))),
+            "got {actions:?}"
+        );
+    }
+
+    /// Everything but the cycle being drained is retired at once, and none of it counts as a failure.
+    ///
+    /// A drain works for exactly one cycle: the batch's later members are queued behind it and can
+    /// receive no share while it drains, and there is no successor coming, so holding their
+    /// reconstructor state open would cost memory for the length of the drain and buy nothing. The
+    /// failure counter must not move either — these cycles were retired by an operator closing a
+    /// Session, not lost by an Entry, and charging them would make a second drain on the same node
+    /// look like an Entry over its budget.
+    #[test]
+    fn a_drain_retires_every_cycle_but_the_one_it_is_recovering() {
+        const BATCH: u32 = 4;
+
+        let cfg = SupervisorConfig {
+            ssas_per_request: BATCH as usize,
+            ..default_cfg()
+        };
+        let t0 = Instant::now();
+        let p = pseudonym();
+        let (mut sup, _) = SessionPixSupervisor::new(cfg, fill_dims(), p, t0);
+        fund_batch(&mut sup, p, 2, t0);
+        commit_unfunded(&mut sup, p, 3..=BATCH, t0);
+
+        let actions = sup.handle_event(
+            &SessionPixEvent::SessionClosed {
+                drainable_surbs: max_cycle_shares(&sup),
+            },
+            t0 + Duration::from_secs(1),
+            0,
+        );
+
+        let retired = actions
+            .iter()
+            .filter_map(|action| match action {
+                SessionPixAction::RetireSsa(id) => Some(id.ssa_index().get()),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            vec![2, 3, 4],
+            retired,
+            "every cycle but the one being drained must be retired, got {actions:?}"
+        );
+        assert!(!sup.closed && sup.draining);
+        assert_eq!(0, sup.failed_cycles, "a drain retires siblings, it does not lose them");
+        assert_eq!(1, sup.ssas.len());
+        assert_eq!(ssa_id(p, 1), sup.ssas[0].ssa_id);
+    }
+
+    /// A drain that finishes closes on its own reason and never asks for a successor.
+    ///
+    /// Both halves matter. `Drained` is what tells an operator the close was the good outcome — the
+    /// deposit was recovered — rather than one more Session lost on a timer. And the successor
+    /// request has to be suppressed on *every* route into it, the early-recovery signal included:
+    /// there is no Session left to serve a successor's quota, so asking for one would commit the
+    /// Entry to a deposit against a cycle that can never be served.
+    #[test]
+    fn a_completed_drain_closes_the_session_without_asking_for_a_successor() {
+        let t0 = Instant::now();
+        let (mut sup, p) = funded_at_front(default_cfg(), fill_dims(), t0);
+        let id = ssa_id(p, 1);
+        assert!(planned_rate(&sup.handle_timers(t0 + SAMPLING_INTERVAL, 0)).is_some());
+
+        sup.handle_event(
+            &SessionPixEvent::SessionClosed {
+                drainable_surbs: max_cycle_shares(&sup),
+            },
+            t0 + Duration::from_secs(2),
+            0,
+        );
+        assert!(sup.draining);
+
+        let early = sup.handle_event(&SessionPixEvent::AlmostRecovered(id), t0 + Duration::from_secs(3), 0);
+        assert!(
+            early.is_empty(),
+            "the early-recovery signal must not order a successor for a Session that is gone, got {early:?}"
+        );
+
+        let actions = sup.handle_event(&SessionPixEvent::Recovered(id), t0 + Duration::from_secs(4), 0);
+        assert!(sup.closed);
+        assert!(
+            matches!(actions.first(), Some(SessionPixAction::SetFillRate(rate)) if rate.is_zero()),
+            "the zero must lead the close, got {actions:?}"
+        );
+        assert!(
+            actions
+                .iter()
+                .any(|action| matches!(action, SessionPixAction::Close(SessionPixCloseReason::Drained))),
+            "got {actions:?}"
+        );
+        assert!(
+            !actions
+                .iter()
+                .any(|action| matches!(action, SessionPixAction::RequestSsa { .. })),
+            "got {actions:?}"
+        );
+    }
+
+    /// A drain that stops making progress is closed by the idle deadline rather than re-armed.
+    ///
+    /// The idle rule normally re-arms whenever no *gated* service was consumed since the last
+    /// progress, so that a merely quiet Entry is never disconnected. A drained Session has no
+    /// application left to consume any, so `served_total` is frozen for good and the re-arm would
+    /// never stop firing — the one bound on a drain admitted against an over-estimated buffer would
+    /// be gone with it.
+    #[test]
+    fn a_stalled_drain_closes_on_the_recovery_idle_deadline() {
+        let cfg = default_cfg();
+        let t0 = Instant::now();
+        let (mut sup, _) = funded_at_front(cfg.clone(), fill_dims(), t0);
+
+        sup.handle_event(
+            &SessionPixEvent::SessionClosed {
+                drainable_surbs: max_cycle_shares(&sup),
+            },
+            t0,
+            0,
+        );
+        assert!(sup.draining);
+
+        // Not one share, and not one packet of gated service either — which is exactly the shape the
+        // re-arm branch was written for, and the shape it must no longer answer to.
+        let actions = sup.handle_deadline(t0 + cfg.max_recovery_idle, 0);
+        assert!(sup.closed);
+        assert!(
+            actions
+                .iter()
+                .any(|action| matches!(action, SessionPixAction::Close(SessionPixCloseReason::RecoveryIdle))),
+            "got {actions:?}"
+        );
+    }
+
+    /// And the hard deadline still ends a drain that is making progress but will not finish.
+    ///
+    /// The immutable per-cycle backstop is not relaxed for a drain: the reconstructor state it holds
+    /// open is the resource the deadline exists to bound, and a closed Session is no reason to hold
+    /// it longer. `check_deadlines` tests the hard clock before the idle one, which is why this
+    /// reports the deadline rather than the silence that came with it.
+    #[test]
+    fn a_drain_still_ends_at_its_hard_recovery_deadline() {
+        let cfg = default_cfg();
+        let t0 = Instant::now();
+        let (mut sup, _) = funded_at_front(cfg.clone(), fill_dims(), t0);
+
+        sup.handle_event(
+            &SessionPixEvent::SessionClosed {
+                drainable_surbs: max_cycle_shares(&sup),
+            },
+            t0,
+            0,
+        );
+        assert!(sup.draining);
+
+        let actions = sup.handle_deadline(t0 + cfg.max_recovery_time, 0);
+        assert!(sup.closed);
+        assert!(
+            actions
+                .iter()
+                .any(|action| matches!(action, SessionPixAction::Close(SessionPixCloseReason::RecoveryDeadline))),
+            "got {actions:?}"
         );
     }
 

--- a/transport/session/src/supervision/worker.rs
+++ b/transport/session/src/supervision/worker.rs
@@ -64,8 +64,10 @@ impl SessionPixSupervisorHandle {
     /// Returns `true` if the event was queued.
     ///
     /// The synchronous counterpart to [`send_event`](Self::send_event), and it exists because one
-    /// caller cannot await: `close_session_with_reason` is a plain `fn`, reached from `poll_close`,
-    /// from a moka eviction listener and from the REST handler, none of which may park on a worker
+    /// caller cannot await: `close_session_with_reason` is a plain `fn`, reached from the manager's
+    /// closure-notification task — which `HoprSession::poll_close` and the empty-read path feed
+    /// through a non-blocking channel — from the public synchronous `SessionManager::close_session`,
+    /// and from `handle_session_error` on a peer `SessionError`. None of them may park on a worker
     /// that happens to be mid-tick.
     ///
     /// A refusal is not lost work, which is what makes dropping acceptable here where it would not be

--- a/transport/session/src/supervision/worker.rs
+++ b/transport/session/src/supervision/worker.rs
@@ -59,6 +59,34 @@ impl SessionPixSupervisorHandle {
         }
     }
 
+    /// Deliver a PIX event without blocking, dropping it if the channel is full.
+    ///
+    /// Returns `true` if the event was queued.
+    ///
+    /// The synchronous counterpart to [`send_event`](Self::send_event), and it exists because one
+    /// caller cannot await: `close_session_with_reason` is a plain `fn`, reached from `poll_close`,
+    /// from a moka eviction listener and from the REST handler, none of which may park on a worker
+    /// that happens to be mid-tick.
+    ///
+    /// A refusal is not lost work, which is what makes dropping acceptable here where it would not be
+    /// for a lifecycle transition. The only event sent this way is
+    /// [`SessionPixEvent::SessionClosed`], and its caller treats `false` as "this close was not
+    /// answered by the supervisor" and falls back to the immediate teardown that has always been the
+    /// behaviour on that path.
+    pub fn try_send_event(&self, ev: SessionPixEvent) -> bool {
+        match self.cmd_tx.try_send(WorkerCommand::Event(ev)) {
+            Ok(()) => true,
+            Err(TrySendError::Full(_)) => {
+                tracing::debug!("supervisor command channel full — dropping event");
+                false
+            }
+            Err(TrySendError::Disconnected(_)) => {
+                tracing::warn!("PIX supervisor command channel closed");
+                false
+            }
+        }
+    }
+
     /// Send an action result feedback to the supervisor, awaiting capacity if
     /// the channel is full.
     pub async fn send_action_result(&self, action: SessionPixAction, ok: bool) -> Result<(), ()> {


### PR DESCRIPTION
Closes #8317

## The Change

When a PIX Session is closed at the Exit while its funded cycle is still in flight (the session server closes it, an explicit `close_session`, or a peer `SessionError`), the Exit no longer tears everything down at once. If the SURBs it already holds, net of the fill reserve, cover the rest of the cycle's emission, it keeps the existing keep-alive stream running until the cycle recovers, so the deposit both sides already paid for is released instead of stranded.

## How

- The supervisor decides: a new `SessionClosed` event carries the spendable SURB estimate, and the supervisor either drains the funded front cycle or closes at once. New close reasons `SessionClosed` and `Drained`.
- While draining it retires every sibling cycle, never asks for a successor, plans fill at `max_rate`, and ends on `Recovered`, `max_recovery_idle` (no longer service-gated for a closed Session) or `max_recovery_time`.
- The SURB reserve stays in force and the reserve-exempt SURB-level notification is switched off for the duration, so a drain can never originate a packet with no SURB to carry it.
- No new tasks and no new `SessionSlot` fields: the slot stays in the cache until the driver's existing `Close` teardown runs. A second explicit close, or idle eviction, still forces the immediate teardown.
- New `fill.drain_after_close` config flag, default `true`, inert without `fill.enabled`. With it off every close path is byte-for-byte what it was.

Out-of-repo follow-up, as with #8396: hoprd's `SupervisorConfig` mirror needs `fill.drain_after_close`.