### PR TITLE
chore(renovate): run on numeric release branches

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,6 +7,7 @@
     "group:allDigest",
     ":disableDependencyDashboard"
   ],
+  "baseBranchPatterns": ["$default", "/^release\\/\\d.*/"],
   "prCreation": "not-pending",
   "semanticCommits": "enabled",
   "rangeStrategy": "bump",

--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
     "group:allDigest",
     ":disableDependencyDashboard"
   ],
-  "baseBranchPatterns": ["$default", "/^release\\/\\d.*/"],
+  "baseBranchPatterns": ["$default", "/^release\\/\\d+\\.\\d+$/"],
   "prCreation": "not-pending",
   "semanticCommits": "enabled",
   "rangeStrategy": "bump",


### PR DESCRIPTION
## What

Extend Renovate so it processes supported **stable release branches** in addition to the default (development) branch. Until now Renovate only raised dependency and security update PRs against the default branch, so shipped release lines silently missed important updates.

## How

Adds a single `baseBranchPatterns` key to `renovate.json` on the default branch:

```
"baseBranchPatterns": ["$default", "/^release\\/\\d+\\.\\d+$/"]
```

Renovate reads its config only from the default branch, so this one edit is sufficient — no changes on the release branches themselves. `$default` keeps the development branch updated; the end-anchored `/^release\/\d+\.\d+$/` regex matches exactly the `release/<major>.<minor>` scheme produced by the release-promotion workflow (e.g. `release/4.1`, `release/0.11`) and deliberately excludes non-numeric legacy branches as well as hotfix/patch/nested suffixes (`release/4-hotfix`, `release/4.1.2`, `release/4/foo`), so no noise is generated on stale or unsupported lines. New numeric release branches are picked up automatically as they are cut.

Verified with `renovate-config-validator` (Renovate 43.x) and the repo pre-commit Renovate hook — both pass.

Refs hoprnet/gitops#422 (DEV-148)
